### PR TITLE
Fix Shift+Enter sending same byte as Enter

### DIFF
--- a/deps/egui_term/src/bindings.rs
+++ b/deps/egui_term/src/bindings.rs
@@ -234,7 +234,7 @@ fn default_keyboard_bindings() -> Vec<(Binding<InputKind>, BindingAction)> {
         Backslash,    Modifiers::CTRL; BindingAction::Char('\x1c');
         Minus,        Modifiers::CTRL; BindingAction::Char('\x1f');
         // SHIFT
-        Enter,      Modifiers::SHIFT; BindingAction::Char('\x0d');
+        Enter,      Modifiers::SHIFT; BindingAction::Esc("\x1b[13;2u".into());
         Backspace,  Modifiers::SHIFT; BindingAction::Char('\x7f');
         Tab,        Modifiers::SHIFT; BindingAction::Esc("\x1b[Z".into());
         End,        Modifiers::SHIFT, +TerminalMode::ALT_SCREEN; BindingAction::Esc("\x1b[1;2F".into());


### PR DESCRIPTION
## Summary
- Shift+Enter was mapped to `\x0d` (carriage return), identical to plain Enter
- Terminal apps like Claude Code and Gemini CLI couldn't distinguish the two, so Shift+Enter submitted the prompt instead of inserting a newline
- Now sends `\x1b[13;2u` (kitty keyboard protocol), which apps recognize as a distinct "shifted return" event

One-line change in `deps/egui_term/src/bindings.rs:237`.

Closes #10

## Test plan
- [ ] Open Claude Code in PLEXI, type a prompt, press Shift+Enter — should insert a newline
- [ ] Press Enter — should still submit normally
- [ ] Test in Gemini CLI with same steps