### PR TITLE
Add file drag-and-drop support for terminal panes

### DIFF
--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -234,6 +234,23 @@ impl<'a> TerminalView<'a> {
             }
         }
 
+        // Handle file drops — paste paths into PTY
+        let dropped_files = layout.ctx.input(|i| i.raw.dropped_files.clone());
+        for file in dropped_files {
+            if let Some(path) = &file.path {
+                let path_str = path.display().to_string();
+                let escaped = if path_str
+                    .contains(|c: char| c.is_whitespace() || "\"'\\()&|;$`!#".contains(c))
+                {
+                    format!("'{}'", path_str.replace('\'', "'\\''"))
+                } else {
+                    path_str
+                };
+                self.backend
+                    .process_command(BackendCommand::Write(escaped.as_bytes().to_vec()));
+            }
+        }
+
         // Check for link hover every frame (not just on mouse move) so that
         // pressing/releasing Cmd updates the hyperlink state immediately.
         if has_pointer && modifiers.command_only() {


### PR DESCRIPTION
## Summary
- Detect files dropped onto a terminal pane via egui's `raw_input.dropped_files`
- Paste the file path into the PTY as text (same pipeline as Cmd+V paste)
- Paths with spaces or shell-special characters are automatically single-quoted

One file changed: `deps/egui_term/src/view.rs` (+17 lines in `process_input()`)

Closes #9

## Test plan
- [ ] Drag a file from Finder onto a terminal pane — path should appear as typed text
- [ ] Drag a file with spaces in the path — should be wrapped in single quotes
- [ ] Drag a file with an apostrophe in the name — should be properly escaped (`'\\''`)
- [ ] Normal keyboard input and Cmd+V paste still work unchanged
- [ ] Drag an image into Claude Code — path should paste, allowing Claude to reference it