### PR TITLE
Add theme config via ~/.config/plexi/config.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -2752,7 +2753,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -3090,6 +3091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3434,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,14 +3465,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3450,8 +3495,14 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -4382,6 +4433,15 @@ dependencies = [
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.11"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::keys::{self, Action, Direction};
 use crate::pane::TerminalPane;
 use crate::shell;
@@ -194,6 +195,7 @@ pub struct PlexiApp {
     pty_event_tx: mpsc::Sender<(u64, PtyEvent)>,
     theme: TerminalTheme,
     font: TerminalFont,
+    colors: Colors,
     next_pane_id: u64,
     ctx: egui::Context,
     contexts: Vec<Context>,
@@ -212,7 +214,11 @@ impl PlexiApp {
 
         theme::setup_fonts(&cc.egui_ctx);
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
-        theme::setup_style(&cc.egui_ctx);
+
+        let config = config::PlexiConfig::load();
+        let theme_cfg = config.theme.unwrap_or_default();
+        let colors = Colors::from_config(&theme_cfg);
+        theme::setup_style(&cc.egui_ctx, &colors);
 
         let (tx, rx) = mpsc::channel();
 
@@ -229,7 +235,7 @@ impl PlexiApp {
                     } else {
                         dirs::home_dir()
                     };
-                    let settings = Self::make_backend_settings(cwd);
+                    let settings = Self::make_backend_settings(cwd, &colors);
                     if let Some(pane) =
                         TerminalPane::new(saved_pane.id, cc.egui_ctx.clone(), tx.clone(), settings)
                     {
@@ -253,8 +259,9 @@ impl PlexiApp {
                 return Self {
                     pty_event_rx: rx,
                     pty_event_tx: tx,
-                    theme: theme::rebecca(),
+                    theme: theme::terminal_theme(&theme_cfg),
                     font: theme::terminal_font(),
+                    colors,
                     next_pane_id: ws.next_pane_id,
                     ctx: cc.egui_ctx.clone(),
                     contexts,
@@ -269,7 +276,7 @@ impl PlexiApp {
         }
 
         // Default: single context with single pane
-        let settings = Self::make_backend_settings(None);
+        let settings = Self::make_backend_settings(None, &colors);
         let pane = TerminalPane::new(0, cc.egui_ctx.clone(), tx.clone(), settings)
             .expect("failed to create initial terminal");
         let mut panes = HashMap::new();
@@ -285,8 +292,9 @@ impl PlexiApp {
         Self {
             pty_event_rx: rx,
             pty_event_tx: tx,
-            theme: theme::rebecca(),
+            theme: theme::terminal_theme(&theme_cfg),
             font: theme::terminal_font(),
+            colors,
             next_pane_id: 1,
             ctx: cc.egui_ctx.clone(),
             contexts: vec![Context {
@@ -306,12 +314,12 @@ impl PlexiApp {
         }
     }
 
-    fn make_backend_settings(working_directory: Option<PathBuf>) -> BackendSettings {
+    fn make_backend_settings(working_directory: Option<PathBuf>, colors: &Colors) -> BackendSettings {
         BackendSettings {
             shell: shell::detect_shell(),
             args: vec!["-l".to_string()],
             env: shell::build_env(),
-            dynamic_colors: theme::terminal_dynamic_colors(),
+            dynamic_colors: theme::terminal_dynamic_colors(colors),
             working_directory,
             ..Default::default()
         }
@@ -339,7 +347,7 @@ impl PlexiApp {
         self.next_pane_id += 1;
 
         let cwd = self.contexts[self.active_context].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(cwd);
+        let settings = Self::make_backend_settings(cwd, &self.colors);
         let Some(pane) =
             TerminalPane::new(new_id, self.ctx.clone(), self.pty_event_tx.clone(), settings)
         else {
@@ -419,7 +427,7 @@ impl PlexiApp {
         self.next_pane_id += 1;
 
         let cwd = self.contexts[self.active_context].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(cwd);
+        let settings = Self::make_backend_settings(cwd, &self.colors);
         let Some(pane) =
             TerminalPane::new(new_id, self.ctx.clone(), self.pty_event_tx.clone(), settings)
         else {
@@ -598,7 +606,7 @@ impl PlexiApp {
         let new_id = self.next_pane_id;
         self.next_pane_id += 1;
 
-        let settings = Self::make_backend_settings(Some(home.clone()));
+        let settings = Self::make_backend_settings(Some(home.clone()), &self.colors);
         let Some(pane) =
             TerminalPane::new(new_id, self.ctx.clone(), self.pty_event_tx.clone(), settings)
         else {
@@ -766,7 +774,7 @@ impl eframe::App for PlexiApp {
             .exact_height(28.0)
             .frame(
                 egui::Frame::new()
-                    .fill(Colors::BG_TOOLBAR)
+                    .fill(self.colors.bg_toolbar)
                     .inner_margin(egui::Margin {
                         left: 8,
                         right: 8,
@@ -781,7 +789,7 @@ impl eframe::App for PlexiApp {
         // Separator line under toolbar
         egui::TopBottomPanel::top("toolbar_sep")
             .exact_height(1.0)
-            .frame(egui::Frame::new().fill(Colors::BORDER))
+            .frame(egui::Frame::new().fill(self.colors.border))
             .show(ctx, |_ui| {});
 
         // Sidebar
@@ -790,7 +798,7 @@ impl eframe::App for PlexiApp {
                 .exact_width(220.0)
                 .frame(
                     egui::Frame::new()
-                        .fill(Colors::BG_SIDEBAR)
+                        .fill(self.colors.bg_sidebar)
                         .inner_margin(egui::Margin::same(0)),
                 )
                 .show(ctx, |ui| {
@@ -801,7 +809,7 @@ impl eframe::App for PlexiApp {
         // Central panel — terminal tiles
         egui::CentralPanel::default()
             .frame(egui::Frame {
-                fill: Colors::BG_DARKEST,
+                fill: self.colors.bg_darkest,
                 inner_margin: egui::Margin::same(4),
                 outer_margin: egui::Margin::ZERO,
                 ..Default::default()
@@ -834,6 +842,7 @@ impl eframe::App for PlexiApp {
                     close_exited: None,
                     tab_info,
                     zoomed_pane,
+                    colors: self.colors,
                 };
                 ctx.tree.ui(&mut behavior, ui);
 
@@ -864,12 +873,11 @@ impl eframe::App for PlexiApp {
                         let inset = 10.0;
                         let zoom_rect = panel_rect.shrink(inset);
 
-                        // Thicker blue border (2px)
-                        let accent = Color32::from_rgb(137, 180, 250);
+                        // Thicker accent border (2px)
                         ui.painter().rect_stroke(
                             zoom_rect,
                             CornerRadius::same(4),
-                            Stroke::new(2.0, accent),
+                            Stroke::new(2.0, self.colors.accent),
                             StrokeKind::Inside,
                         );
 
@@ -879,7 +887,7 @@ impl eframe::App for PlexiApp {
                             egui::UiBuilder::new().max_rect(inner_rect),
                         );
                         egui::Frame::new()
-                            .fill(Colors::TERMINAL_BG)
+                            .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))
                             .show(&mut child_ui, |ui| {
                                 if let Some(pane) = ctx.panes.get_mut(&pane_id) {
@@ -888,14 +896,14 @@ impl eframe::App for PlexiApp {
                                         ui.painter().rect_filled(
                                             rect,
                                             0.0,
-                                            Colors::TERMINAL_BG,
+                                            self.colors.terminal_bg,
                                         );
                                         ui.allocate_new_ui(
                                             egui::UiBuilder::new().max_rect(rect),
                                             |ui| {
                                                 ui.centered_and_justified(|ui| {
                                                     ui.colored_label(
-                                                        Color32::from_rgb(0x6c, 0x70, 0x86),
+                                                        self.colors.text_dim,
                                                         "[process exited]",
                                                     );
                                                 });
@@ -927,12 +935,11 @@ impl eframe::App for PlexiApp {
                                     let start_x = rect.left() + 2.0;
                                     let y = rect.top() + 2.0 + dot_radius;
 
-                                    let accent = Color32::from_rgb(137, 180, 250);
-                                    let dim = Color32::from_rgb(0x45, 0x47, 0x5a);
+                                    let dim = self.colors.bg_active;
 
                                     for i in 0..count {
                                         let cx = start_x + (i as f32) * dot_spacing + dot_radius;
-                                        let color = if i == active_idx { accent } else { dim };
+                                        let color = if i == active_idx { self.colors.accent } else { dim };
                                         ui.painter().circle_filled(egui::pos2(cx, y), dot_radius, color);
                                     }
                                 }
@@ -972,7 +979,7 @@ impl PlexiApp {
             if ui
                 .add(
                     egui::Button::new(
-                        RichText::new(toggle_text).size(11.0).color(Colors::TEXT_DIM),
+                        RichText::new(toggle_text).size(11.0).color(self.colors.text_dim),
                     )
                     .frame(false),
                 )
@@ -989,13 +996,13 @@ impl PlexiApp {
             ui.label(
                 RichText::new(&active_ctx.name)
                     .size(12.0)
-                    .color(Colors::TEXT_PRIMARY)
+                    .color(self.colors.text_primary)
                     .strong(),
             );
             ui.label(
                 RichText::new(active_ctx.path.display().to_string())
                     .size(11.0)
-                    .color(Colors::TEXT_DIM)
+                    .color(self.colors.text_dim)
                     .family(egui::FontFamily::Monospace),
             );
             let pane_count = active_ctx.panes.len();
@@ -1006,7 +1013,7 @@ impl PlexiApp {
                     if pane_count == 1 { "" } else { "s" }
                 ))
                 .size(11.0)
-                .color(Colors::TEXT_SECTION),
+                .color(self.colors.text_section),
             );
 
             // Right side — help button
@@ -1014,7 +1021,7 @@ impl PlexiApp {
                 if ui
                     .add(
                         egui::Button::new(
-                            RichText::new("?").size(12.0).color(Colors::TEXT_DIM),
+                            RichText::new("?").size(12.0).color(self.colors.text_dim),
                         )
                         .frame(false),
                     )
@@ -1038,7 +1045,7 @@ impl PlexiApp {
             ui.label(
                 RichText::new("PLEXI")
                     .size(16.0)
-                    .color(Colors::TEXT_PRIMARY)
+                    .color(self.colors.text_primary)
                     .strong(),
             );
         });
@@ -1051,7 +1058,7 @@ impl PlexiApp {
                 egui::pos2(rect.min.x, rect.min.y),
                 egui::pos2(rect.min.x + sidebar_width, rect.min.y),
             ],
-            Stroke::new(1.0, Colors::BORDER),
+            Stroke::new(1.0, self.colors.border),
         );
         ui.add_space(4.0);
 
@@ -1063,14 +1070,14 @@ impl PlexiApp {
             ui.label(
                 RichText::new("Contexts")
                     .size(10.0)
-                    .color(Colors::TEXT_SECTION),
+                    .color(self.colors.text_section),
             );
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 ui.add_space(12.0);
                 if ui
                     .add(
                         egui::Button::new(
-                            RichText::new("+").size(12.0).color(Colors::TEXT_DIM),
+                            RichText::new("+").size(12.0).color(self.colors.text_dim),
                         )
                         .frame(false),
                     )
@@ -1116,9 +1123,9 @@ impl PlexiApp {
                     let rect = ui.max_rect();
 
                     let fill = if is_active {
-                        Colors::BG_ACTIVE
+                        self.colors.bg_active
                     } else if hover {
-                        Colors::BG_HOVER
+                        self.colors.bg_hover
                     } else {
                         Color32::TRANSPARENT
                     };
@@ -1129,7 +1136,7 @@ impl PlexiApp {
                         ui.painter().rect_filled(
                             Rect::from_min_size(rect.min, Vec2::new(3.0, rect.height())),
                             CornerRadius::ZERO,
-                            Colors::ACCENT,
+                            self.colors.accent,
                         );
                     }
 
@@ -1173,9 +1180,9 @@ impl PlexiApp {
                         }
                     } else {
                         let text_color = if is_active {
-                            Colors::TEXT_PRIMARY
+                            self.colors.text_primary
                         } else {
-                            Colors::TEXT_DIM
+                            self.colors.text_dim
                         };
                         ui.label(
                             RichText::new(&self.contexts[i].name)
@@ -1192,7 +1199,7 @@ impl PlexiApp {
                                         egui::Button::new(
                                             RichText::new("\u{2715}")
                                                 .size(13.0)
-                                                .color(Colors::TEXT_DIM),
+                                                .color(self.colors.text_dim),
                                         )
                                         .frame(false),
                                     )
@@ -1307,8 +1314,8 @@ impl PlexiApp {
             .anchor(Align2::RIGHT_TOP, Vec2::new(-16.0, 44.0))
             .show(ctx, |ui| {
                 egui::Frame::new()
-                    .fill(Colors::BG_SIDEBAR)
-                    .stroke(Stroke::new(1.0, Colors::BORDER))
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
                     .corner_radius(R6)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
@@ -1316,7 +1323,7 @@ impl PlexiApp {
                         ui.label(
                             RichText::new("Keyboard Shortcuts")
                                 .size(13.0)
-                                .color(Colors::TEXT_PRIMARY)
+                                .color(self.colors.text_primary)
                                 .strong(),
                         );
                         ui.add_space(8.0);
@@ -1340,14 +1347,14 @@ impl PlexiApp {
                                 ui.label(
                                     RichText::new(key)
                                         .size(11.0)
-                                        .color(Colors::ACCENT)
+                                        .color(self.colors.accent)
                                         .family(egui::FontFamily::Monospace),
                                 );
                                 ui.add_space(8.0);
                                 ui.label(
                                     RichText::new(desc)
                                         .size(11.0)
-                                        .color(Colors::TEXT_DIM),
+                                        .color(self.colors.text_dim),
                                 );
                             });
                         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,67 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Default)]
+pub struct PlexiConfig {
+    pub theme: Option<ThemeConfig>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct ThemeConfig {
+    // UI chrome
+    pub bg_darkest: Option<String>,
+    pub bg_sidebar: Option<String>,
+    pub bg_toolbar: Option<String>,
+    pub terminal_bg: Option<String>,
+    pub bg_hover: Option<String>,
+    pub bg_active: Option<String>,
+    pub text_primary: Option<String>,
+    pub text_dim: Option<String>,
+    pub text_section: Option<String>,
+    pub accent: Option<String>,
+    pub border: Option<String>,
+    // Terminal ANSI palette
+    pub foreground: Option<String>,
+    pub background: Option<String>,
+    pub black: Option<String>,
+    pub red: Option<String>,
+    pub green: Option<String>,
+    pub yellow: Option<String>,
+    pub blue: Option<String>,
+    pub magenta: Option<String>,
+    pub cyan: Option<String>,
+    pub white: Option<String>,
+    pub bright_black: Option<String>,
+    pub bright_red: Option<String>,
+    pub bright_green: Option<String>,
+    pub bright_yellow: Option<String>,
+    pub bright_blue: Option<String>,
+    pub bright_magenta: Option<String>,
+    pub bright_cyan: Option<String>,
+    pub bright_white: Option<String>,
+    pub bright_foreground: Option<String>,
+}
+
+fn config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("plexi")
+        .join("config.toml")
+}
+
+impl PlexiConfig {
+    pub fn load() -> Self {
+        let path = config_path();
+        let data = match std::fs::read_to_string(&path) {
+            Ok(d) => d,
+            Err(_) => return Self::default(),
+        };
+        match toml::from_str(&data) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                log::warn!("Failed to parse config file: {e}");
+                Self::default()
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod config;
 mod keys;
 #[cfg(target_os = "macos")]
 mod macos_menu;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,3 +1,4 @@
+use crate::config::ThemeConfig;
 use egui::{Color32, FontId};
 use egui_term::{ColorPalette, FontSettings, TerminalFont, TerminalTheme};
 use std::collections::HashMap;
@@ -7,88 +8,143 @@ pub const FONT_SIZE: f32 = 14.0;
 const FONT_NAME: &str = "JetBrainsMono Nerd Font";
 const FALLBACK_FONT_NAME: &str = "DejaVu Sans";
 
-pub struct Colors;
-
-impl Colors {
-    // Background layers
-    pub const BG_DARKEST: Color32 = Color32::from_rgb(0x11, 0x11, 0x1b);
-    pub const BG_SIDEBAR: Color32 = Color32::from_rgb(0x18, 0x18, 0x25);
-    pub const BG_TOOLBAR: Color32 = Color32::from_rgb(0x18, 0x18, 0x25);
-    pub const TERMINAL_BG: Color32 = Color32::from_rgb(0x29, 0x2a, 0x44);
-    pub const BG_HOVER: Color32 = Color32::from_rgb(0x2a, 0x2a, 0x3c);
-    pub const BG_ACTIVE: Color32 = Color32::from_rgb(0x31, 0x31, 0x44);
-    // Text
-    pub const TEXT_PRIMARY: Color32 = Color32::from_rgb(0xcd, 0xd6, 0xf4);
-    pub const TEXT_DIM: Color32 = Color32::from_rgb(0x6c, 0x70, 0x86);
-    pub const TEXT_SECTION: Color32 = Color32::from_rgb(0x58, 0x5b, 0x70);
-
-    // Accent
-    pub const ACCENT: Color32 = Color32::from_rgb(0x89, 0xb4, 0xfa);
-    // Borders
-    pub const BORDER: Color32 = Color32::from_rgb(0x2a, 0x2a, 0x3c);
+fn parse_hex_or(s: &Option<String>, default: Color32) -> Color32 {
+    let s = match s {
+        Some(s) => s.trim_start_matches('#'),
+        None => return default,
+    };
+    if s.len() != 6 {
+        return default;
+    }
+    match (
+        u8::from_str_radix(&s[0..2], 16),
+        u8::from_str_radix(&s[2..4], 16),
+        u8::from_str_radix(&s[4..6], 16),
+    ) {
+        (Ok(r), Ok(g), Ok(b)) => Color32::from_rgb(r, g, b),
+        _ => default,
+    }
 }
 
-pub fn setup_style(ctx: &egui::Context) {
+#[derive(Clone, Copy)]
+pub struct Colors {
+    // Background layers
+    pub bg_darkest: Color32,
+    pub bg_sidebar: Color32,
+    pub bg_toolbar: Color32,
+    pub terminal_bg: Color32,
+    pub bg_hover: Color32,
+    pub bg_active: Color32,
+    // Text
+    pub text_primary: Color32,
+    pub text_dim: Color32,
+    pub text_section: Color32,
+    // Accent / borders
+    pub accent: Color32,
+    pub border: Color32,
+    // Terminal fg/bg as bytes for dynamic colors
+    pub terminal_fg_bytes: [u8; 3],
+    pub terminal_bg_bytes: [u8; 3],
+}
+
+impl Colors {
+    pub fn from_config(cfg: &ThemeConfig) -> Self {
+        Self {
+            bg_darkest:   parse_hex_or(&cfg.bg_darkest,   Color32::from_rgb(0x11, 0x11, 0x1b)),
+            bg_sidebar:   parse_hex_or(&cfg.bg_sidebar,   Color32::from_rgb(0x18, 0x18, 0x25)),
+            bg_toolbar:   parse_hex_or(&cfg.bg_toolbar,   Color32::from_rgb(0x18, 0x18, 0x25)),
+            terminal_bg:  parse_hex_or(&cfg.terminal_bg,  Color32::from_rgb(0x29, 0x2a, 0x44)),
+            bg_hover:     parse_hex_or(&cfg.bg_hover,     Color32::from_rgb(0x2a, 0x2a, 0x3c)),
+            bg_active:    parse_hex_or(&cfg.bg_active,    Color32::from_rgb(0x31, 0x31, 0x44)),
+            text_primary: parse_hex_or(&cfg.text_primary, Color32::from_rgb(0xcd, 0xd6, 0xf4)),
+            text_dim:     parse_hex_or(&cfg.text_dim,     Color32::from_rgb(0x6c, 0x70, 0x86)),
+            text_section: parse_hex_or(&cfg.text_section, Color32::from_rgb(0x58, 0x5b, 0x70)),
+            accent:       parse_hex_or(&cfg.accent,       Color32::from_rgb(0x89, 0xb4, 0xfa)),
+            border:       parse_hex_or(&cfg.border,       Color32::from_rgb(0x2a, 0x2a, 0x3c)),
+            terminal_fg_bytes: hex_to_bytes(cfg.foreground.as_deref(), [0xe8, 0xe6, 0xed]),
+            terminal_bg_bytes: hex_to_bytes(cfg.background.as_deref(), [0x29, 0x2a, 0x44]),
+        }
+    }
+}
+
+fn hex_to_bytes(s: Option<&str>, default: [u8; 3]) -> [u8; 3] {
+    let s = match s {
+        Some(s) => s.trim_start_matches('#'),
+        None => return default,
+    };
+    if s.len() != 6 {
+        return default;
+    }
+    match (
+        u8::from_str_radix(&s[0..2], 16),
+        u8::from_str_radix(&s[2..4], 16),
+        u8::from_str_radix(&s[4..6], 16),
+    ) {
+        (Ok(r), Ok(g), Ok(b)) => [r, g, b],
+        _ => default,
+    }
+}
+
+pub fn setup_style(ctx: &egui::Context, colors: &Colors) {
     let mut style = (*ctx.style()).clone();
     style.visuals.dark_mode = true;
-    style.visuals.panel_fill = Colors::BG_DARKEST;
-    style.visuals.window_fill = Colors::BG_SIDEBAR;
-    style.visuals.override_text_color = Some(Colors::TEXT_PRIMARY);
-    style.visuals.widgets.noninteractive.bg_fill = Colors::BG_SIDEBAR;
-    style.visuals.widgets.inactive.bg_fill = Colors::BG_SIDEBAR;
-    style.visuals.widgets.hovered.bg_fill = Colors::BG_HOVER;
-    style.visuals.widgets.active.bg_fill = Colors::BG_ACTIVE;
+    style.visuals.panel_fill = colors.bg_darkest;
+    style.visuals.window_fill = colors.bg_sidebar;
+    style.visuals.override_text_color = Some(colors.text_primary);
+    style.visuals.widgets.noninteractive.bg_fill = colors.bg_sidebar;
+    style.visuals.widgets.inactive.bg_fill = colors.bg_sidebar;
+    style.visuals.widgets.hovered.bg_fill = colors.bg_hover;
+    style.visuals.widgets.active.bg_fill = colors.bg_active;
     style.spacing.item_spacing = egui::vec2(8.0, 4.0);
     ctx.set_style(style);
 }
 
-pub fn rebecca() -> TerminalTheme {
+pub fn terminal_theme(cfg: &ThemeConfig) -> TerminalTheme {
+    let fg = cfg.foreground.as_deref().unwrap_or("#e8e6ed");
+    let bg = cfg.background.as_deref().unwrap_or("#292a44");
     TerminalTheme::new(Box::new(ColorPalette {
-        foreground: "#e8e6ed".into(),
-        background: "#292a44".into(),
-        // Ghostty built-in Rebecca theme
-        black: "#12131e".into(),
-        red: "#dd7755".into(),
-        green: "#04dbb5".into(),
-        yellow: "#f2e7b7".into(),
-        blue: "#7aa5ff".into(),
-        magenta: "#bf9cf9".into(),
-        cyan: "#56d3c2".into(),
-        white: "#e4e3e9".into(),
-        bright_black: "#666699".into(),
-        bright_red: "#ff92cd".into(),
-        bright_green: "#01eac0".into(),
-        bright_yellow: "#fffca8".into(),
-        bright_blue: "#69c0fa".into(),
-        bright_magenta: "#c17ff8".into(),
-        bright_cyan: "#8bfde1".into(),
-        bright_white: "#f4f2f9".into(),
-        bright_foreground: Some("#f4f2f9".into()),
-        // Match named dim colors to normal colors; egui_term already applies
-        // its own dimming multiplier in view.rs.
-        dim_foreground: "#e8e6ed".into(),
-        dim_black: "#12131e".into(),
-        dim_red: "#dd7755".into(),
-        dim_green: "#04dbb5".into(),
-        dim_yellow: "#f2e7b7".into(),
-        dim_blue: "#7aa5ff".into(),
-        dim_magenta: "#bf9cf9".into(),
-        dim_cyan: "#56d3c2".into(),
-        dim_white: "#e4e3e9".into(),
+        foreground: fg.into(),
+        background: bg.into(),
+        black:   cfg.black.as_deref().unwrap_or("#12131e").into(),
+        red:     cfg.red.as_deref().unwrap_or("#dd7755").into(),
+        green:   cfg.green.as_deref().unwrap_or("#04dbb5").into(),
+        yellow:  cfg.yellow.as_deref().unwrap_or("#f2e7b7").into(),
+        blue:    cfg.blue.as_deref().unwrap_or("#7aa5ff").into(),
+        magenta: cfg.magenta.as_deref().unwrap_or("#bf9cf9").into(),
+        cyan:    cfg.cyan.as_deref().unwrap_or("#56d3c2").into(),
+        white:   cfg.white.as_deref().unwrap_or("#e4e3e9").into(),
+        bright_black:   cfg.bright_black.as_deref().unwrap_or("#666699").into(),
+        bright_red:     cfg.bright_red.as_deref().unwrap_or("#ff92cd").into(),
+        bright_green:   cfg.bright_green.as_deref().unwrap_or("#01eac0").into(),
+        bright_yellow:  cfg.bright_yellow.as_deref().unwrap_or("#fffca8").into(),
+        bright_blue:    cfg.bright_blue.as_deref().unwrap_or("#69c0fa").into(),
+        bright_magenta: cfg.bright_magenta.as_deref().unwrap_or("#c17ff8").into(),
+        bright_cyan:    cfg.bright_cyan.as_deref().unwrap_or("#8bfde1").into(),
+        bright_white:   cfg.bright_white.as_deref().unwrap_or("#f4f2f9").into(),
+        bright_foreground: Some(cfg.bright_foreground.as_deref().unwrap_or("#f4f2f9").into()),
+        dim_foreground: fg.into(),
+        dim_black:   cfg.black.as_deref().unwrap_or("#12131e").into(),
+        dim_red:     cfg.red.as_deref().unwrap_or("#dd7755").into(),
+        dim_green:   cfg.green.as_deref().unwrap_or("#04dbb5").into(),
+        dim_yellow:  cfg.yellow.as_deref().unwrap_or("#f2e7b7").into(),
+        dim_blue:    cfg.blue.as_deref().unwrap_or("#7aa5ff").into(),
+        dim_magenta: cfg.magenta.as_deref().unwrap_or("#bf9cf9").into(),
+        dim_cyan:    cfg.cyan.as_deref().unwrap_or("#56d3c2").into(),
+        dim_white:   cfg.white.as_deref().unwrap_or("#e4e3e9").into(),
     }))
+}
+
+pub fn terminal_dynamic_colors(colors: &Colors) -> HashMap<usize, [u8; 3]> {
+    HashMap::from([
+        (256, colors.terminal_fg_bytes),
+        (257, colors.terminal_bg_bytes),
+    ])
 }
 
 pub fn terminal_font() -> TerminalFont {
     TerminalFont::new(FontSettings {
         font_type: FontId::proportional(FONT_SIZE),
     })
-}
-
-pub fn terminal_dynamic_colors() -> HashMap<usize, [u8; 3]> {
-    HashMap::from([
-        (256, [0xe8, 0xe6, 0xed]),
-        (257, [0x29, 0x2a, 0x44]),
-    ])
 }
 
 pub fn font_definitions() -> egui::FontDefinitions {

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -16,6 +16,7 @@ pub struct PlexiBehavior<'a> {
     pub close_exited: Option<TileId>,
     pub tab_info: HashMap<TileId, (usize, usize)>, // tile_id -> (index, count)
     pub zoomed_pane: Option<TileId>,
+    pub colors: Colors,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -39,7 +40,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         // The zoomed pane is rendered separately in the overlay (app.rs).
         if self.zoomed_pane.is_some() {
             egui::Frame::new()
-                .fill(egui::Color32::from_rgb(0x11, 0x11, 0x1b))
+                .fill(self.colors.bg_darkest)
                 .inner_margin(egui::Margin::same(8))
                 .show(ui, |_ui| {});
             return UiResponse::None;
@@ -47,7 +48,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
 
         if let Some(pane) = self.panes.get_mut(pane_id) {
             egui::Frame::new()
-                .fill(Colors::TERMINAL_BG)
+                .fill(self.colors.terminal_bg)
                 .inner_margin(egui::Margin::same(8))
                 .show(ui, |ui| {
                     if pane.exited {
@@ -56,12 +57,12 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                         ui.painter().rect_filled(
                             rect,
                             0.0,
-                            Colors::TERMINAL_BG,
+                            self.colors.terminal_bg,
                         );
                         ui.allocate_new_ui(egui::UiBuilder::new().max_rect(rect), |ui| {
                             ui.centered_and_justified(|ui| {
                                 ui.colored_label(
-                                    egui::Color32::from_rgb(0x6c, 0x70, 0x86),
+                                    self.colors.text_dim,
                                     "[process exited]",
                                 );
                             });
@@ -91,12 +92,11 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                         let start_x = rect.left() + 2.0;
                         let y = rect.top() + 2.0 + dot_radius;
 
-                        let accent = egui::Color32::from_rgb(137, 180, 250); // Catppuccin blue
-                        let dim = egui::Color32::from_rgb(0x45, 0x47, 0x5a);
+                        let dim = self.colors.bg_active;
 
                         for i in 0..count {
                             let cx = start_x + (i as f32) * dot_spacing + dot_radius;
-                            let color = if i == active_idx { accent } else { dim };
+                            let color = if i == active_idx { self.colors.accent } else { dim };
                             ui.painter().circle_filled(egui::pos2(cx, y), dot_radius, color);
                         }
                     }
@@ -110,7 +110,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         let label = format!("Terminal {}", pane + 1);
         egui::RichText::new(label)
             .size(11.0)
-            .color(Colors::TEXT_DIM)
+            .color(self.colors.text_dim)
             .into()
     }
 
@@ -151,8 +151,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         rect: egui::Rect,
     ) {
         if self.focused_tile == Some(tile_id) {
-            // Catppuccin Mocha blue
-            let stroke = egui::Stroke::new(1.5, egui::Color32::from_rgb(137, 180, 250));
+            let stroke = egui::Stroke::new(1.5, self.colors.accent);
             let rect = rect.shrink(0.75);
             painter.rect_stroke(rect, 0.0, stroke, egui::StrokeKind::Inside);
         }


### PR DESCRIPTION
Closes #8.

## What changed
All colors in Plexi were hardcoded. This PR adds a `~/.config/plexi/config.toml` that lets users override any color at startup.

## How it works
- New `src/config.rs` loads the TOML config at startup using the same pattern as `workspace.rs`
- `Colors` in `theme.rs` is now a runtime instance struct (built from config) instead of hardcoded constants
- `ThemeConfig` fields are all `Option<String>` hex values — any omitted field falls back to the current Rebecca defaults
- Missing file, empty file, invalid TOML, and invalid hex values all fall back gracefully with no panic

## Config format
```toml
# ~/.config/plexi/config.toml
[theme]
accent       = "#89b4fa"
text_primary = "#cdd6f4"
foreground   = "#e8e6ed"
red          = "#dd7755"
# ...all fields optional
```

## Testing
1. No config file → app starts, colors match current Rebecca theme
2. Set `accent = "#ff0000"` → focus border, shortcut keys, sidebar indicator all turn red
3. Set `red = "#ff0000"` → ANSI red in terminal changes, UI chrome unaffected
4. Malformed hex / bad TOML → falls back to defaults, no crash