### PR TITLE
Add command palette, named panes, and theme config

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,17 @@ impl Context {
         }
     }
 
+    fn activate_tab_for(&mut self, tile_id: TileId) {
+        let result = self.find_ancestor_tabs(tile_id);
+        if let Some((tabs_id, child_tile)) = result {
+            if let Some(Tile::Container(Container::Tabs(tabs))) =
+                self.tree.tiles.get_mut(tabs_id)
+            {
+                tabs.set_active(child_tile);
+            }
+        }
+    }
+
     fn find_logical_parent(&self, tile_id: TileId) -> Option<(TileId, TileId)> {
         let mut current = tile_id;
         loop {
@@ -1021,6 +1032,7 @@ impl eframe::App for PlexiApp {
 }
 
 const R6: CornerRadius = CornerRadius::same(6);
+const MODAL_WIDTH: f32 = 400.0;
 
 impl PlexiApp {
     fn draw_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -1495,6 +1507,7 @@ impl PlexiApp {
             self.active_context = ctx_idx;
             self.contexts[ctx_idx].focused_pane = Some(tile_id);
             self.contexts[ctx_idx].zoomed_pane = None;
+            self.contexts[ctx_idx].activate_tab_for(tile_id);
             self.show_command_palette = false;
             return;
         }
@@ -1531,14 +1544,14 @@ impl PlexiApp {
                     .corner_radius(R6)
                     .inner_margin(egui::Margin::symmetric(12, 10))
                     .show(ui, |ui| {
-                        ui.set_width(400.0);
+                        ui.set_width(MODAL_WIDTH);
 
                         // Search input
                         let te_id = egui::Id::new("palette_search");
                         let te = ui.add(
                             egui::TextEdit::singleline(&mut self.palette_query)
                                 .id(te_id)
-                                .desired_width(400.0)
+                                .desired_width(MODAL_WIDTH)
                                 .hint_text("Jump to pane...")
                                 .font(egui::TextStyle::Body),
                         );
@@ -1624,6 +1637,7 @@ impl PlexiApp {
                                 self.active_context = *ci;
                                 self.contexts[*ci].focused_pane = Some(*tile_id);
                                 self.contexts[*ci].zoomed_pane = None;
+                                self.contexts[*ci].activate_tab_for(*tile_id);
                                 self.show_command_palette = false;
                             }
                             if click_response.hovered() {
@@ -1658,7 +1672,7 @@ impl PlexiApp {
                     .corner_radius(R6)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
-                        ui.set_width(300.0);
+                        ui.set_width(MODAL_WIDTH);
                         ui.label(
                             RichText::new("Rename Pane")
                                 .size(13.0)
@@ -1671,7 +1685,7 @@ impl PlexiApp {
                         let te = ui.add(
                             egui::TextEdit::singleline(&mut self.rename_buffer)
                                 .id(te_id)
-                                .desired_width(300.0)
+                                .desired_width(MODAL_WIDTH)
                                 .hint_text("Pane name...")
                                 .font(egui::TextStyle::Body),
                         );

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -73,10 +73,47 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                         }
                     } else {
                         let has_tabs = self.tab_info.contains_key(&tile_id);
-                        // Reserve space for dot indicators above terminal
-                        if has_tabs {
+                        let has_name = self.pane_names.contains_key(pane_id);
+                        let name_bar_height = 20.0;
+
+                        // Reserve space for name bar or dot indicators above terminal
+                        if has_name {
+                            // Draw centered name bar
+                            let bar_rect = egui::Rect::from_min_size(
+                                ui.cursor().min,
+                                egui::vec2(ui.available_width(), name_bar_height),
+                            );
+                            ui.advance_cursor_after_rect(bar_rect);
+
+                            let name = &self.pane_names[pane_id];
+
+                            // If tabs exist, draw dots on the left side of the bar
+                            if let Some(&(active_idx, count)) = self.tab_info.get(&tile_id) {
+                                let dot_radius = 4.0;
+                                let dot_spacing = 12.0;
+                                let start_x = bar_rect.left() - 6.0;
+                                let y = bar_rect.center().y;
+                                let dim = self.colors.bg_active;
+
+                                for i in 0..count {
+                                    let cx = start_x + (i as f32) * dot_spacing + dot_radius;
+                                    let color = if i == active_idx { self.colors.accent } else { dim };
+                                    ui.painter().circle_filled(egui::pos2(cx, y), dot_radius, color);
+                                }
+                            }
+
+                            // Center the name text in the bar
+                            ui.painter().text(
+                                bar_rect.center(),
+                                egui::Align2::CENTER_CENTER,
+                                name,
+                                egui::FontId::proportional(11.0),
+                                self.colors.text_dim,
+                            );
+                        } else if has_tabs {
                             ui.add_space(14.0);
                         }
+
                         let terminal = TerminalView::new(ui, &mut pane.backend)
                             .set_focus(is_focused)
                             .set_theme(self.theme.clone())
@@ -85,40 +122,23 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                         ui.add(terminal);
                     }
 
-                    // Draw pane name label (top-left) if named
-                    if let Some(name) = self.pane_names.get(pane_id) {
-                        let rect = ui.max_rect();
-                        let has_tabs = self.tab_info.contains_key(&tile_id);
-                        let dots_offset = if has_tabs {
-                            let count = self.tab_info[&tile_id].1;
-                            (count as f32) * 12.0 + 8.0
-                        } else {
-                            0.0
-                        };
-                        let text_pos = egui::pos2(rect.left() + 4.0 + dots_offset, rect.top() + 2.0);
-                        ui.painter().text(
-                            text_pos,
-                            egui::Align2::LEFT_TOP,
-                            name,
-                            egui::FontId::proportional(10.0),
-                            self.colors.text_dim,
-                        );
-                    }
+                    // Draw tab indicator dots (top-left) when 2+ tabs and NO name bar
+                    // (when a name bar exists, dots are already drawn inside it)
+                    if !self.pane_names.contains_key(pane_id) {
+                        if let Some(&(active_idx, count)) = self.tab_info.get(&tile_id) {
+                            let dot_radius = 4.0;
+                            let dot_spacing = 12.0;
+                            let rect = ui.max_rect();
+                            let start_x = rect.left() + 2.0;
+                            let y = rect.top() + 2.0 + dot_radius;
 
-                    // Draw tab indicator dots (top-left) when 2+ tabs
-                    if let Some(&(active_idx, count)) = self.tab_info.get(&tile_id) {
-                        let dot_radius = 4.0;
-                        let dot_spacing = 12.0;
-                        let rect = ui.max_rect();
-                        let start_x = rect.left() + 2.0;
-                        let y = rect.top() + 2.0 + dot_radius;
+                            let dim = self.colors.bg_active;
 
-                        let dim = self.colors.bg_active;
-
-                        for i in 0..count {
-                            let cx = start_x + (i as f32) * dot_spacing + dot_radius;
-                            let color = if i == active_idx { self.colors.accent } else { dim };
-                            ui.painter().circle_filled(egui::pos2(cx, y), dot_radius, color);
+                            for i in 0..count {
+                                let cx = start_x + (i as f32) * dot_spacing + dot_radius;
+                                let color = if i == active_idx { self.colors.accent } else { dim };
+                                ui.painter().circle_filled(egui::pos2(cx, y), dot_radius, color);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
## Summary
- **Theme config**: Load custom colors from `~/.config/plexi/config.toml`
- **Command palette** (Cmd+P): Fuzzy search and jump to any pane by name or number
- **Named panes** (Cmd+Shift+R): Rename panes with a centered top bar label
- Shared modal width constant for palette and rename dialogs
- Tab dots integrate into the name bar when a pane is named

## Test plan
- [ ] Verify `Cmd+P` opens command palette and filters panes
- [ ] Verify `Cmd+Shift+R` opens rename dialog and name appears centered in top bar
- [ ] Verify named panes don't overlap terminal content
- [ ] Verify tab dots still render correctly for unnamed tabbed panes
- [ ] Verify custom theme loads from `~/.config/plexi/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)