### PR TITLE
feat: wire Anthropic API into agent mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "ureq",
  "zeroize",
 ]
 
@@ -3206,6 +3207,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rodio"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3290,41 @@ dependencies = [
  "errno",
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3586,6 +3636,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
@@ -3950,6 +4006,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4363,24 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ image = { version = "0.25", default-features = false, features = ["bmp", "gif", 
 rodio = { version = "0.19", default-features = false, features = ["mp3", "flac", "vorbis", "wav"] }
 zeroize = "1"
 notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
+ureq = { version = "2.10", features = ["json", "tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src/agent_llm.rs
+++ b/src/agent_llm.rs
@@ -1,0 +1,183 @@
+//! Worker-thread Anthropic API client for agent mode.
+//!
+//! MVP: single-turn, non-streaming messages API call. The UI thread spawns an
+//! `LlmWorker`, sends `LlmRequest`s via its channel, and polls `try_recv()`
+//! each frame for `LlmResponse`s. HTTP happens entirely on the worker thread
+//! so egui is never blocked.
+//!
+//! Streaming, multi-turn context, and tool use are intentionally out of scope
+//! here — they'll land in follow-up PRs.
+
+use std::sync::mpsc;
+use std::thread;
+
+const ANTHROPIC_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const MODEL: &str = "claude-sonnet-4-20250514";
+const MAX_TOKENS: u32 = 4096;
+
+/// Request sent from the UI thread to the LLM worker.
+#[derive(Debug)]
+pub enum LlmRequest {
+    /// Single-turn completion: a system prompt and a user message.
+    Complete { prompt: String, system: String },
+}
+
+/// Response sent from the LLM worker back to the UI thread.
+#[derive(Debug)]
+pub enum LlmResponse {
+    /// Reserved for future streaming. Not emitted in the MVP.
+    #[allow(dead_code)]
+    Token(String),
+    /// Full assistant response (non-streaming MVP path).
+    Complete(String),
+    /// Terminal error — surface this in the conversation.
+    Error(String),
+}
+
+/// Handle held by the UI thread. Drop to shut the worker down.
+pub struct LlmWorker {
+    tx: mpsc::Sender<LlmRequest>,
+    rx: mpsc::Receiver<LlmResponse>,
+    _handle: thread::JoinHandle<()>,
+}
+
+impl LlmWorker {
+    /// Spawn a worker thread that owns an HTTP client and the given API key.
+    pub fn spawn(api_key: String) -> Self {
+        let (req_tx, req_rx) = mpsc::channel::<LlmRequest>();
+        let (resp_tx, resp_rx) = mpsc::channel::<LlmResponse>();
+
+        let handle = thread::Builder::new()
+            .name("plexi-agent-llm".to_string())
+            .spawn(move || run_worker(api_key, req_rx, resp_tx))
+            .expect("failed to spawn agent LLM worker thread");
+
+        Self {
+            tx: req_tx,
+            rx: resp_rx,
+            _handle: handle,
+        }
+    }
+
+    /// Enqueue a request. Fails if the worker thread has shut down.
+    pub fn send(&self, req: LlmRequest) -> Result<(), String> {
+        self.tx
+            .send(req)
+            .map_err(|e| format!("agent LLM worker disconnected: {e}"))
+    }
+
+    /// Non-blocking: drain a single pending response, if any.
+    pub fn try_recv(&self) -> Option<LlmResponse> {
+        match self.rx.try_recv() {
+            Ok(resp) => Some(resp),
+            Err(mpsc::TryRecvError::Empty) => None,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                log::warn!("agent_llm: worker disconnected");
+                None
+            }
+        }
+    }
+}
+
+fn run_worker(
+    api_key: String,
+    rx: mpsc::Receiver<LlmRequest>,
+    tx: mpsc::Sender<LlmResponse>,
+) {
+    // One agent per worker lifetime. ureq::Agent is cheap to clone and
+    // safe to reuse across calls.
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(std::time::Duration::from_secs(15))
+        .timeout_read(std::time::Duration::from_secs(120))
+        .build();
+
+    while let Ok(req) = rx.recv() {
+        match req {
+            LlmRequest::Complete { prompt, system } => {
+                let result = call_anthropic(&agent, &api_key, &system, &prompt);
+                let resp = match result {
+                    Ok(text) => LlmResponse::Complete(text),
+                    Err(err) => {
+                        log::error!("agent_llm: Anthropic API call failed: {err}");
+                        LlmResponse::Error(err)
+                    }
+                };
+                if tx.send(resp).is_err() {
+                    log::warn!("agent_llm: response channel closed, shutting worker down");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Non-streaming call to the Anthropic messages API. Returns the assistant
+/// text on success or a human-readable error string on any failure.
+fn call_anthropic(
+    agent: &ureq::Agent,
+    api_key: &str,
+    system: &str,
+    user_prompt: &str,
+) -> Result<String, String> {
+    let body = serde_json::json!({
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "system": system,
+        "messages": [
+            { "role": "user", "content": user_prompt }
+        ],
+    });
+
+    let result = agent
+        .post(ANTHROPIC_URL)
+        .set("x-api-key", api_key)
+        .set("anthropic-version", ANTHROPIC_VERSION)
+        .set("content-type", "application/json")
+        .send_json(body);
+
+    match result {
+        Ok(response) => {
+            let json: serde_json::Value = response
+                .into_json()
+                .map_err(|e| format!("failed to parse Anthropic response JSON: {e}"))?;
+            extract_text(&json)
+        }
+        Err(ureq::Error::Status(code, response)) => {
+            let body = response
+                .into_string()
+                .unwrap_or_else(|_| "<no body>".to_string());
+            Err(format!("Anthropic API returned HTTP {code}: {body}"))
+        }
+        Err(ureq::Error::Transport(t)) => {
+            Err(format!("Anthropic API transport error: {t}"))
+        }
+    }
+}
+
+/// Pull the assistant text out of an Anthropic `messages` response.
+/// The response looks like `{ "content": [ { "type": "text", "text": "..." } ], ... }`.
+fn extract_text(json: &serde_json::Value) -> Result<String, String> {
+    let content = json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .ok_or_else(|| format!("Anthropic response missing 'content' array: {json}"))?;
+
+    let mut out = String::new();
+    for block in content {
+        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+            if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(text);
+            }
+        }
+    }
+
+    if out.is_empty() {
+        Err(format!("Anthropic response had no text blocks: {json}"))
+    } else {
+        Ok(out)
+    }
+}

--- a/src/agent_mode.rs
+++ b/src/agent_mode.rs
@@ -1,6 +1,15 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use crate::agent_llm::{LlmRequest, LlmResponse, LlmWorker};
+
+/// Plexi's user-facing CLI app id. Secrets stored via the secrets manager
+/// or `plexi secret set` use this namespace, and agent mode reads from it.
+const SECRETS_APP_ID: &str = "plexi-run";
+
+/// Key the user must set to enable the LLM backend.
+const API_KEY_NAME: &str = "ANTHROPIC_API_KEY";
+
 /// State machine for agent mode within a terminal pane.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AgentModeState {
@@ -11,6 +20,7 @@ pub enum AgentModeState {
     /// Agent is processing (LLM call in progress).
     Processing,
     /// Agent is streaming a response back.
+    #[allow(dead_code)]
     Responding,
 }
 
@@ -34,6 +44,10 @@ pub struct AgentMode {
     pub input_buffer: String,
     pub conversation: Vec<AgentMessage>,
     pub directory_scope: PathBuf,
+    /// Lazily-initialized LLM worker. `None` until activate() runs once
+    /// successfully; stays `None` if the API key is missing (we surface
+    /// an inline error message in the conversation instead).
+    llm: Option<LlmWorker>,
 }
 
 impl AgentMode {
@@ -43,15 +57,46 @@ impl AgentMode {
             input_buffer: String::new(),
             conversation: Vec::new(),
             directory_scope,
+            llm: None,
         }
     }
 
-    /// Activate agent mode. Called when `/` is pressed at an empty prompt.
+    /// Activate agent mode. Lazily spawns the LLM worker on first activation.
+    /// If `ANTHROPIC_API_KEY` is missing, we still enter agent mode but push
+    /// a system message explaining how to fix it.
     pub fn activate(&mut self) {
-        if self.state == AgentModeState::Inactive {
-            self.state = AgentModeState::WaitingForInput;
-            self.input_buffer.clear();
-            log::info!("Agent mode activated in {}", self.directory_scope.display());
+        if self.state != AgentModeState::Inactive {
+            return;
+        }
+        self.state = AgentModeState::WaitingForInput;
+        self.input_buffer.clear();
+        log::info!("Agent mode activated in {}", self.directory_scope.display());
+
+        // Lazy-init the LLM worker. Only do this the first time we activate.
+        if self.llm.is_none() {
+            self.try_spawn_worker();
+        }
+    }
+
+    /// Attempt to load the API key from the Plexi secrets store and spawn a
+    /// worker thread. On success, sets `self.llm`. On failure, pushes a
+    /// friendly system message into the conversation telling the user how
+    /// to set it.
+    fn try_spawn_worker(&mut self) {
+        let dir_str = self.directory_scope.to_string_lossy().to_string();
+        match crate::secrets::resolve_secret(API_KEY_NAME, SECRETS_APP_ID, &dir_str) {
+            Some(key) => {
+                log::info!("agent_mode: loaded {API_KEY_NAME} from secrets, spawning LLM worker");
+                let worker = LlmWorker::spawn(key.to_string());
+                self.llm = Some(worker);
+            }
+            None => {
+                log::warn!("agent_mode: {API_KEY_NAME} not found in secrets (app_id={SECRETS_APP_ID})");
+                self.push_system_message(format!(
+                    "No {API_KEY_NAME} found. Open the Secrets manager (from the sidebar) and \
+add a secret with key \"{API_KEY_NAME}\" to enable the agent."
+                ));
+            }
         }
     }
 
@@ -62,8 +107,8 @@ impl AgentMode {
         log::info!("Agent mode deactivated");
     }
 
-    /// Submit the current input buffer as a user message.
-    /// Returns the submitted text if non-empty, None otherwise.
+    /// Submit the current input buffer as a user message and dispatch it to
+    /// the LLM worker. Returns the submitted text if non-empty, None otherwise.
     pub fn submit(&mut self) -> Option<String> {
         let text = self.input_buffer.trim().to_string();
         if text.is_empty() {
@@ -75,21 +120,106 @@ impl AgentMode {
             timestamp: SystemTime::now(),
         });
         self.input_buffer.clear();
-        self.state = AgentModeState::Processing;
+
+        // No worker → surface an error inline and stay in waiting state so
+        // the user can edit secrets and try again.
+        let Some(worker) = self.llm.as_ref() else {
+            self.push_system_message(format!(
+                "Cannot reach the LLM: {API_KEY_NAME} is not set. \
+Add it in the Secrets manager, then press Escape and Ctrl+/ again."
+            ));
+            self.state = AgentModeState::WaitingForInput;
+            return Some(text);
+        };
+
+        let system = build_system_prompt(&self.directory_scope);
+        let request = LlmRequest::Complete {
+            prompt: text.clone(),
+            system,
+        };
+        match worker.send(request) {
+            Ok(()) => {
+                self.state = AgentModeState::Processing;
+            }
+            Err(err) => {
+                log::error!("agent_mode: failed to dispatch LLM request: {err}");
+                self.push_system_message(format!("Failed to send request to LLM worker: {err}"));
+                self.state = AgentModeState::WaitingForInput;
+            }
+        }
+
         Some(text)
     }
 
-    /// Push a stub agent response. Placeholder for real LLM integration.
-    pub fn push_stub_response(&mut self, content: String) {
+    /// Drain any pending responses from the LLM worker and apply them to
+    /// the conversation. Call from the UI render loop every frame. Returns
+    /// `true` if any state changed (so the caller can request a repaint).
+    pub fn poll_llm(&mut self) -> bool {
+        if self.llm.is_none() {
+            return false;
+        }
+        // Drain responses up front so we don't hold an immutable borrow of
+        // `self.llm` across mutable calls like `push_system_message`.
+        let mut pending: Vec<LlmResponse> = Vec::new();
+        if let Some(worker) = self.llm.as_ref() {
+            while let Some(resp) = worker.try_recv() {
+                pending.push(resp);
+            }
+        }
+        let changed = !pending.is_empty();
+        for resp in pending {
+            match resp {
+                LlmResponse::Complete(text) => {
+                    self.conversation.push(AgentMessage {
+                        role: MessageRole::Agent,
+                        content: text,
+                        timestamp: SystemTime::now(),
+                    });
+                    self.state = AgentModeState::WaitingForInput;
+                }
+                LlmResponse::Token(chunk) => {
+                    // Streaming not wired up yet, but if a token arrives,
+                    // append it to the last agent message or start a new one.
+                    match self.conversation.last_mut() {
+                        Some(msg) if msg.role == MessageRole::Agent => {
+                            msg.content.push_str(&chunk);
+                        }
+                        _ => {
+                            self.conversation.push(AgentMessage {
+                                role: MessageRole::Agent,
+                                content: chunk,
+                                timestamp: SystemTime::now(),
+                            });
+                        }
+                    }
+                    self.state = AgentModeState::Responding;
+                }
+                LlmResponse::Error(err) => {
+                    self.push_system_message(format!("LLM error: {err}"));
+                    self.state = AgentModeState::WaitingForInput;
+                }
+            }
+        }
+        changed
+    }
+
+    fn push_system_message(&mut self, content: String) {
         self.conversation.push(AgentMessage {
-            role: MessageRole::Agent,
+            role: MessageRole::System,
             content,
             timestamp: SystemTime::now(),
         });
-        self.state = AgentModeState::WaitingForInput;
     }
 
     pub fn is_active(&self) -> bool {
         self.state != AgentModeState::Inactive
     }
+}
+
+fn build_system_prompt(cwd: &std::path::Path) -> String {
+    format!(
+        "You are an assistant inside Plexi, a terminal multiplexer. \
+The user is currently working in directory: {}. Respond concisely.",
+        cwd.display()
+    )
 }

--- a/src/agent_ui.rs
+++ b/src/agent_ui.rs
@@ -21,6 +21,15 @@ pub fn render_agent_mode(
         return true;
     }
 
+    // Drain any LLM responses that arrived since the last frame. If something
+    // changed, make sure we render another frame promptly. Also keep polling
+    // while a request is in flight so we pick up the reply as soon as the
+    // worker thread produces it.
+    let changed = agent.poll_llm();
+    if changed || agent.state == crate::agent_mode::AgentModeState::Processing {
+        ui.ctx().request_repaint_after(std::time::Duration::from_millis(50));
+    }
+
     let available = ui.available_rect_before_wrap();
 
     // Background fill
@@ -139,15 +148,12 @@ fn draw_input(ui: &mut egui::Ui, agent: &mut AgentMode, colors: &Colors) {
             response.request_focus();
         }
 
-        // Submit on Enter
+        // Submit on Enter — agent.submit() now dispatches to the LLM worker
+        // thread. The response lands via agent.poll_llm() on a later frame.
         if response.lost_focus()
             && ui.input(|i| i.key_pressed(egui::Key::Enter))
         {
-            if let Some(text) = agent.submit() {
-                // Stub: echo the input back as a placeholder response
-                let stub = format!("[stub] Received: \"{text}\" — LLM backend not connected.");
-                agent.push_stub_response(stub);
-            }
+            let _ = agent.submit();
         }
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod agent_context;
+mod agent_llm;
 mod agent_mode;
 mod agent_ui;
 mod app;


### PR DESCRIPTION
## Summary

- Replaces the stub echo in agent mode with a real single-turn Anthropic Messages API call (`claude-sonnet-4-20250514`).
- HTTP runs on a dedicated `LlmWorker` thread with ureq; requests and responses move over mpsc channels so egui never blocks.
- API key is loaded once (on first `activate`) from the existing secrets infrastructure — `ANTHROPIC_API_KEY` under app_id `plexi-run`, resolved by walking from the pane's cwd up to `$HOME`. Missing key surfaces a friendly system message in the agent panel pointing at the Secrets manager.
- `agent_ui::render_agent_mode` drains the worker channel each frame via `AgentMode::poll_llm()` and requests a repaint while `Processing` so replies land promptly.

## Out of scope (follow-ups)

- Streaming tokens (`LlmResponse::Token` is scaffolded but not emitted)
- Multi-turn context — MVP sends only the latest user message
- Tool use (file read, shell exec)
- Cost reporting via `cost_report`
- Bare `/` prompt detection (issue #104)

## Test plan

- [ ] Open the Secrets manager (sidebar), add a secret with key `ANTHROPIC_API_KEY` scoped to any ancestor of the cwd (e.g. `$HOME`), app_id `plexi-run`
- [ ] Launch Plexi alpha (`just install-alpha`), open a pane, press `Ctrl+/`
- [ ] Type `hello` and press Enter — a real Claude response should appear within a few seconds
- [ ] Delete the secret, reopen Plexi, press `Ctrl+/`, submit a message — should see the friendly "No ANTHROPIC_API_KEY found" system message
- [ ] Set a bogus key value, submit a message — should see an "LLM error: Anthropic API returned HTTP 401: ..." system message in the conversation
- [ ] Press Escape to deactivate, re-enter — conversation history persists for the pane