### PR TITLE
Phase 1: feature-gate native deps for wasm32 target (#105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,8 +1517,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2940,12 +2952,14 @@ name = "plexi"
 version = "1.1.2"
 dependencies = [
  "chrono",
+ "console_error_panic_hook",
  "dirs",
  "eframe",
  "egui",
  "egui_term",
  "egui_tiles",
  "fern",
+ "getrandom 0.2.17",
  "image",
  "log",
  "notify",
@@ -2956,6 +2970,8 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "wasm-bindgen",
+ "web-sys",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,36 @@ short_description = "Spatial terminal window manager"
 osx_minimum_system_version = "12.0"
 
 [dependencies]
+# Cross-platform UI + data dependencies — compile for native and wasm32.
 egui = "0.31"
 eframe = { version = "0.31", features = ["default_fonts", "wgpu"] }
 egui_tiles = { version = "0.12.0", features = ["serde"] }
-egui_term = { path = "deps/egui_term" }
-dirs = "6"
-fern = "0.7"
 log = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["wasmbind"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "tiff", "webp"] }
-rodio = { version = "0.19", default-features = false, features = ["mp3", "flac", "vorbis", "wav"] }
 zeroize = "1"
+
+# Native-only dependencies — anything that touches the OS (PTY, filesystem,
+# subprocess, audio devices, Keychain, file watching, on-disk logging).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+egui_term = { path = "deps/egui_term" }
+dirs = "6"
+fern = "0.7"
+rodio = { version = "0.19", default-features = false, features = ["mp3", "flac", "vorbis", "wav"] }
 notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
 
+# macOS-only — AppKit menu bar integration.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
 objc2-app-kit = { version = "0.2.2", features = ["NSApplication", "NSMenu", "NSMenuItem", "NSRunningApplication", "NSWindow"] }
 objc2-foundation = { version = "0.2.2", features = ["NSThread", "NSString"] }
+
+# WASM-only dependencies — browser APIs and JS interop.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Document", "Location", "Storage"] }
+getrandom = { version = "0.2", features = ["js"] }
+console_error_panic_hook = "0.1"

--- a/docs/specs/wasm-pwa-deployment.md
+++ b/docs/specs/wasm-pwa-deployment.md
@@ -1,6 +1,6 @@
 # Plexi WASM + PWA Mobile Deployment
 
-**Status:** Design  
+**Status:** Phase 1 complete (scaffolding)
 **Last updated:** 2026-04-11
 
 ---
@@ -443,3 +443,39 @@ The app protocol (`PlexiEvent` / `DrawCommand`) defined in `app-infrastructure.m
 ### Enables: `sync-architecture.md`
 
 The WebSocket server built for WASM deployment is also the foundation for multi-machine sync. Once Plexi has a WebSocket server that bridges the app protocol, extending it to peer-to-peer sync (machine A's Plexi connecting to machine B's Plexi) requires only adding routing and conflict resolution on top of the same transport.
+
+---
+
+## 11. Phase 1 Status (2026-04-11)
+
+Issue #105 / `feature/wasm-phase1-feature-gates`.
+
+### What works
+
+- **Both targets compile cleanly.** `cargo build` (native) and `cargo build --target wasm32-unknown-unknown` both succeed from a clean state.
+- **Cargo.toml dependency split.** Native-only crates (`egui_term`, `rodio`, `notify`, `dirs`, `fern`) moved into `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`. WASM-only crates (`wasm-bindgen`, `web-sys`, `getrandom` with `js` feature, `console_error_panic_hook`) added under `[target.'cfg(target_arch = "wasm32")'.dependencies]`. `chrono` now enables its `wasmbind` feature on all targets.
+- **Module-level gating in `main.rs`.** Every `mod` declaration for a native-only file is wrapped in `#[cfg(not(target_arch = "wasm32"))]`. The native `main()` function is also cfg-gated, and a no-op WASM `main()` stub exists so the binary crate has an entry symbol on `wasm32-unknown-unknown`.
+- **Wasm subset compiled.** Currently only two modules are universal: `app_protocol` (JSON protocol types) and `agent_mode` (pure state machine). These are the seed of the shared UI/domain layer the WASM client will be built on in Phase 3.
+
+### What's still blocked
+
+Phase 1 was scoped as "dependency + module gating, no behaviour changes." Splitting the actual rendering core to compile for WASM requires a refactor that's deliberately deferred.
+
+- **`app.rs`, `pane.rs`, `pane_ops.rs`, `tiling.rs`, `theme.rs`, `command_palette.rs`** all import from `egui_term` (alacritty_terminal wrapper) directly. The PTY terminal view type appears in struct fields and render methods. Decoupling them requires introducing a render-only terminal grid type that `egui_term::TerminalView` and a future WASM draw-command consumer can both satisfy. That's Phase 2/3 work.
+- **`app_trait.rs`** depends on `theme::Colors` and `tiling::PaneId`, so every app (text_editor, quick_note, file_browser, secrets, audio, process_app) transitively drags in the native render stack.
+- **`config.rs`, `logging.rs`, `context.rs`, `workspace.rs`** all use `dirs`, `fern`, or `std::process`. They need client/server splits — the client-side config arrives over WebSocket, logging goes to `console_log`.
+- **`app_permissions.rs` and `features.rs`** only touch `config` and `app_trait` — they're the lowest-hanging fruit for the next round of universal-izing, once `config` is split.
+- **No WASM UI yet.** The wasm binary currently has an empty `main()`. Wiring up `eframe::WebRunner` is Phase 3.
+
+### Follow-up work for Phase 2+
+
+1. Introduce a client/server split for `config.rs` — pure `PlexiConfig` struct on both sides, `load()` native-only.
+2. Introduce a render abstraction for terminal grids so `tiling.rs` and `app.rs` don't import `egui_term` directly.
+3. Start `ws_bridge.rs` — WebSocket transport module for WASM.
+4. Port `file_browser/mod.rs` rendering into a universal module, with `read_dir` calls behind a trait that has a native (`std::fs`) and a WASM (WS request) implementation.
+
+### Files touched in Phase 1
+
+- `Cargo.toml` — dependency reorganisation
+- `src/main.rs` — module gating, cfg-split entry point
+- `docs/specs/wasm-pwa-deployment.md` — this section

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,103 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-mod agent_context;
-mod agent_mode;
-mod agent_ui;
-mod app;
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 1 of the WASM/PWA split (see docs/specs/wasm-pwa-deployment.md).
+//
+// Every module that touches the OS — PTY, filesystem, subprocess, Keychain,
+// audio devices, file watching — is gated behind `cfg(not(target_arch = "wasm32"))`.
+// The UI rendering modules (`app`, `pane`, `pane_ops`, `tiling`, `theme`,
+// `command_palette`, `file_browser`) also depend transitively on `egui_term`
+// and `shell`, which are native-only, so they are gated here as well until a
+// later phase isolates the rendering core from the PTY/shell layer.
+//
+// The wasm build currently compiles only the self-contained leaf modules
+// (protocol types, trait definitions, pure state structs). A real wasm UI is
+// Phase 3 work — this phase just sets up the compile scaffolding.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Shared modules — compile on every target ────────────────────────────────
+//
+// These modules are pure data/protocol definitions with no OS dependencies.
+// They're the seed of what will eventually be the WASM-compilable UI layer.
 mod app_protocol;
-mod app_registry;
-mod app_api;
-mod app_permissions;
-mod audio_app;
-mod app_trait;
-mod cli;
-mod command_palette;
-mod file_browser;
-mod process_app;
-mod quick_note_app;
-mod secrets_app;
-mod text_editor_app;
-mod config;
-mod context;
-mod cost_tracker;
-mod logging;
+mod agent_mode;
+
+// `features` and `app_permissions` transitively reference `config` and
+// `app_trait`, which are native-only. Gated until they're decoupled.
+#[cfg(not(target_arch = "wasm32"))]
 mod features;
+#[cfg(not(target_arch = "wasm32"))]
+mod app_permissions;
+
+// ── Native-only modules ──────────────────────────────────────────────────────
+//
+// Everything below depends on `std::fs`, `std::process`, `egui_term`,
+// `rodio`, `notify`, `dirs`, or macOS-specific crates. Gated until Phase 2
+// introduces a WebSocket transport that replaces direct OS access.
+#[cfg(not(target_arch = "wasm32"))]
+mod agent_context;
+#[cfg(not(target_arch = "wasm32"))]
+mod agent_ui;
+#[cfg(not(target_arch = "wasm32"))]
+mod app;
+#[cfg(not(target_arch = "wasm32"))]
+mod app_registry;
+#[cfg(not(target_arch = "wasm32"))]
+mod app_api;
+#[cfg(not(target_arch = "wasm32"))]
+mod audio_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod app_trait;
+#[cfg(not(target_arch = "wasm32"))]
+mod cli;
+#[cfg(not(target_arch = "wasm32"))]
+mod command_palette;
+#[cfg(not(target_arch = "wasm32"))]
+mod file_browser;
+#[cfg(not(target_arch = "wasm32"))]
+mod process_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod quick_note_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod secrets_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod text_editor_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod config;
+#[cfg(not(target_arch = "wasm32"))]
+mod context;
+#[cfg(not(target_arch = "wasm32"))]
+mod cost_tracker;
+#[cfg(not(target_arch = "wasm32"))]
+mod logging;
+#[cfg(not(target_arch = "wasm32"))]
 mod keys;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
 mod macos_menu;
+#[cfg(not(target_arch = "wasm32"))]
 mod overlays;
+#[cfg(not(target_arch = "wasm32"))]
 mod pane;
+#[cfg(not(target_arch = "wasm32"))]
 mod pane_ops;
+#[cfg(not(target_arch = "wasm32"))]
 mod secrets;
+#[cfg(not(target_arch = "wasm32"))]
 mod shell;
+#[cfg(not(target_arch = "wasm32"))]
 mod sidebar;
+#[cfg(not(target_arch = "wasm32"))]
 mod theme;
+#[cfg(not(target_arch = "wasm32"))]
 mod tiling;
+#[cfg(not(target_arch = "wasm32"))]
 mod workspace;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Native entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(target_arch = "wasm32"))]
 fn main() -> eframe::Result {
     let log_level = crate::config::PlexiConfig::load()
         .log
@@ -171,4 +234,19 @@ fn main() -> eframe::Result {
         native_options,
         Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc)))),
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WASM entry point — stub for Phase 1
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// This compiles the shared modules above (protocol, trait, pure state) for
+// wasm32-unknown-unknown so we can verify the dependency gating in Cargo.toml
+// is correct. A real WASM UI requires Phase 3 (ws_bridge + WebRunner wiring).
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    // No-op: the real wasm entry point will live in a separate `wasm_main`
+    // module once Phase 3 wires up `eframe::WebRunner`. For now, `main` only
+    // exists so `cargo build --target wasm32-unknown-unknown` has an entry
+    // symbol for the binary crate.
 }


### PR DESCRIPTION
Phase 1 of the WASM/PWA deployment plan in `docs/specs/wasm-pwa-deployment.md`. Tracks issue #105.

## Summary

Sets up the compile-boundary scaffolding so the codebase compiles for both native and `wasm32-unknown-unknown`. Zero runtime behaviour changes — this is a pure refactor PR.

- `cargo build` (native) still passes
- `cargo build --target wasm32-unknown-unknown` now passes from a clean state

## What's gated

**Cargo.toml**
- Native-only deps moved under `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`: `egui_term`, `rodio`, `notify`, `dirs`, `fern`
- WASM-only deps added: `wasm-bindgen`, `web-sys`, `getrandom` (with `js` feature), `console_error_panic_hook`
- `chrono` enables `wasmbind`
- macOS `objc2` deps untouched (already target-gated)

**src/main.rs**
- Every native-only `mod` declaration wrapped in `#[cfg(not(target_arch = "wasm32"))]`
- Native `main()` is cfg-gated; a no-op WASM `main()` stub exists so the binary crate has an entry symbol on `wasm32-unknown-unknown`
- Only `app_protocol` and `agent_mode` compile universally right now — they're the seed of the shared UI/domain layer for Phase 3

## What's still blocked (intentionally)

Getting the *rendering core* to compile for WASM requires decoupling `app.rs`, `pane.rs`, `pane_ops.rs`, `tiling.rs`, `theme.rs`, and `command_palette.rs` from `egui_term` (alacritty_terminal) and `shell`. Those imports appear in struct fields and render methods throughout, so pulling them out is a real refactor — not a `cfg` drive-by.

The same applies to `app_trait.rs` (depends on `theme::Colors` and `tiling::PaneId`), which transitively drags every app module into the native stack. `config.rs`, `logging.rs`, `context.rs`, `workspace.rs` all need client/server splits.

`app_permissions.rs` and `features.rs` are the lowest-hanging fruit for the next round — they only depend on `config` and `app_trait`.

Follow-up work is documented in the new **Phase 1 Status** section of `docs/specs/wasm-pwa-deployment.md`.

## Test plan

- [x] `cargo build` passes (native)
- [x] `cargo build --target wasm32-unknown-unknown` passes from a clean `cargo clean --target wasm32-unknown-unknown`
- [ ] `just install-alpha` and smoke-test the native app still launches (ran locally; reviewers should confirm)