### PR TITLE
feat: macOS Finder "Open in Plexi" service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ Each app is a subdirectory with a `manifest.toml` and an executable entry point:
 
 `just install` uses `cargo bundle --release` to produce a proper macOS `.app` bundle (reads metadata from `Cargo.toml`), then copies it to `/Applications/Plexi.app` and extracts the binary to `/usr/local/bin/plexi`. The `install.sh` curl script does the same thing for fresh installs from GitHub.
 
+After copying the bundle, the install recipes also run:
+
+- `lsregister -f <bundle>` — tells Launch Services about the new bundle
+- `pbs -update` — refreshes the macOS Services cache so the Finder "Open in Plexi" service (declared in Info.plist via `assets/Info.plist.ext`) appears in the right-click Services submenu without a logout cycle
+
+If the service ever fails to show up, run those two commands manually against the installed `.app`. The `NSServices` entry is appended to the generated `Info.plist` by `cargo bundle`'s `osx_info_plist_exts` config (see `Cargo.toml` `[package.metadata.bundle]`). Validate any changes to `assets/Info.plist.ext` with `plutil -lint <bundle>/Contents/Info.plist` after running `cargo bundle`.
+
 **After every completed code change, run the install command for the active branch:**
 - `alpha` branch → `just install-alpha`
 - `main` branch → `just install`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ identifier = "com.ianjamesburke.plexi"
 icon = ["assets/app-icon.icns"]
 short_description = "Spatial terminal window manager"
 osx_minimum_system_version = "12.0"
+osx_info_plist_exts = ["assets/Info.plist.ext"]
 
 [dependencies]
 egui = "0.31"
@@ -29,5 +30,5 @@ notify = { version = "6", default-features = false, features = ["macos_kqueue"] 
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
-objc2-app-kit = { version = "0.2.2", features = ["NSApplication", "NSMenu", "NSMenuItem", "NSRunningApplication", "NSWindow"] }
-objc2-foundation = { version = "0.2.2", features = ["NSThread", "NSString"] }
+objc2-app-kit = { version = "0.2.2", features = ["NSApplication", "NSMenu", "NSMenuItem", "NSPasteboard", "NSRunningApplication", "NSWindow"] }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSString", "NSThread", "NSURL"] }

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,29 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [DECISION] Finder "Open in Plexi" service via in-process NSServicesProvider
+
+Added the Layer 0 macOS Finder Service. Right-clicking a folder in Finder → Services → "Open in Plexi" launches/focuses Plexi and opens the folder as a new context. Same machinery handles `plexi <path>` from the terminal on first launch.
+
+**Approach taken** — in-process service provider, no helper binary:
+- `assets/Info.plist.ext` declares `NSServices` entry (`NSMessage = openInPlexi`, `NSPortName = Plexi`, `NSSendTypes = NSFilenamesPboardType + public.file-url`). Injected into the generated Info.plist via `cargo bundle`'s `osx_info_plist_exts`.
+- `src/finder_service.rs` defines a `PlexiServiceHandler` NSObject subclass (using the same `objc2::declare::ClassBuilder` pattern already used by `macos_menu.rs`) with a single method `openInPlexi:userData:error:`.
+- `PlexiApp::new` calls `finder_service::register()` which allocs the handler, calls `NSApp.setServicesProvider(...)`, and invokes `NSUpdateDynamicServices()`.
+- The callback reads paths from the NSPasteboard (`propertyListForType:NSFilenamesPboardType`, falling back to `public.file-url`) and pushes them into a `Mutex<Vec<PathBuf>>`. `PlexiApp::update` drains the queue each frame and calls `open_path_as_context(path)` — a new sibling to `new_context()` that names the context after the folder's basename.
+- Activation: the callback calls `NSApp.activateIgnoringOtherApps(true)` so Plexi comes to the front when invoked from a background state.
+
+**Alternatives rejected:**
+- *Swift/Objective-C helper binary* — the task description suggested this as the "cleanest" option, but the existing `macos_menu.rs` already demonstrates that in-process objc2 class declaration works fine in eframe. Shipping a second binary duplicates the install footprint and the service provider has to be in the same process anyway to focus Plexi.
+- *AppleScript .app wrapper* — even more install complexity and an extra process.
+- *Apple Events `openFile:` via `CFBundleDocumentTypes`* — would put Plexi in Finder's "Open With…" submenu instead of Services, but eframe doesn't expose a hook for the `NSApplicationDelegate application:openFile:` method, so catching the event would require AppDelegate swizzling. Services provider is the straightforward supported path.
+
+**Install/refresh:** `just install`, `install-alpha`, `install-beta` now run `lsregister -f <bundle>` + `pbs -update` after copying the bundle, so the service appears without a logout cycle. Verified via `/System/Library/CoreServices/pbs -dump_pboard` — both `Plexi.app` and `Plexi Alpha.app` register with `NSMessage = openInPlexi`.
+
+**`plexi <path>` CLI:** added as a fall-through case in `main.rs` args dispatch. If the extra arg is a directory, canonicalizes and pushes it through the same `finder_service::queue_path` channel. If the arg isn't a known subcommand and isn't a directory, falls through to the GUI silently (unchanged behavior). This starts a fresh Plexi instance — it does NOT forward to an already-running instance. Forwarding to a running instance would require handling Apple Events, which is deferred; users who want that case should use the Finder service.
+
+**Gotcha — `cargo-bundle` osx_info_plist_exts:** the mechanism is "blindly append the file contents before closing `<dict>`". This means the fragment file must contain raw `<key>/<value>` pairs (no wrapping `<dict>`, no `<?xml>` header). Easy to get wrong — validate every time with `plutil -lint <bundle>/Contents/Info.plist` after bundling.
+
+**Gotcha — objc2 msg_send! with Retained<AnyObject>:** the `msg_send!` macro path fails with "OptionEncode not implemented for Retained<AnyObject>" when the dep graph contains multiple objc2 versions (we have 0.5 direct + 0.6 pulled in by arboard). Use the generated typed bindings (`NSPasteboard::propertyListForType`) instead — they go through the single version we directly depend on.
+
 ## 2026-04-11 — [CHANGED] Layer 0/1/2/4 implemented in parallel via worktree sub-agents
 
 Massive parallel build session. Created branches per roadmap layer, launched isolated worktree agents to implement each, then merged into `layer-merged` (PR #103 → alpha).

--- a/assets/Info.plist.ext
+++ b/assets/Info.plist.ext
@@ -1,0 +1,24 @@
+  <key>NSServices</key>
+  <array>
+    <dict>
+      <key>NSMenuItem</key>
+      <dict>
+        <key>default</key>
+        <string>Open in Plexi</string>
+      </dict>
+      <key>NSMessage</key>
+      <string>openInPlexi</string>
+      <key>NSPortName</key>
+      <string>Plexi</string>
+      <key>NSSendTypes</key>
+      <array>
+        <string>NSFilenamesPboardType</string>
+        <string>public.file-url</string>
+      </array>
+      <key>NSRequiredContext</key>
+      <dict>
+        <key>NSTextContent</key>
+        <string>FilePath</string>
+      </dict>
+    </dict>
+  </array>

--- a/justfile
+++ b/justfile
@@ -12,6 +12,9 @@ install:
     cp target/release/bundle/osx/Plexi.app/Contents/MacOS/plexi /usr/local/bin/plexi
     rm -rf /Applications/Plexi.app
     cp -r target/release/bundle/osx/Plexi.app /Applications/Plexi.app
+    # Register the bundle and refresh the Finder "Open in Plexi" service.
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /Applications/Plexi.app || true
+    /System/Library/CoreServices/pbs -update || true
 
 # Deprecated: use install-alpha or install-beta instead
 install-apps:
@@ -60,6 +63,10 @@ install-alpha:
     alpha_bin="$(find "$app_src/Contents/MacOS" -maxdepth 1 -type f | head -n 1)"
     cp "$alpha_bin" /usr/local/bin/plexi-alpha
 
+    # Register the bundle and refresh the Finder "Open in Plexi" service.
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$app_dest" || true
+    /System/Library/CoreServices/pbs -update || true
+
     echo "Installed $app_dest"
     echo "CLI binary: /usr/local/bin/plexi-alpha"
     echo "Config dir: ~/.plexi-alpha/"
@@ -104,6 +111,10 @@ install-beta:
 
     beta_bin="$(find "$app_src/Contents/MacOS" -maxdepth 1 -type f | head -n 1)"
     cp "$beta_bin" /usr/local/bin/plexi-beta
+
+    # Register the bundle and refresh the Finder "Open in Plexi" service.
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$app_dest" || true
+    /System/Library/CoreServices/pbs -update || true
 
     echo "Installed $app_dest"
     echo "CLI binary: /usr/local/bin/plexi-beta"

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,6 +42,8 @@ impl PlexiApp {
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         #[cfg(target_os = "macos")]
         crate::macos_menu::customize_app_menu();
+        #[cfg(target_os = "macos")]
+        crate::finder_service::register();
 
         theme::setup_fonts(&cc.egui_ctx);
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
@@ -390,6 +392,17 @@ impl eframe::App for PlexiApp {
         self.drain_pty_events();
         self.dispatch_app_key_events(ctx);
         self.sync_app_cwd();
+
+        // Consume any paths queued by the macOS Finder service
+        // ("Open in Plexi") or by `plexi <path>` on startup, and open each
+        // one as a new context.
+        #[cfg(target_os = "macos")]
+        {
+            for path in crate::finder_service::drain_pending_paths() {
+                self.open_path_as_context(path);
+                ctx.request_repaint();
+            }
+        }
 
         // Check if the focused app wants to close itself (e.g. after saving).
         {

--- a/src/finder_service.rs
+++ b/src/finder_service.rs
@@ -1,0 +1,238 @@
+//! macOS Finder Service: "Open in Plexi"
+//!
+//! Registers Plexi as a macOS Service provider so right-clicking a folder in
+//! Finder (Services submenu) offers "Open in Plexi". Selecting it launches or
+//! focuses Plexi and opens the folder as a new context.
+//!
+//! The service is declared in `assets/Info.plist.ext` under the `NSServices`
+//! key. macOS invokes `openInPlexi:userData:error:` on our registered provider
+//! object, passing an `NSPasteboard` containing the selected file paths.
+//!
+//! Incoming paths are pushed into a process-wide queue that `PlexiApp::update`
+//! drains once per frame on the main thread. We intentionally do NOT mutate
+//! application state from the Objective-C callback — all UI work happens in
+//! the egui update loop.
+
+use objc2::declare::ClassBuilder;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject, Sel};
+use objc2::{sel, ClassType};
+use objc2_app_kit::{NSApplication, NSPasteboard};
+use objc2_foundation::{MainThreadMarker, NSArray, NSString};
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// Process-wide queue of folder paths received from the Finder service.
+/// Populated from the Objective-C callback thread (always main thread for
+/// services) and drained by `PlexiApp::update` each frame.
+static PENDING_PATHS: OnceLock<Mutex<Vec<PathBuf>>> = OnceLock::new();
+
+fn pending_paths() -> &'static Mutex<Vec<PathBuf>> {
+    PENDING_PATHS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Push a path onto the queue. Exposed for the CLI fallback (`plexi <path>`)
+/// and for the service callback.
+pub fn queue_path(path: PathBuf) {
+    match pending_paths().lock() {
+        Ok(mut q) => {
+            log::info!("finder_service: queued path {}", path.display());
+            q.push(path);
+        }
+        Err(e) => {
+            log::error!("finder_service: failed to lock pending_paths queue: {e}");
+        }
+    }
+}
+
+/// Drain and return any paths that have been queued since the last call.
+/// Called by `PlexiApp::update` on the main thread each frame.
+pub fn drain_pending_paths() -> Vec<PathBuf> {
+    match pending_paths().lock() {
+        Ok(mut q) => std::mem::take(&mut *q),
+        Err(e) => {
+            log::error!("finder_service: failed to lock pending_paths queue during drain: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Register a PlexiServiceHandler NSObject subclass exactly once.
+fn register_service_class() -> &'static objc2::runtime::AnyClass {
+    static CLASS: OnceLock<&'static objc2::runtime::AnyClass> = OnceLock::new();
+    CLASS.get_or_init(|| {
+        let superclass = NSObject::class();
+        let mut builder = ClassBuilder::new("PlexiServiceHandler", superclass)
+            .expect("PlexiServiceHandler class already registered");
+
+        // Objective-C signature:
+        //     - (void)openInPlexi:(NSPasteboard *)pboard
+        //                userData:(NSString *)userData
+        //                   error:(NSString **)error;
+        //
+        // macOS dispatches to this when the user invokes the
+        // "Open in Plexi" service. We read file paths from the pasteboard,
+        // queue them for the update loop, and activate the app.
+        unsafe extern "C" fn open_in_plexi(
+            _this: &AnyObject,
+            _cmd: Sel,
+            pboard: *mut NSPasteboard,
+            _user_data: *mut NSString,
+            _error: *mut *mut NSString,
+        ) {
+            if pboard.is_null() {
+                log::warn!("finder_service: openInPlexi received null pasteboard");
+                return;
+            }
+
+            let pboard_ref: &NSPasteboard = unsafe { &*pboard };
+            let paths = unsafe { read_paths_from_pasteboard(pboard_ref) };
+
+            if paths.is_empty() {
+                log::warn!("finder_service: openInPlexi received no usable paths");
+                return;
+            }
+
+            for p in paths {
+                queue_path(p);
+            }
+
+            // Bring Plexi to the front. The service dispatch path does not
+            // activate the app by itself if it was already running in the
+            // background.
+            if let Some(mtm) = MainThreadMarker::new() {
+                let app = NSApplication::sharedApplication(mtm);
+                #[allow(deprecated)]
+                app.activateIgnoringOtherApps(true);
+            }
+        }
+
+        unsafe {
+            builder.add_method(
+                sel!(openInPlexi:userData:error:),
+                open_in_plexi
+                    as unsafe extern "C" fn(
+                        _,
+                        _,
+                        *mut NSPasteboard,
+                        *mut NSString,
+                        *mut *mut NSString,
+                    ),
+            );
+        }
+
+        builder.register()
+    })
+}
+
+/// Read file paths from a service pasteboard.
+///
+/// Modern AppKit prefers `NSFilenamesPboardType` as a property list (array of
+/// NSString paths). Older/newer variants may instead vend `public.file-url`
+/// strings. We try both so the service is robust against the system type
+/// the caller provides.
+unsafe fn read_paths_from_pasteboard(pboard: &NSPasteboard) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+
+    // 1) NSFilenamesPboardType -> NSArray<NSString> of absolute paths.
+    //    `NSFilenamesPboardType` is an `extern "C" static` of type
+    //    `&'static NSPasteboardType` (which is `&'static NSString`), so we
+    //    dereference once to get the `&NSPasteboardType` the binding wants.
+    let filenames_type: &objc2_app_kit::NSPasteboardType =
+        unsafe { objc2_app_kit::NSFilenamesPboardType };
+    let plist: Option<Retained<AnyObject>> = pboard.propertyListForType(filenames_type);
+    if let Some(obj) = plist {
+        // The property list for NSFilenamesPboardType is an NSArray<NSString>.
+        let array: &NSArray<NSString> =
+            unsafe { &*(Retained::as_ptr(&obj) as *const NSArray<NSString>) };
+        let count = array.count();
+        for i in 0..count {
+            let s = array.objectAtIndex(i);
+            let rust_str = s.to_string();
+            let pb = PathBuf::from(rust_str);
+            if !pb.as_os_str().is_empty() {
+                out.push(pb);
+            }
+        }
+        // Keep the retain alive until here.
+        let _ = obj;
+    }
+
+    // 2) Fall back to public.file-url as a string.
+    if out.is_empty() {
+        let url_type = NSString::from_str("public.file-url");
+        let s: Option<Retained<NSString>> = unsafe { pboard.stringForType(&url_type) };
+        if let Some(url_str) = s {
+            let rust_str = url_str.to_string();
+            if let Some(stripped) = rust_str.strip_prefix("file://") {
+                // Strip any trailing newlines or percent encoding.
+                let decoded = percent_decode(stripped);
+                let pb = PathBuf::from(decoded);
+                if !pb.as_os_str().is_empty() {
+                    out.push(pb);
+                }
+            } else {
+                let pb = PathBuf::from(rust_str);
+                if !pb.as_os_str().is_empty() {
+                    out.push(pb);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Minimal percent-decoder for file:// URLs. Handles the common `%20` etc.
+/// without pulling in a new dependency.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| input.to_string())
+}
+
+/// Install the Plexi service provider on NSApp. Safe to call multiple times —
+/// only the first call does anything.
+pub fn register() {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    if REGISTERED.get().is_some() {
+        return;
+    }
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        log::warn!("finder_service: register() called off main thread; skipping");
+        return;
+    };
+
+    let cls = register_service_class();
+    let handler: Retained<NSObject> = unsafe { objc2::msg_send_id![cls, new] };
+
+    let app = NSApplication::sharedApplication(mtm);
+    unsafe { app.setServicesProvider(Some(&*handler)) };
+
+    // Leak the handler — NSApp holds it weakly, and we want it to live for
+    // the entire process lifetime.
+    std::mem::forget(handler);
+
+    // Prompt the OS to rescan our Info.plist service registration so the
+    // menu item appears without a logout cycle. This is a no-op if the
+    // service is already registered.
+    unsafe { objc2_app_kit::NSUpdateDynamicServices() };
+
+    let _ = REGISTERED.set(());
+    log::info!("finder_service: registered Plexi service provider");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ mod context;
 mod cost_tracker;
 mod logging;
 mod features;
+#[cfg(target_os = "macos")]
+mod finder_service;
 mod keys;
 #[cfg(target_os = "macos")]
 mod macos_menu;
@@ -129,7 +131,25 @@ fn main() -> eframe::Result {
                     }
                 }
             }
-            _ => {} // Not a CLI subcommand — fall through to GUI
+            other => {
+                // `plexi <path>` — open the given directory as a new context
+                // on launch. Same code path as the macOS Finder service:
+                // queue the path, and PlexiApp::update will pick it up.
+                // Anything that is not a known subcommand and not a directory
+                // falls through to the GUI without error.
+                let path = std::path::PathBuf::from(other);
+                if path.is_dir() {
+                    let abs = path.canonicalize().unwrap_or(path);
+                    #[cfg(target_os = "macos")]
+                    {
+                        finder_service::queue_path(abs);
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        let _ = abs;
+                    }
+                }
+            }
         }
     }
 

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -334,6 +334,43 @@ impl PlexiApp {
         self.active_context = self.contexts.len() - 1;
     }
 
+    /// Open a folder as a new context — used by the macOS Finder service
+    /// ("Open in Plexi") and by `plexi <path>` on the CLI. The context is
+    /// named after the folder's last path component.
+    pub(crate) fn open_path_as_context(&mut self, path: PathBuf) {
+        if !path.is_dir() {
+            log::warn!(
+                "open_path_as_context: path is not a directory, ignoring: {}",
+                path.display()
+            );
+            return;
+        }
+
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(path.clone()))
+        else {
+            log::error!(
+                "open_path_as_context: failed to create terminal for {}",
+                path.display()
+            );
+            return;
+        };
+
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+
+        self.contexts.push(Context {
+            name,
+            path,
+            tree,
+            panes,
+            focused_pane: Some(root_tile),
+            zoomed_pane: None,
+        });
+        self.active_context = self.contexts.len() - 1;
+    }
+
     pub(crate) fn reset_active_context(&mut self) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()))


### PR DESCRIPTION
## Summary

Adds the Layer 0 macOS Finder Service so right-clicking any folder in Finder → Services → **Open in Plexi** launches or focuses Plexi and opens the folder as a new context. The same code path handles `plexi <path>` from the terminal on startup.

- **In-process NSServicesProvider** — reuses the existing `objc2::declare::ClassBuilder` pattern from `macos_menu.rs`, no helper binary required
- **`NSServices` entry injected into `Info.plist`** via `cargo bundle`'s `osx_info_plist_exts` (fragment at `assets/Info.plist.ext`)
- **Install recipes refresh Launch Services + pbs** so the service appears without a logout cycle

## Files touched

- `assets/Info.plist.ext` (new) — `NSServices` fragment merged into the bundle plist
- `src/finder_service.rs` (new) — `PlexiServiceHandler` NSObject subclass + `register()` + path queue
- `Cargo.toml` — adds `osx_info_plist_exts`, `NSPasteboard`/`NSArray`/`NSURL` features on objc2-app-kit/foundation
- `src/main.rs` — wires in the `finder_service` module and `plexi <path>` CLI dispatch
- `src/app.rs` — calls `finder_service::register()` on startup; drains the path queue each frame
- `src/pane_ops.rs` — `open_path_as_context(path)` sibling to `new_context()`, names context after the folder's basename
- `justfile` — `install`, `install-alpha`, `install-beta` now run `lsregister -f` + `pbs -update`
- `CLAUDE.md`, `DEV_LOG.md` — docs and decision log

## Alternatives considered

- **Helper binary (Swift/Obj-C/AppleScript)** — rejected. The objc2 class-declaration pattern already works in-process (see `macos_menu.rs`), and the provider has to live in Plexi's process anyway for focus/activation. A second binary adds install footprint for no benefit.
- **`CFBundleDocumentTypes` + `application:openFile:` Apple Event** — rejected. Would land Plexi in Finder's *Open With…* submenu, but eframe doesn't expose the `NSApplicationDelegate` open-file hook and intercepting it would require AppDelegate swizzling.

## Design notes

- `NSRequiredContext` uses `NSTextContent = FilePath`, same as Ghostty's "New Ghostty Tab Here" service — verified by diffing `pbs -dump_pboard` output.
- `plexi <path>` from the CLI starts a **new** Plexi instance with that folder. It does NOT forward to an already-running Plexi (that would require handling Apple Events, deferred). For the attach-to-running case, users should use the Finder service.
- The service callback only pushes to a `Mutex<Vec<PathBuf>>`. All UI mutation happens in `PlexiApp::update`, keeping the objc callback minimal and main-thread-safe.
- `cargo-bundle`'s `osx_info_plist_exts` works by blindly appending the file contents before the closing `</dict>`. The fragment file must NOT include a wrapping `<dict>` or `<?xml>` header. Validate with `plutil -lint <bundle>/Contents/Info.plist` after running `cargo bundle`.
- Ran into `OptionEncode not implemented for Retained<AnyObject>` when using `msg_send!` directly — the dep graph has both objc2 0.5 (direct) and 0.6 (via arboard). Fix: use the generated typed binding `NSPasteboard::propertyListForType` instead.

## Test plan

- [ ] `cargo build` — passes cleanly (verified)
- [ ] `just install-alpha` — verified; bundle has `NSServices`; `plutil -lint` OK; `pbs -dump_pboard | grep openInPlexi` shows both `Plexi.app` and `Plexi Alpha.app` registered
- [ ] **Finder right-click test (manual):**
  1. Fully quit any running Plexi/Plexi Alpha
  2. `just install-alpha`
  3. In Finder, right-click any folder → **Services** → **Open in Plexi**
  4. Expected: Plexi Alpha launches, active context is named after the folder, terminal cwd is the folder
- [ ] **Already-running test (manual):**
  1. Launch Plexi Alpha
  2. In Finder, right-click a different folder → Services → Open in Plexi
  3. Expected: Plexi Alpha comes to the front, a new context is appended, it becomes active
- [ ] **CLI path test (manual):**
  1. `plexi-alpha ~/Documents` from a plain terminal (not inside a Plexi pane)
  2. Expected: Plexi Alpha launches with `Documents` as the active context
- [ ] If the service doesn't show in Finder after install: run `lsregister -f "/Applications/Plexi Alpha.app"` then `pbs -update` manually — and/or log out + back in as a last resort (macOS caches the Services menu very aggressively)

## Install behavior

The `NSServices` entry is part of the bundle `Info.plist` from the first build. `just install*` now runs:

```
lsregister -f <bundle>
pbs -update
```

after copying to `/Applications/`, which should make the menu item live immediately. No extra user action required.