### PR TITLE
feat: drop events — apps can register drop targets, receive Drop events

### DIFF
--- a/examples/git-log/plexi_sdk.py
+++ b/examples/git-log/plexi_sdk.py
@@ -150,6 +150,44 @@ class RenderContext:
             "color": color, "width": width,
         })
 
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
     def list(self, items: list, selected: int = 0, item_height: float = 40.0):
         """
         High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
@@ -211,6 +249,7 @@ class App:
         @app.on_resize      fn(width: float, height: float)
         @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
         @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
     """
 
     def __init__(self, app_id: str = ""):
@@ -223,6 +262,7 @@ class App:
         self._on_resize: Optional[Callable] = None
         self._on_get_state: Optional[Callable] = None
         self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
         self._emitter = Emitter(app_id=app_id)
 
     def on_render(self, fn: Callable) -> Callable:
@@ -255,6 +295,17 @@ class App:
         """Register handler for set_state requests. Receives a dict with
         keys: user_state, derived, session, persistent."""
         self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
         return fn
 
     def _handle_get_state(self):
@@ -339,6 +390,14 @@ class App:
 
             elif event_type == "set_state":
                 self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
 
             elif event_type == "shutdown":
                 break

--- a/examples/hello-app/bin/plexi-app
+++ b/examples/hello-app/bin/plexi-app
@@ -6,6 +6,7 @@ Demonstrates:
   - Init / Render / Key / Command event handling
   - Drawing rects, text, and a list
   - Sending RunInTerminal commands back to the shell
+  - Declaring a drop target and handling Drop events
 
 Drop this in ~/.plexi/apps/hello-app/bin/plexi-app (chmod +x) and add
 the manifest.toml alongside it.
@@ -17,6 +18,9 @@ import json
 def send(obj):
     print(json.dumps(obj), flush=True)
 
+def log(level, message):
+    send({"type": "log", "level": level, "message": message})
+
 width = 800
 height = 600
 items = [
@@ -27,6 +31,7 @@ items = [
 ]
 selected = 0
 last_command = None
+dropped_paths: list[str] = []  # most recent drop result, shown in the drop zone
 
 COMMANDS = [item["secondary"] for item in items]
 
@@ -48,12 +53,42 @@ def render():
     send({"type": "line", "x1": 0, "y1": 44, "x2": width, "y2": 44,
           "color": "#313244", "width": 1.0})
 
-    # Command list
+    # Command list (top half, above the drop zone)
+    drop_zone_h = 120
+    drop_zone_y = max(60, height - drop_zone_h - 40)
     send({
         "type": "list",
         "items": items,
         "selected": selected,
         "item_height": 28.0,
+    })
+
+    # Drop zone — drag files from Finder here.
+    send({"type": "rect",
+          "x": 20, "y": drop_zone_y, "w": width - 40, "h": drop_zone_h,
+          "fill": "#1a1b26", "radius": 8})
+    send({"type": "text", "x": 40, "y": drop_zone_y + 16,
+          "text": "Drop files here",
+          "size": 12.0, "color": "#89b4fa", "bold": True})
+    if dropped_paths:
+        for i, p in enumerate(dropped_paths[:4]):
+            send({"type": "text", "x": 40, "y": drop_zone_y + 40 + i * 14,
+                  "text": p, "size": 10.0, "color": "#a6e3a1",
+                  "monospace": True})
+    else:
+        send({"type": "text", "x": 40, "y": drop_zone_y + 40,
+              "text": "(drag any file from Finder onto this area)",
+              "size": 10.0, "color": "#585b70"})
+
+    # Register the drop target with Plexi. Empty accept = accept anything.
+    # This must be re-emitted every frame; Plexi does not persist it.
+    send({
+        "type": "drop_target",
+        "id": "assets",
+        "x": 20, "y": drop_zone_y,
+        "w": width - 40, "h": drop_zone_h,
+        "accept": [],
+        "label": "Drop to add to hello-app",
     })
 
     # Status bar at bottom
@@ -101,6 +136,15 @@ for line in sys.stdin:
             cmd = COMMANDS[selected]
             last_command = cmd
             send({"type": "run_in_terminal", "command": cmd})
+
+    elif t == "drop":
+        target_id = event.get("target_id", "")
+        paths = event.get("paths", [])
+        dropped_paths = paths
+        # Print to stderr so we can verify the round-trip end-to-end
+        # (stderr from external apps is forwarded to plexi.log).
+        print(f"hello-app: drop on '{target_id}' -> {paths}", file=sys.stderr, flush=True)
+        log("info", f"drop on '{target_id}': {len(paths)} file(s)")
 
     elif t == "command":
         # User typed something in the terminal command bar

--- a/examples/plexi-browser/plexi_sdk.py
+++ b/examples/plexi-browser/plexi_sdk.py
@@ -150,6 +150,44 @@ class RenderContext:
             "color": color, "width": width,
         })
 
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
     def list(self, items: list, selected: int = 0, item_height: float = 40.0):
         """
         High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
@@ -211,6 +249,7 @@ class App:
         @app.on_resize      fn(width: float, height: float)
         @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
         @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
     """
 
     def __init__(self, app_id: str = ""):
@@ -223,6 +262,7 @@ class App:
         self._on_resize: Optional[Callable] = None
         self._on_get_state: Optional[Callable] = None
         self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
         self._emitter = Emitter(app_id=app_id)
 
     def on_render(self, fn: Callable) -> Callable:
@@ -255,6 +295,17 @@ class App:
         """Register handler for set_state requests. Receives a dict with
         keys: user_state, derived, session, persistent."""
         self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
         return fn
 
     def _handle_get_state(self):
@@ -339,6 +390,14 @@ class App:
 
             elif event_type == "set_state":
                 self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
 
             elif event_type == "shutdown":
                 break

--- a/examples/wikipedia/plexi_sdk.py
+++ b/examples/wikipedia/plexi_sdk.py
@@ -150,6 +150,44 @@ class RenderContext:
             "color": color, "width": width,
         })
 
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
     def list(self, items: list, selected: int = 0, item_height: float = 40.0):
         """
         High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
@@ -211,6 +249,7 @@ class App:
         @app.on_resize      fn(width: float, height: float)
         @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
         @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
     """
 
     def __init__(self, app_id: str = ""):
@@ -223,6 +262,7 @@ class App:
         self._on_resize: Optional[Callable] = None
         self._on_get_state: Optional[Callable] = None
         self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
         self._emitter = Emitter(app_id=app_id)
 
     def on_render(self, fn: Callable) -> Callable:
@@ -255,6 +295,17 @@ class App:
         """Register handler for set_state requests. Receives a dict with
         keys: user_state, derived, session, persistent."""
         self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
         return fn
 
     def _handle_get_state(self):
@@ -339,6 +390,14 @@ class App:
 
             elif event_type == "set_state":
                 self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
 
             elif event_type == "shutdown":
                 break

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -150,6 +150,44 @@ class RenderContext:
             "color": color, "width": width,
         })
 
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
     def list(self, items: list, selected: int = 0, item_height: float = 40.0):
         """
         High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
@@ -211,6 +249,7 @@ class App:
         @app.on_resize      fn(width: float, height: float)
         @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
         @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
     """
 
     def __init__(self, app_id: str = ""):
@@ -223,6 +262,7 @@ class App:
         self._on_resize: Optional[Callable] = None
         self._on_get_state: Optional[Callable] = None
         self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
         self._emitter = Emitter(app_id=app_id)
 
     def on_render(self, fn: Callable) -> Callable:
@@ -255,6 +295,17 @@ class App:
         """Register handler for set_state requests. Receives a dict with
         keys: user_state, derived, session, persistent."""
         self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
         return fn
 
     def _handle_get_state(self):
@@ -339,6 +390,14 @@ class App:
 
             elif event_type == "set_state":
                 self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
 
             elif event_type == "shutdown":
                 break

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -60,6 +60,16 @@ pub enum PlexiEvent {
     Click { x: f32, y: f32, button: MouseButton },
     /// User submitted a command via the terminal command bar.
     Command { text: String },
+    /// Files were dropped on a registered drop target region.
+    ///
+    /// `target_id` matches the `id` of the `DropTarget` draw command that
+    /// declared the region. Paths are absolute paths in the host filesystem.
+    /// Paths that don't match the target's `accept` list are filtered out
+    /// by Plexi before this event is sent.
+    Drop {
+        target_id: String,
+        paths: Vec<String>,
+    },
     /// Request the app's current state (for undo/redo/save).
     GetState,
     /// Restore app state from a previous snapshot.
@@ -169,6 +179,28 @@ pub enum DrawCommand {
         operation_id: Option<String>,
         #[serde(default)]
         timestamp: Option<String>,
+    },
+    /// Declare a drop target region. Stateless per frame: apps must re-emit
+    /// this on every render frame for the drop zone to remain active.
+    ///
+    /// When the user drags files from outside Plexi over this region, Plexi
+    /// will draw a subtle highlight and the optional `label`. When files are
+    /// dropped, Plexi filters paths by extension against `accept` (empty =
+    /// accept anything) and sends a `PlexiEvent::Drop` to the app with the
+    /// matching `id`.
+    DropTarget {
+        id: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        /// File extensions (lowercase, no dot) or MIME types to accept.
+        /// Empty list means accept anything.
+        #[serde(default)]
+        accept: Vec<String>,
+        /// Optional hint text shown over the target while hovering with files.
+        #[serde(default)]
+        label: Option<String>,
     },
     /// End of frame — Plexi will render everything queued since last FrameDone.
     FrameDone,

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -69,6 +69,17 @@ pub trait App: Send {
     /// Apps that track directories (like the file browser) should update.
     fn sync_cwd(&mut self, _new_cwd: &std::path::Path) {}
 
+    /// Offer dropped files to the app. Return `true` if the app consumed the
+    /// drop (one of its declared drop targets contained `local_pos`). When
+    /// `true`, the host will NOT fall back to the default terminal-paste
+    /// behaviour for these paths.
+    ///
+    /// `local_pos` is in the app's local coordinate space (same origin as
+    /// DrawCommand coordinates — top-left of the app surface).
+    fn handle_drop(&mut self, _local_pos: egui::Pos2, _paths: &[PathBuf]) -> bool {
+        false
+    }
+
     /// Serialise app state to JSON for workspace persistence.
     fn serialize_state(&self) -> Option<serde_json::Value> {
         None

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -458,6 +458,42 @@ impl ProcessApp {
                     );
                 }
 
+                DrawCommand::DropTarget { x, y, w, h, label, .. } => {
+                    // Drop targets are invisible by default. When files are being
+                    // dragged from outside Plexi, draw a subtle highlight + label so
+                    // the user can see where they can drop.
+                    let rect = egui::Rect::from_min_size(
+                        egui::pos2(origin.x + x, origin.y + y),
+                        egui::vec2(*w, *h),
+                    );
+                    let hovering_with_files = ui.input(|i| !i.raw.hovered_files.is_empty());
+                    if hovering_with_files {
+                        // Subtle fill + outline to signal "droppable here".
+                        let fill = Color32::from_rgba_unmultiplied(
+                            colors.accent.r(),
+                            colors.accent.g(),
+                            colors.accent.b(),
+                            28,
+                        );
+                        ui.painter().rect_filled(rect, 4.0, fill);
+                        ui.painter().rect_stroke(
+                            rect,
+                            4.0,
+                            egui::Stroke::new(1.5, colors.accent),
+                            egui::StrokeKind::Inside,
+                        );
+                        if let Some(label_text) = label {
+                            ui.painter().text(
+                                rect.center(),
+                                egui::Align2::CENTER_CENTER,
+                                label_text,
+                                egui::FontId::proportional(12.0),
+                                colors.text_primary,
+                            );
+                        }
+                    }
+                }
+
                 DrawCommand::List { items, selected, item_height } => {
                     let row_h = if *item_height > 0.0 { *item_height } else { 20.0 };
                     egui::ScrollArea::vertical()
@@ -674,6 +710,65 @@ impl App for ProcessApp {
 
     fn take_pending_commands(&mut self) -> Vec<AppCommand> {
         std::mem::take(&mut self.pending_commands)
+    }
+
+    fn handle_drop(&mut self, local_pos: egui::Pos2, paths: &[PathBuf]) -> bool {
+        // Find the topmost DropTarget in the last committed frame whose rect
+        // contains the drop position. Iterate in reverse so later-declared
+        // targets (painted on top) take precedence.
+        let hit = self.frame.iter().rev().find_map(|cmd| {
+            if let DrawCommand::DropTarget { id, x, y, w, h, accept, .. } = cmd {
+                let rect = egui::Rect::from_min_size(
+                    egui::pos2(*x, *y),
+                    egui::vec2(*w, *h),
+                );
+                if rect.contains(local_pos) {
+                    Some((id.clone(), accept.clone()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        });
+
+        let Some((target_id, accept)) = hit else {
+            return false;
+        };
+
+        // Filter paths against the accept list. Empty accept = accept anything.
+        let accept_lower: Vec<String> =
+            accept.iter().map(|s| s.trim_start_matches('.').to_ascii_lowercase()).collect();
+        let filtered: Vec<String> = paths
+            .iter()
+            .filter(|p| {
+                if accept_lower.is_empty() {
+                    return true;
+                }
+                match p.extension().and_then(|e| e.to_str()) {
+                    Some(ext) => accept_lower.iter().any(|a| a == &ext.to_ascii_lowercase()),
+                    None => false,
+                }
+            })
+            .map(|p| p.display().to_string())
+            .collect();
+
+        if filtered.is_empty() {
+            // Target exists but no paths matched the accept filter. Still
+            // considered "consumed" — the app owns that region and the user's
+            // intent was clearly to drop there.
+            log::debug!(
+                "ProcessApp[{}]: drop on '{}' filtered out all {} path(s)",
+                self.type_id, target_id, paths.len()
+            );
+            return true;
+        }
+
+        self.send_event(&PlexiEvent::Drop {
+            target_id,
+            paths: filtered,
+        });
+        true
     }
 
     fn on_command(&mut self, cmd: &str) -> Option<AppCommand> {

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -67,12 +67,46 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
 
         // Handle file drops — use the same geometric hit test as hover detection
         // so the drop target matches the visual focus with no frame delay.
+        //
+        // Apps in AppActive mode get first crack at the drop via their declared
+        // DropTargets (see App::handle_drop). If no drop target claims the
+        // position, or the pane is in FullTerminal mode, fall back to the
+        // default behaviour: paste the shell-escaped path(s) into the terminal.
         if is_drag_hovering {
             let dropped = ui.input(|i| i.raw.dropped_files.clone());
             if !dropped.is_empty() {
-                if let Some(pane) = self.panes.get_mut(pane_id) {
-                    for file in dropped {
-                        if let Some(path) = &file.path {
+                let paths: Vec<std::path::PathBuf> = dropped
+                    .iter()
+                    .filter_map(|f| f.path.clone())
+                    .collect();
+
+                // Try the active app first. The Frame applied below uses an
+                // inner_margin of 8, so the app's local origin is offset from
+                // the pane's outer rect by (8, 8). Mirror that offset here so
+                // the position we pass to handle_drop matches the coordinate
+                // space of the DropTarget commands the app emitted.
+                let app_consumed = if let Some(pane) = self.panes.get_mut(pane_id) {
+                    if matches!(pane.surface_mode, SurfaceMode::AppActive)
+                        && pane.active_app.is_some()
+                    {
+                        let drop_pos = self
+                            .drag_cursor_pos
+                            .or_else(|| ui.input(|i| i.pointer.interact_pos()))
+                            .unwrap_or_else(|| ui.max_rect().center());
+                        let inner_origin = ui.max_rect().min + egui::vec2(8.0, 8.0);
+                        let local_pos = drop_pos - inner_origin.to_vec2();
+                        let app = pane.active_app.as_mut().unwrap();
+                        app.handle_drop(local_pos, &paths)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                if !app_consumed {
+                    if let Some(pane) = self.panes.get_mut(pane_id) {
+                        for path in &paths {
                             let path_str = path.display().to_string();
                             let escaped = if path_str.contains(|c: char| {
                                 c.is_whitespace() || "\"'\\()&|;$`!#".contains(c)


### PR DESCRIPTION
## Summary
- New `DrawCommand::DropTarget` + `PlexiEvent::Drop` — apps declare drop zones each frame, Plexi forwards filtered drops to the app instead of pasting paths into the terminal.
- `App::handle_drop` trait method with a `ProcessApp` implementation that matches drop position against the last committed frame's `DropTarget`s, filters paths by extension, and routes the event over stdin.
- Python SDK: `ctx.drop_target(...)` + `@app.on_drop` decorator; synced into all example SDK copies.
- Host-side visual feedback (accent fill + outline + optional label) drawn whenever files are being hovered over Plexi.
- `examples/hello-app/bin/plexi-app` gains a drop zone and echoes dropped paths to stderr + the UI for round-trip verification.

## How it fits together
1. App emits `DropTarget` as part of its normal render stream — stateless per frame.
2. While the user is hovering files (`egui::RawInput::hovered_files`), `ProcessApp` paints a subtle highlight over every declared target.
3. On drop, `tiling.rs` routes the event to the active app via `App::handle_drop` BEFORE falling back to the existing terminal-paste behaviour. The app wins only if the drop pos hits a registered target.
4. Filtered paths are sent as `PlexiEvent::Drop { target_id, paths }` over stdin; the Python SDK dispatches to `@app.on_drop`.

The Parallax "drag assets into the project" pattern now has a first-class path.

## Test plan
- [x] `cargo build` — clean (only pre-existing warnings)
- [x] `just install-alpha` — builds, bundles, installs
- [ ] Drag a file from Finder onto the hello-app drop zone → drop event reaches the app (visible in the UI and in `~/.plexi-alpha/plexi.log` via `app::hello-app`)
- [ ] Drag files outside the drop zone → falls back to the existing terminal-paste behaviour
- [ ] Drop targets with an `accept` filter reject non-matching extensions before the event reaches the app
- [ ] Existing apps (git-log, wikipedia, plexi-browser) continue to work unchanged — additive protocol only