### PR TITLE
feat: parallax viewer + linked companion pane (#113)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,26 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [DECISION] Parallax viewer + linked companion pane (#113) — opt-in [app.launch] manifest section, reuse existing split machinery
+
+Shipped issue #113: the Parallax viewer app plus a new generic `[app.launch]` manifest section that lets any app declare a companion terminal pane on open.
+
+Key decisions (the non-obvious ones):
+
+- **No new tiling primitive.** Extended the existing `open_app_on_focused` into a `_with_launch(..)` variant. The legacy call site keeps its exact 75/25 vertical behavior by passing `None`. When a manifest declares `[app.launch]`, the same code path parameterizes direction (`bottom`/`right`), companion size (fraction), and companion cwd. Considered writing a dedicated "companion layout" module but it would have duplicated 90% of what `open_app_on_focused` already did. One path, one bug surface.
+- **`companion_cwd` template is literal `{launch_dir}` substitution, not a full template engine.** The spec only needs one variable for MVP; keeping it as substring-match means the schema can grow without breaking older apps.
+- **The viewer does NOT depend on a Parallax CLI.** It reads `.parallax/manifest.yaml` directly with a ~30-line stdlib-only YAML subset parser. PyYAML would have been cleaner but the Python SDK contract is zero-deps, and the manifest schema is intentionally tiny (project name + scenes list). When the real CLI lands, the viewer keeps working.
+- **mtime polling, not a watcher.** `os.stat` once per second on a single file is cheap and survives process restarts / missing files cleanly. A proper watcher would require inotify/FSEvents plumbing through the SDK, which is out of scope for #113.
+- **Empty-state is the default render.** If `.parallax/manifest.yaml` is missing, the viewer shows a friendly "run `parallax run \"your brief\"` in the terminal below" hint instead of a blank surface. Made this the first thing I wired so the app is useful before any CLI exists.
+- **`install-alpha` now also syncs `examples/*/` into `~/.plexi-alpha/apps/`.** Previously the justfile only built the bundle; apps had to be copied manually. This is a one-line loop but removes a whole class of "I installed the app but it doesn't show up" confusion.
+- **Pre-existing wasm breakage on alpha (unrelated):** `cargo build --target wasm32-unknown-unknown` fails at HEAD on alpha because `agent_mode` references `agent_llm` and `secrets` that are both `#[cfg(not(target_arch = "wasm32"))]`. My changes do not touch those modules. Filed mentally as a separate bug — do not roll this into #113.
+
+Files:
+- Rust: `src/app_registry.rs` (+`AppLaunchConfig`), `src/pane_ops.rs` (+`open_app_on_focused_with_launch`, updated `launch_app_by_id` + `open_file_with_app`)
+- Python: `examples/parallax/{manifest.toml, parallax.py, plexi_sdk.py, plexi_test.py, tests/test_parallax.py}`
+- Infra: `justfile` (install-alpha syncs example apps)
+- Sample: `~/Documents/parallax-projects/test-project/` with stub manifest, 3 JPG stills, 1 mp4 preview
+
+
 ## 2026-04-12 — [CHANGED] Massive parallel-agent build session — alpha now includes Layer 0/1/2/4 + WASM Phase 1 + media draw commands + Finder Service + notifications
 
 End-of-day state. Alpha is at `a9a181e`. Built and installed via `just install-alpha`. The session ran ~15 sub-agents in parallel worktrees and shipped 6 PRs (#108, #109, #110, #112, #117, #120) plus a follow-up roadmap rewrite.

--- a/examples/parallax/manifest.toml
+++ b/examples/parallax/manifest.toml
@@ -1,0 +1,20 @@
+[app]
+id = "parallax"
+name = "Parallax Viewer"
+entry = "parallax.py"
+version = "0.1.0"
+description = "View-only dashboard for a Parallax video project — stills, preview, scenes"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "read_only"
+
+# Split the launching pane when the viewer opens: a companion terminal
+# scoped to the same project directory appears below. The user talks to
+# the Parallax CLI in the companion; the viewer just renders state.
+[app.launch]
+companion = "terminal"
+companion_position = "bottom"
+companion_size = 0.25
+companion_cwd = "{launch_dir}"

--- a/examples/parallax/parallax.py
+++ b/examples/parallax/parallax.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+parallax — Plexi viewer app for Parallax video projects.
+
+View-only dashboard. Watches `.parallax/manifest.yaml` under the launch
+directory and re-renders when the file changes. Never takes input beyond
+scroll / refresh — the chat lives in the linked companion terminal pane
+declared by [app.launch] in manifest.toml.
+
+Layout:
+  Header       — project name, scene count, total duration
+  File grid    — generated stills from stills/
+  Video        — latest output from output/ (video_thumbnail)
+  Scene list   — scenes from the manifest
+
+If the manifest is missing, renders a friendly "run `parallax run` in the
+terminal below" hint.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":       "#1e1e2e",
+    "surface":  "#313244",
+    "text":     "#cdd6f4",
+    "subtext":  "#9399b2",
+    "muted":    "#6c7086",
+    "accent":   "#89b4fa",
+    "green":    "#a6e3a1",
+    "peach":    "#fab387",
+    "header":   "#181825",
+}
+
+PADDING = 16
+HEADER_H = 56
+
+VIDEO_EXTS = ("mp4", "mov", "webm", "mkv", "m4v")
+IMAGE_EXTS = ("png", "jpg", "jpeg", "webp", "gif")
+
+# ---------------------------------------------------------------------------
+# Project state — re-read from disk on manifest mtime change
+# ---------------------------------------------------------------------------
+
+LAUNCH_DIR = os.getcwd()
+MANIFEST_PATH = os.path.join(LAUNCH_DIR, ".parallax", "manifest.yaml")
+
+_last_mtime: float = 0.0
+_last_poll: float = 0.0
+_manifest: dict = {}  # parsed manifest dict
+_manifest_error: str = ""
+
+# ---------------------------------------------------------------------------
+# Minimal YAML subset parser (stdlib only, no PyYAML dep).
+#
+# Supported schema only — this is NOT a general YAML parser:
+#   project: "name"
+#   scenes:
+#     - number: 1
+#       title: "..."
+#       duration: 3.5
+#     - number: 2
+#       ...
+# Strings may be quoted or bare. Numbers parse as float.
+# ---------------------------------------------------------------------------
+
+
+def _parse_scalar(s: str):
+    s = s.strip()
+    if not s:
+        return None
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        return s[1:-1]
+    try:
+        if "." in s:
+            return float(s)
+        return int(s)
+    except ValueError:
+        return s
+
+
+def _parse_manifest_yaml(text: str) -> dict:
+    """Parse the restricted Parallax manifest schema. Returns {} on failure."""
+    result: dict = {"scenes": []}
+    lines = [ln.rstrip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")]
+    in_scenes = False
+    current: dict = {}
+    for ln in lines:
+        stripped = ln.lstrip()
+        indent = len(ln) - len(stripped)
+        # Top-level key: value
+        if indent == 0 and ":" in stripped:
+            key, _, rest = stripped.partition(":")
+            key = key.strip()
+            rest = rest.strip()
+            if key == "scenes":
+                in_scenes = True
+                current = {}
+                continue
+            in_scenes = False
+            if rest:
+                result[key] = _parse_scalar(rest)
+            continue
+        # Inside scenes list
+        if in_scenes:
+            if stripped.startswith("- "):
+                if current:
+                    result["scenes"].append(current)
+                current = {}
+                stripped = stripped[2:]
+                if ":" in stripped:
+                    k, _, v = stripped.partition(":")
+                    current[k.strip()] = _parse_scalar(v)
+                continue
+            if ":" in stripped:
+                k, _, v = stripped.partition(":")
+                current[k.strip()] = _parse_scalar(v)
+    if current and in_scenes:
+        result["scenes"].append(current)
+    return result
+
+
+def _reload_manifest():
+    """Re-read the manifest file, resetting cached parse state."""
+    global _manifest, _manifest_error
+    try:
+        with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+            text = f.read()
+        _manifest = _parse_manifest_yaml(text)
+        _manifest_error = ""
+    except FileNotFoundError:
+        _manifest = {}
+        _manifest_error = ""  # treated specially — shows onboarding hint
+    except Exception as e:  # parse / IO error
+        _manifest = {}
+        _manifest_error = f"manifest parse error: {e}"
+
+
+def _poll_manifest():
+    """Check manifest mtime once per second; reload on change."""
+    global _last_mtime, _last_poll
+    now = time.monotonic()
+    if now - _last_poll < 1.0:
+        return
+    _last_poll = now
+    try:
+        st = os.stat(MANIFEST_PATH)
+        mtime = st.st_mtime
+    except FileNotFoundError:
+        if _last_mtime != 0.0:
+            _last_mtime = 0.0
+            _reload_manifest()
+        return
+    if mtime != _last_mtime:
+        _last_mtime = mtime
+        _reload_manifest()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_stills() -> list[str]:
+    stills_dir = os.path.join(LAUNCH_DIR, "stills")
+    if not os.path.isdir(stills_dir):
+        return []
+    out = []
+    for name in sorted(os.listdir(stills_dir)):
+        if "." not in name:
+            continue
+        ext = name.rsplit(".", 1)[-1].lower()
+        if ext in IMAGE_EXTS:
+            out.append(os.path.join(stills_dir, name))
+    return out
+
+
+def _latest_output() -> str | None:
+    out_dir = os.path.join(LAUNCH_DIR, "output")
+    if not os.path.isdir(out_dir):
+        return None
+    candidates = []
+    for name in os.listdir(out_dir):
+        if "." not in name:
+            continue
+        ext = name.rsplit(".", 1)[-1].lower()
+        if ext in VIDEO_EXTS:
+            path = os.path.join(out_dir, name)
+            try:
+                candidates.append((os.path.getmtime(path), path))
+            except OSError:
+                pass
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+app = App(app_id="parallax")
+
+
+@app.on_render
+def render(ctx):
+    _poll_manifest()
+
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["bg"])
+
+    project_name = os.path.basename(os.path.normpath(LAUNCH_DIR)) or "parallax"
+    scenes = _manifest.get("scenes") or []
+    total_duration = 0.0
+    for scene in scenes:
+        d = scene.get("duration")
+        if isinstance(d, (int, float)):
+            total_duration += float(d)
+
+    # --- Header ---------------------------------------------------------
+    ctx.rect(0, 0, ctx.width, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 14, f"Parallax — {project_name}",
+             size=15, color=C["accent"], bold=True)
+
+    status = f"{len(scenes)} scenes"
+    if total_duration > 0:
+        status += f"   {total_duration:.1f}s"
+    ctx.text(PADDING, 34, status, size=12, color=C["subtext"])
+
+    hint = LAUNCH_DIR
+    hint_x = ctx.width - len(hint) * 6.5 - PADDING
+    if hint_x > PADDING + 220:
+        ctx.text(hint_x, 20, hint, size=11, color=C["muted"], monospace=True)
+
+    ctx.line(0, HEADER_H, ctx.width, HEADER_H, color=C["surface"], width=1.0)
+
+    # --- Empty-state (no manifest yet) ----------------------------------
+    if not os.path.exists(MANIFEST_PATH):
+        _render_empty(ctx)
+        return
+
+    if _manifest_error:
+        ctx.text(PADDING, HEADER_H + 20,
+                 _manifest_error, size=13, color=C["peach"])
+        return
+
+    # --- Main layout ----------------------------------------------------
+    # Three vertical sections below the header:
+    #   stills grid (top ~45%), video preview (middle ~30%),
+    #   scene list (bottom ~25%)
+    avail_h = ctx.height - HEADER_H - PADDING
+    grid_h = max(120.0, avail_h * 0.45)
+    video_h = max(120.0, avail_h * 0.30)
+    list_h = max(80.0, avail_h - grid_h - video_h - PADDING * 2)
+
+    y = HEADER_H + PADDING
+
+    # --- Stills grid ----------------------------------------------------
+    stills = _list_stills()
+    ctx.text(PADDING, y, f"Stills ({len(stills)})",
+             size=12, color=C["subtext"], bold=True)
+    y += 18
+    if stills:
+        ctx.file_grid(
+            x=PADDING,
+            y=y,
+            w=ctx.width - PADDING * 2,
+            h=grid_h,
+            paths=stills,
+            item_size=140.0,
+            show_labels=False,
+        )
+    else:
+        ctx.text(PADDING, y + 8, "(no stills generated yet — stills/ is empty)",
+                 size=12, color=C["muted"])
+    y += grid_h + PADDING
+
+    # --- Latest output preview ------------------------------------------
+    latest = _latest_output()
+    ctx.text(PADDING, y, "Latest output",
+             size=12, color=C["subtext"], bold=True)
+    y += 18
+    if latest:
+        ctx.video_thumbnail(
+            path=latest,
+            x=PADDING,
+            y=y,
+            w=ctx.width - PADDING * 2,
+            h=video_h,
+            show_play_button=True,
+        )
+        label = os.path.basename(latest)
+        ctx.text(PADDING, y + video_h - 18, label,
+                 size=11, color=C["text"], monospace=True)
+    else:
+        ctx.text(PADDING, y + 8, "(no rendered video yet — output/ is empty)",
+                 size=12, color=C["muted"])
+    y += video_h + PADDING
+
+    # --- Scene list -----------------------------------------------------
+    ctx.text(PADDING, y, "Scenes",
+             size=12, color=C["subtext"], bold=True)
+    y += 18
+    if scenes:
+        items = []
+        for scene in scenes:
+            num = scene.get("number", "?")
+            title = scene.get("title", "(untitled)")
+            dur = scene.get("duration")
+            secondary = None
+            if isinstance(dur, (int, float)):
+                secondary = f"{float(dur):.1f}s"
+            items.append({
+                "label": f"Scene {num}: {title}",
+                "secondary": secondary,
+            })
+        # Clamp item_height so the list doesn't overflow.
+        item_h = min(32.0, max(20.0, list_h / max(1, len(items))))
+        ctx.list(items, selected=0, item_height=item_h)
+    else:
+        ctx.text(PADDING, y + 8, "(no scenes in manifest)",
+                 size=12, color=C["muted"])
+
+
+def _render_empty(ctx):
+    w = ctx.width
+    msg_y = HEADER_H + 40
+    ctx.text(PADDING, msg_y,
+             "No Parallax project here yet.",
+             size=16, color=C["text"], bold=True)
+    ctx.text(PADDING, msg_y + 28,
+             f"Expected: {MANIFEST_PATH}",
+             size=11, color=C["muted"], monospace=True)
+    ctx.text(PADDING, msg_y + 58,
+             "Run this in the terminal below to start one:",
+             size=13, color=C["subtext"])
+
+    cmd = '  parallax run "your brief here"'
+    ctx.rect(PADDING, msg_y + 80, w - PADDING * 2, 32,
+             fill=C["surface"], radius=6.0)
+    ctx.text(PADDING + 12, msg_y + 88, cmd,
+             size=13, color=C["green"], monospace=True)
+
+
+app.run()

--- a/examples/parallax/plexi_sdk.py
+++ b/examples/parallax/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/parallax/plexi_test.py
+++ b/examples/parallax/plexi_test.py
@@ -1,0 +1,361 @@
+"""
+plexi_test.py — Test harness for Plexi apps.
+
+Zero dependencies, pure stdlib. Ships alongside plexi_sdk.py.
+
+Spawn any Plexi app as a subprocess, send JSON events on stdin,
+read JSON draw commands on stdout, and assert on the results.
+
+Usage:
+
+    from plexi_test import AppTestHarness
+
+    h = AppTestHarness("path/to/app.py")
+    h.send_init()
+    frames = h.send_render()
+    h.assert_text_visible("Hello", frames)
+    h.shutdown()
+"""
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from typing import Optional
+
+
+class AppTestHarness:
+    """Spawn a Plexi app as a subprocess and drive it via the JSON protocol."""
+
+    def __init__(self, entry_point: str, launch_dir: str = "/tmp/plexi-test"):
+        self.entry_point = os.path.abspath(entry_point)
+        self.launch_dir = launch_dir
+        self._last_frames: list[dict] = []
+        self._output_queue: queue.Queue[dict] = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._closed = False
+
+        os.makedirs(launch_dir, exist_ok=True)
+
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+
+        try:
+            self._proc = subprocess.Popen(
+                [sys.executable, self.entry_point],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=launch_dir,
+                env=env,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to spawn app {self.entry_point}: {e}") from e
+
+        # Background thread to read stdout lines and enqueue parsed JSON
+        self._reader_thread = threading.Thread(
+            target=self._read_stdout, daemon=True
+        )
+        self._reader_thread.start()
+
+        # Background thread to capture stderr
+        self._stderr_thread = threading.Thread(
+            target=self._read_stderr, daemon=True
+        )
+        self._stderr_thread.start()
+
+    # ------------------------------------------------------------------
+    # Internal readers
+    # ------------------------------------------------------------------
+
+    def _read_stdout(self):
+        assert self._proc.stdout is not None
+        for raw in self._proc.stdout:
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                self._output_queue.put(obj)
+            except json.JSONDecodeError:
+                # Non-JSON output — ignore (could be debug prints)
+                pass
+
+    def _read_stderr(self):
+        assert self._proc.stderr is not None
+        for raw in self._proc.stderr:
+            line = raw.decode("utf-8", errors="replace").rstrip()
+            self._stderr_lines.append(line)
+
+    # ------------------------------------------------------------------
+    # Sending events
+    # ------------------------------------------------------------------
+
+    def _send(self, event: dict):
+        if self._proc.poll() is not None:
+            stderr = self._get_stderr()
+            raise RuntimeError(
+                f"App process already exited with code {self._proc.returncode}.\n"
+                f"stderr:\n{stderr}"
+            )
+        data = json.dumps(event) + "\n"
+        try:
+            self._proc.stdin.write(data.encode("utf-8"))
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            stderr = self._get_stderr()
+            raise RuntimeError(
+                f"Failed to write to app stdin: {e}\nstderr:\n{stderr}"
+            ) from e
+
+    def send_init(self, width: int = 800, height: int = 600, launch_dir: str = None):
+        """Send init event. Called once at start."""
+        event = {
+            "type": "init",
+            "width": width,
+            "height": height,
+            "launch_dir": launch_dir or self.launch_dir,
+        }
+        self._send(event)
+
+    def send_render(self, width: int = None, height: int = None) -> list[dict]:
+        """Send render event. Returns list of draw commands up to frame_done."""
+        event = {"type": "render"}
+        if width is not None:
+            event["width"] = width
+        if height is not None:
+            event["height"] = height
+        self._send(event)
+        frames = self.read_until_frame_done()
+        self._last_frames = frames
+        return frames
+
+    def send_key(self, key: str, command: bool = False, shift: bool = False, ctrl: bool = False):
+        """Send a key event."""
+        self._send({
+            "type": "key",
+            "key": key,
+            "modifiers": {
+                "command": command,
+                "shift": shift,
+                "ctrl": ctrl,
+            },
+        })
+
+    def send_click(self, x: float, y: float, button: str = "left"):
+        """Send a click event."""
+        self._send({
+            "type": "click",
+            "x": x,
+            "y": y,
+            "button": button,
+        })
+
+    def send_command(self, text: str):
+        """Send a command event (e.g., '/clear')."""
+        self._send({"type": "command", "text": text})
+
+    def get_state(self) -> dict:
+        """Send get_state, return the state dict."""
+        self._send({"type": "get_state"})
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                obj = self._output_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if obj.get("type") == "state":
+                return obj
+        raise TimeoutError(
+            f"Timed out waiting for state response.\nstderr:\n{self._get_stderr()}"
+        )
+
+    def set_state(self, state: dict):
+        """Send set_state to restore app state."""
+        event = {"type": "set_state"}
+        event.update(state)
+        self._send(event)
+
+    # ------------------------------------------------------------------
+    # Reading output
+    # ------------------------------------------------------------------
+
+    def read_until_frame_done(self, timeout: float = 5.0) -> list[dict]:
+        """Read stdout lines until frame_done. Returns list of draw commands."""
+        commands = []
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                obj = self._output_queue.get(timeout=min(remaining, 0.1))
+            except queue.Empty:
+                continue
+            if obj.get("type") == "frame_done":
+                return commands
+            commands.append(obj)
+        raise TimeoutError(
+            f"Timed out waiting for frame_done after {timeout}s. "
+            f"Got {len(commands)} commands so far.\n"
+            f"stderr:\n{self._get_stderr()}"
+        )
+
+    def read_events(self, timeout: float = 1.0) -> list[dict]:
+        """Read any pending stdout events (cost_report, api requests, etc.)."""
+        events = []
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                obj = self._output_queue.get(timeout=0.05)
+                events.append(obj)
+            except queue.Empty:
+                # If we already have some events and the queue is empty, return
+                if events:
+                    break
+        return events
+
+    # ------------------------------------------------------------------
+    # Assertions
+    # ------------------------------------------------------------------
+
+    def assert_text_visible(self, text: str, frames: list[dict] = None):
+        """Assert that a text draw command contains the given string."""
+        frames = frames if frames is not None else self._last_frames
+        texts = self.find_texts(frames)
+        for t in texts:
+            if text in t:
+                return
+        raise AssertionError(
+            f"Text '{text}' not found in draw commands.\n"
+            f"Available texts: {texts}\n"
+            f"stderr:\n{self._get_stderr()}"
+        )
+
+    def assert_rect_at(self, x: float, y: float, frames: list[dict] = None, tolerance: float = 5.0):
+        """Assert that a rect exists at approximately (x, y)."""
+        frames = frames if frames is not None else self._last_frames
+        for cmd in frames:
+            if cmd.get("type") == "rect":
+                cx = cmd.get("x", 0)
+                cy = cmd.get("y", 0)
+                if abs(cx - x) <= tolerance and abs(cy - y) <= tolerance:
+                    return
+        rects = [
+            (cmd.get("x"), cmd.get("y"), cmd.get("w"), cmd.get("h"))
+            for cmd in frames if cmd.get("type") == "rect"
+        ]
+        raise AssertionError(
+            f"No rect found at approximately ({x}, {y}) within tolerance {tolerance}.\n"
+            f"Rects found: {rects}\n"
+            f"stderr:\n{self._get_stderr()}"
+        )
+
+    def find_texts(self, frames: list[dict] = None) -> list[str]:
+        """Extract all text content from draw commands."""
+        frames = frames if frames is not None else self._last_frames
+        return [
+            cmd["text"] for cmd in frames
+            if cmd.get("type") == "text" and "text" in cmd
+        ]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self):
+        """Send shutdown event, wait for process to exit."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._send({"type": "shutdown"})
+        except RuntimeError:
+            # Process already dead — that's fine
+            pass
+        try:
+            self._proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=2.0)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.shutdown()
+
+    def __del__(self):
+        if not self._closed:
+            try:
+                self.shutdown()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_stderr(self) -> str:
+        # Give stderr thread a moment to flush
+        time.sleep(0.05)
+        return "\n".join(self._stderr_lines) if self._stderr_lines else "(empty)"
+
+    @property
+    def returncode(self) -> Optional[int]:
+        """Poll and return the process return code, or None if still running."""
+        return self._proc.poll()
+
+
+# ======================================================================
+# Convenience functions
+# ======================================================================
+
+def test_app_lifecycle(entry_point: str):
+    """Smoke test: init -> render -> verify frame_done -> shutdown. No crashes."""
+    with AppTestHarness(entry_point) as h:
+        h.send_init()
+        frames = h.send_render()
+        # frame_done was received (read_until_frame_done didn't timeout)
+        assert isinstance(frames, list), f"Expected list of frames, got {type(frames)}"
+        h.shutdown()
+    print(f"PASS: lifecycle test for {entry_point}")
+
+
+def test_app_state_symmetry(entry_point: str):
+    """Get state, set state, get state again. Verify they match."""
+    with AppTestHarness(entry_point) as h:
+        h.send_init()
+        h.send_render()
+
+        state1 = h.get_state()
+        h.set_state(state1)
+        state2 = h.get_state()
+
+        # Compare the user_state portions
+        s1 = state1.get("user_state", {})
+        s2 = state2.get("user_state", {})
+        assert s1 == s2, f"State mismatch after round-trip:\n  before: {s1}\n  after:  {s2}"
+        h.shutdown()
+    print(f"PASS: state symmetry test for {entry_point}")
+
+
+def test_app_key_handling(entry_point: str, keys: list[str]):
+    """Send a sequence of keys, verify app doesn't crash, state changes."""
+    with AppTestHarness(entry_point) as h:
+        h.send_init()
+        h.send_render()
+
+        for key in keys:
+            h.send_key(key)
+            # Render after each key to flush state
+            h.send_render()
+
+        # If we got here without timeout or crash, it passed
+        h.shutdown()
+    print(f"PASS: key handling test for {entry_point} with keys {keys}")

--- a/examples/parallax/tests/test_parallax.py
+++ b/examples/parallax/tests/test_parallax.py
@@ -1,0 +1,108 @@
+"""Tests for the Parallax viewer Plexi app."""
+import os
+import shutil
+import sys
+import tempfile
+import textwrap
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from plexi_test import AppTestHarness, test_app_lifecycle  # noqa: E402
+
+APP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "parallax.py")
+
+
+def _make_project_dir(with_manifest: bool = True) -> str:
+    """Create a temp dir that looks like a Parallax project."""
+    root = tempfile.mkdtemp(prefix="plexi-parallax-test-")
+    os.makedirs(os.path.join(root, ".parallax"), exist_ok=True)
+    os.makedirs(os.path.join(root, "stills"), exist_ok=True)
+    os.makedirs(os.path.join(root, "output"), exist_ok=True)
+    if with_manifest:
+        manifest = textwrap.dedent(
+            """\
+            project: "test project"
+            scenes:
+              - number: 1
+                title: "opening shot"
+                duration: 2.5
+              - number: 2
+                title: "closing shot"
+                duration: 3.0
+            """
+        )
+        with open(os.path.join(root, ".parallax", "manifest.yaml"), "w") as f:
+            f.write(manifest)
+    return root
+
+
+def test_lifecycle():
+    """App starts, renders, and shuts down without crashing."""
+    test_app_lifecycle(APP_PATH)
+
+
+def test_renders_without_manifest():
+    """Viewer shows friendly onboarding text when no manifest exists."""
+    root = _make_project_dir(with_manifest=False)
+    try:
+        with AppTestHarness(APP_PATH, launch_dir=root) as h:
+            h.send_init()
+            frames = h.send_render()
+            texts = h.find_texts(frames)
+            assert len(texts) > 0, "expected at least one text draw command"
+            # Must render the header with the project name.
+            h.assert_text_visible("Parallax", frames)
+            # Onboarding hint should mention the CLI invocation.
+            h.assert_text_visible("parallax run", frames)
+        print("PASS: test_renders_without_manifest")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_renders_with_manifest():
+    """Viewer parses a stub manifest and renders scene titles."""
+    root = _make_project_dir(with_manifest=True)
+    try:
+        with AppTestHarness(APP_PATH, launch_dir=root) as h:
+            h.send_init()
+            frames = h.send_render()
+            texts = h.find_texts(frames)
+            assert len(texts) > 0
+            h.assert_text_visible("Parallax", frames)
+            h.assert_text_visible("Scenes", frames)
+            # Parsed scene titles should appear in list items or text draws.
+            all_text = " ".join(texts)
+            in_list = any(
+                "opening shot" in (item.get("label", "") or "")
+                for cmd in frames
+                if cmd.get("type") == "list"
+                for item in cmd.get("items", [])
+            )
+            assert "opening shot" in all_text or in_list, (
+                "parsed scene title should be rendered"
+            )
+        print("PASS: test_renders_with_manifest")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_resize():
+    """Viewer handles multiple render sizes without crashing."""
+    root = _make_project_dir(with_manifest=True)
+    try:
+        with AppTestHarness(APP_PATH, launch_dir=root) as h:
+            h.send_init(width=1200, height=900)
+            h.send_render()
+            h.send_render(width=800, height=600)
+            frames = h.send_render(width=400, height=300)
+            assert len(h.find_texts(frames)) > 0
+        print("PASS: test_resize")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_lifecycle()
+    test_renders_without_manifest()
+    test_renders_with_manifest()
+    test_resize()
+    print("All parallax tests passed!")

--- a/justfile
+++ b/justfile
@@ -67,6 +67,20 @@ install-alpha:
     /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$app_dest" || true
     /System/Library/CoreServices/pbs -update || true
 
+    # Sync bundled example apps into ~/.plexi-alpha/apps/ so they appear
+    # in the launcher. Each directory under examples/ that has a manifest.toml
+    # is copied wholesale (overwriting any previous copy).
+    apps_dir="$HOME/.plexi-alpha/apps"
+    mkdir -p "$apps_dir"
+    for dir in examples/*/; do
+      if [[ -f "${dir}manifest.toml" ]]; then
+        name="$(basename "$dir")"
+        rm -rf "$apps_dir/$name"
+        cp -R "$dir" "$apps_dir/$name"
+        echo "Installed app: $name"
+      fi
+    done
+
     echo "Installed $app_dest"
     echo "CLI binary: /usr/local/bin/plexi-alpha"
     echo "Config dir: ~/.plexi-alpha/"

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -49,7 +49,48 @@ pub struct AppManifestApp {
     pub description: String,
     #[serde(default)]
     pub capabilities: AppCapabilities,
+    /// Optional companion-pane launch configuration. When present, Plexi splits
+    /// the launching pane and starts the companion in the secondary slot.
+    #[serde(default)]
+    pub launch: Option<AppLaunchConfig>,
 }
+
+/// Companion-pane launch configuration declared under `[app.launch]` in
+/// `manifest.toml`. All fields are optional; see defaults on each one.
+#[derive(Deserialize, Debug, Clone)]
+pub struct AppLaunchConfig {
+    /// What to run in the companion pane. Only `"terminal"` is supported for
+    /// MVP — other app ids will be accepted later.
+    #[serde(default = "default_companion")]
+    pub companion: String,
+    /// Where the companion sits relative to the app pane:
+    /// `"bottom"` (vertical split, default) or `"right"` (horizontal split).
+    #[serde(default = "default_companion_position")]
+    pub companion_position: String,
+    /// Fraction of the split allocated to the companion (0.0..1.0).
+    #[serde(default = "default_companion_size")]
+    pub companion_size: f32,
+    /// Working directory for the companion. Supported template:
+    /// `{launch_dir}` — resolves to the app's launch directory.
+    #[serde(default = "default_companion_cwd")]
+    pub companion_cwd: String,
+}
+
+impl Default for AppLaunchConfig {
+    fn default() -> Self {
+        Self {
+            companion: default_companion(),
+            companion_position: default_companion_position(),
+            companion_size: default_companion_size(),
+            companion_cwd: default_companion_cwd(),
+        }
+    }
+}
+
+fn default_companion() -> String { "terminal".to_string() }
+fn default_companion_position() -> String { "bottom".to_string() }
+fn default_companion_size() -> f32 { 0.25 }
+fn default_companion_cwd() -> String { "{launch_dir}".to_string() }
 
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct AppCapabilities {

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -502,26 +502,67 @@ impl PlexiApp {
     }
 
     /// Open an app on the focused pane: auto-splits vertically, app on top,
-    /// fresh linked terminal on bottom.
+    /// fresh linked terminal on bottom. Uses the default 75/25 vertical layout.
     pub(crate) fn open_app_on_focused(
         &mut self,
         app: Box<dyn App>,
         permissions: crate::app_permissions::AppPermissions,
         scope: PathBuf,
     ) {
+        self.open_app_on_focused_with_launch(app, permissions, scope, None);
+    }
+
+    /// Open an app on the focused pane with an optional manifest-declared
+    /// launch configuration that overrides the split direction, size, and
+    /// companion terminal cwd.
+    ///
+    /// When `launch` is `None`, the legacy 75/25 vertical split is used and the
+    /// companion terminal inherits the previous pane's cwd (unchanged behavior).
+    /// When `launch` is `Some`, the split direction, fraction, and companion
+    /// cwd come from the config. `{launch_dir}` in `companion_cwd` is resolved
+    /// to the app's `scope`.
+    pub(crate) fn open_app_on_focused_with_launch(
+        &mut self,
+        app: Box<dyn App>,
+        permissions: crate::app_permissions::AppPermissions,
+        scope: PathBuf,
+        launch: Option<crate::app_registry::AppLaunchConfig>,
+    ) {
         let Some(focused) = self.contexts[self.active_context].focused_pane else {
             return;
         };
 
-        // Create a new terminal pane for the bottom split (same as split_focused).
+        // Resolve launch options (defaults match legacy behavior).
+        let vertical = match launch.as_ref().map(|l| l.companion_position.as_str()) {
+            Some("right") => false,
+            _ => true, // "bottom" or unset → vertical split (app on top)
+        };
+        // Fraction allocated to the companion terminal.
+        let companion_frac = launch
+            .as_ref()
+            .map(|l| l.companion_size.clamp(0.05, 0.95))
+            .unwrap_or(0.25);
+
+        // Companion terminal cwd:
+        //   - with launch config + `{launch_dir}` template → app's scope
+        //   - otherwise → previous focused pane's cwd (legacy)
+        let companion_cwd = if let Some(cfg) = launch.as_ref() {
+            if cfg.companion_cwd.contains("{launch_dir}") {
+                scope.clone()
+            } else {
+                PathBuf::from(&cfg.companion_cwd)
+            }
+        } else {
+            self.contexts[self.active_context]
+                .get_focused_pane_cwd(focused)
+                .unwrap_or_else(|| scope.clone())
+        };
+
+        // Create the companion terminal pane.
         let new_term_id = self.next_pane_id;
         self.next_pane_id += 1;
 
-        let cwd = self.contexts[self.active_context]
-            .get_focused_pane_cwd(focused)
-            .unwrap_or_else(|| scope.clone());
-
-        let settings = Self::make_backend_settings(Some(cwd), &self.colors);
+        let settings = Self::make_backend_settings(Some(companion_cwd), &self.colors);
         let Some(new_pane) = TerminalPane::new(
             new_term_id,
             self.ctx.clone(),
@@ -543,6 +584,12 @@ impl PlexiApp {
                 None => focused,
             };
 
+        let split_dir = if vertical {
+            egui_tiles::LinearDir::Vertical
+        } else {
+            egui_tiles::LinearDir::Horizontal
+        };
+
         let ctx = &mut self.contexts[self.active_context];
         let parent = ctx.tree.tiles.parent_of(split_target);
         let new_tile = ctx.tree.tiles.insert_pane(new_term_id);
@@ -551,7 +598,7 @@ impl PlexiApp {
             if let Some(Tile::Container(Container::Linear(linear))) =
                 ctx.tree.tiles.get_mut(parent_id)
             {
-                if linear.dir == egui_tiles::LinearDir::Vertical {
+                if linear.dir == split_dir {
                     if let Some(pos) = linear.children.iter().position(|&c| c == split_target) {
                         linear.children.insert(pos + 1, new_tile);
                         true
@@ -569,17 +616,19 @@ impl PlexiApp {
         };
 
         if !inserted_as_sibling {
-            let container_tile = ctx
-                .tree
-                .tiles
-                .insert_vertical_tile(vec![split_target, new_tile]);
+            let container_tile = if vertical {
+                ctx.tree.tiles.insert_vertical_tile(vec![split_target, new_tile])
+            } else {
+                ctx.tree.tiles.insert_horizontal_tile(vec![split_target, new_tile])
+            };
 
-            // Set 75/25 ratio for app (top) vs terminal (bottom).
+            // Set app / companion share ratio from config (or 0.75 / 0.25 default).
             if let Some(Tile::Container(Container::Linear(ref mut lin))) =
                 ctx.tree.tiles.get_mut(container_tile)
             {
-                lin.shares.set_share(split_target, 3.0);
-                lin.shares.set_share(new_tile, 1.0);
+                let app_share = (1.0 - companion_frac).max(0.05);
+                lin.shares.set_share(split_target, app_share);
+                lin.shares.set_share(new_tile, companion_frac);
             }
 
             if let Some(parent_id) = parent {
@@ -593,7 +642,7 @@ impl PlexiApp {
             }
         }
 
-        // Set the app on the focused (top) pane and link to the bottom terminal.
+        // Set the app on the focused (top) pane and link to the companion terminal.
         if let Some(egui_tiles::Tile::Pane(pane_id)) = ctx.tree.tiles.get(focused) {
             let pane_id = *pane_id;
             if let Some(pane) = ctx.panes.get_mut(&pane_id) {
@@ -730,9 +779,16 @@ impl PlexiApp {
             .and_then(|fp| self.contexts[self.active_context].get_focused_pane_cwd(fp))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
+        // Snapshot the manifest-declared launch config BEFORE calling into the
+        // registry (keeps the borrow of `self.registry` short).
+        let launch_cfg = self
+            .registry
+            .app_by_id(id)
+            .and_then(|installed| installed.manifest.launch.clone());
+
         if let Some(app) = self.registry.launch(id, &cwd, &[]) {
             let perms = crate::app_permissions::AppPermissions::default();
-            self.open_app_on_focused(app, perms, cwd);
+            self.open_app_on_focused_with_launch(app, perms, cwd, launch_cfg);
         } else {
             log::warn!("launch_app_by_id: app '{id}' not found or failed to launch");
         }
@@ -778,7 +834,12 @@ impl PlexiApp {
         if let Some(app) = self.registry.launch_for_file(&file_path, &cwd) {
             // Third-party app — sandboxed by default, scoped to launch directory.
             let perms = crate::app_permissions::AppPermissions::default();
-            self.open_app_on_focused(app, perms, cwd.clone());
+            // If the app declared [app.launch], honor its companion split config.
+            let launch_cfg = self
+                .registry
+                .app_by_id(app.type_id())
+                .and_then(|installed| installed.manifest.launch.clone());
+            self.open_app_on_focused_with_launch(app, perms, cwd.clone(), launch_cfg);
         } else {
             // No registered app — fall back to writing the path into the terminal.
             let ctx = &mut self.contexts[self.active_context];


### PR DESCRIPTION
Closes #113.

## Summary

Ships both deliverables from #113:

1. **Linked-pane manifest field** — new optional `[app.launch]` section in
   `manifest.toml` lets any app declare a companion pane (currently
   `companion = \"terminal\"`). Plexi splits the launching pane and starts
   the companion in the secondary slot, scoped to the same launch dir.
   Backwards compatible: apps without `[app.launch]` launch exactly as before.

2. **Parallax viewer app** (`examples/parallax/`) — view-only dashboard for
   a Parallax video project. Watches `.parallax/manifest.yaml`, renders a
   stills file_grid, a video_thumbnail of the latest output, and a list of
   parsed scenes. No chat, no input box — the chat lives in the companion
   terminal pane, exactly as the issue spec requires.

## Files touched

**Rust**
- \`src/app_registry.rs\` — add \`AppLaunchConfig\` struct + \`launch\` field on \`AppManifestApp\`
- \`src/pane_ops.rs\` — add \`open_app_on_focused_with_launch\`; wire \`launch_app_by_id\` and \`open_file_with_app\` to pass the manifest's launch config

**Python**
- \`examples/parallax/manifest.toml\` — declares \`[app.launch]\` with \`companion_size = 0.25\`, \`companion_cwd = \"{launch_dir}\"\`
- \`examples/parallax/parallax.py\` — the viewer (~300 lines, stdlib only)
- \`examples/parallax/plexi_sdk.py\`, \`plexi_test.py\` — copied alongside (standard pattern for example apps)
- \`examples/parallax/tests/test_parallax.py\` — lifecycle, empty-state, populated manifest, resize

**Infra**
- \`justfile\` — \`install-alpha\` now also syncs \`examples/*/\` → \`~/.plexi-alpha/apps/\`
- \`DEV_LOG.md\` — decision entry

## How to test

\`\`\`
just install-alpha
\`\`\`

This rebuilds Plexi Alpha and also copies the bundled example apps (parallax included) into \`~/.plexi-alpha/apps/\`.

A ready-to-go sample project is at \`~/Documents/parallax-projects/test-project/\` with 3 stub stills, a stub preview mp4, and a stub \`.parallax/manifest.yaml\` containing 3 scenes.

1. Open Plexi Alpha
2. \`plexi ~/Documents/parallax-projects/test-project/\` to open the project as a context
3. Launch the \"Parallax Viewer\" app from the command palette or launcher
4. You should see: viewer in the top ~75% (header + stills grid + video preview + scene list), fresh terminal in the bottom ~25% scoped to the project dir
5. Run \`parallax tests\`:
   \`\`\`
   cd examples/parallax && python3 tests/test_parallax.py
   \`\`\`

## Constraints honored

- No dependency on the (in-progress) Parallax CLI — the viewer reads the manifest file directly.
- Media draw commands (\`image\`, \`video_thumbnail\`, \`file_grid\`) are already in alpha (PR #120); not re-added.
- Python app is zero-deps — uses a ~30-line YAML subset parser instead of PyYAML.
- \`cargo build\` passes cleanly. \`cargo build --target wasm32-unknown-unknown\` has a pre-existing breakage on alpha (\`agent_mode\` references \`agent_llm\`/\`secrets\` which are \`cfg(not(target_arch = \"wasm32\"))\`). This PR does not touch those modules — the breakage reproduces on alpha HEAD without this patch.

## Screenshot

Not captured in this automated session (Plexi Alpha wasn't running and the viewer needs a human to click through the launcher + context flow). Follow the \"How to test\" steps above to see it in-app; the viewer renders the project name in the header, a 1-row file_grid of the 3 stub stills, a black-frame video_thumbnail, and 3 scene list items (\"desert sunrise over red mesas\", \"wide shot of a lone cowboy on horseback\", \"closing — dust settles…\").