### PR TITLE
feat: advanced UI SDK (python side) — canvas, hit test, frame timer, tweens

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,31 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [CHANGED] Advanced UI SDK (Python side) — Canvas, HitTester, DragHandler, FocusManager, FrameTimer, Tween + easings
+
+Shipped `sdk/python/plexi_sdk_advanced.py` (~460 lines, stdlib-only) and `sdk/python/tests/test_plexi_sdk_advanced.py` (17 tests, all passing). Imports and extends the simple SDK without forking it. Unblocks future canvas/game/animation apps (snake, aquarium, pyflow) on the Python side.
+
+**Modules shipped:**
+- `Canvas(offset, scale, bounds)` — pan/zoom transform context. `with canvas.transform(ctx):` patches `ctx.rect/text/line/image` for the duration of the block to pre-apply offset+scale, then restores cleanly on exit (delete-instance-attr so descriptor lookup falls back to the class method). Also `screen_to_canvas` / `canvas_to_screen` / `zoom_to_fit(content_bounds, viewport, padding)`.
+- `HitTester` / `HitRegion` — O(n) registered-rect hit testing. `register/clear/test`. Topmost (last-registered) wins.
+- `DragHandler(threshold)` — `start`/`update`/`end`/`active`/`payload`. Threshold-gated: deltas are `(0,0)` until the user moves past the pixel threshold.
+- `FocusManager` — `set` / `current` / `register` / `dispatch`. Keyboard routing for named widgets.
+- `FrameTimer(interval)` — `ready()` / `elapsed()` / `set_interval(new)`. Uses `time.monotonic()` so it works WITHOUT protocol-level `delta_time`. Accepts an optional `dt_override` arg for forward compatibility.
+- `Tween(start, end, duration, easing)` — wall-clock interpolation. `value()` / `done` / `reset()`. Easings: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `ease_out_cubic`, `ease_out_bounce`.
+
+**Deliberately deferred to Rust-side follow-ups (issue #132):**
+- `mouse_down` / `mouse_up` / `mouse_move` / `scroll` events — `DragHandler` and `Canvas.handle_input` are stubs/partial until these land.
+- `delta_time` / `time` on render events — `FrameTimer`/`Tween` use `time.monotonic()` for now; the `dt_override` hook is in place for the upgrade.
+- New draw commands (`bezier`, `circle`, `arc`, `clip`/`clip_end`, `opacity`/`opacity_end`) — needed for node-graph edges and clipped scroll containers.
+- `mouse_tracking = true` capability flag in `manifest.toml`.
+
+**Also deferred:** `LayerStack` (spec calls it deferrable; the simple SDK already accumulates draw commands in append order, and a layer abstraction isn't free without either tagging commands by layer index on `_commands` or running user callbacks twice — skip until an app actually needs it). Documented as a TODO comment in the file.
+
+**Key decision: monkey-patch ctx draw methods inside `transform()`.** The simple SDK's `RenderContext` doesn't expose a transform stack or a hook to wrap draw calls. Editing the simple SDK to add one was out of scope (constraint: "do not modify plexi_sdk.py"). Monkey-patching the bound methods on a per-instance basis for the duration of a `with` block is the cleanest path that satisfies "transform applies to all draws inside" without forking the SDK or making apps thread a transform argument through every call. On `__enter__` we capture whether the instance had a pre-existing instance attribute for each method (it doesn't, by default), set the patched function as an instance attribute, and on `__exit__` either restore the original instance attribute or `delattr` so descriptor lookup resumes through the class method. Test confirms this restores correctly even on exception.
+
+**Why `time.monotonic()` for FrameTimer/Tween instead of protocol time:** the spec shows `ft.ready(ctx.delta_time)` but `delta_time` doesn't exist in the protocol yet. Wall-clock `time.monotonic()` is correct enough for MVP — frame timer accuracy is bounded by render frequency anyway, and a monotonic-clock-driven tween renders identically to a delta-driven tween at any given instant. The `dt_override` parameter on `FrameTimer.ready()` is the forward-compatibility hook: once Plexi sends `delta_time` on render events, apps pass it through and the API stays stable.
+
+**Out of scope and untouched:** all `src/*.rs` files, the simple `plexi_sdk.py`, all installed apps under `~/.plexi-alpha/apps/`, and `sdk/python/examples/`. `cargo check` passes (verified pre-commit). No new dependencies added.
+
 ## 2026-04-12 — [CHANGED] Massive parallel-agent build session — alpha now includes Layer 0/1/2/4 + WASM Phase 1 + media draw commands + Finder Service + notifications
 
 End-of-day state. Alpha is at `a9a181e`. Built and installed via `just install-alpha`. The session ran ~15 sub-agents in parallel worktrees and shipped 6 PRs (#108, #109, #110, #112, #117, #120) plus a follow-up roadmap rewrite.

--- a/sdk/python/plexi_sdk_advanced.py
+++ b/sdk/python/plexi_sdk_advanced.py
@@ -1,0 +1,460 @@
+"""
+plexi_sdk_advanced.py — Advanced UI SDK for Plexi (Python).
+
+Higher-level abstractions over plexi_sdk.py for canvas/game/interactive apps:
+canvas transforms, hit testing, drag handling, focus routing, frame timing,
+and tween animation. Zero new dependencies — stdlib + plexi_sdk only.
+
+Apps copy this file next to plexi_sdk.py:
+
+    from plexi_sdk import App
+    from plexi_sdk_advanced import Canvas, HitTester, FrameTimer, Tween, ease_out_cubic
+
+Spec: docs/specs/core-advanced-ui-sdk.md
+
+NOTE: Several modules here depend on Rust-side protocol extensions that have
+not landed yet (mouse_down/up/move events, scroll, delta_time on render). The
+Python side is shipped first so apps that need it can begin work; the dynamic
+parts gracefully degrade until the protocol catches up. See follow-up issue
+listed in DEV_LOG for the Rust-side work.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Tuple
+
+from plexi_sdk import RenderContext  # noqa: F401  (re-exported for convenience)
+
+
+# ----------------------------------------------------------------------------
+# Canvas — pan/zoom transform context
+# ----------------------------------------------------------------------------
+
+
+class Canvas:
+    """Pan/zoom coordinate space for draw calls.
+
+    Use as a context manager via ``canvas.transform(ctx)`` to apply offset+scale
+    to all draws inside the block.
+    """
+
+    def __init__(
+        self,
+        offset: Tuple[float, float] = (0.0, 0.0),
+        scale: float = 1.0,
+        bounds: Optional[Tuple[float, float, float, float]] = None,
+    ):
+        self.offset: Tuple[float, float] = offset
+        self.scale: float = scale
+        # Optional content bounds (x, y, w, h) — used by zoom_to_fit / clamping.
+        self.bounds: Optional[Tuple[float, float, float, float]] = bounds
+
+    # -- coordinate conversion ------------------------------------------------
+
+    def screen_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert screen pixel to canvas coordinate."""
+        ox, oy = self.offset
+        return ((x - ox) / self.scale, (y - oy) / self.scale)
+
+    def canvas_to_screen(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert canvas coordinate to screen pixel."""
+        ox, oy = self.offset
+        return (x * self.scale + ox, y * self.scale + oy)
+
+    # -- viewport fitting -----------------------------------------------------
+
+    def zoom_to_fit(
+        self,
+        content_bounds: Tuple[float, float, float, float],
+        viewport: Tuple[float, float],
+        padding: float = 20.0,
+    ) -> None:
+        """Set offset/scale so ``content_bounds`` fills the viewport with padding."""
+        cx, cy, cw, ch = content_bounds
+        vw, vh = viewport
+        if cw <= 0 or ch <= 0 or vw <= 0 or vh <= 0:
+            return
+        avail_w = max(1.0, vw - 2 * padding)
+        avail_h = max(1.0, vh - 2 * padding)
+        self.scale = min(avail_w / cw, avail_h / ch)
+        # Center the content rect inside the viewport at the new scale.
+        scaled_w = cw * self.scale
+        scaled_h = ch * self.scale
+        self.offset = (
+            (vw - scaled_w) / 2.0 - cx * self.scale,
+            (vh - scaled_h) / 2.0 - cy * self.scale,
+        )
+
+    # -- transform context manager -------------------------------------------
+
+    def transform(self, ctx: RenderContext) -> "_CanvasTransform":
+        """Returns a context manager that patches ``ctx`` draw methods to
+        pre-apply offset+scale. Restores originals on exit.
+        """
+        return _CanvasTransform(self, ctx)
+
+    # -- input (stub for future protocol extensions) -------------------------
+
+    def handle_input(self, event: Any) -> bool:  # pragma: no cover
+        """Stub. Pan/zoom from mouse_move/scroll requires Rust-side protocol
+        events that don't exist yet. Returns False (event not handled).
+        """
+        return False
+
+
+class _CanvasTransform:
+    """Context manager that monkey-patches ``ctx`` draw methods to apply the
+    canvas's offset+scale. The simple SDK's RenderContext doesn't expose a
+    transform stack, so we patch the bound methods for the duration of the
+    block. Original methods restored on exit (even on exception).
+    """
+
+    # Methods to wrap. Each entry is (method_name, point_args, size_args).
+    # point_args are scaled-and-offset; size_args are scale-only.
+    _METHODS: Tuple[Tuple[str, Tuple[str, ...], Tuple[str, ...]], ...] = (
+        ("rect", ("x", "y"), ("w", "h")),
+        ("text", ("x", "y"), ("size",)),
+        ("line", ("x1", "y1", "x2", "y2"), ("width",)),
+        ("image", ("x", "y"), ("w", "h")),
+    )
+
+    def __init__(self, canvas: Canvas, ctx: RenderContext):
+        self._canvas = canvas
+        self._ctx = ctx
+        self._originals: dict = {}
+
+    def __enter__(self) -> "_CanvasTransform":
+        canvas = self._canvas
+        ctx = self._ctx
+
+        for name, point_args, size_args in self._METHODS:
+            class_method = getattr(type(ctx), name, None)
+            if class_method is None:
+                continue
+            # Capture whether the instance had its own attribute pre-patch so
+            # we restore exactly (delete vs. reset).
+            had_instance_attr = name in ctx.__dict__
+            original_instance_value = ctx.__dict__.get(name)
+            self._originals[name] = (had_instance_attr, original_instance_value)
+            bound_original = getattr(ctx, name)
+            setattr(ctx, name, _wrap_draw(bound_original, canvas, point_args, size_args))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for name, (had_instance_attr, original_value) in self._originals.items():
+            if had_instance_attr:
+                setattr(self._ctx, name, original_value)
+            else:
+                # Delete the patched instance attribute so descriptor lookup
+                # falls back through to the class method (clean restore).
+                try:
+                    delattr(self._ctx, name)
+                except AttributeError:
+                    pass
+        self._originals.clear()
+
+
+def _wrap_draw(
+    original: Callable,
+    canvas: Canvas,
+    point_args: Tuple[str, ...],
+    size_args: Tuple[str, ...],
+) -> Callable:
+    """Wrap a draw method so coordinates are translated through the canvas."""
+
+    def wrapped(*args, **kwargs):
+        # Re-read offset/scale on every call so live updates apply.
+        cox, coy = canvas.offset
+        s = canvas.scale
+
+        # Map positional args by inspecting parameter names of the original.
+        # Easiest robust path: convert positional to kwargs by reading the
+        # method's parameter order. Use __code__.co_varnames (skip 'self').
+        code = getattr(original, "__code__", None)
+        if code is not None and args:
+            varnames = code.co_varnames[1 : code.co_argcount]
+            for i, val in enumerate(args):
+                if i < len(varnames):
+                    kwargs[varnames[i]] = val
+            args = ()
+
+        # Pair x/y point args (translate + scale).
+        # point_args may be a flat list of names: handle as pairs (x,y),(x1,y1)...
+        for i in range(0, len(point_args), 2):
+            xn = point_args[i]
+            yn = point_args[i + 1] if i + 1 < len(point_args) else None
+            if xn in kwargs and yn is not None and yn in kwargs:
+                kwargs[xn] = kwargs[xn] * s + cox
+                kwargs[yn] = kwargs[yn] * s + coy
+
+        # Scale-only args (sizes, widths).
+        for sn in size_args:
+            if sn in kwargs:
+                kwargs[sn] = kwargs[sn] * s
+
+        return original(**kwargs)
+
+    return wrapped
+
+
+# ----------------------------------------------------------------------------
+# HitTester — register rectangles, test a point
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class HitRegion:
+    """A registered hit-test rectangle."""
+
+    id: Any
+    x: float
+    y: float
+    w: float
+    h: float
+
+    def contains(self, x: float, y: float) -> bool:
+        return self.x <= x < self.x + self.w and self.y <= y < self.y + self.h
+
+
+class HitTester:
+    """Register rectangles with IDs each frame, then test a point.
+
+    O(n) is fine for MVP — designed for ~100 nodes max. Last-registered wins
+    (matches painter's-model draw order: top-of-stack is hit first).
+    """
+
+    def __init__(self):
+        self._regions: list[HitRegion] = []
+
+    def clear(self) -> None:
+        """Reset registered regions. Call at the start of each render frame."""
+        self._regions.clear()
+
+    def register(self, id: Any, x: float, y: float, w: float, h: float) -> HitRegion:
+        """Add a region. Returns the created HitRegion."""
+        region = HitRegion(id=id, x=x, y=y, w=w, h=h)
+        self._regions.append(region)
+        return region
+
+    def test(self, x: float, y: float) -> Optional[HitRegion]:
+        """Return topmost (last-registered) region containing the point."""
+        for region in reversed(self._regions):
+            if region.contains(x, y):
+                return region
+        return None
+
+
+# ----------------------------------------------------------------------------
+# DragHandler — minimal drag state machine
+# ----------------------------------------------------------------------------
+
+
+class DragHandler:
+    """Drag-gesture state machine.
+
+    NOTE: Full drag requires ``mouse_move`` and ``mouse_up`` events that are
+    not yet in the Plexi protocol. Apps using this get partial functionality
+    until those events land. Track via the follow-up issue referenced in
+    DEV_LOG entry for this PR.
+    """
+
+    def __init__(self, threshold: float = 4.0):
+        self.threshold: float = threshold
+        self.active: bool = False
+        self.payload: Any = None
+        self._start: Tuple[float, float] = (0.0, 0.0)
+        self._last: Tuple[float, float] = (0.0, 0.0)
+        self._armed: bool = False
+
+    def start(self, x: float, y: float, payload: Any = None) -> None:
+        """Begin tracking a potential drag at (x, y)."""
+        self._start = (x, y)
+        self._last = (x, y)
+        self.payload = payload
+        self._armed = True
+        self.active = False
+
+    def update(self, x: float, y: float) -> Tuple[float, float]:
+        """Return delta since last update. Returns (0, 0) before threshold."""
+        if not self._armed:
+            return (0.0, 0.0)
+        if not self.active:
+            sx, sy = self._start
+            if math.hypot(x - sx, y - sy) >= self.threshold:
+                self.active = True
+                self._last = (x, y)
+                return (0.0, 0.0)
+            return (0.0, 0.0)
+        lx, ly = self._last
+        dx, dy = x - lx, y - ly
+        self._last = (x, y)
+        return (dx, dy)
+
+    def end(self) -> Any:
+        """Stop tracking. Returns the payload supplied at start."""
+        payload = self.payload
+        self.active = False
+        self._armed = False
+        self.payload = None
+        return payload
+
+
+# ----------------------------------------------------------------------------
+# FocusManager — route keyboard input to named widgets
+# ----------------------------------------------------------------------------
+
+
+class FocusManager:
+    """Tracks which named widget currently owns keyboard focus."""
+
+    def __init__(self):
+        self.current: Optional[str] = None
+        self._handlers: dict[str, Callable] = {}
+
+    def set(self, name: Optional[str]) -> None:
+        """Set the focused widget name (or None to clear)."""
+        self.current = name
+
+    def register(self, name: str, handler: Callable) -> None:
+        """Register a handler for a named widget. Optional — apps can also
+        check ``focus.current`` directly in their on_key handler."""
+        self._handlers[name] = handler
+
+    def dispatch(self, *args, **kwargs) -> bool:
+        """Dispatch to the current focus handler if registered. Returns True
+        if a handler was called."""
+        if self.current and self.current in self._handlers:
+            self._handlers[self.current](*args, **kwargs)
+            return True
+        return False
+
+
+# ----------------------------------------------------------------------------
+# FrameTimer — fixed-interval tick loop using wall-clock time
+# ----------------------------------------------------------------------------
+
+
+class FrameTimer:
+    """Ticks True every ``interval`` seconds. Uses ``time.monotonic()`` so it
+    works without protocol-level delta_time. ``dt_override`` is accepted for
+    forward compatibility once Plexi sends delta_time on render events.
+    """
+
+    def __init__(self, interval: float):
+        self.interval: float = interval
+        self._last_tick: float = time.monotonic()
+
+    def ready(self, dt_override: Optional[float] = None) -> bool:
+        """Return True once per ``interval`` window. Resets the window on True."""
+        now = time.monotonic()
+        if (now - self._last_tick) >= self.interval:
+            self._last_tick = now
+            return True
+        return False
+
+    def elapsed(self) -> float:
+        """Seconds since the last tick that returned True."""
+        return time.monotonic() - self._last_tick
+
+    def set_interval(self, new_interval: float) -> None:
+        """Change the tick interval (e.g. snake speed-up)."""
+        self.interval = new_interval
+
+
+# ----------------------------------------------------------------------------
+# Easing functions
+# ----------------------------------------------------------------------------
+
+
+def linear(t: float) -> float:
+    return t
+
+
+def ease_in(t: float) -> float:
+    return t * t
+
+
+def ease_out(t: float) -> float:
+    return 1.0 - (1.0 - t) * (1.0 - t)
+
+
+def ease_in_out(t: float) -> float:
+    if t < 0.5:
+        return 2.0 * t * t
+    return 1.0 - (-2.0 * t + 2.0) ** 2 / 2.0
+
+
+def ease_out_cubic(t: float) -> float:
+    return 1.0 - (1.0 - t) ** 3
+
+
+def ease_out_bounce(t: float) -> float:
+    n1 = 7.5625
+    d1 = 2.75
+    if t < 1.0 / d1:
+        return n1 * t * t
+    if t < 2.0 / d1:
+        t -= 1.5 / d1
+        return n1 * t * t + 0.75
+    if t < 2.5 / d1:
+        t -= 2.25 / d1
+        return n1 * t * t + 0.9375
+    t -= 2.625 / d1
+    return n1 * t * t + 0.984375
+
+
+# ----------------------------------------------------------------------------
+# Tween — interpolate a value over wall-clock time
+# ----------------------------------------------------------------------------
+
+
+class Tween:
+    """Interpolate a value from ``start`` to ``end`` over ``duration`` seconds."""
+
+    def __init__(
+        self,
+        start: float,
+        end: float,
+        duration: float,
+        easing: Callable[[float], float] = linear,
+    ):
+        self.start: float = start
+        self.end: float = end
+        self.duration: float = max(1e-9, duration)
+        self.easing: Callable[[float], float] = easing
+        self._t0: float = time.monotonic()
+
+    def reset(self) -> None:
+        """Restart the tween from t=0 at the current wall-clock time."""
+        self._t0 = time.monotonic()
+
+    def value(self, now: Optional[float] = None) -> float:
+        """Return the interpolated value at the current (or supplied) time."""
+        t_now = now if now is not None else time.monotonic()
+        elapsed = t_now - self._t0
+        if elapsed <= 0.0:
+            return self.start
+        if elapsed >= self.duration:
+            return self.end
+        t = elapsed / self.duration
+        return self.start + (self.end - self.start) * self.easing(t)
+
+    @property
+    def done(self) -> bool:
+        return (time.monotonic() - self._t0) >= self.duration
+
+
+# ----------------------------------------------------------------------------
+# LayerStack — TODO: deferred until simple SDK exposes a draw-order hook.
+# ----------------------------------------------------------------------------
+#
+# The simple SDK already accumulates draw commands in append order and flushes
+# them at frame end (RenderContext._commands + _flush). A LayerStack would need
+# to either (a) intercept _commands during a `with layer.draw(...)` block and
+# tag each command with a layer index, then sort on flush, or (b) maintain its
+# own per-layer command lists. Both work, but require either patching
+# _commands or running the user's draw callbacks twice. Spec calls this
+# deferrable; skipping for MVP.

--- a/sdk/python/tests/test_plexi_sdk_advanced.py
+++ b/sdk/python/tests/test_plexi_sdk_advanced.py
@@ -1,0 +1,220 @@
+"""Unit tests for plexi_sdk_advanced. Stdlib unittest, no external deps.
+
+Run with:
+    python3 sdk/python/tests/test_plexi_sdk_advanced.py
+"""
+
+import os
+import sys
+import time
+import unittest
+
+# Make `import plexi_sdk[_advanced]` work when this file is run directly.
+HERE = os.path.dirname(os.path.abspath(__file__))
+SDK_DIR = os.path.abspath(os.path.join(HERE, ".."))
+if SDK_DIR not in sys.path:
+    sys.path.insert(0, SDK_DIR)
+
+from plexi_sdk import RenderContext  # noqa: E402
+from plexi_sdk_advanced import (  # noqa: E402
+    Canvas,
+    DragHandler,
+    FocusManager,
+    FrameTimer,
+    HitTester,
+    Tween,
+    ease_in,
+    ease_out_cubic,
+    linear,
+)
+
+
+class TestCanvas(unittest.TestCase):
+    def test_screen_canvas_roundtrip_identity(self):
+        canvas = Canvas()
+        for x, y in [(0.0, 0.0), (123.4, -56.7), (1000.0, 999.0)]:
+            cx, cy = canvas.screen_to_canvas(x, y)
+            sx, sy = canvas.canvas_to_screen(cx, cy)
+            self.assertAlmostEqual(sx, x, places=6)
+            self.assertAlmostEqual(sy, y, places=6)
+
+    def test_roundtrip_with_offset_and_scale(self):
+        canvas = Canvas(offset=(50.0, -20.0), scale=2.5)
+        for x, y in [(0.0, 0.0), (10.0, 10.0), (-7.5, 42.0)]:
+            cx, cy = canvas.screen_to_canvas(x, y)
+            sx, sy = canvas.canvas_to_screen(cx, cy)
+            self.assertAlmostEqual(sx, x, places=6)
+            self.assertAlmostEqual(sy, y, places=6)
+
+    def test_zoom_to_fit_centers_content(self):
+        canvas = Canvas()
+        # 100x100 content into 200x200 viewport, no padding for predictability.
+        canvas.zoom_to_fit((0.0, 0.0, 100.0, 100.0), (200.0, 200.0), padding=0.0)
+        self.assertAlmostEqual(canvas.scale, 2.0, places=6)
+        # Content (0,0)..(100,100) at scale 2 → screen (0,0)..(200,200): centered.
+        sx, sy = canvas.canvas_to_screen(0.0, 0.0)
+        self.assertAlmostEqual(sx, 0.0, places=6)
+        self.assertAlmostEqual(sy, 0.0, places=6)
+        sx, sy = canvas.canvas_to_screen(100.0, 100.0)
+        self.assertAlmostEqual(sx, 200.0, places=6)
+        self.assertAlmostEqual(sy, 200.0, places=6)
+
+    def test_transform_patches_and_restores_ctx(self):
+        canvas = Canvas(offset=(10.0, 20.0), scale=2.0)
+        ctx = RenderContext(800.0, 600.0)
+        original_rect = ctx.rect
+        original_text = ctx.text
+        with canvas.transform(ctx):
+            self.assertNotEqual(ctx.rect, original_rect)
+            ctx.rect(5.0, 5.0, 10.0, 10.0, fill="#ff0000")
+        # Methods restored — bound methods compare equal when same instance+func.
+        self.assertEqual(ctx.rect, original_rect)
+        self.assertEqual(ctx.text, original_text)
+        # The recorded command should reflect canvas-space (5,5) → screen
+        # (5*2+10, 5*2+20) = (20, 30) and size 10*2 = 20.
+        cmd = ctx._commands[0]
+        self.assertEqual(cmd["type"], "rect")
+        self.assertAlmostEqual(cmd["x"], 20.0)
+        self.assertAlmostEqual(cmd["y"], 30.0)
+        self.assertAlmostEqual(cmd["w"], 20.0)
+        self.assertAlmostEqual(cmd["h"], 20.0)
+        self.assertEqual(cmd["fill"], "#ff0000")
+
+    def test_transform_restores_on_exception(self):
+        canvas = Canvas(scale=3.0)
+        ctx = RenderContext(800.0, 600.0)
+        original_rect = ctx.rect
+        with self.assertRaises(RuntimeError):
+            with canvas.transform(ctx):
+                raise RuntimeError("boom")
+        self.assertEqual(ctx.rect, original_rect)
+
+
+class TestHitTester(unittest.TestCase):
+    def test_topmost_wins_on_overlap(self):
+        ht = HitTester()
+        ht.register("bottom", 0, 0, 100, 100)
+        ht.register("top", 50, 50, 100, 100)
+        # Inside both — top (last-registered) wins.
+        hit = ht.test(60, 60)
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit.id, "top")
+        # Inside only bottom.
+        hit = ht.test(10, 10)
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit.id, "bottom")
+        # Outside both.
+        self.assertIsNone(ht.test(500, 500))
+
+    def test_clear_resets_state(self):
+        ht = HitTester()
+        ht.register("a", 0, 0, 10, 10)
+        ht.clear()
+        self.assertIsNone(ht.test(5, 5))
+
+
+class TestDragHandler(unittest.TestCase):
+    def test_threshold_not_yet_passed(self):
+        drag = DragHandler(threshold=4.0)
+        drag.start(100.0, 100.0, payload="node-1")
+        # Move 2px — under threshold.
+        dx, dy = drag.update(102.0, 100.0)
+        self.assertEqual((dx, dy), (0.0, 0.0))
+        self.assertFalse(drag.active)
+
+    def test_threshold_activates_drag(self):
+        drag = DragHandler(threshold=4.0)
+        drag.start(100.0, 100.0, payload="node-1")
+        # Move 5px — over threshold; first activation returns (0,0).
+        dx, dy = drag.update(105.0, 100.0)
+        self.assertEqual((dx, dy), (0.0, 0.0))
+        self.assertTrue(drag.active)
+        # Subsequent move yields the actual delta.
+        dx, dy = drag.update(110.0, 103.0)
+        self.assertAlmostEqual(dx, 5.0)
+        self.assertAlmostEqual(dy, 3.0)
+        # Cumulative deltas track from the previous update, not from start.
+        dx, dy = drag.update(108.0, 105.0)
+        self.assertAlmostEqual(dx, -2.0)
+        self.assertAlmostEqual(dy, 2.0)
+
+    def test_payload_round_trips(self):
+        drag = DragHandler(threshold=1.0)
+        drag.start(0.0, 0.0, payload={"id": 7})
+        drag.update(2.0, 0.0)
+        payload = drag.end()
+        self.assertEqual(payload, {"id": 7})
+        self.assertFalse(drag.active)
+        self.assertIsNone(drag.payload)
+
+
+class TestFrameTimer(unittest.TestCase):
+    def test_ready_fires_after_interval(self):
+        ft = FrameTimer(interval=0.05)
+        # Immediately after construction, not ready.
+        self.assertFalse(ft.ready())
+        # Wait past interval.
+        time.sleep(0.07)
+        self.assertTrue(ft.ready())
+        # Resets — not ready again immediately.
+        self.assertFalse(ft.ready())
+
+    def test_set_interval(self):
+        ft = FrameTimer(interval=10.0)
+        ft.set_interval(0.01)
+        self.assertEqual(ft.interval, 0.01)
+        time.sleep(0.02)
+        self.assertTrue(ft.ready())
+
+
+class TestTween(unittest.TestCase):
+    def test_value_at_endpoints(self):
+        tw = Tween(start=0.0, end=100.0, duration=1.0, easing=linear)
+        # t=0
+        self.assertAlmostEqual(tw.value(tw._t0), 0.0)
+        # t=duration
+        self.assertAlmostEqual(tw.value(tw._t0 + 1.0), 100.0)
+        # Past duration clamps to end.
+        self.assertAlmostEqual(tw.value(tw._t0 + 99.0), 100.0)
+
+    def test_monotonic_between(self):
+        tw = Tween(start=0.0, end=100.0, duration=1.0, easing=linear)
+        prev = -1.0
+        for i in range(11):
+            v = tw.value(tw._t0 + i / 10.0)
+            self.assertGreaterEqual(v, prev)
+            prev = v
+
+    def test_easing_function_used(self):
+        # ease_in is t*t — at t=0.5, value should be 0.25 of the way.
+        tw = Tween(start=0.0, end=100.0, duration=1.0, easing=ease_in)
+        v = tw.value(tw._t0 + 0.5)
+        self.assertAlmostEqual(v, 25.0, places=4)
+        # ease_out_cubic at t=0.5 = 1 - 0.5^3 = 0.875
+        tw2 = Tween(start=0.0, end=100.0, duration=1.0, easing=ease_out_cubic)
+        v2 = tw2.value(tw2._t0 + 0.5)
+        self.assertAlmostEqual(v2, 87.5, places=4)
+
+
+class TestFocusManager(unittest.TestCase):
+    def test_set_and_current(self):
+        focus = FocusManager()
+        self.assertIsNone(focus.current)
+        focus.set("editor")
+        self.assertEqual(focus.current, "editor")
+        focus.set(None)
+        self.assertIsNone(focus.current)
+
+    def test_dispatch_to_registered_handler(self):
+        focus = FocusManager()
+        received = []
+        focus.register("editor", lambda key: received.append(key))
+        # Nothing focused — dispatch is a no-op and returns False.
+        self.assertFalse(focus.dispatch("a"))
+        focus.set("editor")
+        self.assertTrue(focus.dispatch("x"))
+        self.assertEqual(received, ["x"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Ships the Python side of the Advanced UI SDK described in `docs/specs/core-advanced-ui-sdk.md`. New file `sdk/python/plexi_sdk_advanced.py` (~460 lines, stdlib only) imports and extends the simple `plexi_sdk.py` without forking it. Unblocks future canvas/game/animation apps (snake, aquarium, pyflow) on the Python side.

This PR is intentionally Python-only. The matching Rust-side protocol work (new mouse events, `delta_time`, new draw commands) is deferred to a separate PR — tracked in #132.

## Modules shipped

- **`Canvas`** — pan/zoom transform context. `with canvas.transform(ctx):` patches `ctx.rect/text/line/image` for the duration of the block to pre-apply offset+scale, then restores cleanly on exit. Plus `screen_to_canvas` / `canvas_to_screen` / `zoom_to_fit`.
- **`HitTester` / `HitRegion`** — register rectangles each frame, test a point. Topmost (last-registered) wins.
- **`DragHandler`** — threshold-gated drag state machine (`start` / `update` / `end` / `active` / `payload`).
- **`FocusManager`** — keyboard routing for named widgets (`set` / `current` / `register` / `dispatch`).
- **`FrameTimer`** — fixed-interval tick loop using `time.monotonic()` so it works WITHOUT protocol-level `delta_time`. Accepts `dt_override` for forward compatibility.
- **`Tween` + easings** — wall-clock interpolation with `linear`, `ease_in`, `ease_out`, `ease_in_out`, `ease_out_cubic`, `ease_out_bounce`.

## Deferred (Rust-side follow-up: #132)

- New input events: `mouse_down`, `mouse_up`, `mouse_move`, `scroll` — `DragHandler` and `Canvas.handle_input` are stubs/partial until these land.
- `delta_time` / `time` on render events — `FrameTimer`/`Tween` use `time.monotonic()` for now; the `dt_override` hook is in place for the upgrade.
- New draw commands: `bezier`, `circle`, `arc`, `clip`/`clip_end`, `opacity`/`opacity_end`.
- `mouse_tracking = true` capability flag in `manifest.toml`.

`LayerStack` is also deferred (spec calls it deferrable). Documented as a TODO comment in the file — revisit when an app actually needs it.

## Apps this unblocks

- **snake** — `FrameTimer` for tick rate, `set_interval` for speed-up.
- **aquarium** — `Tween` + easings for fish motion, `Canvas` if it goes pannable.
- **pyflow** (future) — `Canvas` for the node graph, `HitTester` for node selection. (Full drag waits on Rust-side mouse events.)

## Test plan

- [x] Run unit tests: `python3 sdk/python/tests/test_plexi_sdk_advanced.py` — 17 passing
- [x] `cargo check` — clean (verified no Rust files touched)
- [x] No new dependencies (stdlib + plexi_sdk only)
- [x] Line count under 500 (460)
- [ ] Reviewer: confirm the monkey-patch approach in `Canvas.transform` is acceptable given the constraint that the simple SDK can't be modified in this PR

## Files

- `sdk/python/plexi_sdk_advanced.py` (new, 460 lines)
- `sdk/python/tests/test_plexi_sdk_advanced.py` (new, 220 lines)
- `DEV_LOG.md` (new top entry)