### PR TITLE
feat: mouse events, delta_time, SetCursor (#132)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,33 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [CHANGED] Mouse events, delta_time, SetCursor — issue #132
+
+Added full mouse input and animation timing to the app protocol. New `PlexiEvent` variants: `MouseDown`, `MouseUp`, `MouseMove`, `Scroll`. `Render` now carries `delta_time: f32` (seconds since last frame). New `DrawCommand` variants: `SetCursor` (maps string → `egui::CursorIcon`), `MouseTracking` (stateful opt-in for move events).
+
+**Key decisions:**
+- Mouse methods (`send_mouse_down`, `send_mouse_up`, `send_mouse_move`, `send_scroll`, `mouse_tracking_enabled`) live on the `App` trait with default no-ops, not on `ProcessApp` directly. This avoids downcasting in `tiling.rs` and keeps the pattern consistent with `handle_drop`.
+- Mouse events detected in `tiling.rs` inside the `AppActive` arm, gated on `is_focused`. `PointerButton` events (press/release) and `MouseMoved` events are pulled from `ui.input(|i| i.events)`. Scroll uses `i.smooth_scroll_delta` — smoother than raw scroll delta on trackpads.
+- `mouse_tracking` initialized from manifest at launch via new `ProcessApp::launch(mouse_tracking: bool)` parameter (one call site). Apps can also toggle it at runtime via `MouseTracking` draw command.
+- `SetCursor` is stateless per-frame: cleared by `pending_cursor.take()` each `ui()` call. Apps must re-emit it every frame (same as `DropTarget`).
+- `delta_time` computed from `Instant::now()` diff on `ProcessApp`. Reset on hot-reload restart.
+- Python SDK: `RenderContext` gets `delta_time` field populated from event. New decorators `on_mouse_down/up/move/scroll`. New `ctx.set_cursor()` and `ctx.mouse_tracking()` draw helpers. `App.delta_time` stored at class level for access outside render handler.
+
+## 2026-04-12 — [GOTCHA] macOS system Python is 3.9 — `str | None` union syntax crashes all apps launched from the GUI
+
+When Plexi is installed as a `.app` bundle and launched from Finder (or Spotlight), macOS GUI apps do not inherit the user's shell PATH. The shebang `#!/usr/bin/env python3` resolves to `/usr/bin/python3` which is **Python 3.9.6** — Apple's system Python, frozen at a pre-union-type version. The user's Homebrew Python 3.11+ at `/usr/local/bin/python3` is **never found**.
+
+`str | None` (PEP 604 union syntax) requires Python 3.10+. Any app file using this syntax crashes immediately at module load time with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. Same for `list[str]` as a subscript in type annotations if on 3.8 (3.9 handles it fine).
+
+**Fix applied:** Add `from __future__ import annotations` as the first statement after the shebang in every app Python file. This defers ALL annotation evaluation to string form at compile time, making `str | None` safe on Python 3.7+.
+
+**Files fixed:** `examples/parallax/parallax.py`, `examples/hello-app/hello_app.py`, `examples/github-issues/github_issues.py`.
+
+**Do NOT do:** write `Optional[str]` as a workaround — that's uglier and still requires `from typing import Optional`. The `from __future__ import annotations` fix is global and cleaner.
+
+**Long-term fix:** Bundle a specific Python with the app so version is guaranteed. Track as a follow-up issue.
+
+**Also fixed:** `just install-alpha` syncs apps but doesn't set +x on .py entry points. After any `install-alpha`, run `chmod +x ~/.plexi-alpha/apps/*/*.py`.
+
 ## 2026-04-12 — [CHANGED] Inline (Warp-style) agent mode + fix #123 — bytes injected into the alacritty grid via a borrowed VTE parser
 
 Killed the full-pane agent panel. Agent turns now render directly into the same scrollback grid as shell output: a `>>> ` prompt indicator appears, keystrokes echo into the grid, the LLM reply is converted from markdown to ANSI and written into the grid, then a fresh `>>> ` appears for the next turn. Escape exits and hands control back to the shell.

--- a/examples/aquarium/aquarium.py
+++ b/examples/aquarium/aquarium.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+aquarium — Plexi app
+Ambient underwater scene with procedurally animated fish and plants.
+No user input required — pure ambient animation.
+"""
+
+import math
+import os
+import random
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha + aquatic palette
+# ---------------------------------------------------------------------------
+
+C = {
+    "water_top":    "#2a2a4e",
+    "water_bottom": "#1e1e3e",
+    "sand":         "#585b70",
+    "sand_light":   "#6c7086",
+    "plant_green":  "#a6e3a1",
+    "plant_teal":   "#94e2d5",
+    "bubble":       "#cdd6f4",
+    "text":         "#cdd6f4",
+    "subtext":      "#6c7086",
+}
+
+# Fish color palette — vivid but not garish
+FISH_COLORS = [
+    "#89b4fa",  # blue
+    "#f38ba8",  # pink/red
+    "#fab387",  # peach/orange
+    "#f9e2af",  # yellow
+    "#a6e3a1",  # green
+    "#94e2d5",  # teal
+    "#cba6f7",  # mauve/purple
+    "#89dceb",  # sky
+]
+
+SAND_H = 28       # height of sand strip at bottom
+NUM_FISH = 12
+NUM_PLANTS = 5
+MAX_BUBBLES = 15
+
+# ---------------------------------------------------------------------------
+# Entity classes
+# ---------------------------------------------------------------------------
+
+
+class Fish:
+    def __init__(self, width, height):
+        self.reset(width, height, initial=True)
+
+    def reset(self, width, height, initial=False):
+        self.size = random.uniform(20.0, 55.0)
+        self.speed = random.uniform(25.0, 75.0)
+        self.direction = random.choice([-1, 1])
+        self.base_y = random.uniform(height * 0.1, height - SAND_H - self.size * 1.2)
+        self.amplitude = random.uniform(5.0, 18.0)
+        self.freq = random.uniform(0.4, 1.2)
+        self.phase = random.uniform(0.0, math.pi * 2)
+        self.color = random.choice(FISH_COLORS)
+        self.depth = random.uniform(0.3, 1.0)   # 0=background,1=foreground
+        self.tail_phase = random.uniform(0.0, math.pi * 2)
+        self.bubble_timer = random.uniform(0.5, 4.0)
+
+        # Position
+        if initial:
+            self.x = random.uniform(0, width)
+        else:
+            if self.direction > 0:
+                self.x = -self.size * 2
+            else:
+                self.x = width + self.size * 2
+        self.y = self.base_y
+
+
+class Plant:
+    def __init__(self, x, height):
+        self.x = x
+        self.segments = random.randint(3, 5)
+        self.seg_len = random.uniform(20.0, 35.0)
+        self.height = self.segments * self.seg_len
+        self.sway_amp = random.uniform(6.0, 14.0)
+        self.sway_freq = random.uniform(0.4, 0.8)
+        self.phase = random.uniform(0.0, math.pi * 2)
+        self.color = random.choice([C["plant_green"], C["plant_teal"]])
+        self.base_y = height - SAND_H
+
+
+class Bubble:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+        self.r = random.uniform(2.0, 5.0)
+        self.speed = random.uniform(18.0, 40.0)
+        self.drift_freq = random.uniform(0.8, 2.0)
+        self.drift_phase = random.uniform(0.0, math.pi * 2)
+        self.drift_amp = random.uniform(4.0, 10.0)
+        self.opacity = random.uniform(0.5, 0.9)
+        self.birth_time = time.monotonic()
+
+    @property
+    def alive(self):
+        return self.opacity > 0.05 and self.y > 0
+
+
+# ---------------------------------------------------------------------------
+# Scene state
+# ---------------------------------------------------------------------------
+
+_start_time = time.monotonic()
+_last_time = _start_time
+_fish = []
+_plants = []
+_bubbles = []
+_initialized = False
+
+
+def _init_scene(width, height):
+    global _fish, _plants, _bubbles, _initialized
+    _fish = [Fish(width, height) for _ in range(NUM_FISH)]
+    plant_xs = []
+    for i in range(NUM_PLANTS):
+        px = width * (i + 0.5) / NUM_PLANTS + random.uniform(-20, 20)
+        plant_xs.append(max(20.0, min(width - 20.0, px)))
+    _plants = [Plant(px, height) for px in plant_xs]
+    _bubbles = []
+    _initialized = True
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+
+def _lerp_color(c1_hex, c2_hex, t):
+    """Interpolate between two hex colors, return hex string."""
+    def parse(h):
+        h = h.lstrip("#")
+        return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    r1, g1, b1 = parse(c1_hex)
+    r2, g2, b2 = parse(c2_hex)
+    r = int(r1 + (r2 - r1) * t)
+    g = int(g1 + (g2 - g1) * t)
+    b = int(b1 + (b2 - b1) * t)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _hex_with_alpha(hex_color, opacity):
+    """Return hex color with alpha channel (as 8-char hex including opacity byte)."""
+    # Plexi rect fill takes a standard hex — approximate opacity by blending with water color
+    # using _lerp_color toward the background. This avoids needing true RGBA support.
+    alpha_hex = f"#{hex_color.lstrip('#')}{int(opacity * 255):02x}"
+    return alpha_hex
+
+
+def _draw_background(ctx, now):
+    w = ctx.width
+    h = ctx.height
+    # Water gradient — bands from bottom (dark) to top (slightly lighter)
+    bands = 10
+    band_h = (h - SAND_H) / bands
+    for i in range(bands):
+        t = i / bands  # 0=bottom,1=top
+        color = _lerp_color(C["water_bottom"], C["water_top"], t)
+        by = h - SAND_H - (i + 1) * band_h
+        ctx.rect(0, by, w, band_h + 1.0, fill=color)
+
+    # Sand strip
+    ctx.rect(0, h - SAND_H, w, SAND_H, fill=C["sand"])
+    # Sand highlight line
+    ctx.rect(0, h - SAND_H, w, 3.0, fill=C["sand_light"])
+
+
+def _draw_plants(ctx, now, plants):
+    for plant in plants:
+        sway = math.sin(now * plant.sway_freq + plant.phase) * plant.sway_amp
+        # Draw segments from base upward, each slightly offset by sway
+        x = plant.x
+        y = plant.base_y
+        for seg in range(plant.segments):
+            seg_sway = sway * (seg + 1) / plant.segments
+            nx = plant.x + seg_sway
+            ny = y - plant.seg_len
+            ctx.line(x, y, nx, ny, color=plant.color, width=3.0)
+            x, y = nx, ny
+
+
+def _draw_fish(ctx, now, fish, width, height):
+    for f in fish:
+        # Depth affects opacity approximation — blend toward bg color
+        opacity = 0.4 + 0.6 * f.depth
+        body_color = _lerp_color(C["water_bottom"], f.color, opacity)
+
+        s = f.size
+        cx = f.x
+        cy = f.y
+        flip = f.direction  # 1=right, -1=left
+
+        # Body — rounded rect approximation
+        bw = s
+        bh = s * 0.45
+        bx = cx - bw / 2.0
+        by = cy - bh / 2.0
+        ctx.rect(bx, by, bw, bh, fill=body_color, radius=bh * 0.45)
+
+        # Tail — triangle drawn as two lines converging at a tip
+        tail_wag = math.sin(now * 3.5 + f.tail_phase) * (s * 0.15)
+        tail_base_x = cx - flip * bw * 0.45
+        tail_tip_x = tail_base_x - flip * s * 0.4
+        tail_tip_y = cy + tail_wag
+        tail_top_y = cy - bh * 0.35
+        tail_bot_y = cy + bh * 0.35
+        ctx.line(tail_base_x, tail_top_y, tail_tip_x, tail_tip_y,
+                 color=body_color, width=2.5)
+        ctx.line(tail_base_x, tail_bot_y, tail_tip_x, tail_tip_y,
+                 color=body_color, width=2.5)
+
+        # Eye — small white dot, positioned toward the head
+        eye_x = cx + flip * bw * 0.28
+        eye_y = cy - bh * 0.1
+        eye_r = max(2.0, s * 0.07)
+        ctx.rect(eye_x - eye_r, eye_y - eye_r, eye_r * 2, eye_r * 2,
+                 fill="#ffffff", radius=eye_r)
+        # Pupil
+        pupil_r = max(1.0, eye_r * 0.55)
+        ctx.rect(eye_x - pupil_r + flip * pupil_r * 0.3,
+                 eye_y - pupil_r,
+                 pupil_r * 2, pupil_r * 2,
+                 fill="#000000", radius=pupil_r)
+
+
+def _draw_bubbles(ctx, now, bubbles):
+    for b in bubbles:
+        if not b.alive:
+            continue
+        drift = math.sin(now * b.drift_freq + b.drift_phase) * b.drift_amp
+        draw_x = b.x + drift
+        draw_y = b.y
+        # Approximate opacity by blending bubble color with water
+        bubble_color = _lerp_color(C["water_top"], C["bubble"], b.opacity * 0.6)
+        d = b.r * 2
+        ctx.rect(draw_x - b.r, draw_y - b.r, d, d, fill=bubble_color, radius=b.r)
+
+
+# ---------------------------------------------------------------------------
+# Update logic
+# ---------------------------------------------------------------------------
+
+
+def _update(now, dt, width, height):
+    # Update fish
+    for f in _fish:
+        f.x += f.speed * f.direction * dt * f.depth
+        f.y = f.base_y + math.sin(now * f.freq + f.phase) * f.amplitude
+
+        # Wrap around screen
+        margin = f.size * 2
+        if f.direction > 0 and f.x > width + margin:
+            f.reset(width, height)
+        elif f.direction < 0 and f.x < -margin:
+            f.reset(width, height)
+
+        # Random bubble emission
+        f.bubble_timer -= dt
+        if f.bubble_timer <= 0 and len(_bubbles) < MAX_BUBBLES:
+            mouth_x = f.x + f.direction * f.size * 0.45
+            mouth_y = f.y - f.size * 0.05
+            _bubbles.append(Bubble(mouth_x, mouth_y))
+            f.bubble_timer = random.uniform(2.0, 6.0)
+
+    # Emit bubbles from plant tips occasionally
+    if len(_bubbles) < MAX_BUBBLES and random.random() < 0.02:
+        plant = random.choice(_plants) if _plants else None
+        if plant:
+            sway = math.sin(now * plant.sway_freq + plant.phase) * plant.sway_amp
+            tip_x = plant.x + sway
+            tip_y = plant.base_y - plant.height
+            _bubbles.append(Bubble(tip_x, tip_y))
+
+    # Update bubbles
+    for b in _bubbles:
+        b.y -= b.speed * dt
+        age = now - b.birth_time
+        # Fade out over 3 seconds
+        b.opacity = max(0.0, 0.9 - age / 3.0)
+        # Grow slightly as they rise
+        b.r = min(b.r + 0.2 * dt, 8.0)
+
+    # Remove dead bubbles
+    _bubbles[:] = [b for b in _bubbles if b.alive]
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="aquarium")
+
+
+@app.on_render
+def render(ctx):
+    global _last_time, _initialized
+
+    now = time.monotonic() - _start_time
+    wall_now = time.monotonic()
+    dt = min(0.1, wall_now - _last_time)
+    _last_time = wall_now
+
+    if not _initialized or ctx.width < 10 or ctx.height < 10:
+        _init_scene(ctx.width, ctx.height)
+
+    # Update positions before drawing
+    _update(now, dt, ctx.width, ctx.height)
+
+    # Draw layers bottom-to-top
+    _draw_background(ctx, now)
+    _draw_plants(ctx, now, _plants)
+
+    # Sort fish by depth so background fish draw first
+    sorted_fish = sorted(_fish, key=lambda f: f.depth)
+    _draw_fish(ctx, now, sorted_fish, ctx.width, ctx.height)
+
+    _draw_bubbles(ctx, now, _bubbles)
+
+
+@app.on_resize
+def on_resize(width, height):
+    _init_scene(width, height)
+
+
+app.run()

--- a/examples/aquarium/manifest.toml
+++ b/examples/aquarium/manifest.toml
@@ -1,0 +1,9 @@
+[app]
+id = "aquarium"
+name = "Aquarium"
+entry = "aquarium.py"
+version = "0.1.0"
+description = "Ambient underwater scene with procedural fish and plants"
+
+[app.capabilities]
+# No capabilities needed — pure rendering

--- a/examples/aquarium/plexi_sdk.py
+++ b/examples/aquarium/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/snake/manifest.toml
+++ b/examples/snake/manifest.toml
@@ -1,0 +1,9 @@
+[app]
+id = "snake"
+name = "Snake"
+entry = "snake.py"
+version = "0.1.0"
+description = "Classic Snake — proof of concept game"
+
+[app.capabilities]
+# No capabilities needed — pure rendering + input

--- a/examples/snake/plexi_sdk.py
+++ b/examples/snake/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/snake/snake.py
+++ b/examples/snake/snake.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+snake — Plexi app
+Classic Snake game. Keyboard controlled, fixed-tick game loop.
+
+Controls:
+  Arrow keys / WASD   Change direction
+  Enter               Start / restart
+  Escape              Return to title
+  p                   Pause / unpause
+"""
+
+import math
+import os
+import random
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":       "#1e1e2e",
+    "surface":  "#313244",
+    "overlay":  "#45475a",
+    "text":     "#cdd6f4",
+    "subtext":  "#6c7086",
+    "accent":   "#89b4fa",  # snake head
+    "tail":     "#45475a",  # snake tail end
+    "food":     "#f38ba8",  # food
+    "green":    "#a6e3a1",
+    "yellow":   "#f9e2af",
+    "header":   "#181825",
+}
+
+# ---------------------------------------------------------------------------
+# Game constants
+# ---------------------------------------------------------------------------
+
+GRID_COLS = 20
+GRID_ROWS = 20
+BASE_INTERVAL = 0.15   # seconds per tick at speed 1
+MIN_INTERVAL  = 0.07   # fastest possible tick
+SPEED_STEP    = 5      # eat this many foods to increase speed
+
+# Direction vectors
+UP    = (0, -1)
+DOWN  = (0,  1)
+LEFT  = (-1, 0)
+RIGHT = (1,  0)
+OPPOSITE = {UP: DOWN, DOWN: UP, LEFT: RIGHT, RIGHT: LEFT}
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+STATE_TITLE    = "title"
+STATE_PLAYING  = "playing"
+STATE_PAUSED   = "paused"
+STATE_GAMEOVER = "gameover"
+
+
+class SnakeGame:
+    def __init__(self):
+        self.state = STATE_TITLE
+        self.score = 0
+        self.high_score = 0
+
+        # Snake body: list of (col, row) tuples, head first
+        self.body = []
+        self.direction = RIGHT
+        self.input_queue = []   # buffered direction changes
+
+        self.food = (0, 0)
+        self.tick_interval = BASE_INTERVAL
+        self._last_tick = time.monotonic()
+
+    def start(self):
+        mid = GRID_COLS // 2
+        self.body = [(mid, GRID_ROWS // 2), (mid - 1, GRID_ROWS // 2), (mid - 2, GRID_ROWS // 2)]
+        self.direction = RIGHT
+        self.input_queue = []
+        self.score = 0
+        self.tick_interval = BASE_INTERVAL
+        self._last_tick = time.monotonic()
+        self._spawn_food()
+        self.state = STATE_PLAYING
+
+    def _spawn_food(self):
+        body_set = set(self.body)
+        candidates = [
+            (c, r)
+            for c in range(GRID_COLS)
+            for r in range(GRID_ROWS)
+            if (c, r) not in body_set
+        ]
+        if candidates:
+            self.food = random.choice(candidates)
+
+    def tick(self):
+        """Advance one game step. Returns True if the game is still running."""
+        if self.input_queue:
+            candidate = self.input_queue.pop(0)
+            if candidate != OPPOSITE.get(self.direction, None):
+                self.direction = candidate
+
+        dx, dy = self.direction
+        hx, hy = self.body[0]
+        new_head = (hx + dx, hy + dy)
+
+        # Wall collision
+        nx, ny = new_head
+        if nx < 0 or nx >= GRID_COLS or ny < 0 or ny >= GRID_ROWS:
+            self._die()
+            return False
+
+        # Self collision (check against all but the tail, which will move)
+        if new_head in set(self.body[:-1]):
+            self._die()
+            return False
+
+        ate = new_head == self.food
+        self.body.insert(0, new_head)
+        if ate:
+            self.score += 1
+            self._spawn_food()
+            # Speed up every SPEED_STEP foods
+            speed_level = self.score // SPEED_STEP
+            self.tick_interval = max(MIN_INTERVAL, BASE_INTERVAL - speed_level * 0.01)
+        else:
+            self.body.pop()
+
+        return True
+
+    def _die(self):
+        if self.score > self.high_score:
+            self.high_score = self.score
+        self.state = STATE_GAMEOVER
+
+    def queue_direction(self, new_dir):
+        # Don't add a duplicate of the last queued direction
+        last = self.input_queue[-1] if self.input_queue else self.direction
+        if new_dir == last or new_dir == OPPOSITE.get(last, None):
+            return
+        self.input_queue.append(new_dir)
+
+
+game = SnakeGame()
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="snake")
+
+
+@app.on_render
+def render(ctx):
+    now = time.monotonic()
+
+    # Tick the game loop at fixed interval
+    if game.state == STATE_PLAYING:
+        elapsed = now - game._last_tick
+        if elapsed >= game.tick_interval:
+            game._last_tick = now
+            game.tick()
+
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["bg"])
+
+    if game.state == STATE_TITLE:
+        _render_title(ctx, now)
+    elif game.state in (STATE_PLAYING, STATE_PAUSED):
+        _render_game(ctx, now)
+        if game.state == STATE_PAUSED:
+            _render_overlay(ctx, "PAUSED", "Press p to resume", now)
+    elif game.state == STATE_GAMEOVER:
+        _render_game(ctx, now)
+        _render_gameover(ctx)
+
+
+def _cell_layout(ctx):
+    """Return (cell_size, offset_x, offset_y) for the current pane size."""
+    cell_size = max(8, min(ctx.width // GRID_COLS, ctx.height // GRID_ROWS))
+    offset_x = (ctx.width - cell_size * GRID_COLS) / 2.0
+    offset_y = (ctx.height - cell_size * GRID_ROWS) / 2.0
+    return cell_size, offset_x, offset_y
+
+
+def _render_title(ctx, now):
+    w = ctx.width
+    h = ctx.height
+    cx = w / 2.0
+    cy = h / 2.0
+
+    ctx.text(cx - 60, cy - 60, "SNAKE", size=32, color=C["accent"], bold=True)
+    ctx.text(cx - 90, cy, "Press Enter to start", size=14, color=C["text"])
+
+    if game.high_score > 0:
+        hs_label = f"High score: {game.high_score}"
+        ctx.text(cx - len(hs_label) * 4, cy + 30, hs_label, size=13, color=C["subtext"])
+
+    ctx.text(cx - 110, cy + 70,
+             "Arrow keys / WASD  |  p = pause  |  Esc = menu",
+             size=11, color=C["subtext"])
+
+
+def _render_game(ctx, now):
+    cell_size, ox, oy = _cell_layout(ctx)
+    cs = cell_size
+
+    # Grid lines
+    for c in range(GRID_COLS + 1):
+        x = ox + c * cs
+        ctx.line(x, oy, x, oy + GRID_ROWS * cs, color=C["surface"], width=1.0)
+    for r in range(GRID_ROWS + 1):
+        y = oy + r * cs
+        ctx.line(ox, y, ox + GRID_COLS * cs, y, color=C["surface"], width=1.0)
+
+    # Snake body (tail → head, so head draws on top)
+    body_len = len(game.body)
+    for i, (col, row) in enumerate(reversed(game.body)):
+        ratio = i / max(1, body_len - 1)
+        # Interpolate from tail color to head color
+        r_head, g_head, b_head = 0x89, 0xb4, 0xfa
+        r_tail, g_tail, b_tail = 0x45, 0x47, 0x5a
+        ri = int(r_tail + (r_head - r_tail) * (1.0 - ratio))
+        gi = int(g_tail + (g_head - g_tail) * (1.0 - ratio))
+        bi = int(b_tail + (b_head - b_tail) * (1.0 - ratio))
+        color = f"#{ri:02x}{gi:02x}{bi:02x}"
+        pad = max(1, cs // 8)
+        bx = ox + col * cs + pad
+        by = oy + row * cs + pad
+        bw = cs - pad * 2
+        bh = cs - pad * 2
+        radius = max(1.0, cs / 5.0)
+        ctx.rect(bx, by, bw, bh, fill=color, radius=radius)
+
+    # Food — pulsing scale via sine
+    pulse = 0.85 + 0.15 * math.sin(now * 4.0)
+    fc, fr = game.food
+    food_cs = cs * pulse
+    food_pad = (cs - food_cs) / 2.0
+    fx = ox + fc * cs + food_pad
+    fy = oy + fr * cs + food_pad
+    ctx.rect(fx, fy, food_cs, food_cs, fill=C["food"], radius=food_cs / 3.0)
+
+    # Score
+    score_label = f"Score: {game.score}"
+    ctx.text(ctx.width - len(score_label) * 8 - 8, 8, score_label,
+             size=13, color=C["text"], bold=True)
+
+    speed_level = game.score // SPEED_STEP + 1
+    level_label = f"Spd {speed_level}"
+    ctx.text(ctx.width - len(level_label) * 8 - 8, 26, level_label,
+             size=11, color=C["subtext"])
+
+
+def _render_overlay(ctx, title, subtitle, now):
+    w = ctx.width
+    h = ctx.height
+    # Semi-transparent dark panel
+    panel_w = 260.0
+    panel_h = 100.0
+    px = (w - panel_w) / 2.0
+    py = (h - panel_h) / 2.0
+    ctx.rect(px, py, panel_w, panel_h, fill=C["header"], radius=10.0)
+    ctx.text(px + panel_w / 2 - len(title) * 9, py + 18, title,
+             size=20, color=C["yellow"], bold=True)
+    ctx.text(px + panel_w / 2 - len(subtitle) * 5, py + 56, subtitle,
+             size=13, color=C["subtext"])
+
+
+def _render_gameover(ctx):
+    w = ctx.width
+    h = ctx.height
+    panel_w = 280.0
+    panel_h = 130.0
+    px = (w - panel_w) / 2.0
+    py = (h - panel_h) / 2.0
+    ctx.rect(px, py, panel_w, panel_h, fill=C["header"], radius=10.0)
+    ctx.text(px + panel_w / 2 - 72, py + 14, "GAME OVER",
+             size=22, color=C["food"], bold=True)
+    score_line = f"Score: {game.score}"
+    ctx.text(px + panel_w / 2 - len(score_line) * 5, py + 50,
+             score_line, size=14, color=C["text"])
+    ctx.text(px + panel_w / 2 - 90, py + 80,
+             "Enter = restart   Esc = menu", size=12, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    if game.state == STATE_TITLE:
+        if key == "Enter":
+            game.start()
+
+    elif game.state == STATE_PLAYING:
+        if key in ("ArrowUp", "w", "W"):
+            game.queue_direction(UP)
+        elif key in ("ArrowDown", "s", "S"):
+            game.queue_direction(DOWN)
+        elif key in ("ArrowLeft", "a", "A"):
+            game.queue_direction(LEFT)
+        elif key in ("ArrowRight", "d", "D"):
+            game.queue_direction(RIGHT)
+        elif key == "p":
+            game.state = STATE_PAUSED
+        elif key == "Escape":
+            game.state = STATE_TITLE
+
+    elif game.state == STATE_PAUSED:
+        if key == "p":
+            game.state = STATE_PLAYING
+            game._last_tick = time.monotonic()
+        elif key == "Escape":
+            game.state = STATE_TITLE
+
+    elif game.state == STATE_GAMEOVER:
+        if key == "Enter":
+            game.start()
+        elif key == "Escape":
+            game.state = STATE_TITLE
+
+
+app.run()

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -149,6 +149,7 @@ class RenderContext:
     def __init__(self, width: float, height: float, app_id: str = ""):
         self.width = width
         self.height = height
+        self.delta_time: float = 0.0
         self._app_id = app_id
         self._commands: list = []
 
@@ -317,6 +318,23 @@ class RenderContext:
             cmd["columns"] = columns
         self._commands.append(cmd)
 
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
     def run_in_terminal(self, command: str):
         """Queue a terminal command to run at end of this frame."""
         self._commands.append({"type": "run_in_terminal", "command": command})
@@ -378,19 +396,24 @@ class App:
     Base class for Plexi apps. Register event handlers via decorators.
 
     Handlers:
-        @app.on_render      fn(ctx: RenderContext)
-        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
-        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
-        @app.on_command     fn(text: str, emit: Emitter)
-        @app.on_resize      fn(width: float, height: float)
-        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
-        @app.on_set_state   fn(state: dict) — restore app from state buckets
-        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
     """
 
     def __init__(self, app_id: str = ""):
         self.width: float = 800.0
         self.height: float = 600.0
+        self.delta_time: float = 0.0
         self._on_render: Optional[Callable] = None
         self._on_key: Optional[Callable] = None
         self._on_click: Optional[Callable] = None
@@ -399,6 +422,10 @@ class App:
         self._on_get_state: Optional[Callable] = None
         self._on_set_state: Optional[Callable] = None
         self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
         self._emitter = Emitter(app_id=app_id)
 
     def on_render(self, fn: Callable) -> Callable:
@@ -442,6 +469,43 @@ class App:
         accept list.
         """
         self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
         return fn
 
     def _handle_get_state(self):
@@ -495,7 +559,9 @@ class App:
             elif event_type == "render":
                 self.width = event.get("width", self.width)
                 self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
                 ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
                 if self._on_render:
                     self._on_render(ctx)
                 ctx._flush()
@@ -532,6 +598,42 @@ class App:
                     self._on_drop(
                         event.get("target_id", ""),
                         event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
                         self._emitter,
                     )
 

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -48,7 +48,7 @@ pub enum PlexiEvent {
         pixels_per_point: f32,
     },
     /// Request a new frame. App should reply with DrawCommands + FrameDone.
-    Render { width: f32, height: f32 },
+    Render { width: f32, height: f32, delta_time: f32 },
     /// Surface was resized.
     Resize { width: f32, height: f32 },
     /// A key was pressed.
@@ -58,6 +58,15 @@ pub enum PlexiEvent {
     },
     /// Mouse click at logical coordinates within the app surface.
     Click { x: f32, y: f32, button: MouseButton },
+    /// Mouse button pressed (distinct from Click which fires on release).
+    MouseDown { x: f32, y: f32, button: String },
+    /// Mouse button released.
+    MouseUp { x: f32, y: f32, button: String },
+    /// Mouse moved over the app surface. Only sent when `mouse_tracking = true`
+    /// in the app's manifest capabilities.
+    MouseMove { x: f32, y: f32 },
+    /// Scroll wheel / trackpad scroll over the app surface.
+    Scroll { x: f32, y: f32, delta_x: f32, delta_y: f32 },
     /// User submitted a command via the terminal command bar.
     Command { text: String },
     /// Files were dropped on a registered drop target region.
@@ -282,6 +291,16 @@ pub enum DrawCommand {
         #[serde(default)]
         label: Option<String>,
     },
+    /// Set the cursor icon for the app pane.
+    ///
+    /// Values: `"default"`, `"pointer"`, `"grab"`, `"grabbing"`, `"crosshair"`, `"text"`.
+    /// The cursor reverts to `"default"` at the start of each frame; apps must
+    /// re-emit this on every render frame where they want a non-default cursor.
+    SetCursor { cursor: String },
+    /// Enable or disable mouse-move event delivery. When disabled (default),
+    /// Plexi does not send `MouseMove` events to avoid flooding the pipe.
+    /// This command is stateful — the setting persists until changed.
+    MouseTracking { enabled: bool },
     /// End of frame — Plexi will render everything queued since last FrameDone.
     FrameDone,
 }

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -113,6 +113,9 @@ pub struct AppCapabilities {
     /// Can write secrets to Keychain via the API.
     #[serde(default)]
     pub secrets_write: bool,
+    /// Opt-in to receiving `MouseMove` events. Off by default to avoid pipe flooding.
+    #[serde(default)]
+    pub mouse_tracking: bool,
 }
 
 fn default_fs_permission() -> String {
@@ -263,6 +266,7 @@ impl AppRegistry {
             &installed.bin_path,
             cwd,
             args,
+            installed.manifest.capabilities.mouse_tracking,
         ) {
             Ok(app) => {
                 log::info!("AppRegistry: launched '{}' from {:?}", id, installed.bin_path);

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -97,6 +97,24 @@ pub trait App: Send {
     /// Only meaningful for ProcessApps that support the get_state/set_state protocol.
     fn undo(&mut self) {}
 
+    /// Returns true if this app wants to receive mouse-move events.
+    /// Default: false (opt-in via manifest or `MouseTracking` draw command).
+    fn mouse_tracking_enabled(&self) -> bool {
+        false
+    }
+
+    /// Forward a mouse-down event. `button` is one of `"left"`, `"right"`, `"middle"`.
+    fn send_mouse_down(&mut self, _x: f32, _y: f32, _button: &str) {}
+
+    /// Forward a mouse-up event. `button` is one of `"left"`, `"right"`, `"middle"`.
+    fn send_mouse_up(&mut self, _x: f32, _y: f32, _button: &str) {}
+
+    /// Forward a mouse-move event (only called when `mouse_tracking_enabled()` returns true).
+    fn send_mouse_move(&mut self, _x: f32, _y: f32) {}
+
+    /// Forward a scroll event. `x/y` is the cursor position; `delta_x/delta_y` is the scroll delta.
+    fn send_scroll(&mut self, _x: f32, _y: f32, _delta_x: f32, _delta_y: f32) {}
+
     /// Trigger redo (pop next state from redo stack and restore).
     fn redo(&mut self) {}
 }

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -62,6 +62,12 @@ pub struct ProcessApp {
     pending_redo: bool,
     /// Per-app cost tracker for LLM API usage.
     cost_tracker: CostTracker,
+    /// Timestamp of the last Render event sent, used to compute delta_time.
+    last_render_time: Instant,
+    /// Whether this app should receive MouseMove events (opt-in via manifest or DrawCommand).
+    mouse_tracking: bool,
+    /// Pending cursor icon override requested by the app this frame.
+    pending_cursor: Option<egui::CursorIcon>,
 }
 
 /// Snapshot of an app's state buckets.
@@ -73,6 +79,54 @@ pub struct AppState {
     pub persistent: serde_json::Value,
 }
 
+/// Probe well-known locations for a Python interpreter that is >= 3.10.
+///
+/// macOS GUI app bundles do not inherit the user's shell PATH, so
+/// `/usr/bin/env python3` resolves to Apple's frozen system Python (3.9).
+/// We probe explicit paths — first match that reports version >= 3.10 wins.
+/// Falls back to `python3` (shebang-resolved) if none of the known paths work,
+/// so the old behaviour is preserved rather than failing silently.
+fn find_python() -> std::ffi::OsString {
+    let candidates = [
+        "/opt/homebrew/bin/python3",   // Apple Silicon Homebrew
+        "/usr/local/bin/python3",      // Intel Homebrew
+        "/opt/homebrew/bin/python3.13",
+        "/opt/homebrew/bin/python3.12",
+        "/opt/homebrew/bin/python3.11",
+        "/opt/homebrew/bin/python3.10",
+        "/usr/local/bin/python3.13",
+        "/usr/local/bin/python3.12",
+        "/usr/local/bin/python3.11",
+        "/usr/local/bin/python3.10",
+    ];
+
+    for candidate in &candidates {
+        let path = std::path::Path::new(candidate);
+        if !path.exists() {
+            continue;
+        }
+        // Ask the interpreter for its version string ("3.11.6\n").
+        let ok = std::process::Command::new(candidate)
+            .args(["-c", "import sys; v=sys.version_info; exit(0 if v>=(3,10) else 1)"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            log::debug!("process_app: using Python interpreter: {candidate}");
+            return std::ffi::OsString::from(candidate);
+        }
+    }
+
+    log::warn!(
+        "process_app: no Python >= 3.10 found at known paths; \
+         falling back to `python3` (may be system 3.9 in GUI context). \
+         Install Python 3.10+ via: brew install python@3.13"
+    );
+    std::ffi::OsString::from("python3")
+}
+
 impl ProcessApp {
     /// Spawn an app binary at `bin_path`.
     pub fn launch(
@@ -82,11 +136,22 @@ impl ProcessApp {
         bin_path: &PathBuf,
         cwd: &PathBuf,
         args: &[String],
+        mouse_tracking: bool,
     ) -> Result<Self, std::io::Error> {
         let type_id: String = type_id.into();
         let display_name: String = display_name.into();
 
-        let mut child = std::process::Command::new(bin_path)
+        // For Python scripts, bypass the shebang and use an explicit interpreter
+        // so macOS GUI bundles (which don't inherit shell PATH) always get >= 3.10.
+        let (cmd, extra_args): (std::ffi::OsString, Vec<std::ffi::OsString>) =
+            if bin_path.extension().and_then(|e| e.to_str()) == Some("py") {
+                (find_python(), vec![bin_path.as_os_str().to_owned()])
+            } else {
+                (bin_path.as_os_str().to_owned(), vec![])
+            };
+
+        let mut child = std::process::Command::new(&cmd)
+            .args(&extra_args)
             .args(args)
             .current_dir(cwd)
             .stdin(Stdio::piped())
@@ -171,6 +236,9 @@ impl ProcessApp {
             pending_undo: false,
             pending_redo: false,
             cost_tracker,
+            last_render_time: Instant::now(),
+            mouse_tracking,
+            pending_cursor: None,
         })
     }
 
@@ -236,8 +304,15 @@ impl ProcessApp {
         self.stdin = None;
         self.draw_rx = None;
 
-        // Respawn.
-        let mut child = match std::process::Command::new(&self.bin_path)
+        // Respawn — same Python interpreter logic as initial launch.
+        let (cmd, extra_args): (std::ffi::OsString, Vec<std::ffi::OsString>) =
+            if self.bin_path.extension().and_then(|e| e.to_str()) == Some("py") {
+                (find_python(), vec![self.bin_path.as_os_str().to_owned()])
+            } else {
+                (self.bin_path.as_os_str().to_owned(), vec![])
+            };
+        let mut child = match std::process::Command::new(&cmd)
+            .args(&extra_args)
             .args(&self.args)
             .current_dir(&self.cwd)
             .stdin(Stdio::piped())
@@ -305,6 +380,9 @@ impl ProcessApp {
         self.frame.clear();
         self.pending_frame.clear();
         self.initialized = false; // will re-send Init on next ui() call
+        self.last_render_time = Instant::now();
+        self.mouse_tracking = false; // new process must opt in again
+        self.pending_cursor = None;
     }
 
     /// Request the app's current state snapshot.
@@ -705,13 +783,15 @@ impl ProcessApp {
                 }
 
                 // RunInTerminal / Cd / Log / State / CostReport / Notification /
-                // FrameDone handled at the App trait level, not here.
+                // SetCursor / MouseTracking / FrameDone handled at the App trait level, not here.
                 DrawCommand::RunInTerminal { .. }
                 | DrawCommand::Cd { .. }
                 | DrawCommand::Log { .. }
                 | DrawCommand::State { .. }
                 | DrawCommand::CostReport { .. }
                 | DrawCommand::Notification { .. }
+                | DrawCommand::SetCursor { .. }
+                | DrawCommand::MouseTracking { .. }
                 | DrawCommand::FrameDone => {}
             }
         }
@@ -1007,7 +1087,9 @@ impl App for ProcessApp {
         }
 
         // Request a new frame.
-        self.send_event(&PlexiEvent::Render { width: size.x, height: size.y });
+        let delta_time = self.last_render_time.elapsed().as_secs_f32();
+        self.last_render_time = Instant::now();
+        self.send_event(&PlexiEvent::Render { width: size.x, height: size.y, delta_time });
 
         // Drain all draw commands that arrived since last frame (including response
         // to the Render we just sent — they come async so we take whatever is ready).
@@ -1070,8 +1152,27 @@ impl App for ProcessApp {
                     };
                     crate::notification_log::record(priority, title, body, src);
                 }
+                DrawCommand::SetCursor { cursor } => {
+                    let icon = match cursor.as_str() {
+                        "pointer"   => egui::CursorIcon::PointingHand,
+                        "grab"      => egui::CursorIcon::Grab,
+                        "grabbing"  => egui::CursorIcon::Grabbing,
+                        "crosshair" => egui::CursorIcon::Crosshair,
+                        "text"      => egui::CursorIcon::Text,
+                        _           => egui::CursorIcon::Default,
+                    };
+                    self.pending_cursor = Some(icon);
+                }
+                DrawCommand::MouseTracking { enabled } => {
+                    self.mouse_tracking = enabled;
+                }
                 other => self.pending_frame.push(other),
             }
+        }
+
+        // Apply cursor override requested by the app this frame, then clear it.
+        if let Some(icon) = self.pending_cursor.take() {
+            ui.ctx().set_cursor_icon(icon);
         }
 
         // Render the current frame.
@@ -1216,6 +1317,28 @@ impl App for ProcessApp {
         Some(serde_json::json!({
             "type_id": self.type_id,
         }))
+    }
+
+    fn mouse_tracking_enabled(&self) -> bool {
+        self.mouse_tracking
+    }
+
+    fn send_mouse_down(&mut self, x: f32, y: f32, button: &str) {
+        self.send_event(&PlexiEvent::MouseDown { x, y, button: button.to_string() });
+    }
+
+    fn send_mouse_up(&mut self, x: f32, y: f32, button: &str) {
+        self.send_event(&PlexiEvent::MouseUp { x, y, button: button.to_string() });
+    }
+
+    fn send_mouse_move(&mut self, x: f32, y: f32) {
+        if self.mouse_tracking {
+            self.send_event(&PlexiEvent::MouseMove { x, y });
+        }
+    }
+
+    fn send_scroll(&mut self, x: f32, y: f32, delta_x: f32, delta_y: f32) {
+        self.send_event(&PlexiEvent::Scroll { x, y, delta_x, delta_y });
     }
 
     fn undo(&mut self) {

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -232,6 +232,62 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                                     media_cache: self.media_cache,
                                 };
                                 app.ui(ui, &app_ctx);
+
+                                // Forward mouse events to the focused app.
+                                // The app surface origin is the inner margin (8px) from the Frame.
+                                if is_focused {
+                                    let inner_origin = ui.min_rect().min + egui::vec2(8.0, 8.0);
+
+                                    ui.input(|i| {
+                                        // Mouse button presses and releases.
+                                        for event in &i.events {
+                                            match event {
+                                                egui::Event::PointerButton { pos, button, pressed, .. } => {
+                                                    if ui.max_rect().contains(*pos) {
+                                                        let lx = pos.x - inner_origin.x;
+                                                        let ly = pos.y - inner_origin.y;
+                                                        let btn = match button {
+                                                            egui::PointerButton::Primary   => "left",
+                                                            egui::PointerButton::Secondary => "right",
+                                                            egui::PointerButton::Middle    => "middle",
+                                                            _                              => "left",
+                                                        };
+                                                        if *pressed {
+                                                            app.send_mouse_down(lx, ly, btn);
+                                                        } else {
+                                                            app.send_mouse_up(lx, ly, btn);
+                                                        }
+                                                    }
+                                                }
+                                                egui::Event::MouseMoved(_) => {
+                                                    // MouseMove: only forward if the app opted in.
+                                                    if app.mouse_tracking_enabled() {
+                                                        if let Some(pos) = i.pointer.hover_pos() {
+                                                            if ui.max_rect().contains(pos) {
+                                                                let lx = pos.x - inner_origin.x;
+                                                                let ly = pos.y - inner_origin.y;
+                                                                app.send_mouse_move(lx, ly);
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                _ => {}
+                                            }
+                                        }
+
+                                        // Scroll delta — send whenever there is a non-zero scroll.
+                                        let scroll = i.smooth_scroll_delta;
+                                        if scroll.length_sq() > 0.0 {
+                                            if let Some(pos) = i.pointer.hover_pos() {
+                                                if ui.max_rect().contains(pos) {
+                                                    let lx = pos.x - inner_origin.x;
+                                                    let ly = pos.y - inner_origin.y;
+                                                    app.send_scroll(lx, ly, scroll.x, scroll.y);
+                                                }
+                                            }
+                                        }
+                                    });
+                                }
                             } else {
                                 // App was dropped — fall back to full terminal.
                                 let font_size = pane.font_size;


### PR DESCRIPTION
## Summary

- Adds `MouseDown`, `MouseUp`, `MouseMove`, `Scroll` `PlexiEvent` variants sent from Plexi → app subprocess
- Adds `delta_time: f32` field to the existing `Render` event (seconds since last frame)
- Adds `SetCursor` and `MouseTracking` `DrawCommand` variants (app → Plexi)
- Adds `mouse_tracking = false` capability flag to `AppCapabilities` manifest schema
- Wires mouse detection in `tiling.rs` for focused `AppActive` panes
- Extends Python SDK with `on_mouse_down/up/move/scroll` decorators and `ctx.set_cursor()` / `ctx.mouse_tracking()` helpers

## Implementation notes

- Mouse event methods live on the `App` trait with default no-ops — no downcasting needed in `tiling.rs`
- `MouseMove` is gated on `app.mouse_tracking_enabled()` to avoid flooding the pipe
- `SetCursor` is stateless per-frame (cleared each `ui()` call via `pending_cursor.take()`); apps re-emit it each frame like `DropTarget`
- `delta_time` computed from `Instant` diff on `ProcessApp`, reset on hot-reload restart
- `mouse_tracking` initialised from manifest at launch; apps can also toggle at runtime via `MouseTracking` draw command
- Scroll uses `i.smooth_scroll_delta` (better trackpad feel than raw delta)

## Test plan

- [ ] `cargo check` passes (verified — no new warnings)
- [ ] Hot-reload resets `mouse_tracking` and `pending_cursor` on restart
- [ ] Python SDK `on_mouse_down/up/move/scroll` decorators dispatch correctly from event loop
- [ ] `ctx.delta_time` populated on every render event
- [ ] `mouse_tracking = true` in manifest opts app into `MouseMove` events from first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)