### PR TITLE
feat: Navigator directory hotlist app (#89)

### DIFF
--- a/examples/navigator/manifest.toml
+++ b/examples/navigator/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "navigator"
+name = "Navigator"
+entry = "navigator.py"
+version = "0.1.0"
+description = "Harpoon-style directory hotlist — pin directories and jump to them by slot number"
+
+[app.capabilities]
+file_types = []
+terminal_write = true
+filesystem = "read_only"

--- a/examples/navigator/navigator.py
+++ b/examples/navigator/navigator.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+navigator — Plexi app
+
+Harpoon-style directory hotlist. Pin directories, jump to them by slot number
+or by navigating the list. Persists to ~/.plexi-alpha/navigator.json.
+
+Controls:
+  j / ArrowDown    Move selection down
+  k / ArrowUp      Move selection up
+  1–9              Jump directly to slot N (and cd to it)
+  Enter            cd to selected directory
+  a                Add cwd to hotlist
+  d / Delete       Remove selected entry
+  r                Refresh / reload list from disk
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+PINS_FILE = os.path.expanduser("~/.plexi-alpha/navigator.json")
+
+
+def _load_pins() -> list:
+    """Load pinned directories from disk. Returns empty list on any error."""
+    try:
+        with open(PINS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        pins = data.get("pins", [])
+        if not isinstance(pins, list):
+            return []
+        return [p for p in pins if isinstance(p, str)]
+    except FileNotFoundError:
+        return []
+    except (json.JSONDecodeError, OSError) as e:
+        sys.stderr.write(f"navigator: failed to load {PINS_FILE}: {e}\n")
+        return []
+
+
+def _save_pins(pins: list):
+    """Persist pinned directories to disk. Fails loudly on error."""
+    try:
+        os.makedirs(os.path.dirname(PINS_FILE), exist_ok=True)
+        with open(PINS_FILE, "w", encoding="utf-8") as f:
+            json.dump({"pins": pins}, f, indent=2)
+    except OSError as e:
+        sys.stderr.write(f"navigator: failed to save {PINS_FILE}: {e}\n")
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+pins: list = _load_pins()
+selected: int = 0
+
+
+def _clamp_selected():
+    global selected
+    if not pins:
+        selected = 0
+    else:
+        selected = max(0, min(selected, len(pins) - 1))
+
+
+def _shorten_path(path: str) -> str:
+    """Replace $HOME prefix with ~."""
+    home = os.path.expanduser("~")
+    if path == home:
+        return "~"
+    if path.startswith(home + os.sep):
+        return "~" + path[len(home):]
+    return path
+
+
+def _add_cwd(emit):
+    """Add the current working directory to pins if not already present."""
+    global pins, selected
+    cwd = os.getcwd()
+    if cwd not in pins:
+        pins.append(cwd)
+        _save_pins(pins)
+        selected = len(pins) - 1
+        emit.info(f"navigator: pinned {cwd}")
+    else:
+        # Move selection to existing entry.
+        selected = pins.index(cwd)
+
+
+def _remove_selected():
+    global pins, selected
+    if not pins:
+        return
+    pins.pop(selected)
+    _save_pins(pins)
+    _clamp_selected()
+
+
+def _cd_to(path: str, emit):
+    """Emit a cd command for the linked terminal."""
+    emit.cd(path)
+
+
+# ---------------------------------------------------------------------------
+# Theme — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "header":  "#181825",
+    "surface": "#313244",
+    "sel_bg":  "#45475a",
+    "text":    "#cdd6f4",
+    "subtext": "#a6adc8",
+    "muted":   "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "red":     "#f38ba8",
+    "missing": "#585b70",  # dimmed color for directories that no longer exist
+}
+
+HEADER_H = 48
+FOOTER_H = 28
+PADDING  = 16
+ITEM_H   = 28
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+app = App(app_id="navigator")
+
+
+@app.on_render
+def render(ctx):
+    w = ctx.width
+    h = ctx.height
+
+    # Background
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    n = len(pins)
+    header_title = f"Navigator — {n} pin{'s' if n != 1 else ''}"
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 15, header_title, size=14, color=C["accent"], bold=True)
+    hint_text = "[a] pin  [d] remove  [Enter] cd  [1–9] jump"
+    hint_x = w - len(hint_text) * 6.5 - PADDING
+    if hint_x > PADDING + len(header_title) * 8 + 16:
+        ctx.text(hint_x, 17, hint_text, size=11, color=C["muted"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    # Empty state
+    if not pins:
+        msg = "No pinned directories yet."
+        hint = "Navigate to a directory in any terminal pane and press `a` to pin it."
+        msg_y = HEADER_H + (h - HEADER_H - FOOTER_H) // 2 - 18
+        ctx.text(PADDING, msg_y, msg, size=13, color=C["subtext"])
+        # Wrap hint roughly
+        max_chars = max(20, int((w - 2 * PADDING) / 7.5))
+        hint_y = msg_y + 22
+        word_buf = ""
+        for word in hint.split():
+            trial = (word_buf + " " + word).strip()
+            if len(trial) > max_chars:
+                ctx.text(PADDING, hint_y, word_buf.strip(), size=12, color=C["muted"])
+                hint_y += 18
+                word_buf = word
+            else:
+                word_buf = trial
+        if word_buf.strip():
+            ctx.text(PADDING, hint_y, word_buf.strip(), size=12, color=C["muted"])
+
+        _draw_footer(ctx)
+        return
+
+    # List
+    list_y = HEADER_H + 4
+    list_h = h - HEADER_H - FOOTER_H - 4
+    visible_rows = max(1, int(list_h / ITEM_H))
+
+    # Scroll so selected stays visible.
+    scroll = 0
+    if selected >= visible_rows:
+        scroll = selected - visible_rows + 1
+
+    for idx in range(scroll, min(len(pins), scroll + visible_rows)):
+        row = idx - scroll
+        y = list_y + row * ITEM_H
+        is_sel = (idx == selected)
+        path = pins[idx]
+        exists = os.path.isdir(path)
+
+        if is_sel:
+            ctx.rect(0, y, w, ITEM_H, fill=C["sel_bg"])
+
+        # Slot number
+        slot = idx + 1
+        slot_text = str(slot) if slot <= 9 else " "
+        slot_color = C["accent"] if is_sel else C["muted"]
+        ctx.text(PADDING, y + 7, slot_text, size=12, color=slot_color, monospace=True)
+
+        # Path — shortened, dimmed if missing
+        short_path = _shorten_path(path)
+        path_color = (C["text"] if is_sel else C["subtext"]) if exists else C["missing"]
+
+        path_x = PADDING + 22
+        # Truncate if too long
+        max_chars = max(10, int((w - path_x - PADDING) / 7.5))
+        display_path = short_path
+        if len(display_path) > max_chars:
+            display_path = "\u2026" + display_path[-(max_chars - 1):]
+
+        ctx.text(path_x, y + 7, display_path, size=13, color=path_color, monospace=True)
+
+        # Missing indicator
+        if not exists:
+            miss_text = "missing"
+            miss_x = w - PADDING - len(miss_text) * 7 - 4
+            if miss_x > path_x + len(display_path) * 7.5 + 8:
+                ctx.text(miss_x, y + 8, miss_text, size=11, color=C["missing"])
+
+    _draw_footer(ctx)
+
+
+def _draw_footer(ctx):
+    w = ctx.width
+    h = ctx.height
+    ctx.rect(0, h - FOOTER_H, w, FOOTER_H, fill=C["header"])
+    ctx.line(0, h - FOOTER_H, w, h - FOOTER_H, color=C["surface"], width=1.0)
+    footer_hint = "[j/k] navigate  [Enter] cd  [a] pin cwd  [d] remove  [r] reload"
+    ctx.text(PADDING, h - FOOTER_H + 8, footer_hint, size=11, color=C["muted"])
+
+
+# ---------------------------------------------------------------------------
+# Input
+# ---------------------------------------------------------------------------
+
+@app.on_key
+def on_key(key, _mods, emit):
+    global selected, pins
+
+    if key in ("j", "ArrowDown"):
+        if pins:
+            selected = min(selected + 1, len(pins) - 1)
+
+    elif key in ("k", "ArrowUp"):
+        if pins:
+            selected = max(selected - 1, 0)
+
+    elif key == "Enter":
+        if pins and 0 <= selected < len(pins):
+            _cd_to(pins[selected], emit)
+
+    elif key == "a":
+        _add_cwd(emit)
+
+    elif key in ("d", "Delete"):
+        _remove_selected()
+
+    elif key == "r":
+        pins = _load_pins()
+        _clamp_selected()
+
+    elif len(key) == 1 and key.isdigit() and key != "0":
+        slot = int(key)
+        idx = slot - 1
+        if idx < len(pins):
+            selected = idx
+            _cd_to(pins[idx], emit)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+app.run()

--- a/examples/navigator/plexi_sdk.py
+++ b/examples/navigator/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break


### PR DESCRIPTION
## Summary

- Adds `examples/navigator/` — a Harpoon-style directory hotlist app for Plexi
- Pins directories to `~/.plexi-alpha/navigator.json` with full persistence on every mutation
- `j`/`k`/arrows to navigate, `1`–`9` to jump directly to a slot, `Enter` to cd, `a` to pin cwd, `d`/Delete to remove, `r` to reload

## Behaviour

- Header shows "Navigator — N pins"
- Each row shows slot number + `~`-shortened path in monospace; missing directories render in muted `#585b70` with a "missing" badge
- Empty state shows a friendly onboarding message
- Catppuccin Mocha theme, 28px item height
- No pip dependencies — stdlib only, Python 3.9 compatible (`from __future__ import annotations`)
- `manifest.toml`: `id = "navigator"`, `name = "Navigator"`, no `[app.launch]` companion pane

## Test plan

- [ ] Install: `just install-alpha` then `chmod +x ~/.plexi-alpha/apps/navigator/navigator.py`
- [ ] Launch Navigator from Plexi
- [ ] Navigate to a directory in a terminal pane, switch to Navigator, press `a` — verify it appears
- [ ] Press `1` — verify terminal cds to that directory
- [ ] Press `d` — verify entry removed and `navigator.json` updated
- [ ] Delete the pinned directory from disk, press `r` — verify it shows as "missing" in muted color
- [ ] Press `Enter` on a valid entry — verify terminal cds

🤖 Generated with [Claude Code](https://claude.com/claude-code)