### PR TITLE
feat: PyFlow node graph app

### DIFF
--- a/examples/pyflow/manifest.toml
+++ b/examples/pyflow/manifest.toml
@@ -1,0 +1,9 @@
+[app]
+id = "pyflow"
+name = "PyFlow"
+entry = "pyflow.py"
+version = "0.1.0"
+description = "Visual node graph editor — connect nodes by wiring output ports to input ports"
+
+[app.capabilities]
+mouse_tracking = true

--- a/examples/pyflow/plexi_sdk.py
+++ b/examples/pyflow/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/pyflow/plexi_sdk_advanced.py
+++ b/examples/pyflow/plexi_sdk_advanced.py
@@ -1,0 +1,460 @@
+"""
+plexi_sdk_advanced.py — Advanced UI SDK for Plexi (Python).
+
+Higher-level abstractions over plexi_sdk.py for canvas/game/interactive apps:
+canvas transforms, hit testing, drag handling, focus routing, frame timing,
+and tween animation. Zero new dependencies — stdlib + plexi_sdk only.
+
+Apps copy this file next to plexi_sdk.py:
+
+    from plexi_sdk import App
+    from plexi_sdk_advanced import Canvas, HitTester, FrameTimer, Tween, ease_out_cubic
+
+Spec: docs/specs/core-advanced-ui-sdk.md
+
+NOTE: Several modules here depend on Rust-side protocol extensions that have
+not landed yet (mouse_down/up/move events, scroll, delta_time on render). The
+Python side is shipped first so apps that need it can begin work; the dynamic
+parts gracefully degrade until the protocol catches up. See follow-up issue
+listed in DEV_LOG for the Rust-side work.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Tuple
+
+from plexi_sdk import RenderContext  # noqa: F401  (re-exported for convenience)
+
+
+# ----------------------------------------------------------------------------
+# Canvas — pan/zoom transform context
+# ----------------------------------------------------------------------------
+
+
+class Canvas:
+    """Pan/zoom coordinate space for draw calls.
+
+    Use as a context manager via ``canvas.transform(ctx)`` to apply offset+scale
+    to all draws inside the block.
+    """
+
+    def __init__(
+        self,
+        offset: Tuple[float, float] = (0.0, 0.0),
+        scale: float = 1.0,
+        bounds: Optional[Tuple[float, float, float, float]] = None,
+    ):
+        self.offset: Tuple[float, float] = offset
+        self.scale: float = scale
+        # Optional content bounds (x, y, w, h) — used by zoom_to_fit / clamping.
+        self.bounds: Optional[Tuple[float, float, float, float]] = bounds
+
+    # -- coordinate conversion ------------------------------------------------
+
+    def screen_to_canvas(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert screen pixel to canvas coordinate."""
+        ox, oy = self.offset
+        return ((x - ox) / self.scale, (y - oy) / self.scale)
+
+    def canvas_to_screen(self, x: float, y: float) -> Tuple[float, float]:
+        """Convert canvas coordinate to screen pixel."""
+        ox, oy = self.offset
+        return (x * self.scale + ox, y * self.scale + oy)
+
+    # -- viewport fitting -----------------------------------------------------
+
+    def zoom_to_fit(
+        self,
+        content_bounds: Tuple[float, float, float, float],
+        viewport: Tuple[float, float],
+        padding: float = 20.0,
+    ) -> None:
+        """Set offset/scale so ``content_bounds`` fills the viewport with padding."""
+        cx, cy, cw, ch = content_bounds
+        vw, vh = viewport
+        if cw <= 0 or ch <= 0 or vw <= 0 or vh <= 0:
+            return
+        avail_w = max(1.0, vw - 2 * padding)
+        avail_h = max(1.0, vh - 2 * padding)
+        self.scale = min(avail_w / cw, avail_h / ch)
+        # Center the content rect inside the viewport at the new scale.
+        scaled_w = cw * self.scale
+        scaled_h = ch * self.scale
+        self.offset = (
+            (vw - scaled_w) / 2.0 - cx * self.scale,
+            (vh - scaled_h) / 2.0 - cy * self.scale,
+        )
+
+    # -- transform context manager -------------------------------------------
+
+    def transform(self, ctx: RenderContext) -> "_CanvasTransform":
+        """Returns a context manager that patches ``ctx`` draw methods to
+        pre-apply offset+scale. Restores originals on exit.
+        """
+        return _CanvasTransform(self, ctx)
+
+    # -- input (stub for future protocol extensions) -------------------------
+
+    def handle_input(self, event: Any) -> bool:  # pragma: no cover
+        """Stub. Pan/zoom from mouse_move/scroll requires Rust-side protocol
+        events that don't exist yet. Returns False (event not handled).
+        """
+        return False
+
+
+class _CanvasTransform:
+    """Context manager that monkey-patches ``ctx`` draw methods to apply the
+    canvas's offset+scale. The simple SDK's RenderContext doesn't expose a
+    transform stack, so we patch the bound methods for the duration of the
+    block. Original methods restored on exit (even on exception).
+    """
+
+    # Methods to wrap. Each entry is (method_name, point_args, size_args).
+    # point_args are scaled-and-offset; size_args are scale-only.
+    _METHODS: Tuple[Tuple[str, Tuple[str, ...], Tuple[str, ...]], ...] = (
+        ("rect", ("x", "y"), ("w", "h")),
+        ("text", ("x", "y"), ("size",)),
+        ("line", ("x1", "y1", "x2", "y2"), ("width",)),
+        ("image", ("x", "y"), ("w", "h")),
+    )
+
+    def __init__(self, canvas: Canvas, ctx: RenderContext):
+        self._canvas = canvas
+        self._ctx = ctx
+        self._originals: dict = {}
+
+    def __enter__(self) -> "_CanvasTransform":
+        canvas = self._canvas
+        ctx = self._ctx
+
+        for name, point_args, size_args in self._METHODS:
+            class_method = getattr(type(ctx), name, None)
+            if class_method is None:
+                continue
+            # Capture whether the instance had its own attribute pre-patch so
+            # we restore exactly (delete vs. reset).
+            had_instance_attr = name in ctx.__dict__
+            original_instance_value = ctx.__dict__.get(name)
+            self._originals[name] = (had_instance_attr, original_instance_value)
+            bound_original = getattr(ctx, name)
+            setattr(ctx, name, _wrap_draw(bound_original, canvas, point_args, size_args))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for name, (had_instance_attr, original_value) in self._originals.items():
+            if had_instance_attr:
+                setattr(self._ctx, name, original_value)
+            else:
+                # Delete the patched instance attribute so descriptor lookup
+                # falls back through to the class method (clean restore).
+                try:
+                    delattr(self._ctx, name)
+                except AttributeError:
+                    pass
+        self._originals.clear()
+
+
+def _wrap_draw(
+    original: Callable,
+    canvas: Canvas,
+    point_args: Tuple[str, ...],
+    size_args: Tuple[str, ...],
+) -> Callable:
+    """Wrap a draw method so coordinates are translated through the canvas."""
+
+    def wrapped(*args, **kwargs):
+        # Re-read offset/scale on every call so live updates apply.
+        cox, coy = canvas.offset
+        s = canvas.scale
+
+        # Map positional args by inspecting parameter names of the original.
+        # Easiest robust path: convert positional to kwargs by reading the
+        # method's parameter order. Use __code__.co_varnames (skip 'self').
+        code = getattr(original, "__code__", None)
+        if code is not None and args:
+            varnames = code.co_varnames[1 : code.co_argcount]
+            for i, val in enumerate(args):
+                if i < len(varnames):
+                    kwargs[varnames[i]] = val
+            args = ()
+
+        # Pair x/y point args (translate + scale).
+        # point_args may be a flat list of names: handle as pairs (x,y),(x1,y1)...
+        for i in range(0, len(point_args), 2):
+            xn = point_args[i]
+            yn = point_args[i + 1] if i + 1 < len(point_args) else None
+            if xn in kwargs and yn is not None and yn in kwargs:
+                kwargs[xn] = kwargs[xn] * s + cox
+                kwargs[yn] = kwargs[yn] * s + coy
+
+        # Scale-only args (sizes, widths).
+        for sn in size_args:
+            if sn in kwargs:
+                kwargs[sn] = kwargs[sn] * s
+
+        return original(**kwargs)
+
+    return wrapped
+
+
+# ----------------------------------------------------------------------------
+# HitTester — register rectangles, test a point
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class HitRegion:
+    """A registered hit-test rectangle."""
+
+    id: Any
+    x: float
+    y: float
+    w: float
+    h: float
+
+    def contains(self, x: float, y: float) -> bool:
+        return self.x <= x < self.x + self.w and self.y <= y < self.y + self.h
+
+
+class HitTester:
+    """Register rectangles with IDs each frame, then test a point.
+
+    O(n) is fine for MVP — designed for ~100 nodes max. Last-registered wins
+    (matches painter's-model draw order: top-of-stack is hit first).
+    """
+
+    def __init__(self):
+        self._regions: list[HitRegion] = []
+
+    def clear(self) -> None:
+        """Reset registered regions. Call at the start of each render frame."""
+        self._regions.clear()
+
+    def register(self, id: Any, x: float, y: float, w: float, h: float) -> HitRegion:
+        """Add a region. Returns the created HitRegion."""
+        region = HitRegion(id=id, x=x, y=y, w=w, h=h)
+        self._regions.append(region)
+        return region
+
+    def test(self, x: float, y: float) -> Optional[HitRegion]:
+        """Return topmost (last-registered) region containing the point."""
+        for region in reversed(self._regions):
+            if region.contains(x, y):
+                return region
+        return None
+
+
+# ----------------------------------------------------------------------------
+# DragHandler — minimal drag state machine
+# ----------------------------------------------------------------------------
+
+
+class DragHandler:
+    """Drag-gesture state machine.
+
+    NOTE: Full drag requires ``mouse_move`` and ``mouse_up`` events that are
+    not yet in the Plexi protocol. Apps using this get partial functionality
+    until those events land. Track via the follow-up issue referenced in
+    DEV_LOG entry for this PR.
+    """
+
+    def __init__(self, threshold: float = 4.0):
+        self.threshold: float = threshold
+        self.active: bool = False
+        self.payload: Any = None
+        self._start: Tuple[float, float] = (0.0, 0.0)
+        self._last: Tuple[float, float] = (0.0, 0.0)
+        self._armed: bool = False
+
+    def start(self, x: float, y: float, payload: Any = None) -> None:
+        """Begin tracking a potential drag at (x, y)."""
+        self._start = (x, y)
+        self._last = (x, y)
+        self.payload = payload
+        self._armed = True
+        self.active = False
+
+    def update(self, x: float, y: float) -> Tuple[float, float]:
+        """Return delta since last update. Returns (0, 0) before threshold."""
+        if not self._armed:
+            return (0.0, 0.0)
+        if not self.active:
+            sx, sy = self._start
+            if math.hypot(x - sx, y - sy) >= self.threshold:
+                self.active = True
+                self._last = (x, y)
+                return (0.0, 0.0)
+            return (0.0, 0.0)
+        lx, ly = self._last
+        dx, dy = x - lx, y - ly
+        self._last = (x, y)
+        return (dx, dy)
+
+    def end(self) -> Any:
+        """Stop tracking. Returns the payload supplied at start."""
+        payload = self.payload
+        self.active = False
+        self._armed = False
+        self.payload = None
+        return payload
+
+
+# ----------------------------------------------------------------------------
+# FocusManager — route keyboard input to named widgets
+# ----------------------------------------------------------------------------
+
+
+class FocusManager:
+    """Tracks which named widget currently owns keyboard focus."""
+
+    def __init__(self):
+        self.current: Optional[str] = None
+        self._handlers: dict[str, Callable] = {}
+
+    def set(self, name: Optional[str]) -> None:
+        """Set the focused widget name (or None to clear)."""
+        self.current = name
+
+    def register(self, name: str, handler: Callable) -> None:
+        """Register a handler for a named widget. Optional — apps can also
+        check ``focus.current`` directly in their on_key handler."""
+        self._handlers[name] = handler
+
+    def dispatch(self, *args, **kwargs) -> bool:
+        """Dispatch to the current focus handler if registered. Returns True
+        if a handler was called."""
+        if self.current and self.current in self._handlers:
+            self._handlers[self.current](*args, **kwargs)
+            return True
+        return False
+
+
+# ----------------------------------------------------------------------------
+# FrameTimer — fixed-interval tick loop using wall-clock time
+# ----------------------------------------------------------------------------
+
+
+class FrameTimer:
+    """Ticks True every ``interval`` seconds. Uses ``time.monotonic()`` so it
+    works without protocol-level delta_time. ``dt_override`` is accepted for
+    forward compatibility once Plexi sends delta_time on render events.
+    """
+
+    def __init__(self, interval: float):
+        self.interval: float = interval
+        self._last_tick: float = time.monotonic()
+
+    def ready(self, dt_override: Optional[float] = None) -> bool:
+        """Return True once per ``interval`` window. Resets the window on True."""
+        now = time.monotonic()
+        if (now - self._last_tick) >= self.interval:
+            self._last_tick = now
+            return True
+        return False
+
+    def elapsed(self) -> float:
+        """Seconds since the last tick that returned True."""
+        return time.monotonic() - self._last_tick
+
+    def set_interval(self, new_interval: float) -> None:
+        """Change the tick interval (e.g. snake speed-up)."""
+        self.interval = new_interval
+
+
+# ----------------------------------------------------------------------------
+# Easing functions
+# ----------------------------------------------------------------------------
+
+
+def linear(t: float) -> float:
+    return t
+
+
+def ease_in(t: float) -> float:
+    return t * t
+
+
+def ease_out(t: float) -> float:
+    return 1.0 - (1.0 - t) * (1.0 - t)
+
+
+def ease_in_out(t: float) -> float:
+    if t < 0.5:
+        return 2.0 * t * t
+    return 1.0 - (-2.0 * t + 2.0) ** 2 / 2.0
+
+
+def ease_out_cubic(t: float) -> float:
+    return 1.0 - (1.0 - t) ** 3
+
+
+def ease_out_bounce(t: float) -> float:
+    n1 = 7.5625
+    d1 = 2.75
+    if t < 1.0 / d1:
+        return n1 * t * t
+    if t < 2.0 / d1:
+        t -= 1.5 / d1
+        return n1 * t * t + 0.75
+    if t < 2.5 / d1:
+        t -= 2.25 / d1
+        return n1 * t * t + 0.9375
+    t -= 2.625 / d1
+    return n1 * t * t + 0.984375
+
+
+# ----------------------------------------------------------------------------
+# Tween — interpolate a value over wall-clock time
+# ----------------------------------------------------------------------------
+
+
+class Tween:
+    """Interpolate a value from ``start`` to ``end`` over ``duration`` seconds."""
+
+    def __init__(
+        self,
+        start: float,
+        end: float,
+        duration: float,
+        easing: Callable[[float], float] = linear,
+    ):
+        self.start: float = start
+        self.end: float = end
+        self.duration: float = max(1e-9, duration)
+        self.easing: Callable[[float], float] = easing
+        self._t0: float = time.monotonic()
+
+    def reset(self) -> None:
+        """Restart the tween from t=0 at the current wall-clock time."""
+        self._t0 = time.monotonic()
+
+    def value(self, now: Optional[float] = None) -> float:
+        """Return the interpolated value at the current (or supplied) time."""
+        t_now = now if now is not None else time.monotonic()
+        elapsed = t_now - self._t0
+        if elapsed <= 0.0:
+            return self.start
+        if elapsed >= self.duration:
+            return self.end
+        t = elapsed / self.duration
+        return self.start + (self.end - self.start) * self.easing(t)
+
+    @property
+    def done(self) -> bool:
+        return (time.monotonic() - self._t0) >= self.duration
+
+
+# ----------------------------------------------------------------------------
+# LayerStack — TODO: deferred until simple SDK exposes a draw-order hook.
+# ----------------------------------------------------------------------------
+#
+# The simple SDK already accumulates draw commands in append order and flushes
+# them at frame end (RenderContext._commands + _flush). A LayerStack would need
+# to either (a) intercept _commands during a `with layer.draw(...)` block and
+# tag each command with a layer index, then sort on flush, or (b) maintain its
+# own per-layer command lists. Both work, but require either patching
+# _commands or running the user's draw callbacks twice. Spec calls this
+# deferrable; skipping for MVP.

--- a/examples/pyflow/pyflow.py
+++ b/examples/pyflow/pyflow.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""
+pyflow — Plexi app
+Visual node graph editor. Drag nodes, wire ports, pan the canvas.
+
+Controls:
+  Drag node header        Move node
+  Click output port       Begin wiring an edge
+  Click input port        Complete edge (while wiring)
+  Escape                  Cancel edge wiring
+  Delete / Backspace      Delete selected node
+  Drag empty space        Pan canvas
+  Scroll                  Pan canvas
+"""
+
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+from plexi_sdk_advanced import Canvas, HitTester, DragHandler
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha palette
+# ---------------------------------------------------------------------------
+
+C = {
+    "base":     "#1e1e2e",
+    "mantle":   "#181825",
+    "crust":    "#11111b",
+    "surface0": "#313244",
+    "surface1": "#45475a",
+    "surface2": "#585b70",
+    "overlay0": "#6c7086",
+    "overlay1": "#7f849c",
+    "text":     "#cdd6f4",
+    "subtext0": "#a6adc8",
+    "subtext1": "#bac2de",
+    "blue":     "#89b4fa",
+    "lavender": "#b4befe",
+    "sapphire": "#74c7ec",
+    "sky":      "#89dceb",
+    "teal":     "#94e2d5",
+    "green":    "#a6e3a1",
+    "yellow":   "#f9e2af",
+    "peach":    "#fab387",
+    "maroon":   "#eba0ac",
+    "red":      "#f38ba8",
+    "mauve":    "#cba6f7",
+    "pink":     "#f5c2e7",
+    "flamingo": "#f2cdcd",
+}
+
+# ---------------------------------------------------------------------------
+# Layout constants
+# ---------------------------------------------------------------------------
+
+NODE_W        = 200
+NODE_HEADER_H = 32
+PORT_ROW_H    = 26
+PORT_RADIUS   = 6
+PORT_PADDING  = 14   # x distance from node edge to port centre
+TOOLBAR_H     = 44
+EDGE_CURVE    = 80   # bezier handle length
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class Port:
+    """Represents one input or output port on a node."""
+
+    def __init__(self, name, type_label, is_output=False):
+        self.name = name
+        self.type_label = type_label
+        self.is_output = is_output
+
+
+class Node:
+    """A single node on the canvas."""
+
+    def __init__(self, node_id, title, inputs, outputs, x=100.0, y=100.0):
+        self.id = node_id
+        self.title = title
+        self.inputs = inputs    # list of Port
+        self.outputs = outputs  # list of Port
+        self.x = x
+        self.y = y
+
+    @property
+    def height(self):
+        """Total rendered height of the node."""
+        rows = max(len(self.inputs) + len(self.outputs), 1)
+        return NODE_HEADER_H + rows * PORT_ROW_H + 8
+
+    def input_port_pos(self, port_index):
+        """Canvas-space centre of an input port."""
+        y = self.y + NODE_HEADER_H + port_index * PORT_ROW_H + PORT_ROW_H / 2
+        return (self.x + PORT_PADDING, y)
+
+    def output_port_pos(self, port_index):
+        """Canvas-space centre of an output port."""
+        base = self.y + NODE_HEADER_H + len(self.inputs) * PORT_ROW_H
+        y = base + port_index * PORT_ROW_H + PORT_ROW_H / 2
+        return (self.x + NODE_W - PORT_PADDING, y)
+
+
+class Edge:
+    """A wired connection between an output port and an input port."""
+
+    def __init__(self, src_node_id, src_port_index, dst_node_id, dst_port_index):
+        self.src_node_id = src_node_id
+        self.src_port_index = src_port_index
+        self.dst_node_id = dst_node_id
+        self.dst_port_index = dst_port_index
+
+
+# ---------------------------------------------------------------------------
+# Hard-coded example graph
+# ---------------------------------------------------------------------------
+
+
+def make_example_nodes():
+    return [
+        Node(
+            "load_image", "Load Image",
+            inputs=[],
+            outputs=[Port("image", "Image")],
+            x=60, y=80,
+        ),
+        Node(
+            "blur", "Blur",
+            inputs=[Port("image", "Image"), Port("radius", "float")],
+            outputs=[Port("image", "Image")],
+            x=340, y=60,
+        ),
+        Node(
+            "threshold", "Threshold",
+            inputs=[Port("image", "Image"), Port("value", "float")],
+            outputs=[Port("mask", "Mask")],
+            x=340, y=240,
+        ),
+        Node(
+            "save", "Save",
+            inputs=[Port("image", "Image"), Port("path", "str")],
+            outputs=[],
+            x=620, y=140,
+        ),
+    ]
+
+
+def make_example_edges():
+    return [
+        Edge("load_image", 0, "blur", 0),
+        Edge("blur", 0, "save", 0),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# App state
+# ---------------------------------------------------------------------------
+
+
+class PyFlow:
+    def __init__(self):
+        self.canvas = Canvas(offset=(20.0, TOOLBAR_H + 10.0), scale=1.0)
+        self.hit = HitTester()
+        self.node_drag = DragHandler(threshold=3.0)
+        self.pan_drag = DragHandler(threshold=3.0)
+
+        self.nodes = make_example_nodes()
+        self.edges = make_example_edges()
+
+        self.selected_node_id = None
+
+        # Edge wiring state
+        self.wiring = False            # True while dragging a new edge
+        self.wire_src_node_id = None
+        self.wire_src_port_index = None
+        self.wire_cursor_x = 0.0      # screen coords of cursor tip
+        self.wire_cursor_y = 0.0
+
+        # Which node is currently being dragged
+        self.dragging_node_id = None
+
+        # Pan drag tracking
+        self.panning = False
+
+    def node_by_id(self, node_id):
+        for n in self.nodes:
+            if n.id == node_id:
+                return n
+        return None
+
+    def delete_selected(self):
+        if self.selected_node_id is None:
+            return
+        nid = self.selected_node_id
+        self.nodes = [n for n in self.nodes if n.id != nid]
+        self.edges = [
+            e for e in self.edges
+            if e.src_node_id != nid and e.dst_node_id != nid
+        ]
+        self.selected_node_id = None
+
+    def edge_exists(self, dst_node_id, dst_port_index):
+        """Check if an input port already has an edge."""
+        for e in self.edges:
+            if e.dst_node_id == dst_node_id and e.dst_port_index == dst_port_index:
+                return True
+        return False
+
+
+state = PyFlow()
+app = App(app_id="pyflow")
+
+# ---------------------------------------------------------------------------
+# Hit-region ID helpers
+# ---------------------------------------------------------------------------
+
+# IDs are tuples so we can pattern-match on type easily.
+# ("node", node_id)
+# ("out_port", node_id, port_index)
+# ("in_port", node_id, port_index)
+# ("canvas_bg",)
+# ("toolbar_btn", btn_name)
+
+
+# ---------------------------------------------------------------------------
+# Draw helpers
+# ---------------------------------------------------------------------------
+
+
+def draw_toolbar(ctx):
+    """Fixed toolbar at top — not affected by canvas pan/zoom."""
+    ctx.rect(0, 0, ctx.width, TOOLBAR_H, fill=C["mantle"], radius=0)
+
+    # Title
+    ctx.text(16, 13, "PyFlow", size=15, color=C["text"], bold=True)
+
+    # Hint text
+    hint = "Click output port to wire  |  Drag nodes  |  Drag canvas to pan"
+    ctx.text(ctx.width / 2 - 160, 14, hint, size=11, color=C["overlay0"])
+
+
+def draw_bezier_edge(ctx, sx, sy, ex, ey, color, width=2.0):
+    """Approximate a cubic bezier with line segments (no bezier draw cmd yet)."""
+    cx1 = sx + EDGE_CURVE
+    cy1 = sy
+    cx2 = ex - EDGE_CURVE
+    cy2 = ey
+    steps = 24
+    prev_x, prev_y = sx, sy
+    for i in range(1, steps + 1):
+        t = i / steps
+        t2 = t * t
+        t3 = t2 * t
+        mt = 1.0 - t
+        mt2 = mt * mt
+        mt3 = mt2 * mt
+        x = mt3 * sx + 3 * mt2 * t * cx1 + 3 * mt * t2 * cx2 + t3 * ex
+        y = mt3 * sy + 3 * mt2 * t * cy1 + 3 * mt * t2 * cy2 + t3 * ey
+        ctx.line(prev_x, prev_y, x, y, color=color, width=width)
+        prev_x, prev_y = x, y
+
+
+def draw_port_circle(ctx, sx, sy, filled, color):
+    """Draw a filled or hollow port indicator using a small rect as circle proxy."""
+    r = PORT_RADIUS
+    ctx.rect(sx - r, sy - r, r * 2, r * 2, fill=color, radius=r)
+    if not filled:
+        # Punch an inner hole with the node body color
+        ir = r - 2
+        ctx.rect(sx - ir, sy - ir, ir * 2, ir * 2, fill=C["surface0"], radius=ir)
+
+
+def port_is_connected_output(state, node_id, port_index):
+    for e in state.edges:
+        if e.src_node_id == node_id and e.src_port_index == port_index:
+            return True
+    return False
+
+
+def port_is_connected_input(state, node_id, port_index):
+    for e in state.edges:
+        if e.dst_node_id == node_id and e.dst_port_index == port_index:
+            return True
+    return False
+
+
+def draw_node(ctx, hit, node, selected, wiring_src_node, wiring_src_port):
+    sx, sy = state.canvas.canvas_to_screen(node.x, node.y)
+    sw = NODE_W * state.canvas.scale
+    sh = node.height * state.canvas.scale
+
+    # Body
+    border_color = C["blue"] if selected else C["surface1"]
+    ctx.rect(sx - 2, sy - 2, sw + 4, sh + 4, fill=border_color, radius=8)
+    ctx.rect(sx, sy, sw, sh, fill=C["surface0"], radius=7)
+
+    # Header
+    ctx.rect(sx, sy, sw, NODE_HEADER_H * state.canvas.scale, fill=C["surface1"], radius=7)
+    ctx.text(
+        sx + sw / 2 - len(node.title) * 4,
+        sy + 9 * state.canvas.scale,
+        node.title,
+        size=13 * state.canvas.scale,
+        color=C["text"],
+        bold=True,
+    )
+
+    # Register header as draggable / selectable
+    hit.register(("node", node.id), sx, sy, sw, NODE_HEADER_H * state.canvas.scale)
+
+    # Input ports
+    for i, port in enumerate(node.inputs):
+        py = sy + (NODE_HEADER_H + i * PORT_ROW_H + PORT_ROW_H / 2) * state.canvas.scale
+        px = sx + PORT_PADDING * state.canvas.scale
+        connected = port_is_connected_input(state, node.id, i)
+        # Highlight if we are wiring and this is a valid target
+        highlight = state.wiring and not connected
+        color = C["green"] if highlight else (C["blue"] if connected else C["overlay1"])
+        draw_port_circle(ctx, px, py, connected, color)
+        ctx.text(
+            px + PORT_RADIUS + 4,
+            py - 6 * state.canvas.scale,
+            port.name + ": " + port.type_label,
+            size=11 * state.canvas.scale,
+            color=C["subtext0"],
+        )
+        hit.register(("in_port", node.id, i), px - PORT_RADIUS * 2, py - PORT_RADIUS * 2,
+                     PORT_RADIUS * 4, PORT_RADIUS * 4)
+
+    # Output ports
+    base_row = len(node.inputs)
+    for i, port in enumerate(node.outputs):
+        py = sy + (NODE_HEADER_H + (base_row + i) * PORT_ROW_H + PORT_ROW_H / 2) * state.canvas.scale
+        px = sx + (NODE_W - PORT_PADDING) * state.canvas.scale
+        connected = port_is_connected_output(state, node.id, i)
+        # Dim if we are currently wiring from this port
+        is_src = wiring_src_node == node.id and wiring_src_port == i
+        color = C["mauve"] if is_src else (C["blue"] if connected else C["overlay1"])
+        draw_port_circle(ctx, px, py, True, color)
+        label = "→ " + port.type_label
+        ctx.text(
+            px - PORT_RADIUS - len(label) * 7,
+            py - 6 * state.canvas.scale,
+            label,
+            size=11 * state.canvas.scale,
+            color=C["subtext0"],
+        )
+        hit.register(("out_port", node.id, i), px - PORT_RADIUS * 2, py - PORT_RADIUS * 2,
+                     PORT_RADIUS * 4, PORT_RADIUS * 4)
+
+
+def draw_edges(ctx):
+    for edge in state.edges:
+        src = state.node_by_id(edge.src_node_id)
+        dst = state.node_by_id(edge.dst_node_id)
+        if src is None or dst is None:
+            continue
+        scx, scy = src.output_port_pos(edge.src_port_index)
+        dcx, dcy = dst.input_port_pos(edge.dst_port_index)
+        ssx, ssy = state.canvas.canvas_to_screen(scx, scy)
+        dsx, dsy = state.canvas.canvas_to_screen(dcx, dcy)
+        draw_bezier_edge(ctx, ssx, ssy, dsx, dsy, color=C["blue"], width=2.0)
+
+
+def draw_wiring_preview(ctx):
+    """Draw the in-progress edge while user is wiring."""
+    if not state.wiring:
+        return
+    src = state.node_by_id(state.wire_src_node_id)
+    if src is None:
+        return
+    scx, scy = src.output_port_pos(state.wire_src_port_index)
+    ssx, ssy = state.canvas.canvas_to_screen(scx, scy)
+    draw_bezier_edge(ctx, ssx, ssy, state.wire_cursor_x, state.wire_cursor_y,
+                     color=C["mauve"], width=1.5)
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+@app.on_render
+def render(ctx):
+    hit = state.hit
+    hit.clear()
+
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["base"])
+
+    # Register canvas background (below toolbar)
+    hit.register(("canvas_bg",), 0, TOOLBAR_H, ctx.width, ctx.height - TOOLBAR_H)
+
+    # Dot grid
+    draw_dot_grid(ctx)
+
+    # Edges
+    draw_edges(ctx)
+
+    # Wiring preview
+    draw_wiring_preview(ctx)
+
+    # Nodes (draw selected last so it renders on top)
+    for node in state.nodes:
+        if node.id != state.selected_node_id:
+            draw_node(ctx, hit, node, False,
+                      state.wire_src_node_id, state.wire_src_port_index)
+    if state.selected_node_id:
+        sel_node = state.node_by_id(state.selected_node_id)
+        if sel_node:
+            draw_node(ctx, hit, sel_node, True,
+                      state.wire_src_node_id, state.wire_src_port_index)
+
+    # Toolbar (drawn last — on top of canvas)
+    draw_toolbar(ctx)
+
+    # Cursor
+    if state.wiring or state.node_drag.active:
+        ctx.set_cursor("grabbing")
+    elif state.panning:
+        ctx.set_cursor("grabbing")
+
+
+def draw_dot_grid(ctx):
+    """Faint dot grid that moves with the canvas pan."""
+    ox, oy = state.canvas.offset
+    spacing = 32.0 * state.canvas.scale
+    if spacing < 8:
+        return
+
+    # Compute first dot position mod spacing
+    start_x = ox % spacing
+    start_y = (oy - TOOLBAR_H) % spacing
+
+    x = start_x
+    while x < ctx.width:
+        y = TOOLBAR_H + start_y
+        while y < ctx.height:
+            # Draw a tiny 2x2 rect as a dot
+            ctx.rect(x - 1, y - 1, 2, 2, fill=C["surface1"])
+            y += spacing
+        x += spacing
+
+
+# ---------------------------------------------------------------------------
+# Mouse events
+# ---------------------------------------------------------------------------
+
+
+@app.on_mouse_down
+def on_mouse_down(x, y, button, emit):
+    if y < TOOLBAR_H:
+        return
+
+    region = state.hit.test(x, y)
+    if region is None:
+        return
+
+    rid = region.id
+
+    # Output port — start wiring
+    if rid[0] == "out_port":
+        _, node_id, port_idx = rid
+        state.wiring = True
+        state.wire_src_node_id = node_id
+        state.wire_src_port_index = port_idx
+        state.wire_cursor_x = x
+        state.wire_cursor_y = y
+        return
+
+    # Input port — complete wiring if active
+    if rid[0] == "in_port" and state.wiring:
+        _, node_id, port_idx = rid
+        # Don't connect to self
+        if node_id != state.wire_src_node_id:
+            # Remove existing edge to this input (one-in rule)
+            state.edges = [
+                e for e in state.edges
+                if not (e.dst_node_id == node_id and e.dst_port_index == port_idx)
+            ]
+            state.edges.append(Edge(
+                state.wire_src_node_id, state.wire_src_port_index,
+                node_id, port_idx,
+            ))
+        state.wiring = False
+        state.wire_src_node_id = None
+        state.wire_src_port_index = None
+        return
+
+    # Node header — start drag / select
+    if rid[0] == "node":
+        _, node_id = rid
+        if state.wiring:
+            # Cancel wiring on click elsewhere
+            state.wiring = False
+            state.wire_src_node_id = None
+            state.wire_src_port_index = None
+            return
+        state.selected_node_id = node_id
+        state.dragging_node_id = node_id
+        state.node_drag.start(x, y, payload=node_id)
+        return
+
+    # Canvas background — start pan
+    if rid[0] == "canvas_bg":
+        if state.wiring:
+            state.wiring = False
+            state.wire_src_node_id = None
+            state.wire_src_port_index = None
+            return
+        state.selected_node_id = None
+        state.panning = True
+        state.pan_drag.start(x, y)
+
+
+@app.on_mouse_up
+def on_mouse_up(x, y, button, emit):
+    if state.node_drag._armed:
+        state.node_drag.end()
+        state.dragging_node_id = None
+    if state.panning:
+        state.pan_drag.end()
+        state.panning = False
+
+
+@app.on_mouse_move
+def on_mouse_move(x, y, emit):
+    # Update wiring cursor
+    if state.wiring:
+        state.wire_cursor_x = x
+        state.wire_cursor_y = y
+
+    # Node drag
+    if state.node_drag._armed and state.dragging_node_id:
+        dx, dy = state.node_drag.update(x, y)
+        if state.node_drag.active and (dx != 0 or dy != 0):
+            node = state.node_by_id(state.dragging_node_id)
+            if node:
+                # Convert screen delta to canvas delta
+                node.x += dx / state.canvas.scale
+                node.y += dy / state.canvas.scale
+
+    # Canvas pan
+    if state.panning and state.pan_drag._armed:
+        dx, dy = state.pan_drag.update(x, y)
+        if dx != 0 or dy != 0:
+            ox, oy = state.canvas.offset
+            state.canvas.offset = (ox + dx, oy + dy)
+
+
+@app.on_scroll
+def on_scroll(x, y, delta_x, delta_y, emit):
+    # Pan the canvas with scroll
+    if y < TOOLBAR_H:
+        return
+    ox, oy = state.canvas.offset
+    state.canvas.offset = (ox - delta_x * 1.5, oy - delta_y * 1.5)
+
+
+# ---------------------------------------------------------------------------
+# Keyboard
+# ---------------------------------------------------------------------------
+
+
+@app.on_key
+def on_key(key, mods, emit):
+    if key in ("Delete", "Backspace"):
+        state.delete_selected()
+    elif key == "Escape":
+        if state.wiring:
+            state.wiring = False
+            state.wire_src_node_id = None
+            state.wire_src_port_index = None
+        else:
+            state.selected_node_id = None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+app.run()


### PR DESCRIPTION
## Summary

- Adds `examples/pyflow/` — a visual node graph editor app for Plexi
- Draggable nodes with input/output ports; edges drawn as approximated cubic bezier curves
- Click an output port to begin wiring, click an input port to complete; Escape to cancel
- Drag node headers to move them; drag empty canvas or scroll to pan
- Delete/Backspace removes the selected node and its edges
- Starts with a hardcoded Load Image → Blur → Save / Threshold example graph
- Catppuccin Mocha palette, dot-grid background that moves with the canvas
- `mouse_tracking = true` in manifest; uses `HitTester` + `DragHandler` from advanced SDK

## Test plan

- [ ] Install app to `~/.plexi-alpha/apps/pyflow/` and launch in Plexi alpha
- [ ] Verify nodes render with correct port counts and labels
- [ ] Drag node headers — nodes should follow cursor
- [ ] Click an output port (right side) — wiring preview bezier should follow cursor
- [ ] Click an input port (left side) — edge should appear and snap into place
- [ ] Click empty canvas while wiring — edge should be cancelled
- [ ] Escape while wiring — edge cancelled
- [ ] Select a node (click its header), press Delete — node and its edges removed
- [ ] Drag empty canvas area — canvas should pan
- [ ] Two-finger scroll — canvas should pan

🤖 Generated with [Claude Code](https://claude.com/claude-code)