### PR TITLE
feat: Pulse beat sequencer app

### DIFF
--- a/examples/pulse/manifest.toml
+++ b/examples/pulse/manifest.toml
@@ -1,0 +1,9 @@
+[app]
+id = "pulse"
+name = "Pulse"
+entry = "pulse.py"
+version = "0.1.0"
+description = "Visual beat sequencer. Build rhythms, watch them pulse."
+
+[app.capabilities]
+# No capabilities needed — pure rendering + input

--- a/examples/pulse/plexi_sdk.py
+++ b/examples/pulse/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/pulse/pulse.py
+++ b/examples/pulse/pulse.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+"""
+pulse — Plexi app
+Visual beat sequencer. 8 instruments x 16 steps. Build rhythms, watch them pulse.
+
+Controls:
+  Arrow keys    Move cursor
+  Space/Enter   Toggle cell
+  [/]           Decrease/Increase BPM
+  m             Mute row
+  r             Randomize row
+  c             Clear all
+  p             Pause/resume
+"""
+
+import math
+import os
+import random
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Audio setup — graceful degradation if pygame/numpy missing
+# ---------------------------------------------------------------------------
+
+AUDIO_OK = False
+sounds: dict[int, object] = {}
+
+try:
+    import numpy as np
+    import pygame
+    import pygame.sndarray
+
+    pygame.mixer.pre_init(frequency=44100, size=-16, channels=1, buffer=512)
+    pygame.mixer.init()
+    SAMPLE_RATE = 44100
+
+    def _make_sound(samples: "np.ndarray") -> "pygame.mixer.Sound":
+        samples = np.clip(samples, -1.0, 1.0)
+        pcm = (samples * 32767).astype(np.int16)
+        return pygame.sndarray.make_sound(pcm)
+
+    def _sine(freq: float, dur: float, env_decay: float = 1.0) -> "np.ndarray":
+        t = np.linspace(0, dur, int(SAMPLE_RATE * dur), endpoint=False)
+        env = np.exp(-t * env_decay / dur * 10)
+        return np.sin(2 * np.pi * freq * t) * env
+
+    def _noise(dur: float, env_decay: float = 1.0) -> "np.ndarray":
+        n = int(SAMPLE_RATE * dur)
+        t = np.linspace(0, dur, n, endpoint=False)
+        env = np.exp(-t * env_decay / dur * 10)
+        return (np.random.uniform(-1, 1, n) * env)
+
+    def _sweep(f0: float, f1: float, dur: float) -> "np.ndarray":
+        n = int(SAMPLE_RATE * dur)
+        t = np.linspace(0, dur, n, endpoint=False)
+        freqs = np.linspace(f0, f1, n)
+        phase = np.cumsum(freqs) / SAMPLE_RATE * 2 * np.pi
+        env = np.exp(-t * 8)
+        return np.sin(phase) * env
+
+    # Row index → sound generator
+    _generators = [
+        lambda: _sweep(80, 30, 0.15),                          # 0 Kick
+        lambda: _noise(0.10, 1.0) * 0.6 + _sine(180, 0.10),   # 1 Snare
+        lambda: _noise(0.05, 1.2),                             # 2 Hi-Hat
+        lambda: _noise(0.08, 1.5) * 0.7 + _sine(220, 0.08),   # 3 Clap
+        lambda: _sweep(120, 60, 0.12),                         # 4 Tom
+        lambda: _sine(300, 0.08) * 0.9,                        # 5 Rim
+        lambda: _sine(562, 0.20) * 0.8,                        # 6 Cowbell
+        lambda: _sweep(55, 40, 0.20),                          # 7 Bass
+    ]
+
+    for i, gen in enumerate(_generators):
+        try:
+            sounds[i] = _make_sound(gen())
+        except Exception:
+            pass
+
+    AUDIO_OK = True
+except Exception:
+    pass
+
+
+def play_sound(row: int):
+    if not AUDIO_OK:
+        return
+    snd = sounds.get(row)
+    if snd is not None:
+        try:
+            snd.play()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+BG          = "#1e1e2e"
+SURFACE     = "#313244"
+OVERLAY     = "#45475a"
+TEXT        = "#cdd6f4"
+SUBTEXT     = "#6c7086"
+HEADER      = "#181825"
+PLAYHEAD    = "#ffffff"
+
+ROW_COLORS = [
+    "#f38ba8",  # Kick
+    "#fab387",  # Snare
+    "#f9e2af",  # Hi-Hat
+    "#a6e3a1",  # Clap
+    "#89b4fa",  # Tom
+    "#94e2d5",  # Rim
+    "#cba6f7",  # Cowbell
+    "#eba0ac",  # Bass
+]
+
+ROW_NAMES = ["Kick", "Snare", "Hi-Hat", "Clap", "Tom", "Rim", "Cowbell", "Bass"]
+
+ROWS = 8
+COLS = 16
+BPM_MIN = 60
+BPM_MAX = 200
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+grid: list[list[bool]] = [[False] * COLS for _ in range(ROWS)]
+muted: list[bool] = [False] * ROWS
+cursor_row = 0
+cursor_col = 0
+bpm = 120
+paused = False
+
+# Playhead
+current_step = 0
+_last_step_time = time.monotonic()
+
+# Active pulses: list of (row, col, start_time)
+pulses: list[tuple[int, int, float]] = []
+
+PULSE_DURATION = 0.3  # seconds
+
+
+def step_interval() -> float:
+    return 60.0 / bpm / 4  # 16th notes
+
+
+def _hex_to_rgb(h: str) -> tuple[int, int, int]:
+    h = h.lstrip("#")
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def _rgb_with_alpha(color: str, alpha: float) -> str:
+    r, g, b = _hex_to_rgb(color)
+    ri = int(r * alpha + int(BG.lstrip("#")[0:2], 16) * (1 - alpha))
+    gi = int(g * alpha + int(BG.lstrip("#")[2:4], 16) * (1 - alpha))
+    bi = int(b * alpha + int(BG.lstrip("#")[4:6], 16) * (1 - alpha))
+    return f"#{ri:02x}{gi:02x}{bi:02x}"
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="pulse")
+
+
+@app.on_render
+def render(ctx):
+    global current_step, _last_step_time, paused
+
+    now = time.monotonic()
+
+    # Advance playhead
+    if not paused:
+        elapsed = now - _last_step_time
+        if elapsed >= step_interval():
+            _last_step_time = now
+            current_step = (current_step + 1) % COLS
+            # Fire sounds and pulses for active cells in this column
+            for row in range(ROWS):
+                if grid[row][current_step] and not muted[row]:
+                    play_sound(row)
+                    pulses.append((row, current_step, now))
+
+    # Expire old pulses
+    pulses[:] = [(r, c, t) for (r, c, t) in pulses if now - t < PULSE_DURATION]
+
+    # ---- Layout ----
+    header_h = 36.0
+    footer_h = 24.0
+    label_w = 56.0
+    pad = 8.0
+
+    grid_x = pad + label_w
+    grid_y = header_h + pad
+    grid_w = ctx.width - grid_x - pad
+    grid_h = ctx.height - header_h - footer_h - pad * 2
+
+    cell_w = grid_w / COLS
+    cell_h = grid_h / ROWS
+
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=BG)
+
+    # Header
+    ctx.rect(0, 0, ctx.width, header_h, fill=HEADER)
+    state_label = "PAUSED" if paused else f"BPM {bpm}"
+    ctx.text(pad, 10, "PULSE", size=15, color=TEXT, bold=True)
+    ctx.text(pad + 70, 11, state_label, size=13, color=SUBTEXT)
+    step_label = f"Step {current_step + 1:02d}/16"
+    ctx.text(ctx.width - len(step_label) * 7.5 - pad, 11, step_label, size=12, color=SUBTEXT)
+    hint = "[ ] bpm  m mute  r rand  c clear  p pause"
+    ctx.text(ctx.width / 2 - len(hint) * 3.5, 11, hint, size=10, color=SUBTEXT)
+
+    # Row labels + mute indicators
+    for row in range(ROWS):
+        color = ROW_COLORS[row]
+        ry = grid_y + row * cell_h
+        label_color = SUBTEXT if muted[row] else color
+        ctx.text(pad, ry + cell_h / 2 - 6, ROW_NAMES[row], size=10, color=label_color)
+        if muted[row]:
+            ctx.text(pad, ry + cell_h / 2 + 4, "mute", size=8, color=OVERLAY)
+
+    # Playhead band (behind cells)
+    ph_x = grid_x + current_step * cell_w
+    ctx.rect(ph_x, grid_y, cell_w, grid_h, fill=_rgb_with_alpha(PLAYHEAD, 0.08))
+
+    # Grid cells
+    cell_pad = 2.0
+    for row in range(ROWS):
+        color = ROW_COLORS[row]
+        dim_color = _rgb_with_alpha(color, 0.18)
+        for col in range(COLS):
+            cx = grid_x + col * cell_w + cell_pad
+            cy = grid_y + row * cell_h + cell_pad
+            cw = cell_w - cell_pad * 2
+            ch = cell_h - cell_pad * 2
+            radius = 3.0
+
+            if grid[row][col]:
+                fill = _rgb_with_alpha(color, 0.85) if muted[row] else color
+            else:
+                fill = dim_color
+
+            ctx.rect(cx, cy, cw, ch, fill=fill, radius=radius)
+
+            # Cursor border (draw as four thin rects)
+            if row == cursor_row and col == cursor_col:
+                bw = 2.0
+                ctx.rect(cx, cy, cw, bw, fill="#ffffff")
+                ctx.rect(cx, cy + ch - bw, cw, bw, fill="#ffffff")
+                ctx.rect(cx, cy, bw, ch, fill="#ffffff")
+                ctx.rect(cx + cw - bw, cy, bw, ch, fill="#ffffff")
+
+    # Pulse rings
+    for (pr, pc, pt) in pulses:
+        age = now - pt
+        t = age / PULSE_DURATION        # 0..1
+        alpha = max(0.0, 1.0 - t)
+        max_expand = min(cell_w, cell_h) * 1.2
+        expand = t * max_expand
+
+        color = ROW_COLORS[pr]
+        ring_x = grid_x + pc * cell_w + cell_w / 2
+        ring_y = grid_y + pr * cell_h + cell_h / 2
+        hw = cell_w / 2 + expand
+        hh = cell_h / 2 + expand
+        bw = max(1.0, 3.0 * (1.0 - t))
+
+        rw = hw * 2
+        rh = hh * 2
+        rx = ring_x - hw
+        ry = ring_y - hh
+        ring_color = _rgb_with_alpha(color, alpha)
+
+        ctx.rect(rx, ry, rw, bw, fill=ring_color)
+        ctx.rect(rx, ry + rh - bw, rw, bw, fill=ring_color)
+        ctx.rect(rx, ry, bw, rh, fill=ring_color)
+        ctx.rect(rx + rw - bw, ry, bw, rh, fill=ring_color)
+
+    # Footer
+    fy = ctx.height - footer_h
+    ctx.rect(0, fy, ctx.width, footer_h, fill=HEADER)
+    audio_label = "audio: on" if AUDIO_OK else "audio: off (install pygame + numpy)"
+    ctx.text(pad, fy + 7, audio_label, size=10, color=SUBTEXT)
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global cursor_row, cursor_col, bpm, paused, current_step, _last_step_time
+
+    if key == "ArrowUp":
+        cursor_row = (cursor_row - 1) % ROWS
+    elif key == "ArrowDown":
+        cursor_row = (cursor_row + 1) % ROWS
+    elif key == "ArrowLeft":
+        cursor_col = (cursor_col - 1) % COLS
+    elif key == "ArrowRight":
+        cursor_col = (cursor_col + 1) % COLS
+
+    elif key in ("Enter", " "):
+        grid[cursor_row][cursor_col] = not grid[cursor_row][cursor_col]
+
+    elif key == "[":
+        bpm = max(BPM_MIN, bpm - 5)
+    elif key == "]":
+        bpm = min(BPM_MAX, bpm + 5)
+
+    elif key == "m":
+        muted[cursor_row] = not muted[cursor_row]
+
+    elif key == "r":
+        for col in range(COLS):
+            grid[cursor_row][col] = random.random() < 0.35
+
+    elif key == "c":
+        for row in range(ROWS):
+            for col in range(COLS):
+                grid[row][col] = False
+        pulses.clear()
+
+    elif key == "p":
+        paused = not paused
+        if not paused:
+            _last_step_time = time.monotonic()
+
+
+app.run()


### PR DESCRIPTION
## Summary
- Adds `examples/pulse/` — an 8x16 visual beat sequencer Plexi app
- Synthesized audio via pygame + numpy (kick sweep, snare, hi-hat, clap, tom, rim, cowbell, bass) generated entirely in-memory at startup; degrades gracefully to visual-only if pygame/numpy unavailable
- Expanding pulse ring animations (rect outlines that grow and fade over 0.3s) fire on each active cell hit by the playhead
- Full Catppuccin Mocha color palette with per-row colors, translucent playhead band, and white cursor border

## Controls
`Arrow keys` move cursor · `Space`/`Enter` toggle · `[`/`]` BPM · `m` mute row · `r` randomize row · `c` clear all · `p` pause

## Test plan
- [ ] Open Pulse in a Plexi pane — grid renders with header showing "PULSE" and BPM
- [ ] Arrow keys move the white cursor border around the grid
- [ ] Space/Enter toggles cells between dim and bright row color
- [ ] `p` pauses/resumes the playhead sweep; playhead band moves left→right
- [ ] Active cells flash/pulse rings when the playhead crosses them
- [ ] `[`/`]` changes BPM displayed in header and audibly speeds/slows the beat
- [ ] `m` mutes a row (label goes dim, sounds stop); `r` randomizes current row; `c` clears all

🤖 Generated with [Claude Code](https://claude.com/claude-code)