### PR TITLE
feat: Seedclock farming game app

### DIFF
--- a/examples/seedclock/manifest.toml
+++ b/examples/seedclock/manifest.toml
@@ -1,0 +1,10 @@
+[app]
+id = "seedclock"
+name = "Seedclock"
+entry = "seedclock.py"
+version = "0.1.0"
+description = "One-season farming game. Race to 50 coins before the frost."
+icon = "🌾"
+
+[app.capabilities]
+# No capabilities needed — pure rendering + input

--- a/examples/seedclock/plexi_sdk.py
+++ b/examples/seedclock/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/seedclock/seedclock.py
+++ b/examples/seedclock/seedclock.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+seedclock — Plexi app
+One-season farming game. Plant crops, manage weather, hit 50 coins before frost.
+
+Controls:
+  Arrow keys    Move cursor
+  p             Plant seed at cursor
+  h             Harvest ready crop
+  m             Open/close market
+  1-4           Buy seed in market (wheat/tomato/carrot/corn)
+  Space         Advance day (debug)
+  Escape        Close market / return to title
+  Enter         Start / restart
+"""
+from __future__ import annotations
+
+import os
+import random
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Palette — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+C = {
+    "bg":       "#1e1e2e",
+    "surface":  "#313244",
+    "overlay":  "#45475a",
+    "text":     "#cdd6f4",
+    "subtext":  "#6c7086",
+    "header":   "#181825",
+    "green":    "#a6e3a1",
+    "gold":     "#f9e2af",
+    "red":      "#f38ba8",
+    "orange":   "#fab387",
+    "yellow":   "#f9e2af",
+    "blue":     "#89b4fa",
+    "mauve":    "#cba6f7",
+    "seeded":   "#45475a",
+    "growing":  "#a6e3a1",
+}
+
+# ---------------------------------------------------------------------------
+# Crop definitions
+# ---------------------------------------------------------------------------
+CROPS = {
+    "wheat":  {"days": 4, "price": 3, "seed_cost": 1, "color": "#f9e2af"},
+    "tomato": {"days": 6, "price": 6, "seed_cost": 2, "color": "#f38ba8"},
+    "carrot": {"days": 3, "price": 2, "seed_cost": 1, "color": "#fab387"},
+    "corn":   {"days": 8, "price": 9, "seed_cost": 3, "color": "#f9e2af"},
+}
+CROP_ORDER = ["wheat", "tomato", "carrot", "corn"]
+
+# Grid dimensions
+GRID_COLS = 10
+GRID_ROWS = 6
+TOTAL_DAYS = 20
+WIN_COINS = 50
+DAY_SECONDS = 30.0  # real seconds per game day
+
+# Growth stages
+EMPTY   = 0
+SEEDED  = 1
+GROWING = 2
+READY   = 3
+
+# Weather
+WEATHER_CLEAR   = "clear"
+WEATHER_DROUGHT = "drought"
+WEATHER_RAIN    = "rain"
+WEATHER_FROST   = "frost"
+
+WEATHER_COLORS = {
+    WEATHER_CLEAR:   None,
+    WEATHER_DROUGHT: "#fab387",
+    WEATHER_RAIN:    "#89b4fa",
+    WEATHER_FROST:   "#cba6f7",
+}
+
+WEATHER_LABELS = {
+    WEATHER_DROUGHT: "DROUGHT — growth slowed 50%",
+    WEATHER_RAIN:    "RAIN — growth sped up 50%",
+    WEATHER_FROST:   "FROST WARNING — harvest ready crops soon!",
+}
+
+# States
+STATE_TITLE   = "title"
+STATE_PLAYING = "playing"
+STATE_MARKET  = "market"
+STATE_WIN     = "win"
+STATE_LOSE    = "lose"
+
+
+# ---------------------------------------------------------------------------
+# Game model
+# ---------------------------------------------------------------------------
+
+class Cell:
+    def __init__(self):
+        self.stage: int = EMPTY
+        self.crop: str | None = None
+        self.days_planted: float = 0.0  # fractional days grown
+        self.frost_timer: float = 0.0   # days until frost kills ready crop
+
+
+class Game:
+    def __init__(self):
+        self.state = STATE_TITLE
+        self.coins = 10
+        self.day = 1
+        self.cursor_x = 0
+        self.cursor_y = 0
+        self.selected_seed = "wheat"
+        self.grid: list[list[Cell]] = [[Cell() for _ in range(GRID_COLS)] for _ in range(GRID_ROWS)]
+        self.weather = WEATHER_CLEAR
+        self.weather_days_left = 0
+        self.next_weather_in = random.randint(3, 5)
+        self.weather_banner_time = 0.0
+        self._day_timer = 0.0
+        self._last_tick = time.monotonic()
+
+    # ---- Day progression ---------------------------------------------------
+
+    def tick_time(self):
+        """Called every render frame; advances fractional day timer."""
+        now = time.monotonic()
+        elapsed = now - self._last_tick
+        self._last_tick = now
+
+        speed = 1.0
+        if self.weather == WEATHER_DROUGHT:
+            speed = 0.5
+        elif self.weather == WEATHER_RAIN:
+            speed = 1.5
+
+        day_fraction = (elapsed / DAY_SECONDS) * speed
+
+        # Grow crops
+        for row in self.grid:
+            for cell in row:
+                if cell.stage in (SEEDED, GROWING):
+                    cell.days_planted += day_fraction
+                    crop_days = CROPS[cell.crop]["days"]
+                    if cell.stage == SEEDED and cell.days_planted >= 1.0:
+                        cell.stage = GROWING
+                    if cell.stage == GROWING and cell.days_planted >= crop_days:
+                        cell.stage = READY
+                        cell.frost_timer = 2.0  # frost grace period
+                elif cell.stage == READY and self.weather == WEATHER_FROST:
+                    cell.frost_timer -= day_fraction
+                    if cell.frost_timer <= 0:
+                        cell.stage = EMPTY
+                        cell.crop = None
+                        cell.days_planted = 0.0
+
+        # Advance day counter (raw, unscaled by weather)
+        self._day_timer += elapsed / DAY_SECONDS
+        days_passed = int(self._day_timer)
+        if days_passed > 0:
+            self._day_timer -= days_passed
+            self.advance_days(days_passed)
+
+    def advance_days(self, count: int = 1):
+        self.day += count
+        self.next_weather_in -= count
+        if self.weather_days_left > 0:
+            self.weather_days_left -= count
+            if self.weather_days_left <= 0:
+                self.weather = WEATHER_CLEAR
+        if self.next_weather_in <= 0:
+            self._trigger_weather()
+        if self.day > TOTAL_DAYS:
+            self.state = STATE_LOSE
+
+    def _trigger_weather(self):
+        options = [WEATHER_DROUGHT, WEATHER_RAIN, WEATHER_FROST]
+        self.weather = random.choice(options)
+        self.weather_days_left = random.randint(2, 4)
+        self.next_weather_in = random.randint(3, 5)
+        self.weather_banner_time = time.monotonic()
+
+    def advance_day_manual(self):
+        self._last_tick = time.monotonic()
+        self.advance_days(1)
+
+    # ---- Actions -----------------------------------------------------------
+
+    def plant(self):
+        cell = self._cursor_cell()
+        if cell.stage != EMPTY:
+            return
+        cost = CROPS[self.selected_seed]["seed_cost"]
+        if self.coins < cost:
+            return
+        self.coins -= cost
+        cell.stage = SEEDED
+        cell.crop = self.selected_seed
+        cell.days_planted = 0.0
+        cell.frost_timer = 0.0
+
+    def harvest(self):
+        cell = self._cursor_cell()
+        if cell.stage != READY:
+            return
+        self.coins += CROPS[cell.crop]["price"]
+        cell.stage = EMPTY
+        cell.crop = None
+        cell.days_planted = 0.0
+        if self.coins >= WIN_COINS:
+            self.state = STATE_WIN
+
+    def buy_seed(self, index: int):
+        if index < 0 or index >= len(CROP_ORDER):
+            return
+        name = CROP_ORDER[index]
+        cost = CROPS[name]["seed_cost"]
+        if self.coins >= cost:
+            self.coins -= cost
+            self.selected_seed = name
+
+    def _cursor_cell(self) -> Cell:
+        return self.grid[self.cursor_y][self.cursor_x]
+
+    def move_cursor(self, dx: int, dy: int):
+        self.cursor_x = max(0, min(GRID_COLS - 1, self.cursor_x + dx))
+        self.cursor_y = max(0, min(GRID_ROWS - 1, self.cursor_y + dy))
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+game = Game()
+app = App(app_id="seedclock")
+
+
+@app.on_render
+def render(ctx):
+    if game.state in (STATE_PLAYING, STATE_MARKET):
+        game.tick_time()
+
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["bg"])
+
+    if game.state == STATE_TITLE:
+        _render_title(ctx)
+    elif game.state in (STATE_PLAYING, STATE_MARKET):
+        _render_game(ctx)
+        if game.state == STATE_MARKET:
+            _render_market(ctx)
+        _render_weather_banner(ctx)
+    elif game.state == STATE_WIN:
+        _render_game(ctx)
+        _render_end(ctx, won=True)
+    elif game.state == STATE_LOSE:
+        _render_game(ctx)
+        _render_end(ctx, won=False)
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+HEADER_H = 40.0
+CELL_PAD = 3.0
+
+
+def _grid_layout(ctx):
+    """Return (cell_w, cell_h, grid_x, grid_y)."""
+    cell_w = ctx.width / GRID_COLS
+    cell_h = (ctx.height - HEADER_H) / GRID_ROWS
+    return cell_w, cell_h, 0.0, HEADER_H
+
+
+def _render_header(ctx):
+    ctx.rect(0, 0, ctx.width, HEADER_H, fill=C["header"])
+    ctx.text(12, 10, f"Day {game.day}/{TOTAL_DAYS}", size=14, color=C["text"], bold=True)
+    ctx.text(12, 24, f"Coins: {game.coins}c  |  Goal: {WIN_COINS}c", size=11, color=C["subtext"])
+    seed_label = f"Seed: {game.selected_seed}  [m=market  p=plant  h=harvest  Space=+day]"
+    ctx.text(ctx.width / 2 - len(seed_label) * 3.5, 14, seed_label, size=11, color=C["subtext"])
+
+
+def _cell_color(cell: Cell) -> str:
+    if cell.stage == EMPTY:
+        return C["surface"]
+    if cell.stage == SEEDED:
+        return C["seeded"]
+    if cell.stage == GROWING:
+        return C["growing"]
+    if cell.stage == READY:
+        return CROPS[cell.crop]["color"]
+    return C["surface"]
+
+
+def _render_game(ctx):
+    _render_header(ctx)
+    cell_w, cell_h, gx, gy = _grid_layout(ctx)
+
+    for row_i, row in enumerate(game.grid):
+        for col_i, cell in enumerate(row):
+            x = gx + col_i * cell_w + CELL_PAD
+            y = gy + row_i * cell_h + CELL_PAD
+            w = cell_w - CELL_PAD * 2
+            h = cell_h - CELL_PAD * 2
+            fill = _cell_color(cell)
+            ctx.rect(x, y, w, h, fill=fill, radius=4.0)
+
+            # Growth progress bar for seeded/growing
+            if cell.stage in (SEEDED, GROWING):
+                crop_days = CROPS[cell.crop]["days"]
+                pct = min(1.0, cell.days_planted / crop_days)
+                bar_h = 3.0
+                ctx.rect(x, y + h - bar_h, w * pct, bar_h, fill=C["green"])
+
+            # Stage indicators
+            if cell.stage == SEEDED:
+                ctx.text(x + w / 2 - 4, y + h / 2 - 6, "·", size=14, color=C["text"])
+            elif cell.stage == READY:
+                ctx.text(x + 4, y + 4, "!", size=11, color=C["header"], bold=True)
+
+    # Cursor highlight
+    cx = gx + game.cursor_x * cell_w + CELL_PAD
+    cy = gy + game.cursor_y * cell_h + CELL_PAD
+    cw = cell_w - CELL_PAD * 2
+    ch = cell_h - CELL_PAD * 2
+    ctx.rect(cx, cy, cw, ch, fill=C["blue"], radius=4.0)
+    cursor_cell = game.grid[game.cursor_y][game.cursor_x]
+    fill = _cell_color(cursor_cell)
+    ctx.rect(cx + 3, cy + 3, cw - 6, ch - 6, fill=fill, radius=2.0)
+    # Redraw progress bar on cursor cell
+    if cursor_cell.stage in (SEEDED, GROWING):
+        crop_days = CROPS[cursor_cell.crop]["days"]
+        pct = min(1.0, cursor_cell.days_planted / crop_days)
+        ctx.rect(cx + 3, cy + ch - 5, (cw - 6) * pct, 3.0, fill=C["green"])
+    if cursor_cell.stage == READY:
+        ctx.text(cx + 7, cy + 7, "!", size=11, color=C["header"], bold=True)
+
+
+def _render_weather_banner(ctx):
+    now = time.monotonic()
+    if game.weather == WEATHER_CLEAR:
+        return
+    since = now - game.weather_banner_time
+    if since > 5.0:
+        return
+    label = WEATHER_LABELS.get(game.weather, "")
+    color = WEATHER_COLORS.get(game.weather, C["text"])
+    bw = min(ctx.width * 0.6, 400.0)
+    bx = (ctx.width - bw) / 2
+    ctx.rect(bx, HEADER_H + 8, bw, 28, fill=C["header"], radius=6.0)
+    ctx.text(bx + 10, HEADER_H + 14, label, size=12, color=color, bold=True)
+
+
+def _render_market(ctx):
+    panel_w = 320.0
+    panel_h = 220.0
+    px = (ctx.width - panel_w) / 2
+    py = (ctx.height - panel_h) / 2
+    ctx.rect(px, py, panel_w, panel_h, fill=C["header"], radius=10.0)
+    ctx.text(px + panel_w / 2 - 36, py + 12, "MARKET", size=16, color=C["gold"], bold=True)
+    ctx.text(px + 12, py + 38, f"Coins: {game.coins}c", size=12, color=C["text"])
+
+    for i, name in enumerate(CROP_ORDER):
+        c = CROPS[name]
+        row_y = py + 65 + i * 36
+        ctx.rect(px + 10, row_y, panel_w - 20, 30, fill=C["surface"], radius=4.0)
+        ctx.text(px + 16, row_y + 7, f"[{i+1}]", size=12, color=C["subtext"], monospace=True)
+        ctx.text(px + 48, row_y + 7, name.capitalize(), size=12, color=C["text"], bold=True)
+        detail = f"seed={c['seed_cost']}c  sell={c['price']}c  {c['days']}d"
+        ctx.text(px + 130, row_y + 9, detail, size=10, color=C["subtext"])
+        ctx.rect(px + panel_w - 28, row_y + 7, 14, 14, fill=c["color"], radius=3.0)
+
+    ctx.text(px + panel_w / 2 - 56, py + panel_h - 22,
+             "Esc to close market", size=11, color=C["subtext"])
+
+
+def _render_title(ctx):
+    cx = ctx.width / 2
+    cy = ctx.height / 2
+    ctx.text(cx - 80, cy - 60, "SEEDCLOCK", size=28, color=C["gold"], bold=True)
+    ctx.text(cx - 110, cy - 20,
+             "Race to 50 coins before the frost.", size=13, color=C["text"])
+    ctx.text(cx - 130, cy + 14,
+             "Arrows=move  p=plant  h=harvest  m=market", size=11, color=C["subtext"])
+    ctx.text(cx - 110, cy + 34,
+             "Space=+day  1-4=select seed  Esc=quit", size=11, color=C["subtext"])
+    ctx.text(cx - 68, cy + 70, "Press Enter to start", size=13, color=C["blue"])
+
+
+def _render_end(ctx, won: bool):
+    panel_w = 300.0
+    panel_h = 140.0
+    px = (ctx.width - panel_w) / 2
+    py = (ctx.height - panel_h) / 2
+    ctx.rect(px, py, panel_w, panel_h, fill=C["header"], radius=10.0)
+    if won:
+        ctx.text(px + panel_w / 2 - 36, py + 14, "YOU WIN!", size=20, color=C["green"], bold=True)
+        ctx.text(px + panel_w / 2 - 80, py + 50,
+                 f"Reached {game.coins} coins by day {game.day}.", size=12, color=C["text"])
+    else:
+        ctx.text(px + panel_w / 2 - 48, py + 14, "FROST WINS", size=20, color=C["mauve"], bold=True)
+        ctx.text(px + panel_w / 2 - 76, py + 50,
+                 f"Season ended with {game.coins} coins.", size=12, color=C["text"])
+    ctx.text(px + panel_w / 2 - 94, py + 100,
+             "Enter = play again   Esc = title", size=12, color=C["subtext"])
+
+
+# ---------------------------------------------------------------------------
+# Input
+# ---------------------------------------------------------------------------
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    if game.state == STATE_TITLE:
+        if key == "Enter":
+            game.__init__()
+            game.state = STATE_PLAYING
+
+    elif game.state == STATE_PLAYING:
+        if key == "ArrowUp":
+            game.move_cursor(0, -1)
+        elif key == "ArrowDown":
+            game.move_cursor(0, 1)
+        elif key == "ArrowLeft":
+            game.move_cursor(-1, 0)
+        elif key == "ArrowRight":
+            game.move_cursor(1, 0)
+        elif key == "p":
+            game.plant()
+        elif key == "h":
+            game.harvest()
+        elif key == "m":
+            game.state = STATE_MARKET
+        elif key == " ":
+            game.advance_day_manual()
+        elif key == "Escape":
+            game.state = STATE_TITLE
+        elif key in ("1", "2", "3", "4"):
+            game.selected_seed = CROP_ORDER[int(key) - 1]
+
+    elif game.state == STATE_MARKET:
+        if key == "Escape":
+            game.state = STATE_PLAYING
+        elif key in ("1", "2", "3", "4"):
+            game.buy_seed(int(key) - 1)
+            game.state = STATE_PLAYING
+
+    elif game.state in (STATE_WIN, STATE_LOSE):
+        if key == "Enter":
+            game.__init__()
+            game.state = STATE_PLAYING
+        elif key == "Escape":
+            game.__init__()
+            game.state = STATE_TITLE
+
+
+app.run()

--- a/examples/seedclock/seedclock.py
+++ b/examples/seedclock/seedclock.py
@@ -142,7 +142,7 @@ class Game:
         # Grow crops
         for row in self.grid:
             for cell in row:
-                if cell.stage in (SEEDED, GROWING):
+                if cell.stage in (SEEDED, GROWING) and cell.crop is not None:
                     cell.days_planted += day_fraction
                     crop_days = CROPS[cell.crop]["days"]
                     if cell.stage == SEEDED and cell.days_planted >= 1.0:
@@ -204,7 +204,7 @@ class Game:
 
     def harvest(self):
         cell = self._cursor_cell()
-        if cell.stage != READY:
+        if cell.stage != READY or cell.crop is None:
             return
         self.coins += CROPS[cell.crop]["price"]
         cell.stage = EMPTY
@@ -290,7 +290,7 @@ def _cell_color(cell: Cell) -> str:
         return C["seeded"]
     if cell.stage == GROWING:
         return C["growing"]
-    if cell.stage == READY:
+    if cell.stage == READY and cell.crop is not None:
         return CROPS[cell.crop]["color"]
     return C["surface"]
 
@@ -309,7 +309,7 @@ def _render_game(ctx):
             ctx.rect(x, y, w, h, fill=fill, radius=4.0)
 
             # Growth progress bar for seeded/growing
-            if cell.stage in (SEEDED, GROWING):
+            if cell.stage in (SEEDED, GROWING) and cell.crop is not None:
                 crop_days = CROPS[cell.crop]["days"]
                 pct = min(1.0, cell.days_planted / crop_days)
                 bar_h = 3.0
@@ -331,7 +331,7 @@ def _render_game(ctx):
     fill = _cell_color(cursor_cell)
     ctx.rect(cx + 3, cy + 3, cw - 6, ch - 6, fill=fill, radius=2.0)
     # Redraw progress bar on cursor cell
-    if cursor_cell.stage in (SEEDED, GROWING):
+    if cursor_cell.stage in (SEEDED, GROWING) and cursor_cell.crop is not None:
         crop_days = CROPS[cursor_cell.crop]["days"]
         pct = min(1.0, cursor_cell.days_planted / crop_days)
         ctx.rect(cx + 3, cy + ch - 5, (cw - 6) * pct, 3.0, fill=C["green"])


### PR DESCRIPTION
## Summary
- Adds `examples/seedclock/` — a one-season farming game Plexi app
- 10x6 crop grid, 4 crop types (wheat/tomato/carrot/corn) with distinct growth times and sell prices
- 20-day season with 30s real-time days (Space to advance manually); win by hitting 50 coins before frost
- Random weather events every 3-5 days: drought (–50% growth), rain (+50% growth), frost (kills ready crops after 2 days)
- Market overlay (m key): buy seeds 1-4, see prices and grow times
- Full Catppuccin Mocha palette, progress bars on growing cells, cursor highlight, win/lose screens with replay

## Test plan
- [ ] Launch app in Plexi alpha: `plexi open seedclock`
- [ ] Title screen renders; Enter starts game
- [ ] Arrow keys move cursor; p plants at empty cell, h harvests ready cell
- [ ] m opens market; 1-4 buys seed and returns to game; Esc closes market
- [ ] Space advances day; day counter increments in header
- [ ] Weather banner appears when event triggers (drought/rain/frost)
- [ ] Reaching 50 coins shows WIN screen; Enter replays, Esc returns to title
- [ ] Day 20 without 50 coins shows LOSE screen