### PR TITLE
feat: Port Watcher visual network monitor app

### DIFF
--- a/examples/port-watcher/manifest.toml
+++ b/examples/port-watcher/manifest.toml
@@ -1,0 +1,9 @@
+[app]
+id = "port-watcher"
+name = "Port Watcher"
+entry = "port_watcher.py"
+version = "0.1.0"
+description = "Live network port monitor. Watch connections swarm like bees."
+
+[app.capabilities]
+# Polls lsof for TCP connections — requires no special permissions beyond what lsof provides

--- a/examples/port-watcher/plexi_sdk.py
+++ b/examples/port-watcher/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/port-watcher/port_watcher.py
+++ b/examples/port-watcher/port_watcher.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+port_watcher — Plexi app
+Live visual network port monitor. Listening ports appear as hive cells;
+active connections orbit them as animated bee dots.
+"""
+
+import math
+import os
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+
+BG        = "#1e1e2e"
+SURFACE   = "#313244"
+TEXT      = "#cdd6f4"
+SUBTEXT   = "#6c7086"
+BLUE      = "#89b4fa"   # web servers
+GREEN     = "#a6e3a1"   # databases
+ORANGE    = "#fab387"   # unknown
+BEE       = "#f9e2af"
+BEE_FLASH = "#ffffff"
+BORDER_DIM= "#45475a"
+
+WEB_PROCS = {"python", "python3", "node", "nginx", "apache", "ruby", "uvicorn",
+             "gunicorn", "caddy", "httpd", "deno", "bun"}
+DB_PROCS  = {"postgres", "postgresql", "mysqld", "mongod", "redis-server",
+             "mariadb", "sqlite", "pgbouncer", "mysql"}
+
+def proc_color(name: str) -> str:
+    n = name.lower()
+    if any(p in n for p in WEB_PROCS):
+        return BLUE
+    if any(p in n for p in DB_PROCS):
+        return GREEN
+    return ORANGE
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class Connection:
+    def __init__(self, remote: str, state: str):
+        self.remote  = remote
+        self.state   = state
+        self.born    = time.monotonic()
+        self.angle   = 0.0        # orbit angle, radians
+        self.flash   = 3          # frames remaining for new-bee flash
+
+class PortEntry:
+    def __init__(self, port: int, pid: int, proc: str):
+        self.port  = port
+        self.pid   = pid
+        self.proc  = proc
+        self.conns: list[Connection] = []
+        self.pulse_t = 0.0        # time of last high-water-mark
+
+# ---------------------------------------------------------------------------
+# lsof polling
+# ---------------------------------------------------------------------------
+
+def _poll_lsof() -> dict[int, PortEntry]:
+    """Run lsof and return a dict keyed by port number."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-iTCP", "-n", "-P", "-sTCP:LISTEN,ESTABLISHED"],
+            capture_output=True, text=True, timeout=5,
+        )
+        lines = result.stdout.splitlines()
+    except Exception:
+        return {}
+
+    entries: dict[int, PortEntry] = {}
+    listen_ports: set[int] = set()
+
+    # First pass — collect LISTEN rows to know which ports are our hive cells
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 10:
+            continue
+        proc   = parts[0]
+        pid_s  = parts[1]
+        name_f = parts[8] if len(parts) > 8 else ""
+        state  = parts[9] if len(parts) > 9 else ""
+        if state != "(LISTEN)":
+            continue
+        try:
+            pid  = int(pid_s)
+            port = int(name_f.rsplit(":", 1)[-1])
+        except (ValueError, IndexError):
+            continue
+        if port not in entries:
+            entries[port] = PortEntry(port, pid, proc)
+        listen_ports.add(port)
+
+    # Second pass — attach ESTABLISHED connections to matching local port
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 10:
+            continue
+        name_f = parts[8] if len(parts) > 8 else ""
+        state  = parts[9] if len(parts) > 9 else ""
+        if state != "(ESTABLISHED)":
+            continue
+        # name_f looks like  local:port->remote:port
+        try:
+            arrow_idx = name_f.index("->")
+            local_part  = name_f[:arrow_idx]
+            remote_part = name_f[arrow_idx + 2:]
+            local_port  = int(local_part.rsplit(":", 1)[-1])
+        except (ValueError, IndexError):
+            continue
+        if local_port in entries:
+            entries[local_port].conns.append(Connection(remote_part, "ESTABLISHED"))
+
+    return entries
+
+# ---------------------------------------------------------------------------
+# App state
+# ---------------------------------------------------------------------------
+
+_ports: dict[int, PortEntry] = {}
+_port_keys: list[int] = []      # sorted list of ports (grid order)
+_selected_idx: int = 0
+_detail_mode: bool = False
+_detail_scroll: int = 0
+_filter: str = ""
+_filter_mode: bool = False
+_kill_confirm: bool = False
+_last_poll: float = 0.0
+_start: float = time.monotonic()
+_frame: int = 0
+
+POLL_INTERVAL = 1.0
+
+def _now() -> float:
+    return time.monotonic() - _start
+
+def _refresh():
+    global _ports, _port_keys, _selected_idx
+    raw = _poll_lsof()
+
+    # Merge: preserve existing Connection objects (for orbit continuity), add new ones
+    next_ports: dict[int, PortEntry] = {}
+    for port, entry in raw.items():
+        if port in _ports:
+            existing = _ports[port]
+            # Update metadata
+            existing.proc = entry.proc
+            existing.pid  = entry.pid
+            # Reconcile connections: keep existing where remote matches
+            old_remotes = {c.remote: c for c in existing.conns}
+            new_conns = []
+            for c in entry.conns:
+                if c.remote in old_remotes:
+                    new_conns.append(old_remotes[c.remote])
+                else:
+                    new_conns.append(c)
+            existing.conns = new_conns
+            if len(existing.conns) > 10:
+                existing.pulse_t = time.monotonic()
+            next_ports[port] = existing
+        else:
+            if len(entry.conns) > 10:
+                entry.pulse_t = time.monotonic()
+            next_ports[port] = entry
+
+    _ports = next_ports
+    _filtered_keys = _visible_keys()
+    # Clamp selection
+    if _selected_idx >= len(_filtered_keys):
+        _selected_idx = max(0, len(_filtered_keys) - 1)
+    _port_keys = _filtered_keys
+
+def _visible_keys() -> list[int]:
+    keys = sorted(_ports.keys())
+    if _filter:
+        fl = _filter.lower()
+        keys = [p for p in keys if fl in str(p) or fl in _ports[p].proc.lower()]
+    return keys
+
+# ---------------------------------------------------------------------------
+# Grid layout helpers
+# ---------------------------------------------------------------------------
+
+CELL_W = 160.0
+CELL_H = 100.0
+CELL_PAD = 14.0
+HEADER_H = 36.0
+
+def _grid_cols(width: float) -> int:
+    return max(1, int(width // (CELL_W + CELL_PAD)))
+
+def _cell_rect(idx: int, cols: int) -> tuple[float, float, float, float]:
+    row = idx // cols
+    col = idx % cols
+    x = CELL_PAD + col * (CELL_W + CELL_PAD)
+    y = HEADER_H + CELL_PAD + row * (CELL_H + CELL_PAD)
+    return x, y, CELL_W, CELL_H
+
+# ---------------------------------------------------------------------------
+# Drawing
+# ---------------------------------------------------------------------------
+
+def _draw_header(ctx, width: float):
+    ctx.rect(0, 0, width, HEADER_H, fill=SURFACE)
+    title = "Port Watcher"
+    if _filter_mode:
+        title = f"Filter: {_filter}_"
+    elif _filter:
+        title = f"Port Watcher  [filter: {_filter}]"
+    ctx.text(12, 10, title, size=14, color=TEXT, bold=True)
+    hints = "j/k nav  Enter detail  f filter  r refresh  q quit"
+    ctx.text(width - 420, 11, hints, size=11, color=SUBTEXT)
+
+def _draw_cell(ctx, entry: PortEntry, x: float, y: float, w: float, h: float,
+               selected: bool, now: float):
+    # Pulse effect for high-traffic ports
+    pulse = 0.0
+    age = now - (entry.pulse_t - _start)
+    if age < 1.5:
+        pulse = math.sin(age * math.pi * 4) * (1.0 - age / 1.5)
+    pulse = max(0.0, pulse)
+
+    border_col = proc_color(entry.proc) if selected else BORDER_DIM
+    bg_col     = SURFACE
+
+    # Outer border rect
+    bw = 2.0 + pulse * 2.0
+    ctx.rect(x - bw, y - bw, w + bw * 2, h + bw * 2, fill=border_col, radius=8.0)
+    ctx.rect(x, y, w, h, fill=bg_col, radius=6.0)
+
+    # Port number
+    ctx.text(x + 10, y + 10, str(entry.port), size=22, color=proc_color(entry.proc), bold=True)
+
+    # Process name (truncated)
+    pname = entry.proc[:16]
+    ctx.text(x + 10, y + 40, pname, size=11, color=SUBTEXT)
+
+    # Connection count
+    nc = len(entry.conns)
+    conn_label = f"{nc} conn" if nc != 1 else "1 conn"
+    ctx.text(x + 10, y + 58, conn_label, size=11, color=TEXT)
+
+    # PID
+    ctx.text(x + 10, y + 74, f"pid {entry.pid}", size=10, color=SUBTEXT)
+
+    # Bee dots orbiting the cell
+    _draw_bees(ctx, entry, x + w / 2, y + h / 2, w / 2 + 18, now)
+
+def _draw_bees(ctx, entry: PortEntry, cx: float, cy: float,
+               orbit_r: float, now: float):
+    nc = len(entry.conns)
+    if nc == 0:
+        return
+    # Orbit speed: faster with more connections, capped
+    speed = min(0.4 + nc * 0.05, 1.2)
+    for i, conn in enumerate(entry.conns[:20]):  # cap rendered bees at 20
+        base_angle = (2 * math.pi * i / max(nc, 1))
+        conn.angle = base_angle + now * speed
+        bx = cx + orbit_r * math.cos(conn.angle) - 2
+        by = cy + orbit_r * math.sin(conn.angle) - 2
+        color = BEE_FLASH if conn.flash > 0 else BEE
+        if conn.flash > 0:
+            conn.flash -= 1
+        ctx.rect(bx, by, 4, 4, fill=color, radius=2.0)
+
+def _draw_grid(ctx, now: float):
+    w = ctx.width
+    cols = _grid_cols(w)
+    for i, port in enumerate(_port_keys):
+        entry = _ports.get(port)
+        if entry is None:
+            continue
+        x, y, cw, ch = _cell_rect(i, cols)
+        if y > ctx.height:
+            break  # off screen
+        _draw_cell(ctx, entry, x, y, cw, ch, selected=(i == _selected_idx), now=now)
+
+def _draw_detail(ctx, now: float):
+    port = _port_keys[_selected_idx] if _port_keys else None
+    if port is None:
+        return
+    entry = _ports.get(port)
+    if entry is None:
+        return
+
+    w, h = ctx.width, ctx.height
+    ctx.rect(0, 0, w, h, fill=BG)
+
+    # Header bar
+    ctx.rect(0, 0, w, 40, fill=SURFACE)
+    ctx.text(12, 10, f"Port {entry.port}  —  {entry.proc}  (pid {entry.pid})",
+             size=14, color=proc_color(entry.proc), bold=True)
+    ctx.text(w - 120, 13, "Esc to go back", size=11, color=SUBTEXT)
+
+    # Column headers
+    ctx.text(16, 52, "REMOTE", size=11, color=SUBTEXT, bold=True)
+    ctx.text(300, 52, "STATE", size=11, color=SUBTEXT, bold=True)
+    ctx.text(420, 52, "AGE", size=11, color=SUBTEXT, bold=True)
+    ctx.line(16, 68, w - 16, 68, color=BORDER_DIM, width=1.0)
+
+    row_h = 28.0
+    start_y = 76.0
+    conns = entry.conns
+
+    # Kill confirm overlay
+    if _kill_confirm:
+        ctx.rect(w // 2 - 140, h // 2 - 40, 280, 80, fill=SURFACE, radius=8.0)
+        ctx.text(w // 2 - 120, h // 2 - 24,
+                 f"Kill process {entry.pid}? (y/n)", size=13, color="#f38ba8", bold=True)
+        return
+
+    for i, conn in enumerate(conns[_detail_scroll:_detail_scroll + 30]):
+        ry = start_y + i * row_h
+        if ry + row_h > h:
+            break
+        age_s = int(now - (conn.born - _start))
+        age_label = f"{age_s}s" if age_s < 60 else f"{age_s // 60}m{age_s % 60}s"
+        color = BEE_FLASH if conn.flash > 0 else TEXT
+        ctx.text(16,  ry, conn.remote[:35], size=12, color=color)
+        ctx.text(300, ry, conn.state,       size=12, color=SUBTEXT)
+        ctx.text(420, ry, age_label,         size=12, color=SUBTEXT)
+
+    if not conns:
+        ctx.text(16, start_y, "No active connections.", size=12, color=SUBTEXT)
+
+def _draw_empty(ctx):
+    ctx.text(ctx.width / 2 - 80, ctx.height / 2 - 10,
+             "No listening ports found.", size=13, color=SUBTEXT)
+    ctx.text(ctx.width / 2 - 60, ctx.height / 2 + 12,
+             "Press r to refresh.", size=11, color=SUBTEXT)
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="port-watcher")
+
+@app.on_render
+def render(ctx):
+    global _last_poll, _frame
+    _frame += 1
+    now = _now()
+
+    # Poll on interval
+    if now - _last_poll >= POLL_INTERVAL or _last_poll == 0.0:
+        _refresh()
+        _last_poll = now
+
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=BG)
+
+    if _detail_mode and _port_keys:
+        _draw_detail(ctx, now)
+    else:
+        _draw_header(ctx, ctx.width)
+        if _port_keys:
+            _draw_grid(ctx, now)
+        else:
+            _draw_empty(ctx)
+
+@app.on_key
+def on_key(key: str, mods: dict, emit):
+    global _selected_idx, _detail_mode, _detail_scroll
+    global _filter, _filter_mode, _kill_confirm, _last_poll
+
+    if _filter_mode:
+        if key == "Escape" or key == "Enter":
+            _filter_mode = False
+            _refresh()
+        elif key == "Backspace":
+            _filter = _filter[:-1]
+        elif len(key) == 1:
+            _filter += key
+        return
+
+    if _kill_confirm:
+        if key == "y":
+            port = _port_keys[_selected_idx] if _port_keys else None
+            if port is not None:
+                entry = _ports.get(port)
+                if entry:
+                    try:
+                        subprocess.run(["kill", str(entry.pid)], timeout=3)
+                    except Exception:
+                        pass
+                    _last_poll = 0.0  # force refresh
+        _kill_confirm = False
+        return
+
+    if key == "Escape":
+        _detail_mode = False
+        _kill_confirm = False
+
+    elif key in ("j", "ArrowDown"):
+        if _detail_mode:
+            _detail_scroll += 1
+        else:
+            _selected_idx = min(_selected_idx + 1, max(0, len(_port_keys) - 1))
+
+    elif key in ("k", "ArrowUp"):
+        if _detail_mode:
+            _detail_scroll = max(0, _detail_scroll - 1)
+        else:
+            _selected_idx = max(0, _selected_idx - 1)
+
+    elif key in ("h", "ArrowLeft") and not _detail_mode:
+        _selected_idx = max(0, _selected_idx - 1)
+
+    elif key in ("l", "ArrowRight") and not _detail_mode:
+        _selected_idx = min(_selected_idx + 1, max(0, len(_port_keys) - 1))
+
+    elif key == "Enter" and not _detail_mode and _port_keys:
+        _detail_mode = True
+        _detail_scroll = 0
+
+    elif key == "f" and not _detail_mode:
+        _filter_mode = True
+
+    elif key == "r":
+        _last_poll = 0.0  # trigger immediate refresh next render
+
+    elif key == "K" and _detail_mode and _port_keys:
+        _kill_confirm = True
+
+@app.on_resize
+def on_resize(width: float, height: float):
+    pass  # layout is computed dynamically from ctx dimensions each frame
+
+app.run()


### PR DESCRIPTION
## Summary

- Adds `examples/port-watcher/` — a live TCP port monitor Plexi app
- Polls `lsof -iTCP` every second; renders listening ports as grid "hive cells" with animated bee dots orbiting for each active connection
- Detail view shows all connections with remote IP, state, and age; `K` to kill the process (with confirm prompt)

## Visual
- Grid of rounded hive cells colored by process type: blue (web servers), green (databases), orange (unknown)
- Bee dots (4×4 yellow rects) orbit each cell, one per ESTABLISHED connection, with white flash on appearance
- High-connection ports (>10) pulse the cell border
- Filter mode (`f`), force refresh (`r`), j/k/arrow navigation, Enter for detail view, Esc to go back

## Test plan
- [ ] Copy to `~/.plexi-alpha/apps/port-watcher/` and open in Plexi
- [ ] Verify grid populates with real listening ports within 1 second
- [ ] Open browser / curl a local server — confirm bee dots appear on the relevant cell
- [ ] Test filter mode, detail view scroll, and kill confirm flow (`K` → `y`)
- [ ] Verify graceful no-crash when lsof fails or returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)