### PR TITLE
feat: Kona app marketplace

### DIFF
--- a/examples/kona/kona.py
+++ b/examples/kona/kona.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""
+kona — Plexi app store
+Browse and install Plexi apps from the community registry.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":       "#1e1e2e",
+    "surface":  "#313244",
+    "overlay":  "#45475a",
+    "text":     "#cdd6f4",
+    "subtext":  "#6c7086",
+    "accent":   "#89b4fa",   # not installed
+    "installed":"#a6e3a1",   # installed
+    "dimmed":   "#45475a",
+    "header":   "#181825",
+    "red":      "#f38ba8",
+    "yellow":   "#f9e2af",
+    "green":    "#a6e3a1",
+}
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REGISTRY_URL  = "https://raw.githubusercontent.com/ianjamesburke/plexi-registry/main/registry.json"
+CACHE_PATH    = pathlib.Path.home() / ".plexi-alpha" / "kona_cache.json"
+APPS_DIR      = pathlib.Path.home() / ".plexi-alpha" / "apps"
+CACHE_TTL_S   = 3600  # 1 hour
+
+HEADER_H      = 32.0
+FILTER_H      = 32.0
+ROW_H         = 52.0
+DETAIL_PADDING = 20.0
+
+TAG_CYCLE = ["all", "game", "productivity", "creative", "system"]
+
+SPINNER_FRAMES = ["|", "/", "-", "\\"]
+SPINNER_FPS    = 8
+
+VIEW_BROWSE  = "browse"
+VIEW_DETAIL  = "detail"
+VIEW_INSTALL = "install"
+
+class State:
+    def __init__(self):
+        self.view = VIEW_BROWSE
+
+        # Registry
+        self.registry: list[dict] = []
+        self.loading = True
+        self.load_error: str | None = None
+
+        # Browse
+        self.cursor = 0
+        self.scroll_offset = 0.0
+        self.filter_active = False
+        self.filter_text = ""
+        self.filter_cursor_blink = True
+        self.tag_filter_idx = 0  # index into TAG_CYCLE
+
+        # Detail / install
+        self.selected_entry: dict | None = None
+        self.confirm_uninstall = False
+
+        # Install
+        self.install_status = ""
+        self.install_error: str | None = None
+        self.install_done = False
+        self.install_done_name = ""
+        self.install_done_time = 0.0
+        self._install_thread: threading.Thread | None = None
+
+        # Timing
+        self._start = time.monotonic()
+
+    @property
+    def elapsed(self) -> float:
+        return time.monotonic() - self._start
+
+    def filtered_entries(self) -> list[dict]:
+        entries = self.registry
+        tag_filter = TAG_CYCLE[self.tag_filter_idx]
+        if tag_filter != "all":
+            entries = [e for e in entries if tag_filter in e.get("tags", [])]
+        q = self.filter_text.lower().strip()
+        if q:
+            def match(e):
+                return (
+                    q in e.get("name", "").lower()
+                    or q in e.get("description", "").lower()
+                    or any(q in t.lower() for t in e.get("tags", []))
+                )
+            entries = [e for e in entries if match(e)]
+        return entries
+
+    def clamp_cursor(self, entries):
+        if entries:
+            self.cursor = max(0, min(self.cursor, len(entries) - 1))
+        else:
+            self.cursor = 0
+
+
+state = State()
+
+def _load_registry():
+    try:
+        if CACHE_PATH.exists():
+            raw = CACHE_PATH.read_text()
+            cached = json.loads(raw)
+            age = time.time() - cached.get("timestamp", 0)
+            if age < CACHE_TTL_S:
+                state.registry = cached.get("apps", [])
+                state.loading = False
+                return
+    except Exception:
+        pass
+
+    # Fetch from network
+    try:
+        with urllib.request.urlopen(REGISTRY_URL, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        apps = data if isinstance(data, list) else data.get("apps", [])
+        state.registry = apps
+        # Write cache
+        try:
+            CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+            CACHE_PATH.write_text(json.dumps({"timestamp": time.time(), "apps": apps}))
+        except Exception:
+            pass
+        state.loading = False
+        return
+    except Exception as fetch_err:
+        try:
+            if CACHE_PATH.exists():
+                raw = CACHE_PATH.read_text()
+                cached = json.loads(raw)
+                state.registry = cached.get("apps", [])
+                state.loading = False
+                return
+        except Exception:
+            pass
+        state.load_error = f"Unable to load registry: {fetch_err}"
+        state.loading = False
+
+
+threading.Thread(target=_load_registry, daemon=True).start()
+def _parse_entry_from_manifest(manifest_text: str) -> str | None:
+    try:
+        import tomllib  # type: ignore
+        data = tomllib.loads(manifest_text)
+        return data.get("entry") or data.get("app", {}).get("entry")
+    except ImportError:
+        pass
+    try:
+        import tomli  # type: ignore
+        data = tomli.loads(manifest_text)
+        return data.get("entry") or data.get("app", {}).get("entry")
+    except ImportError:
+        pass
+    # Regex fallback
+    m = re.search(r'entry\s*=\s*["\']([^"\']+)["\']', manifest_text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _fallback_install(entry: dict, app_dir: pathlib.Path) -> None:
+    repo = entry.get("repo", "")
+    path = entry.get("path", "")
+    base_url = f"https://raw.githubusercontent.com/{repo}/alpha/{path}"
+    manifest_url = f"{base_url}/manifest.toml"
+    try:
+        with urllib.request.urlopen(manifest_url, timeout=10) as r:
+            manifest_text = r.read().decode("utf-8")
+    except Exception as e:
+        raise RuntimeError(f"Failed to fetch manifest: {e}") from e
+
+    entry_file = _parse_entry_from_manifest(manifest_text)
+    if not entry_file:
+        raise RuntimeError("Could not determine entry filename from manifest")
+
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "manifest.toml").write_text(manifest_text)
+
+    entry_url = f"{base_url}/{entry_file}"
+    try:
+        with urllib.request.urlopen(entry_url, timeout=10) as r:
+            entry_content = r.read()
+        entry_path = app_dir / entry_file
+        entry_path.write_bytes(entry_content)
+        os.chmod(entry_path, 0o755)
+    except Exception as e:
+        raise RuntimeError(f"Failed to fetch entry file: {e}") from e
+
+    sdk_url = f"{base_url}/plexi_sdk.py"
+    try:
+        with urllib.request.urlopen(sdk_url, timeout=10) as r:
+            (app_dir / "plexi_sdk.py").write_bytes(r.read())
+    except Exception:
+        try:
+            our_sdk = pathlib.Path(__file__).parent / "plexi_sdk.py"
+            if our_sdk.exists():
+                shutil.copy(our_sdk, app_dir / "plexi_sdk.py")
+        except Exception:
+            pass
+
+
+def _do_install(entry: dict):
+    app_id = entry.get("id", "unknown")
+    app_dir = APPS_DIR / app_id
+    name = entry.get("name", app_id)
+
+    state.install_status = f"Installing {name}..."
+    state.install_error = None
+    state.install_done = False
+
+    # Attempt 1: CLI
+    try:
+        repo = entry.get("repo", "")
+        result = subprocess.run(
+            ["plexi-alpha", "app", "install", f"{repo}/{app_id}"],
+            capture_output=True, timeout=30,
+        )
+        if result.returncode == 0:
+            state.install_done = True
+            state.install_done_name = name
+            state.install_done_time = time.monotonic()
+            state.install_status = f"Installed! Reload Plexi to use {name}."
+            return
+    except Exception:
+        pass
+
+    # Attempt 2: Fallback direct download
+    try:
+        _fallback_install(entry, app_dir)
+        state.install_done = True
+        state.install_done_name = name
+        state.install_done_time = time.monotonic()
+        state.install_status = f"Installed! Reload Plexi to use {name}."
+    except Exception as e:
+        state.install_error = str(e)
+        state.install_status = f"Install failed: {e}"
+
+
+def start_install(entry: dict):
+    state.view = VIEW_INSTALL
+    state.install_done = False
+    state.install_error = None
+    state.install_status = ""
+    t = threading.Thread(target=_do_install, args=(entry,), daemon=True)
+    state._install_thread = t
+    t.start()
+
+
+def uninstall_app(app_id: str):
+    try:
+        shutil.rmtree(APPS_DIR / app_id)
+    except Exception:
+        pass
+
+
+def is_installed(app_id: str) -> bool:
+    return (APPS_DIR / app_id).exists()
+
+
+def truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars - 1] + "…"
+
+
+def visible_rows(pane_h: float) -> int:
+    usable = pane_h - HEADER_H - (FILTER_H if state.filter_active else 0)
+    return max(1, int(usable // ROW_H))
+
+
+def render_header(ctx, title: str, subtitle: str = ""):
+    ctx.rect(0, 0, ctx.width, HEADER_H, fill=C["header"])
+    ctx.text(12, 9, title, size=14, color=C["text"], bold=True)
+    if subtitle:
+        sub_x = ctx.width - len(subtitle) * 7 - 12
+        ctx.text(max(200, sub_x), 10, subtitle, size=12, color=C["subtext"])
+
+
+def render_tag_pill(ctx, tag: str, x: float, y: float):
+    w = len(tag) * 7 + 10
+    ctx.rect(x, y, w, 16, fill=C["surface"], radius=4.0)
+    ctx.text(x + 5, y + 2, tag, size=10, color=C["subtext"])
+    return w + 6
+
+
+def render_browse(ctx, now: float):
+    entries = state.filtered_entries()
+    state.clamp_cursor(entries)
+
+    n = len(entries)
+    tag_label = TAG_CYCLE[state.tag_filter_idx]
+    tag_str = f"[{tag_label}]"
+    subtitle_parts = []
+    if n > 0:
+        subtitle_parts.append(f"{n} apps")
+    if tag_label != "all":
+        subtitle_parts.append(tag_str)
+    subtitle = "  ".join(subtitle_parts) if subtitle_parts else ""
+    render_header(ctx, "Kona — Plexi App Store", subtitle)
+
+    if state.loading:
+        ctx.text(12, HEADER_H + 20, "Loading registry...", size=13, color=C["subtext"])
+        return
+
+    if state.load_error:
+        ctx.text(12, HEADER_H + 20, state.load_error, size=13, color=C["red"])
+        return
+
+    if not entries:
+        msg = "No apps match." if state.filter_text or tag_label != "all" else "Registry is empty."
+        ctx.text(12, HEADER_H + 20, msg, size=13, color=C["subtext"])
+    else:
+        vis = visible_rows(ctx.height)
+
+        # Keep cursor in scroll window
+        if state.cursor < int(state.scroll_offset):
+            state.scroll_offset = float(state.cursor)
+        elif state.cursor >= int(state.scroll_offset) + vis:
+            state.scroll_offset = float(state.cursor - vis + 1)
+
+        for i in range(vis):
+            idx = int(state.scroll_offset) + i
+            if idx >= n:
+                break
+            entry = entries[idx]
+            app_id = entry.get("id", "")
+            name = entry.get("name", app_id)
+            desc = entry.get("description", "")
+            tags = entry.get("tags", [])
+            installed = is_installed(app_id)
+
+            ry = HEADER_H + i * ROW_H
+
+            if idx == state.cursor:
+                ctx.rect(0, ry, ctx.width, ROW_H, fill=C["surface"])
+                ctx.rect(0, ry, 3, ROW_H, fill=C["accent"])
+
+            name_color = C["dimmed"] if installed else C["accent"]
+            ctx.text(12, ry + 9, name, size=13, color=name_color, bold=True)
+
+            max_desc_chars = max(10, int((ctx.width - 24 - 90) / 7))
+            ctx.text(12, ry + 28, truncate(desc, max_desc_chars), size=11, color=C["subtext"])
+
+            # Right-side installed badge
+            if installed:
+                badge = "installed"
+                bx = ctx.width - len(badge) * 7 - 16
+                ctx.rect(bx - 4, ry + 14, len(badge) * 7 + 8, 16, fill=C["surface"], radius=4.0)
+                ctx.text(bx, ry + 16, badge, size=10, color=C["installed"])
+
+            # Tag pills (first tag only, to keep rows clean)
+            if tags:
+                tx = ctx.width - len(tags[0]) * 7 - 20
+                if not installed:
+                    render_tag_pill(ctx, tags[0], tx, ry + 14)
+
+    # Filter bar at bottom
+    if state.filter_active:
+        fy = ctx.height - FILTER_H
+        ctx.rect(0, fy, ctx.width, FILTER_H, fill=C["surface"])
+        prompt = "/"
+        query_display = state.filter_text
+        # Blinking cursor
+        blink = int(now * 2) % 2 == 0
+        if blink:
+            query_display += "|"
+        ctx.text(12, fy + 8, f"{prompt} {query_display}", size=13, color=C["text"])
+
+    # Hint bar (only when filter not active)
+    if not state.filter_active:
+        hints = "j/k navigate  /  filter  Tab  tag  Enter  open"
+        ctx.text(12, ctx.height - 18, hints, size=10, color=C["dimmed"])
+
+
+def render_detail(ctx, now: float):
+    if not state.selected_entry:
+        state.view = VIEW_BROWSE
+        return
+
+    entry = state.selected_entry
+    app_id = entry.get("id", "")
+    name = entry.get("name", app_id)
+    author = entry.get("author", "unknown")
+    version = entry.get("version", "")
+    tags = entry.get("tags", [])
+    desc = entry.get("description", "")
+    installed = is_installed(app_id)
+
+    render_header(ctx, name, f"v{version}" if version else "")
+
+    y = HEADER_H + DETAIL_PADDING
+
+    # Author
+    ctx.text(DETAIL_PADDING, y, f"by {author}", size=12, color=C["subtext"])
+    y += 22
+
+    # Tags row
+    tx = DETAIL_PADDING
+    for tag in tags:
+        w = render_tag_pill(ctx, tag, tx, y)
+        tx += w
+    if tags:
+        y += 26
+
+    # Description (word-wrapped)
+    words = desc.split()
+    line = ""
+    max_w = max(10, int((ctx.width - DETAIL_PADDING * 2) / 7))
+    for word in words:
+        if len(line) + len(word) + 1 <= max_w:
+            line = (line + " " + word).strip()
+        else:
+            if line:
+                ctx.text(DETAIL_PADDING, y, line, size=13, color=C["text"])
+                y += 20
+            line = word
+    if line:
+        ctx.text(DETAIL_PADDING, y, line, size=13, color=C["text"])
+        y += 28
+
+    # Install status
+    if installed:
+        ctx.text(DETAIL_PADDING, y, "Already installed", size=13, color=C["installed"])
+        y += 24
+        if state.confirm_uninstall:
+            ctx.text(DETAIL_PADDING, y, f"Uninstall {name}? (y/n)", size=13, color=C["yellow"])
+        else:
+            ctx.text(DETAIL_PADDING, y, "u  uninstall    q / Backspace  back", size=11, color=C["subtext"])
+    else:
+        ctx.text(DETAIL_PADDING, y, "Not installed", size=13, color=C["subtext"])
+        y += 24
+        ctx.text(DETAIL_PADDING, y, "i  install    q / Backspace  back", size=11, color=C["subtext"])
+
+
+def render_install(ctx, now: float):
+    if not state.selected_entry:
+        state.view = VIEW_BROWSE
+        return
+
+    name = state.selected_entry.get("name", "")
+    render_header(ctx, f"Installing {name}")
+
+    cx = ctx.width / 2
+    cy = ctx.height / 2
+
+    if state.install_done:
+        ctx.text(cx - 160, cy - 10, state.install_status, size=14, color=C["installed"])
+        ctx.text(cx - 100, cy + 20, "Backspace / q  to go back", size=11, color=C["subtext"])
+    elif state.install_error:
+        ctx.text(cx - 160, cy - 10, state.install_status, size=13, color=C["red"])
+        ctx.text(cx - 100, cy + 20, "Backspace / q  to go back", size=11, color=C["subtext"])
+    else:
+        frame_idx = int(now * SPINNER_FPS) % len(SPINNER_FRAMES)
+        spinner = SPINNER_FRAMES[frame_idx]
+        ctx.text(cx - 10, cy - 10, spinner, size=20, color=C["accent"], monospace=True)
+        ctx.text(cx - 100, cy + 20, state.install_status or "Working...", size=13, color=C["text"])
+
+
+app = App(app_id="kona")
+
+
+@app.on_render
+def render(ctx):
+    now = state.elapsed
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["bg"])
+
+    # Auto-return from install done after 3 seconds
+    if state.view == VIEW_INSTALL and state.install_done:
+        if time.monotonic() - state.install_done_time > 3.0:
+            state.view = VIEW_DETAIL
+
+    if state.view == VIEW_BROWSE:
+        render_browse(ctx, now)
+    elif state.view == VIEW_DETAIL:
+        render_detail(ctx, now)
+    elif state.view == VIEW_INSTALL:
+        render_install(ctx, now)
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    # ------------------------------------------------------------------ install
+    if state.view == VIEW_INSTALL:
+        if key in ("Backspace", "q", "Escape") and (state.install_done or state.install_error):
+            state.view = VIEW_DETAIL
+            state.install_done = False
+        return
+
+    # ------------------------------------------------------------------ detail
+    if state.view == VIEW_DETAIL:
+        entry = state.selected_entry
+        if not entry:
+            state.view = VIEW_BROWSE
+            return
+        app_id = entry.get("id", "")
+
+        if state.confirm_uninstall:
+            if key == "y":
+                uninstall_app(app_id)
+                state.confirm_uninstall = False
+            elif key in ("n", "Escape", "q", "Backspace"):
+                state.confirm_uninstall = False
+            return
+
+        if key in ("Backspace", "q", "Escape"):
+            state.view = VIEW_BROWSE
+            state.confirm_uninstall = False
+        elif key == "i" and not is_installed(app_id):
+            start_install(entry)
+        elif key == "u" and is_installed(app_id):
+            state.confirm_uninstall = True
+        return
+
+    # ------------------------------------------------------------------ browse
+    entries = state.filtered_entries()
+
+    if state.filter_active:
+        if key == "Escape":
+            state.filter_active = False
+            state.filter_text = ""
+        elif key == "Backspace":
+            state.filter_text = state.filter_text[:-1]
+            if not state.filter_text:
+                state.filter_active = False
+        elif key == "Enter":
+            state.filter_active = False
+            if entries:
+                state.selected_entry = entries[state.cursor]
+                state.view = VIEW_DETAIL
+        elif len(key) == 1:
+            state.filter_text += key
+            state.cursor = 0
+            state.scroll_offset = 0.0
+        return
+
+    # Normal browse
+    if key in ("j", "ArrowDown"):
+        state.cursor = min(state.cursor + 1, max(0, len(entries) - 1))
+    elif key in ("k", "ArrowUp"):
+        state.cursor = max(state.cursor - 1, 0)
+    elif key == "/":
+        state.filter_active = True
+        state.filter_text = ""
+        state.cursor = 0
+        state.scroll_offset = 0.0
+    elif key == "Escape":
+        state.filter_text = ""
+        state.cursor = 0
+        state.scroll_offset = 0.0
+    elif key == "Tab":
+        state.tag_filter_idx = (state.tag_filter_idx + 1) % len(TAG_CYCLE)
+        state.cursor = 0
+        state.scroll_offset = 0.0
+    elif key == "Enter" and entries:
+        state.selected_entry = entries[state.cursor]
+        state.view = VIEW_DETAIL
+        state.confirm_uninstall = False
+
+
+@app.on_scroll
+def on_scroll(x, y, delta_x, delta_y, _emit):
+    if state.view == VIEW_BROWSE:
+        entries = state.filtered_entries()
+        n = len(entries)
+        if n == 0:
+            return
+        state.scroll_offset = max(0.0, min(state.scroll_offset + delta_y * 0.1, float(n - 1)))
+        state.cursor = int(state.scroll_offset)
+
+
+app.run()

--- a/examples/kona/manifest.toml
+++ b/examples/kona/manifest.toml
@@ -1,0 +1,6 @@
+app_id = "kona"
+name = "Kona"
+description = "Plexi app store — browse and install apps."
+entry = "kona.py"
+icon = "🏪"
+version = "0.1.0"

--- a/examples/kona/plexi_sdk.py
+++ b/examples/kona/plexi_sdk.py
@@ -1,0 +1,641 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self.delta_time: float = 0.0
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def set_cursor(self, cursor: str):
+        """Set the cursor icon for the app pane for this frame.
+
+        Values: 'default', 'pointer', 'grab', 'grabbing', 'crosshair', 'text'.
+        Must be re-emitted each frame to persist (cursor resets to 'default' each frame).
+        """
+        self._commands.append({"type": "set_cursor", "cursor": cursor})
+
+    def mouse_tracking(self, enabled: bool):
+        """Enable or disable mouse-move event delivery.
+
+        When enabled, Plexi sends MouseMove events to this app on every frame.
+        Off by default — enable only when needed to avoid flooding the pipe.
+        This setting persists until changed; you do not need to re-emit each frame.
+        """
+        self._commands.append({"type": "mouse_tracking", "enabled": enabled})
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render        fn(ctx: RenderContext)
+        @app.on_key           fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click         fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command       fn(text: str, emit: Emitter)
+        @app.on_resize        fn(width: float, height: float)
+        @app.on_get_state     fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state     fn(state: dict) — restore app from state buckets
+        @app.on_drop          fn(target_id: str, paths: list[str], emit: Emitter)
+        @app.on_mouse_down    fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_up      fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_mouse_move    fn(x: float, y: float, emit: Emitter)
+        @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self.delta_time: float = 0.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._on_mouse_down: Optional[Callable] = None
+        self._on_mouse_up: Optional[Callable] = None
+        self._on_mouse_move: Optional[Callable] = None
+        self._on_scroll: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def on_mouse_down(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button presses.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_down = fn
+        return fn
+
+    def on_mouse_up(self, fn: Callable) -> Callable:
+        """Register a handler for mouse button releases.
+
+        The handler receives (x: float, y: float, button: str, emit: Emitter).
+        `button` is one of 'left', 'right', 'middle'.
+        """
+        self._on_mouse_up = fn
+        return fn
+
+    def on_mouse_move(self, fn: Callable) -> Callable:
+        """Register a handler for mouse movement.
+
+        The handler receives (x: float, y: float, emit: Emitter).
+        Only called when mouse_tracking = true in manifest capabilities or after
+        the app emits a MouseTracking draw command.
+        """
+        self._on_mouse_move = fn
+        return fn
+
+    def on_scroll(self, fn: Callable) -> Callable:
+        """Register a handler for scroll wheel / trackpad scroll events.
+
+        The handler receives (x: float, y: float, delta_x: float, delta_y: float, emit: Emitter).
+        `x, y` is the cursor position; `delta_x, delta_y` is the scroll amount in logical pixels.
+        """
+        self._on_scroll = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                self.delta_time = event.get("delta_time", 0.0)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx.delta_time = self.delta_time
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_down":
+                if self._on_mouse_down:
+                    self._on_mouse_down(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_up":
+                if self._on_mouse_up:
+                    self._on_mouse_up(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "left"),
+                        self._emitter,
+                    )
+
+            elif event_type == "mouse_move":
+                if self._on_mouse_move:
+                    self._on_mouse_move(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "scroll":
+                if self._on_scroll:
+                    self._on_scroll(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("delta_x", 0.0),
+                        event.get("delta_y", 0.0),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break


### PR DESCRIPTION
## Summary

- Adds `examples/kona/` — a full Plexi app store for browsing and installing community apps
- Browse view with `j`/`k` navigation, `/` fuzzy filter, `Tab` tag cycling, and `Enter` to open detail
- Detail view with install (`i`) and uninstall (`u`) actions; confirm prompt for uninstall
- Install view with spinner animation, two-stage install (CLI → fallback direct GitHub download), and 3-second success toast

## Implementation notes

- Registry fetched from `https://raw.githubusercontent.com/ianjamesburke/plexi-registry/main/registry.json` in a background thread on startup
- Cache written to `~/.plexi-alpha/kona_cache.json` with a 1-hour TTL; stale cache used as fallback if fetch fails
- Fallback install downloads `manifest.toml` → entry file → `plexi_sdk.py` directly from GitHub raw, parses entry filename via `tomllib`/`tomli`/regex
- Catppuccin Mocha color scheme, header bar, selected-row accent bar, tag pills

## Test plan

- [ ] Launch kona in a Plexi pane and verify registry loads (or "Unable to load registry" if offline)
- [ ] Navigate with `j`/`k`, filter with `/`, cycle tags with `Tab`
- [ ] Open detail view, install an app, verify it appears in `~/.plexi-alpha/apps/`
- [ ] Uninstall and confirm the directory is removed
- [ ] Kill network, relaunch — verify stale cache is used