### PR TITLE
fix: kona installer respects branch field in registry entries

### DIFF
--- a/examples/kona/kona.py
+++ b/examples/kona/kona.py
@@ -187,7 +187,8 @@ def _parse_entry_from_manifest(manifest_text: str) -> str | None:
 def _fallback_install(entry: dict, app_dir: pathlib.Path) -> None:
     repo = entry.get("repo", "")
     path = entry.get("path", "")
-    base_url = f"https://raw.githubusercontent.com/{repo}/alpha/{path}"
+    branch = entry.get("branch", "alpha")
+    base_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{path}"
     manifest_url = f"{base_url}/manifest.toml"
     try:
         with urllib.request.urlopen(manifest_url, timeout=10) as r:


### PR DESCRIPTION
## Summary

- `_fallback_install` in `kona.py` now reads `entry.get("branch", "alpha")` instead of hardcoding `"alpha"`, so apps with a custom `branch` field in the registry fetch from the correct ref
- Updated the `parallax` registry entry in `ianjamesburke/plexi-registry` to point to `ianjamesburke/parallax` repo at `path: plexi`, `branch: main` (was pointing to `ianjamesburke/PLEXI`)

## Test plan

- [ ] Install an app whose registry entry has `"branch": "main"` (e.g. Parallax) — confirm it fetches from `main` not `alpha`
- [ ] Install an app with no `branch` field — confirm it still defaults to `alpha`