### PR TITLE
feat: add Learn Plexi tutorial game app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "plexi"
+name = "plexi-alpha"
 version = "1.1.2"
 dependencies = [
  "chrono",

--- a/examples/learn-plexi/learn_plexi.py
+++ b/examples/learn-plexi/learn_plexi.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+learn-plexi — Plexi app
+Gamified interactive tutorial that teaches new users the core Plexi keybindings.
+
+Controls:
+  Enter        Advance on welcome screen
+  Any key      Acknowledge and advance on levels 3, 4, 5
+  r            Restart from the done screen
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha palette
+# ---------------------------------------------------------------------------
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#9399b2",
+    "muted":   "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "yellow":  "#f9e2af",
+    "peach":   "#fab387",
+    "header":  "#181825",
+}
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+TOTAL_LEVELS = 6
+
+current_level = 0   # 0 = welcome, 1 = hjkl, 2 = new context, 3 = split, 4 = close, 5 = done
+
+# Level 2 (hjkl) pane-size tracking
+_last_size: tuple[float, float] = (0.0, 0.0)
+_left_pane: bool = False    # True once size has shrunk (focus left)
+_returned: bool = False     # True once focus has returned (size grew back)
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+app = App(app_id="learn-plexi")
+
+
+def reset_state():
+    global current_level, _last_size, _left_pane, _returned
+    current_level = 0
+    _last_size = (0.0, 0.0)
+    _left_pane = False
+    _returned = False
+
+
+# ---------------------------------------------------------------------------
+# Drawing helpers
+# ---------------------------------------------------------------------------
+
+def draw_background(ctx):
+    ctx.rect(0, 0, ctx.width, ctx.height, fill=C["bg"])
+
+
+def draw_progress_bar(ctx, completed: int, total: int):
+    """Render a segmented progress bar near the bottom of the pane."""
+    bar_y = ctx.height - 44
+    bar_h = 6
+    margin = 20
+    gap = 6
+    total_gap = gap * (total - 1)
+    seg_w = (ctx.width - margin * 2 - total_gap) / total
+
+    for i in range(total):
+        x = margin + i * (seg_w + gap)
+        fill = C["accent"] if i < completed else C["surface"]
+        ctx.rect(x, bar_y, seg_w, bar_h, fill=fill, radius=3.0)
+
+
+def draw_footer(ctx, level_display: int, total: int):
+    label = f"learn-plexi  •  level {level_display}/{total}"
+    ctx.text(ctx.width / 2 - 90, ctx.height - 26, label,
+             size=11, color=C["muted"], monospace=True)
+
+
+def draw_level_header(ctx, level_num: int, title: str):
+    """Level number pill + title."""
+    ctx.rect(20, 16, ctx.width - 40, 44, fill=C["header"], radius=8.0)
+    level_str = f"Level {level_num}"
+    ctx.text(28, 26, level_str, size=11, color=C["accent"], bold=True)
+    ctx.text(28 + 72, 24, title, size=15, color=C["text"], bold=True)
+
+
+def draw_instruction(ctx, lines: list[str], y_start: float = 120):
+    """Draw multi-line instruction text centered-ish."""
+    line_h = 26
+    for i, line in enumerate(lines):
+        ctx.text(28, y_start + i * line_h, line, size=14, color=C["text"])
+
+
+def draw_hint(ctx, hint: str, y: float | None = None):
+    if y is None:
+        y = ctx.height - 76
+    ctx.text(28, y, hint, size=12, color=C["subtext"])
+
+
+# ---------------------------------------------------------------------------
+# Level renderers
+# ---------------------------------------------------------------------------
+
+def render_welcome(ctx):
+    draw_background(ctx)
+
+    # Big logo area
+    logo_y = ctx.height * 0.25
+    ctx.text(ctx.width / 2 - 52, logo_y, "PLEXI", size=48, color=C["accent"], bold=True)
+    ctx.text(ctx.width / 2 - 72, logo_y + 62, "terminal multiplexer", size=14, color=C["subtext"])
+
+    # Prompt
+    ctx.text(ctx.width / 2 - 88, logo_y + 110, "Press  Enter  to begin", size=16, color=C["text"])
+
+    draw_progress_bar(ctx, 0, TOTAL_LEVELS)
+    draw_footer(ctx, 0, TOTAL_LEVELS)
+
+
+def render_hjkl(ctx):
+    global _last_size, _left_pane, _returned
+
+    draw_background(ctx)
+    draw_level_header(ctx, 1, "Navigate panes")
+
+    w, h = ctx.width, ctx.height
+    size_now = (w, h)
+
+    # Track pane size changes to detect focus leaving/returning
+    if _last_size != (0.0, 0.0):
+        prev_area = _last_size[0] * _last_size[1]
+        curr_area = size_now[0] * size_now[1]
+        if not _left_pane and curr_area < prev_area * 0.9:
+            _left_pane = True
+        elif _left_pane and not _returned and curr_area > prev_area * 1.1:
+            _returned = True
+    _last_size = size_now
+
+    lines = [
+        "Use  h j k l  to move focus between panes.",
+        "",
+        "Move focus away from this pane and back.",
+        "Complete this action to unlock the next level.",
+    ]
+    draw_instruction(ctx, lines)
+
+    # Keyboard-style key boxes
+    keys = [("h", "← left"), ("j", "↓ down"), ("k", "↑ up"), ("l", "→ right")]
+    box_w, box_h = 52, 44
+    gap = 12
+    total_w = len(keys) * box_w + (len(keys) - 1) * gap
+    start_x = (w - total_w) / 2
+    key_y = h * 0.52
+
+    for i, (key_char, label) in enumerate(keys):
+        kx = start_x + i * (box_w + gap)
+        ctx.rect(kx, key_y, box_w, box_h, fill=C["surface"], radius=6.0)
+        ctx.text(kx + box_w / 2 - 6, key_y + 10, key_char,
+                 size=18, color=C["accent"], bold=True, monospace=True)
+        ctx.text(kx + box_w / 2 - 24, key_y + box_h + 6, label,
+                 size=10, color=C["muted"])
+
+    # Status indicator
+    if _returned:
+        status = "Great job! Moving to the next level..."
+        status_color = C["green"]
+    elif _left_pane:
+        status = "Good — now come back to this pane!"
+        status_color = C["yellow"]
+    else:
+        status = "Start by moving focus away with h, j, k, or l"
+        status_color = C["subtext"]
+
+    ctx.text(28, h * 0.80, status, size=13, color=status_color)
+
+    draw_progress_bar(ctx, 1, TOTAL_LEVELS)
+    draw_footer(ctx, 1, TOTAL_LEVELS)
+
+
+def render_new_context(ctx):
+    draw_background(ctx)
+    draw_level_header(ctx, 2, "New context")
+
+    lines = [
+        "Press  Cmd+T  to open a new context.",
+        "(Like a new tab in your browser.)",
+        "",
+        "Come back here when you're done,",
+        "then press any key to continue.",
+    ]
+    draw_instruction(ctx, lines)
+
+    # Visual shortcut display
+    btn_y = ctx.height * 0.62
+    ctx.rect(ctx.width / 2 - 60, btn_y, 120, 38, fill=C["surface"], radius=8.0)
+    ctx.text(ctx.width / 2 - 36, btn_y + 11, "Cmd + T",
+             size=14, color=C["accent"], bold=True, monospace=True)
+
+    draw_hint(ctx, "Press any key to continue after opening a context")
+    draw_progress_bar(ctx, 2, TOTAL_LEVELS)
+    draw_footer(ctx, 2, TOTAL_LEVELS)
+
+
+def render_split(ctx):
+    draw_background(ctx)
+    draw_level_header(ctx, 3, "Split a pane")
+
+    lines = [
+        "Press  Cmd+D  to split this pane vertically.",
+        "",
+        "Splitting lets you view multiple things side-by-side",
+        "in the same context.",
+    ]
+    draw_instruction(ctx, lines)
+
+    # Split illustration
+    ill_y = ctx.height * 0.58
+    ill_w = 180
+    ill_h = 70
+    ill_x = ctx.width / 2 - ill_w / 2
+    ctx.rect(ill_x, ill_y, ill_w, ill_h, fill=C["surface"], radius=6.0)
+    mid = ill_x + ill_w / 2
+    ctx.line(mid, ill_y + 8, mid, ill_y + ill_h - 8,
+             color=C["accent"], width=2.0)
+    ctx.text(ill_x + 16, ill_y + ill_h / 2 - 8, "pane", size=11, color=C["muted"])
+    ctx.text(mid + 16, ill_y + ill_h / 2 - 8, "pane", size=11, color=C["muted"])
+
+    draw_hint(ctx, "Press any key to continue after splitting")
+    draw_progress_bar(ctx, 3, TOTAL_LEVELS)
+    draw_footer(ctx, 3, TOTAL_LEVELS)
+
+
+def render_close(ctx):
+    draw_background(ctx)
+    draw_level_header(ctx, 4, "Close a pane")
+
+    lines = [
+        "Press  Cmd+W  to close a pane.",
+        "",
+        "Use this to tidy up when you're done",
+        "with a split or context.",
+    ]
+    draw_instruction(ctx, lines)
+
+    btn_y = ctx.height * 0.62
+    ctx.rect(ctx.width / 2 - 66, btn_y, 132, 38, fill=C["surface"], radius=8.0)
+    ctx.text(ctx.width / 2 - 40, btn_y + 11, "Cmd + W",
+             size=14, color=C["peach"], bold=True, monospace=True)
+
+    draw_hint(ctx, "Press any key to continue after closing a pane")
+    draw_progress_bar(ctx, 4, TOTAL_LEVELS)
+    draw_footer(ctx, 4, TOTAL_LEVELS)
+
+
+def render_done(ctx):
+    draw_background(ctx)
+
+    w, h = ctx.width, ctx.height
+
+    # Celebration header
+    ctx.rect(20, 16, w - 40, 52, fill=C["header"], radius=8.0)
+    ctx.text(w / 2 - 100, 28, "You know Plexi!", size=20, color=C["green"], bold=True)
+
+    # Reference card
+    card_y = 90
+    card_x = 28
+    col2_x = w / 2 + 8
+    card_w = w / 2 - 36
+
+    ctx.text(card_x, card_y, "Keybinding reference", size=13, color=C["accent"], bold=True)
+
+    shortcuts = [
+        ("h / j / k / l", "Move focus left / down / up / right"),
+        ("Cmd+T",          "Open new context"),
+        ("Cmd+D",          "Split pane vertically"),
+        ("Cmd+W",          "Close pane"),
+    ]
+
+    row_h = 28
+    for i, (key, desc) in enumerate(shortcuts):
+        ry = card_y + 24 + i * row_h
+        ctx.rect(card_x, ry, card_w, row_h - 4, fill=C["surface"], radius=4.0)
+        ctx.text(card_x + 10, ry + 8, key,
+                 size=12, color=C["yellow"], bold=True, monospace=True)
+        ctx.text(col2_x, ry + 8, desc, size=12, color=C["text"])
+
+    # Restart hint
+    restart_y = card_y + 24 + len(shortcuts) * row_h + 16
+    ctx.text(card_x, restart_y, "Press  r  to restart the tutorial",
+             size=13, color=C["subtext"])
+
+    draw_progress_bar(ctx, TOTAL_LEVELS, TOTAL_LEVELS)
+    draw_footer(ctx, TOTAL_LEVELS, TOTAL_LEVELS)
+
+
+# ---------------------------------------------------------------------------
+# Event handlers
+# ---------------------------------------------------------------------------
+
+LEVEL_RENDERERS = [
+    render_welcome,
+    render_hjkl,
+    render_new_context,
+    render_split,
+    render_close,
+    render_done,
+]
+
+
+@app.on_render
+def render(ctx):
+    renderer = LEVEL_RENDERERS[current_level]
+    renderer(ctx)
+
+
+@app.on_key
+def on_key(key: str, mods: dict, emit):
+    global current_level, _left_pane, _returned, _last_size
+
+    # Level 0 — welcome: only Enter advances
+    if current_level == 0:
+        if key == "Enter":
+            current_level = 1
+        return
+
+    # Level 1 — hjkl: advance only after leaving and returning
+    if current_level == 1:
+        # Any key press after _returned triggers advance
+        if _returned:
+            current_level = 2
+            # Reset hjkl tracking for potential replay
+            _left_pane = False
+            _returned = False
+            _last_size = (0.0, 0.0)
+        return
+
+    # Levels 2, 3, 4 — acknowledgment: any key advances
+    if current_level in (2, 3, 4):
+        current_level += 1
+        return
+
+    # Level 5 — done: r restarts
+    if current_level == 5:
+        if key == "r":
+            reset_state()
+        return
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+app.run()

--- a/examples/learn-plexi/manifest.toml
+++ b/examples/learn-plexi/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "learn-plexi"
+name = "Learn Plexi"
+entry = "learn_plexi.py"
+version = "0.1.0"
+description = "Interactive tutorial — learn Plexi keybindings through a short game"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/learn-plexi/plexi_sdk.py
+++ b/examples/learn-plexi/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break


### PR DESCRIPTION
## Summary

- Adds `examples/learn-plexi/` — a 6-level gamified tutorial that teaches new users core Plexi keybindings through interaction
- Levels: Welcome → hjkl navigation (with live pane-size detection) → Cmd+T → Cmd+D → Cmd+W → Done (reference card)
- Catppuccin Mocha palette, progress bar, keyboard-style key boxes for hjkl level, split illustration for Cmd+D level
- No external deps — stdlib + plexi_sdk only

## Test plan

- [ ] Open learn-plexi from the app launcher in Plexi Alpha
- [ ] Level 0: confirm Enter advances to level 1
- [ ] Level 1: move focus away with hjkl, confirm status text changes; return focus, press any key to advance
- [ ] Levels 2–4: press any key to advance through each acknowledgment level
- [ ] Level 5: verify reference card shows all 4 shortcuts; press `r` to restart
- [ ] Verify progress bar fills as levels complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)