### PR TITLE
chore: suppress Pyright false positives (plexi_sdk import + unused params)

### DIFF
--- a/examples/kona/kona.py
+++ b/examples/kona/kona.py
@@ -17,7 +17,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from plexi_sdk import App
+from plexi_sdk import App  # type: ignore[import]
 
 # ---------------------------------------------------------------------------
 # Colors — Catppuccin Mocha
@@ -399,7 +399,7 @@ def render_browse(ctx, now: float):
         ctx.text(12, ctx.height - 18, hints, size=10, color=C["dimmed"])
 
 
-def render_detail(ctx, now: float):
+def render_detail(ctx, _now: float):
     if not state.selected_entry:
         state.view = VIEW_BROWSE
         return

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "reportMissingImports": "none",
+  "reportUnusedParameter": "none"
+}


### PR DESCRIPTION
## Summary
- Adds `pyrightconfig.json` with `reportMissingImports: none` and `reportUnusedParameter: none` — suppresses the runtime-only `plexi_sdk` import error and unused `_`-prefixed param hints that appear in every app file
- Fixes `kona.py` to use `_now` instead of `now` in `render_detail` signature

These are all false positives: `plexi_sdk` is co-located at runtime, and unused params are intentional SDK callback stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)