### PR TITLE
feat: click video thumbnail to open in system player

### DIFF
--- a/examples/parallax/manifest.toml
+++ b/examples/parallax/manifest.toml
@@ -9,6 +9,7 @@ description = "View-only dashboard for a Parallax video project — stills, prev
 file_types = []
 terminal_write = false
 filesystem = "read_only"
+mouse_tracking = true
 
 # Split the launching pane when the viewer opens: a companion terminal
 # scoped to the same project directory appears below. The user talks to

--- a/examples/parallax/parallax.py
+++ b/examples/parallax/parallax.py
@@ -60,6 +60,7 @@ _last_mtime: float = 0.0
 _last_poll: float = 0.0
 _manifest: dict = {}       # parsed manifest dict
 _manifest_error: str = ""
+_video_rect: tuple = (0, 0, 0, 0)  # (x, y, w, h) of latest video thumbnail
 
 # ---------------------------------------------------------------------------
 # Minimal YAML subset parser (stdlib only, no PyYAML dep).
@@ -375,11 +376,14 @@ def render(ctx):
              size=12, color=C["subtext"], bold=True)
     y += 18
     if latest:
+        global _video_rect
+        vw = ctx.width - PADDING * 2
+        _video_rect = (PADDING, y, vw, video_h)
         ctx.video_thumbnail(
             path=latest,
             x=PADDING,
             y=y,
-            w=ctx.width - PADDING * 2,
+            w=vw,
             h=video_h,
             show_play_button=True,
         )
@@ -443,6 +447,21 @@ def _render_empty(ctx):
              fill=C["surface"], radius=6.0)
     ctx.text(PADDING + 12, msg_y + 148, cmd2,
              size=12, color=C["green"], monospace=True)
+
+
+@app.on_mouse_down
+def on_mouse_down(x, y, button, emit):
+    if button != "left":
+        return
+    vx, vy, vw, vh = _video_rect
+    if vx <= x <= vx + vw and vy <= y <= vy + vh:
+        path = _latest_output()
+        if path:
+            import subprocess
+            try:
+                subprocess.Popen(["open", path])
+            except Exception as e:
+                emit.warn(f"could not open video: {e}")
 
 
 app.run()


### PR DESCRIPTION
## Summary

- Tracks the video thumbnail rect (`_video_rect`) each render cycle when a video output is present
- Adds `mouse_tracking = true` to `[app.capabilities]` in `manifest.toml`
- Adds `@app.on_mouse_down` handler that detects left-clicks within the thumbnail rect and opens the video via `subprocess.Popen(["open", path])`

## Test plan

- [ ] Open Parallax viewer on a project with a rendered video in `output/`
- [ ] Click the video thumbnail — video should open in QuickTime (or default system player)
- [ ] Click outside the thumbnail — nothing should happen
- [ ] Right-click the thumbnail — nothing should happen (button guard)
- [ ] Verify no regression when no video output exists (empty-state render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)