### PR TITLE
feat: add weather, hacker-news, pomodoro, json-viewer, todo example apps

### DIFF
--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+calc — Plexi app
+Calculator with expression evaluation and visual keypad reference.
+
+Controls:
+  0-9 . + - * /   Build expression
+  Enter            Evaluate
+  Backspace        Delete last character
+  Escape / c       Clear
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "surface1":"#45475a",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "peach":   "#fab387",
+    "red":     "#f38ba8",
+    "header":  "#181825",
+}
+
+PADDING  = 16
+HEADER_H = 40
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+expression: str = ""
+result:     str = ""
+is_error:   bool = False
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ALLOWED_CHARS = set("0123456789.+-*/() ")
+
+
+def _evaluate(expr: str) -> tuple[str, bool]:
+    """Evaluate expression safely. Returns (result_str, is_error)."""
+    expr = expr.strip()
+    if not expr:
+        return ("", False)
+    # Only allow safe characters
+    for ch in expr:
+        if ch not in _ALLOWED_CHARS:
+            return (f"Error: invalid character '{ch}'", True)
+    try:
+        val = eval(expr, {"__builtins__": {}})  # noqa: S307
+        # Format: remove trailing .0 for integers
+        if isinstance(val, float) and val == int(val):
+            return (str(int(val)), False)
+        return (str(val), False)
+    except ZeroDivisionError:
+        return ("Error: division by zero", True)
+    except SyntaxError:
+        return ("Error: invalid expression", True)
+    except Exception as e:
+        return (f"Error: {e}", True)
+
+# ---------------------------------------------------------------------------
+# Keypad layout (visual reference only)
+# ---------------------------------------------------------------------------
+
+KEYPAD_ROWS = [
+    ["7", "8", "9", "/"],
+    ["4", "5", "6", "*"],
+    ["1", "2", "3", "-"],
+    ["0", ".", "=", "+"],
+]
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App()
+
+
+@app.on_render
+def render(ctx):
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 12, "Calculator", size=13, color=C["accent"], bold=True)
+    hint = "0-9 +-*/()  Enter=eval  Backspace=del  Esc/c=clear"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 14, hint, size=10, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    # Expression display
+    expr_y = HEADER_H + PADDING
+    ctx.rect(PADDING, expr_y, w - PADDING * 2, 40, fill=C["surface"], radius=6.0)
+    display_expr = expression if expression else "0"
+    # right-align expression text
+    expr_char_w = 10.0
+    max_expr_chars = int((w - PADDING * 2 - 16) / expr_char_w)
+    visible_expr = display_expr[-max_expr_chars:] if len(display_expr) > max_expr_chars else display_expr
+    ctx.text(PADDING + 8, expr_y + 12, visible_expr, size=18, color=C["text"], monospace=True)
+
+    # Result display
+    result_y = expr_y + 52
+    if result:
+        res_color = C["peach"] if is_error else C["green"]
+        # Large result
+        rsize = 28 if not is_error else 14
+        rx = PADDING + 8
+        ctx.text(rx, result_y, result, size=rsize, color=res_color, monospace=True, bold=not is_error)
+    else:
+        ctx.text(PADDING + 8, result_y, "—", size=22, color=C["subtext"], monospace=True)
+
+    # Divider before keypad
+    kpad_top = result_y + 52
+    ctx.line(PADDING, kpad_top, w - PADDING, kpad_top, color=C["surface"], width=1.0)
+
+    # Keypad grid (visual reference)
+    kpad_y = kpad_top + 12
+    key_w = 56.0
+    key_h = 44.0
+    key_gap = 8.0
+    total_kpad_w = 4 * key_w + 3 * key_gap
+    kpad_x = (w - total_kpad_w) / 2
+
+    for row_i, row in enumerate(KEYPAD_ROWS):
+        for col_i, label in enumerate(row):
+            kx = kpad_x + col_i * (key_w + key_gap)
+            ky = kpad_y + row_i * (key_h + key_gap)
+            # Different bg for operators
+            is_op = label in ("/ * - + =".split())
+            bg = C["accent"] if label == "=" else (C["surface1"] if is_op else C["surface"])
+            txt = C["header"] if label == "=" else (C["accent"] if is_op else C["text"])
+            ctx.rect(kx, ky, key_w, key_h, fill=bg, radius=6.0)
+            lbl = "=" if label == "=" else label
+            lx = kx + key_w / 2 - len(lbl) * 5.5
+            ly = ky + key_h / 2 - 7
+            ctx.text(lx, ly, lbl, size=14, color=txt, bold=True)
+
+    # Bottom label
+    ctx.text(
+        w / 2 - 60, kpad_y + 4 * (key_h + key_gap) + 4,
+        "visual reference only",
+        size=10, color=C["subtext"],
+    )
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global expression, result, is_error
+
+    if key in ("Escape", "c"):
+        expression = ""
+        result = ""
+        is_error = False
+    elif key == "Backspace":
+        expression = expression[:-1]
+        result = ""
+        is_error = False
+    elif key == "Enter":
+        result, is_error = _evaluate(expression)
+        if not is_error and result:
+            # Keep result in expression so user can keep chaining
+            expression = result
+            result = ""
+    elif len(key) == 1 and key in _ALLOWED_CHARS and key != " ":
+        expression += key
+        result = ""
+        is_error = False
+
+
+app.run()

--- a/examples/calc/manifest.toml
+++ b/examples/calc/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "calc"
+name = "Calculator"
+entry = "calc.py"
+version = "0.1.0"
+description = "Calculator with expression evaluation and visual keypad reference"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/calc/plexi_sdk.py
+++ b/examples/calc/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/color-palette/color_palette.py
+++ b/examples/color-palette/color_palette.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+color-palette — Plexi app
+Catppuccin Mocha color reference. Navigate the grid, press Enter/Space to copy hex.
+
+Controls:
+  j / ↓   Move down
+  k / ↑   Move up
+  h / ←   Move left
+  l / →   Move right
+  Enter   Copy hex value to clipboard (macOS pbcopy)
+  Space   Copy hex value to clipboard (macOS pbcopy)
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha palette
+# ---------------------------------------------------------------------------
+
+PALETTE: list[tuple[str, str]] = [
+    ("Rosewater", "#f5e0dc"),
+    ("Flamingo",  "#f2cdcd"),
+    ("Pink",      "#f5c2e7"),
+    ("Mauve",     "#cba6f7"),
+    ("Red",       "#f38ba8"),
+    ("Maroon",    "#eba0ac"),
+    ("Peach",     "#fab387"),
+    ("Yellow",    "#f9e2af"),
+    ("Green",     "#a6e3a1"),
+    ("Teal",      "#94e2d5"),
+    ("Sky",       "#89dceb"),
+    ("Sapphire",  "#74c7ec"),
+    ("Blue",      "#89b4fa"),
+    ("Lavender",  "#b4befe"),
+    ("Text",      "#cdd6f4"),
+    ("Subtext1",  "#bac2de"),
+    ("Subtext0",  "#a6adc8"),
+    ("Overlay2",  "#7f849c"),
+    ("Overlay1",  "#6c7086"),
+    ("Overlay0",  "#585b70"),
+    ("Surface2",  "#45475a"),
+    ("Surface1",  "#313244"),
+    ("Surface0",  "#1e1e2e"),
+    ("Base",      "#1e1e2e"),
+    ("Mantle",    "#181825"),
+    ("Crust",     "#11111b"),
+]
+
+# ---------------------------------------------------------------------------
+# Colors (UI chrome)
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "header":  "#181825",
+}
+
+HEADER_H   = 40
+PADDING    = 16
+SWATCH_W   = 80
+SWATCH_H   = 56
+GAP        = 12
+COLS       = 4    # default; recalculated in render
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+selected:     int   = 0
+copied_at:    float = 0.0
+copied_hex:   str   = ""
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App()
+
+
+def _copy_to_clipboard(text: str):
+    try:
+        subprocess.run(["pbcopy"], input=text.encode(), check=True, timeout=2)
+    except Exception:
+        pass  # silently skip on non-macOS
+
+
+@app.on_render
+def render(ctx):
+    global selected
+
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 12, "Color Palette — Catppuccin Mocha", size=13, color=C["accent"], bold=True)
+    hint = "hjkl/arrows=navigate  Enter=copy hex"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 14, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    # Compute grid dimensions
+    available_w = w - PADDING * 2
+    cols = max(1, int((available_w + GAP) / (SWATCH_W + GAP)))
+    rows = (len(PALETTE) + cols - 1) // cols
+
+    grid_x0 = PADDING
+    grid_y0 = HEADER_H + PADDING
+
+    for i, (name, hex_val) in enumerate(PALETTE):
+        col = i % cols
+        row = i // cols
+        sx = grid_x0 + col * (SWATCH_W + GAP)
+        sy = grid_y0 + row * (SWATCH_H + GAP + 28)  # 28 extra for two text lines
+
+        is_sel = (i == selected)
+
+        # Selection outline
+        if is_sel:
+            ctx.rect(sx - 3, sy - 3, SWATCH_W + 6, SWATCH_H + 6,
+                     fill=C["accent"], radius=6.0)
+
+        # Swatch
+        ctx.rect(sx, sy, SWATCH_W, SWATCH_H, fill=hex_val, radius=4.0)
+
+        # Name
+        ctx.text(sx, sy + SWATCH_H + 4, name, size=11, color=C["text"])
+        # Hex
+        ctx.text(sx, sy + SWATCH_H + 18, hex_val, size=10, color=C["subtext"])
+
+    # "Copied!" flash
+    now = time.monotonic()
+    if copied_hex and (now - copied_at) < 1.0:
+        msg = f"Copied {copied_hex}!"
+        msg_w = len(msg) * 7.5 + 16
+        ctx.rect(w / 2 - msg_w / 2, h - 36, msg_w, 24, fill=C["surface"], radius=4.0)
+        ctx.text(w / 2 - len(msg) * 3.75, h - 28, msg, size=12, color=C["green"])
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global selected, copied_at, copied_hex
+
+    # Recalculate cols based on last known width (stored on app object)
+    w = app.width
+    available_w = w - PADDING * 2
+    cols = max(1, int((available_w + GAP) / (SWATCH_W + GAP)))
+    n = len(PALETTE)
+
+    if key in ("j", "ArrowDown"):
+        selected = min(selected + cols, n - 1)
+    elif key in ("k", "ArrowUp"):
+        selected = max(selected - cols, 0)
+    elif key in ("h", "ArrowLeft"):
+        selected = max(selected - 1, 0)
+    elif key in ("l", "ArrowRight"):
+        selected = min(selected + 1, n - 1)
+    elif key in ("Enter", " "):
+        _, hex_val = PALETTE[selected]
+        _copy_to_clipboard(hex_val)
+        copied_hex = hex_val
+        copied_at = time.monotonic()
+
+
+app.run()

--- a/examples/color-palette/manifest.toml
+++ b/examples/color-palette/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "color-palette"
+name = "Color Palette"
+entry = "color_palette.py"
+version = "0.1.0"
+description = "Catppuccin Mocha color reference — browse swatches, Enter to copy hex"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/color-palette/plexi_sdk.py
+++ b/examples/color-palette/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/diff-viewer/diff_viewer.py
+++ b/examples/diff-viewer/diff_viewer.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+diff-viewer — Plexi app
+Renders `git diff HEAD` with syntax highlighting.
+
+Controls:
+  j / ↓   Scroll down
+  k / ↑   Scroll up
+  r       Re-run diff
+"""
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "red":     "#f38ba8",
+    "peach":   "#fab387",
+    "header":  "#181825",
+}
+
+PADDING  = 16
+LINE_H   = 17
+HEADER_H = 40
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+diff_lines: list[dict] = []   # {text: str, color: str}
+scroll:     int = 0
+error_msg:  str = ""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _color_for_line(line: str) -> str:
+    if line.startswith("+") and not line.startswith("+++"):
+        return C["green"]
+    if line.startswith("-") and not line.startswith("---"):
+        return C["red"]
+    if line.startswith("@@"):
+        return C["accent"]
+    if line.startswith("diff ") or line.startswith("index "):
+        return C["subtext"]
+    return C["text"]
+
+
+def _run_diff():
+    global diff_lines, error_msg, scroll
+    try:
+        result = subprocess.run(
+            ["git", "diff", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 and result.stderr:
+            stderr = result.stderr.strip()
+            if "not a git repository" in stderr.lower():
+                error_msg = "Not a git repository."
+                diff_lines = []
+                return
+            error_msg = f"git error: {stderr[:120]}"
+            diff_lines = []
+            return
+
+        raw = result.stdout
+        error_msg = ""
+        if not raw.strip():
+            diff_lines = [{"text": "No changes (working tree is clean).", "color": C["subtext"]}]
+        else:
+            diff_lines = [
+                {"text": line, "color": _color_for_line(line)}
+                for line in raw.splitlines()
+            ]
+        scroll = 0
+    except FileNotFoundError:
+        error_msg = "git not found in PATH."
+        diff_lines = []
+    except subprocess.TimeoutExpired:
+        error_msg = "git diff timed out."
+        diff_lines = []
+    except Exception as e:
+        error_msg = f"Unexpected error: {e}"
+        diff_lines = []
+
+
+# Initial run
+_run_diff()
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App()
+
+
+@app.on_render
+def render(ctx):
+    global scroll
+
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 12, "Diff Viewer — git diff HEAD", size=13, color=C["accent"], bold=True)
+    hint = "j/k=scroll  r=refresh"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 14, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    if error_msg:
+        ctx.text(PADDING, HEADER_H + 20, error_msg, size=13, color=C["peach"])
+        return
+
+    # Body
+    body_h = h - HEADER_H - PADDING
+    visible = max(1, int(body_h / LINE_H))
+    max_scroll = max(0, len(diff_lines) - visible)
+    clamped = max(0, min(scroll, max_scroll))
+    if clamped != scroll:
+        scroll = clamped
+
+    for i, entry in enumerate(diff_lines[scroll: scroll + visible]):
+        y = HEADER_H + PADDING + i * LINE_H
+        text = entry["text"]
+        color = entry["color"]
+        # Truncate to approximate visible width
+        max_chars = int((w - PADDING * 2) / 7.0)
+        if len(text) > max_chars:
+            text = text[:max_chars - 1] + "…"
+        ctx.text(PADDING, y, text, size=12, color=color, monospace=True)
+
+    # Scroll indicator
+    if len(diff_lines) > visible:
+        pct = int(scroll / max(1, max_scroll) * 100)
+        label = f"{pct}%  {scroll + 1}/{len(diff_lines)}"
+        ctx.text(w - PADDING - len(label) * 7, h - 12, label, size=11, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global scroll
+    if key in ("j", "ArrowDown"):
+        scroll += 1
+    elif key in ("k", "ArrowUp"):
+        scroll = max(0, scroll - 1)
+    elif key == "r":
+        _run_diff()
+
+
+app.run()

--- a/examples/diff-viewer/manifest.toml
+++ b/examples/diff-viewer/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "diff-viewer"
+name = "Diff Viewer"
+entry = "diff_viewer.py"
+version = "0.1.0"
+description = "Git diff viewer with syntax highlighting — j/k to scroll, r to refresh"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/diff-viewer/plexi_sdk.py
+++ b/examples/diff-viewer/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/hacker-news/hacker_news.py
+++ b/examples/hacker-news/hacker_news.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+hacker-news — Plexi app
+Browse Hacker News top stories.
+
+Controls (list view):
+  j / ↓    Next story
+  k / ↑    Previous story
+  Enter    Open detail
+
+Controls (detail view):
+  o        Open URL in browser
+  Escape/q Back to list
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "overlay": "#45475a",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "yellow":  "#f9e2af",
+    "red":     "#f38ba8",
+    "orange":  "#fab387",
+    "header":  "#181825",
+}
+
+PADDING  = 16
+HEADER_H = 48
+ITEM_H   = 52
+TOP_N    = 30
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+VIEW_LIST   = "list"
+VIEW_DETAIL = "detail"
+VIEW_LOAD   = "loading"
+
+view: str     = VIEW_LOAD
+stories: list = []
+selected: int = 0
+detail: dict | None  = None
+load_msg: str = "Loading top stories…"
+
+result_q: queue.Queue = queue.Queue()
+
+# ---------------------------------------------------------------------------
+# HN API helpers
+# ---------------------------------------------------------------------------
+
+BASE = "https://hacker-news.firebaseio.com/v0"
+HEADERS = {"User-Agent": "Plexi/0.1 (https://github.com/ianjamesburke/PLEXI)"}
+
+
+def _get(url: str) -> object:
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read().decode())
+
+
+def _fetch_story(sid: int) -> dict | None:
+    try:
+        return _get(f"{BASE}/item/{sid}.json")  # type: ignore[return-value]
+    except Exception:
+        return None
+
+
+def _domain(url: str | None) -> str:
+    if not url:
+        return "self"
+    try:
+        host = url.split("//", 1)[1].split("/")[0]
+        return host.removeprefix("www.")
+    except Exception:
+        return ""
+
+
+def _time_ago(ts: int | None) -> str:
+    if not ts:
+        return ""
+    delta = int(time.time()) - ts
+    if delta < 60:
+        return "just now"
+    if delta < 3600:
+        return f"{delta // 60}m ago"
+    if delta < 86400:
+        return f"{delta // 3600}h ago"
+    return f"{delta // 86400}d ago"
+
+
+def fetch_top_stories():
+    try:
+        ids = _get(f"{BASE}/topstories.json")
+        top_ids = ids[:TOP_N]  # type: ignore[index]
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            items = list(pool.map(_fetch_story, top_ids))
+        stories_out = [s for s in items if s and s.get("type") == "story"]
+        result_q.put({"action": "list_done", "stories": stories_out})
+    except Exception as exc:
+        result_q.put({"action": "error", "message": str(exc)})
+
+
+def start_fetch_list():
+    global view, load_msg
+    view = VIEW_LOAD
+    load_msg = "Loading top stories…"
+    t = threading.Thread(target=fetch_top_stories, daemon=True)
+    t.start()
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="hacker-news")
+
+
+@app.on_render
+def render(ctx):
+    global view, stories, selected, detail, load_msg
+
+    # Drain queue
+    try:
+        while True:
+            msg = result_q.get_nowait()
+            action = msg["action"]
+            if action == "list_done":
+                stories = msg["stories"]
+                selected = 0
+                view = VIEW_LIST
+            elif action == "error":
+                load_msg = f"Error: {msg['message']}"
+                view = VIEW_LOAD
+    except queue.Empty:
+        pass
+
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 14, "Hacker News", size=14, color=C["orange"], bold=True)
+
+    if view == VIEW_LOAD:
+        _render_loading(ctx, w, h)
+    elif view == VIEW_DETAIL:
+        _render_detail(ctx, w, h)
+    else:
+        _render_list(ctx, w, h)
+
+
+def _render_loading(ctx, w: float, h: float):
+    ctx.text(PADDING, HEADER_H + 20, load_msg, size=13, color=C["subtext"])
+
+
+def _render_list(ctx, w: float, h: float):
+    hint = "j/k=nav  Enter=open"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 16, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    items = []
+    for i, s in enumerate(stories):
+        rank = f"#{i+1}"
+        title = s.get("title", "")
+        score = s.get("score", 0)
+        comments = s.get("descendants", 0)
+        domain = _domain(s.get("url"))
+        label = f"{rank}  {title}"
+        secondary = f"▲ {score}  💬 {comments}  {domain}"
+        items.append({"label": label, "secondary": secondary})
+
+    ctx.list(items, selected=selected, item_height=float(ITEM_H))
+
+    # Re-paint header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 14, "Hacker News", size=14, color=C["orange"], bold=True)
+    ctx.text(w - len(hint) * 7.2 - PADDING, 16, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+
+def _render_detail(ctx, w: float, h: float):
+    if not detail:
+        return
+
+    hint = "o=open URL  Esc/q=back"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 16, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    y = HEADER_H + PADDING
+
+    # Title
+    title = detail.get("title", "")
+    ctx.text(PADDING, y, title, size=16, color=C["text"], bold=True)
+    y += 28
+
+    # URL / domain
+    url = detail.get("url") or ""
+    if url:
+        ctx.text(PADDING, y, _domain(url), size=12, color=C["accent"])
+        y += 20
+
+    # Meta row
+    score    = detail.get("score", 0)
+    author   = detail.get("by", "")
+    comments = detail.get("descendants", 0)
+    ts       = detail.get("time")
+    meta = f"▲ {score}  by {author}  💬 {comments}  {_time_ago(ts)}"
+    ctx.text(PADDING, y, meta, size=12, color=C["subtext"])
+    y += 28
+
+    ctx.line(0, y, w, y, color=C["surface"], width=1.0)
+    y += 12
+
+    # Self-post text if present
+    text_body = detail.get("text") or ""
+    if text_body:
+        # Strip HTML tags simply
+        import re
+        clean = re.sub(r"<[^>]+>", " ", text_body).strip()
+        import textwrap
+        lines = textwrap.wrap(clean, 80)
+        for line in lines[:30]:
+            ctx.text(PADDING, y, line, size=12, color=C["text"])
+            y += 18
+    else:
+        ctx.text(PADDING, y, "Press o to open in browser.", size=12, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key: str, _mods: dict, _emit):
+    global view, selected, detail
+
+    if view == VIEW_LOAD:
+        return
+
+    if view == VIEW_LIST:
+        if key in ("j", "ArrowDown"):
+            selected = min(selected + 1, len(stories) - 1)
+        elif key in ("k", "ArrowUp"):
+            selected = max(selected - 1, 0)
+        elif key == "Enter" and stories:
+            detail = stories[selected]
+            view = VIEW_DETAIL
+
+    elif view == VIEW_DETAIL:
+        if key in ("Escape", "q"):
+            view = VIEW_LIST
+            detail = None
+        elif key == "o":
+            url = detail.get("url") if detail else None
+            if url:
+                try:
+                    subprocess.Popen(["open", url])
+                except Exception:
+                    pass
+
+
+# Kick off initial load
+start_fetch_list()
+
+app.run()

--- a/examples/hacker-news/manifest.toml
+++ b/examples/hacker-news/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "hacker-news"
+name = "Hacker News"
+entry = "hacker_news.py"
+version = "0.1.0"
+description = "Browse Hacker News top stories — list and detail views"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/hacker-news/plexi_sdk.py
+++ b/examples/hacker-news/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/json-viewer/json_viewer.py
+++ b/examples/json-viewer/json_viewer.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+json-viewer — Plexi app
+Collapsible tree viewer for JSON files.
+
+Launch via PLEXI_LAUNCH_PATH env var pointing to a .json file,
+or open any .json file from Plexi's file picker.
+
+Controls:
+  j / ↓    Move down
+  k / ↑    Move up
+  Enter / Space    Expand / collapse node
+  q        Quit (close app)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "yellow":  "#f9e2af",
+    "red":     "#f38ba8",
+    "mauve":   "#cba6f7",
+    "peach":   "#fab387",
+    "header":  "#181825",
+    "sel":     "#313244",
+}
+
+PADDING  = 16
+HEADER_H = 48
+ITEM_H   = 20
+INDENT_W = 16
+
+# ---------------------------------------------------------------------------
+# Tree node
+# ---------------------------------------------------------------------------
+
+class Node:
+    def __init__(self, key: str | None, value: object, depth: int = 0):
+        self.key = key
+        self.value = value
+        self.depth = depth
+        self.expanded: bool = depth < 2  # auto-expand first two levels
+        self.children: list[Node] = []
+        self._build_children()
+
+    def _build_children(self):
+        if isinstance(self.value, dict):
+            for k, v in self.value.items():
+                self.children.append(Node(str(k), v, self.depth + 1))
+        elif isinstance(self.value, list):
+            for i, v in enumerate(self.value):
+                self.children.append(Node(f"[{i}]", v, self.depth + 1))
+
+    @property
+    def is_container(self) -> bool:
+        return isinstance(self.value, (dict, list))
+
+    @property
+    def child_count(self) -> int:
+        return len(self.children)
+
+    def type_label(self) -> str:
+        if isinstance(self.value, dict):
+            return f"{{}} {len(self.value)} keys"
+        if isinstance(self.value, list):
+            return f"[] {len(self.value)} items"
+        return ""
+
+    def value_str(self) -> str:
+        if isinstance(self.value, str):
+            snippet = self.value[:60]
+            suffix = "…" if len(self.value) > 60 else ""
+            return f'"{snippet}{suffix}"'
+        if self.value is None:
+            return "null"
+        if isinstance(self.value, bool):
+            return "true" if self.value else "false"
+        return str(self.value)
+
+    def value_color(self) -> str:
+        if isinstance(self.value, str):
+            return C["green"]
+        if self.value is None:
+            return C["subtext"]
+        if isinstance(self.value, bool):
+            return C["mauve"]
+        if isinstance(self.value, (int, float)):
+            return C["yellow"]
+        return C["text"]
+
+
+def flatten(node: Node, out: list[Node]):
+    out.append(node)
+    if node.is_container and node.expanded:
+        for child in node.children:
+            flatten(child, out)
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+root: Node | None = None
+error_msg: str = ""
+flat: list[Node] = []
+cursor: int = 0
+scroll: int = 0
+
+# ---------------------------------------------------------------------------
+# Load
+# ---------------------------------------------------------------------------
+
+def load_file(path: str):
+    global root, error_msg, flat, cursor, scroll
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        root = Node(os.path.basename(path), data, depth=0)
+        error_msg = ""
+    except json.JSONDecodeError as exc:
+        error_msg = f"JSON parse error: {exc}"
+        root = None
+    except OSError as exc:
+        error_msg = f"Cannot open file: {exc}"
+        root = None
+    _rebuild_flat()
+
+
+def _rebuild_flat():
+    global flat
+    flat = []
+    if root:
+        flatten(root, flat)
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="json-viewer")
+
+# Try PLEXI_LAUNCH_PATH at startup
+_launch_path = os.environ.get("PLEXI_LAUNCH_PATH", "")
+if _launch_path and os.path.isfile(_launch_path):
+    load_file(_launch_path)
+
+
+@app.on_render
+def render(ctx):
+    global scroll, cursor
+
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    title = "JSON Viewer"
+    if root:
+        title += f"  —  {root.key}"
+    ctx.text(PADDING, 14, title, size=14, color=C["accent"], bold=True)
+    hint = "j/k=nav  Space=expand  q=quit"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 16, hint, size=10, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    body_y = HEADER_H + PADDING
+    body_h = h - body_y - PADDING
+
+    if error_msg:
+        ctx.text(PADDING, body_y, error_msg, size=13, color=C["red"])
+        return
+
+    if root is None:
+        ctx.text(PADDING, body_y, "Drop a JSON file here or open via file picker.", size=13, color=C["subtext"])
+        # Drop target hint
+        ctx.rect(PADDING, body_y + 30, w - PADDING * 2, 80, fill=C["surface"], radius=8.0)
+        ctx.text(w / 2 - 80, body_y + 62, "Drop .json file here", size=13, color=C["subtext"])
+        ctx.drop_target("json", PADDING, body_y + 30, w - PADDING * 2, 80,
+                        accept=["json"], label="Drop JSON file")
+        return
+
+    # Visible rows
+    visible = max(1, int(body_h / ITEM_H))
+
+    # Clamp scroll to keep cursor visible
+    if cursor < scroll:
+        scroll = cursor
+    elif cursor >= scroll + visible:
+        scroll = cursor - visible + 1
+    scroll = max(0, min(scroll, max(0, len(flat) - visible)))
+
+    for i, node in enumerate(flat[scroll:scroll + visible]):
+        row_idx = scroll + i
+        ry = body_y + i * ITEM_H
+
+        # Selection highlight
+        if row_idx == cursor:
+            ctx.rect(0, ry, w, ITEM_H, fill=C["sel"])
+
+        x = PADDING + node.depth * INDENT_W
+
+        # Expand/collapse indicator
+        if node.is_container:
+            arrow = "▼" if node.expanded else "▶"
+            ctx.text(x, ry + 2, arrow, size=11, color=C["subtext"])
+            x += 14
+
+        # Key
+        if node.key is not None:
+            ctx.text(x, ry + 2, node.key, size=12, color=C["accent"], bold=True)
+            x += len(node.key) * 7.5 + 4
+            ctx.text(x, ry + 2, ": ", size=12, color=C["subtext"])
+            x += 10
+
+        # Value / type label
+        if node.is_container:
+            ctx.text(x, ry + 2, node.type_label(), size=12, color=C["subtext"])
+        else:
+            ctx.text(x, ry + 2, node.value_str(), size=12, color=node.value_color())
+
+    # Scroll indicator
+    if len(flat) > visible:
+        pct = scroll / max(1, len(flat) - visible)
+        bar_h = max(20, int(body_h * visible / len(flat)))
+        bar_y = body_y + int((body_h - bar_h) * pct)
+        ctx.rect(w - 4, bar_y, 3, bar_h, fill=C["overlay"], radius=1.5)
+
+
+@app.on_key
+def on_key(key: str, _mods: dict, _emit):
+    global cursor, scroll
+
+    if key in ("j", "ArrowDown"):
+        cursor = min(cursor + 1, len(flat) - 1)
+    elif key in ("k", "ArrowUp"):
+        cursor = max(cursor - 1, 0)
+    elif key in ("Enter", " "):
+        if flat and 0 <= cursor < len(flat):
+            node = flat[cursor]
+            if node.is_container:
+                node.expanded = not node.expanded
+                _rebuild_flat()
+                # Clamp cursor after collapse
+                cursor = min(cursor, len(flat) - 1)
+    elif key == "q":
+        pass  # Plexi handles quit via the pane close button; q is a no-op here
+
+
+@app.on_drop
+def on_drop(target_id: str, paths: list, _emit):
+    if paths:
+        load_file(paths[0])
+        global cursor, scroll
+        cursor = 0
+        scroll = 0
+
+
+app.run()

--- a/examples/json-viewer/manifest.toml
+++ b/examples/json-viewer/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "json-viewer"
+name = "JSON Viewer"
+entry = "json_viewer.py"
+version = "0.1.0"
+description = "Collapsible tree viewer for JSON files"
+
+[app.capabilities]
+file_types = ["json"]
+terminal_write = false
+filesystem = "read"

--- a/examples/json-viewer/plexi_sdk.py
+++ b/examples/json-viewer/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/markdown-preview/manifest.toml
+++ b/examples/markdown-preview/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "markdown-preview"
+name = "Markdown Preview"
+entry = "markdown_preview.py"
+version = "0.1.0"
+description = "Live markdown preview — polls mtime every second, re-renders on change"
+
+[app.capabilities]
+file_types = ["md", "markdown"]
+terminal_write = false
+filesystem = "none"

--- a/examples/markdown-preview/markdown_preview.py
+++ b/examples/markdown-preview/markdown_preview.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+markdown-preview — Plexi app
+Live preview of a Markdown file. Polls mtime every second and re-renders on change.
+
+Supported patterns:
+  # / ## / ###   ATX headers (bold accent, scaled size)
+  **bold**        bold text
+  `code`          monospace green inline code
+  ```…```         fenced code blocks (surface-colored background)
+  - / * bullet    bullet points with • prefix
+  blank lines     vertical spacing
+
+Controls:
+  j / ↓   Scroll down
+  k / ↑   Scroll up
+  r       Reload file now
+"""
+
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+_launch_path = os.environ.get("PLEXI_LAUNCH_PATH", "")
+if _launch_path and os.path.isfile(_launch_path):
+    FILE_PATH: str = os.path.abspath(_launch_path)
+else:
+    FILE_PATH = os.path.join(os.getcwd(), "README.md")
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":       "#1e1e2e",
+    "surface":  "#313244",
+    "surface1": "#45475a",
+    "text":     "#cdd6f4",
+    "subtext":  "#6c7086",
+    "accent":   "#89b4fa",
+    "green":    "#a6e3a1",
+    "peach":    "#fab387",
+    "header":   "#181825",
+}
+
+PADDING    = 16
+LINE_H     = 20
+HEADER_H   = 40
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+_lines:       list[dict] = []   # parsed render lines
+_scroll:      int = 0
+_last_mtime:  float = 0.0
+_last_poll:   float = 0.0
+_error_msg:   str = ""
+
+# ---------------------------------------------------------------------------
+# Markdown parser — produces a list of "render line" dicts
+# ---------------------------------------------------------------------------
+
+_BOLD_RE  = re.compile(r"\*\*(.+?)\*\*")
+_CODE_RE  = re.compile(r"`([^`]+)`")
+
+_FENCED_OPEN  = re.compile(r"^```")
+_ATX_H1       = re.compile(r"^#\s+(.*)")
+_ATX_H2       = re.compile(r"^##\s+(.*)")
+_ATX_H3       = re.compile(r"^###\s+(.*)")
+_BULLET       = re.compile(r"^[-*]\s+(.*)")
+
+
+def _parse_inline(text: str) -> list[dict]:
+    """Split text into spans: {text, bold, mono}."""
+    spans: list[dict] = []
+    i = 0
+    while i < len(text):
+        # Try bold
+        m = _BOLD_RE.search(text, i)
+        c = _CODE_RE.search(text, i)
+        # pick the earlier match
+        first = None
+        if m and c:
+            first = m if m.start() <= c.start() else c
+        elif m:
+            first = m
+        elif c:
+            first = c
+
+        if first is None:
+            spans.append({"text": text[i:], "bold": False, "mono": False})
+            break
+
+        if first.start() > i:
+            spans.append({"text": text[i:first.start()], "bold": False, "mono": False})
+
+        if first is m:
+            spans.append({"text": first.group(1), "bold": True, "mono": False})
+        else:
+            spans.append({"text": first.group(1), "bold": False, "mono": True})
+        i = first.end()
+
+    return spans
+
+
+def _parse(content: str) -> list[dict]:
+    """
+    Returns a flat list of render-line dicts:
+      {kind: "h1"|"h2"|"h3"|"bullet"|"code_line"|"para"|"blank"|"fence_start"|"fence_end",
+       spans: [...], raw: str}
+    """
+    result: list[dict] = []
+    in_fence = False
+
+    for raw_line in content.splitlines():
+        line = raw_line
+
+        if in_fence:
+            if _FENCED_OPEN.match(line):
+                in_fence = False
+                result.append({"kind": "fence_end", "spans": [], "raw": line})
+            else:
+                result.append({"kind": "code_line", "spans": [{"text": line, "bold": False, "mono": True}], "raw": line})
+            continue
+
+        if _FENCED_OPEN.match(line):
+            in_fence = True
+            result.append({"kind": "fence_start", "spans": [], "raw": line})
+            continue
+
+        if not line.strip():
+            result.append({"kind": "blank", "spans": [], "raw": ""})
+            continue
+
+        m = _ATX_H3.match(line)
+        if m:
+            result.append({"kind": "h3", "spans": _parse_inline(m.group(1)), "raw": line})
+            continue
+
+        m = _ATX_H2.match(line)
+        if m:
+            result.append({"kind": "h2", "spans": _parse_inline(m.group(1)), "raw": line})
+            continue
+
+        m = _ATX_H1.match(line)
+        if m:
+            result.append({"kind": "h1", "spans": _parse_inline(m.group(1)), "raw": line})
+            continue
+
+        m = _BULLET.match(line)
+        if m:
+            result.append({"kind": "bullet", "spans": _parse_inline("• " + m.group(1)), "raw": line})
+            continue
+
+        result.append({"kind": "para", "spans": _parse_inline(line), "raw": line})
+
+    return result
+
+
+def _reload():
+    global _lines, _error_msg, _last_mtime
+    try:
+        mtime = os.path.getmtime(FILE_PATH)
+        with open(FILE_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        _lines = _parse(content)
+        _last_mtime = mtime
+        _error_msg = ""
+    except FileNotFoundError:
+        _error_msg = f"File not found: {FILE_PATH}"
+        _lines = []
+    except Exception as e:
+        _error_msg = f"Error reading file: {e}"
+        _lines = []
+
+
+# Initial load
+_reload()
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App()
+
+
+@app.on_render
+def render(ctx):
+    global _scroll, _last_poll, _last_mtime
+
+    # Poll mtime every second
+    now = time.monotonic()
+    if now - _last_poll >= 1.0:
+        _last_poll = now
+        try:
+            mtime = os.path.getmtime(FILE_PATH)
+            if mtime != _last_mtime:
+                _reload()
+        except OSError:
+            pass
+
+    w = ctx.width
+    h = ctx.height
+
+    # Background
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    fname = os.path.basename(FILE_PATH)
+    ctx.text(PADDING, 12, fname, size=13, color=C["accent"], bold=True)
+    hint = "j/k=scroll  r=reload"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 14, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    if _error_msg:
+        ctx.text(PADDING, HEADER_H + 20, _error_msg, size=13, color=C["peach"])
+        return
+
+    # Render lines
+    body_h = h - HEADER_H - PADDING
+    visible = max(1, int(body_h / LINE_H))
+
+    # Clamp scroll
+    max_scroll = max(0, len(_lines) - visible)
+    clamped = max(0, min(_scroll, max_scroll))
+    if clamped != _scroll:
+        _scroll = clamped
+
+    y = HEADER_H + PADDING
+    in_fence = False
+    fence_x = PADDING
+    fence_rects: list[tuple[float, float]] = []   # (y_start, y_end) of each fence block
+
+    # First pass: identify fence regions for background rects
+    fi = 0
+    fs: float | None = None
+    for rline in _lines:
+        if rline["kind"] == "fence_start":
+            fs = fi
+        elif rline["kind"] == "fence_end" and fs is not None:
+            fence_rects.append((fs, fi))
+            fs = None
+        fi += 1
+
+    visible_lines = _lines[_scroll: _scroll + visible + 2]
+
+    # Draw fence backgrounds first
+    yi = HEADER_H + PADDING
+    abs_i = _scroll
+    fence_bg_drawn: set[int] = set()
+    for idx, rline in enumerate(_lines[_scroll:_scroll + visible + 2]):
+        real_idx = _scroll + idx
+        for (fb, fe) in fence_rects:
+            if fb <= real_idx <= fe and fb not in fence_bg_drawn:
+                # find how many lines in this block are visible
+                start_y = HEADER_H + PADDING + idx * LINE_H
+                block_len = fe - fb + 1
+                ctx.rect(
+                    PADDING - 4, start_y - 2,
+                    w - PADDING * 2 + 8, block_len * LINE_H + 4,
+                    fill=C["surface"], radius=4.0,
+                )
+                fence_bg_drawn.add(fb)
+
+    # Draw text
+    for idx, rline in enumerate(visible_lines):
+        ly = HEADER_H + PADDING + idx * LINE_H
+        kind = rline["kind"]
+
+        if kind == "blank":
+            continue
+        if kind in ("fence_start", "fence_end"):
+            continue
+
+        if kind == "h1":
+            x = PADDING
+            for sp in rline["spans"]:
+                ctx.text(x, ly - 2, sp["text"], size=20, color=C["accent"], bold=True)
+                x += len(sp["text"]) * 11.5
+        elif kind == "h2":
+            x = PADDING
+            for sp in rline["spans"]:
+                ctx.text(x, ly - 1, sp["text"], size=16, color=C["accent"], bold=True)
+                x += len(sp["text"]) * 9.2
+        elif kind == "h3":
+            x = PADDING
+            for sp in rline["spans"]:
+                ctx.text(x, ly, sp["text"], size=14, color=C["peach"], bold=True)
+                x += len(sp["text"]) * 8.0
+        elif kind == "code_line":
+            x = PADDING + 4
+            for sp in rline["spans"]:
+                ctx.text(x, ly, sp["text"], size=12, color=C["green"], monospace=True)
+        elif kind == "bullet":
+            x = PADDING
+            for sp in rline["spans"]:
+                color = C["text"]
+                ctx.text(x, ly, sp["text"], size=13, color=color, bold=sp["bold"],
+                         monospace=sp["mono"])
+                x += len(sp["text"]) * (7.2 if not sp["mono"] else 7.0)
+        else:  # para
+            x = PADDING
+            for sp in rline["spans"]:
+                color = C["green"] if sp["mono"] else C["text"]
+                ctx.text(x, ly, sp["text"], size=13, color=color,
+                         bold=sp["bold"], monospace=sp["mono"])
+                x += len(sp["text"]) * (7.0 if sp["mono"] else 7.2)
+
+    # Scroll %
+    if len(_lines) > visible:
+        pct = int(_scroll / max(1, max_scroll) * 100)
+        label = f"{pct}%"
+        ctx.text(w - PADDING - len(label) * 7, h - 12, label, size=11, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global _scroll
+    if key in ("j", "ArrowDown"):
+        _scroll += 1
+    elif key in ("k", "ArrowUp"):
+        _scroll = max(0, _scroll - 1)
+    elif key == "r":
+        _reload()
+        _scroll = 0
+
+
+app.run()

--- a/examples/markdown-preview/plexi_sdk.py
+++ b/examples/markdown-preview/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/parallax/manifest.toml
+++ b/examples/parallax/manifest.toml
@@ -9,6 +9,7 @@ description = "View-only dashboard for a Parallax video project — stills, prev
 file_types = []
 terminal_write = false
 filesystem = "read_only"
+mouse_tracking = true
 
 # Split the launching pane when the viewer opens: a companion terminal
 # scoped to the same project directory appears below. The user talks to

--- a/examples/parallax/parallax.py
+++ b/examples/parallax/parallax.py
@@ -60,6 +60,7 @@ _last_mtime: float = 0.0
 _last_poll: float = 0.0
 _manifest: dict = {}       # parsed manifest dict
 _manifest_error: str = ""
+_video_rect: tuple = (0, 0, 0, 0)  # (x, y, w, h) of latest video thumbnail
 
 # ---------------------------------------------------------------------------
 # Minimal YAML subset parser (stdlib only, no PyYAML dep).
@@ -375,11 +376,14 @@ def render(ctx):
              size=12, color=C["subtext"], bold=True)
     y += 18
     if latest:
+        global _video_rect
+        vw = ctx.width - PADDING * 2
+        _video_rect = (PADDING, y, vw, video_h)
         ctx.video_thumbnail(
             path=latest,
             x=PADDING,
             y=y,
-            w=ctx.width - PADDING * 2,
+            w=vw,
             h=video_h,
             show_play_button=True,
         )
@@ -443,6 +447,21 @@ def _render_empty(ctx):
              fill=C["surface"], radius=6.0)
     ctx.text(PADDING + 12, msg_y + 148, cmd2,
              size=12, color=C["green"], monospace=True)
+
+
+@app.on_mouse_down
+def on_mouse_down(x, y, button, emit):
+    if button != "left":
+        return
+    vx, vy, vw, vh = _video_rect
+    if vx <= x <= vx + vw and vy <= y <= vy + vh:
+        path = _latest_output()
+        if path:
+            import subprocess
+            try:
+                subprocess.Popen(["open", path])
+            except Exception as e:
+                emit.warn(f"could not open video: {e}")
 
 
 app.run()

--- a/examples/pomodoro/manifest.toml
+++ b/examples/pomodoro/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "pomodoro"
+name = "Pomodoro"
+entry = "pomodoro.py"
+version = "0.1.0"
+description = "Focus timer with pomodoro technique — 25/5/15 minute intervals"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/pomodoro/plexi_sdk.py
+++ b/examples/pomodoro/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/pomodoro/pomodoro.py
+++ b/examples/pomodoro/pomodoro.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+pomodoro — Plexi app
+Focus timer using the Pomodoro Technique.
+
+Controls:
+  Space    Start / Pause
+  r        Reset current timer
+  b        Short break (5 min)
+  l        Long break (15 min)
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":        "#1e1e2e",
+    "surface":   "#313244",
+    "overlay":   "#45475a",
+    "text":      "#cdd6f4",
+    "subtext":   "#6c7086",
+    "accent":    "#89b4fa",
+    "green":     "#a6e3a1",
+    "yellow":    "#f9e2af",
+    "red":       "#f38ba8",
+    "mauve":     "#cba6f7",
+    "peach":     "#fab387",
+    "header":    "#181825",
+    "flash_bg":  "#45475a",
+}
+
+# ---------------------------------------------------------------------------
+# Timer state
+# ---------------------------------------------------------------------------
+
+STATE_IDLE  = "idle"
+STATE_FOCUS = "focus"
+STATE_SHORT = "short_break"
+STATE_LONG  = "long_break"
+
+DURATIONS = {
+    STATE_IDLE:  25 * 60,
+    STATE_FOCUS: 25 * 60,
+    STATE_SHORT:  5 * 60,
+    STATE_LONG:  15 * 60,
+}
+
+STATE_LABELS = {
+    STATE_IDLE:  "Ready to focus",
+    STATE_FOCUS: "Focus",
+    STATE_SHORT: "Short Break",
+    STATE_LONG:  "Long Break",
+}
+
+STATE_COLORS = {
+    STATE_IDLE:  C["subtext"],
+    STATE_FOCUS: C["red"],
+    STATE_SHORT: C["green"],
+    STATE_LONG:  C["accent"],
+}
+
+timer_state: str   = STATE_IDLE
+running: bool      = False
+remaining: float   = float(DURATIONS[STATE_IDLE])
+last_tick: float   = 0.0
+sessions: int      = 0   # completed focus pomodoros
+
+flash_frames: int  = 0   # remaining frames to flash background
+
+PADDING  = 20
+HEADER_H = 44
+ARC_SEGS = 60
+ARC_R    = 90.0   # radius of progress ring (logical px)
+ARC_W    = 10.0   # segment "width" in degrees
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="pomodoro")
+
+
+@app.on_render
+def render(ctx):
+    global remaining, last_tick, flash_frames, timer_state, running, sessions
+
+    now = time.monotonic()
+
+    # Tick the timer
+    if running and last_tick > 0:
+        delta = now - last_tick
+        remaining -= delta
+        if remaining <= 0:
+            remaining = 0.0
+            running = False
+            flash_frames = 3
+            _on_complete(ctx)
+    last_tick = now if running else 0.0
+
+    w = ctx.width
+    h = ctx.height
+
+    # Flash background on completion
+    bg = C["flash_bg"] if flash_frames > 0 else C["bg"]
+    if flash_frames > 0:
+        flash_frames -= 1
+    ctx.rect(0, 0, w, h, fill=bg)
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 14, "Pomodoro", size=14, color=C["red"], bold=True)
+    hint = "Space=start/pause  r=reset  b=break  l=long break"
+    ctx.text(w - len(hint) * 6.8 - PADDING, 16, hint, size=10, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    cx = w / 2
+    cy = (h + HEADER_H) / 2 - 20
+
+    total = float(DURATIONS.get(timer_state, DURATIONS[STATE_FOCUS]))
+    progress = 1.0 - (remaining / total) if total > 0 else 0.0
+
+    # Progress ring — 60 rect segments around a circle
+    filled = int(progress * ARC_SEGS)
+    seg_deg = 360.0 / ARC_SEGS
+    ring_color = STATE_COLORS.get(timer_state, C["accent"])
+    for i in range(ARC_SEGS):
+        angle_rad = math.radians(i * seg_deg - 90)
+        sx = cx + math.cos(angle_rad) * ARC_R
+        sy = cy + math.sin(angle_rad) * ARC_R
+        color = ring_color if i < filled else C["surface"]
+        ctx.rect(sx - 4, sy - 4, 8, 8, fill=color, radius=2.0)
+
+    # MM:SS countdown
+    mins = int(remaining) // 60
+    secs = int(remaining) % 60
+    time_str = f"{mins:02d}:{secs:02d}"
+    # Center the text (approximate: each char ~14px wide at size 40)
+    tw = len(time_str) * 24
+    ctx.text(cx - tw / 2, cy - 22, time_str, size=40, color=C["text"], bold=True, monospace=True)
+
+    # State label
+    label = STATE_LABELS.get(timer_state, "")
+    lw = len(label) * 8
+    lcolor = STATE_COLORS.get(timer_state, C["subtext"])
+    ctx.text(cx - lw / 2, cy + 26, label, size=14, color=lcolor)
+
+    # Paused / running indicator
+    status = "▶ Running" if running else ("⏸ Paused" if timer_state != STATE_IDLE else "Press Space to start")
+    sw = len(status) * 7
+    ctx.text(cx - sw / 2, cy + 50, status, size=12, color=C["subtext"])
+
+    # Session dots
+    dot_y = cy + 80
+    dot_spacing = 20.0
+    total_dots = max(sessions + 1, 4)
+    dots_w = total_dots * dot_spacing
+    dot_start = cx - dots_w / 2
+    for i in range(total_dots):
+        dx = dot_start + i * dot_spacing
+        color = C["red"] if i < sessions else C["overlay"]
+        ctx.rect(dx, dot_y, 10, 10, fill=color, radius=5.0)
+
+    ctx.text(cx - 30, dot_y + 18, f"{sessions} sessions", size=11, color=C["subtext"])
+
+
+def _on_complete(ctx):
+    global sessions, timer_state
+    if timer_state == STATE_FOCUS:
+        sessions += 1
+        ctx.notification("Pomodoro complete!", f"Session #{sessions} done. Take a break.", priority=2)
+    elif timer_state in (STATE_SHORT, STATE_LONG):
+        ctx.notification("Break over", "Time to focus!", priority=2)
+    timer_state = STATE_IDLE
+    remaining_reset()
+
+
+def remaining_reset():
+    global remaining
+    remaining = float(DURATIONS.get(timer_state, DURATIONS[STATE_FOCUS]))
+
+
+@app.on_key
+def on_key(key: str, _mods: dict, _emit):
+    global running, timer_state, remaining, last_tick
+
+    if key == " ":
+        if timer_state == STATE_IDLE:
+            timer_state = STATE_FOCUS
+            remaining = float(DURATIONS[STATE_FOCUS])
+        running = not running
+        last_tick = time.monotonic() if running else 0.0
+
+    elif key == "r":
+        running = False
+        last_tick = 0.0
+        remaining = float(DURATIONS.get(timer_state, DURATIONS[STATE_FOCUS]))
+
+    elif key == "b":
+        running = False
+        last_tick = 0.0
+        timer_state = STATE_SHORT
+        remaining = float(DURATIONS[STATE_SHORT])
+
+    elif key == "l":
+        running = False
+        last_tick = 0.0
+        timer_state = STATE_LONG
+        remaining = float(DURATIONS[STATE_LONG])
+
+
+app.run()

--- a/examples/stopwatch/manifest.toml
+++ b/examples/stopwatch/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "stopwatch"
+name = "Stopwatch"
+entry = "stopwatch.py"
+version = "0.1.0"
+description = "Precise stopwatch with lap times — Space to start/stop, l for lap, r to reset"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/stopwatch/plexi_sdk.py
+++ b/examples/stopwatch/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/stopwatch/stopwatch.py
+++ b/examples/stopwatch/stopwatch.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+stopwatch — Plexi app
+Precise stopwatch with lap recording.
+
+Controls:
+  Space   Start / Stop
+  l       Record lap (while running)
+  r       Reset (while stopped)
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Colors — Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "peach":   "#fab387",
+    "red":     "#f38ba8",
+    "header":  "#181825",
+}
+
+PADDING  = 16
+MAX_LAPS = 10
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+running:     bool  = False
+start_time:  float = 0.0     # time.monotonic() when last started
+elapsed:     float = 0.0     # accumulated seconds before the current run
+laps:        list[float] = []  # absolute elapsed at each lap press (newest first)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _current_elapsed() -> float:
+    if running:
+        return elapsed + (time.monotonic() - start_time)
+    return elapsed
+
+
+def _fmt(seconds: float) -> str:
+    """Format seconds as MM:SS.mm"""
+    total_ms = int(seconds * 100)
+    mins = total_ms // 6000
+    secs = (total_ms % 6000) // 100
+    ms   = total_ms % 100
+    return f"{mins:02d}:{secs:02d}.{ms:02d}"
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App()
+
+
+@app.on_render
+def render(ctx):
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, 40, fill=C["header"])
+    ctx.text(PADDING, 12, "Stopwatch", size=13, color=C["accent"], bold=True)
+    hint = "Space=start/stop  l=lap  r=reset"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 14, hint, size=11, color=C["subtext"])
+    ctx.line(0, 40, w, 40, color=C["surface"], width=1.0)
+
+    # Main timer — centered
+    cur = _current_elapsed()
+    time_str = _fmt(cur)
+    # Large display: approx 9.5px per char at size=48
+    char_w = 30.0
+    tx = max(PADDING, (w - len(time_str) * char_w) / 2)
+    ty = 80.0
+    timer_color = C["green"] if running else C["text"]
+    ctx.text(tx, ty, time_str, size=48, color=timer_color, monospace=True, bold=True)
+
+    # Status label
+    status = "RUNNING" if running else "STOPPED"
+    status_color = C["green"] if running else C["peach"]
+    sx = max(PADDING, (w - len(status) * 7.5) / 2)
+    ctx.text(sx, ty + 64, status, size=12, color=status_color)
+
+    # Lap count
+    if laps:
+        lc = f"{len(laps)} lap{'s' if len(laps) != 1 else ''}"
+        ctx.text(w / 2 - len(lc) * 3.6, ty + 80, lc, size=11, color=C["subtext"])
+
+    # Divider before laps
+    divider_y = ty + 104
+    ctx.line(PADDING, divider_y, w - PADDING, divider_y, color=C["surface"], width=1.0)
+
+    # Lap list (newest first, max 10)
+    lap_y = divider_y + 12
+    lap_h = 24.0
+    for i, lap_elapsed in enumerate(laps[:MAX_LAPS]):
+        label_num = f"Lap {len(laps) - i}"
+        label_time = _fmt(lap_elapsed)
+        # lap delta
+        if i < len(laps) - 1:
+            delta = lap_elapsed - laps[i + 1]
+        else:
+            delta = lap_elapsed
+        label_delta = f"+{_fmt(delta)}"
+
+        row_y = lap_y + i * lap_h
+        # alternating row bg
+        if i % 2 == 0:
+            ctx.rect(PADDING - 4, row_y - 2, w - PADDING * 2 + 8, lap_h, fill=C["surface"], radius=2.0)
+
+        ctx.text(PADDING, row_y, label_num, size=12, color=C["subtext"])
+        ctx.text(w / 2 - len(label_time) * 3.5, row_y, label_time, size=12, color=C["text"], monospace=True)
+        ctx.text(w - PADDING - len(label_delta) * 7.0, row_y, label_delta, size=11, color=C["accent"], monospace=True)
+
+    if not laps and not running:
+        ctx.text(PADDING, lap_y, "No laps recorded.", size=12, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key, _mods, _emit):
+    global running, start_time, elapsed, laps
+
+    if key == " ":
+        if running:
+            # Stop — accumulate elapsed
+            elapsed += time.monotonic() - start_time
+            running = False
+        else:
+            # Start
+            start_time = time.monotonic()
+            running = True
+
+    elif key == "l" and running:
+        laps.insert(0, _current_elapsed())
+        if len(laps) > MAX_LAPS:
+            laps = laps[:MAX_LAPS]
+
+    elif key == "r" and not running:
+        elapsed = 0.0
+        laps = []
+
+
+app.run()

--- a/examples/todo/manifest.toml
+++ b/examples/todo/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "todo"
+name = "Todo"
+entry = "todo.py"
+version = "0.1.0"
+description = "Persistent todo list saved to ~/.plexi-alpha/todo.txt"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "write"

--- a/examples/todo/plexi_sdk.py
+++ b/examples/todo/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/todo/todo.py
+++ b/examples/todo/todo.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+todo — Plexi app
+Persistent todo list saved to ~/.plexi-alpha/todo.txt.
+
+Controls:
+  j / ↓    Move down
+  k / ↑    Move up
+  Space / Enter    Toggle done
+  a        Add item (type at inline prompt, Enter to confirm, Esc to cancel)
+  d        Delete selected item
+  q        Quit
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "red":     "#f38ba8",
+    "yellow":  "#f9e2af",
+    "header":  "#181825",
+    "sel":     "#313244",
+    "done":    "#585b70",
+}
+
+PADDING    = 16
+HEADER_H   = 48
+ITEM_H     = 28
+FOOTER_H   = 36
+
+TODO_PATH  = os.path.expanduser("~/.plexi-alpha/todo.txt")
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def load_todos() -> list[dict]:
+    """Load todos from file. Each line: `[x] text` or `[ ] text`."""
+    todos = []
+    try:
+        os.makedirs(os.path.dirname(TODO_PATH), exist_ok=True)
+        if not os.path.exists(TODO_PATH):
+            return todos
+        with open(TODO_PATH, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                done = line.startswith("[x] ")
+                text = line[4:] if line.startswith(("[x] ", "[ ] ")) else line
+                todos.append({"text": text, "done": done})
+    except OSError as exc:
+        pass  # return empty list; error will surface on next save
+    return todos
+
+
+def save_todos(todos: list[dict]):
+    try:
+        os.makedirs(os.path.dirname(TODO_PATH), exist_ok=True)
+        with open(TODO_PATH, "w", encoding="utf-8") as f:
+            for t in todos:
+                prefix = "[x] " if t["done"] else "[ ] "
+                f.write(prefix + t["text"] + "\n")
+    except OSError as exc:
+        pass  # non-fatal; data lives in memory
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+todos: list[dict] = load_todos()
+cursor: int = 0
+scroll: int = 0
+
+MODE_LIST  = "list"
+MODE_ADD   = "add"
+mode: str  = MODE_LIST
+add_buf: str = ""
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="todo")
+
+
+@app.on_render
+def render(ctx):
+    global scroll, cursor
+
+    w = ctx.width
+    h = ctx.height
+
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    count_done = sum(1 for t in todos if t["done"])
+    ctx.text(PADDING, 14, f"Todo  ({count_done}/{len(todos)} done)", size=14, color=C["accent"], bold=True)
+    hint = "a=add  d=delete  Space=toggle"
+    ctx.text(w - len(hint) * 7.2 - PADDING, 16, hint, size=10, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    body_y = HEADER_H + PADDING
+    body_h = h - body_y - FOOTER_H
+
+    # Visible rows
+    visible = max(1, int(body_h / ITEM_H))
+
+    # Clamp scroll to keep cursor visible
+    if cursor < scroll:
+        scroll = cursor
+    elif cursor >= scroll + visible:
+        scroll = cursor - visible + 1
+    scroll = max(0, min(scroll, max(0, len(todos) - visible)))
+
+    if not todos:
+        ctx.text(PADDING, body_y + 10, "No todos yet. Press a to add one.", size=13, color=C["subtext"])
+    else:
+        for i, todo in enumerate(todos[scroll:scroll + visible]):
+            row_idx = scroll + i
+            ry = body_y + i * ITEM_H
+
+            # Selection highlight
+            if row_idx == cursor and mode == MODE_LIST:
+                ctx.rect(0, ry, w, ITEM_H, fill=C["sel"], radius=4.0)
+
+            # Checkbox
+            check = "✓" if todo["done"] else "○"
+            check_color = C["green"] if todo["done"] else C["subtext"]
+            ctx.text(PADDING, ry + 6, check, size=13, color=check_color)
+
+            # Item text
+            text = todo["text"]
+            text_color = C["done"] if todo["done"] else C["text"]
+            # Strikethrough visual: prepend ~~ prefix for done items
+            if todo["done"]:
+                text = "~~" + text + "~~"
+            ctx.text(PADDING + 24, ry + 6, text, size=13, color=text_color)
+
+    # Footer: add prompt or status bar
+    footer_y = h - FOOTER_H
+    ctx.rect(0, footer_y, w, FOOTER_H, fill=C["header"])
+    ctx.line(0, footer_y, w, footer_y, color=C["surface"], width=1.0)
+
+    if mode == MODE_ADD:
+        prompt = f"New item: {add_buf}_"
+        ctx.text(PADDING, footer_y + 10, prompt, size=13, color=C["yellow"])
+        ctx.text(w - 120, footer_y + 10, "Enter=save  Esc=cancel", size=10, color=C["subtext"])
+    else:
+        ctx.text(PADDING, footer_y + 10, TODO_PATH, size=10, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key: str, _mods: dict, _emit):
+    global cursor, scroll, mode, add_buf, todos
+
+    if mode == MODE_ADD:
+        if key == "Escape":
+            mode = MODE_LIST
+            add_buf = ""
+        elif key == "Enter":
+            text = add_buf.strip()
+            if text:
+                todos.append({"text": text, "done": False})
+                save_todos(todos)
+                cursor = len(todos) - 1
+            mode = MODE_LIST
+            add_buf = ""
+        elif key == "Backspace":
+            add_buf = add_buf[:-1]
+        elif len(key) == 1 and key.isprintable():
+            add_buf += key
+        return
+
+    # MODE_LIST
+    if key in ("j", "ArrowDown"):
+        cursor = min(cursor + 1, len(todos) - 1) if todos else 0
+    elif key in ("k", "ArrowUp"):
+        cursor = max(cursor - 1, 0)
+    elif key in (" ", "Enter"):
+        if todos and 0 <= cursor < len(todos):
+            todos[cursor]["done"] = not todos[cursor]["done"]
+            save_todos(todos)
+    elif key == "a":
+        mode = MODE_ADD
+        add_buf = ""
+    elif key == "d":
+        if todos and 0 <= cursor < len(todos):
+            todos.pop(cursor)
+            cursor = min(cursor, len(todos) - 1)
+            save_todos(todos)
+    elif key == "q":
+        pass  # Plexi handles pane close
+
+
+app.run()

--- a/examples/weather/manifest.toml
+++ b/examples/weather/manifest.toml
@@ -1,0 +1,11 @@
+[app]
+id = "weather"
+name = "Weather"
+entry = "weather.py"
+version = "0.1.0"
+description = "Current weather from wttr.in — auto-refreshes every 5 minutes"
+
+[app.capabilities]
+file_types = []
+terminal_write = false
+filesystem = "none"

--- a/examples/weather/plexi_sdk.py
+++ b/examples/weather/plexi_sdk.py
@@ -1,0 +1,539 @@
+"""
+plexi_sdk.py — Plexi external app SDK (Python)
+
+Zero dependencies, pure stdlib. Copy this file into your app directory.
+
+Protocol: newline-delimited JSON over stdin/stdout.
+  - Plexi sends PlexiEvent objects  {"type": "render", "width": ..., "height": ...}
+  - App responds with DrawCommand objects {"type": "rect", ...} + {"type": "frame_done"}
+
+Usage:
+
+    from plexi_sdk import App
+
+    app = App()
+
+    @app.on_render
+    def render(ctx):
+        ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+        ctx.text(20, 20, "Hello Plexi!", size=16, color="#cdd6f4")
+
+    app.run()
+
+Key handlers can emit terminal commands via the Emitter passed as the second arg:
+
+    @app.on_key
+    def on_key(key, mods, emit):
+        if key == "Enter":
+            emit.run_in_terminal("echo hello")
+
+State management (Plexi handles undo/redo/save):
+
+    @app.on_get_state
+    def get_state():
+        return {
+            "user_state": {"cursor": 0, "selected": None},
+            "derived": {},
+            "session": {"scroll_offset": 120},
+            "persistent": {"bookmarks": [1, 5, 9]},
+        }
+
+    @app.on_set_state
+    def set_state(state):
+        cursor = state["user_state"].get("cursor", 0)
+        # ... restore your app's internal state from the buckets
+
+Cost reporting (for apps that call LLM APIs):
+
+    emit.cost_report(
+        service="anthropic", model="claude-sonnet-4-20250514",
+        input_tokens=1500, output_tokens=500, cost_usd=0.01,
+    )
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+
+class Emitter:
+    """Emit commands to Plexi immediately (outside a render frame)."""
+
+    def __init__(self, app_id: str = ""):
+        self._app_id = app_id
+
+    def run_in_terminal(self, command: str):
+        """Execute a shell command in the linked terminal."""
+        print(json.dumps({"type": "run_in_terminal", "command": command}), flush=True)
+
+    def cd(self, path: str):
+        """Change the linked terminal's working directory."""
+        print(json.dumps({"type": "cd", "path": path}), flush=True)
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        print(json.dumps({"type": "log", "level": level, "message": message}), flush=True)
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def cost_report(
+        self,
+        service: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        operation_id: Optional[str] = None,
+    ):
+        """Report LLM API cost to Plexi for logging and tracking."""
+        print(json.dumps({
+            "type": "cost_report",
+            "app_id": self._app_id,
+            "service": service,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+            "operation_id": operation_id or str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }), flush=True)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        print(json.dumps(cmd), flush=True)
+
+
+class RenderContext:
+    """
+    Passed to the on_render handler. Accumulates draw commands, then flushes.
+
+    All coordinates are in logical pixels within the app surface.
+    """
+
+    def __init__(self, width: float, height: float, app_id: str = ""):
+        self.width = width
+        self.height = height
+        self._app_id = app_id
+        self._commands: list = []
+
+    def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
+        """Fill a rectangle."""
+        self._commands.append({
+            "type": "rect", "x": x, "y": y, "w": w, "h": h,
+            "fill": fill, "radius": radius,
+        })
+
+    def text(self, x: float, y: float, text: str, size: float, color: str,
+             monospace: bool = False, bold: bool = False):
+        """Draw text at a position."""
+        self._commands.append({
+            "type": "text", "x": x, "y": y, "text": text, "size": size,
+            "color": color, "monospace": monospace, "bold": bold,
+        })
+
+    def line(self, x1: float, y1: float, x2: float, y2: float,
+             color: str, width: float = 1.0):
+        """Draw a horizontal or diagonal line."""
+        self._commands.append({
+            "type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
+            "color": color, "width": width,
+        })
+
+    def drop_target(
+        self,
+        id: str,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        accept: Optional[list] = None,
+        label: Optional[str] = None,
+    ):
+        """
+        Declare a region that can accept dropped files from outside Plexi.
+
+        Drop targets are stateless — you must re-emit this on every render
+        frame for the region to remain active.
+
+        Args:
+            id:     App-local identifier for this drop zone. Echoed back in
+                    the on_drop handler so you can tell which zone received
+                    the drop when you declare multiple.
+            x, y, w, h: Region in the app's local coordinate space.
+            accept: List of file extensions (lowercase, no dot) to accept,
+                    e.g. ["png", "jpg", "mp4"]. Empty or None = accept
+                    anything. Paths that don't match are filtered out by
+                    Plexi before your on_drop handler is called.
+            label:  Optional hint text shown by Plexi over the target while
+                    the user is hovering with files from Finder.
+        """
+        cmd = {
+            "type": "drop_target",
+            "id": id,
+            "x": x, "y": y, "w": w, "h": h,
+            "accept": accept or [],
+        }
+        if label:
+            cmd["label"] = label
+        self._commands.append(cmd)
+
+    def list(self, items: list, selected: int = 0, item_height: float = 40.0):
+        """
+        High-level scrollable list. Plexi handles layout, scroll, and selection highlight.
+
+        Each item is a dict with keys:
+            label      (str)           — primary text
+            secondary  (str | None)    — dimmed subtitle
+            is_dir     (bool)          — show folder indicator
+        """
+        self._commands.append({
+            "type": "list", "items": items,
+            "selected": selected, "item_height": item_height,
+        })
+
+    def image(self, path: str, x: float, y: float, w: float, h: float,
+              fit: str = "contain", rounding: float = 0.0):
+        """
+        Draw an image from a file on disk.
+
+        Plexi decodes and caches the texture (keyed by absolute path + mtime).
+        `path` may be absolute or relative to the app's cwd.
+
+        `fit` controls how the image is placed in the rect:
+            "contain" — fit inside, preserve aspect, letterbox (default)
+            "cover"   — fill the rect, preserve aspect, crop overflow
+            "fill"    — stretch to the rect, ignoring aspect ratio
+
+        `rounding` is the corner radius in logical pixels.
+        """
+        cmd: dict = {
+            "type": "image",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+        }
+        if fit != "contain":
+            cmd["fit"] = fit
+        if rounding > 0:
+            cmd["rounding"] = rounding
+        self._commands.append(cmd)
+
+    def video_thumbnail(self, path: str, x: float, y: float, w: float, h: float,
+                        show_play_button: bool = True,
+                        timestamp_seconds: float = 0.0):
+        """
+        Draw a thumbnail for a video file.
+
+        Plexi extracts a single frame at `timestamp_seconds` using ffmpeg and
+        caches the result under ~/.cache/plexi/thumbnails/. Extraction runs on
+        a background thread so the first render returns a loading placeholder
+        and the real thumbnail appears a frame later.
+
+        If `show_play_button` is True (default), a centered play triangle is
+        overlaid. Clicking the rect opens the original video with the system
+        default player (`open` on macOS).
+        """
+        self._commands.append({
+            "type": "video_thumbnail",
+            "path": path,
+            "x": x, "y": y, "w": w, "h": h,
+            "show_play_button": show_play_button,
+            "timestamp_seconds": timestamp_seconds,
+        })
+
+    def file_grid(self, x: float, y: float, w: float, h: float,
+                  path: Optional[str] = None,
+                  filter: Optional[list] = None,
+                  paths: Optional[list] = None,
+                  item_size: float = 96.0,
+                  columns: Optional[int] = None,
+                  show_labels: bool = True):
+        """
+        Draw a grid of files with auto-generated thumbnails.
+
+        Two modes — exactly one must be provided:
+            path  + optional filter  — walk a directory non-recursively
+            paths                    — explicit list of file paths to show
+
+        `filter` accepts glob patterns or bare extensions, e.g.
+        ["*.png", "*.jpg"] or ["png", "mp4"].
+
+        Image files render via the shared image texture cache; video files
+        (mp4/mov/webm/mkv/m4v/avi) render via the video thumbnail cache.
+        Other file types show a generic icon with the extension label.
+
+        Clicking an item opens it with the system default handler.
+        """
+        if path is None and paths is None:
+            raise ValueError("file_grid requires either 'path' or 'paths'")
+        cmd: dict = {
+            "type": "file_grid",
+            "x": x, "y": y, "w": w, "h": h,
+            "item_size": item_size,
+            "show_labels": show_labels,
+        }
+        if path is not None:
+            cmd["path"] = path
+            if filter:
+                cmd["filter"] = filter
+        if paths is not None:
+            cmd["paths"] = paths
+        if columns is not None:
+            cmd["columns"] = columns
+        self._commands.append(cmd)
+
+    def run_in_terminal(self, command: str):
+        """Queue a terminal command to run at end of this frame."""
+        self._commands.append({"type": "run_in_terminal", "command": command})
+
+    def cd(self, path: str):
+        """Queue a cd command for the linked terminal at end of this frame."""
+        self._commands.append({"type": "cd", "path": path})
+
+    def log(self, level: str, message: str):
+        """Forward a log message to Plexi's logger (level: error|warn|info|debug)."""
+        self._commands.append({"type": "log", "level": level, "message": message})
+
+    def info(self, message: str):
+        """Log at info level."""
+        self.log("info", message)
+
+    def warn(self, message: str):
+        """Log at warn level."""
+        self.log("warn", message)
+
+    def error(self, message: str):
+        """Log at error level."""
+        self.log("error", message)
+
+    def debug(self, message: str):
+        """Log at debug level."""
+        self.log("debug", message)
+
+    def notification(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        priority: int = 1,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
+        """
+        cmd = {
+            "type": "notification",
+            "priority": priority,
+            "title": title,
+            "source_app": self._app_id,
+        }
+        if body:
+            cmd["body"] = body
+        self._commands.append(cmd)
+
+    def _flush(self):
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        print(json.dumps({"type": "frame_done"}), flush=True)
+        self._commands.clear()
+
+
+class App:
+    """
+    Base class for Plexi apps. Register event handlers via decorators.
+
+    Handlers:
+        @app.on_render      fn(ctx: RenderContext)
+        @app.on_key         fn(key: str, mods: dict, emit: Emitter)
+        @app.on_click       fn(x: float, y: float, button: str, emit: Emitter)
+        @app.on_command     fn(text: str, emit: Emitter)
+        @app.on_resize      fn(width: float, height: float)
+        @app.on_get_state   fn() -> dict with keys: user_state, derived, session, persistent
+        @app.on_set_state   fn(state: dict) — restore app from state buckets
+        @app.on_drop        fn(target_id: str, paths: list[str], emit: Emitter)
+    """
+
+    def __init__(self, app_id: str = ""):
+        self.width: float = 800.0
+        self.height: float = 600.0
+        self._on_render: Optional[Callable] = None
+        self._on_key: Optional[Callable] = None
+        self._on_click: Optional[Callable] = None
+        self._on_command: Optional[Callable] = None
+        self._on_resize: Optional[Callable] = None
+        self._on_get_state: Optional[Callable] = None
+        self._on_set_state: Optional[Callable] = None
+        self._on_drop: Optional[Callable] = None
+        self._emitter = Emitter(app_id=app_id)
+
+    def on_render(self, fn: Callable) -> Callable:
+        self._on_render = fn
+        return fn
+
+    def on_key(self, fn: Callable) -> Callable:
+        self._on_key = fn
+        return fn
+
+    def on_click(self, fn: Callable) -> Callable:
+        self._on_click = fn
+        return fn
+
+    def on_command(self, fn: Callable) -> Callable:
+        self._on_command = fn
+        return fn
+
+    def on_resize(self, fn: Callable) -> Callable:
+        self._on_resize = fn
+        return fn
+
+    def on_get_state(self, fn: Callable) -> Callable:
+        """Register handler for get_state requests. Should return a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_get_state = fn
+        return fn
+
+    def on_set_state(self, fn: Callable) -> Callable:
+        """Register handler for set_state requests. Receives a dict with
+        keys: user_state, derived, session, persistent."""
+        self._on_set_state = fn
+        return fn
+
+    def on_drop(self, fn: Callable) -> Callable:
+        """Register a handler for file drops onto declared drop targets.
+
+        The handler receives (target_id: str, paths: list[str], emit: Emitter).
+        `target_id` matches the id you passed to ctx.drop_target(). `paths`
+        are absolute host filesystem paths already filtered by the target's
+        accept list.
+        """
+        self._on_drop = fn
+        return fn
+
+    def _handle_get_state(self):
+        """Respond to a get_state request from Plexi."""
+        if self._on_get_state:
+            state = self._on_get_state()
+        else:
+            state = {}
+        # Ensure all four buckets exist.
+        result = {
+            "type": "state",
+            "user_state": state.get("user_state", {}),
+            "derived": state.get("derived", {}),
+            "session": state.get("session", {}),
+            "persistent": state.get("persistent", {}),
+        }
+        print(json.dumps(result), flush=True)
+
+    def _handle_set_state(self, event: dict):
+        """Handle a set_state request from Plexi."""
+        if self._on_set_state:
+            self._on_set_state({
+                "user_state": event.get("user_state", {}),
+                "derived": event.get("derived", {}),
+                "session": event.get("session", {}),
+                "persistent": event.get("persistent", {}),
+            })
+
+    def run(self):
+        """Start the event loop. Blocks until Plexi sends Shutdown."""
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type in ("init", "resize"):
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if event_type == "resize" and self._on_resize:
+                    self._on_resize(self.width, self.height)
+
+            elif event_type == "render":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                if self._on_render:
+                    self._on_render(ctx)
+                ctx._flush()
+
+            elif event_type == "key":
+                if self._on_key:
+                    self._on_key(
+                        event.get("key", ""),
+                        event.get("modifiers", {}),
+                        self._emitter,
+                    )
+
+            elif event_type == "click":
+                if self._on_click:
+                    self._on_click(
+                        event.get("x", 0.0),
+                        event.get("y", 0.0),
+                        event.get("button", "primary"),
+                        self._emitter,
+                    )
+
+            elif event_type == "command":
+                if self._on_command:
+                    self._on_command(event.get("text", ""), self._emitter)
+
+            elif event_type == "get_state":
+                self._handle_get_state()
+
+            elif event_type == "set_state":
+                self._handle_set_state(event)
+
+            elif event_type == "drop":
+                if self._on_drop:
+                    self._on_drop(
+                        event.get("target_id", ""),
+                        event.get("paths", []),
+                        self._emitter,
+                    )
+
+            elif event_type == "shutdown":
+                break

--- a/examples/weather/weather.py
+++ b/examples/weather/weather.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+weather — Plexi app
+Current weather from wttr.in. Auto-refreshes every 5 minutes.
+
+Controls:
+  r    Force refresh
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import queue
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from plexi_sdk import App
+
+# ---------------------------------------------------------------------------
+# Catppuccin Mocha
+# ---------------------------------------------------------------------------
+
+C = {
+    "bg":      "#1e1e2e",
+    "surface": "#313244",
+    "overlay": "#45475a",
+    "text":    "#cdd6f4",
+    "subtext": "#6c7086",
+    "accent":  "#89b4fa",
+    "green":   "#a6e3a1",
+    "yellow":  "#f9e2af",
+    "red":     "#f38ba8",
+    "header":  "#181825",
+    "mauve":   "#cba6f7",
+}
+
+PADDING   = 20
+HEADER_H  = 48
+AUTO_REFRESH_S = 300  # 5 minutes
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+weather_data: dict | None = None
+error_msg: str = ""
+loading: bool = False
+last_fetch_ts: float = 0.0
+
+result_q: queue.Queue = queue.Queue()
+
+# ---------------------------------------------------------------------------
+# Condition icons (wttr.in weatherCode ranges)
+# ---------------------------------------------------------------------------
+
+def condition_icon(code: int) -> str:
+    if code == 113:
+        return "☀️"
+    if code in (116, 119, 122):
+        return "☁️"
+    if code in (143, 248, 260):
+        return "🌫️"
+    if code in (176, 179, 182, 185, 281, 284, 293, 296, 299, 302, 305, 308,
+                311, 314, 317, 320, 323, 326):
+        return "🌧️"
+    if code in (200, 386, 389, 392, 395):
+        return "⛈️"
+    if code in (227, 230, 338, 335, 332, 329, 326, 323):
+        return "❄️"
+    if code in (263, 266, 353, 356, 359, 362, 365, 368, 371, 374, 377):
+        return "🌦️"
+    return "🌡️"
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_weather():
+    try:
+        url = "https://wttr.in/?format=j1"
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "Plexi/0.1 (https://github.com/ianjamesburke/PLEXI)"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+        result_q.put({"ok": True, "data": data})
+    except Exception as exc:
+        result_q.put({"ok": False, "error": str(exc)})
+
+
+def start_fetch():
+    global loading
+    loading = True
+    t = threading.Thread(target=fetch_weather, daemon=True)
+    t.start()
+
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+
+def parse_data(raw: dict) -> dict:
+    try:
+        nearest = raw["nearest_area"][0]
+        area = nearest.get("areaName", [{}])[0].get("value", "Unknown")
+        country = nearest.get("country", [{}])[0].get("value", "")
+        location = f"{area}, {country}" if country else area
+
+        current = raw["current_condition"][0]
+        temp_c = int(current.get("temp_C", 0))
+        temp_f = int(current.get("temp_F", 0))
+        feels_c = int(current.get("FeelsLikeC", 0))
+        feels_f = int(current.get("FeelsLikeF", 0))
+        humidity = int(current.get("humidity", 0))
+        wind_kmph = int(current.get("windspeedKmph", 0))
+        desc = current.get("weatherDesc", [{}])[0].get("value", "")
+        code = int(current.get("weatherCode", 113))
+
+        return {
+            "location": location,
+            "temp_c": temp_c,
+            "temp_f": temp_f,
+            "feels_c": feels_c,
+            "feels_f": feels_f,
+            "humidity": humidity,
+            "wind_kmph": wind_kmph,
+            "desc": desc,
+            "code": code,
+            "icon": condition_icon(code),
+        }
+    except Exception as exc:
+        return {"error": f"Parse error: {exc}"}
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app = App(app_id="weather")
+
+
+@app.on_render
+def render(ctx):
+    global weather_data, error_msg, loading, last_fetch_ts
+
+    now = time.monotonic()
+
+    # Drain queue
+    try:
+        while True:
+            msg = result_q.get_nowait()
+            loading = False
+            if msg["ok"]:
+                parsed = parse_data(msg["data"])
+                if "error" in parsed:
+                    error_msg = parsed["error"]
+                    weather_data = None
+                else:
+                    weather_data = parsed
+                    error_msg = ""
+                    last_fetch_ts = now
+            else:
+                error_msg = msg["error"]
+    except queue.Empty:
+        pass
+
+    # Auto-refresh
+    if not loading and (now - last_fetch_ts) >= AUTO_REFRESH_S:
+        start_fetch()
+
+    w = ctx.width
+    h = ctx.height
+
+    # Background
+    ctx.rect(0, 0, w, h, fill=C["bg"])
+
+    # Header
+    ctx.rect(0, 0, w, HEADER_H, fill=C["header"])
+    ctx.text(PADDING, 14, "Weather", size=14, color=C["accent"], bold=True)
+    hint = "r=refresh"
+    ctx.text(w - len(hint) * 7.5 - PADDING, 16, hint, size=11, color=C["subtext"])
+    ctx.line(0, HEADER_H, w, HEADER_H, color=C["surface"], width=1.0)
+
+    y = HEADER_H + PADDING
+
+    if loading and weather_data is None:
+        ctx.text(PADDING, y, "Fetching weather…", size=13, color=C["subtext"])
+        return
+
+    if error_msg and weather_data is None:
+        ctx.text(PADDING, y, f"Error: {error_msg}", size=13, color=C["red"])
+        ctx.text(PADDING, y + 22, "Press r to retry.", size=11, color=C["subtext"])
+        return
+
+    if weather_data is None:
+        return
+
+    d = weather_data
+
+    # Big icon
+    ctx.text(PADDING, y, d["icon"], size=52, color=C["text"])
+
+    # Location
+    ctx.text(PADDING + 80, y + 4, d["location"], size=16, color=C["text"], bold=True)
+
+    # Condition description
+    ctx.text(PADDING + 80, y + 28, d["desc"], size=13, color=C["subtext"])
+
+    y += 70
+
+    # Temperature row
+    ctx.rect(PADDING, y, w - PADDING * 2, 56, fill=C["surface"], radius=8.0)
+    ctx.text(PADDING + 16, y + 10, f"{d['temp_c']}°C", size=22, color=C["yellow"], bold=True)
+    ctx.text(PADDING + 16, y + 36, "Temperature", size=10, color=C["subtext"])
+    sep_x = PADDING + 16 + 90
+    ctx.text(sep_x, y + 10, f"{d['temp_f']}°F", size=22, color=C["mauve"], bold=True)
+    ctx.text(sep_x, y + 36, "Fahrenheit", size=10, color=C["subtext"])
+
+    y += 68
+
+    # Details row — feels like / humidity / wind
+    col_w = (w - PADDING * 2) / 3
+    labels = [
+        (f"{d['feels_c']}°C / {d['feels_f']}°F", "Feels like"),
+        (f"{d['humidity']}%",                      "Humidity"),
+        (f"{d['wind_kmph']} km/h",                 "Wind"),
+    ]
+    for i, (val, lbl) in enumerate(labels):
+        cx = PADDING + i * col_w
+        ctx.rect(cx, y, col_w - 4, 52, fill=C["surface"], radius=8.0)
+        ctx.text(cx + 10, y + 10, val, size=15, color=C["text"], bold=True)
+        ctx.text(cx + 10, y + 32, lbl, size=10, color=C["subtext"])
+
+    # Last updated
+    if last_fetch_ts:
+        age_s = int(now - last_fetch_ts)
+        if age_s < 60:
+            age_str = "just now"
+        else:
+            age_str = f"{age_s // 60}m ago"
+        ctx.text(PADDING, h - PADDING, f"Updated {age_str}", size=10, color=C["subtext"])
+
+
+@app.on_key
+def on_key(key: str, _mods: dict, _emit):
+    global loading
+    if key == "r" and not loading:
+        start_fetch()
+
+
+# Kick off initial fetch
+start_fetch()
+
+app.run()


### PR DESCRIPTION
## Summary

- **weather** — fetches current conditions from `wttr.in` (no API key), displays temp °C/°F, feels-like, humidity, wind, condition icon; auto-refreshes every 5 min, `r` to force refresh
- **hacker-news** — top 30 stories via HN Firebase API (thread pool, max 5 workers); list view with rank/score/comments/domain, detail view with `o` to open URL in browser
- **pomodoro** — 25/5/15 min focus timer with 60-segment progress ring drawn as rects, Space to start/pause, `r`/`b`/`l` to reset/break/long-break, fires `emit.notification` on completion
- **json-viewer** — collapsible tree for any JSON file; auto-expands first 2 levels, color-coded value types (string=green, number=yellow, bool=mauve, null=subtext), drop-target support, `PLEXI_LAUNCH_PATH` env var for file association
- **todo** — persistent list at `~/.plexi-alpha/todo.txt` (`[x]`/`[ ]` format); inline add prompt, toggle/delete, done items shown in muted color with `~~` strikethrough

All apps: stdlib + plexi_sdk only, Catppuccin Mocha palette, `from __future__ import annotations` on every file.

## Test plan

- [ ] `ls ~/.plexi-alpha/apps/` shows all 5 new directories
- [ ] Weather app loads and displays current conditions
- [ ] HN app loads top stories; Enter opens detail; `o` opens browser
- [ ] Pomodoro timer counts down; Space pauses; notification fires on completion
- [ ] JSON viewer opens a `.json` file via drag-drop or `PLEXI_LAUNCH_PATH`; expand/collapse works
- [ ] Todo add/toggle/delete persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)