### PR TITLE
fix(pomodoro): break timers auto-start on b/l press

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,9 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [FIX] Pomodoro break timers now auto-start (issue #171)
+
+`examples/pomodoro/pomodoro.py` — pressing `b` (short break) or `l` (long break) used to set `running = False` and require a second Shift+Space to start the timer, which broke the end-of-focus → break handoff. Now the `b` / `l` handlers set `running = True` and reset `last_tick` so the break counts down immediately. Updated the header hint accordingly.
+
 ## 2026-04-14 — [DECISION] mermaid-viewer: keyboard-driven diagram editor + --filter=mermaid file browser
 
 Added `EntryFilter::Mermaid` to `src/file_browser/mod.rs` (matches `.mmd` files and dirs). Added `examples/mermaid-viewer/` with four files: `mermaid_parser.py` (regex-based parser for flowchart/graph LR/TD syntax, 4 node shapes, solid/dashed/labeled edges), `graph_layout.py` (BFS layering → pixel coords, LR and TD), `mermaid_viewer.py` (full app: VIEW/EDIT_LABEL/ADD_NODE/CONNECTING modes, zoom/pan, hot-reload on mtime, spawns file-browser sidebar on direct launch), `manifest.toml`.

--- a/examples/pomodoro/pomodoro.py
+++ b/examples/pomodoro/pomodoro.py
@@ -6,8 +6,8 @@ Focus timer using the Pomodoro Technique.
 Controls:
   Space    Start / Pause
   r        Reset current timer
-  b        Short break (5 min)
-  l        Long break (15 min)
+  b        Start short break (5 min)
+  l        Start long break (15 min)
 """
 from __future__ import annotations
 
@@ -206,16 +206,16 @@ def on_key(key: str, _mods: dict, _emit):
         remaining = float(DURATIONS.get(timer_state, DURATIONS[STATE_FOCUS]))
 
     elif key == "b":
-        running = False
-        last_tick = 0.0
         timer_state = STATE_SHORT
         remaining = float(DURATIONS[STATE_SHORT])
+        running = True
+        last_tick = time.monotonic()
 
     elif key == "l":
-        running = False
-        last_tick = 0.0
         timer_state = STATE_LONG
         remaining = float(DURATIONS[STATE_LONG])
+        running = True
+        last_tick = time.monotonic()
 
 
 app.run()


### PR DESCRIPTION
## Summary

Fixes #171 — pressing `b` (short break) or `l` (long break) in the pomodoro app used to pause the timer and require a second Shift+Space to start it. Now the break starts counting down immediately, matching the expected "seamless transition from focus → break" UX.

## Changes

- `examples/pomodoro/pomodoro.py` — `b` / `l` handlers now set `running = True` and reset `last_tick` so the new timer starts instantly.
- Updated the header hint text to match the new behavior.

## Test plan

- [ ] Launch pomodoro, press `b` — short break timer should start counting down from 5:00 immediately.
- [ ] Press `l` — long break timer should start counting down from 15:00 immediately.
- [ ] Space still pauses/resumes as before.
- [ ] End of a focus session → press `b` → break auto-starts.