### PR TITLE
feat(agent): print scope header on activation

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,9 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [CHANGED] Agent mode prints a scope header on activation (issue #118)
+
+When agent mode activates, it now emits a dim `agent ─ <project>  <~/path>` header into the terminal grid right before the first `>>> ` prompt, so the user can see which directory the agent is scoped to. Rendered inline via ANSI (bold magenta project name + dim gray full path, home collapsed to `~`) to match the existing Warp-style output path — no new UI surface. Helper `build_scope_header` lives in `agent_mode.rs`; uses the already-present `dirs` crate for home collapse.
+
 ## 2026-04-12 — [FIX] Pomodoro break timers now auto-start (issue #171)
 
 `examples/pomodoro/pomodoro.py` — pressing `b` (short break) or `l` (long break) used to set `running = False` and require a second Shift+Space to start the timer, which broke the end-of-focus → break handoff. Now the `b` / `l` handlers set `running = True` and reset `last_tick` so the break counts down immediately. Updated the header hint accordingly.

--- a/src/agent_mode.rs
+++ b/src/agent_mode.rs
@@ -90,8 +90,9 @@ impl AgentMode {
     }
 
     /// Activate agent mode. Lazily spawns the LLM worker on first activation,
-    /// then enqueues the initial `>>> ` prompt indicator bytes so the render
-    /// layer will draw it into the terminal grid on the next frame.
+    /// then enqueues a scope header line followed by the initial `>>> ` prompt
+    /// indicator bytes so the render layer will draw both into the terminal
+    /// grid on the next frame.
     pub fn activate(&mut self) {
         if self.state != AgentModeState::Inactive {
             return;
@@ -105,6 +106,11 @@ impl AgentMode {
             self.llm = Some(LlmWorker::spawn());
         }
 
+        // Scope header: bold project name + dim full path, so the user sees
+        // which directory the agent is scoped to (issue #118). Only emitted
+        // on the first activation of a session, before the first prompt.
+        let header = build_scope_header(&self.directory_scope);
+        self.enqueue(header.into_bytes());
         self.enqueue(PROMPT_ANSI.as_bytes().to_vec());
     }
 
@@ -378,4 +384,41 @@ fn build_system_prompt(cwd: &std::path::Path) -> String {
 The user is currently working in directory: {}. Respond concisely.",
         cwd.display()
     )
+}
+
+/// Build the scope header line shown when agent mode activates.
+///
+/// Renders as a bold magenta project name followed by a dim gray full path,
+/// with the home directory collapsed to `~`. Example:
+///
+/// ```text
+/// agent ─ PLEXI  ~/Documents/GitHub/PLEXI
+/// ```
+///
+/// Returns a ready-to-emit ANSI string (with leading CRLF) so callers can
+/// enqueue it directly into the terminal grid.
+fn build_scope_header(cwd: &std::path::Path) -> String {
+    let project = cwd
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| cwd.display().to_string());
+
+    let display_path = collapse_home(cwd);
+
+    format!(
+        "\r\n\x1b[2magent ─\x1b[0m \x1b[1;35m{project}\x1b[0m  \x1b[2;90m{display_path}\x1b[0m\r\n"
+    )
+}
+
+/// Replace the user's home directory prefix with `~` for display.
+fn collapse_home(path: &std::path::Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(stripped) = path.strip_prefix(&home) {
+            if stripped.as_os_str().is_empty() {
+                return "~".to_string();
+            }
+            return format!("~/{}", stripped.display());
+        }
+    }
+    path.display().to_string()
 }


### PR DESCRIPTION
## Summary

Fixes #118 — when agent mode activates, the terminal grid now shows a dim scope header line (bold magenta project name, dim gray full path) right before the first `>>> ` prompt, so the user can see which directory the agent is scoped to.

## Rendering

```
agent ─ PLEXI  ~/Documents/GitHub/PLEXI
>>>
```

Inline ANSI, rendered via the existing `pending_output` → `write_agent_bytes` path. No new UI surface — the data already lived on `AgentMode.directory_scope`, it just wasn't surfaced to the user.

## Changes

- `src/agent_mode.rs` — emit `build_scope_header(&self.directory_scope)` bytes in `activate()` before the `PROMPT_ANSI`.
- New helpers `build_scope_header` and `collapse_home` (replaces `$HOME` with `~`).

## Test plan

- [ ] Open a terminal pane in a project directory, press Ctrl+/ to activate agent mode. Header shows `agent ─ <project>  ~/path/to/project` before the prompt.
- [ ] Activate agent mode in `$HOME` directly — path collapses to `~`.
- [ ] Activate agent mode in a non-home path (e.g. `/tmp`) — full path renders.
- [ ] Deactivate and re-activate — header re-renders as expected.