### PR TITLE
feat(sdk): support [app.launch].startup_message manifest field

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,11 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-12 — [CHANGED] Apps can declare a startup message via `[app.launch].startup_message` (issue #185)
+
+New optional manifest field: `[app.launch].startup_message = "Starting X…"`. When present, Plexi writes the string in dim italics into the companion terminal's scrollback grid at launch, via `TerminalBackend::write_agent_bytes` (same path agent-mode uses — bytes never touch the PTY, so the shell has no idea they exist).
+
+Both launch paths write the message: the fast in-pane `AppWithCompanion` path writes to the same pane's backend, and the legacy auto-split path writes to the newly-created companion `TerminalPane` before it's inserted into the context. Helper `format_startup_message` lives at the bottom of `src/pane_ops.rs`. No example manifest has opted in yet — this is plumbing only.
+
 ## 2026-04-12 — [CHANGED] Agent mode prints a scope header on activation (issue #118)
 
 When agent mode activates, it now emits a dim `agent ─ <project>  <~/path>` header into the terminal grid right before the first `>>> ` prompt, so the user can see which directory the agent is scoped to. Rendered inline via ANSI (bold magenta project name + dim gray full path, home collapsed to `~`) to match the existing Warp-style output path — no new UI surface. Helper `build_scope_header` lives in `agent_mode.rs`; uses the already-present `dirs` crate for home collapse.

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -95,6 +95,13 @@ pub struct AppLaunchConfig {
     /// `{launch_dir}` — resolves to the app's launch directory.
     #[serde(default = "default_companion_cwd")]
     pub companion_cwd: String,
+    /// Optional message written into the linked terminal's scrollback grid
+    /// when the app launches. Rendered in dim italics so it reads as a
+    /// system-emitted notice rather than real shell output. Not echoed to
+    /// the shell's PTY — the shell has no idea these bytes exist, same as
+    /// agent-mode output.
+    #[serde(default)]
+    pub startup_message: Option<String>,
 }
 
 impl Default for AppLaunchConfig {
@@ -105,6 +112,7 @@ impl Default for AppLaunchConfig {
             companion_position: default_companion_position(),
             companion_size: default_companion_size(),
             companion_cwd: default_companion_cwd(),
+            startup_message: None,
         }
     }
 }

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -601,6 +601,12 @@ impl PlexiApp {
                 let pane_id = *pane_id;
                 if let Some(pane) = ctx.panes.get_mut(&pane_id) {
                     pane.open_app_with_companion(app, permissions, scope);
+                    // Write manifest-declared startup message into this same
+                    // pane's terminal grid — it IS the companion.
+                    if let Some(msg) = launch.as_ref().and_then(|l| l.startup_message.as_deref()) {
+                        let bytes = format_startup_message(msg);
+                        pane.backend.write_agent_bytes(&bytes);
+                    }
                 }
             }
             ctx.focused_pane = Some(focused);
@@ -641,7 +647,7 @@ impl PlexiApp {
         self.next_pane_id += 1;
 
         let settings = Self::make_backend_settings(Some(companion_cwd), &self.colors);
-        let Some(new_pane) = TerminalPane::new(
+        let Some(mut new_pane) = TerminalPane::new(
             new_term_id,
             self.ctx.clone(),
             self.pty_event_tx.clone(),
@@ -651,6 +657,12 @@ impl PlexiApp {
             log::error!("Failed to create linked terminal pane for app");
             return;
         };
+        // Write manifest-declared startup message into the new companion
+        // terminal's grid before inserting it into the context.
+        if let Some(msg) = launch.as_ref().and_then(|l| l.startup_message.as_deref()) {
+            let bytes = format_startup_message(msg);
+            new_pane.backend.write_agent_bytes(&bytes);
+        }
         self.contexts[self.active_context]
             .panes
             .insert(new_term_id, new_pane);
@@ -1317,4 +1329,12 @@ impl PlexiApp {
         }
         log::debug!("focus_pane_by_id: pane {pane_id} not found");
     }
+}
+
+/// Format a manifest-declared `[app.launch].startup_message` into dim italic
+/// ANSI bytes suitable for `TerminalBackend::write_agent_bytes`. Wrapped in
+/// leading/trailing CRLF so the message always lands on its own line
+/// regardless of where the cursor was.
+fn format_startup_message(msg: &str) -> Vec<u8> {
+    format!("\r\n\x1b[2;3m{msg}\x1b[0m\r\n").into_bytes()
 }


### PR DESCRIPTION
## Summary

Fixes #185 — apps can now declare a startup message in `manifest.toml` that Plexi writes into the companion terminal on launch, so users get visible feedback that the app started.

## Manifest usage

```toml
[app.launch]
companion = "terminal"
companion_position = "bottom"
companion_size = 0.25
startup_message = "Starting Parallax viewer…"
```

## How it renders

The message lands in the companion terminal's scrollback grid in dim italics, on its own line, via `TerminalBackend::write_agent_bytes` — the same mechanism agent mode uses to inject system notices into the terminal without touching the shell's PTY. The shell has no idea these bytes exist, so they can't be accidentally executed or corrupt a running process.

## Why not write to stdin

The issue mentioned writing to stdin, but that would expose the message to the shell's input buffer — at worst it'd be picked up as a command. Writing to the grid via `write_agent_bytes` is the correct path and matches the existing pattern for agent-mode output.

## Changes

- `src/app_registry.rs` — new `startup_message: Option<String>` field on `AppLaunchConfig` with `#[serde(default)]` (backward compatible).
- `src/pane_ops.rs` — both the fast in-pane `AppWithCompanion` path and the legacy auto-split path write the message to the companion terminal's backend. New helper `format_startup_message` wraps the message in `\r\n\x1b[2;3m…\x1b[0m\r\n`.

## Test plan

- [ ] Add `startup_message = "Test message"` to an example app's `[app.launch]` section. Launch the app — the companion terminal grid shows the message in dim italics on its own line.
- [ ] Remove the field — no message renders, existing behavior unchanged.
- [ ] Verify the message survives scrollback and doesn't leak into the shell's command buffer.