### PR TITLE
feat(plexi-iq): Stage 0 scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-anthropic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
+dependencies = [
+ "backoff",
+ "derive_builder",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +502,20 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
 
 [[package]]
 name = "base64"
@@ -952,10 +985,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -1044,6 +1177,12 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
@@ -1324,6 +1463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,10 +1604,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1502,11 +1688,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1557,9 +1750,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1785,6 +1980,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2283,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2239,6 +2563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2657,17 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2458,7 +2805,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -2835,6 +3182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,6 +3267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +3337,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "plexi"
 version = "1.1.2"
 dependencies = [
+ "async-anthropic",
+ "async-trait",
  "chrono",
  "console_error_panic_hook",
  "dirs",
@@ -2993,7 +3354,9 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
+ "rmcp",
  "rodio",
+ "schemars",
  "serde",
  "serde_json",
  "syntect",
@@ -3121,6 +3484,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,8 +3566,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3159,7 +3587,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3169,6 +3607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3216,6 +3663,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3718,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3786,40 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -3352,11 +3910,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3378,12 +3949,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -3409,6 +4020,38 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3448,6 +4091,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +4131,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -3633,6 +4299,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +4334,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -3745,6 +4427,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3903,6 +4594,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,6 +4725,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4800,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -4140,6 +4942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +5053,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5267,7 +6091,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,16 @@ rodio = { version = "0.19", default-features = false, features = ["mp3", "flac",
 notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
 ureq = { version = "2.10", features = ["json", "tls"] }
 
+# Plexi IQ (Stage 0 scaffolding — §9 of docs/specs/plexi-iq.md).
+# These are pulled in for the upcoming in-process agent harness. Stage 0
+# only uses them to type-check the stub module tree under src/plexi_iq/;
+# real usage lands in Stage 1. Native-only — the agent harness runs against
+# real network/subprocess backends, not in the browser.
+async-anthropic = "0.6"
+async-trait = "0.1"
+schemars = { version = "1", features = ["derive"] }
+rmcp = { version = "1", default-features = false, features = ["client", "macros"] }
+
 # macOS-only — AppKit menu bar integration.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src/plexi_iq/backend/anthropic_api.rs
+++ b/src/plexi_iq/backend/anthropic_api.rs
@@ -1,0 +1,49 @@
+//! Native mode — direct Anthropic Messages API via `async-anthropic`.
+//!
+//! Stage 0: empty struct + stub `LlmBackend` impl that `todo!()`s. Stage 1
+//! will:
+//!
+//! - Construct an `async_anthropic::Client` from the configured API key
+//!   (`ANTHROPIC_API_KEY` env var or Plexi secrets).
+//! - Translate `LlmRequest` into an Anthropic `MessagesRequest` with
+//!   `cache_control` markers on the system prefix + last stable user turn
+//!   (spec §4).
+//! - Enable the 1M context beta header behind a config flag (spec §8
+//!   risk #6).
+//! - Expose `max_thinking_tokens` per call (spec §3.6).
+//!
+//! No `async-anthropic` calls in Stage 0 — just the trait surface.
+
+use super::{BillingModel, LlmBackend, LlmError, LlmRequest, StreamEvent};
+
+/// Direct Anthropic Messages API backend. Owns the tool loop in Plexi IQ.
+#[derive(Debug, Default)]
+pub struct AnthropicApiBackend {}
+
+impl AnthropicApiBackend {
+    /// Placeholder constructor. Stage 1 will take an API key + model routing
+    /// config and build a real `async_anthropic::Client`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmBackend for AnthropicApiBackend {
+    fn name(&self) -> &str {
+        "anthropic-api"
+    }
+
+    fn supports_tool_dispatch(&self) -> bool {
+        // Native mode — Plexi IQ owns the tool loop. See spec §3.6.
+        true
+    }
+
+    fn billing_model(&self) -> BillingModel {
+        BillingModel::Metered
+    }
+
+    async fn stream(&self, _request: LlmRequest) -> Result<StreamEvent, LlmError> {
+        todo!("Plexi IQ Stage 1: stream via async-anthropic (spec §3.6 native mode).")
+    }
+}

--- a/src/plexi_iq/backend/claude_cli.rs
+++ b/src/plexi_iq/backend/claude_cli.rs
@@ -1,0 +1,50 @@
+//! Proxied mode — slot-in of the existing `src/agent_llm.rs` wrapper.
+//!
+//! Stage 0: empty struct + stub `LlmBackend` impl that `todo!()`s. Stage 1
+//! will move the existing `claude -p --resume <session_id>` subprocess
+//! logic (currently in `src/agent_llm.rs` on the `dev` branch, not yet in
+//! this alpha worktree) behind this backend.
+//!
+//! Capability note (spec §3.6, risk #12): in proxied mode, Claude Code
+//! owns the tool loop internally. Plexi IQ sees only prompts + streamed
+//! text. `supports_tool_dispatch()` therefore returns `false`, and the
+//! turn loop will skip building a tool schema and collecting tool_use
+//! blocks when this backend is active. The pane-header badge must show
+//! "proxied — tool dispatch disabled" so users don't silently lose
+//! app-protocol tools, MCP, or subagents-as-panes.
+
+use super::{BillingModel, LlmBackend, LlmError, LlmRequest, StreamEvent};
+
+/// `claude -p --resume` subprocess backend. Wraps the existing
+/// `agent_llm.rs` in the `LlmBackend` trait. Stage 1 plumbs the real
+/// subprocess in.
+#[derive(Debug, Default)]
+pub struct ClaudeCliBackend {}
+
+impl ClaudeCliBackend {
+    /// Placeholder constructor. Stage 1 will accept the path to the
+    /// `claude` binary and an optional session ID for `--resume`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmBackend for ClaudeCliBackend {
+    fn name(&self) -> &str {
+        "claude-cli"
+    }
+
+    fn supports_tool_dispatch(&self) -> bool {
+        // Proxied mode — Claude Code owns the tool loop. See spec §3.6.
+        false
+    }
+
+    fn billing_model(&self) -> BillingModel {
+        BillingModel::Subscription
+    }
+
+    async fn stream(&self, _request: LlmRequest) -> Result<StreamEvent, LlmError> {
+        todo!("Plexi IQ Stage 1: slot in src/agent_llm.rs behind this trait (spec §3.6 proxied mode).")
+    }
+}

--- a/src/plexi_iq/backend/mod.rs
+++ b/src/plexi_iq/backend/mod.rs
@@ -1,0 +1,84 @@
+//! LLM backend abstraction for Plexi IQ.
+//!
+//! Two concrete backends land in Stage 1 behind this trait (spec §3.6):
+//!
+//! - `AnthropicApiBackend` — native mode, direct Messages API via
+//!   `async-anthropic`. Plexi IQ owns the tool loop.
+//! - `ClaudeCliBackend` — proxied mode, slots the existing
+//!   `src/agent_llm.rs` `claude -p --resume` wrapper in behind the trait.
+//!   Claude Code owns the tool loop internally; Plexi IQ sees only
+//!   streamed text.
+//!
+//! Stage 0 is just the trait shape. Both implementations are `todo!()`
+//! stubs so Stage 1 can fill them in without touching the trait.
+
+pub mod anthropic_api;
+pub mod claude_cli;
+
+pub use anthropic_api::AnthropicApiBackend;
+pub use claude_cli::ClaudeCliBackend;
+
+/// Whether the backend is billed per-token or via a flat subscription.
+/// Drives the cost ledger (§10) and the pre-flight budget gate (§8, risk #10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BillingModel {
+    /// Per-token USD. Pre-flight enforcement against a dollar envelope.
+    Metered,
+    /// Flat-rate upstream (e.g. Claude Code subscription). Rate limits are
+    /// enforced by the provider, not Plexi IQ.
+    Subscription,
+}
+
+/// Streaming event yielded by `LlmBackend::stream`. Stage 1 will flesh this
+/// out to cover text deltas, tool-use start/delta/stop, and message stop with
+/// a stop reason; for now it's a single opaque variant so the trait signature
+/// can be stable.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// Placeholder — replaced in Stage 1 with the full event taxonomy
+    /// described in spec §3.2.
+    Placeholder,
+}
+
+/// Request object passed to `LlmBackend::stream`. Stage 1 will expand this
+/// into the full Messages API envelope (system prompt, messages, tools,
+/// cache breakpoints, max_thinking_tokens, etc.).
+#[derive(Debug, Clone, Default)]
+pub struct LlmRequest {
+    /// Placeholder — real fields land in Stage 1.
+    pub _placeholder: (),
+}
+
+/// Error type for backend streaming. Stage 1 will split this into
+/// transport / rate-limit / budget / abort variants.
+#[derive(Debug)]
+pub enum LlmError {
+    /// Placeholder — real variants land in Stage 1.
+    Todo,
+}
+
+/// The core backend contract. See spec §3.6 for the capability split and
+/// §7 for why this is Anthropic-only (no multi-provider abstraction).
+///
+/// Stage 1 will almost certainly change the `stream` return type to a
+/// proper `Stream<Item = Result<StreamEvent, LlmError>>` once we settle on
+/// whether to use `futures::Stream` or a custom channel.
+#[async_trait::async_trait]
+pub trait LlmBackend: Send + Sync {
+    /// Human-readable backend name for logs and the pane-header badge.
+    fn name(&self) -> &str;
+
+    /// Whether this backend exposes raw tool_use events to Plexi IQ's
+    /// turn loop. Native mode returns `true`; proxied mode returns
+    /// `false` because Claude Code owns its own tool loop.
+    fn supports_tool_dispatch(&self) -> bool;
+
+    /// How this backend bills — drives the cost ledger and pre-flight
+    /// budget gate.
+    fn billing_model(&self) -> BillingModel;
+
+    /// Stream a single LLM request. Stage 1 will change the return type
+    /// to a real async stream; for now this is a placeholder signature
+    /// so the trait compiles.
+    async fn stream(&self, request: LlmRequest) -> Result<StreamEvent, LlmError>;
+}

--- a/src/plexi_iq/context.rs
+++ b/src/plexi_iq/context.rs
@@ -1,0 +1,51 @@
+//! Tool execution context.
+//!
+//! Stage 0: stub fields for pane ID and directory scope. Stage 1 will
+//! add the rest per spec §3.3:
+//!
+//! - `session: &SessionState` — Read-before-Edit guard lives here
+//! - `app_bus: Option<&AppBus>` — gates app-protocol tools when the
+//!   pane has a companion app
+//! - `plexi_ctx: &PlexiCtx` — handle for the subagent `Task` tool to
+//!   spawn new panes and look up the pane tree
+//!
+//! These are all left as comments for now because the concrete types
+//! (`SessionState`, `AppBus`, `PlexiCtx`) haven't been introduced yet.
+
+use std::path::PathBuf;
+
+/// Opaque pane identifier. Stage 1 will wire this to the real `PaneId`
+/// type from `src/pane.rs`; for now it's a newtype wrapper so the
+/// signature of `ToolContext` can settle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct PaneId(pub u64);
+
+/// Everything a `Tool::run` call needs. Passed by reference so tools
+/// never own pane/session state.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    /// Which pane this agent instance is bound to.
+    pub pane_id: PaneId,
+
+    /// Filesystem scope for file-touching tools. Tools must refuse
+    /// absolute paths that escape this directory (Stage 1 enforcement).
+    pub directory_scope: PathBuf,
+    // TODO (Stage 1, spec §3.3):
+    //   pub session: &'a SessionState,
+    //   pub app_bus: Option<&'a AppBus>,
+    //   pub plexi_ctx: &'a PlexiCtx,
+    //
+    // These require types that don't exist yet in this worktree. They
+    // land in Stage 1 alongside the turn-loop driver in `loop.rs`.
+}
+
+impl ToolContext {
+    /// Construct a minimal context. Stage 1 will replace this with a
+    /// real builder once the session/app_bus/plexi_ctx fields land.
+    pub fn new(pane_id: PaneId, directory_scope: PathBuf) -> Self {
+        Self {
+            pane_id,
+            directory_scope,
+        }
+    }
+}

--- a/src/plexi_iq/loop.rs
+++ b/src/plexi_iq/loop.rs
@@ -1,0 +1,24 @@
+//! Turn loop driver — stream → collect tool_use → dispatch → reply.
+//!
+//! Stage 0: stub only. The real implementation lands in Stage 1; see
+//! `docs/specs/plexi-iq.md` §3.2 for the target pseudocode and §3.6 for
+//! the `supports_tool_dispatch()` branch that decides whether this loop
+//! owns tool dispatch or treats the backend call as opaque prompting.
+//!
+//! NOTE: the file is named `loop.rs` to match the spec, but `loop` is a
+//! Rust keyword, so `mod.rs` mounts it as `pub mod turn_loop` via
+//! `#[path = "loop.rs"]`.
+
+use crate::plexi_iq::backend::LlmBackend;
+use crate::plexi_iq::context::ToolContext;
+
+/// Run a single user turn through the agent loop. Stage 1 will implement
+/// the streaming/tool-dispatch logic; for now this is a `todo!()` so the
+/// trait surface and call sites can be sketched without behavior.
+pub async fn run_turn<B: LlmBackend + ?Sized>(
+    _backend: &B,
+    _ctx: &ToolContext,
+    _user_input: &str,
+) -> ! {
+    todo!("Plexi IQ Stage 1: implement the streaming turn loop (spec §3.2).")
+}

--- a/src/plexi_iq/mod.rs
+++ b/src/plexi_iq/mod.rs
@@ -1,0 +1,47 @@
+//! Plexi IQ — in-process agent harness.
+//!
+//! Stage 0 scaffolding. See `docs/specs/plexi-iq.md` §3 for the module
+//! layout and §9 for the staging plan. Nothing in this module is wired
+//! into the running application yet — `AgentMode` still shells out via
+//! the existing `claude -p --resume` path. This tree exists purely so
+//! Stage 1 has a clean foundation to start building on.
+//!
+//! Re-exports below expose the public types (`PlexiIq`, `PlexiIqConfig`,
+//! `PlexiIqInstance`) that Stage 1 will flesh out.
+
+#![allow(dead_code)] // Stage 0: stubs only.
+
+pub mod backend;
+pub mod context;
+#[path = "loop.rs"]
+pub mod turn_loop;
+pub mod prompt;
+pub mod tools;
+
+pub use backend::{BillingModel, LlmBackend};
+pub use context::ToolContext;
+pub use tools::{Tool, ToolRegistry, ToolResult};
+
+use std::path::PathBuf;
+
+/// Top-level Plexi IQ handle — owns shared configuration and spawns per-pane
+/// `PlexiIqInstance`s. Stage 1 will give this real fields (backend factory,
+/// global budget ledger handle, MCP client pool, etc.). For now it is a
+/// zero-sized marker so downstream code can name the type.
+#[derive(Debug, Default)]
+pub struct PlexiIq {}
+
+/// Configuration passed when constructing a `PlexiIq`. See spec §3.6 for the
+/// backend-selection logic and §10 for budget fields that will land here.
+#[derive(Debug, Clone, Default)]
+pub struct PlexiIqConfig {
+    /// Optional override for the directory scope used when bootstrapping
+    /// instances. When `None`, instances will inherit the pane's cwd.
+    pub default_directory_scope: Option<PathBuf>,
+}
+
+/// Per-pane agent instance. Owns its own conversation, tool registry, and
+/// session state. Stage 1 will add the turn loop driver and the channels that
+/// connect it to the pane's `AgentMode` state machine.
+#[derive(Debug, Default)]
+pub struct PlexiIqInstance {}

--- a/src/plexi_iq/prompt.rs
+++ b/src/plexi_iq/prompt.rs
@@ -1,0 +1,18 @@
+//! System-prompt assembly for Plexi IQ.
+//!
+//! Stage 0: empty. Stage 1 will implement the five-layer assembly
+//! described in spec §4:
+//!
+//!   1. Base harness prompt (static, part of cache prefix)
+//!   2. Plexi-specific addendum (static per instance)
+//!   3. Environment block (pane ID, directory scope, active app,
+//!      available MCP servers — cacheable for pane lifetime)
+//!   4. `CLAUDE.md` contents from `directory_scope` or any ancestor
+//!   5. Inherited scrollback (when tabbing shell → agent; spec §6)
+//!
+//! Cache breakpoints: one `cache_control` marker after block 4, one on
+//! the last stable user turn during the loop (spec §4).
+//!
+//! TODO (Stage 1): implement `build_system_prompt(&PlexiIqInstance) ->
+//! String` and a helper that walks upward from `directory_scope` to find
+//! the nearest `CLAUDE.md`.

--- a/src/plexi_iq/tools/mod.rs
+++ b/src/plexi_iq/tools/mod.rs
@@ -1,0 +1,82 @@
+//! Tool trait and registry for Plexi IQ.
+//!
+//! Stage 0: trait surface and empty `ToolRegistry`. Stage 1 will add the
+//! built-in tools (`Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`,
+//! `TodoWrite`, `Task`) and the dynamic slots for app-protocol + MCP
+//! tools. See spec §3.3 and §3.4.
+
+use crate::plexi_iq::context::ToolContext;
+
+/// Outcome of a tool invocation. Stage 1 will expand the error side into
+/// transport / validation / bus_closed / denied variants (spec §8 risk #5).
+#[derive(Debug)]
+pub enum ToolResult {
+    /// Tool completed and produced a result payload the model should see.
+    Ok(serde_json::Value),
+    /// Tool failed. The `String` message is echoed back to the model as a
+    /// tool_result with `is_error: true`.
+    Error(String),
+}
+
+/// The core tool contract. Mirrors Claude Code's built-in tool shape so the
+/// model's training transfers directly (spec §3.4).
+///
+/// `description` must be ≥3 sentences covering: when to use, constraints,
+/// and at least one example. Use `schemars::JsonSchema` on the input struct
+/// and call `schemars::schema_for!(Input)` inside `input_schema()` for the
+/// built-ins (spec §3.3).
+#[async_trait::async_trait]
+pub trait Tool: Send + Sync {
+    /// Stable tool name — what the model writes in `tool_use.name`.
+    fn name(&self) -> &str;
+
+    /// Human- and model-facing description. See trait-level note on
+    /// required structure.
+    fn description(&self) -> &str;
+
+    /// JSON Schema for the tool's input. Generated via `schemars` for
+    /// built-ins; synthesized from the app manifest for app-protocol
+    /// tools.
+    fn input_schema(&self) -> serde_json::Value;
+
+    /// Execute the tool. `ctx` carries pane ID, directory scope, session
+    /// state (Read-before-Edit guard), and the optional app bus handle.
+    async fn run(&self, input: serde_json::Value, ctx: &ToolContext) -> ToolResult;
+}
+
+/// Registry of tools available to a single `PlexiIqInstance`.
+///
+/// Stage 0: empty shell. Stage 1 will populate it from four sources
+/// (built-ins, app-protocol, MCP, subagent `Task`) and rebuild it when
+/// the pane's companion app changes (spec §3.4: "dynamic per instance").
+#[derive(Default)]
+pub struct ToolRegistry {
+    tools: Vec<Box<dyn Tool>>,
+}
+
+impl ToolRegistry {
+    /// Build an empty registry. Stage 1 will add constructor variants
+    /// that seed built-ins, merge app-protocol tools, etc.
+    pub fn new() -> Self {
+        Self { tools: Vec::new() }
+    }
+
+    /// Number of registered tools. Stage 1 will add real accessors
+    /// (by-name lookup, schema export, etc.).
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Whether the registry has any tools registered.
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+impl std::fmt::Debug for ToolRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToolRegistry")
+            .field("tool_count", &self.tools.len())
+            .finish()
+    }
+}


### PR DESCRIPTION
## Summary

Stage 0 of the Plexi IQ agent harness per `docs/specs/plexi-iq.md` §9. Pure scaffolding — module tree, Cargo deps, and trait stubs. Zero behavior change: `AgentMode` is untouched and still relies on the existing `claude -p --resume` path.

## What's stubbed

New files under `src/plexi_iq/`:

| File | Stubs |
|---|---|
| `mod.rs` | `PlexiIq`, `PlexiIqConfig`, `PlexiIqInstance` type stubs + re-exports |
| `loop.rs` | `run_turn()` — `todo!()` body |
| `backend/mod.rs` | `LlmBackend` async trait (`name`, `supports_tool_dispatch`, `billing_model`, `stream`) + `BillingModel { Metered, Subscription }` + placeholder `StreamEvent` / `LlmRequest` / `LlmError` |
| `backend/anthropic_api.rs` | `AnthropicApiBackend` — native mode, `supports_tool_dispatch = true`, `Metered`, `stream` = `todo!()` |
| `backend/claude_cli.rs` | `ClaudeCliBackend` — proxied mode, `supports_tool_dispatch = false`, `Subscription`, `stream` = `todo!()`. Comment notes this will slot in `src/agent_llm.rs` in Stage 1. |
| `tools/mod.rs` | `Tool` async trait (`name`, `description`, `input_schema`, `run`) + empty `ToolRegistry` + `ToolResult` |
| `context.rs` | `ToolContext { pane_id, directory_scope }` with TODO comments for `session` / `app_bus` / `plexi_ctx` per §3.3 |
| `prompt.rs` | Empty module with TODO referencing §4 assembly |

The `loop.rs` file is mounted as `pub mod turn_loop` via `#[path = "loop.rs"]` because `loop` is a Rust keyword.

## Cargo deps added

| Crate | Requested | Shipped | Why |
|---|---|---|---|
| `async-anthropic` | `0.3` | `0.6` | Spec version is stale on crates.io; 0.6.0 is latest |
| `schemars` | `0.8` | `1` with `derive` | 0.8 is superseded; 1.x is current stable |
| `rmcp` | `0.1` | `1` with `default-features = false`, `client`, `macros` | 0.1 is well behind; 1.4.0 is latest. Default features pull in a transport/server/base64 chain that Stage 0 doesn't need. |
| `async-trait` | _(not in spec)_ | `0.1` | Required so `LlmBackend` and `Tool` async methods coexist with `Send + Sync`. Native async-fn-in-trait has dyn-compat issues for this use case. |

All four versions resolved cleanly; see `Cargo.lock` diff.

## Why this is zero-behavior-change

**The off-limits list includes `src/main.rs`, so `mod plexi_iq;` is not yet declared.** The scaffolding files are present on disk but not compiled into the binary — Cargo ignores unreferenced `.rs` files under `src/`. This was a deliberate choice to respect the off-limits rule, with the trade-off that the stubs themselves are not type-checked until Stage 1's first edit.

**Recommendation:** Stage 1 should begin with a one-line edit to `src/main.rs` adding `mod plexi_iq;`, at which point the stubs become compilable and Stage 1 can start filling them in. That single line is the only outstanding work from Stage 0.

Stage 0 verification therefore relies on: (a) Cargo resolving the new deps cleanly (confirmed — lockfile updated with all 5 crates and transitive tokio), (b) the full `cargo build` / `cargo check --all-targets` / `cargo test` suite still passing with no new warnings, and (c) `just install-alpha` succeeding and producing an identical-behaving Plexi Alpha bundle.

## Verification

- [x] `cargo build` — succeeds, 36 warnings (all pre-existing, zero new)
- [x] `cargo check --all-targets` — succeeds
- [x] `cargo test` — 15 passed, 0 failed
- [x] `just install-alpha` — succeeds, `/Applications/Plexi Alpha.app` bundled + installed
- [x] No off-limits files modified (`agent_mode.rs`, `agent_llm.rs`, `main.rs`, `command_palette.rs`, `config.rs`, `quick_note_app.rs`, `app.rs`, `pane_ops.rs`, the backlog-triage example, `CLAUDE.md`, `DEV_LOG.md`, `ROADMAP.md`, or the spec itself)

## Spec reference

- `docs/specs/plexi-iq.md` §3.1 — module tree
- `docs/specs/plexi-iq.md` §3.3 — Tool trait + ToolContext fields
- `docs/specs/plexi-iq.md` §3.6 — native vs proxied backend modes
- `docs/specs/plexi-iq.md` §7 — dependency rationale
- `docs/specs/plexi-iq.md` §9 Stage 0 — this PR