### PR TITLE
feat(secrets): SecretGet API for external apps

### DIFF
--- a/examples/git-log/plexi_sdk.py
+++ b/examples/git-log/plexi_sdk.py
@@ -61,15 +61,26 @@ import os
 import pathlib
 import sys
 import uuid
+from collections import deque
 from datetime import datetime, timezone
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Deque, List, Optional, Tuple
 
 
 class Emitter:
-    """Emit commands to Plexi immediately (outside a render frame)."""
+    """Emit commands to Plexi immediately (outside a render frame).
 
-    def __init__(self, app_id: str = ""):
+    The emitter also owns the synchronous request/response path used by
+    `get_secret()`. It shares a pending-event deque with the parent `App`
+    so that any events read from stdin while waiting for a response (and
+    which are unrelated to that response) get processed by the main loop
+    on its next iteration instead of being dropped.
+    """
+
+    def __init__(self, app_id: str = "", pending_events: Optional[Deque[dict]] = None):
         self._app_id = app_id
+        # Shared with App.run(); None only in cases where the emitter is
+        # constructed standalone (e.g. legacy tests).
+        self._pending_events: Deque[dict] = pending_events if pending_events is not None else deque()
 
     def run_in_terminal(self, command: str):
         """Execute a shell command in the linked terminal."""
@@ -98,6 +109,44 @@ class Emitter:
     def debug(self, message: str):
         """Log at debug level."""
         self.log("debug", message)
+
+    def get_secret(self, name: str) -> Optional[str]:
+        """
+        Fetch a secret by name from Plexi's Keychain-backed store.
+
+        Resolution walks up from the app's launch directory to the user's
+        home, returning the first matching value. Returns None if the
+        secret is missing, Keychain is unavailable, or any other
+        resolution error occurred (the host logs the failure; the app
+        should not crash on a missing secret).
+
+        Blocks until Plexi responds. Safe to call from `on_render`,
+        `on_key`, `on_click`, or `on_command` handlers. Any unrelated
+        events that arrive while waiting for the response are queued and
+        processed by the main loop on its next iteration.
+        """
+        # Fire the request.
+        print(json.dumps({"type": "secret_get", "name": name}), flush=True)
+
+        # Block until we see the matching secret_response. Other events
+        # get stashed for the main loop so nothing is lost.
+        while True:
+            line = sys.stdin.readline()
+            if not line:
+                # stdin closed — treat as host death; no secret available.
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "secret_response" and event.get("name") == name:
+                value = event.get("value")
+                return value if isinstance(value, str) else None
+            # Unrelated event — stash for the main loop.
+            self._pending_events.append(event)
 
     def cost_report(
         self,
@@ -344,12 +393,24 @@ class RenderContext:
     All coordinates are in logical pixels within the app surface.
     """
 
-    def __init__(self, width: float, height: float, app_id: str = ""):
+    def __init__(
+        self,
+        width: float,
+        height: float,
+        app_id: str = "",
+        emitter: Optional[Emitter] = None,
+    ):
         self.width = width
         self.height = height
         self.delta_time: float = 0.0
         self._app_id = app_id
+        # Carried so helpers like get_secret() can piggyback on the
+        # existing Emitter (and its shared pending-events deque).
+        self._emitter: Emitter = emitter if emitter is not None else Emitter(app_id)
         self._commands: list = []
+        # Carried so helpers like get_secret() can piggyback on the
+        # existing Emitter (and its shared pending-events deque).
+        self._emitter: Emitter = emitter if emitter is not None else Emitter()
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
         """Fill a rectangle."""
@@ -586,6 +647,17 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def get_secret(self, name: str) -> Optional[str]:
+        """
+        Fetch a secret by name from Plexi's Keychain-backed store.
+
+        Blocking request/response. See `Emitter.get_secret()` for full
+        semantics. Safe to call from inside `on_render` — the request is
+        sent immediately (not queued with the frame) so the response
+        arrives before the handler returns.
+        """
+        return self._emitter.get_secret(name)
+
     def notify(
         self,
         title: str,
@@ -716,7 +788,11 @@ class App:
         self._on_mouse_move: Optional[Callable] = None
         self._on_scroll: Optional[Callable] = None
         self._on_pipe_data: Optional[Callable] = None
-        self._emitter = Emitter(app_id=app_id)
+        # Events that arrived on stdin while a blocking request (e.g.
+        # get_secret) was waiting for its response. Drained at the top of
+        # each run-loop iteration before reading a fresh line from stdin.
+        self._pending_events: Deque[dict] = deque()
+        self._emitter = Emitter(app_id=app_id, pending_events=self._pending_events)
         # Breakpoints: list of (min_width, min_height, render_fn).
         # Walked in descending area order on each render to pick the
         # most specific match whose constraints fit the current pane.
@@ -1064,15 +1140,24 @@ class App:
         # Pull min-size from the manifest (if set_min_size was not called).
         self._load_manifest_layout()
 
-        for line in sys.stdin:
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+        while True:
+            # Drain any events that were queued by a blocking helper (e.g.
+            # get_secret) during a prior handler. These were read off stdin
+            # while waiting for a specific response, so they need to be
+            # replayed here before pulling more.
+            if self._pending_events:
+                event = self._pending_events.popleft()
+            else:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
             event_type = event.get("type", "")
 
@@ -1099,7 +1184,12 @@ class App:
                 ):
                     self._render_min_size_fallback(self.width, self.height)
                     continue
-                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx = RenderContext(
+                    self.width,
+                    self.height,
+                    app_id=self._emitter._app_id,
+                    emitter=self._emitter,
+                )
                 ctx.delta_time = self.delta_time
                 # Breakpoint dispatch (if registered) overrides on_render.
                 if self._breakpoints:
@@ -1189,6 +1279,12 @@ class App:
                         event.get("value"),
                         self._emitter,
                     )
+
+            elif event_type == "secret_response":
+                # Should normally be consumed by the blocking get_secret()
+                # helper. If one arrives at top level (e.g. a late response
+                # after timeout), there's nothing sensible to do — drop it.
+                pass
 
             elif event_type == "shutdown":
                 break

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -61,15 +61,26 @@ import os
 import pathlib
 import sys
 import uuid
+from collections import deque
 from datetime import datetime, timezone
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Deque, List, Optional, Tuple
 
 
 class Emitter:
-    """Emit commands to Plexi immediately (outside a render frame)."""
+    """Emit commands to Plexi immediately (outside a render frame).
 
-    def __init__(self, app_id: str = ""):
+    The emitter also owns the synchronous request/response path used by
+    `get_secret()`. It shares a pending-event deque with the parent `App`
+    so that any events read from stdin while waiting for a response (and
+    which are unrelated to that response) get processed by the main loop
+    on its next iteration instead of being dropped.
+    """
+
+    def __init__(self, app_id: str = "", pending_events: Optional[Deque[dict]] = None):
         self._app_id = app_id
+        # Shared with App.run(); None only in cases where the emitter is
+        # constructed standalone (e.g. legacy tests).
+        self._pending_events: Deque[dict] = pending_events if pending_events is not None else deque()
 
     def run_in_terminal(self, command: str):
         """Execute a shell command in the linked terminal."""
@@ -98,6 +109,44 @@ class Emitter:
     def debug(self, message: str):
         """Log at debug level."""
         self.log("debug", message)
+
+    def get_secret(self, name: str) -> Optional[str]:
+        """
+        Fetch a secret by name from Plexi's Keychain-backed store.
+
+        Resolution walks up from the app's launch directory to the user's
+        home, returning the first matching value. Returns None if the
+        secret is missing, Keychain is unavailable, or any other
+        resolution error occurred (the host logs the failure; the app
+        should not crash on a missing secret).
+
+        Blocks until Plexi responds. Safe to call from `on_render`,
+        `on_key`, `on_click`, or `on_command` handlers. Any unrelated
+        events that arrive while waiting for the response are queued and
+        processed by the main loop on its next iteration.
+        """
+        # Fire the request.
+        print(json.dumps({"type": "secret_get", "name": name}), flush=True)
+
+        # Block until we see the matching secret_response. Other events
+        # get stashed for the main loop so nothing is lost.
+        while True:
+            line = sys.stdin.readline()
+            if not line:
+                # stdin closed — treat as host death; no secret available.
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "secret_response" and event.get("name") == name:
+                value = event.get("value")
+                return value if isinstance(value, str) else None
+            # Unrelated event — stash for the main loop.
+            self._pending_events.append(event)
 
     def cost_report(
         self,
@@ -344,12 +393,24 @@ class RenderContext:
     All coordinates are in logical pixels within the app surface.
     """
 
-    def __init__(self, width: float, height: float, app_id: str = ""):
+    def __init__(
+        self,
+        width: float,
+        height: float,
+        app_id: str = "",
+        emitter: Optional[Emitter] = None,
+    ):
         self.width = width
         self.height = height
         self.delta_time: float = 0.0
         self._app_id = app_id
+        # Carried so helpers like get_secret() can piggyback on the
+        # existing Emitter (and its shared pending-events deque).
+        self._emitter: Emitter = emitter if emitter is not None else Emitter(app_id)
         self._commands: list = []
+        # Carried so helpers like get_secret() can piggyback on the
+        # existing Emitter (and its shared pending-events deque).
+        self._emitter: Emitter = emitter if emitter is not None else Emitter()
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
         """Fill a rectangle."""
@@ -586,6 +647,17 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def get_secret(self, name: str) -> Optional[str]:
+        """
+        Fetch a secret by name from Plexi's Keychain-backed store.
+
+        Blocking request/response. See `Emitter.get_secret()` for full
+        semantics. Safe to call from inside `on_render` — the request is
+        sent immediately (not queued with the frame) so the response
+        arrives before the handler returns.
+        """
+        return self._emitter.get_secret(name)
+
     def notify(
         self,
         title: str,
@@ -716,7 +788,11 @@ class App:
         self._on_mouse_move: Optional[Callable] = None
         self._on_scroll: Optional[Callable] = None
         self._on_pipe_data: Optional[Callable] = None
-        self._emitter = Emitter(app_id=app_id)
+        # Events that arrived on stdin while a blocking request (e.g.
+        # get_secret) was waiting for its response. Drained at the top of
+        # each run-loop iteration before reading a fresh line from stdin.
+        self._pending_events: Deque[dict] = deque()
+        self._emitter = Emitter(app_id=app_id, pending_events=self._pending_events)
         # Breakpoints: list of (min_width, min_height, render_fn).
         # Walked in descending area order on each render to pick the
         # most specific match whose constraints fit the current pane.
@@ -1064,15 +1140,24 @@ class App:
         # Pull min-size from the manifest (if set_min_size was not called).
         self._load_manifest_layout()
 
-        for line in sys.stdin:
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+        while True:
+            # Drain any events that were queued by a blocking helper (e.g.
+            # get_secret) during a prior handler. These were read off stdin
+            # while waiting for a specific response, so they need to be
+            # replayed here before pulling more.
+            if self._pending_events:
+                event = self._pending_events.popleft()
+            else:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
             event_type = event.get("type", "")
 
@@ -1099,7 +1184,12 @@ class App:
                 ):
                     self._render_min_size_fallback(self.width, self.height)
                     continue
-                ctx = RenderContext(self.width, self.height, app_id=self._emitter._app_id)
+                ctx = RenderContext(
+                    self.width,
+                    self.height,
+                    app_id=self._emitter._app_id,
+                    emitter=self._emitter,
+                )
                 ctx.delta_time = self.delta_time
                 # Breakpoint dispatch (if registered) overrides on_render.
                 if self._breakpoints:
@@ -1189,6 +1279,12 @@ class App:
                         event.get("value"),
                         self._emitter,
                     )
+
+            elif event_type == "secret_response":
+                # Should normally be consumed by the blocking get_secret()
+                # helper. If one arrives at top level (e.g. a late response
+                # after timeout), there's nothing sensible to do — drop it.
+                pass
 
             elif event_type == "shutdown":
                 break

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "plexi-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -29,9 +29,10 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::VecDeque;
 use std::env;
 use std::fs::{create_dir_all, read_to_string, OpenOptions};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufReader, Stdin, Write};
 use std::path::PathBuf;
 
 // ── Inbound events (Plexi → app) ─────────────────────────────────────────────
@@ -106,6 +107,10 @@ pub enum PlexiEvent {
         #[serde(default)]
         persistent: Value,
     },
+    /// Response to a prior `DrawCommand::SecretGet`. The SDK's
+    /// `Emitter::get_secret` helper reads stdin until it sees this event
+    /// with a matching `name`. See `Emitter::get_secret` for details.
+    SecretResponse { name: String, value: Option<String> },
     Shutdown,
 }
 
@@ -281,6 +286,8 @@ pub enum DrawCommand {
         #[serde(default)]
         wire_channels: Vec<String>,
     },
+    /// Request a secret by name. Plexi responds with `PlexiEvent::SecretResponse`.
+    SecretGet { name: String },
     FrameDone,
 }
 
@@ -461,18 +468,31 @@ impl StateSnapshot {
 
 // ── Emitter: write commands outside a render frame ───────────────────────────
 
-/// Sends draw commands to Plexi outside of a render frame.
+/// Sends draw commands to Plexi outside of a render frame and handles
+/// synchronous request/response helpers like [`Emitter::get_secret`].
 ///
 /// Each call writes a single newline-delimited JSON object to stdout.
 /// `app_id` is set automatically by the runtime from the `PLEXI_APP_ID` env
 /// var so cost reports and notifications are attributed correctly.
+///
+/// The emitter owns the buffered stdin reader so that blocking helpers can
+/// read response events directly, and carries a shared `pending_events`
+/// buffer: any non-matching events pulled off stdin while waiting for a
+/// specific response are stashed here for the main [`run`] loop to process
+/// on its next iteration, instead of being dropped.
 pub struct Emitter {
     app_id: String,
+    stdin: BufReader<Stdin>,
+    pending_events: VecDeque<PlexiEvent>,
 }
 
 impl Emitter {
     fn new() -> Self {
-        Self { app_id: env::var("PLEXI_APP_ID").unwrap_or_default() }
+        Self {
+            app_id: env::var("PLEXI_APP_ID").unwrap_or_default(),
+            stdin: BufReader::new(io::stdin()),
+            pending_events: VecDeque::new(),
+        }
     }
 
     /// The app id this emitter was constructed with (from `PLEXI_APP_ID`).
@@ -497,6 +517,44 @@ impl Emitter {
     /// Change the linked terminal's working directory immediately.
     pub fn cd(&self, path: &str) {
         self.write(&DrawCommand::Cd { path: path.to_string() });
+    }
+
+    /// Fetch a secret by name from Plexi's Keychain-backed store.
+    ///
+    /// Resolution walks up from the app's launch directory to the user's
+    /// home, returning the first matching value. Returns `None` if the
+    /// secret is missing, Keychain is unavailable, or any other resolution
+    /// error occurred (the host logs the failure; the app should not crash
+    /// on a missing secret).
+    ///
+    /// Blocks until Plexi responds. Safe to call from any handler; any
+    /// unrelated events that arrive while waiting are queued and processed
+    /// by the main loop on its next iteration.
+    pub fn get_secret(&mut self, name: &str) -> Option<String> {
+        self.write(&DrawCommand::SecretGet { name: name.to_string() });
+
+        loop {
+            let mut line = String::new();
+            match self.stdin.read_line(&mut line) {
+                Ok(0) => return None, // stdin closed
+                Ok(_) => {}
+                Err(_) => return None,
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let event: PlexiEvent = match serde_json::from_str(trimmed) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            match event {
+                PlexiEvent::SecretResponse { name: resp_name, value } if resp_name == name => {
+                    return value;
+                }
+                other => self.pending_events.push_back(other),
+            }
+        }
     }
 
     /// Forward a log message to Plexi's logger (`error`|`warn`|`info`|`debug`).
@@ -1319,7 +1377,6 @@ fn render_min_size_fallback(width: f32, height: f32, min_w: f32, min_h: f32) {
 
 /// Start the Plexi event loop. Blocks until Plexi sends `Shutdown`.
 pub fn run(app: &mut dyn App) {
-    let stdin = io::stdin();
     let mut emitter = Emitter::new();
     let app_id = emitter.app_id().to_string();
 
@@ -1333,19 +1390,28 @@ pub fn run(app: &mut dyn App) {
         }
     };
 
-    for line in stdin.lock().lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => break,
-        };
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let event: PlexiEvent = match serde_json::from_str(line) {
-            Ok(e) => e,
-            Err(_) => continue,
+    loop {
+        // Drain any events that were queued by a blocking helper (e.g.
+        // `Emitter::get_secret`) during the previous handler. These were read
+        // off stdin while waiting for a specific response, so they need to be
+        // replayed here before pulling more.
+        let event = if let Some(e) = emitter.pending_events.pop_front() {
+            e
+        } else {
+            let mut line = String::new();
+            match emitter.stdin.read_line(&mut line) {
+                Ok(0) => break, // stdin closed
+                Ok(_) => {}
+                Err(_) => break,
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<PlexiEvent>(trimmed) {
+                Ok(e) => e,
+                Err(_) => continue,
+            }
         };
 
         match event {
@@ -1406,6 +1472,10 @@ pub fn run(app: &mut dyn App) {
             }
             PlexiEvent::SetState { user_state, derived, session, persistent } => {
                 app.on_set_state(&user_state, &derived, &session, &persistent);
+            }
+            PlexiEvent::SecretResponse { .. } => {
+                // Should normally be consumed by a blocking get_secret() call.
+                // A stray top-level response is silently dropped.
             }
             PlexiEvent::Shutdown => break,
         }

--- a/src/app_api.rs
+++ b/src/app_api.rs
@@ -23,6 +23,10 @@ pub enum ApiRequest {
     WriteFile { path: String, content: String },
     /// Store a secret in Keychain (scoped to app + directory). Requires secrets_write.
     SecretStore { key: String, value: String },
+    /// Retrieve a secret by name. Walks up from the app's launch directory to the
+    /// user's home directory, returning the first matching value. Returns
+    /// `ApiResponse::Secret { value: None }` if not found.
+    SecretGet { name: String },
     /// Request secure input from user (Plexi renders the masked field).
     SecureInput { prompt: String, mask: bool },
 }
@@ -35,6 +39,9 @@ pub enum ApiResponse {
     FileContent { content: String },
     WriteOk,
     SecretStored,
+    /// Response to a `SecretGet` request. `value` is `None` if the secret is
+    /// missing or resolution failed for any reason (e.g. Keychain error).
+    Secret { name: String, value: Option<String> },
     /// The secure input result comes asynchronously after user interaction.
     SecureInputPending { request_id: String },
     Error { message: String },
@@ -121,6 +128,7 @@ pub fn handle_api_request(
             }
             handle_secret_store(key, value, app_id, scope_root)
         }
+        ApiRequest::SecretGet { name } => handle_secret_get(name, app_id, scope_root),
         ApiRequest::SecureInput { prompt, mask } => handle_secure_input(prompt, *mask),
     }
 }
@@ -283,6 +291,19 @@ fn handle_secret_store(key: &str, value: &str, app_id: &str, scope_root: &Path) 
     }
 }
 
+/// Resolve a secret by walking up from the app's launch directory to home.
+/// Always returns `ApiResponse::Secret` — missing or error cases set `value: None`
+/// so the app can branch on a single shape without handling `Error` separately.
+fn handle_secret_get(name: &str, app_id: &str, scope_root: &Path) -> ApiResponse {
+    let dir_str = scope_root.display().to_string();
+    let value = crate::secrets::resolve_secret(name, app_id, &dir_str)
+        .map(|z| z.to_string());
+    ApiResponse::Secret {
+        name: name.to_string(),
+        value,
+    }
+}
+
 fn handle_secure_input(_prompt: &str, _mask: bool) -> ApiResponse {
     // Secure input is handled by the UI layer. We return a pending token;
     // the actual value is delivered asynchronously via a separate channel.
@@ -300,4 +321,57 @@ fn uuid_v4_simple() -> String {
     // Not cryptographically random, but sufficient for request correlation.
     // Replace with a proper UUID crate if one is already in the dependency tree.
     format!("{:016x}", nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_get_request_roundtrip() {
+        let req = ApiRequest::SecretGet { name: "OPENAI_API_KEY".into() };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"type\":\"secret_get\""));
+        assert!(json.contains("\"name\":\"OPENAI_API_KEY\""));
+        let decoded: ApiRequest = serde_json::from_str(&json).unwrap();
+        match decoded {
+            ApiRequest::SecretGet { name } => assert_eq!(name, "OPENAI_API_KEY"),
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn secret_response_roundtrip_some() {
+        let resp = ApiResponse::Secret {
+            name: "OPENAI_API_KEY".into(),
+            value: Some("sk-abc".into()),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"type\":\"secret\""));
+        let decoded: ApiResponse = serde_json::from_str(&json).unwrap();
+        match decoded {
+            ApiResponse::Secret { name, value } => {
+                assert_eq!(name, "OPENAI_API_KEY");
+                assert_eq!(value.as_deref(), Some("sk-abc"));
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn secret_response_roundtrip_none() {
+        let resp = ApiResponse::Secret {
+            name: "MISSING".into(),
+            value: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let decoded: ApiResponse = serde_json::from_str(&json).unwrap();
+        match decoded {
+            ApiResponse::Secret { name, value } => {
+                assert_eq!(name, "MISSING");
+                assert!(value.is_none());
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
 }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -102,6 +102,13 @@ pub enum PlexiEvent {
         #[serde(default)]
         persistent: serde_json::Value,
     },
+    /// Response to a prior `DrawCommand::SecretGet` request. The SDK's
+    /// `get_secret` helper reads stdin until it sees this event with a
+    /// matching `name`, stashing any other events that arrive in the
+    /// meantime so the main loop processes them on its next pass.
+    ///
+    /// `value` is `None` if the secret is missing or resolution failed.
+    SecretResponse { name: String, value: Option<String> },
     /// App is being closed. Process should exit.
     Shutdown,
     /// A value arrived on a named pipe channel from another app.
@@ -395,6 +402,13 @@ pub enum DrawCommand {
     PipeSubscribe {
         channel: String,
     },
+    /// Request a secret by name. Plexi resolves against the Keychain, walking
+    /// up from the app's launch directory to home, and sends the result back
+    /// as a `PlexiEvent::SecretResponse` with the same `name`.
+    ///
+    /// Missing secrets and resolution failures both return `value: None` — the
+    /// SDK should not crash the app on a failed lookup.
+    SecretGet { name: String },
     /// End of frame — Plexi will render everything queued since last FrameDone.
     FrameDone,
 }

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -24,6 +24,9 @@ pub struct ProcessApp {
     type_id: String,
     display_name: String,
     accepted_exts: Vec<String>,
+    /// Directory the app was launched in — used as the scope root for secret
+    /// resolution (walk-up search from this directory to $HOME).
+    scope_root: PathBuf,
     process: Option<Child>,
     stdin: Option<ChildStdin>,
     /// Receives draw commands from the subprocess on a background thread.
@@ -246,6 +249,7 @@ impl ProcessApp {
             type_id,
             display_name,
             accepted_exts,
+            scope_root: cwd.clone(),
             process: Some(child),
             stdin: Some(stdin),
             draw_rx: Some(draw_rx),
@@ -844,7 +848,7 @@ impl ProcessApp {
 
                 // RunInTerminal / Cd / Log / State / CostReport / Notification /
                 // SetCursor / MouseTracking / SpawnApp / PipeWrite / PipeSubscribe /
-                // FrameDone handled at the App trait level, not here.
+                // SecretGet / FrameDone handled at the App trait level, not here.
                 DrawCommand::RunInTerminal { .. }
                 | DrawCommand::Cd { .. }
                 | DrawCommand::Log { .. }
@@ -856,6 +860,7 @@ impl ProcessApp {
                 | DrawCommand::SpawnApp { .. }
                 | DrawCommand::PipeWrite { .. }
                 | DrawCommand::PipeSubscribe { .. }
+                | DrawCommand::SecretGet { .. }
                 | DrawCommand::FrameDone => {}
             }
         }
@@ -1292,6 +1297,18 @@ impl App for ProcessApp {
                 }
                 DrawCommand::PipeSubscribe { channel: _ } => {
                     // Phase 0 no-op: silently consume. Forward-compat only.
+                }
+                DrawCommand::SecretGet { name } => {
+                    // Resolve against the Keychain, walking up from the app's launch
+                    // directory. Missing secrets and any failure return None — the
+                    // SDK's get_secret() turns that into Python None / Rust Option::None.
+                    let dir_str = self.scope_root.display().to_string();
+                    let value = crate::secrets::resolve_secret(&name, &self.type_id, &dir_str)
+                        .map(|z| z.to_string());
+                    self.send_event(&PlexiEvent::SecretResponse {
+                        name: name.clone(),
+                        value,
+                    });
                 }
                 other => self.pending_frame.push(other),
             }


### PR DESCRIPTION
## Summary

Ships the `SecretGet` app API request end-to-end so external apps can fetch secrets from Plexi's Keychain-backed store instead of relying on environment variables. This unblocks the Parallax `SecretGet` integration (the last pending item in Layer 3) and is a prerequisite for the eventual Intelligence Gateway where Plexi owns API keys on behalf of apps — the design that was deferred under the working name of an "intelligence protocol" for exactly this purpose.

## New API surface

**Wire protocol (`src/app_protocol.rs`):**
- `DrawCommand::SecretGet { name }` — outbound, app to Plexi. First request/response command on the existing stdio channel.
- `PlexiEvent::SecretResponse { name, value }` — inbound, Plexi to app. `value: None` for missing secrets or any resolution failure.

**Structured API (`src/app_api.rs`, kept in parity with the wire types):**
- `ApiRequest::SecretGet { name: String }`
- `ApiResponse::Secret { name: String, value: Option<String> }` — echoes `name` so SDKs can correlate.

**Host (`src/process_app.rs`):**
- `ProcessApp` now stores its launch `cwd` as `scope_root`.
- Drain loop handles `SecretGet` by calling `secrets::resolve_secret(name, type_id, scope_root)` and writing a `PlexiEvent::SecretResponse` back via `send_event`.
- Missing secrets and any Keychain/filesystem failure return `value: None` without crashing the app (fail quiet, host logs the warning).

## SDK methods added

**Python (`sdk/python/plexi_sdk.py`):**
- `Emitter.get_secret(name: str) -> Optional[str]`
- `RenderContext.get_secret(name: str) -> Optional[str]`

The Emitter now carries a shared `pending_events` deque. `get_secret` fires the request then blocks on `sys.stdin.readline()` until it sees a `secret_response` with a matching `name`. Any unrelated events read off stdin while waiting are stashed in the deque; `App.run()` drains the deque at the top of each loop iteration before reading more stdin, so nothing is lost and handlers remain synchronous.

**Rust (`sdk/rust/src/lib.rs`, bumped to 0.2.0):**
- `Emitter::get_secret(&mut self, name: &str) -> Option<String>`

This is the first `stdin`-reading helper in the Rust SDK. `Emitter` was refactored from a unit struct to own a `BufReader<Stdin>` and a `VecDeque<PlexiEvent>`. `run()` now reads events via the Emitter so the two share a single stdin source. Future request/response helpers follow the same pattern.

## Tests

- `src/app_api.rs`: three serde round-trip unit tests for the new variants (`secret_get` request, `secret` response with `Some` value, `secret` response with `None`). All 18 existing Rust tests continue to pass.
- Python SDK: manually verified via in-process round-trip (simulated stdin with `secret_response` and interleaved `key` events) — confirmed both the happy path and the `None` path, and confirmed that stashed events are replayed to the main loop.
- `cargo test` green, `cargo build` green, `just install-alpha` green.

## Notes

- The task brief referenced mirroring an existing `cost_report` / `spawn_app` request/response pattern on the SDKs and a `scripts/sync-sdk.py` vendored-copy sync. Neither exists in this codebase yet — the SDKs previously had no synchronous request/response primitive, so this PR establishes that pattern. Only one vendored Python SDK copy (`examples/git-log/plexi_sdk.py`) exists and it is synced manually.
- `ApiRequest`/`ApiResponse` in `src/app_api.rs` remain unused at runtime (they predate the `DrawCommand` wire protocol) but were kept in parity with the wire types so a future unification pass can converge them without reshuffling variants.

## Test plan

- [ ] Launch `just install-alpha`, open a test app that calls `emit.get_secret("TEST_KEY")` with `TEST_KEY` stored via `secrets_app` in the current directory, confirm the value round-trips.
- [ ] Confirm missing-secret case returns `None` in Python and `Option::None` in Rust without crashing the app.
- [ ] Integrate into Parallax to unblock the Layer 3 `SecretGet` path.