### PR TITLE
feat(notifications): urgency model, socket ingestion, action types, focus-pane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,34 @@ jobs:
           zip -r Plexi-${{ github.ref_name }}.zip Plexi.app
 
       - name: Create GitHub Release
+        id: create_release
         uses: softprops/action-gh-release@v2
         with:
           files: target/release/bundle/osx/Plexi-${{ github.ref_name }}.zip
           generate_release_notes: true
+
+      - name: Compute SHA256
+        id: sha256
+        run: |
+          sha=$(shasum -a 256 target/release/bundle/osx/Plexi-${{ github.ref_name }}.zip | awk '{print $1}')
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          version="${{ github.ref_name }}"
+          version="${version#v}"   # strip leading 'v'
+          sha="${{ steps.sha256.outputs.sha256 }}"
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ianjamesburke/homebrew-plexi.git" tap
+          cd tap
+
+          sed -i '' "s/version \".*\"/version \"${version}\"/" Casks/plexi.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${sha}\"/" Casks/plexi.rb
+
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+          git add Casks/plexi.rb
+          git commit -m "chore: update cask to v${version}"
+          git push

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,49 @@
+# Plexi Vision
+
+> All the beauty of technology in one piece of software.
+
+## The Foundational Claim
+
+Every piece of software ever built was designed for humans to operate directly. AI has been grafted onto that assumption — chat boxes appended to CRMs, "AI features" bolted onto word processors, recommendation engines bolted onto search. This is e-commerce duct-taped to a physical storefront.
+
+The internet didn't improve retail. It created Amazon. Businesses that won the internet age weren't businesses that added e-commerce to their existing model — they were internet-native businesses that completely reimagined what business could be on the new substrate. The businesses that lost were the ones that duct-taped a website to their physical operation.
+
+We are in that moment now, with agents.
+
+The right move is not to add AI to software designed for humans. It is to reimagine what software is when agents are first-class users of it — and build that from scratch.
+
+**Plexi is that reimagination.**
+
+## What This Means
+
+Plexi is the first agent-native computing environment. A terminal multiplexer in form. A new substrate in function.
+
+An app in Plexi is not a UI. It is a **capability** — something that can be used by a human, an agent, or both simultaneously, through the same install, with the same permissions, on the same protocol.
+
+The human is not removed from the loop. They are elevated above it.
+
+You see what you need to see. You say what you want. Plexi does it. When it's ambiguous, it asks. When it needs permission, it shows you exactly what it's about to do and waits for you.
+
+## The Non-Negotiables
+
+**Agent-native first, human-friendly always.**
+Every capability must be invokable by an agent. The UI is the human face of a capability, not the capability itself.
+
+**One install, three interfaces.**
+A single app directory is a UI, a skill, and potentially an agent. Nothing is duplicated.
+
+**The permission model is the product.**
+Every capability declared, every permission granted, every LLM call logged. Not as friction — as legibility.
+
+**PGAP is the only path to intelligence.**
+No app calls Anthropic directly. No agent makes uncounted LLM calls. Everything routes through PGAP.
+
+**Beautiful is not cosmetic.**
+The draw protocol enforces discipline. If something looks bad, fixing it means improving the capability.
+
+**Directory is the permission boundary.**
+When you launch Plexi inside a directory, everything installed, spawned, or agentic within that scope is provably incapable of reaching anything outside it. Parent directories, sibling projects, and the wider filesystem are invisible by construction — not by convention, not by policy, not by "we promise." A subdirectory Plexi is a sealed box, and the seal is the product.
+
+---
+
+*This file is the source of truth for Plexi's foundational vision. Do not paraphrase it in other documents — reference it directly. The north star compass lives at `~/.agents/skills/plexi-north-star/SKILL.md` and builds on this foundation.*

--- a/examples/apiary/plexi_sdk.py
+++ b/examples/apiary/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/app-store/plexi_sdk.py
+++ b/examples/app-store/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/aquarium/plexi_sdk.py
+++ b/examples/aquarium/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/backlog-triage/plexi_sdk.py
+++ b/examples/backlog-triage/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/calc/plexi_sdk.py
+++ b/examples/calc/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/clipboard-stack/plexi_sdk.py
+++ b/examples/clipboard-stack/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/color-palette/plexi_sdk.py
+++ b/examples/color-palette/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/diff-viewer/plexi_sdk.py
+++ b/examples/diff-viewer/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/git-blame/plexi_sdk.py
+++ b/examples/git-blame/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/git-log/plexi_sdk.py
+++ b/examples/git-log/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/github-issues/plexi_sdk.py
+++ b/examples/github-issues/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/hacker-news/plexi_sdk.py
+++ b/examples/hacker-news/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/hello-app/plexi_sdk.py
+++ b/examples/hello-app/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/json-viewer/plexi_sdk.py
+++ b/examples/json-viewer/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/learn-plexi/plexi_sdk.py
+++ b/examples/learn-plexi/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/lichen/plexi_sdk.py
+++ b/examples/lichen/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/markdown-preview/plexi_sdk.py
+++ b/examples/markdown-preview/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/mermaid-viewer/plexi_sdk.py
+++ b/examples/mermaid-viewer/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/navigator/plexi_sdk.py
+++ b/examples/navigator/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/permissions-viewer/plexi_sdk.py
+++ b/examples/permissions-viewer/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/plexi-browser/plexi_sdk.py
+++ b/examples/plexi-browser/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/pomodoro/plexi_sdk.py
+++ b/examples/pomodoro/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/port-watcher/plexi_sdk.py
+++ b/examples/port-watcher/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/pulse/plexi_sdk.py
+++ b/examples/pulse/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/pyflow/plexi_sdk.py
+++ b/examples/pyflow/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/sandfall/plexi_sdk.py
+++ b/examples/sandfall/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/seedclock/plexi_sdk.py
+++ b/examples/seedclock/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/snake/plexi_sdk.py
+++ b/examples/snake/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/spiral-viewer/plexi_sdk.py
+++ b/examples/spiral-viewer/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/stopwatch/plexi_sdk.py
+++ b/examples/stopwatch/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/text-editor/plexi_sdk.py
+++ b/examples/text-editor/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/todo/plexi_sdk.py
+++ b/examples/todo/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/weather/plexi_sdk.py
+++ b/examples/weather/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/examples/wikipedia/plexi_sdk.py
+++ b/examples/wikipedia/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -52,6 +52,8 @@ Cost reporting (for apps that call LLM APIs):
 """
 
 
+from __future__ import annotations
+
 __version__ = "0.3.0"
 
 import json
@@ -119,29 +121,55 @@ class Emitter:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }), flush=True)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification to Plexi's notification log.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+
+        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
+        increments the status-bar unread count, and appears in the
+        notification palette (Cmd+Shift+N).
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        print(json.dumps(cmd), flush=True)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification to Plexi's notification log.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        The notification is recorded to ~/.plexi-alpha/notifications.jsonl,
-        increments the status-bar unread count, and appears in the
-        notification palette (Cmd+Shift+N).
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        print(json.dumps(cmd), flush=True)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,
@@ -558,26 +586,51 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def notify(
+        self,
+        title: str,
+        body: Optional[str] = None,
+        urgency: str = "low",
+        action_type: str = "dismiss",
+        action_payload: Optional[dict] = None,
+        expires_at: Optional[int] = None,
+        visible_after: Optional[int] = None,
+    ):
+        """
+        Raise a notification from inside a render frame.
+
+        urgency: "low" | "medium" | "high"
+        action_type: "dismiss" | "focus" | "confirm" | "text_input"
+        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+        expires_at: unix timestamp (seconds); notification is dropped if already past
+        visible_after: unix timestamp (seconds); defer display until this time
+        """
+        cmd: dict = {
+            "type": "notification",
+            "title": title,
+            "source_app": self._app_id,
+            "urgency": urgency,
+            "action_type": action_type,
+        }
+        if body is not None:
+            cmd["body"] = body
+        if action_payload is not None:
+            cmd["action_payload"] = action_payload
+        if expires_at is not None:
+            cmd["expires_at"] = expires_at
+        if visible_after is not None:
+            cmd["visible_after"] = visible_after
+        self._commands.append(cmd)
+
     def notification(
         self,
         title: str,
         body: Optional[str] = None,
         priority: int = 1,
     ):
-        """
-        Raise a notification from inside a render frame.
-
-        Priority: 0 = info, 1 = normal, 2 = high, 3 = urgent.
-        """
-        cmd = {
-            "type": "notification",
-            "priority": priority,
-            "title": title,
-            "source_app": self._app_id,
-        }
-        if body:
-            cmd["body"] = body
-        self._commands.append(cmd)
+        """Deprecated: use notify() instead. Kept for backwards compatibility."""
+        urgency = {0: "low", 1: "low", 2: "medium", 3: "high"}.get(priority, "low")
+        self.notify(title=title, body=body, urgency=urgency)
 
     def spawn_app(
         self,

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,8 @@ pub struct PlexiApp {
     /// In-memory registry of every active parent → child pane spawn relationship.
     /// Drives cascade/orphan semantics when a pane closes.
     pub(crate) spawn_relationships: crate::app_protocol::SpawnRelationships,
+    /// Receives notifications from the Unix socket listener thread.
+    pub(crate) notify_rx: Option<mpsc::Receiver<crate::notification_log::Notification>>,
 }
 
 impl PlexiApp {
@@ -68,6 +70,10 @@ impl PlexiApp {
         theme::setup_style(&cc.egui_ctx, &colors);
 
         let (tx, rx) = mpsc::channel();
+
+        // Start the Unix socket listener for external notification ingestion.
+        let (notify_tx, notify_rx_channel) = mpsc::channel::<crate::notification_log::Notification>();
+        crate::notify_socket::start(notify_tx);
 
         let cwd = std::env::current_dir().unwrap_or_default();
         let registry = AppRegistry::load(&cwd);
@@ -196,6 +202,7 @@ impl PlexiApp {
                     features: features.clone(),
                     media_cache: RefCell::new(MediaCache::new()),
                     spawn_relationships: crate::app_protocol::SpawnRelationships::new(),
+                    notify_rx: Some(notify_rx_channel),
                 };
             }
         }
@@ -248,6 +255,7 @@ impl PlexiApp {
             features,
             media_cache: RefCell::new(MediaCache::new()),
             spawn_relationships: crate::app_protocol::SpawnRelationships::new(),
+            notify_rx: Some(notify_rx_channel),
         }
     }
 
@@ -443,6 +451,15 @@ pub(crate) fn shell_escape(s: &str) -> String {
 
 impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Drain notifications from the Unix socket listener.
+        if let Some(rx) = &self.notify_rx {
+            while let Ok(n) = rx.try_recv() {
+                if let Ok(mut log) = crate::notification_log::global().lock() {
+                    log.push_from_socket(n);
+                }
+            }
+        }
+
         self.drain_pty_events();
         self.dispatch_app_key_events(ctx);
         self.sync_app_cwd();

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -35,6 +35,16 @@
 
 use serde::{Deserialize, Serialize};
 
+// ── Serde default helpers ─────────────────────────────────────────────────────
+
+fn notification_default_urgency() -> String {
+    "low".to_string()
+}
+
+fn notification_default_action_type() -> String {
+    "dismiss".to_string()
+}
+
 // ── Events sent FROM Plexi TO the app ────────────────────────────────────────
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -270,16 +280,29 @@ pub enum DrawCommand {
     /// Raise a notification. Plexi records it to the notification log,
     /// increments the status-bar unread count, and surfaces it in the
     /// notification palette (Cmd+Shift+N).
-    ///
-    /// Priorities: `0` = info, `1` = normal, `2` = high, `3` = urgent.
-    /// The MVP does not style by priority — the value is just logged.
     Notification {
-        priority: u8,
         title: String,
         #[serde(default)]
         body: Option<String>,
         /// The `app_id` of the emitter (e.g. `"parallax"`).
         source_app: String,
+        /// Urgency level: "low" | "medium" | "high". Defaults to "low".
+        #[serde(default = "notification_default_urgency")]
+        urgency: String,
+        /// Unix timestamp (seconds). Host drops the notification if this is
+        /// already past at ingestion time.
+        #[serde(default)]
+        expires_at: Option<i64>,
+        /// Unix timestamp (seconds). Defer rendering in the palette until then.
+        #[serde(default)]
+        visible_after: Option<i64>,
+        /// Action triggered when the user presses Enter on this notification.
+        /// "focus" | "confirm" | "text_input" | "dismiss" (default).
+        #[serde(default = "notification_default_action_type")]
+        action_type: String,
+        /// Type-dependent payload. For "focus": `{"pane_id": u64, "fullscreen": bool}`.
+        #[serde(default)]
+        action_payload: Option<serde_json::Value>,
     },
     /// Declare a drop target region. Stateless per frame: apps must re-emit
     /// this on every render frame for the drop zone to remain active.

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -66,9 +66,9 @@ impl PlexiApp {
             rank(a).cmp(&rank(b))
         });
 
-        // ── App entries (appended after panes) ─────────────────────────────
+        // ── App entries (appended after panes, sorted by MRU) ─────────────
         // Collect outside the borrow of self.registry to avoid borrow conflicts
-        let app_entries: Vec<(String, String, String)> = self
+        let mut app_entries: Vec<(String, String, String)> = self
             .registry
             .list()
             .into_iter()
@@ -80,6 +80,14 @@ impl PlexiApp {
             })
             .map(|app| (app.manifest.id.clone(), app.manifest.name.clone(), app.manifest.description.clone()))
             .collect();
+
+        // Sort by MRU: apps in visit history first (by recency), then alphabetical
+        let mru = &self.app_visit_history;
+        app_entries.sort_by(|(id_a, name_a, _), (id_b, name_b, _)| {
+            let rank_a = mru.iter().position(|s| s == id_a).unwrap_or(usize::MAX);
+            let rank_b = mru.iter().position(|s| s == id_b).unwrap_or(usize::MAX);
+            rank_a.cmp(&rank_b).then_with(|| name_a.cmp(name_b))
+        });
 
         for (id, name, description) in app_entries {
             entries.push(PaletteEntry::App { id, name, description });
@@ -191,9 +199,22 @@ impl PlexiApp {
                         let current_ctx = self.active_context;
                         let current_focused = self.contexts[self.active_context].focused_pane;
 
+                        // Fixed list height — never adjusts with content so the modal
+                        // stays the same size regardless of how many items are visible.
+                        let screen_h = ctx.screen_rect().height();
+                        let list_height = (screen_h * 0.60).max(320.0).min(screen_h - 200.0);
+
                         // Track whether we've drawn the Apps section header
                         let mut shown_apps_header = false;
                         let mut click_action: Option<Action> = None;
+                        let mut selected_rect: Option<egui::Rect> = None;
+
+                        let scroll_id = egui::Id::new("palette_scroll");
+                        egui::ScrollArea::vertical()
+                            .id_salt(scroll_id)
+                            .max_height(list_height)
+                            .min_scrolled_height(list_height)
+                            .show(ui, |ui| {
 
                         for (i, entry) in entries.iter().enumerate() {
                             let is_selected = i == self.palette_selected;
@@ -206,6 +227,7 @@ impl PlexiApp {
 
                                     let row_rect = Rect::from_min_size(ui.cursor().min, Vec2::new(MODAL_WIDTH, 36.0));
                                     ui.painter().rect_filled(row_rect, CornerRadius::same(4), fill);
+                                    if is_selected { selected_rect = Some(row_rect); }
 
                                     ui.allocate_ui_with_layout(
                                         Vec2::new(MODAL_WIDTH, 36.0),
@@ -246,6 +268,7 @@ impl PlexiApp {
                                     let fill = if is_selected { self.colors.bg_active } else { Color32::TRANSPARENT };
                                     let row_rect = Rect::from_min_size(ui.cursor().min, Vec2::new(MODAL_WIDTH, 36.0));
                                     ui.painter().rect_filled(row_rect, CornerRadius::same(4), fill);
+                                    if is_selected { selected_rect = Some(row_rect); }
 
                                     ui.allocate_ui_with_layout(
                                         Vec2::new(MODAL_WIDTH, 36.0),
@@ -275,6 +298,17 @@ impl PlexiApp {
                             }
                         }
 
+                        if entries.is_empty() {
+                            ui.label(RichText::new("No matching panes or apps").size(11.0).color(self.colors.text_dim));
+                        }
+
+                        }); // end ScrollArea
+
+                        // Scroll to keep selected row visible
+                        if let Some(rect) = selected_rect {
+                            ui.scroll_to_rect(rect, None);
+                        }
+
                         if let Some(act) = click_action {
                             match act {
                                 Action::JumpPane(ctx_idx, tile_id) => {
@@ -292,10 +326,6 @@ impl PlexiApp {
                                     self.launch_app_by_id(&id);
                                 }
                             }
-                        }
-
-                        if entries.is_empty() {
-                            ui.label(RichText::new("No matching panes or apps").size(11.0).color(self.colors.text_dim));
                         }
                     });
             });

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -283,7 +283,12 @@ impl PlexiApp {
                                                     ui.label(RichText::new(name).size(12.0).color(self.colors.text_primary));
                                                 });
                                                 if !description.is_empty() {
-                                                    ui.label(RichText::new(description).size(9.0).color(self.colors.text_dim));
+                                                    let desc = if description.len() > 58 {
+                                                        format!("{}…", &description[..58])
+                                                    } else {
+                                                        description.clone()
+                                                    };
+                                                    ui.label(RichText::new(desc).size(9.0).color(self.colors.text_dim));
                                                 }
                                             });
                                         },

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,54 @@ impl PlexiConfig {
     }
 }
 
+// ── App MRU persistence ───────────────────────────────────────────────────────
+
+/// Load the app visit history from `app_mru.json` in the config directory.
+/// Returns an empty list if the file doesn't exist or can't be parsed.
+pub fn load_app_mru() -> Vec<String> {
+    let path = config_dir().join("app_mru.json");
+    let data = match std::fs::read_to_string(&path) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+    serde_json::from_str(&data).unwrap_or_default()
+}
+
+/// Persist the app visit history to `app_mru.json` in the config directory.
+/// Silently ignores errors (best-effort persistence).
+pub fn save_app_mru(history: &[String]) {
+    let path = config_dir().join("app_mru.json");
+    if let Ok(json) = serde_json::to_string(history) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+// ── Window size persistence ───────────────────────────────────────────────────
+
+/// Persist the window size to `window.json` in the config directory.
+/// Silently ignores errors (best-effort persistence).
+pub fn save_window_size(w: f32, h: f32) {
+    let path = config_dir().join("window.json");
+    let json = format!("{{\"width\":{w},\"height\":{h}}}");
+    let _ = std::fs::write(path, json);
+}
+
+/// Load the persisted window size from `window.json`.
+/// Returns `None` if the file doesn't exist, can't be parsed, or has
+/// unreasonable dimensions (< 400 or > 8000 in either axis).
+pub fn load_window_size() -> Option<(f32, f32)> {
+    let path = config_dir().join("window.json");
+    let data = std::fs::read_to_string(&path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&data).ok()?;
+    let w = v["width"].as_f64()? as f32;
+    let h = v["height"].as_f64()? as f32;
+    if (400.0..=8000.0).contains(&w) && (300.0..=8000.0).contains(&h) {
+        Some((w, h))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ mod notification_log;
 #[cfg(not(target_arch = "wasm32"))]
 mod notification_palette;
 #[cfg(not(target_arch = "wasm32"))]
+mod notify_socket;
+#[cfg(not(target_arch = "wasm32"))]
 mod keys;
 #[cfg(not(target_arch = "wasm32"))]
 mod media_cache;

--- a/src/notification_log.rs
+++ b/src/notification_log.rs
@@ -19,6 +19,14 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
+fn default_urgency() -> String {
+    "low".to_string()
+}
+
+fn default_action_type() -> String {
+    "dismiss".to_string()
+}
+
 /// A notification record.
 ///
 /// `timestamp` is UTC; `read` defaults to false and flips when the user clicks
@@ -28,13 +36,33 @@ use std::sync::{Mutex, OnceLock};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Notification {
     pub timestamp: chrono::DateTime<chrono::Utc>,
-    pub priority: u8,
     pub title: String,
     #[serde(default)]
     pub body: Option<String>,
     pub source_app: String,
     #[serde(default)]
     pub read: bool,
+    /// Urgency level: "low" | "medium" | "high". Replaces the old `priority: u8`.
+    #[serde(default = "default_urgency")]
+    pub urgency: String,
+    /// Unix timestamp (seconds). If set and already past, the notification is
+    /// dropped on ingestion.
+    #[serde(default)]
+    pub expires_at: Option<i64>,
+    /// Unix timestamp (seconds). Defer rendering until this time has passed.
+    #[serde(default)]
+    pub visible_after: Option<i64>,
+    /// Action triggered when the user presses Enter on this notification.
+    /// Values: "focus" | "confirm" | "text_input" | "dismiss".
+    #[serde(default = "default_action_type")]
+    pub action_type: String,
+    /// Type-dependent payload for `action_type`.
+    /// For "focus": `{"pane_id": u64, "fullscreen": bool}`.
+    #[serde(default)]
+    pub action_payload: Option<serde_json::Value>,
+    /// Who emitted this notification: "app:<id>", "claude-code", "socket", etc.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 /// In-memory + on-disk notification log.
@@ -74,15 +102,30 @@ impl NotificationLog {
     }
 
     /// Append a new notification to memory and to the JSONL log on disk.
+    /// Drops the notification silently if `expires_at` is set and already past.
     pub fn append(&mut self, n: Notification) {
+        if let Some(exp) = n.expires_at {
+            if exp < chrono::Utc::now().timestamp() {
+                log::debug!(
+                    "NotificationLog: dropping expired notification \"{}\" (expires_at={exp})",
+                    n.title
+                );
+                return;
+            }
+        }
         if let Err(e) = self.append_to_disk(&n) {
             log::warn!("NotificationLog: failed to write notifications.jsonl: {e}");
         }
         log::info!(
             "notification from {}: [{}] {}",
-            n.source_app, n.priority, n.title
+            n.source_app, n.urgency, n.title
         );
         self.notifications.push(n);
+    }
+
+    /// Append a notification received from the Unix socket listener.
+    pub fn push_from_socket(&mut self, n: Notification) {
+        self.append(n);
     }
 
     /// Number of unread notifications currently in the log.
@@ -139,14 +182,29 @@ pub fn global() -> &'static Mutex<NotificationLog> {
 
 /// Record a notification into the global log. Convenience wrapper that
 /// acquires the mutex and builds the `Notification` struct.
-pub fn record(priority: u8, title: String, body: Option<String>, source_app: String) {
+pub fn record(
+    title: String,
+    body: Option<String>,
+    source_app: String,
+    urgency: String,
+    expires_at: Option<i64>,
+    visible_after: Option<i64>,
+    action_type: String,
+    action_payload: Option<serde_json::Value>,
+    source: Option<String>,
+) {
     let n = Notification {
         timestamp: chrono::Utc::now(),
-        priority,
         title,
         body,
         source_app,
         read: false,
+        urgency,
+        expires_at,
+        visible_after,
+        action_type,
+        action_payload,
+        source,
     };
     match global().lock() {
         Ok(mut log) => log.append(n),

--- a/src/notification_palette.rs
+++ b/src/notification_palette.rs
@@ -42,6 +42,9 @@ impl PlexiApp {
             Close,
             MarkReadAt(usize),
             MarkAllRead,
+            /// Enter pressed: dispatch based on the selected notification's
+            /// `action_type`, then mark it read and close.
+            ActivateSelected,
         }
         let mut action: Option<Action> = None;
 
@@ -60,11 +63,13 @@ impl PlexiApp {
             {
                 self.notification_palette_selected -= 1;
             }
-            // Enter / Delete / Backspace — mark the selected row read. The MVP
-            // collapses open/dismiss into one action (mark read); Enter also
-            // focuses the source pane if the emitting app happens to be open.
-            let want_mark = input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
-                || input.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
+            // Enter → dispatch action_type; Delete/Backspace → mark read only.
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+                && self.notification_palette_selected < total
+            {
+                action = Some(Action::ActivateSelected);
+            }
+            let want_mark = input.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
                 || input.consume_key(egui::Modifiers::NONE, egui::Key::Backspace);
             if want_mark && self.notification_palette_selected < total {
                 let (log_idx, _) = ordered[self.notification_palette_selected];
@@ -151,15 +156,14 @@ impl PlexiApp {
                                     );
                                     ui.painter().rect_filled(row_rect, CornerRadius::same(4), fill);
 
-                                    // Priority / read dot — small circle left-side.
+                                    // Urgency / read dot — small circle left-side.
                                     let dot_color = if n.read {
                                         self.colors.text_section
                                     } else {
-                                        match n.priority {
-                                            0 => self.colors.text_dim,
-                                            1 => self.colors.accent,
-                                            2 => Color32::from_rgb(0xf9, 0xc8, 0x6a),
-                                            _ => Color32::from_rgb(0xdd, 0x77, 0x55),
+                                        match n.urgency.as_str() {
+                                            "high" => Color32::from_rgb(0xdd, 0x77, 0x55),
+                                            "medium" => Color32::from_rgb(0xf9, 0xc8, 0x6a),
+                                            _ => self.colors.text_dim, // "low" or unknown
                                         }
                                     };
                                     ui.painter().circle_filled(
@@ -245,6 +249,37 @@ impl PlexiApp {
             Some(Action::MarkAllRead) => {
                 if let Ok(mut log) = notification_log::global().lock() {
                     log.mark_all_read();
+                }
+            }
+            Some(Action::ActivateSelected) => {
+                if self.notification_palette_selected < total {
+                    let (log_idx, ref n) = ordered[self.notification_palette_selected];
+                    match n.action_type.as_str() {
+                        "focus" => {
+                            // Payload: {"pane_id": u64, "fullscreen": bool}
+                            let pane_id = n
+                                .action_payload
+                                .as_ref()
+                                .and_then(|p| p.get("pane_id"))
+                                .and_then(|v| v.as_u64());
+                            let fullscreen = n
+                                .action_payload
+                                .as_ref()
+                                .and_then(|p| p.get("fullscreen"))
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            if let Some(pid) = pane_id {
+                                self.focus_pane_by_id(pid, fullscreen);
+                            }
+                        }
+                        // "confirm" and "text_input" degrade to mark-read + close
+                        // until inline sub-prompt UI is implemented.
+                        _ => {}
+                    }
+                    if let Ok(mut log) = notification_log::global().lock() {
+                        log.mark_read(log_idx);
+                    }
+                    self.show_notification_palette = false;
                 }
             }
             None => {}

--- a/src/notify_socket.rs
+++ b/src/notify_socket.rs
@@ -1,0 +1,81 @@
+//! Unix socket listener for external notification ingestion.
+//!
+//! External processes (Claude Code hooks, scripts) write a JSON `Notification`
+//! payload to `~/.plexi-alpha/notify.sock` (or `~/.plexi/notify.sock` on
+//! stable) and disconnect. Plexi appends each received notification to the
+//! global `NotificationLog`.
+//!
+//! The socket is line-oriented: each connection may send one or more
+//! newline-terminated JSON objects. Empty lines are ignored.
+
+use std::io::{BufRead, BufReader};
+use std::os::unix::net::UnixListener;
+use std::sync::mpsc;
+
+use crate::notification_log::Notification;
+
+/// Spawn the socket listener thread. Returns immediately; the listener runs in
+/// the background. Notifications are sent to `tx` for the main thread to drain
+/// via `PlexiApp::notify_rx` in the egui update loop.
+pub fn start(tx: mpsc::Sender<Notification>) {
+    let sock_path = crate::config::config_dir().join("notify.sock");
+
+    // Remove a stale socket from a previous run so bind succeeds.
+    let _ = std::fs::remove_file(&sock_path);
+
+    std::thread::spawn(move || {
+        let listener = match UnixListener::bind(&sock_path) {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!(
+                    "notify_socket: failed to bind {}: {e}",
+                    sock_path.display()
+                );
+                return;
+            }
+        };
+        log::info!("notify_socket: listening at {}", sock_path.display());
+
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    let tx = tx.clone();
+                    std::thread::spawn(move || {
+                        let reader = BufReader::new(stream);
+                        for line in reader.lines() {
+                            match line {
+                                Ok(l) if !l.trim().is_empty() => {
+                                    match serde_json::from_str::<Notification>(&l) {
+                                        Ok(mut n) => {
+                                            // Default source to "socket" if the
+                                            // sender didn't set one.
+                                            if n.source.is_none() {
+                                                n.source = Some("socket".to_string());
+                                            }
+                                            if let Err(e) = tx.send(n) {
+                                                log::warn!(
+                                                    "notify_socket: channel closed: {e}"
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::warn!(
+                                                "notify_socket: malformed payload: {e}"
+                                            );
+                                        }
+                                    }
+                                }
+                                Ok(_) => {} // blank line
+                                Err(e) => {
+                                    log::warn!("notify_socket: read error: {e}");
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                }
+                Err(e) => log::warn!("notify_socket: accept error: {e}"),
+            }
+        }
+    });
+}

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -1299,4 +1299,22 @@ impl PlexiApp {
             }
         }
     }
+
+    /// Focus a pane by its `PaneId` (u64). Searches all contexts.
+    /// Optionally enters fullscreen (zoomed) mode on the target pane.
+    /// No-op if no pane with that id is found.
+    pub(crate) fn focus_pane_by_id(&mut self, pane_id: u64, fullscreen: bool) {
+        for ci in 0..self.contexts.len() {
+            if let Some(tile_id) = self.contexts[ci].tree.tiles.find_pane(&pane_id) {
+                self.active_context = ci;
+                self.contexts[ci].focused_pane = Some(tile_id);
+                if fullscreen {
+                    self.contexts[ci].zoomed_pane = Some(tile_id);
+                }
+                self.contexts[ci].activate_tab_for(tile_id);
+                return;
+            }
+        }
+        log::debug!("focus_pane_by_id: pane {pane_id} not found");
+    }
 }

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1205,7 +1205,16 @@ impl App for ProcessApp {
                         operation_id.as_deref(), timestamp.as_deref(),
                     );
                 }
-                DrawCommand::Notification { priority, title, body, source_app } => {
+                DrawCommand::Notification {
+                    title,
+                    body,
+                    source_app,
+                    urgency,
+                    expires_at,
+                    visible_after,
+                    action_type,
+                    action_payload,
+                } => {
                     // Trust the app's self-reported source_app if set, otherwise
                     // fall back to the ProcessApp's own type_id. This guards
                     // against apps that forget to populate the field.
@@ -1214,7 +1223,18 @@ impl App for ProcessApp {
                     } else {
                         source_app
                     };
-                    crate::notification_log::record(priority, title, body, src);
+                    let source_tag = format!("app:{}", self.type_id);
+                    crate::notification_log::record(
+                        title,
+                        body,
+                        src,
+                        urgency,
+                        expires_at,
+                        visible_after,
+                        action_type,
+                        action_payload,
+                        Some(source_tag),
+                    );
                 }
                 DrawCommand::SetCursor { cursor } => {
                     let icon = match cursor.as_str() {


### PR DESCRIPTION
## Summary

Extends the existing notification system with the full protocol spec from #218 and #219.

- **Urgency model**: replaces `priority: u8` with `urgency: String` (`"low"`/`"medium"`/`"high"`). Old `notifications.jsonl` records load safely via `#[serde(default)]`.
- **New fields**: `expires_at`, `visible_after`, `action_type`, `action_payload`, `source` — all with serde defaults for backwards compat
- **Unix socket ingestion** (`src/notify_socket.rs`): listens at `~/.plexi-alpha/notify.sock` — any process (Claude Code hooks, scripts) can push JSON notifications without a draw pipe
- **Enter-key dispatch** in notification palette: `"focus"` navigates to pane by ID (optionally fullscreen); `"confirm"`/`"text_input"` degrade to mark-read+close
- **`focus_pane_by_id()`** on `PlexiApp`: searches all contexts, sets `focused_pane` + optionally `zoomed_pane`, activates tab
- **Python SDK**: `notify()` extended on both `Emitter` and `RenderContext`; all 34 vendored copies synced
- **Release workflow**: SHA256 computation step + homebrew tap auto-update after GitHub release upload

## Test plan
- [ ] `cargo build --release` — 0 errors
- [ ] `echo '{"title":"test","urgency":"high","source_app":"test","action_type":"dismiss"}' | nc -U ~/.plexi-alpha/notify.sock` — appears in Cmd+Shift+N palette
- [ ] Enter on a notification with `action_type: "dismiss"` — marks read, closes
- [ ] Old `notifications.jsonl` with `priority` field still loads without errors

## Related
Closes #218, references #219, #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)