### PR TITLE
fix(file-browser): default to 75% upper split on launch (#237)

### DIFF
--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -781,6 +781,15 @@ impl PlexiApp {
         // Built-in file browser gets full permissions.
         let perms = crate::app_permissions::AppPermissions::builtin();
         self.open_app_on_focused(app, perms, cwd);
+
+        // Pin file browser to a 75% upper split (companion = 25%). See #237.
+        if let Some((_id, pane)) = self.contexts[self.active_context].focused_pane_mut() {
+            if let crate::app_trait::SurfaceMode::AppWithCompanion { ref mut companion_fraction } =
+                pane.surface_mode
+            {
+                *companion_fraction = 0.25;
+            }
+        }
     }
 
     /// Open an app on the focused pane WITHOUT creating a linked terminal split.


### PR DESCRIPTION
## Summary

Pin the built-in file browser to a 75% upper split (app = 75%, companion terminal = 25%) at the `open_file_browser` launch site so it lands deterministically regardless of future drift in `DEFAULT_COMPANION_FRACTION` or unrelated manifest defaults.

## Scenario

**C (narrow variant).** The file browser is a built-in Rust app (`src/file_browser/mod.rs`) with no manifest — Scenario A/B (manifest field) don't apply. The only launch site is `PlexiApp::open_file_browser` in `src/pane_ops.rs`, so the fix is scoped to that single function.

## Change

`src/pane_ops.rs` — 9 lines added after `open_app_on_focused` in `open_file_browser`. After the app is embedded, we look up the focused pane and, if its `SurfaceMode` is `AppWithCompanion`, overwrite `companion_fraction` to `0.25`. No other app launch path is touched.

```rust
// Pin file browser to a 75% upper split (companion = 25%). See #237.
if let Some((_id, pane)) = self.contexts[self.active_context].focused_pane_mut() {
    if let crate::app_trait::SurfaceMode::AppWithCompanion { ref mut companion_fraction } =
        pane.surface_mode
    {
        *companion_fraction = 0.25;
    }
}
```

## Test plan

- [ ] Launch the file browser from a blank Plexi window — verify it takes the top 75% with the terminal at the bottom 25%.
- [ ] Launch the file browser from a pane that already has a terminal with history — verify the terminal is preserved and now occupies the bottom 25%.
- [ ] Open wikipedia / git-log — verify their split ratios are unchanged from current behavior.
- [ ] `cargo check` passes (confirmed locally — 42 unrelated warnings, no errors).

Closes #237