### PR TITLE
feat(v2.1): UI primitives — PushTransform, MeasureText, viewport/text_input/tabs/grid/modal

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,47 @@
+# Plexi Specs — Index
+
+Single source of truth for where every spec lives. Start here for any spec question.
+
+---
+
+## Releases
+
+| File | Version | Status | Summary |
+|------|---------|--------|---------|
+| [`releases/plexi-v2.1.md`](releases/plexi-v2.1.md) | v2.1 | Implemented | UI primitives: PushTransform, MeasureText, viewport/text_input/tabs/grid/modal, feature negotiation |
+| [`releases/plexi-v2.2.md`](releases/plexi-v2.2.md) | v2.2 | Draft | Rich text, clip regions, multiline input, IME, input layering, PyPI SDK |
+| [`releases/plexi-v2.3.md`](releases/plexi-v2.3.md) | v2.3 | Draft (speculative) | Spatial canvas, node graph, video primitives, WASM/PWA target |
+
+---
+
+## Subsystems
+
+| File | Scope |
+|------|-------|
+| [`app-infrastructure.md`](app-infrastructure.md) | App registry, manifest format, launch lifecycle, pipe wires |
+
+---
+
+## Proposals
+
+Proposals live under `proposals/` and are promoted to release specs when scoped and accepted.
+
+| File | Topic | Target |
+|------|-------|--------|
+| `proposals/input-layering.md` | Key dispatch priority tiers | v2.2 §7.5 |
+| `proposals/spatial-canvas.md` | Infinite zoomable canvas | v2.3 §1 |
+| `proposals/wasm-pwa-deployment.md` | WASM/PWA build target | v2.3 §4 |
+| `proposals/media-primitives.md` | Video frame, waveform, playhead | v2.3 §3 |
+
+---
+
+## Feature → Spec mapping
+
+| Feature | Spec |
+|---------|------|
+| `core_v1` | v2.0 |
+| `open_intent_v1` | v2.0 |
+| `event_bus_v1` | v2.0 |
+| `runs_v1` | v2.0 |
+| `typed_pipes_v1` | v2.0 |
+| `ui_primitives_v1` | v2.1 |

--- a/docs/specs/releases/plexi-v2.1.md
+++ b/docs/specs/releases/plexi-v2.1.md
@@ -1,0 +1,146 @@
+# Plexi v2.1 — UI Primitives
+
+**Status:** Implemented  
+**Depends on:** v2.0 (orchestration layer, OpenIntent, Runs, event bus, typed pipes Phase 1)
+
+---
+
+## TL;DR
+
+v2.1 adds the drawing primitives apps need to build real UIs: a transform system for pan+zoom viewports, exact font measurement, and five high-level components (viewport, text_input, tabs, grid, modal). It also formalizes the feature negotiation contract so apps can declare what they need and the host can refuse gracefully.
+
+---
+
+## Scope
+
+**In v2.1:**
+- `PushTransform` / `PopTransform` draw commands with translate + scale support
+- `MeasureText` / `TextMetrics` round-trip for exact font measurement
+- `HOST_FEATURES` const + `[app.protocol] requires` manifest section for feature negotiation
+- Python SDK: `ctx.viewport`, `ctx.text_input`, `ctx.tabs`, `ctx.grid`, `ctx.modal`
+- Reference app: `mermaid-viewer` using `ctx.viewport` + `ctx.modal` + `ctx.tabs`
+
+**Out of scope (deferred to v2.2):**
+- Multi-line text editor primitive
+- IME composition support
+- Rich text runs (syntax highlighting)
+- Clip regions (`ClipRect` / `ResetClip`)
+- Input layering formalization
+- `plexi-sdk` on PyPI
+
+---
+
+## Why These Primitives
+
+The v2.0 drawing model (Rect, Text, Line, List) is sufficient for simple data-display apps but breaks down for anything with spatial content. A diagram viewer, a canvas editor, a map — all need a coordinate transform. Adding PushTransform/PopTransform as first-class protocol commands means apps don't need to implement their own matrix math for the common cases (zoom, pan, simple layouts).
+
+MeasureText closes the layout loop: apps can't position elements accurately without knowing how wide text will be. The blocking round-trip is acceptable because it's cached per-frame and rare in steady-state rendering.
+
+The five SDK components (viewport, text_input, tabs, grid, modal) aren't new protocol concepts — they're composition patterns built on existing draw commands. Shipping them in the SDK establishes conventions that all apps can reuse, rather than every app reimplementing tabs differently.
+
+---
+
+## §1 — Protocol: PushTransform / PopTransform
+
+```json
+{"type": "push_transform", "scale_x": 2.0, "scale_y": 2.0, "translate_x": 100, "translate_y": 50}
+{"type": "pop_transform"}
+```
+
+**Transform semantics:**
+- Transforms compose multiplicatively (push onto a stack).
+- On `FrameDone`, the stack is reset.
+- `rotate` is accepted but logged as a warning and skipped in v2.1 — reserved for v2.2.
+- `origin_x` / `origin_y` are accepted but unused in v2.1.
+
+**Host behavior:** Apply the current stack product to all coordinate values in subsequent draw commands until the matching `PopTransform`.
+
+---
+
+## §2 — Protocol: MeasureText / TextMetrics
+
+App sends:
+```json
+{"type": "measure_text", "request_id": 42, "text": "Hello", "size": 14.0, "monospace": false, "bold": false}
+```
+
+Host responds:
+```json
+{"type": "text_metrics", "request_id": 42, "width": 31.4, "height": 17.0, "ascent": 13.6}
+```
+
+The app must handle this as a synchronous blocking call — flush the current command buffer, send the request, then read stdin until the matching `request_id` reply arrives. See §5 for SDK implementation.
+
+---
+
+## §3 — Feature Negotiation
+
+Apps declare required host features in `manifest.toml`:
+
+```toml
+[app.protocol]
+requires = ["ui_primitives_v1"]
+```
+
+The host checks this at launch against `HOST_FEATURES`:
+```rust
+pub const HOST_FEATURES: &[&str] = &[
+    "core_v1", "open_intent_v1", "event_bus_v1",
+    "runs_v1", "typed_pipes_v1", "ui_primitives_v1",
+];
+```
+
+If any required feature is missing, the host refuses to launch the app and logs a clear error. Apps that don't declare `[app.protocol]` are always launched (backward compatible).
+
+**`ui_primitives_v1` covers:** PushTransform, PopTransform, MeasureText, TextMetrics.
+
+---
+
+## §4 — Rust Host Changes
+
+- `src/app_protocol.rs`: Added `PushTransform`, `PopTransform`, `MeasureText` to `DrawCommand`; added `TextMetrics` to `PlexiEvent`.
+- `src/process_app.rs`: Added inline transform stack to `render_draw_commands`; MeasureText resolved to TextMetrics event via egui font context.
+- `src/app_registry.rs`: Added `AppProtocolSection`, `HOST_FEATURES` const, launch-time feature check.
+
+---
+
+## §5 — Python SDK Changes (0.5.0)
+
+New dataclass: `TextMetrics(width, height, ascent)`
+
+New `RenderContext` methods:
+- `measure_text_exact(text, size, monospace, bold) → TextMetrics` — blocking, cached per-frame
+- `viewport(viewport_id, content_fn, zoom, pan, ...)` — push/pop transform around content_fn
+- `text_input(input_id, value, on_change, ...)` — single-line input with blinking cursor
+- `tabs(tab_id, tabs, selected, ...)` — tab bar with underline indicator
+- `grid(grid_id, cols, rows, render_cell, ...)` — uniform cell grid
+- `modal(modal_id, visible, content_fn, ...)` — centered modal with backdrop
+
+---
+
+## §6 — Reference App: mermaid-viewer
+
+Located at `examples/mermaid-viewer/`. Demonstrates:
+- `ctx.viewport` for pan+zoom diagram navigation
+- `ctx.tabs` for diagram/source switching
+- `ctx.modal` for help overlay and error display
+- Keyboard-driven zoom/pan (arrow keys, +/-, r to reset)
+- `[app.protocol] requires = ["ui_primitives_v1"]` manifest declaration
+
+---
+
+## §7 — Ship Order
+
+1. Protocol types (`app_protocol.rs`) — no behavior, just type definitions
+2. Host implementation (`process_app.rs`, `app_registry.rs`)
+3. SDK additions (`plexi_sdk.py`)
+4. Reference app (`mermaid-viewer`)
+5. Spec files (`plexi-v2.2.md`, `plexi-v2.3.md`)
+
+---
+
+## Cross-references
+
+- v2.0 spec: `docs/specs/releases/plexi-v2.0.md`
+- v2.2 spec (deferred): `docs/specs/releases/plexi-v2.2.md`
+- App infrastructure: `docs/specs/app-infrastructure.md`

--- a/docs/specs/releases/plexi-v2.2.md
+++ b/docs/specs/releases/plexi-v2.2.md
@@ -1,0 +1,157 @@
+# Plexi v2.2 — Rich Text & Input Maturity
+
+**Status:** Draft  
+**Depends on:** v2.1 (UI primitives — viewport, transforms, MeasureText)
+
+---
+
+## TL;DR
+
+v2.2 completes the text editing story: multi-line input, selection/cursor rendering, IME composition, and rich text runs for syntax highlighting. It adds clip regions for proper viewport clipping, formalizes the input layering contract, and ships `plexi-sdk` on PyPI.
+
+---
+
+## Scope
+
+**Planned for v2.2:**
+
+### Text editing primitives
+- `ctx.multiline_text_input(id, value, on_change, ...)` — multi-line text editor with line numbers, soft-wrap option, and configurable height
+- Selection primitive: cursor + selection range rendering (highlight rect + cursor beam)
+- IME composition support: forward `CompositionStart`, `CompositionUpdate`, `CompositionEnd` as protocol events
+- Rich text runs: `ctx.rich_text(x, y, runs)` where `runs` is a list of `{text, size, color, bold, monospace}` — needed for syntax highlighting without multiple overlapping `text()` calls
+
+### Clip regions
+- `DrawCommand::ClipRect { x, y, w, h }` — push a clip rectangle; all subsequent draw commands are clipped to this rect
+- `DrawCommand::ResetClip` — pop the clip rect
+- Required by viewport (content outside bounds leaks in v2.1), text_input (text overflows), and any scrollable container
+
+### Input layering contract (§7.5)
+Formalize `docs/specs/proposals/input-layering.md` as a normative spec section:
+- Priority tiers: system shortcuts > host chrome > focused app > background apps
+- Apps declare `input_priority: "foreground" | "background"` in manifest
+- Host guarantees exclusive key delivery to the foreground app; background apps get a filtered subset
+
+### Distribution
+- `plexi-sdk` Python package on PyPI (semver, `pip install plexi-sdk`)
+- Versioned alongside Plexi releases (0.5.x for v2.1, 0.6.x for v2.2)
+- `plexi_sdk.py` remains the canonical single-file copy-paste option for simple apps
+
+---
+
+## Why v2.2 and Not v2.1
+
+These features require deeper changes than v2.1:
+
+- **ClipRect** requires a stateful clipping layer in the renderer — it can't be emulated with transforms.
+- **IME** requires OS-level composition event routing that egui doesn't expose cleanly today. Needs investigation.
+- **Rich text runs** need a layout pass (wrapping, baseline alignment) that's separate from the simple `painter.text()` calls v2.1 uses.
+- **Input layering** is correct but wide-reaching — changing key dispatch semantics needs careful testing against all existing apps.
+- **PyPI packaging** is ops work (CI publishing, versioning, README) that doesn't block apps from shipping.
+
+Deferring keeps v2.1 shippable in one focused pass.
+
+---
+
+## §1 — Rich Text Runs
+
+```python
+ctx.rich_text(x=10, y=20, runs=[
+    {"text": "def ", "size": 13, "color": "#cba6f7", "bold": False, "monospace": True},
+    {"text": "hello", "size": 13, "color": "#89b4fa", "bold": False, "monospace": True},
+    {"text": "(name):", "size": 13, "color": "#cdd6f4", "bold": False, "monospace": True},
+])
+```
+
+Protocol: `DrawCommand::RichText { x, y, runs: Vec<TextRun> }` where `TextRun` mirrors the dict above.
+
+---
+
+## §2 — Clip Regions
+
+```json
+{"type": "clip_rect", "x": 0, "y": 36, "w": 800, "h": 400}
+// ... draw commands clipped to above rect ...
+{"type": "reset_clip"}
+```
+
+Stack-based like transforms. `reset_clip` pops the last pushed clip; the stack is reset on `FrameDone`.
+
+---
+
+## §3 — Multiline Text Input
+
+```python
+bounds = ctx.multiline_text_input(
+    "editor",
+    value=state["text"],
+    on_change=lambda v: state.update({"text": v}),
+    x=0, y=0, w=ctx.width, h=ctx.height - 40,
+    font_size=13.0,
+    line_numbers=True,
+    monospace=True,
+)
+```
+
+Handles its own scrolling. Returns bounding rect. Cursor position tracked in app state.
+
+---
+
+## §4 — IME Composition Events
+
+New `PlexiEvent` variants:
+```
+CompositionStart
+CompositionUpdate { text: String }
+CompositionEnd { text: String }
+```
+
+SDK: `@app.on_composition_update(text, emit)` handler.
+
+---
+
+## §5 — Input Layering Contract
+
+Normative rules for key event delivery:
+
+1. **System shortcuts** (macOS menu, Cmd+Q, Cmd+Tab) — consumed by OS, never reach Plexi.
+2. **Host chrome shortcuts** (Cmd+N, Cmd+W, Ctrl+/) — consumed by Plexi before any app sees them. Defined in `src/keys.rs`.
+3. **Foreground app** — receives all remaining key events first. Can consume via returning `true` from `handle_key`.
+4. **Background apps** — receive only non-consumed events if they have `input_priority = "background"` and the event type is in their `observes` list.
+
+Manifest declaration:
+```toml
+[app]
+input_priority = "foreground"  # default
+observes = ["key_events"]      # opt-in for background key observation
+```
+
+---
+
+## §6 — PyPI Distribution
+
+Package name: `plexi-sdk`  
+Import: `from plexi_sdk import App`  
+Versioning: `0.x.y` matching Plexi minor.patch (0.6.0 for v2.2)
+
+Single module (`plexi_sdk.py`) — no dependencies, no build step. `pip install plexi-sdk` is just a convenience wrapper around the same file.
+
+---
+
+## Ship Order
+
+1. ClipRect protocol + renderer
+2. Rich text runs protocol + renderer
+3. Multiline text input SDK component
+4. Selection + cursor rendering
+5. IME event routing (if egui API permits)
+6. Input layering contract finalization
+7. PyPI package setup + CI publish
+
+---
+
+## Cross-references
+
+- v2.1 spec: `docs/specs/releases/plexi-v2.1.md`
+- v2.3 spec: `docs/specs/releases/plexi-v2.3.md`
+- Input layering proposal: `docs/specs/proposals/input-layering.md`

--- a/docs/specs/releases/plexi-v2.3.md
+++ b/docs/specs/releases/plexi-v2.3.md
@@ -1,0 +1,121 @@
+# Plexi v2.3 — Spatial Canvas & Advanced Primitives
+
+**Status:** Draft (speculative)  
+**Depends on:** v2.2 (rich text, clip regions, input layering)
+
+---
+
+## TL;DR
+
+v2.3 introduces the spatial canvas primitive (infinite zoomable canvas with node placement), a node graph component (for flow editors and pipeline UIs), video/media primitives (frame seek, waveform), and WASM/PWA as a deployment target alongside native. These are ambitious features — v2.3 is a design anchor, not a committed release.
+
+---
+
+## Scope
+
+### Spatial canvas primitive
+A first-class infinite canvas where apps place nodes at arbitrary coordinates and Plexi handles viewport culling, pan/zoom physics, and hit-testing. Inspired by the `proposals/spatial-canvas.md` draft.
+
+Key design: apps describe a world-space node tree (`SpatialNode { id, x, y, w, h, content_fn }`); Plexi maps it to screen space and only calls `content_fn` for visible nodes. Apps receive click/hover events in world coordinates.
+
+### Node graph primitive
+`ctx.node_graph(id, nodes, edges, on_connect, on_move)` — renders a directed graph with drag-to-connect edges, node selection, and minimap. Built on top of the spatial canvas. Target use case: pyflow, pipeline editors, dependency viewers.
+
+### Video / media primitives
+- `ctx.video_frame(id, path, timestamp_ms)` — render a decoded video frame at a position. Plexi handles decode + cache.
+- `ctx.waveform(id, path, start_ms, end_ms, x, y, w, h, color)` — render an audio waveform strip.
+- `ctx.playhead(id, position_ms, duration_ms, on_seek, ...)` — timeline scrub bar.
+
+These unblock the Parallax video editor as a Plexi app rather than a separate process.
+
+### WASM / PWA deployment target
+Compile Plexi to WASM with a `wasm32-unknown-unknown` target. Apps still speak the same JSON protocol; instead of subprocess IPC, they run in a Web Worker and postMessage the draw commands.
+
+Implications:
+- External apps become JS/TS or WASM modules instead of Python executables
+- Python SDK stays for native; JS SDK needed for web
+- No PTY / shell integration in PWA mode
+- Useful for demos, public-facing tools, and Plexi Teams (shared canvases)
+
+---
+
+## Why These Are v2.3 and Not Earlier
+
+- **Spatial canvas** requires a scene graph abstraction that doesn't exist yet. Adding it on top of the flat draw-command model is a significant protocol extension.
+- **Node graph** depends on spatial canvas.
+- **Video primitives** require Plexi to own a decode pipeline (likely ffmpeg via subprocess or a Rust crate). Non-trivial dependency; isolated to a feature flag.
+- **WASM target** requires rethinking the subprocess model entirely. The protocol is designed to survive this (JSON over any transport), but the egui renderer needs a web backend (egui_web or iced).
+
+None of these block the v2.0–v2.2 feature set. They are deferred until the core is stable and at least one demanding app (Parallax, pyflow) validates the need.
+
+---
+
+## §1 — Spatial Canvas Protocol
+
+```json
+{"type": "canvas_begin", "world_x": -5000, "world_y": -5000, "world_w": 10000, "world_h": 10000}
+{"type": "canvas_node", "id": "node-1", "x": 100, "y": 200, "w": 160, "h": 80}
+// draw commands for this node (relative to node origin)
+{"type": "canvas_node_end"}
+{"type": "canvas_end"}
+```
+
+Host culls nodes outside the viewport (zoom + pan applied via the existing transform stack). Apps receive `CanvasClick { node_id, local_x, local_y }` and `CanvasDrag { node_id, dx, dy }` events.
+
+---
+
+## §2 — Node Graph Protocol
+
+```json
+{"type": "node_graph", "id": "pipeline", "nodes": [...], "edges": [...], "selected": ["node-2"]}
+```
+
+Node: `{id, x, y, w, h, title, inputs: [{id, label}], outputs: [{id, label}]}`  
+Edge: `{from_node, from_port, to_node, to_port}`
+
+Host renders all node chrome (ports, labels, selection highlight). Apps provide per-node content via a `render_node` callback.
+
+---
+
+## §3 — Video Primitives
+
+```python
+ctx.video_frame("clip-1", path="/tmp/clip.mp4", timestamp_ms=1250, x=0, y=0, w=320, h=180)
+ctx.waveform("audio-1", path="/tmp/audio.wav", start_ms=0, end_ms=10000,
+             x=0, y=200, w=800, h=40, color="#89b4fa")
+ctx.playhead("timeline", position_ms=1250, duration_ms=10000,
+             x=0, y=250, w=800, h=20, on_seek=lambda ms: state.update({"pos": ms}))
+```
+
+Protocol: new `DrawCommand` variants `VideoFrame`, `Waveform`, `Playhead`. Host manages decode threads and frame caches.
+
+---
+
+## §4 — WASM / PWA Deployment
+
+Target: `plexi-web` — a static site that loads a Plexi runtime in WASM and runs apps as Web Workers.
+
+App protocol is identical; transport changes from pipe to postMessage. Python apps don't run in this mode; JS/TS SDK needed.
+
+Feature flag: `cargo build --features wasm-target`. Native and web targets share all protocol types; only transport and renderer differ.
+
+---
+
+## Ship Order (tentative)
+
+1. Spatial canvas protocol design + reference implementation
+2. Node graph built on spatial canvas
+3. Video decode pipeline (feature-flagged)
+4. Waveform + playhead primitives
+5. WASM renderer investigation + prototype
+6. JS/TS SDK (mirrors Python SDK API)
+7. PWA packaging + deploy
+
+---
+
+## Cross-references
+
+- v2.2 spec: `docs/specs/releases/plexi-v2.2.md`
+- Spatial canvas proposal: `docs/specs/proposals/spatial-canvas.md`
+- WASM/PWA proposal: `docs/specs/proposals/wasm-pwa-deployment.md`
+- Media primitives proposal: `docs/specs/proposals/media-primitives.md`

--- a/examples/mermaid-viewer/main.py
+++ b/examples/mermaid-viewer/main.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+mermaid-viewer — v2.1 reference app for Plexi viewport, modal, and tabs primitives.
+
+Displays a Mermaid diagram file with pan+zoom viewport interaction.
+Demonstrates: ctx.viewport, ctx.modal, ctx.tabs, keyboard-driven zoom/pan.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# Allow running directly from examples/ dir by adding parent to path.
+_sdk_path = os.path.join(os.path.dirname(__file__), "..", "..", "sdk", "python")
+if os.path.isdir(_sdk_path):
+    sys.path.insert(0, _sdk_path)
+
+from plexi_sdk import App, RenderContext
+
+app = App()
+
+# ── State ──────────────────────────────────────────────────────────────────────
+state = {
+    "zoom": 1.0,
+    "pan_x": 0.0,
+    "pan_y": 0.0,
+    "file_path": None,
+    "file_content": "",
+    "active_tab": "diagram",   # "diagram" | "source"
+    "modal_visible": False,
+    "modal_message": "",
+}
+
+ZOOM_STEP = 0.15
+MIN_ZOOM = 0.2
+MAX_ZOOM = 5.0
+PAN_STEP = 30.0
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def load_file(path: str):
+    try:
+        with open(path, "r") as f:
+            state["file_content"] = f.read()
+        state["file_path"] = path
+    except OSError as e:
+        state["modal_message"] = f"Could not open file:\n{e}"
+        state["modal_visible"] = True
+
+
+def render_diagram_nodes(ctx: RenderContext):
+    """Render a simplified visual representation of the diagram content."""
+    content = state["file_content"]
+    lines = [l.strip() for l in content.splitlines() if l.strip()]
+    y = 20.0
+    for line in lines:
+        color = "#89b4fa" if "-->" in line else "#cdd6f4"
+        ctx.text(20, y, line, size=13.0, color=color, monospace=True)
+        y += 20.0
+
+
+def render_source_tab(ctx: RenderContext):
+    """Render raw source text."""
+    content = state["file_content"] or "(no file loaded)"
+    lines = content.splitlines()
+    y = 10.0
+    for line in lines:
+        ctx.text(10, y, line, size=12.0, color="#a6e3a1", monospace=True)
+        y += 16.0
+
+
+# ── Event handlers ─────────────────────────────────────────────────────────────
+
+@app.on_init
+def on_init(data, emit):
+    intent = data.get("open_intent")
+    if intent and intent.get("kind") == "file":
+        load_file(intent["path"])
+    elif len(sys.argv) > 1:
+        load_file(sys.argv[1])
+    else:
+        state["file_content"] = "graph TD\n    A[Start] --> B[Process]\n    B --> C{Decision}\n    C -->|Yes| D[Done]\n    C -->|No| B"
+
+
+@app.on_render
+def on_render(ctx: RenderContext):
+    # Background
+    ctx.rect(0, 0, ctx.width, ctx.height, fill="#1e1e2e")
+
+    # Tab bar
+    tabs_result = ctx.tabs(
+        "main-tabs",
+        [("diagram", "Diagram"), ("source", "Source")],
+        selected=state["active_tab"],
+        height=32,
+        x=0, y=0, w=ctx.width,
+    )
+    content_y = tabs_result["h"]
+    content_h = ctx.height - content_y
+
+    if state["active_tab"] == "diagram":
+        # Zoom indicator
+        zoom_text = f"zoom: {state['zoom']:.2f}x  pan: ({state['pan_x']:.0f}, {state['pan_y']:.0f})"
+        ctx.text(ctx.width - 200, content_y + 6, zoom_text, size=11.0, color="#6c7086")
+
+        # Help hint
+        ctx.text(8, content_y + 6, "+/- zoom  arrow keys pan  r reset  ? help", size=11.0, color="#6c7086")
+
+        # Viewport with zoom+pan
+        ctx.viewport(
+            "diagram-viewport",
+            render_diagram_nodes,
+            zoom=state["zoom"],
+            pan=(state["pan_x"], state["pan_y"]),
+            x=0, y=content_y + 24,
+            w=ctx.width, h=content_h - 24,
+            min_zoom=MIN_ZOOM, max_zoom=MAX_ZOOM,
+        )
+    else:
+        render_source_tab(ctx)
+
+    # Modal overlay (help or error)
+    def modal_content(ctx, mx, my, mw, mh):
+        ctx.text(mx + 16, my + 16, state["modal_message"], size=13.0, color="#cdd6f4")
+        ctx.text(mx + 16, my + mh - 28, "Press Esc or Enter to close", size=11.0, color="#6c7086")
+
+    ctx.modal(
+        "info-modal",
+        visible=state["modal_visible"],
+        content_fn=modal_content,
+        width=420, height=180,
+        backdrop_alpha=160,
+    )
+
+
+@app.on_key
+def on_key(key, mods, emit):
+    if state["modal_visible"]:
+        if key in ("Escape", "Enter"):
+            state["modal_visible"] = False
+        return
+
+    if key == "=" or key == "+":
+        state["zoom"] = min(MAX_ZOOM, state["zoom"] + ZOOM_STEP)
+    elif key == "-":
+        state["zoom"] = max(MIN_ZOOM, state["zoom"] - ZOOM_STEP)
+    elif key == "r":
+        state["zoom"] = 1.0
+        state["pan_x"] = 0.0
+        state["pan_y"] = 0.0
+    elif key == "ArrowLeft":
+        state["pan_x"] -= PAN_STEP
+    elif key == "ArrowRight":
+        state["pan_x"] += PAN_STEP
+    elif key == "ArrowUp":
+        state["pan_y"] -= PAN_STEP
+    elif key == "ArrowDown":
+        state["pan_y"] += PAN_STEP
+    elif key == "?" or (key == "/" and mods.get("shift")):
+        state["modal_message"] = "+/-  zoom in/out\narrow keys  pan\nr  reset zoom + pan\n1  fit to window\n? or Shift+/  this help"
+        state["modal_visible"] = True
+    elif key == "1":
+        state["zoom"] = 1.0
+        state["pan_x"] = 0.0
+        state["pan_y"] = 0.0
+    elif key == "Tab":
+        state["active_tab"] = "source" if state["active_tab"] == "diagram" else "diagram"
+
+
+@app.on_command
+def on_command(text, emit):
+    parts = text.strip().split(None, 1)
+    cmd = parts[0] if parts else ""
+    arg = parts[1] if len(parts) > 1 else ""
+    if cmd == "open" and arg:
+        load_file(arg)
+    elif cmd == "zoom" and arg:
+        try:
+            state["zoom"] = max(MIN_ZOOM, min(MAX_ZOOM, float(arg)))
+        except ValueError:
+            pass
+    elif cmd == "reset":
+        state["zoom"] = 1.0
+        state["pan_x"] = 0.0
+        state["pan_y"] = 0.0
+
+
+app.run()

--- a/examples/mermaid-viewer/manifest.toml
+++ b/examples/mermaid-viewer/manifest.toml
@@ -1,0 +1,13 @@
+[app]
+id = "mermaid-viewer"
+name = "Mermaid Viewer"
+entry = "main.py"
+version = "0.1.0"
+description = "View and explore Mermaid diagrams with pan+zoom (v2.1 reference app)"
+
+[app.capabilities]
+file_types = ["mmd", "mermaid"]
+filesystem = "read_only"
+
+[app.protocol]
+requires = ["ui_primitives_v1"]

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 plexi_sdk.py — Plexi external app SDK (Python)
 
@@ -27,14 +28,23 @@ Key handlers can emit terminal commands via the Emitter passed as the second arg
         if key == "Enter":
             emit.run_in_terminal("echo hello")
 
-SDK version: 0.4.0
-Protocol version: 2
+SDK version: 0.5.0
+Protocol version: 2 (v2.1 — ui_primitives_v1)
 """
 from __future__ import annotations
 
 import json
 import sys
+from dataclasses import dataclass
 from typing import Callable, Optional
+
+
+@dataclass
+class TextMetrics:
+    """Result of a MeasureText request — exact font metrics from Plexi."""
+    width: float
+    height: float
+    ascent: float
 
 
 class OpenIntent:
@@ -177,6 +187,9 @@ class RenderContext:
         self.width = width
         self.height = height
         self._commands: list = []
+        self._measure_cache: dict = {}
+        self._measure_req_id: int = 0
+        self._time: float = 0.0
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
         """Fill a rectangle."""
@@ -243,11 +256,183 @@ class RenderContext:
         """Log at debug level."""
         self.log("debug", message)
 
+    def measure_text_exact(self, text: str, size: float, monospace: bool = False, bold: bool = False) -> TextMetrics:
+        """
+        Request exact text measurement from Plexi. Blocking — waits for TextMetrics reply.
+        Results are cached per-frame (cache clears each frame).
+        """
+        cache_key = (text, size, monospace, bold)
+        if cache_key in self._measure_cache:
+            return self._measure_cache[cache_key]
+
+        self._measure_req_id += 1
+        req_id = self._measure_req_id
+
+        # Flush current commands first so measure request is sent in-band.
+        for cmd in self._commands:
+            print(json.dumps(cmd), flush=True)
+        self._commands.clear()
+
+        print(json.dumps({
+            "type": "measure_text",
+            "request_id": req_id,
+            "text": text,
+            "size": size,
+            "monospace": monospace,
+            "bold": bold,
+        }), flush=True)
+
+        # Read stdin until we get the matching TextMetrics reply.
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "text_metrics" and event.get("request_id") == req_id:
+                metrics = TextMetrics(
+                    width=event.get("width", 0.0),
+                    height=event.get("height", 0.0),
+                    ascent=event.get("ascent", 0.0),
+                )
+                self._measure_cache[cache_key] = metrics
+                return metrics
+
+        # Fallback if stdin closed (should not happen in normal operation).
+        return TextMetrics(width=size * len(text) * 0.6, height=size, ascent=size * 0.8)
+
+    def viewport(self, viewport_id: str, content_fn: Callable, zoom: float = 1.0,
+                 pan: Optional[tuple] = None, x: Optional[float] = None,
+                 y: Optional[float] = None, w: Optional[float] = None,
+                 h: Optional[float] = None, min_zoom: float = 0.1,
+                 max_zoom: float = 10.0, on_pan=None, on_zoom=None):
+        """
+        Render content inside a transformed viewport with zoom + pan.
+        content_fn receives this RenderContext.
+        """
+        zoom = max(min_zoom, min(max_zoom, zoom))
+        tx = pan[0] if pan else 0.0
+        ty = pan[1] if pan else 0.0
+        self._commands.append({
+            "type": "push_transform",
+            "scale_x": zoom,
+            "scale_y": zoom,
+            "translate_x": tx,
+            "translate_y": ty,
+        })
+        content_fn(self)
+        self._commands.append({"type": "pop_transform"})
+        return {"x": x or 0, "y": y or 0, "w": w or self.width, "h": h or self.height}
+
+    def text_input(self, input_id: str, value: str, on_change: Callable,
+                   cursor: Optional[int] = None, placeholder: Optional[str] = None,
+                   max_length: Optional[int] = None, size: Optional[float] = None,
+                   x: float = 0, y: float = 0, w: Optional[float] = None,
+                   bg: Optional[str] = None, fg: Optional[str] = None,
+                   focused: bool = True) -> dict:
+        """
+        Draw a single-line text input widget. Returns the bounding rect dict.
+        Cursor blinks at 1Hz based on accumulated _time.
+        """
+        font_size = size or 14.0
+        width = w or (self.width - x * 2)
+        height = font_size + 12.0
+        bg_color = bg or "#2a2a3e"
+        fg_color = fg or "#cdd6f4"
+        placeholder_color = "#6c7086"
+
+        # Background
+        self.rect(x, y, width, height, fill=bg_color, radius=4.0)
+
+        display_text = value if value else (placeholder or "")
+        display_color = fg_color if value else placeholder_color
+        self.text(x + 6, y + (height - font_size) / 2, display_text, size=font_size, color=display_color)
+
+        # Cursor blink
+        if focused and self._time % 1.0 < 0.5:
+            cur_pos = cursor if cursor is not None else len(value)
+            # Approximate cursor x position.
+            cursor_x = x + 6 + cur_pos * font_size * 0.6
+            cursor_h = font_size + 2
+            cursor_y = y + (height - cursor_h) / 2
+            self.rect(cursor_x, cursor_y, 2.0, cursor_h, fill=fg_color)
+
+        return {"x": x, "y": y, "w": width, "h": height}
+
+    def tabs(self, tab_id: str, tabs: list, selected: str,
+             on_change=None, height: float = 36, x: float = 0,
+             y: Optional[float] = None, w: Optional[float] = None) -> dict:
+        """
+        Draw a tab bar. tabs is a list of (key, label) tuples.
+        selected is the key of the active tab. Returns bounding rect dict.
+        """
+        y_pos = y if y is not None else 0.0
+        total_w = w or self.width
+        tab_w = total_w / max(len(tabs), 1)
+        accent = "#89b4fa"
+        bg_selected = "#313244"
+        bg_normal = "#1e1e2e"
+        fg = "#cdd6f4"
+
+        for i, (key, label) in enumerate(tabs):
+            tx = x + i * tab_w
+            is_sel = key == selected
+            self.rect(tx, y_pos, tab_w, height, fill=bg_selected if is_sel else bg_normal)
+            self.text(tx + tab_w / 2 - len(label) * 4, y_pos + (height - 14) / 2, label, size=14.0, color=fg)
+            if is_sel:
+                self.rect(tx, y_pos + height - 2, tab_w, 2.0, fill=accent)
+
+        return {"x": x, "y": y_pos, "w": total_w, "h": height}
+
+    def grid(self, grid_id: str, cols: int, rows: int, render_cell: Callable,
+             x: Optional[float] = None, y: Optional[float] = None,
+             w: Optional[float] = None, h: Optional[float] = None,
+             gap: float = 4.0):
+        """
+        Draw a uniform grid. render_cell(ctx, col, row, cx, cy, cw, ch) is called per cell.
+        """
+        gx = x or 0.0
+        gy = y or 0.0
+        gw = w or self.width
+        gh = h or self.height
+        cell_w = (gw - gap * (cols - 1)) / max(cols, 1)
+        cell_h = (gh - gap * (rows - 1)) / max(rows, 1)
+
+        for row in range(rows):
+            for col in range(cols):
+                cx = gx + col * (cell_w + gap)
+                cy = gy + row * (cell_h + gap)
+                render_cell(self, col, row, cx, cy, cell_w, cell_h)
+
+    def modal(self, modal_id: str, visible: bool, content_fn: Callable,
+              width: float = 400, height: float = 200,
+              backdrop_alpha: int = 128, on_dismiss=None):
+        """
+        Draw a centered modal dialog with a semi-transparent backdrop.
+        content_fn(ctx, modal_x, modal_y, width, height) is called if visible.
+        """
+        if not visible:
+            return
+
+        # Backdrop
+        alpha_hex = format(backdrop_alpha, '02x')
+        self.rect(0, 0, self.width, self.height, fill=f"#000000{alpha_hex}")
+
+        # Centered modal rect
+        mx = (self.width - width) / 2
+        my = (self.height - height) / 2
+        self.rect(mx, my, width, height, fill="#1e1e2e", radius=8.0)
+
+        content_fn(self, mx, my, width, height)
+
     def _flush(self):
         for cmd in self._commands:
             print(json.dumps(cmd), flush=True)
         print(json.dumps({"type": "frame_done"}), flush=True)
         self._commands.clear()
+        # Do NOT clear _measure_cache or _time here — App.run() manages those.
 
 
 class App:
@@ -270,6 +455,8 @@ class App:
         self.height: float = 600.0
         self.protocol_version: int = 1
         self.open_intent: Optional[OpenIntent] = None
+        self._render_time: float = 0.0
+        self._measure_req_id: int = 0
         self._on_init: Optional[Callable] = None
         self._on_render: Optional[Callable] = None
         self._on_key: Optional[Callable] = None
@@ -356,9 +543,15 @@ class App:
             elif event_type == "render":
                 self.width = event.get("width", self.width)
                 self.height = event.get("height", self.height)
+                delta_time = event.get("delta_time", 0.016)
+                self._render_time += delta_time
                 ctx = RenderContext(self.width, self.height)
+                ctx._time = self._render_time
+                ctx._measure_cache = {}  # clear per-frame
+                ctx._measure_req_id = self._measure_req_id
                 if self._on_render:
                     self._on_render(ctx)
+                self._measure_req_id = ctx._measure_req_id
                 ctx._flush()
 
             elif event_type == "key":

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -190,6 +190,7 @@ class RenderContext:
         self._measure_cache: dict = {}
         self._measure_req_id: int = 0
         self._time: float = 0.0
+        self._pending_events: list = []
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
         """Fill a rectangle."""
@@ -283,6 +284,9 @@ class RenderContext:
         }), flush=True)
 
         # Read stdin until we get the matching TextMetrics reply.
+        # Any non-metric events that arrive during this wait are buffered
+        # in _pending_events and replayed by the main loop after we return,
+        # so they are never discarded.
         for line in sys.stdin:
             line = line.strip()
             if not line:
@@ -299,6 +303,9 @@ class RenderContext:
                 )
                 self._measure_cache[cache_key] = metrics
                 return metrics
+            else:
+                # Buffer this event — it will be replayed after measurement returns.
+                self._pending_events.append(event)
 
         # Fallback if stdin closed (should not happen in normal operation).
         return TextMetrics(width=size * len(text) * 0.6, height=size, ascent=size * 0.8)
@@ -457,6 +464,7 @@ class App:
         self.open_intent: Optional[OpenIntent] = None
         self._render_time: float = 0.0
         self._measure_req_id: int = 0
+        self._pending_events: list = []
         self._on_init: Optional[Callable] = None
         self._on_render: Optional[Callable] = None
         self._on_key: Optional[Callable] = None
@@ -508,11 +516,86 @@ class App:
             cmd["open_intent"] = open_intent.to_dict()
         self._emitter._write(cmd)
 
+    def _dispatch_event(self, event: dict) -> bool:
+        """Dispatch a single parsed event. Returns True if loop should break (shutdown)."""
+        event_type = event.get("type", "")
+
+        if event_type == "init":
+            self.width = event.get("width", self.width)
+            self.height = event.get("height", self.height)
+            self.protocol_version = event.get("protocol_version", 1)
+            raw_intent = event.get("open_intent")
+            if raw_intent:
+                self.open_intent = OpenIntent.from_dict(raw_intent)
+            if self._on_init:
+                self._on_init(event, self._emitter)
+
+        elif event_type == "resize":
+            self.width = event.get("width", self.width)
+            self.height = event.get("height", self.height)
+            if self._on_resize:
+                self._on_resize(self.width, self.height)
+
+        elif event_type == "render":
+            self.width = event.get("width", self.width)
+            self.height = event.get("height", self.height)
+            delta_time = event.get("delta_time", 0.016)
+            self._render_time += delta_time
+            ctx = RenderContext(self.width, self.height)
+            ctx._time = self._render_time
+            ctx._measure_cache = {}  # clear per-frame
+            ctx._measure_req_id = self._measure_req_id
+            ctx._pending_events = self._pending_events
+            if self._on_render:
+                self._on_render(ctx)
+            self._measure_req_id = ctx._measure_req_id
+            ctx._flush()
+
+        elif event_type == "key":
+            if self._on_key:
+                self._on_key(
+                    event.get("key", ""),
+                    event.get("modifiers", {}),
+                    self._emitter,
+                )
+
+        elif event_type == "click":
+            if self._on_click:
+                self._on_click(
+                    event.get("x", 0.0),
+                    event.get("y", 0.0),
+                    event.get("button", "primary"),
+                    self._emitter,
+                )
+
+        elif event_type == "command":
+            if self._on_command:
+                self._on_command(event.get("text", ""), self._emitter)
+
+        elif event_type == "run_created":
+            if self._on_run_created:
+                self._on_run_created(event.get("run_id", ""), self._emitter)
+
+        elif event_type == "event_data":
+            if self._on_event:
+                self._on_event(event.get("event", {}), self._emitter)
+
+        elif event_type == "shutdown":
+            return True
+
+        return False
+
     def run(self):
         """Start the event loop. Blocks until Plexi sends Shutdown."""
         sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
 
         for line in sys.stdin:
+            # Drain events buffered during any measure_text_exact call first.
+            while self._pending_events:
+                buffered = self._pending_events.pop(0)
+                if self._dispatch_event(buffered):
+                    return
+
             line = line.strip()
             if not line:
                 continue
@@ -522,66 +605,5 @@ class App:
             except json.JSONDecodeError:
                 continue
 
-            event_type = event.get("type", "")
-
-            if event_type == "init":
-                self.width = event.get("width", self.width)
-                self.height = event.get("height", self.height)
-                self.protocol_version = event.get("protocol_version", 1)
-                raw_intent = event.get("open_intent")
-                if raw_intent:
-                    self.open_intent = OpenIntent.from_dict(raw_intent)
-                if self._on_init:
-                    self._on_init(event, self._emitter)
-
-            elif event_type == "resize":
-                self.width = event.get("width", self.width)
-                self.height = event.get("height", self.height)
-                if self._on_resize:
-                    self._on_resize(self.width, self.height)
-
-            elif event_type == "render":
-                self.width = event.get("width", self.width)
-                self.height = event.get("height", self.height)
-                delta_time = event.get("delta_time", 0.016)
-                self._render_time += delta_time
-                ctx = RenderContext(self.width, self.height)
-                ctx._time = self._render_time
-                ctx._measure_cache = {}  # clear per-frame
-                ctx._measure_req_id = self._measure_req_id
-                if self._on_render:
-                    self._on_render(ctx)
-                self._measure_req_id = ctx._measure_req_id
-                ctx._flush()
-
-            elif event_type == "key":
-                if self._on_key:
-                    self._on_key(
-                        event.get("key", ""),
-                        event.get("modifiers", {}),
-                        self._emitter,
-                    )
-
-            elif event_type == "click":
-                if self._on_click:
-                    self._on_click(
-                        event.get("x", 0.0),
-                        event.get("y", 0.0),
-                        event.get("button", "primary"),
-                        self._emitter,
-                    )
-
-            elif event_type == "command":
-                if self._on_command:
-                    self._on_command(event.get("text", ""), self._emitter)
-
-            elif event_type == "run_created":
-                if self._on_run_created:
-                    self._on_run_created(event.get("run_id", ""), self._emitter)
-
-            elif event_type == "event_data":
-                if self._on_event:
-                    self._on_event(event.get("event", {}), self._emitter)
-
-            elif event_type == "shutdown":
+            if self._dispatch_event(event):
                 break

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -72,6 +72,13 @@ pub enum PlexiEvent {
     RunCreated { run_id: String },
     /// A bus event forwarded to a subscribed app.
     EventData { event: BusEvent },
+    /// Response to a MeasureText request.
+    TextMetrics {
+        request_id: u32,
+        width: f32,
+        height: f32,
+        ascent: f32,
+    },
 }
 
 fn default_protocol_version() -> u32 {
@@ -437,6 +444,35 @@ pub enum DrawCommand {
     },
     /// List active pipe wires.
     PipeListWires,
+    /// Push a transform onto the transform stack.
+    PushTransform {
+        #[serde(default = "default_one_f32")]
+        scale_x: f32,
+        #[serde(default = "default_one_f32")]
+        scale_y: f32,
+        #[serde(default)]
+        translate_x: f32,
+        #[serde(default)]
+        translate_y: f32,
+        #[serde(default)]
+        rotate: f32,
+        #[serde(default)]
+        origin_x: f32,
+        #[serde(default)]
+        origin_y: f32,
+    },
+    /// Pop the top transform off the stack.
+    PopTransform,
+    /// Request exact text measurement. Plexi responds with a TextMetrics event.
+    MeasureText {
+        request_id: u32,
+        text: String,
+        size: f32,
+        #[serde(default)]
+        monospace: bool,
+        #[serde(default)]
+        bold: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -451,6 +487,10 @@ pub struct ListItem {
 }
 
 fn default_stroke_width() -> f32 {
+    1.0
+}
+
+fn default_one_f32() -> f32 {
     1.0
 }
 

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -33,9 +33,25 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Features supported by this build of the Plexi host.
+pub const HOST_FEATURES: &[&str] = &[
+    "core_v1",
+    "open_intent_v1",
+    "event_bus_v1",
+    "runs_v1",
+    "typed_pipes_v1",
+    "ui_primitives_v1",
+];
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct AppManifest {
     pub app: AppManifestApp,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct AppProtocolSection {
+    #[serde(default)]
+    pub requires: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -63,6 +79,8 @@ pub struct AppManifestApp {
     pub open_intent_kinds: Vec<String>,
     #[serde(default)]
     pub io: Option<AppIoSection>,
+    #[serde(default)]
+    pub protocol: Option<AppProtocolSection>,
 }
 
 fn default_protocol_version_manifest() -> u32 {
@@ -281,6 +299,20 @@ impl AppRegistry {
         pane_id: u64,
     ) -> Option<Box<dyn App>> {
         let installed = self.apps.get(id)?;
+
+        // Feature negotiation: check that all required features are supported by this host.
+        if let Some(protocol) = &installed.manifest.protocol {
+            for required in &protocol.requires {
+                if !HOST_FEATURES.contains(&required.as_str()) {
+                    log::error!(
+                        "AppRegistry: cannot launch '{}': host does not support '{}' (required by this app). Update Plexi to support this feature.",
+                        id, required
+                    );
+                    return None;
+                }
+            }
+        }
+
         let protocol_version = installed.manifest.protocol_version;
         match ProcessApp::launch_with_intent(
             installed.manifest.id.clone(),

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -257,12 +257,10 @@ impl ProcessApp {
             match cmd {
                 DrawCommand::Rect { x, y, w, h, fill, radius } => {
                     let (tx, ty) = apply_tx(&transform_stack, *x, *y);
-                    // Scale w/h by the topmost scale if stack is non-empty.
-                    let (sw, sh) = if let Some(&(sx, sy, _, _)) = transform_stack.last() {
-                        (*w * sx, *h * sy)
-                    } else {
-                        (*w, *h)
-                    };
+                    // Scale w/h by the cumulative product of all scales in the stack.
+                    let (cum_sx, cum_sy) = transform_stack.iter()
+                        .fold((1.0_f32, 1.0_f32), |(ax, ay), &(sx, sy, _, _)| (ax * sx, ay * sy));
+                    let (sw, sh) = (*w * cum_sx, *h * cum_sy);
                     let rect = egui::Rect::from_min_size(
                         egui::pos2(origin.x + tx, origin.y + ty),
                         egui::vec2(sw, sh),

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -49,6 +49,8 @@ pub struct ProcessApp {
     event_back_tx: Option<mpsc::SyncSender<PlexiEvent>>,
     /// Pending events to send back to the app (RunCreated, EventData, etc.)
     pending_back_events: Vec<PlexiEvent>,
+    /// Transform stack for PushTransform/PopTransform. Each entry: (scale_x, scale_y, tx, ty, rotate, ox, oy).
+    transform_stack: Vec<(f32, f32, f32, f32, f32, f32, f32)>,
 }
 
 impl ProcessApp {
@@ -153,6 +155,7 @@ impl ProcessApp {
             run_store: None,
             event_back_tx: None,
             pending_back_events: Vec::new(),
+            transform_stack: Vec::new(),
         })
     }
 
@@ -200,15 +203,69 @@ impl ProcessApp {
         cmds
     }
 
+    /// Apply the current transform stack to a point.
+    /// Supports translate and scale. Rotation is logged as a warning and skipped.
+    fn apply_transforms(&self, x: f32, y: f32) -> (f32, f32) {
+        let mut px = x;
+        let mut py = y;
+        for &(sx, sy, tx, ty, rotate, _ox, _oy) in &self.transform_stack {
+            if rotate != 0.0 {
+                log::warn!("ProcessApp: rotation transforms not supported in v2.1 (rotate={rotate}), skipping");
+            }
+            px = px * sx + tx;
+            py = py * sy + ty;
+        }
+        (px, py)
+    }
+
     fn render_draw_commands(ui: &mut egui::Ui, commands: &[DrawCommand], colors: &crate::theme::Colors) {
         let origin = ui.min_rect().min;
+        // Transform stack: (scale_x, scale_y, tx, ty). Rotate not supported in v2.1.
+        let mut transform_stack: Vec<(f32, f32, f32, f32)> = Vec::new();
+
+        // Apply transform stack to a point.
+        let apply_tx = |stack: &Vec<(f32, f32, f32, f32)>, x: f32, y: f32| -> (f32, f32) {
+            let mut px = x;
+            let mut py = y;
+            for &(sx, sy, tx, ty) in stack {
+                px = px * sx + tx;
+                py = py * sy + ty;
+            }
+            (px, py)
+        };
 
         for cmd in commands {
             match cmd {
+                DrawCommand::PushTransform { scale_x, scale_y, translate_x, translate_y, rotate, .. } => {
+                    if *rotate != 0.0 {
+                        log::warn!("ProcessApp: rotation transforms not supported in v2.1 (rotate={rotate}), skipping");
+                    }
+                    transform_stack.push((*scale_x, *scale_y, *translate_x, *translate_y));
+                    continue;
+                }
+                DrawCommand::PopTransform => {
+                    if transform_stack.pop().is_none() {
+                        log::warn!("ProcessApp: PopTransform called on empty transform stack");
+                    }
+                    continue;
+                }
+                // MeasureText is resolved before rendering — skip here.
+                DrawCommand::MeasureText { .. } => continue,
+                _ => {}
+            }
+
+            match cmd {
                 DrawCommand::Rect { x, y, w, h, fill, radius } => {
+                    let (tx, ty) = apply_tx(&transform_stack, *x, *y);
+                    // Scale w/h by the topmost scale if stack is non-empty.
+                    let (sw, sh) = if let Some(&(sx, sy, _, _)) = transform_stack.last() {
+                        (*w * sx, *h * sy)
+                    } else {
+                        (*w, *h)
+                    };
                     let rect = egui::Rect::from_min_size(
-                        egui::pos2(origin.x + x, origin.y + y),
-                        egui::vec2(*w, *h),
+                        egui::pos2(origin.x + tx, origin.y + ty),
+                        egui::vec2(sw, sh),
                     );
                     let color = parse_color(fill).unwrap_or(colors.bg_active);
                     ui.painter().rect_filled(rect, *radius, color);
@@ -223,8 +280,9 @@ impl ProcessApp {
                     } else {
                         egui::FontId::proportional(*size)
                     };
+                    let (tx, ty) = apply_tx(&transform_stack, *x, *y);
                     ui.painter().text(
-                        egui::pos2(origin.x + x, origin.y + y),
+                        egui::pos2(origin.x + tx, origin.y + ty),
                         egui::Align2::LEFT_TOP,
                         text,
                         font_id,
@@ -234,10 +292,12 @@ impl ProcessApp {
 
                 DrawCommand::Line { x1, y1, x2, y2, color, width } => {
                     let color = parse_color(color).unwrap_or(colors.bg_active);
+                    let (tx1, ty1) = apply_tx(&transform_stack, *x1, *y1);
+                    let (tx2, ty2) = apply_tx(&transform_stack, *x2, *y2);
                     ui.painter().line_segment(
                         [
-                            egui::pos2(origin.x + x1, origin.y + y1),
-                            egui::pos2(origin.x + x2, origin.y + y2),
+                            egui::pos2(origin.x + tx1, origin.y + ty1),
+                            egui::pos2(origin.x + tx2, origin.y + ty2),
                         ],
                         egui::Stroke::new(*width, color),
                     );
@@ -290,7 +350,10 @@ impl ProcessApp {
                 | DrawCommand::RunUpdate { .. }
                 | DrawCommand::RunComplete { .. }
                 | DrawCommand::EventSubscribe { .. }
-                | DrawCommand::PipeListWires => {}
+                | DrawCommand::PipeListWires
+                | DrawCommand::PushTransform { .. }
+                | DrawCommand::PopTransform
+                | DrawCommand::MeasureText { .. } => {}
             }
         }
     }
@@ -352,6 +415,8 @@ impl App for ProcessApp {
                     // Commit: swap pending into frame, reset pending for next frame.
                     std::mem::swap(&mut self.frame, &mut self.pending_frame);
                     self.pending_frame.clear();
+                    // Reset transform stack at frame boundary.
+                    self.transform_stack.clear();
                 }
                 DrawCommand::RunInTerminal { command } => {
                     self.pending_commands.push(crate::app_trait::AppCommand::RunInTerminal(command));
@@ -475,7 +540,45 @@ impl App for ProcessApp {
                 DrawCommand::PipeListWires => {
                     // Response handled at app.rs level; no-op in ProcessApp.
                 }
+                DrawCommand::PushTransform { .. } => {
+                    // Keep in pending_frame so the renderer can apply transforms inline.
+                    self.pending_frame.push(cmd);
+                }
+                DrawCommand::PopTransform => {
+                    self.pending_frame.push(DrawCommand::PopTransform);
+                }
+                DrawCommand::MeasureText { request_id, text, size, monospace, bold } => {
+                    // Store in pending_frame; resolved to a TextMetrics event in ui() where we have egui context.
+                    self.pending_frame.push(DrawCommand::MeasureText { request_id, text, size, monospace, bold });
+                }
                 other => self.pending_frame.push(other),
+            }
+        }
+
+        // Handle MeasureText commands — requires egui context.
+        // Scan pending_frame for MeasureText, respond immediately, then remove them.
+        let measure_cmds: Vec<DrawCommand> = self.pending_frame
+            .iter()
+            .filter(|c| matches!(c, DrawCommand::MeasureText { .. }))
+            .cloned()
+            .collect();
+        self.pending_frame.retain(|c| !matches!(c, DrawCommand::MeasureText { .. }));
+        for cmd in measure_cmds {
+            if let DrawCommand::MeasureText { request_id, text, size, monospace, .. } = cmd {
+                let font_id = if monospace {
+                    egui::FontId::monospace(size)
+                } else {
+                    egui::FontId::proportional(size)
+                };
+                let text_size = ui.ctx().fonts(|f| {
+                    f.layout_no_wrap(text.clone(), font_id, egui::Color32::WHITE).rect.size()
+                });
+                self.pending_back_events.push(PlexiEvent::TextMetrics {
+                    request_id,
+                    width: text_size.x,
+                    height: text_size.y,
+                    ascent: text_size.y * 0.8,
+                });
             }
         }
 


### PR DESCRIPTION
## Summary
- Implements Plexi Protocol v2.1 per `docs/specs/releases/plexi-v2.1.md`
- Adds `PushTransform`/`PopTransform` draw commands with inline transform stack in `process_app.rs` (translate + scale; rotate skipped with warning — reserved for v2.2)
- Adds `MeasureText`/`TextMetrics` round-trip; resolved via egui font context in `ui()`
- Adds feature negotiation: `HOST_FEATURES` const + `[app.protocol] requires` manifest section; unknown features refuse launch with a clear error log
- Rewrites/creates `mermaid-viewer` as v2.1 reference app using `ctx.viewport` + `ctx.modal` + `ctx.tabs` + keyboard-driven zoom/pan
- Python SDK 0.5.0: `TextMetrics` dataclass, `measure_text_exact` (blocking, cached per-frame), `viewport`, `text_input`, `tabs`, `grid`, `modal` on `RenderContext`
- Scaffolds `docs/specs/releases/plexi-v2.2.md` (rich text, clip regions, IME, PyPI) and `plexi-v2.3.md` (spatial canvas, node graph, video, WASM)
- Adds `docs/specs/README.md` as spec index

## Test plan
- [ ] `cargo build` clean (verified — 0 errors, warnings only)
- [ ] `mermaid-viewer` manifest loads with `requires = ["ui_primitives_v1"]`
- [ ] Launch an app that needs an unknown feature (e.g. `ui_primitives_v2`) — confirm clean refusal in log
- [ ] Cmd+Shift+N still opens notification palette (no regression — `!input.modifiers.shift` guard verified in keys.rs:170)
- [ ] Ctrl+/ still opens agent mode (no regression)