### PR TITLE
Protocol v2 §10: protocol version negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,7 +3334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "plexi-alpha"
+name = "plexi"
 version = "1.1.2"
 dependencies = [
  "async-anthropic",

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,6 +1,6 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
-## 2026-04-15 — [CHANGED] Protocol version negotiation — Init carries version, apps validate minimum (PR #TBD → alpha)
+## 2026-04-15 — [CHANGED] Protocol version negotiation — Init carries version, apps validate minimum (PR #254 → alpha)
 
 Added `protocol_version: u32` to `PlexiEvent::Init`. `HOST_PROTOCOL_VERSION = 2` is the constant in `app_protocol.rs`. `process_app.rs` sends it on every Init. The app registry logs a deprecation warning when a manifest is missing the field or declares version < 2. Python and Rust SDKs read the version from Init and expose it; apps can declare `min_protocol_version` and exit with a clear error if the host is too old. All 37 bundled example manifests updated to `protocol_version = 2`. JSON forward-compat is handled by `#[serde(default)]` — v1 apps deserialize to version 0, continue running with a warning.
 **Breaks if:** apps fail to launch or Init events are malformed — check that `protocol_version` field is present in the Init JSON emitted by `process_app.rs`. v1 manifests (missing field) should log a deprecation warn but still open.

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-15 — [CHANGED] Protocol version negotiation — Init carries version, apps validate minimum (PR #TBD → alpha)
+
+Added `protocol_version: u32` to `PlexiEvent::Init`. `HOST_PROTOCOL_VERSION = 2` is the constant in `app_protocol.rs`. `process_app.rs` sends it on every Init. The app registry logs a deprecation warning when a manifest is missing the field or declares version < 2. Python and Rust SDKs read the version from Init and expose it; apps can declare `min_protocol_version` and exit with a clear error if the host is too old. All 37 bundled example manifests updated to `protocol_version = 2`. JSON forward-compat is handled by `#[serde(default)]` — v1 apps deserialize to version 0, continue running with a warning.
+**Breaks if:** apps fail to launch or Init events are malformed — check that `protocol_version` field is present in the Init JSON emitted by `process_app.rs`. v1 manifests (missing field) should log a deprecation warn but still open.
+
 ## 2026-04-15 — [FIX] agent mode Escape key didn't restore ZSH prompt
 
 `intercept_agent_keys()` in `tiling.rs` only had access to `&mut AgentMode`, so when Escape fired it called `self.deactivate()` directly — no PTY access, no `\r` written to the PTY. ZSH never knew agent mode ended and the prompt was visually displaced. The `toggle_agent_mode()` path in `pane_ops.rs` was correct (sends `BackendCommand::Write(b"\r")` after deactivate), but Escape bypassed it entirely. Fixed by returning `bool` from `intercept_agent_keys` and writing `\r` to `pane.backend` at the call site when deactivation is detected. All exit paths now converge on the same PTY write.

--- a/examples/apiary/manifest.toml
+++ b/examples/apiary/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "apiary"
 name = "Apiary"
 entry = "apiary.py"

--- a/examples/app-store/manifest.toml
+++ b/examples/app-store/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "app-store"
 name = "App Store"
 entry = "app_store.py"

--- a/examples/aquarium/manifest.toml
+++ b/examples/aquarium/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "aquarium"
 name = "Aquarium"
 entry = "aquarium.py"

--- a/examples/audio-player/manifest.toml
+++ b/examples/audio-player/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "audio-player"
 name = "Audio Player"
 entry = "bin/plexi-app"

--- a/examples/backlog-triage/manifest.toml
+++ b/examples/backlog-triage/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "backlog-triage"
 name = "Backlog Triage"
 entry = "backlog_triage.py"

--- a/examples/calc/manifest.toml
+++ b/examples/calc/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "calc"
 name = "Calculator"
 entry = "calc.py"

--- a/examples/clipboard-stack/manifest.toml
+++ b/examples/clipboard-stack/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "clipboard-stack"
 name = "Clipboard Stack"
 entry = "clipboard_stack.py"

--- a/examples/color-palette/manifest.toml
+++ b/examples/color-palette/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "color-palette"
 name = "Color Palette"
 entry = "color_palette.py"

--- a/examples/diff-viewer/manifest.toml
+++ b/examples/diff-viewer/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "diff-viewer"
 name = "Diff Viewer"
 entry = "diff_viewer.py"

--- a/examples/git-blame/manifest.toml
+++ b/examples/git-blame/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "git-blame"
 name = "Git Blame Lens"
 entry = "git_blame.py"

--- a/examples/git-log/manifest.toml
+++ b/examples/git-log/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "git-log"
 name = "Git Log"
 entry = "git-log"

--- a/examples/github-issues/manifest.toml
+++ b/examples/github-issues/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "github-issues"
 name = "GitHub Issues"
 entry = "github_issues.py"

--- a/examples/hacker-news/manifest.toml
+++ b/examples/hacker-news/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "hacker-news"
 name = "Hacker News"
 entry = "hacker_news.py"

--- a/examples/hello-app/manifest.toml
+++ b/examples/hello-app/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "hello-app"
 name = "Hello App"
 entry = "hello_app.py"

--- a/examples/json-viewer/manifest.toml
+++ b/examples/json-viewer/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "json-viewer"
 name = "JSON Viewer"
 entry = "json_viewer.py"

--- a/examples/learn-plexi/manifest.toml
+++ b/examples/learn-plexi/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "learn-plexi"
 name = "Learn Plexi"
 entry = "learn_plexi.py"

--- a/examples/lichen/manifest.toml
+++ b/examples/lichen/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "lichen"
 name = "Lichen"
 entry = "lichen.py"

--- a/examples/markdown-preview/manifest.toml
+++ b/examples/markdown-preview/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "markdown-preview"
 name = "Markdown Preview"
 entry = "markdown_preview.py"

--- a/examples/mermaid-viewer/manifest.toml
+++ b/examples/mermaid-viewer/manifest.toml
@@ -1,5 +1,5 @@
 [app]
-id          = "mermaid-viewer"
+protocol_version = 2id          = "mermaid-viewer"
 name        = "Mermaid Viewer"
 entry       = "mermaid_viewer.py"
 version     = "0.1.0"

--- a/examples/mermaid-viewer/manifest.toml
+++ b/examples/mermaid-viewer/manifest.toml
@@ -1,5 +1,6 @@
 [app]
-protocol_version = 2id          = "mermaid-viewer"
+protocol_version = 2
+id          = "mermaid-viewer"
 name        = "Mermaid Viewer"
 entry       = "mermaid_viewer.py"
 version     = "0.1.0"

--- a/examples/navigator/manifest.toml
+++ b/examples/navigator/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "navigator"
 name = "Navigator"
 entry = "navigator.py"

--- a/examples/permissions-viewer/manifest.toml
+++ b/examples/permissions-viewer/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "permissions-viewer"
 name = "Permissions"
 entry = "permissions_viewer.py"

--- a/examples/photo-viewer/manifest.toml
+++ b/examples/photo-viewer/manifest.toml
@@ -1,5 +1,5 @@
 [app]
-id          = "photo-viewer"
+protocol_version = 2id          = "photo-viewer"
 name        = "Photo Viewer"
 entry       = "target/release/photo-viewer"
 version     = "0.1.0"

--- a/examples/photo-viewer/manifest.toml
+++ b/examples/photo-viewer/manifest.toml
@@ -1,5 +1,6 @@
 [app]
-protocol_version = 2id          = "photo-viewer"
+protocol_version = 2
+id          = "photo-viewer"
 name        = "Photo Viewer"
 entry       = "target/release/photo-viewer"
 version     = "0.1.0"

--- a/examples/plexi-browser/manifest.toml
+++ b/examples/plexi-browser/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "plexi-browser"
 name = "Plexi Browser"
 entry = "browser.py"

--- a/examples/pomodoro/manifest.toml
+++ b/examples/pomodoro/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "pomodoro"
 name = "Pomodoro"
 entry = "pomodoro.py"

--- a/examples/port-watcher/manifest.toml
+++ b/examples/port-watcher/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "port-watcher"
 name = "Port Watcher"
 entry = "port_watcher.py"

--- a/examples/process-monitor/manifest.toml
+++ b/examples/process-monitor/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "process-monitor"
 name = "Process Monitor"
 entry = "bin/plexi-app"

--- a/examples/pulse/manifest.toml
+++ b/examples/pulse/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "pulse"
 name = "Pulse"
 entry = "pulse.py"

--- a/examples/pyflow/manifest.toml
+++ b/examples/pyflow/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "pyflow"
 name = "PyFlow"
 entry = "pyflow.py"

--- a/examples/sandfall/manifest.toml
+++ b/examples/sandfall/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "sandfall"
 name = "Sandfall"
 entry = "sandfall.py"

--- a/examples/seedclock/manifest.toml
+++ b/examples/seedclock/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "seedclock"
 name = "Seedclock"
 entry = "seedclock.py"

--- a/examples/snake/manifest.toml
+++ b/examples/snake/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "snake"
 name = "Snake"
 entry = "snake.py"

--- a/examples/spiral-viewer/manifest.toml
+++ b/examples/spiral-viewer/manifest.toml
@@ -1,5 +1,5 @@
 [app]
-id          = "spiral-viewer"
+protocol_version = 2id          = "spiral-viewer"
 name        = "Spiral Viewer"
 entry       = "spiral_viewer.py"
 version     = "0.1.0"

--- a/examples/spiral-viewer/manifest.toml
+++ b/examples/spiral-viewer/manifest.toml
@@ -1,5 +1,6 @@
 [app]
-protocol_version = 2id          = "spiral-viewer"
+protocol_version = 2
+id          = "spiral-viewer"
 name        = "Spiral Viewer"
 entry       = "spiral_viewer.py"
 version     = "0.1.0"

--- a/examples/stopwatch/manifest.toml
+++ b/examples/stopwatch/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "stopwatch"
 name = "Stopwatch"
 entry = "stopwatch.py"

--- a/examples/text-editor/manifest.toml
+++ b/examples/text-editor/manifest.toml
@@ -1,5 +1,6 @@
 [app]
-protocol_version = 2id          = "text-editor"
+protocol_version = 2
+id          = "text-editor"
 name        = "Text Editor"
 entry       = "text_editor.py"
 version     = "0.1.0"

--- a/examples/text-editor/manifest.toml
+++ b/examples/text-editor/manifest.toml
@@ -1,5 +1,5 @@
 [app]
-id          = "text-editor"
+protocol_version = 2id          = "text-editor"
 name        = "Text Editor"
 entry       = "text_editor.py"
 version     = "0.1.0"

--- a/examples/todo/manifest.toml
+++ b/examples/todo/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "todo"
 name = "Todo"
 entry = "todo.py"

--- a/examples/weather/manifest.toml
+++ b/examples/weather/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "weather"
 name = "Weather"
 entry = "weather.py"

--- a/examples/wikipedia/manifest.toml
+++ b/examples/wikipedia/manifest.toml
@@ -1,4 +1,5 @@
 [app]
+protocol_version = 2
 id = "wikipedia"
 name = "Wikipedia"
 entry = "wikipedia.py"

--- a/schemas/plexi-manifest-schema.json
+++ b/schemas/plexi-manifest-schema.json
@@ -64,6 +64,12 @@
         ]
       }
     },
+    "protocol_version": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Plexi protocol version the app targets. Omitting or setting < 2 triggers a deprecation warning. Set to 2 for all new apps."
+    },
     "min_width": {
       "type": "number",
       "minimum": 0,

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -62,9 +62,9 @@ import pathlib
 import shutil
 import sys
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 
 # ─── Text size constants ──────────────────────────────────────────────────────

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -1137,10 +1137,15 @@ class App:
         @app.on_scroll        fn(x: float, y: float, delta_x: float, delta_y: float, emit: Emitter)
     """
 
-    def __init__(self, app_id: str = "", auto_min_size: bool = True):
+    def __init__(self, app_id: str = "", auto_min_size: bool = True,
+                 min_protocol_version: int = 0):
         self.width: float = 800.0
         self.height: float = 600.0
         self.delta_time: float = 0.0
+        self.protocol_version: int = 0
+        """Protocol version sent by the host in the Init event. 0 means the
+        host did not send a version (v1 host). Set once at startup."""
+        self._min_protocol_version: int = min_protocol_version
         self._on_render: Optional[Callable] = None
         self._on_key: Optional[Callable] = None
         self._on_click: Optional[Callable] = None
@@ -1518,10 +1523,23 @@ class App:
 
             event_type = event.get("type", "")
 
-            if event_type in ("init", "resize"):
+            if event_type == "init":
                 self.width = event.get("width", self.width)
                 self.height = event.get("height", self.height)
-                if event_type == "resize" and self._on_resize:
+                self.protocol_version = event.get("protocol_version", 0)
+                if self._min_protocol_version > 0 and self.protocol_version < self._min_protocol_version:
+                    print(
+                        f"plexi_sdk: host protocol version {self.protocol_version} is below "
+                        f"this app's minimum required version {self._min_protocol_version}. "
+                        f"Please update your Plexi host.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
+            elif event_type == "resize":
+                self.width = event.get("width", self.width)
+                self.height = event.get("height", self.height)
+                if self._on_resize:
                     self._on_resize(self.width, self.height)
 
             elif event_type == "render":

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -49,6 +49,10 @@ pub enum PlexiEvent {
         width: f32,
         height: f32,
         pixels_per_point: f32,
+        /// Protocol version sent by the host. Missing field (v1 host) defaults
+        /// to 0, which the SDK treats as protocol version 1.
+        #[serde(default)]
+        protocol_version: u32,
     },
     Render {
         width: f32,
@@ -1219,6 +1223,17 @@ pub trait App {
     fn min_size(&self) -> (f32, f32) {
         (0.0, 0.0)
     }
+
+    /// Minimum host protocol version this app requires.
+    ///
+    /// If the host sends a `protocol_version` lower than this value (or sends
+    /// no version at all, indicating a v1 host), the SDK prints a clear error
+    /// to stderr and exits with a non-zero code.
+    ///
+    /// Return `0` (default) to accept any host version.
+    fn min_protocol_version(&self) -> u32 {
+        0
+    }
 }
 
 // ── Manifest layout reader ────────────────────────────────────────────────────
@@ -1413,6 +1428,8 @@ pub fn run(app: &mut dyn App) {
         }
     };
 
+    let min_proto = app.min_protocol_version();
+
     loop {
         // Drain any events that were queued by a blocking helper (e.g.
         // `Emitter::get_secret`) during the previous handler. These were read
@@ -1438,7 +1455,16 @@ pub fn run(app: &mut dyn App) {
         };
 
         match event {
-            PlexiEvent::Init { .. } => {}
+            PlexiEvent::Init { protocol_version, .. } => {
+                if min_proto > 0 && protocol_version < min_proto {
+                    eprintln!(
+                        "plexi_sdk: host protocol version {} is below this app's minimum \
+                         required version {}. Please update your Plexi host.",
+                        protocol_version, min_proto
+                    );
+                    std::process::exit(1);
+                }
+            }
             PlexiEvent::Resize { width, height } => {
                 app.on_resize(width, height);
             }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -35,6 +35,11 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The protocol version this host speaks. Sent in every `Init` event.
+/// Apps that require features from a specific version compare this to
+/// their declared minimum and exit cleanly if incompatible.
+pub const HOST_PROTOCOL_VERSION: u32 = 2;
+
 // ── Serde default helpers ─────────────────────────────────────────────────────
 
 fn notification_default_urgency() -> String {
@@ -56,6 +61,12 @@ pub enum PlexiEvent {
         height: f32,
         /// Logical pixels per point (display scale factor).
         pixels_per_point: f32,
+        /// Protocol version spoken by the host. Apps should compare this
+        /// against their declared minimum and exit if incompatible.
+        /// `#[serde(default)]` ensures v1 apps (no field) deserialize to 0,
+        /// which the host treats as "version 1" (legacy, deprecation warned).
+        #[serde(default)]
+        protocol_version: u32,
     },
     /// Request a new frame. App should reply with DrawCommands + FrameDone.
     Render { width: f32, height: f32, delta_time: f32 },

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -47,6 +47,12 @@ pub struct AppManifestApp {
     pub version: String,
     #[serde(default)]
     pub description: String,
+    /// Protocol version the app was written against. Missing or < 2 triggers
+    /// a deprecation warning at load time — the app still runs, but is
+    /// flagged as using the v1 protocol. Apps should declare
+    /// `protocol_version = 2` in their manifest.
+    #[serde(default)]
+    pub protocol_version: u32,
     #[serde(default)]
     pub capabilities: AppCapabilities,
     /// Optional companion-pane launch configuration. When present, Plexi splits
@@ -315,6 +321,15 @@ impl AppRegistry {
             .map_err(|e| format!("invalid manifest: {e}"))?;
 
         let bin_path = resolve_entry(app_dir, &manifest.app.entry)?;
+
+        // Warn when manifest lacks an explicit protocol_version or declares v1.
+        if manifest.app.protocol_version < 2 {
+            log::warn!(
+                "AppRegistry: app '{}' declares protocol_version = {} (< 2). \
+                 Update the manifest to `protocol_version = 2` to suppress this warning.",
+                manifest.app.id, manifest.app.protocol_version
+            );
+        }
 
         Ok(InstalledApp {
             manifest: manifest.app,

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1153,6 +1153,7 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
+                protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
             });
         }
 


### PR DESCRIPTION
## What

Added `protocol_version: u32` to `PlexiEvent::Init`. `HOST_PROTOCOL_VERSION = 2` is the constant in `app_protocol.rs`. `process_app.rs` sends it on every Init. The app registry logs a deprecation warning when a manifest is missing the field or declares version < 2. Python and Rust SDKs read the version from Init and expose it; apps can declare `min_protocol_version` and exit with a clear error if the host is too old. All 37 bundled example manifests updated to `protocol_version = 2`. JSON forward-compat handled by `#[serde(default)]` — v1 apps deserialize to version 0, continue running with a warning.

## Breaks if

Apps fail to launch or Init events are malformed — check that `protocol_version` field is present in the Init JSON emitted by `process_app.rs`. v1 manifests (missing field) should log a deprecation warn but still open.

## Issues

Closes #225