### PR TITLE
feat(pyflow): multi-line code editor + functional graph execution

### DIFF
--- a/examples/pyflow/manifest.toml
+++ b/examples/pyflow/manifest.toml
@@ -3,8 +3,8 @@ protocol_version = 2
 id = "pyflow"
 name = "PyFlow"
 entry = "pyflow.py"
-version = "0.1.0"
-description = "Visual node graph editor — connect nodes by wiring output ports to input ports"
+version = "0.2.0"
+description = "Visual Python node graph editor — write code in each node, run the graph"
 
 [app.capabilities]
 mouse_tracking = true

--- a/examples/pyflow/pyflow.py
+++ b/examples/pyflow/pyflow.py
@@ -468,6 +468,8 @@ def draw_edges(ctx):
 def draw_wiring_preview(ctx):
     if not state.wiring:
         return
+    if state.wire_src_node_id is None or state.wire_src_port_index is None:
+        return
     src = state.node_by_id(state.wire_src_node_id)
     if src is None:
         return
@@ -636,7 +638,9 @@ def on_mouse_down(x, y, button, emit):
     # Input port — complete wiring
     if rid[0] == "in_port" and state.wiring:
         _, node_id, port_idx = rid
-        if node_id != state.wire_src_node_id:
+        if (node_id != state.wire_src_node_id
+                and state.wire_src_node_id is not None
+                and state.wire_src_port_index is not None):
             state.edges = [
                 e for e in state.edges
                 if not (e.dst_node_id == node_id and e.dst_port_index == port_idx)

--- a/examples/pyflow/pyflow.py
+++ b/examples/pyflow/pyflow.py
@@ -638,15 +638,17 @@ def on_mouse_down(x, y, button, emit):
     # Input port — complete wiring
     if rid[0] == "in_port" and state.wiring:
         _, node_id, port_idx = rid
-        if (node_id != state.wire_src_node_id
-                and state.wire_src_node_id is not None
-                and state.wire_src_port_index is not None):
+        src_node_id = state.wire_src_node_id
+        src_port_index = state.wire_src_port_index
+        if (node_id != src_node_id
+                and src_node_id is not None
+                and src_port_index is not None):
             state.edges = [
                 e for e in state.edges
                 if not (e.dst_node_id == node_id and e.dst_port_index == port_idx)
             ]
             state.edges.append(Edge(
-                state.wire_src_node_id, state.wire_src_port_index,
+                src_node_id, src_port_index,
                 node_id, port_idx,
             ))
         state.wiring = False

--- a/examples/pyflow/pyflow.py
+++ b/examples/pyflow/pyflow.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """
 pyflow — Plexi app
-Visual node graph editor. Drag nodes, wire ports, pan the canvas.
+Visual Python node graph editor. Each node has an editable Python code body.
+Run the graph to execute nodes in topological order, passing outputs as inputs.
 
 Controls:
   Drag node header        Move node
   Click output port       Begin wiring an edge
   Click input port        Complete edge (while wiring)
-  Escape                  Cancel edge wiring
-  Delete / Backspace      Delete selected node
+  Click node body         Select node + open code panel
+  Escape                  Cancel edge wiring / close panel
+  Delete / Backspace      Delete selected node (when editor not focused)
   Drag empty space        Pan canvas
-  Scroll                  Pan canvas
+  Cmd+R / toolbar Run     Execute the graph
 """
+from __future__ import annotations
 
 import math
 import os
@@ -56,13 +59,15 @@ C = {
 # Layout constants
 # ---------------------------------------------------------------------------
 
-NODE_W        = 200
-NODE_HEADER_H = 32
-PORT_ROW_H    = 26
-PORT_RADIUS   = 6
-PORT_PADDING  = 14   # x distance from node edge to port centre
-TOOLBAR_H     = 44
-EDGE_CURVE    = 80   # bezier handle length
+NODE_W          = 200
+NODE_HEADER_H   = 32
+PORT_ROW_H      = 26
+PORT_RADIUS     = 6
+PORT_PADDING    = 14
+TOOLBAR_H       = 44
+EDGE_CURVE      = 80
+CODE_PANEL_W    = 360
+NODE_BODY_H     = 32   # preview row below ports
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -70,9 +75,9 @@ EDGE_CURVE    = 80   # bezier handle length
 
 
 class Port:
-    """Represents one input or output port on a node."""
+    """One input or output port on a node."""
 
-    def __init__(self, name, type_label, is_output=False):
+    def __init__(self, name: str, type_label: str, is_output: bool = False):
         self.name = name
         self.type_label = type_label
         self.is_output = is_output
@@ -81,36 +86,48 @@ class Port:
 class Node:
     """A single node on the canvas."""
 
-    def __init__(self, node_id, title, inputs, outputs, x=100.0, y=100.0):
+    def __init__(self, node_id: str, title: str, inputs: list, outputs: list,
+                 x: float = 100.0, y: float = 100.0, code: str = ""):
         self.id = node_id
         self.title = title
-        self.inputs = inputs    # list of Port
-        self.outputs = outputs  # list of Port
+        self.inputs: list = inputs
+        self.outputs: list = outputs
         self.x = x
         self.y = y
+        self.code: str = code
+        self.result = None   # last execution outputs dict
+        self.error: str | None = None
 
     @property
-    def height(self):
-        """Total rendered height of the node."""
+    def height(self) -> float:
         rows = max(len(self.inputs) + len(self.outputs), 1)
-        return NODE_HEADER_H + rows * PORT_ROW_H + 8
+        return NODE_HEADER_H + rows * PORT_ROW_H + NODE_BODY_H + 8
 
-    def input_port_pos(self, port_index):
-        """Canvas-space centre of an input port."""
+    def input_port_pos(self, port_index: int):
         y = self.y + NODE_HEADER_H + port_index * PORT_ROW_H + PORT_ROW_H / 2
         return (self.x + PORT_PADDING, y)
 
-    def output_port_pos(self, port_index):
-        """Canvas-space centre of an output port."""
+    def output_port_pos(self, port_index: int):
         base = self.y + NODE_HEADER_H + len(self.inputs) * PORT_ROW_H
         y = base + port_index * PORT_ROW_H + PORT_ROW_H / 2
         return (self.x + NODE_W - PORT_PADDING, y)
+
+    def preview_text(self) -> tuple:
+        """Returns (text, color) for the node body preview line."""
+        if self.error:
+            return (self.error.split("\n")[0][:40], C["red"])
+        if self.result is not None:
+            r = repr(self.result)
+            return (r[:40] + ("…" if len(r) > 40 else ""), C["green"])
+        first_line = self.code.split("\n")[0].strip()[:40] if self.code else ""
+        return (first_line, C["overlay0"])
 
 
 class Edge:
     """A wired connection between an output port and an input port."""
 
-    def __init__(self, src_node_id, src_port_index, dst_node_id, dst_port_index):
+    def __init__(self, src_node_id: str, src_port_index: int,
+                 dst_node_id: str, dst_port_index: int):
         self.src_node_id = src_node_id
         self.src_port_index = src_port_index
         self.dst_node_id = dst_node_id
@@ -118,43 +135,113 @@ class Edge:
 
 
 # ---------------------------------------------------------------------------
-# Hard-coded example graph
+# Graph execution
 # ---------------------------------------------------------------------------
 
 
-def make_example_nodes():
+def execute_graph(nodes: list, edges: list) -> dict:
+    """Run nodes in topological order. Returns {node_id: result_or_error}."""
+    import math as _math
+
+    node_map = {n.id: n for n in nodes}
+    # Build adjacency: node_id -> list of successor node_ids
+    deps: dict = {n.id: set() for n in nodes}  # n.id -> set of node_ids it depends on
+    for e in edges:
+        deps[e.dst_node_id].add(e.src_node_id)
+
+    # Kahn's algorithm
+    in_degree = {n.id: len(deps[n.id]) for n in nodes}
+    queue = [n.id for n in nodes if in_degree[n.id] == 0]
+    order = []
+    visited = set()
+    while queue:
+        nid = queue.pop(0)
+        order.append(nid)
+        visited.add(nid)
+        # Find successors (nodes that depend on nid)
+        for n in nodes:
+            if nid in deps[n.id]:
+                in_degree[n.id] -= 1
+                if in_degree[n.id] == 0:
+                    queue.append(n.id)
+
+    results: dict = {}  # node_id -> outputs dict
+
+    for nid in order:
+        node = node_map[nid]
+        # Build inputs dict from upstream edges
+        inputs_dict: dict = {}
+        for e in edges:
+            if e.dst_node_id == nid:
+                src_node = node_map.get(e.src_node_id)
+                if src_node and src_node.result is not None:
+                    src_port = src_node.outputs[e.src_port_index]
+                    dst_port = node.inputs[e.dst_port_index]
+                    # Map by destination port name
+                    inputs_dict[dst_port.name] = src_node.result.get(src_port.name)
+
+        outputs_dict: dict = {}
+        try:
+            local_ns: dict = {
+                "inputs": inputs_dict,
+                "outputs": outputs_dict,
+                "math": _math,
+            }
+            exec(node.code, {"__builtins__": __builtins__}, local_ns)
+            node.result = local_ns.get("outputs", {})
+            node.error = None
+        except Exception as exc:
+            node.result = None
+            node.error = str(exc)
+
+        results[nid] = node.result if node.error is None else node.error
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Example graph
+# ---------------------------------------------------------------------------
+
+
+def make_example_nodes() -> list:
     return [
         Node(
-            "load_image", "Load Image",
+            "load_data", "Load Data",
             inputs=[],
-            outputs=[Port("image", "Image")],
+            outputs=[Port("data", "list")],
             x=60, y=80,
+            code='outputs["data"] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]',
         ),
         Node(
-            "blur", "Blur",
-            inputs=[Port("image", "Image"), Port("radius", "float")],
-            outputs=[Port("image", "Image")],
+            "filter", "Filter > 5",
+            inputs=[Port("data", "list")],
+            outputs=[Port("filtered", "list")],
             x=340, y=60,
+            code='outputs["filtered"] = [x for x in inputs.get("data", []) if x > 5]',
         ),
         Node(
-            "threshold", "Threshold",
-            inputs=[Port("image", "Image"), Port("value", "float")],
-            outputs=[Port("mask", "Mask")],
+            "sum_node", "Sum",
+            inputs=[Port("data", "list")],
+            outputs=[Port("total", "int")],
             x=340, y=240,
+            code='outputs["total"] = sum(inputs.get("data", []))',
         ),
         Node(
-            "save", "Save",
-            inputs=[Port("image", "Image"), Port("path", "str")],
+            "display", "Display",
+            inputs=[Port("value", "any"), Port("label", "str")],
             outputs=[],
-            x=620, y=140,
+            x=620, y=160,
+            code='label = inputs.get("label", "result")\nvalue = inputs.get("value", None)\noutputs["display"] = f"{label}: {value}"',
         ),
     ]
 
 
-def make_example_edges():
+def make_example_edges() -> list:
     return [
-        Edge("load_image", 0, "blur", 0),
-        Edge("blur", 0, "save", 0),
+        Edge("load_data", 0, "filter", 0),
+        Edge("load_data", 0, "sum_node", 0),
+        Edge("filter", 0, "display", 0),
     ]
 
 
@@ -173,26 +260,49 @@ class PyFlow:
         self.nodes = make_example_nodes()
         self.edges = make_example_edges()
 
-        self.selected_node_id = None
+        self.selected_node_id: str | None = None
 
         # Edge wiring state
-        self.wiring = False            # True while dragging a new edge
-        self.wire_src_node_id = None
-        self.wire_src_port_index = None
-        self.wire_cursor_x = 0.0      # screen coords of cursor tip
-        self.wire_cursor_y = 0.0
+        self.wiring: bool = False
+        self.wire_src_node_id: str | None = None
+        self.wire_src_port_index: int | None = None
+        self.wire_cursor_x: float = 0.0
+        self.wire_cursor_y: float = 0.0
 
-        # Which node is currently being dragged
-        self.dragging_node_id = None
+        self.dragging_node_id: str | None = None
+        self.panning: bool = False
 
-        # Pan drag tracking
-        self.panning = False
+        # Code panel state
+        self.show_code_panel: bool = False
+        self.editor_lines: list = [""]
+        self.editor_cursor_line: int = 0
+        self.editor_cursor_col: int = 0
 
-    def node_by_id(self, node_id):
+    def node_by_id(self, node_id: str) -> Node | None:
         for n in self.nodes:
             if n.id == node_id:
                 return n
         return None
+
+    def select_node(self, node_id: str | None):
+        self.selected_node_id = node_id
+        if node_id is not None:
+            node = self.node_by_id(node_id)
+            if node:
+                self.editor_lines = node.code.split("\n") if node.code else [""]
+                self.editor_cursor_line = 0
+                self.editor_cursor_col = 0
+                self.show_code_panel = True
+        else:
+            self.show_code_panel = False
+
+    def sync_code_to_node(self, new_lines: list, new_cl: int, new_cc: int):
+        node = self.node_by_id(self.selected_node_id) if self.selected_node_id else None
+        if node:
+            node.code = "\n".join(new_lines)
+        self.editor_lines = new_lines
+        self.editor_cursor_line = new_cl
+        self.editor_cursor_col = new_cc
 
     def delete_selected(self):
         if self.selected_node_id is None:
@@ -204,29 +314,23 @@ class PyFlow:
             if e.src_node_id != nid and e.dst_node_id != nid
         ]
         self.selected_node_id = None
+        self.show_code_panel = False
 
-    def edge_exists(self, dst_node_id, dst_port_index):
-        """Check if an input port already has an edge."""
+    def edge_exists(self, dst_node_id: str, dst_port_index: int) -> bool:
         for e in self.edges:
             if e.dst_node_id == dst_node_id and e.dst_port_index == dst_port_index:
                 return True
         return False
 
+    def canvas_width(self, total_w: float) -> float:
+        """Canvas area width — shrinks when code panel is open."""
+        if self.show_code_panel:
+            return max(100.0, total_w - CODE_PANEL_W)
+        return total_w
+
 
 state = PyFlow()
-app = App(app_id="pyflow")
-
-# ---------------------------------------------------------------------------
-# Hit-region ID helpers
-# ---------------------------------------------------------------------------
-
-# IDs are tuples so we can pattern-match on type easily.
-# ("node", node_id)
-# ("out_port", node_id, port_index)
-# ("in_port", node_id, port_index)
-# ("canvas_bg",)
-# ("toolbar_btn", btn_name)
-
+app = App()
 
 # ---------------------------------------------------------------------------
 # Draw helpers
@@ -234,19 +338,19 @@ app = App(app_id="pyflow")
 
 
 def draw_toolbar(ctx):
-    """Fixed toolbar at top — not affected by canvas pan/zoom."""
     ctx.rect(0, 0, ctx.width, TOOLBAR_H, fill=C["mantle"], radius=0)
-
-    # Title
     ctx.text(16, 13, "PyFlow", size=15, color=C["text"], bold=True)
+    hint = "Click output port to wire  |  Drag nodes  |  Drag canvas to pan  |  Cmd+R to run"
+    ctx.text(ctx.width / 2 - 200, 14, hint, size=11, color=C["overlay0"])
 
-    # Hint text
-    hint = "Click output port to wire  |  Drag nodes  |  Drag canvas to pan"
-    ctx.text(ctx.width / 2 - 160, 14, hint, size=11, color=C["overlay0"])
+    # Run button
+    btn_x = ctx.width - CODE_PANEL_W - 90 if state.show_code_panel else ctx.width - 90
+    ctx.rect(btn_x, 8, 76, 28, fill=C["blue"], radius=6)
+    ctx.text(btn_x + 10, 15, "▶ Run", size=13, color=C["crust"], bold=True)
+    state.hit.register(("toolbar_btn", "run"), btn_x, 8, 76, 28)
 
 
 def draw_bezier_edge(ctx, sx, sy, ex, ey, color, width=2.0):
-    """Approximate a cubic bezier with line segments (no bezier draw cmd yet)."""
     cx1 = sx + EDGE_CURVE
     cy1 = sy
     cx2 = ex - EDGE_CURVE
@@ -267,35 +371,29 @@ def draw_bezier_edge(ctx, sx, sy, ex, ey, color, width=2.0):
 
 
 def draw_port_circle(ctx, sx, sy, filled, color):
-    """Draw a filled or hollow port indicator using a small rect as circle proxy."""
     r = PORT_RADIUS
     ctx.rect(sx - r, sy - r, r * 2, r * 2, fill=color, radius=r)
     if not filled:
-        # Punch an inner hole with the node body color
         ir = r - 2
         ctx.rect(sx - ir, sy - ir, ir * 2, ir * 2, fill=C["surface0"], radius=ir)
 
 
-def port_is_connected_output(state, node_id, port_index):
-    for e in state.edges:
-        if e.src_node_id == node_id and e.src_port_index == port_index:
-            return True
-    return False
+def port_is_connected_output(node_id, port_index):
+    return any(e.src_node_id == node_id and e.src_port_index == port_index
+               for e in state.edges)
 
 
-def port_is_connected_input(state, node_id, port_index):
-    for e in state.edges:
-        if e.dst_node_id == node_id and e.dst_port_index == port_index:
-            return True
-    return False
+def port_is_connected_input(node_id, port_index):
+    return any(e.dst_node_id == node_id and e.dst_port_index == port_index
+               for e in state.edges)
 
 
-def draw_node(ctx, hit, node, selected, wiring_src_node, wiring_src_port):
+def draw_node(ctx, hit, node, selected):
     sx, sy = state.canvas.canvas_to_screen(node.x, node.y)
     sw = NODE_W * state.canvas.scale
     sh = node.height * state.canvas.scale
 
-    # Body
+    # Body + border
     border_color = C["blue"] if selected else C["surface1"]
     ctx.rect(sx - 2, sy - 2, sw + 4, sh + 4, fill=border_color, radius=8)
     ctx.rect(sx, sy, sw, sh, fill=C["surface0"], radius=7)
@@ -310,26 +408,19 @@ def draw_node(ctx, hit, node, selected, wiring_src_node, wiring_src_port):
         color=C["text"],
         bold=True,
     )
-
-    # Register header as draggable / selectable
     hit.register(("node", node.id), sx, sy, sw, NODE_HEADER_H * state.canvas.scale)
 
     # Input ports
     for i, port in enumerate(node.inputs):
         py = sy + (NODE_HEADER_H + i * PORT_ROW_H + PORT_ROW_H / 2) * state.canvas.scale
         px = sx + PORT_PADDING * state.canvas.scale
-        connected = port_is_connected_input(state, node.id, i)
-        # Highlight if we are wiring and this is a valid target
+        connected = port_is_connected_input(node.id, i)
         highlight = state.wiring and not connected
         color = C["green"] if highlight else (C["blue"] if connected else C["overlay1"])
         draw_port_circle(ctx, px, py, connected, color)
-        ctx.text(
-            px + PORT_RADIUS + 4,
-            py - 6 * state.canvas.scale,
-            port.name + ": " + port.type_label,
-            size=11 * state.canvas.scale,
-            color=C["subtext0"],
-        )
+        ctx.text(px + PORT_RADIUS + 4, py - 6 * state.canvas.scale,
+                 port.name + ": " + port.type_label, size=11 * state.canvas.scale,
+                 color=C["subtext0"])
         hit.register(("in_port", node.id, i), px - PORT_RADIUS * 2, py - PORT_RADIUS * 2,
                      PORT_RADIUS * 4, PORT_RADIUS * 4)
 
@@ -338,21 +429,27 @@ def draw_node(ctx, hit, node, selected, wiring_src_node, wiring_src_port):
     for i, port in enumerate(node.outputs):
         py = sy + (NODE_HEADER_H + (base_row + i) * PORT_ROW_H + PORT_ROW_H / 2) * state.canvas.scale
         px = sx + (NODE_W - PORT_PADDING) * state.canvas.scale
-        connected = port_is_connected_output(state, node.id, i)
-        # Dim if we are currently wiring from this port
-        is_src = wiring_src_node == node.id and wiring_src_port == i
+        connected = port_is_connected_output(node.id, i)
+        is_src = state.wire_src_node_id == node.id and state.wire_src_port_index == i
         color = C["mauve"] if is_src else (C["blue"] if connected else C["overlay1"])
         draw_port_circle(ctx, px, py, True, color)
         label = "→ " + port.type_label
-        ctx.text(
-            px - PORT_RADIUS - len(label) * 7,
-            py - 6 * state.canvas.scale,
-            label,
-            size=11 * state.canvas.scale,
-            color=C["subtext0"],
-        )
+        ctx.text(px - PORT_RADIUS - len(label) * 7, py - 6 * state.canvas.scale,
+                 label, size=11 * state.canvas.scale, color=C["subtext0"])
         hit.register(("out_port", node.id, i), px - PORT_RADIUS * 2, py - PORT_RADIUS * 2,
                      PORT_RADIUS * 4, PORT_RADIUS * 4)
+
+    # Body preview row
+    ports_bottom = sy + (NODE_HEADER_H + (len(node.inputs) + len(node.outputs)) * PORT_ROW_H) * state.canvas.scale
+    preview_text, preview_color = node.preview_text()
+    if preview_text:
+        ctx.text(sx + 8, ports_bottom + 6, preview_text,
+                 size=10 * state.canvas.scale, color=preview_color, monospace=True)
+
+    # Register node body for selection (below header)
+    body_y = sy + NODE_HEADER_H * state.canvas.scale
+    body_h = sh - NODE_HEADER_H * state.canvas.scale
+    hit.register(("node_body", node.id), sx, body_y, sw, body_h)
 
 
 def draw_edges(ctx):
@@ -369,7 +466,6 @@ def draw_edges(ctx):
 
 
 def draw_wiring_preview(ctx):
-    """Draw the in-progress edge while user is wiring."""
     if not state.wiring:
         return
     src = state.node_by_id(state.wire_src_node_id)
@@ -379,6 +475,84 @@ def draw_wiring_preview(ctx):
     ssx, ssy = state.canvas.canvas_to_screen(scx, scy)
     draw_bezier_edge(ctx, ssx, ssy, state.wire_cursor_x, state.wire_cursor_y,
                      color=C["mauve"], width=1.5)
+
+
+def draw_dot_grid(ctx, canvas_w):
+    ox, oy = state.canvas.offset
+    spacing = 32.0 * state.canvas.scale
+    if spacing < 8:
+        return
+    start_x = ox % spacing
+    start_y = (oy - TOOLBAR_H) % spacing
+    x = start_x
+    while x < canvas_w:
+        y = TOOLBAR_H + start_y
+        while y < ctx.height:
+            ctx.rect(x - 1, y - 1, 2, 2, fill=C["surface1"])
+            y += spacing
+        x += spacing
+
+
+def draw_code_panel(ctx):
+    """Right-side code editor panel for the selected node."""
+    if not state.show_code_panel:
+        return
+    node = state.node_by_id(state.selected_node_id) if state.selected_node_id else None
+    if node is None:
+        return
+
+    px = ctx.width - CODE_PANEL_W
+    py = TOOLBAR_H
+
+    # Panel background
+    ctx.rect(px, py, CODE_PANEL_W, ctx.height - py, fill=C["mantle"], radius=0)
+    ctx.line(px, py, px, ctx.height, color=C["surface1"], width=1.0)
+
+    # Header
+    ctx.rect(px, py, CODE_PANEL_W, 36, fill=C["surface0"], radius=0)
+    ctx.text(px + 12, py + 10, node.title, size=14, color=C["text"], bold=True)
+    ctx.text(px + 12 + len(node.title) * 8 + 8, py + 11, "— Code", size=12, color=C["overlay0"])
+
+    # Error / result banner
+    banner_y = py + 36
+    banner_h = 0
+    if node.error:
+        banner_h = 28
+        ctx.rect(px, banner_y, CODE_PANEL_W, banner_h, fill="#3b1f2b", radius=0)
+        ctx.text(px + 8, banner_y + 7, "Error: " + node.error.split("\n")[0][:46],
+                 size=11, color=C["red"])
+    elif node.result is not None:
+        banner_h = 28
+        ctx.rect(px, banner_y, CODE_PANEL_W, banner_h, fill="#1e3b2b", radius=0)
+        result_text = repr(node.result)[:50]
+        ctx.text(px + 8, banner_y + 7, "Result: " + result_text,
+                 size=11, color=C["green"])
+
+    # Code editor
+    editor_y = banner_y + banner_h + 8
+    editor_h = ctx.height - editor_y - 48  # leave room for buttons
+    ctx.code_editor(
+        editor_id="node_code",
+        lines=state.editor_lines,
+        cursor_line=state.editor_cursor_line,
+        cursor_col=state.editor_cursor_col,
+        on_change=state.sync_code_to_node,
+        x=px + 4,
+        y=editor_y,
+        w=CODE_PANEL_W - 8,
+        h=editor_h,
+        focused=True,
+    )
+
+    # Buttons
+    btn_y = ctx.height - 36
+    ctx.rect(px + 8, btn_y, 100, 28, fill=C["blue"], radius=6)
+    ctx.text(px + 18, btn_y + 7, "▶ Run Graph", size=12, color=C["crust"], bold=True)
+    state.hit.register(("panel_btn", "run"), px + 8, btn_y, 100, 28)
+
+    ctx.rect(px + 116, btn_y, 60, 28, fill=C["surface1"], radius=6)
+    ctx.text(px + 128, btn_y + 7, "Clear", size=12, color=C["text"])
+    state.hit.register(("panel_btn", "clear"), px + 116, btn_y, 60, 28)
 
 
 # ---------------------------------------------------------------------------
@@ -391,61 +565,25 @@ def render(ctx):
     hit = state.hit
     hit.clear()
 
-    # Background
+    canvas_w = state.canvas_width(ctx.width)
+
     ctx.rect(0, 0, ctx.width, ctx.height, fill=C["base"])
+    hit.register(("canvas_bg",), 0, TOOLBAR_H, canvas_w, ctx.height - TOOLBAR_H)
 
-    # Register canvas background (below toolbar)
-    hit.register(("canvas_bg",), 0, TOOLBAR_H, ctx.width, ctx.height - TOOLBAR_H)
-
-    # Dot grid
-    draw_dot_grid(ctx)
-
-    # Edges
+    draw_dot_grid(ctx, canvas_w)
     draw_edges(ctx)
-
-    # Wiring preview
     draw_wiring_preview(ctx)
 
-    # Nodes (draw selected last so it renders on top)
     for node in state.nodes:
         if node.id != state.selected_node_id:
-            draw_node(ctx, hit, node, False,
-                      state.wire_src_node_id, state.wire_src_port_index)
+            draw_node(ctx, hit, node, False)
     if state.selected_node_id:
         sel_node = state.node_by_id(state.selected_node_id)
         if sel_node:
-            draw_node(ctx, hit, sel_node, True,
-                      state.wire_src_node_id, state.wire_src_port_index)
+            draw_node(ctx, hit, sel_node, True)
 
-    # Toolbar (drawn last — on top of canvas)
+    draw_code_panel(ctx)
     draw_toolbar(ctx)
-
-    # Cursor
-    if state.wiring or state.node_drag.active:
-        ctx.set_cursor("grabbing")
-    elif state.panning:
-        ctx.set_cursor("grabbing")
-
-
-def draw_dot_grid(ctx):
-    """Faint dot grid that moves with the canvas pan."""
-    ox, oy = state.canvas.offset
-    spacing = 32.0 * state.canvas.scale
-    if spacing < 8:
-        return
-
-    # Compute first dot position mod spacing
-    start_x = ox % spacing
-    start_y = (oy - TOOLBAR_H) % spacing
-
-    x = start_x
-    while x < ctx.width:
-        y = TOOLBAR_H + start_y
-        while y < ctx.height:
-            # Draw a tiny 2x2 rect as a dot
-            ctx.rect(x - 1, y - 1, 2, 2, fill=C["surface1"])
-            y += spacing
-        x += spacing
 
 
 # ---------------------------------------------------------------------------
@@ -464,6 +602,27 @@ def on_mouse_down(x, y, button, emit):
 
     rid = region.id
 
+    # Toolbar button
+    if rid[0] == "toolbar_btn":
+        if rid[1] == "run":
+            execute_graph(state.nodes, state.edges)
+        return
+
+    # Panel button
+    if rid[0] == "panel_btn":
+        if rid[1] == "run":
+            execute_graph(state.nodes, state.edges)
+        elif rid[1] == "clear":
+            node = state.node_by_id(state.selected_node_id) if state.selected_node_id else None
+            if node:
+                node.code = ""
+                node.result = None
+                node.error = None
+                state.editor_lines = [""]
+                state.editor_cursor_line = 0
+                state.editor_cursor_col = 0
+        return
+
     # Output port — start wiring
     if rid[0] == "out_port":
         _, node_id, port_idx = rid
@@ -474,12 +633,10 @@ def on_mouse_down(x, y, button, emit):
         state.wire_cursor_y = y
         return
 
-    # Input port — complete wiring if active
+    # Input port — complete wiring
     if rid[0] == "in_port" and state.wiring:
         _, node_id, port_idx = rid
-        # Don't connect to self
         if node_id != state.wire_src_node_id:
-            # Remove existing edge to this input (one-in rule)
             state.edges = [
                 e for e in state.edges
                 if not (e.dst_node_id == node_id and e.dst_port_index == port_idx)
@@ -493,28 +650,34 @@ def on_mouse_down(x, y, button, emit):
         state.wire_src_port_index = None
         return
 
-    # Node header — start drag / select
+    # Node header — drag/select
     if rid[0] == "node":
         _, node_id = rid
         if state.wiring:
-            # Cancel wiring on click elsewhere
             state.wiring = False
             state.wire_src_node_id = None
             state.wire_src_port_index = None
             return
-        state.selected_node_id = node_id
+        state.select_node(node_id)
         state.dragging_node_id = node_id
         state.node_drag.start(x, y, payload=node_id)
         return
 
-    # Canvas background — start pan
+    # Node body — select + open code panel
+    if rid[0] == "node_body":
+        _, node_id = rid
+        if not state.wiring:
+            state.select_node(node_id)
+        return
+
+    # Canvas background — pan
     if rid[0] == "canvas_bg":
         if state.wiring:
             state.wiring = False
             state.wire_src_node_id = None
             state.wire_src_port_index = None
             return
-        state.selected_node_id = None
+        state.select_node(None)
         state.panning = True
         state.pan_drag.start(x, y)
 
@@ -531,22 +694,18 @@ def on_mouse_up(x, y, button, emit):
 
 @app.on_mouse_move
 def on_mouse_move(x, y, emit):
-    # Update wiring cursor
     if state.wiring:
         state.wire_cursor_x = x
         state.wire_cursor_y = y
 
-    # Node drag
     if state.node_drag._armed and state.dragging_node_id:
         dx, dy = state.node_drag.update(x, y)
         if state.node_drag.active and (dx != 0 or dy != 0):
             node = state.node_by_id(state.dragging_node_id)
             if node:
-                # Convert screen delta to canvas delta
                 node.x += dx / state.canvas.scale
                 node.y += dy / state.canvas.scale
 
-    # Canvas pan
     if state.panning and state.pan_drag._armed:
         dx, dy = state.pan_drag.update(x, y)
         if dx != 0 or dy != 0:
@@ -556,7 +715,6 @@ def on_mouse_move(x, y, emit):
 
 @app.on_scroll
 def on_scroll(x, y, delta_x, delta_y, emit):
-    # Pan the canvas with scroll
     if y < TOOLBAR_H:
         return
     ox, oy = state.canvas.offset
@@ -570,6 +728,10 @@ def on_scroll(x, y, delta_x, delta_y, emit):
 
 @app.on_key
 def on_key(key, mods, emit):
+    cmd = mods.get("command", False) or mods.get("ctrl", False)
+    if cmd and key == "r":
+        execute_graph(state.nodes, state.edges)
+        return
     if key in ("Delete", "Backspace"):
         state.delete_selected()
     elif key == "Escape":
@@ -578,7 +740,8 @@ def on_key(key, mods, emit):
             state.wire_src_node_id = None
             state.wire_src_port_index = None
         else:
-            state.selected_node_id = None
+            state.show_code_panel = False
+            state.select_node(None)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/pyflow/pyrightconfig.json
+++ b/examples/pyflow/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+  "pythonVersion": "3.9",
+  "extraPaths": ["."],
+  "reportMissingImports": "none"
+}

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -680,6 +680,8 @@ class RenderContext:
         # render frames, unlike the RenderContext itself which is recreated
         # per frame). Used by scrollable_list() and other stateful components.
         self._app_state: dict = app_state if app_state is not None else {}
+        self._time: float = 0.0
+        self._app: Optional["App"] = None  # set by App.run() before on_render
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0):
         """Fill a rectangle."""
@@ -1359,6 +1361,175 @@ class RenderContext:
             "summary": _payload_dict(summary),
         })
 
+    def code_editor(self, editor_id: str, lines: list, cursor_line: int,
+                    cursor_col: int, on_change, x: float, y: float,
+                    w: float, h: float, focused: bool = True) -> dict:
+        """
+        Draw a multi-line Python code editor with syntax highlighting.
+
+        lines: list[str] — code content, one string per line (app owns state)
+        cursor_line, cursor_col — cursor position (app owns)
+        on_change(new_lines, new_cursor_line, new_cursor_col) — called on edits
+        focused — whether this editor captures key events
+
+        Keyboard handling is routed through App._editor_states when focused=True.
+        Requires ctx._app to be set (done automatically by App.run()).
+        """
+        _app = self._app
+
+        # Register with App for key routing
+        if _app is not None and focused:
+            _app._editor_states[editor_id] = {
+                "lines": lines,
+                "cursor_line": cursor_line,
+                "cursor_col": cursor_col,
+                "on_change": on_change,
+            }
+            _app._focused_editor_id = editor_id
+
+        font_size = 13.0
+        line_h = font_size + 4.0
+        line_num_w = 40.0
+        visible_lines = max(1, int(h / line_h))
+        scroll_line = _app._editor_scroll.get(editor_id, 0) if _app else 0
+
+        # Clamp scroll
+        max_scroll = max(0, len(lines) - visible_lines)
+        scroll_line = min(scroll_line, max_scroll)
+        if _app:
+            _app._editor_scroll[editor_id] = scroll_line
+
+        # Background
+        self.rect(x, y, w, h, fill="#1e1e2e", radius=4.0)
+
+        # Line number column bg
+        self.rect(x, y, line_num_w, h, fill="#181825", radius=0.0)
+
+        # Render visible lines
+        for rel_idx in range(visible_lines):
+            line_idx = scroll_line + rel_idx
+            if line_idx >= len(lines):
+                break
+            ly = y + rel_idx * line_h
+
+            # Current line highlight
+            if focused and line_idx == cursor_line:
+                self.rect(x, ly, w, line_h, fill="#2a2a3e", radius=0.0)
+
+            # Line number
+            line_num_str = str(line_idx + 1)
+            lnx = x + line_num_w - len(line_num_str) * 7 - 4
+            self.text(lnx, ly + 2, line_num_str, size=font_size,
+                      color="#45475a", monospace=True)
+
+            # Syntax-highlighted code
+            line_text = lines[line_idx]
+            self._draw_syntax_line(x + line_num_w + 4, ly + 2, line_text,
+                                   font_size)
+
+        # Cursor (blink)
+        if focused and self._time % 1.0 < 0.5:
+            rel = cursor_line - scroll_line
+            if 0 <= rel < visible_lines:
+                # Approximate char width for monospace
+                char_w = font_size * 0.6
+                cur_x = x + line_num_w + 4 + cursor_col * char_w
+                cur_y = y + rel * line_h
+                self.rect(cur_x, cur_y + 1, 2.0, line_h - 2, fill="#cdd6f4")
+
+        return {"x": x, "y": y, "w": w, "h": h}
+
+    # Syntax color constants
+    _KW = frozenset({
+        'def', 'class', 'return', 'import', 'from', 'if', 'else', 'elif',
+        'for', 'while', 'in', 'not', 'and', 'or', 'True', 'False', 'None',
+        'try', 'except', 'finally', 'with', 'as', 'pass', 'raise', 'yield',
+        'lambda', 'global', 'nonlocal', 'break', 'continue', 'is', 'del',
+    })
+    _COL_KW    = "#569cd6"
+    _COL_STR   = "#ce9178"
+    _COL_CMT   = "#6a9955"
+    _COL_NUM   = "#b5cea8"
+    _COL_PLAIN = "#d4d4d4"
+
+    def _draw_syntax_line(self, x: float, y: float, line: str, size: float):
+        """Draw a single code line with basic syntax highlighting."""
+        char_w = size * 0.6
+
+        # Detect full-line comment
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            self.text(x, y, line, size=size, color=self._COL_CMT, monospace=True)
+            return
+
+        # Split into (token, color) segments
+        segments: list = []
+        i = 0
+        in_str = False
+        str_char = ""
+        tok_start = 0
+
+        def flush_plain(end: int):
+            nonlocal tok_start
+            chunk = line[tok_start:end]
+            if chunk:
+                buf = ""
+                for ch in chunk:
+                    if ch.isalnum() or ch in ("_", "."):
+                        buf += ch
+                    else:
+                        if buf:
+                            if buf in self._KW:
+                                color = self._COL_KW
+                            elif buf.replace(".", "", 1).isdigit():
+                                color = self._COL_NUM
+                            else:
+                                color = self._COL_PLAIN
+                            segments.append((buf, color))
+                            buf = ""
+                        segments.append((ch, self._COL_PLAIN))
+                if buf:
+                    if buf in self._KW:
+                        color = self._COL_KW
+                    elif buf.replace(".", "", 1).isdigit():
+                        color = self._COL_NUM
+                    else:
+                        color = self._COL_PLAIN
+                    segments.append((buf, color))
+            tok_start = end
+
+        while i < len(line):
+            ch = line[i]
+            if in_str:
+                if ch == str_char and (i == 0 or line[i - 1] != "\\"):
+                    str_token = line[tok_start:i + 1]
+                    segments.append((str_token, self._COL_STR))
+                    in_str = False
+                    tok_start = i + 1
+                i += 1
+                continue
+            if ch in ('"', "'"):
+                flush_plain(i)
+                in_str = True
+                str_char = ch
+                tok_start = i
+                i += 1
+                continue
+            if ch == "#":
+                flush_plain(i)
+                segments.append((line[i:], self._COL_CMT))
+                i = len(line)
+                tok_start = i
+                continue
+            i += 1
+
+        flush_plain(len(line))
+
+        cx = x
+        for tok, color in segments:
+            self.text(cx, y, tok, size=size, color=color, monospace=True)
+            cx += len(tok) * char_w
+
     def _flush(self):
         for cmd in self._commands:
             print(json.dumps(cmd), flush=True)
@@ -1598,6 +1769,11 @@ class App:
         # ctx.scrollable_list). Keyed by the app-supplied list_id. Lives on
         # the App because RenderContext is recreated per frame.
         self._scroll_state: dict[str, int] = {}
+        # Code editor state — keyed by editor_id
+        self._editor_states: dict = {}
+        self._editor_scroll: dict = {}   # editor_id -> scroll_line (int)
+        self._focused_editor_id: Optional[str] = None
+        self._render_time: float = 0.0
 
     def on_render(self, fn: Callable) -> Callable:
         self._on_render = fn
@@ -1929,6 +2105,96 @@ class App:
         self._on_run_created = fn
         return fn
 
+    def _route_key_to_editor(self, editor_id: str, es: dict, key: str, mods: dict) -> bool:
+        """Handle a key event for a focused code editor. Returns True if consumed."""
+        lines = [l for l in es["lines"]]  # shallow copy to mutate
+        cl = es["cursor_line"]
+        cc = es["cursor_col"]
+        on_change = es["on_change"]
+        scroll = self._editor_scroll.get(editor_id, 0)
+
+        def clamp_col():
+            nonlocal cc
+            if cl < len(lines):
+                cc = min(cc, len(lines[cl]))
+
+        consumed = True
+        shift = mods.get("shift", False)
+
+        if key == "Enter":
+            current = lines[cl]
+            lines[cl] = current[:cc]
+            lines.insert(cl + 1, current[cc:])
+            cl += 1
+            cc = 0
+        elif key == "Backspace":
+            if cc > 0:
+                lines[cl] = lines[cl][:cc - 1] + lines[cl][cc:]
+                cc -= 1
+            elif cl > 0:
+                prev_len = len(lines[cl - 1])
+                lines[cl - 1] = lines[cl - 1] + lines[cl]
+                del lines[cl]
+                cl -= 1
+                cc = prev_len
+        elif key == "Delete":
+            if cc < len(lines[cl]):
+                lines[cl] = lines[cl][:cc] + lines[cl][cc + 1:]
+            elif cl < len(lines) - 1:
+                lines[cl] = lines[cl] + lines[cl + 1]
+                del lines[cl + 1]
+        elif key == "ArrowLeft":
+            if cc > 0:
+                cc -= 1
+            elif cl > 0:
+                cl -= 1
+                cc = len(lines[cl])
+        elif key == "ArrowRight":
+            if cl < len(lines) and cc < len(lines[cl]):
+                cc += 1
+            elif cl < len(lines) - 1:
+                cl += 1
+                cc = 0
+        elif key == "ArrowUp":
+            if cl > 0:
+                cl -= 1
+                clamp_col()
+                if cl < scroll:
+                    scroll = cl
+                    self._editor_scroll[editor_id] = scroll
+        elif key == "ArrowDown":
+            if cl < len(lines) - 1:
+                cl += 1
+                clamp_col()
+        elif key == "Home":
+            cc = 0
+        elif key == "End":
+            if cl < len(lines):
+                cc = len(lines[cl])
+        elif key == "Tab":
+            lines[cl] = lines[cl][:cc] + "    " + lines[cl][cc:]
+            cc += 4
+        elif key == "a" and mods.get("command", False):
+            cl = 0
+            cc = 0
+        elif len(key) == 1:
+            lines[cl] = lines[cl][:cc] + key + lines[cl][cc:]
+            cc += 1
+        else:
+            consumed = False
+
+        if consumed:
+            clamp_col()
+            # Auto-scroll to keep cursor visible
+            # (visible_lines unknown here; use a default 20 — app will re-clamp)
+            if cl < scroll:
+                self._editor_scroll[editor_id] = cl
+            elif cl >= scroll + 20:
+                self._editor_scroll[editor_id] = cl - 19
+            on_change(lines, cl, cc)
+
+        return consumed
+
     def _handle_get_state(self):
         """Respond to a get_state request from Plexi."""
         if self._on_get_state:
@@ -2029,6 +2295,10 @@ class App:
                 ):
                     self._render_min_size_fallback(self.width, self.height)
                     continue
+                self._render_time += self.delta_time
+                # Clear focused editor each frame — re-registered by code_editor() calls
+                self._focused_editor_id = None
+                self._editor_states.clear()
                 ctx = RenderContext(
                     self.width, self.height,
                     app_id=self._emitter._app_id,
@@ -2036,6 +2306,8 @@ class App:
                     render_mode=self.render_mode,
                 )
                 ctx.delta_time = self.delta_time
+                ctx._time = self._render_time
+                ctx._app = self  # allow code_editor to register state
                 # Breakpoint dispatch (if registered) overrides on_render.
                 if self._breakpoints:
                     fn = self._pick_breakpoint(self.width, self.height)
@@ -2046,12 +2318,18 @@ class App:
                 ctx._flush()
 
             elif event_type == "key":
-                if self._on_key:
-                    self._on_key(
-                        event.get("key", ""),
-                        event.get("modifiers", {}),
-                        self._emitter,
-                    )
+                key = event.get("key", "")
+                mods = event.get("modifiers", {})
+                # Route to focused editor first, unless a Cmd-key combo
+                cmd_held = mods.get("command", False) or mods.get("ctrl", False)
+                editor_consumed = False
+                if self._focused_editor_id and not cmd_held:
+                    eid = self._focused_editor_id
+                    es = self._editor_states.get(eid)
+                    if es:
+                        editor_consumed = self._route_key_to_editor(eid, es, key, mods)
+                if not editor_consumed and self._on_key:
+                    self._on_key(key, mods, self._emitter)
 
             elif event_type == "suspend":
                 if self._on_suspend:

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -660,6 +660,97 @@ def load_manifest(app_file: str = __file__) -> dict:
     return result
 
 
+# ---------------------------------------------------------------------------
+# Module-level syntax colorizers
+# ---------------------------------------------------------------------------
+
+_SYN_KW = frozenset({
+    'def', 'class', 'return', 'import', 'from', 'if', 'else', 'elif',
+    'for', 'while', 'in', 'not', 'and', 'or', 'True', 'False', 'None',
+    'try', 'except', 'finally', 'with', 'as', 'pass', 'raise', 'yield',
+    'lambda', 'global', 'nonlocal', 'break', 'continue', 'is', 'del',
+})
+_COL_KW    = "#569cd6"
+_COL_STR   = "#ce9178"
+_COL_CMT   = "#6a9955"
+_COL_NUM   = "#b5cea8"
+_COL_PLAIN = "#d4d4d4"
+
+
+def _python_colorize(line: str):
+    """
+    Tokenize a single Python source line into (segment, color) pairs.
+    Returns a list — never None.
+    """
+    # Full-line comment fast path
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return [(line, _COL_CMT)]
+
+    segments: list = []
+    i = 0
+    in_str = False
+    str_char = ""
+    tok_start = 0
+
+    def flush_plain(end: int):
+        nonlocal tok_start
+        chunk = line[tok_start:end]
+        if chunk:
+            buf = ""
+            for ch in chunk:
+                if ch.isalnum() or ch in ("_", "."):
+                    buf += ch
+                else:
+                    if buf:
+                        if buf in _SYN_KW:
+                            color = _COL_KW
+                        elif buf.replace(".", "", 1).isdigit():
+                            color = _COL_NUM
+                        else:
+                            color = _COL_PLAIN
+                        segments.append((buf, color))
+                        buf = ""
+                    segments.append((ch, _COL_PLAIN))
+            if buf:
+                if buf in _SYN_KW:
+                    color = _COL_KW
+                elif buf.replace(".", "", 1).isdigit():
+                    color = _COL_NUM
+                else:
+                    color = _COL_PLAIN
+                segments.append((buf, color))
+        tok_start = end
+
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == str_char and (i == 0 or line[i - 1] != "\\"):
+                str_token = line[tok_start:i + 1]
+                segments.append((str_token, _COL_STR))
+                in_str = False
+                tok_start = i + 1
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            flush_plain(i)
+            in_str = True
+            str_char = ch
+            tok_start = i
+            i += 1
+            continue
+        if ch == "#":
+            flush_plain(i)
+            segments.append((line[i:], _COL_CMT))
+            i = len(line)
+            tok_start = i
+            continue
+        i += 1
+
+    flush_plain(len(line))
+    return segments
+
+
 class RenderContext:
     """
     Passed to the on_render handler. Accumulates draw commands, then flushes.
@@ -1361,21 +1452,32 @@ class RenderContext:
             "summary": _payload_dict(summary),
         })
 
-    def code_editor(self, editor_id: str, lines: list, cursor_line: int,
-                    cursor_col: int, on_change, x: float, y: float,
-                    w: float, h: float, focused: bool = True) -> dict:
+    def multiline_text_input(self, editor_id: str, lines: list, cursor_line: int,
+                             cursor_col: int, on_change, x: float, y: float,
+                             w: float, h: float, focused: bool = True,
+                             bg: Optional[str] = None, fg: Optional[str] = None,
+                             font_size: float = 14.0,
+                             line_colorizer=None) -> dict:
         """
-        Draw a multi-line Python code editor with syntax highlighting.
+        Base multi-line text input primitive.
 
-        lines: list[str] — code content, one string per line (app owns state)
+        lines: list[str] — content, one string per line (app owns state)
         cursor_line, cursor_col — cursor position (app owns)
         on_change(new_lines, new_cursor_line, new_cursor_col) — called on edits
         focused — whether this editor captures key events
+        bg, fg — background/foreground colors (defaults to dark theme)
+        font_size — font size in logical pixels
+        line_colorizer — optional callable(line_str) -> list[(segment, color)] | None
+                         If None, each line is drawn in fg. If provided, each line is
+                         drawn segment-by-segment with per-segment colors.
 
         Keyboard handling is routed through App._editor_states when focused=True.
         Requires ctx._app to be set (done automatically by App.run()).
+        Returns bounding rect dict.
         """
         _app = self._app
+        bg_color = bg or "#1e1e2e"
+        fg_color = fg or "#cdd6f4"
 
         # Register with App for key routing
         if _app is not None and focused:
@@ -1387,9 +1489,7 @@ class RenderContext:
             }
             _app._focused_editor_id = editor_id
 
-        font_size = 13.0
         line_h = font_size + 4.0
-        line_num_w = 40.0
         visible_lines = max(1, int(h / line_h))
         scroll_line = _app._editor_scroll.get(editor_id, 0) if _app else 0
 
@@ -1400,10 +1500,7 @@ class RenderContext:
             _app._editor_scroll[editor_id] = scroll_line
 
         # Background
-        self.rect(x, y, w, h, fill="#1e1e2e", radius=4.0)
-
-        # Line number column bg
-        self.rect(x, y, line_num_w, h, fill="#181825", radius=0.0)
+        self.rect(x, y, w, h, fill=bg_color, radius=4.0)
 
         # Render visible lines
         for rel_idx in range(visible_lines):
@@ -1416,117 +1513,92 @@ class RenderContext:
             if focused and line_idx == cursor_line:
                 self.rect(x, ly, w, line_h, fill="#2a2a3e", radius=0.0)
 
-            # Line number
-            line_num_str = str(line_idx + 1)
-            lnx = x + line_num_w - len(line_num_str) * 7 - 4
-            self.text(lnx, ly + 2, line_num_str, size=font_size,
-                      color="#45475a", monospace=True)
-
-            # Syntax-highlighted code
             line_text = lines[line_idx]
-            self._draw_syntax_line(x + line_num_w + 4, ly + 2, line_text,
-                                   font_size)
+            if line_colorizer is not None:
+                segments = line_colorizer(line_text)
+                if segments:
+                    char_w = font_size * 0.6
+                    cx = x + 4
+                    for tok, color in segments:
+                        self.text(cx, ly + 2, tok, size=font_size, color=color, monospace=True)
+                        cx += len(tok) * char_w
+                else:
+                    self.text(x + 4, ly + 2, line_text, size=font_size, color=fg_color, monospace=True)
+            else:
+                self.text(x + 4, ly + 2, line_text, size=font_size, color=fg_color, monospace=True)
 
         # Cursor (blink)
         if focused and self._time % 1.0 < 0.5:
             rel = cursor_line - scroll_line
             if 0 <= rel < visible_lines:
-                # Approximate char width for monospace
                 char_w = font_size * 0.6
-                cur_x = x + line_num_w + 4 + cursor_col * char_w
+                cur_x = x + 4 + cursor_col * char_w
                 cur_y = y + rel * line_h
-                self.rect(cur_x, cur_y + 1, 2.0, line_h - 2, fill="#cdd6f4")
+                self.rect(cur_x, cur_y + 1, 2.0, line_h - 2, fill=fg_color)
 
         return {"x": x, "y": y, "w": w, "h": h}
 
-    # Syntax color constants
-    _KW = frozenset({
-        'def', 'class', 'return', 'import', 'from', 'if', 'else', 'elif',
-        'for', 'while', 'in', 'not', 'and', 'or', 'True', 'False', 'None',
-        'try', 'except', 'finally', 'with', 'as', 'pass', 'raise', 'yield',
-        'lambda', 'global', 'nonlocal', 'break', 'continue', 'is', 'del',
-    })
-    _COL_KW    = "#569cd6"
-    _COL_STR   = "#ce9178"
-    _COL_CMT   = "#6a9955"
-    _COL_NUM   = "#b5cea8"
-    _COL_PLAIN = "#d4d4d4"
+    def code_editor(self, editor_id: str, lines: list, cursor_line: int,
+                    cursor_col: int, on_change, x: float, y: float,
+                    w: float, h: float, focused: bool = True,
+                    language: str = "python") -> dict:
+        """
+        Multi-line code editor with line-number gutter and syntax highlighting.
+
+        Wraps multiline_text_input — draws a 40px line-number gutter, then delegates
+        to multiline_text_input with x offset by 40px and w reduced by 40px.
+        For language="python", passes _python_colorize as the line_colorizer.
+
+        lines: list[str] — code content, one string per line (app owns state)
+        cursor_line, cursor_col — cursor position (app owns)
+        on_change(new_lines, new_cursor_line, new_cursor_col) — called on edits
+        focused — whether this editor captures key events
+        language — syntax highlighting language ("python" supported; others = plain)
+
+        Keyboard handling is routed through App._editor_states when focused=True.
+        Requires ctx._app to be set (done automatically by App.run()).
+        Returns bounding rect dict.
+        """
+        _app = self._app
+        font_size = 13.0
+        line_h = font_size + 4.0
+        line_num_w = 40.0
+        visible_lines = max(1, int(h / line_h))
+        scroll_line = _app._editor_scroll.get(editor_id, 0) if _app else 0
+        max_scroll = max(0, len(lines) - visible_lines)
+        scroll_line = min(scroll_line, max_scroll)
+
+        # Gutter background
+        self.rect(x, y, line_num_w, h, fill="#181825", radius=0.0)
+
+        # Right-aligned line numbers
+        for rel_idx in range(visible_lines):
+            line_idx = scroll_line + rel_idx
+            if line_idx >= len(lines):
+                break
+            ly = y + rel_idx * line_h
+            line_num_str = str(line_idx + 1)
+            lnx = x + line_num_w - len(line_num_str) * 7 - 4
+            self.text(lnx, ly + 2, line_num_str, size=font_size,
+                      color="#45475a", monospace=True)
+
+        # Wrap on_change to forward unchanged
+        def _wrapped_on_change(new_lines, new_cl, new_cc):
+            on_change(new_lines, new_cl, new_cc)
+
+        colorizer = _python_colorize if language == "python" else None
+
+        return self.multiline_text_input(
+            editor_id, lines, cursor_line, cursor_col, _wrapped_on_change,
+            x=x + line_num_w, y=y, w=w - line_num_w, h=h,
+            focused=focused, font_size=font_size, line_colorizer=colorizer,
+        )
 
     def _draw_syntax_line(self, x: float, y: float, line: str, size: float):
-        """Draw a single code line with basic syntax highlighting."""
+        """Draw a single code line with Python syntax highlighting. Delegates to _python_colorize."""
         char_w = size * 0.6
-
-        # Detect full-line comment
-        stripped = line.lstrip()
-        if stripped.startswith("#"):
-            self.text(x, y, line, size=size, color=self._COL_CMT, monospace=True)
-            return
-
-        # Split into (token, color) segments
-        segments: list = []
-        i = 0
-        in_str = False
-        str_char = ""
-        tok_start = 0
-
-        def flush_plain(end: int):
-            nonlocal tok_start
-            chunk = line[tok_start:end]
-            if chunk:
-                buf = ""
-                for ch in chunk:
-                    if ch.isalnum() or ch in ("_", "."):
-                        buf += ch
-                    else:
-                        if buf:
-                            if buf in self._KW:
-                                color = self._COL_KW
-                            elif buf.replace(".", "", 1).isdigit():
-                                color = self._COL_NUM
-                            else:
-                                color = self._COL_PLAIN
-                            segments.append((buf, color))
-                            buf = ""
-                        segments.append((ch, self._COL_PLAIN))
-                if buf:
-                    if buf in self._KW:
-                        color = self._COL_KW
-                    elif buf.replace(".", "", 1).isdigit():
-                        color = self._COL_NUM
-                    else:
-                        color = self._COL_PLAIN
-                    segments.append((buf, color))
-            tok_start = end
-
-        while i < len(line):
-            ch = line[i]
-            if in_str:
-                if ch == str_char and (i == 0 or line[i - 1] != "\\"):
-                    str_token = line[tok_start:i + 1]
-                    segments.append((str_token, self._COL_STR))
-                    in_str = False
-                    tok_start = i + 1
-                i += 1
-                continue
-            if ch in ('"', "'"):
-                flush_plain(i)
-                in_str = True
-                str_char = ch
-                tok_start = i
-                i += 1
-                continue
-            if ch == "#":
-                flush_plain(i)
-                segments.append((line[i:], self._COL_CMT))
-                i = len(line)
-                tok_start = i
-                continue
-            i += 1
-
-        flush_plain(len(line))
-
         cx = x
-        for tok, color in segments:
+        for tok, color in _python_colorize(line):
             self.text(cx, y, tok, size=size, color=color, monospace=True)
             cx += len(tok) * char_w
 


### PR DESCRIPTION
Cherry-pick of pyflow editor work onto current alpha (post #249 SDK). Re-creates closed PR #251.

**Commits:**
- `feat(pyflow)`: multi-line code editor + functional graph execution
- `fix(sdk)`: Pyright attribute and type errors in plexi_sdk + pyflow
- `fix(pyflow)`: narrow wire_src types for Pyright + suppress vendored SDK import warnings
- `refactor(sdk)`: extract multiline_text_input base; code_editor becomes thin wrapper

**Conflict resolution:** The SDK conflicts were resolved by taking the #249 v2 SDK as the baseline and adding the new code editor primitives (multiline_text_input, code_editor, _python_colorize, _route_key_to_editor) on top. All Pyright suppressions were already present in HEAD.