### PR TITLE
feat(protocol): OpenIntent Init payload (§3)

### DIFF
--- a/examples/text-editor/text_editor.py
+++ b/examples/text-editor/text_editor.py
@@ -1156,11 +1156,27 @@ def on_click(x: float, y: float, button: str, emit: Emitter):
 
 
 # ---------------------------------------------------------------------------
-# Initial file load from argv
+# Initial file load — OpenIntent takes priority over argv (§3 of protocol v2)
 # ---------------------------------------------------------------------------
 
-if len(sys.argv) > 1:
-    load_file(sys.argv[1])
+@app.on_init
+def on_init():
+    """Read OpenIntent at startup; fall back to argv for CLI compat."""
+    intent = app.open_intent
+    if intent is not None and intent.kind == "file" and intent.payload:
+        path = intent.payload.get("path", "")
+        if path:
+            load_file(path)
+            # If a line range was supplied, jump to the start line.
+            text_range = intent.payload.get("range")
+            if text_range and "start_line" in text_range:
+                line = max(0, int(text_range["start_line"]) - 1)
+                state.scroll_line = line
+                state.cursor = _line_start(line)
+            return
+    # Fallback: honour argv so `python3 text_editor.py <file>` still works.
+    if len(sys.argv) > 1:
+        load_file(sys.argv[1])
 
 
 if __name__ == "__main__":

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -119,50 +119,6 @@ class TextMetrics:
     ascent: float
 
 
-# ─── v2.0 OpenIntent ─────────────────────────────────────────────────────────
-
-class OpenIntent:
-    """Structured spawn intent passed at app startup via the Init event."""
-
-    def __init__(self, kind_type: str, **kwargs):
-        self.kind_type = kind_type
-        self.kwargs = kwargs
-
-    @classmethod
-    def file(cls, path: str, start_line: Optional[int] = None, end_line: Optional[int] = None) -> "OpenIntent":
-        """Open a file, optionally at a specific line range."""
-        r: dict = {"kind": "file", "path": path}
-        if start_line is not None:
-            r["range"] = {"start_line": start_line, "end_line": end_line or start_line}
-        return cls("file", **r)
-
-    @classmethod
-    def prompt(cls, text: str, model_hint: Optional[str] = None) -> "OpenIntent":
-        """Open with a text prompt."""
-        d: dict = {"kind": "prompt", "text": text}
-        if model_hint:
-            d["model_hint"] = model_hint
-        return cls("prompt", **d)
-
-    @classmethod
-    def bare(cls) -> "OpenIntent":
-        """Open with no structured intent."""
-        return cls("bare", kind="bare")
-
-    @classmethod
-    def resume(cls, snapshot_key: str) -> "OpenIntent":
-        """Resume from a snapshot key."""
-        return cls("resume", kind="resume", snapshot_key=snapshot_key)
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "OpenIntent":
-        """Deserialize from the Init event payload."""
-        kind_type = d.get("kind", "bare")
-        return cls(kind_type, **d)
-
-    def to_dict(self) -> dict:
-        return self.kwargs
-
 
 @dataclass
 class Theme:

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -425,6 +425,8 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
+
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1284,7 +1284,6 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
-                protocol_version: self.protocol_version,
                 open_intent: self.open_intent.clone(),
                 protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 capability_manifest: None,


### PR DESCRIPTION
Implements §3 of the v2 protocol spec. Closes #227.

**What changed:**
- Fixed unclosed brace in `SubscribeScope` enum (`app_protocol.rs`) that was blocking all compilation
- Removed duplicate `protocol_version` field in `ProcessApp::send_event` Init block (`process_app.rs`)
- Pruned the legacy `OpenIntent` class from the Python SDK — the dataclass version (introduced in #249) was already correct; the old one was dead code that shadowed it in the module
- Updated `text-editor` example to read `app.open_intent` in `on_init`, honouring `File` kind with optional line-range jump; falls back to `sys.argv` for CLI compatibility

**Breaks if:** text-editor launched via palette/CLI with `OpenKind::File` does not open the file or scroll to the specified line.