### PR TITLE
fix(command-palette): keyboard focus capture + arrow scroll past viewport

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -740,8 +740,21 @@ impl eframe::App for PlexiApp {
                 .unwrap_or(false)
         };
 
-        // Handle keyboard shortcuts
-        for action in keys::poll_actions(ctx, app_active) {
+        // Handle keyboard shortcuts — skip global key routing when the command
+        // palette is open so it gets exclusive keyboard focus. The palette
+        // handles Escape/Arrow/Enter itself via ctx.input_mut inside
+        // draw_command_palette. We do still consume Cmd+P here to allow
+        // toggling the palette off while it is open.
+        if self.show_command_palette {
+            let toggled_off = ctx.input_mut(|input| {
+                input.consume_key(egui::Modifiers::COMMAND, egui::Key::P)
+            });
+            if toggled_off {
+                self.show_command_palette = false;
+                self.palette_query.clear();
+            }
+        }
+        for action in if self.show_command_palette { vec![] } else { keys::poll_actions(ctx, app_active) } {
             // Log all actions at debug level (noise filter: skip high-frequency navigation/scroll).
             match &action {
                 keys::Action::Navigate(_) | keys::Action::ScrollUp | keys::Action::ScrollDown => {}

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -425,6 +425,8 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
+
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -309,12 +309,14 @@ impl PlexiApp {
                             ui.label(RichText::new("No matching panes or apps").size(11.0).color(self.colors.text_dim));
                         }
 
-                        }); // end ScrollArea
-
-                        // Scroll to keep selected row visible
+                        // Scroll to keep selected row visible — must be called
+                        // inside the ScrollArea closure so it targets this
+                        // scroll area's viewport, not the outer egui Area.
                         if let Some(rect) = selected_rect {
                             ui.scroll_to_rect(rect, None);
                         }
+
+                        }); // end ScrollArea
 
 
                         if let Some(act) = click_action {

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1284,7 +1284,6 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
-                protocol_version: self.protocol_version,
                 open_intent: self.open_intent.clone(),
                 protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 capability_manifest: None,


### PR DESCRIPTION
Closes #239. Closes #240.

## What broke and why

**#240 — focus:** `keys::poll_actions` ran unconditionally every frame, consuming Arrow/Escape/Enter before the palette's own `ctx.input_mut` block could see them. Fix: skip `poll_actions` entirely when the palette is open (it handles its own keys), with a carve-out to still consume Cmd+P so the palette can be dismissed.

**#239 — scroll:** `ui.scroll_to_rect(rect, None)` was called on the *outer* `ui` after the `ScrollArea` closed. This targeted the egui Area's scroll context (which doesn't scroll), leaving the scroll bar mispositioned and arrow-key navigation stuck at the viewport edge. Fix: move the call inside the `ScrollArea` closure where it targets the correct viewport.

## Also fixed (pre-existing compile blockers on alpha)

- `SubscribeScope` enum in `app_protocol.rs` was missing its closing `}` brace, breaking the entire crate parse.
- `PlexiEvent::Init` struct literal in `process_app.rs` had `protocol_version` specified twice; removed the stale `self.protocol_version` copy.

**Breaks if:** Command palette doesn't open on Cmd+P, or typing in the palette sends keystrokes to the underlying pane instead.