### PR TITLE
fix(alpha-bugs): quick note focus + file explorer split + HN back out

### DIFF
--- a/examples/hacker-news/hacker_news.py
+++ b/examples/hacker-news/hacker_news.py
@@ -11,7 +11,7 @@ Controls (list view):
 
 Controls (detail view):
   o        Open URL in browser
-  Enter    Back to list
+  Esc      Back to list (Backspace also works)
 """
 
 import json
@@ -263,7 +263,7 @@ def _render_detail(ctx):
         [
             ("j/k", "scroll"),
             ("o", "open URL"),
-            ("Enter", "back"),
+            ("Esc", "back"),
             ("⌘W", "close"),
         ],
     )
@@ -292,7 +292,7 @@ def on_key(key: str, _mods: dict, _emit):
             detail_scroll += 1
         elif key in ("k", "ArrowUp"):
             detail_scroll = max(0, detail_scroll - 1)
-        elif key == "Enter":
+        elif key in ("Escape", "Backspace", "Enter"):
             view = VIEW_LIST
             detail = None
             detail_scroll = 0

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -425,6 +425,8 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
+
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -953,7 +953,15 @@ impl PlexiApp {
 
         // Built-in file browser gets full permissions.
         let perms = crate::app_permissions::AppPermissions::builtin();
-        self.open_app_on_focused(app, perms, cwd);
+        // Open with a companion terminal taking 25% at the bottom so the file
+        // browser defaults to a 75% upper / 25% lower split (issue #237).
+        let launch = crate::app_registry::AppLaunchConfig {
+            mode: "companion".to_string(),
+            companion: "terminal".to_string(),
+            companion_size: 0.25,
+            ..Default::default()
+        };
+        self.open_app_on_focused_with_launch(app, perms, cwd, Some(launch));
     }
 
     /// Toggle the depth tree browser in the focused pane.

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1286,7 +1286,6 @@ impl App for ProcessApp {
                 pixels_per_point: ui.ctx().pixels_per_point(),
                 protocol_version: self.protocol_version,
                 open_intent: self.open_intent.clone(),
-                protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 capability_manifest: None,
             });
         }

--- a/src/quick_note_app.rs
+++ b/src/quick_note_app.rs
@@ -5,7 +5,10 @@ pub struct QuickNoteApp {
     text: String,
     saved: bool,
     pending_cmds: Vec<AppCommand>,
-    focus_set: bool,
+    /// Tracks whether the pane was focused on the previous frame. When the pane
+    /// gains focus (transitions from unfocused → focused), we re-request egui
+    /// focus on the TextEdit so typing works immediately after Cmd+H/J/K/L.
+    was_pane_focused: bool,
     /// Set to true after save — signals the host to close the app.
     pub should_close: bool,
 }
@@ -16,7 +19,7 @@ impl QuickNoteApp {
             text: String::new(),
             saved: false,
             pending_cmds: Vec::new(),
-            focus_set: false,
+            was_pane_focused: false,
             should_close: false,
         }
     }
@@ -73,6 +76,13 @@ impl App for QuickNoteApp {
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         let colors = ctx.colors;
 
+        // Re-request egui focus whenever the pane becomes the active one.
+        // `was_pane_focused` lets us detect the rising edge (unfocused → focused)
+        // so we don't fight egui every frame — only on the first frame after focus
+        // moves here (e.g. via Cmd+H/J/K/L).
+        let pane_just_focused = ctx.is_focused && !self.was_pane_focused;
+        self.was_pane_focused = ctx.is_focused;
+
         let rect = ui.max_rect();
         ui.painter().rect_filled(rect, 0.0, colors.terminal_bg);
 
@@ -125,9 +135,10 @@ impl App for QuickNoteApp {
                     ),
             );
 
-            if !self.focus_set {
+            // Request focus on first render OR whenever the pane regains focus
+            // (e.g. after Cmd+H/J/K/L navigates back to this pane).
+            if pane_just_focused {
                 response.request_focus();
-                self.focus_set = true;
             }
         });
     }


### PR DESCRIPTION
## Summary

- **#236** — `QuickNoteApp` re-requests egui focus on the rising edge of pane focus (`was_pane_focused` flag tracks the transition). Typing now works immediately after navigating to a quick note pane with Cmd+H/J/K/L.
- **#237** — `open_file_browser` now passes a launch config with `companion="terminal"` / `companion_size=0.25`, giving the file explorer a 75% upper / 25% lower split by default.
- **#238** — HN detail view exits on `Escape` or `Backspace` (in addition to Enter, which still works). Status bar hint updated to show "Esc".
- **Bonus build fix** — two pre-existing alpha compile errors fixed: missing `}` on `SubscribeScope` in `app_protocol.rs`, duplicate `protocol_version` field in `process_app.rs`.

Closes #236. Closes #237. Closes #238.