### PR TITLE
feat(secrets): plexi secrets CLI + Keychain backend

### DIFF
--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -425,6 +425,8 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
+
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,6 +224,143 @@ pub fn list_secrets() -> i32 {
     0
 }
 
+// ── plexi secrets subcommands (plural, v2.0) ──────────────────────────────────
+
+/// `plexi secrets set [--global] <KEY>` — stores a secret, prompting for value on stdin.
+pub fn secrets_set(global: bool, key: &str) -> i32 {
+    let directory = if global {
+        crate::secrets::GLOBAL_SCOPE.to_string()
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d.to_string_lossy().to_string(),
+            Err(e) => {
+                eprintln!("error: could not determine current directory: {e}");
+                return 1;
+            }
+        }
+    };
+
+    eprint!("Enter value for {key}: ");
+    let _ = io::stderr().flush();
+
+    let value = match read_secret_from_stdin() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("\nerror: failed to read secret: {e}");
+            return 1;
+        }
+    };
+    eprintln!(); // newline after hidden input
+
+    if value.is_empty() {
+        eprintln!("error: empty value, nothing stored");
+        return 1;
+    }
+
+    if crate::secrets::store_secret(key, &value, APP_ID, &directory) {
+        let scope = if global { "global".to_string() } else { directory.clone() };
+        eprintln!("Stored secret '{key}' ({scope})");
+        0
+    } else {
+        eprintln!("error: failed to store secret '{key}'");
+        1
+    }
+}
+
+/// `plexi secrets unset [--global] <KEY>` — removes a secret.
+pub fn secrets_unset(global: bool, key: &str) -> i32 {
+    let directory = if global {
+        crate::secrets::GLOBAL_SCOPE.to_string()
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d.to_string_lossy().to_string(),
+            Err(e) => {
+                eprintln!("error: could not determine current directory: {e}");
+                return 1;
+            }
+        }
+    };
+
+    if crate::secrets::delete_secret(key, APP_ID, &directory) {
+        let scope = if global { "global".to_string() } else { directory };
+        eprintln!("Removed secret '{key}' ({scope})");
+        0
+    } else {
+        eprintln!("error: secret '{key}' not found (does it exist at this scope?)");
+        1
+    }
+}
+
+/// `plexi secrets list` — lists key names visible in the current directory (no values).
+pub fn secrets_list() -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d.to_string_lossy().to_string(),
+        Err(e) => {
+            eprintln!("error: could not determine current directory: {e}");
+            return 1;
+        }
+    };
+
+    let entries = crate::secrets::list_secrets_for_dir(APP_ID, &cwd);
+
+    if entries.is_empty() {
+        eprintln!("No secrets visible in {cwd}.");
+        return 0;
+    }
+
+    let mut globals: Vec<&str> = entries
+        .iter()
+        .filter(|e| e.directory == crate::secrets::GLOBAL_SCOPE)
+        .map(|e| e.key.as_str())
+        .collect();
+    globals.sort();
+
+    let mut dir_keys: Vec<&str> = entries
+        .iter()
+        .filter(|e| e.directory != crate::secrets::GLOBAL_SCOPE)
+        .map(|e| e.key.as_str())
+        .collect();
+    dir_keys.sort();
+
+    if !dir_keys.is_empty() {
+        println!("{cwd}:");
+        for k in &dir_keys {
+            println!("  {k}");
+        }
+    }
+
+    if !globals.is_empty() {
+        println!("global:");
+        for k in &globals {
+            println!("  {k}");
+        }
+    }
+
+    0
+}
+
+/// `plexi secrets which <KEY>` — shows which scope a key resolves from.
+pub fn secrets_which(key: &str) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d.to_string_lossy().to_string(),
+        Err(e) => {
+            eprintln!("error: could not determine current directory: {e}");
+            return 1;
+        }
+    };
+
+    match crate::secrets::which_secret(key, APP_ID, &cwd) {
+        Some(scope) => {
+            println!("{key} → {scope}");
+            0
+        }
+        None => {
+            eprintln!("'{key}' is not set in any scope visible from {cwd}");
+            1
+        }
+    }
+}
+
 // ── plexi app subcommands ─────────────────────────────────────────────────────
 
 /// `plexi app init [--lang python|rust] <name>` — scaffold a new app in `.plexi/apps/<name>/`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,70 @@ fn main() -> eframe::Result {
                     }
                 }
             }
+            // `plexi secrets` — v2.0 plural form with --global, unset, which
+            "secrets" => {
+                if args.len() < 3 {
+                    eprintln!("Usage: plexi secrets <set|unset|list|which> [--global] [key]");
+                    std::process::exit(1);
+                }
+                match args[2].as_str() {
+                    "set" => {
+                        // plexi secrets set [--global] <KEY>
+                        let mut global = false;
+                        let mut key = "";
+                        let mut i = 3;
+                        while i < args.len() {
+                            if args[i] == "--global" {
+                                global = true;
+                                i += 1;
+                            } else {
+                                key = args[i].as_str();
+                                i += 1;
+                            }
+                        }
+                        if key.is_empty() {
+                            eprintln!("Usage: plexi secrets set [--global] <KEY>");
+                            std::process::exit(1);
+                        }
+                        std::process::exit(cli::secrets_set(global, key));
+                    }
+                    "unset" => {
+                        // plexi secrets unset [--global] <KEY>
+                        let mut global = false;
+                        let mut key = "";
+                        let mut i = 3;
+                        while i < args.len() {
+                            if args[i] == "--global" {
+                                global = true;
+                                i += 1;
+                            } else {
+                                key = args[i].as_str();
+                                i += 1;
+                            }
+                        }
+                        if key.is_empty() {
+                            eprintln!("Usage: plexi secrets unset [--global] <KEY>");
+                            std::process::exit(1);
+                        }
+                        std::process::exit(cli::secrets_unset(global, key));
+                    }
+                    "list" => {
+                        std::process::exit(cli::secrets_list());
+                    }
+                    "which" => {
+                        if args.len() < 4 {
+                            eprintln!("Usage: plexi secrets which <KEY>");
+                            std::process::exit(1);
+                        }
+                        std::process::exit(cli::secrets_which(&args[3]));
+                    }
+                    other => {
+                        eprintln!("Unknown secrets subcommand: {other}");
+                        eprintln!("Usage: plexi secrets <set|unset|list|which> [--global] [key]");
+                        std::process::exit(1);
+                    }
+                }
+            }
             "app" => {
                 if args.len() < 3 {
                     eprintln!("Usage: plexi app <init|install|uninstall|list> [options]");

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1284,7 +1284,6 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
-                protocol_version: self.protocol_version,
                 open_intent: self.open_intent.clone(),
                 protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 capability_manifest: None,

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -4,6 +4,10 @@ use zeroize::Zeroizing;
 
 const SERVICE_NAME: &str = "plexi";
 
+/// Sentinel directory value used to represent a globally-scoped secret.
+/// Must not be a valid filesystem path on any platform.
+pub const GLOBAL_SCOPE: &str = "__global__";
+
 /// A parsed Keychain entry stored under service="plexi".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretEntry {
@@ -183,8 +187,41 @@ pub fn list_all_secrets() -> Vec<SecretEntry> {
     read_index()
 }
 
+/// List secrets visible in a given directory: global secrets plus any scoped
+/// to that exact directory path. Names only — no values.
+pub fn list_secrets_for_dir(app_id: &str, directory: &str) -> Vec<SecretEntry> {
+    read_index()
+        .into_iter()
+        .filter(|e| {
+            e.app_id == app_id
+                && (e.directory == GLOBAL_SCOPE || e.directory == directory)
+        })
+        .collect()
+}
+
+/// Returns which scope ("global" or the directory path) a key resolves from,
+/// or `None` if not found. Does not return the value.
+pub fn which_secret(key: &str, app_id: &str, launch_dir: &str) -> Option<String> {
+    let index = read_index();
+    // Directory-scoped wins over global.
+    let dir_match = index.iter().find(|e| {
+        e.key == key && e.app_id == app_id && e.directory == launch_dir
+    });
+    if dir_match.is_some() {
+        return Some(launch_dir.to_string());
+    }
+    let global_match = index.iter().find(|e| {
+        e.key == key && e.app_id == app_id && e.directory == GLOBAL_SCOPE
+    });
+    if global_match.is_some() {
+        return Some("global".to_string());
+    }
+    None
+}
+
 /// Walk up from `launch_dir` to the user's home directory, returning the first
-/// matching secret. Returns `None` if no match is found at any level.
+/// matching secret. Falls through to global scope if no directory match found.
+/// Returns `None` if no match is found at any scope.
 #[cfg(target_os = "macos")]
 pub fn resolve_secret(key: &str, app_id: &str, launch_dir: &str) -> Option<Zeroizing<String>> {
     use std::path::PathBuf;
@@ -214,7 +251,8 @@ pub fn resolve_secret(key: &str, app_id: &str, launch_dir: &str) -> Option<Zeroi
         }
     }
 
-    None
+    // Fall through to global scope.
+    retrieve_secret(key, app_id, GLOBAL_SCOPE)
 }
 
 // ── Non-macOS stubs ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #247.

## What ships

- `plexi secrets set [--global] <KEY>` — directory-scoped by default, global with `--global`
- `plexi secrets unset [--global] <KEY>` — removes at the specified scope
- `plexi secrets list` — key names visible in cwd (dir-scoped + global), no values
- `plexi secrets which <KEY>` — shows which scope resolves (directory path or "global")
- Global scope stored as `__global__` sentinel in Keychain account string and index
- `resolve_secret` now falls through to global after exhausting directory walk
- New `list_secrets_for_dir()` and `which_secret()` in `secrets.rs`
- `GLOBAL_SCOPE` exported as `pub const` for use by secrets_app GUI

Also fixes two pre-existing compile errors on alpha:
- Missing `}` closing `SubscribeScope` enum in `app_protocol.rs`
- Duplicate `protocol_version` field in `PlexiEvent::Init` in `process_app.rs`

The old `plexi secret` (singular) subcommand is unchanged for backward compat.