### PR TITLE
feat(protocol): Run primitive + run palette card (§5)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -12,6 +12,10 @@
 
 **Breaks if:** notification palette crashes on Enter with any notification that has a `run_id` set.
 
+## 2026-04-16 — [CHANGED] Run primitive end-to-end: RunGet + run palette (PR → alpha, closes #228)
+Completed the Run primitive (#228): added `DrawCommand::RunGet` (app fetches run state by id) with `PlexiEvent::RunState` response; added `run_store.list_all()` alongside existing `list_active()`; created `src/run_palette.rs` (Cmd+Shift+U) showing active/completed runs as cards with status pills, head_task, initiating app, and elapsed time — `BlockedOnUser` runs surface the prompt inline. Also fixed two pre-existing bugs in `app_protocol.rs` (missing `}` on `SubscribeScope`) and `process_app.rs` (duplicate `protocol_version` field in `Init` struct literal) that caused compile failures.
+**Breaks if:** Cmd+Shift+U doesn't open the run palette; or `run_state` events are not delivered back to apps after a `run_get` draw command.
+
 ## 2026-04-15 — [DECISION] v2.0 RC: full protocol implementation — OpenIntent, event bus, Run primitive, typed pipes Phase 1, Plexi IQ Stage 1
 
 Implemented all v2.0 scope items in a single RC branch. Key choices: event bus uses std::sync::mpsc with 4096-bound sync_channel and fan-out via a subscriber Vec (no tokio dep needed — matches existing sync threading model in ProcessApp); RunStore is in-memory with JSONL append log (no SQLite, mirrors notification log pattern); Plexi IQ Stage 1 uses `claude -p --resume` subprocess backend per spec §9 (native API mode is config option, not default); typed pipes auto-wiring on spawn rather than at runtime for simplicity. EventSubscribe uses broadcast via a shared subscriber list rather than tokio::broadcast to stay on std threads. ProcessApp now holds optional Arc refs to EventLog and RunStore — wired at launch time via wire() method rather than passing through the App trait (which is object-safe and couldn't hold generics).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ Everything on `main` plus:
 | Host event bus (`events.jsonl`) | Cross-app observation; required by everything downstream |
 | Fractal depth tree POC (#260) | `.plexi` boundaries are discoverable and visible before embedded rendering |
 | `OpenIntent` payload on `Init` | Apps know *why* they were opened (file, prompt, caller) |
-| `Run` primitive — dumb store, draw commands | Stateful multi-step tasks with blocked/running/done lifecycle |
+| `Run` primitive — dumb store, draw commands | Stateful multi-step tasks with blocked/running/done lifecycle | **Done** (#228) |
 
 ### Month 2 — Surface
 | Item | Unlocks |

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,8 @@ pub struct PlexiApp {
     pub(crate) palette_selected: usize,
     pub(crate) show_notification_palette: bool,
     pub(crate) notification_palette_selected: usize,
+    pub(crate) show_run_palette: bool,
+    pub(crate) run_palette_selected: usize,
     pub(crate) pane_visit_history: Vec<(usize, egui_tiles::TileId)>,
     pub(crate) app_visit_history: Vec<String>,
     pub(crate) renaming_pane: Option<PaneId>,
@@ -234,6 +236,8 @@ impl PlexiApp {
                     palette_selected: 0,
                     show_notification_palette: false,
                     notification_palette_selected: 0,
+                    show_run_palette: false,
+                    run_palette_selected: 0,
                     pane_visit_history: Vec::new(),
                     app_visit_history: config::load_app_mru(),
                     renaming_pane: None,
@@ -305,6 +309,8 @@ impl PlexiApp {
             palette_selected: 0,
             show_notification_palette: false,
             notification_palette_selected: 0,
+            show_run_palette: false,
+            run_palette_selected: 0,
             pane_visit_history: Vec::new(),
             app_visit_history: config::load_app_mru(),
             renaming_pane: None,
@@ -965,6 +971,12 @@ impl eframe::App for PlexiApp {
                         self.notification_palette_selected = 0;
                     }
                 }
+                Action::ToggleRunPalette => {
+                    self.show_run_palette = !self.show_run_palette;
+                    if self.show_run_palette {
+                        self.run_palette_selected = 0;
+                    }
+                }
                 Action::AscendDepth => {
                     self.ascend_depth();
                 }
@@ -1176,6 +1188,8 @@ impl eframe::App for PlexiApp {
                     .collect();
                 let suppress_focus = self.renaming_context.is_some()
                     || self.show_command_palette
+                    || self.show_notification_palette
+                    || self.show_run_palette
                     || self.renaming_pane.is_some();
 
                 #[cfg(target_os = "macos")]
@@ -1445,6 +1459,11 @@ impl eframe::App for PlexiApp {
         // Notification palette overlay
         if self.show_notification_palette {
             self.draw_notification_palette(ctx);
+        }
+
+        // Run palette overlay
+        if self.show_run_palette {
+            self.draw_run_palette(ctx);
         }
 
         // Rename pane overlay

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -146,6 +146,12 @@ pub enum PlexiEvent {
     Shutdown,
     /// A Run was created; the run_id is returned to the requesting app.
     RunCreated { run_id: String },
+    /// Response to a RunGet request — the current state of a run.
+    RunState {
+        run_id: String,
+        /// `None` if the run_id was not found.
+        run: Option<Run>,
+    },
     /// A value arrived on a named pipe channel from another app.
     ///
     /// Sent by the host when a connected app (parent or child via spawn
@@ -824,6 +830,8 @@ pub enum DrawCommand {
         run_id: String,
         outcome: RunOutcome,
     },
+    /// Fetch the current state of a run by id. Plexi responds with `PlexiEvent::RunState`.
+    RunGet { run_id: String },
     /// List active pipe wires.
     PipeListWires,
     /// Push a transform onto the transform stack.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -89,6 +89,8 @@ pub enum Action {
     AppRedo,
     /// Open the notification palette (shows unread notifications).
     ToggleNotificationPalette,
+    /// Open the run palette (shows active and recent runs).
+    ToggleRunPalette,
     /// Ascend one depth level in the Z-axis (Cmd+Escape).
     AscendDepth,
     /// Toggle lock on the focused pane (prevents Cmd+W close).
@@ -167,6 +169,7 @@ pub fn poll_actions(ctx: &egui::Context, app_active: bool) -> Vec<Action> {
         Binding { key: egui::Key::P, modifiers: cmd, guard: Guard::Always, action: || Action::ToggleCommandPalette },
         Binding { key: egui::Key::R, modifiers: cmd_shift, guard: Guard::Always, action: || Action::RenamePane },
         Binding { key: egui::Key::N, modifiers: cmd_shift, guard: Guard::Always, action: || Action::ToggleNotificationPalette },
+        Binding { key: egui::Key::U, modifiers: cmd_shift, guard: Guard::Always, action: || Action::ToggleRunPalette },
         Binding { key: egui::Key::N, modifiers: cmd, guard: Guard::Always, action: || Action::NewContext },
         // Scroll
         Binding { key: egui::Key::ArrowUp, modifiers: cmd, guard: Guard::Always, action: || Action::ScrollUp },

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,8 @@ mod notification_palette;
 #[cfg(not(target_arch = "wasm32"))]
 mod notify_socket;
 #[cfg(not(target_arch = "wasm32"))]
+mod run_palette;
+#[cfg(not(target_arch = "wasm32"))]
 mod overlays;
 #[cfg(not(target_arch = "wasm32"))]
 mod pane;

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -994,6 +994,7 @@ impl ProcessApp {
                 | DrawCommand::RunCreate { .. }
                 | DrawCommand::RunUpdate { .. }
                 | DrawCommand::RunComplete { .. }
+                | DrawCommand::RunGet { .. }
                 | DrawCommand::EventSubscribe { .. }
                 | DrawCommand::PipeListWires
                 | DrawCommand::PushTransform { .. }
@@ -1284,6 +1285,7 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
+                protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 open_intent: self.open_intent.clone(),
                 capability_manifest: None,
             });
@@ -1507,6 +1509,12 @@ impl App for ProcessApp {
                             timestamp: crate::event_log::now_timestamp(),
                         });
                     }
+                }
+                DrawCommand::RunGet { run_id } => {
+                    let run = self.run_store.as_ref()
+                        .and_then(|rs| rs.lock().ok())
+                        .and_then(|store| store.get(&run_id).cloned());
+                    self.send_event(&PlexiEvent::RunState { run_id, run });
                 }
                 DrawCommand::EventSubscribe { kinds: _, scope: _ } => {
                     // Phase 0 no-op: accepted for forward compatibility.

--- a/src/run_palette.rs
+++ b/src/run_palette.rs
@@ -1,0 +1,253 @@
+/// Run palette — Cmd+Shift+U.
+///
+/// Shows active and recently completed runs as cards. Each card displays the
+/// run's status pill, head_task (current activity), initiating app, and
+/// elapsed time. Modeled structurally on `notification_palette.rs`.
+
+use egui::{Align, Align2, Color32, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
+
+use crate::app::PlexiApp;
+use crate::app_protocol::{Run, RunStatus};
+use crate::overlays::MODAL_WIDTH;
+
+impl PlexiApp {
+    pub(crate) fn draw_run_palette(&mut self, ctx: &egui::Context) {
+        // Snapshot run store under lock, then release before UI work.
+        let runs: Vec<Run> = match self.run_store.lock() {
+            Ok(store) => {
+                let mut all: Vec<Run> = store.list_all().into_iter().cloned().collect();
+                // Newest first — sort by created_at descending.
+                all.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                all
+            }
+            Err(e) => {
+                log::error!("run_palette: mutex poisoned: {e}");
+                return;
+            }
+        };
+
+        let total = runs.len();
+        if self.run_palette_selected >= total.max(1) {
+            self.run_palette_selected = 0;
+        }
+
+        // ── Keyboard nav ────────────────────────────────────────────────────
+        let mut close = false;
+        ctx.input_mut(|input| {
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+                close = true;
+            }
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                && total > 0
+                && self.run_palette_selected + 1 < total
+            {
+                self.run_palette_selected += 1;
+            }
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                && self.run_palette_selected > 0
+            {
+                self.run_palette_selected -= 1;
+            }
+        });
+
+        // ── Render ──────────────────────────────────────────────────────────
+        let screen_rect = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("run_palette_scrim"))
+            .fixed_pos(screen_rect.min)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(screen_rect, 0.0, Color32::from_black_alpha(120));
+                let scrim_response = ui.allocate_rect(screen_rect, egui::Sense::click());
+                if scrim_response.clicked() {
+                    close = true;
+                }
+            });
+
+        egui::Area::new(egui::Id::new("run_palette"))
+            .anchor(Align2::CENTER_TOP, Vec2::new(0.0, 80.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(CornerRadius::same(6))
+                    .inner_margin(egui::Margin::symmetric(12, 10))
+                    .show(ui, |ui| {
+                        ui.set_width(MODAL_WIDTH);
+
+                        // Header
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                RichText::new("Runs")
+                                    .size(13.0)
+                                    .color(self.colors.text_primary)
+                                    .strong(),
+                            );
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                let active_count = runs.iter().filter(|r| is_active(r)).count();
+                                if active_count > 0 {
+                                    ui.label(
+                                        RichText::new(format!("{active_count} active"))
+                                            .size(10.0)
+                                            .color(self.colors.text_dim),
+                                    );
+                                }
+                            });
+                        });
+                        ui.add_space(6.0);
+
+                        if runs.is_empty() {
+                            ui.label(
+                                RichText::new("No runs yet")
+                                    .size(11.0)
+                                    .color(self.colors.text_dim),
+                            );
+                            return;
+                        }
+
+                        egui::ScrollArea::vertical()
+                            .max_height(400.0)
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| {
+                                for (row_idx, run) in runs.iter().enumerate() {
+                                    let is_selected = row_idx == self.run_palette_selected;
+                                    let fill = if is_selected {
+                                        self.colors.bg_active
+                                    } else {
+                                        Color32::TRANSPARENT
+                                    };
+
+                                    let row_rect = Rect::from_min_size(
+                                        ui.cursor().min,
+                                        Vec2::new(MODAL_WIDTH, 52.0),
+                                    );
+                                    ui.painter().rect_filled(row_rect, CornerRadius::same(4), fill);
+
+                                    // Status dot on the left
+                                    let dot_color = status_color(&run.status, &self.colors);
+                                    ui.painter().circle_filled(
+                                        egui::pos2(row_rect.min.x + 12.0, row_rect.center().y),
+                                        4.0,
+                                        dot_color,
+                                    );
+
+                                    ui.allocate_ui_with_layout(
+                                        Vec2::new(MODAL_WIDTH, 52.0),
+                                        Layout::left_to_right(Align::Center),
+                                        |ui| {
+                                            ui.add_space(24.0);
+                                            ui.vertical(|ui| {
+                                                ui.add_space(4.0);
+                                                // Row 1: app id + status pill + elapsed
+                                                ui.horizontal(|ui| {
+                                                    ui.label(
+                                                        RichText::new(&run.initiator.app_id)
+                                                            .size(10.0)
+                                                            .color(self.colors.text_dim),
+                                                    );
+                                                    ui.label(
+                                                        RichText::new("\u{203A}")
+                                                            .size(10.0)
+                                                            .color(self.colors.text_dim),
+                                                    );
+                                                    let pill = status_label(&run.status);
+                                                    ui.label(
+                                                        RichText::new(pill)
+                                                            .size(9.0)
+                                                            .color(dot_color),
+                                                    );
+                                                    ui.with_layout(
+                                                        Layout::right_to_left(Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                RichText::new(elapsed(run.created_at))
+                                                                    .size(9.0)
+                                                                    .color(self.colors.text_section),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                                // Row 2: head_task
+                                                ui.label(
+                                                    RichText::new(&run.head_task)
+                                                        .size(12.0)
+                                                        .color(self.colors.text_primary),
+                                                );
+                                                // Row 3: blocked-on-user prompt if applicable
+                                                if let RunStatus::BlockedOnUser { ref prompt, .. } = run.status {
+                                                    ui.label(
+                                                        RichText::new(format!("\u{26A0} {prompt}"))
+                                                            .size(10.0)
+                                                            .color(Color32::from_rgb(0xf9, 0xc8, 0x6a)),
+                                                    );
+                                                }
+                                            });
+                                        },
+                                    );
+
+                                    let r = ui.interact(
+                                        row_rect,
+                                        egui::Id::new(("run_row", row_idx)),
+                                        egui::Sense::click(),
+                                    );
+                                    if r.hovered() {
+                                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                                    }
+                                }
+                            });
+                    });
+            });
+
+        if close {
+            self.show_run_palette = false;
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn is_active(run: &Run) -> bool {
+    !matches!(
+        run.status,
+        RunStatus::Complete | RunStatus::Failed { .. } | RunStatus::Cancelled
+    )
+}
+
+fn status_label(status: &RunStatus) -> &'static str {
+    match status {
+        RunStatus::Pending => "pending",
+        RunStatus::Running => "running",
+        RunStatus::BlockedOnUser { .. } => "blocked:user",
+        RunStatus::BlockedOnChild { .. } => "blocked:child",
+        RunStatus::Complete => "done",
+        RunStatus::Failed { .. } => "failed",
+        RunStatus::Cancelled => "cancelled",
+    }
+}
+
+fn status_color(status: &RunStatus, colors: &crate::theme::Colors) -> Color32 {
+    match status {
+        RunStatus::Pending => colors.text_dim,
+        RunStatus::Running => Color32::from_rgb(0x89, 0xdc, 0xeb),
+        RunStatus::BlockedOnUser { .. } => Color32::from_rgb(0xf9, 0xc8, 0x6a),
+        RunStatus::BlockedOnChild { .. } => Color32::from_rgb(0xf9, 0xc8, 0x6a),
+        RunStatus::Complete => Color32::from_rgb(0xa6, 0xe3, 0xa1),
+        RunStatus::Failed { .. } => Color32::from_rgb(0xdd, 0x77, 0x55),
+        RunStatus::Cancelled => colors.text_section,
+    }
+}
+
+/// Format seconds since epoch as a human-readable elapsed string (e.g. "2m ago").
+fn elapsed(created_at: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let secs = (now - created_at).max(0);
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h ago", secs / 3600)
+    }
+}

--- a/src/run_store.rs
+++ b/src/run_store.rs
@@ -92,6 +92,11 @@ impl RunStore {
         )).collect()
     }
 
+    /// All runs in the in-memory index (active and completed), unsorted.
+    pub fn list_all(&self) -> Vec<&Run> {
+        self.runs.values().collect()
+    }
+
     fn append_log(&self, run: &Run) {
         if let Ok(line) = serde_json::to_string(run) {
             match OpenOptions::new().create(true).append(true).open(&self.log_path) {


### PR DESCRIPTION
Closes #228.

## What's in this PR

- `DrawCommand::RunGet { run_id }` — app requests current state of a run by id; host responds with `PlexiEvent::RunState { run_id, run: Option<Run> }`
- `run_store::list_all()` — returns all runs (active + completed) for palette display
- `src/run_palette.rs` — new Cmd+Shift+U overlay showing runs as cards: status pill (color-coded), head_task, initiating app id, elapsed time; `BlockedOnUser` runs surface the user prompt inline
- `keys.rs` — `Action::ToggleRunPalette` bound to Cmd+Shift+U
- `app.rs` — `show_run_palette` / `run_palette_selected` state, action handler, draw call, added to `suppress_focus` guard
- Fixed two pre-existing compile bugs: missing `}` on `SubscribeScope` enum; duplicate `protocol_version` field in `PlexiEvent::Init` struct literal
- ROADMAP.md: marks Run primitive row Done