### PR TITLE
feat(protocol): rich notification action payloads (§6)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,17 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-16 — [CHANGED] Rich notification action payloads — closes #229
+
+`NotificationAction` enum was already in `app_protocol.rs` with all 8 variants. Three gaps closed:
+
+1. `notification_log::Notification` now carries `run_id: Option<String>` and `action: Option<NotificationAction>` (structured, v2.0+). The old `action_type: String` / `action_payload: Value` pair is kept as `Option<String>` / `Option<Value>` for backwards-compat JSONL round-tripping from older builds.
+
+2. `notification_palette.rs` now dispatches all 8 action types via `dispatch_notification_action()`. `Focus` and `ExternalUrl` are fully wired. `ResumeRun`, `OpenIntent`, `RunCommand` log a TODO and no-op until their respective host-side paths exist. `Confirm`/`TextInput` degrade to mark-read+close. Run cards (taller rows with run_id pill + action label) render when `run_id` is set.
+
+3. Python SDK: `Emitter.notify()` and `RenderContext.notify()` updated to emit the structured `action` field. Added `NotificationAction` helper class with factory statics for all 8 types. Old `action_type`/`action_payload` params removed in favour of `action: dict`.
+
+**Breaks if:** notification palette crashes on Enter with any notification that has a `run_id` set.
+
 ## 2026-04-15 — [DECISION] v2.0 RC: full protocol implementation — OpenIntent, event bus, Run primitive, typed pipes Phase 1, Plexi IQ Stage 1
 
 Implemented all v2.0 scope items in a single RC branch. Key choices: event bus uses std::sync::mpsc with 4096-bound sync_channel and fan-out via a subscriber Vec (no tokio dep needed — matches existing sync threading model in ProcessApp); RunStore is in-memory with JSONL append log (no SQLite, mirrors notification log pattern); Plexi IQ Stage 1 uses `claude -p --resume` subprocess backend per spec §9 (native API mode is config option, not default); typed pipes auto-wiring on spawn rather than at runtime for simplicity. EventSubscribe uses broadcast via a shared subscriber list rather than tokio::broadcast to stay on std threads. ProcessApp now holds optional Arc refs to EventLog and RunStore — wired at launch time via wire() method rather than passing through the App trait (which is object-safe and couldn't hold generics).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@ Everything on `main` plus:
 ### Month 2 — Surface
 | Item | Unlocks |
 |---|---|
-| Rich notification actions (extends #219) | Notifications can wrap and resume a Run |
+| ~~Rich notification actions (#229)~~ | Done — `NotificationAction` enum, `run_id`, SDK helpers |
 | Render summary protocol | Parent depths can request cheap status without full embedded rendering |
 | Capability enforcement + `permissions.json` | Runtime Yes once / Yes always / No; persistent grants |
 | Typed pipes Phase 1 — manifest `[app.io]`, auto-wire | Apps compose without code changes |

--- a/sdk/python/plexi_sdk.py
+++ b/sdk/python/plexi_sdk.py
@@ -325,6 +325,68 @@ def safe_move(src: pathlib.Path, dest_dir: pathlib.Path) -> str:
         return f"Error: {e}"
 
 
+class NotificationAction:
+    """
+    Factory helpers for structured notification actions (v2.0+).
+
+    Each method returns a dict that can be passed as the `action` argument
+    to `Emitter.notify()` or `RenderContext.notify()`.
+
+    Example::
+
+        emit.notify(
+            "Build finished",
+            action=NotificationAction.external_url("https://ci.example.com/runs/42"),
+        )
+
+        emit.notify(
+            "Run blocked — needs input",
+            action=NotificationAction.resume_run(run_id),
+            run_id=run_id,
+        )
+    """
+
+    @staticmethod
+    def dismiss() -> dict:
+        return {"type": "dismiss"}
+
+    @staticmethod
+    def focus(pane_id: int, fullscreen: bool = False) -> dict:
+        return {"type": "focus", "pane_id": pane_id, "fullscreen": fullscreen}
+
+    @staticmethod
+    def resume_run(run_id: str) -> dict:
+        return {"type": "resume_run", "run_id": run_id}
+
+    @staticmethod
+    def open_intent(open_intent: dict) -> dict:
+        return {"type": "open_intent", "open_intent": open_intent}
+
+    @staticmethod
+    def run_command(app_id: str, command: str, args: Optional[list] = None) -> dict:
+        return {"type": "run_command", "app_id": app_id, "command": command, "args": args or []}
+
+    @staticmethod
+    def external_url(url: str) -> dict:
+        return {"type": "external_url", "url": url}
+
+    @staticmethod
+    def confirm(confirm_text: str, cancel_text: str, on_confirm: dict) -> dict:
+        return {
+            "type": "confirm",
+            "confirm_text": confirm_text,
+            "cancel_text": cancel_text,
+            "on_confirm": on_confirm,
+        }
+
+    @staticmethod
+    def text_input(prompt: str, on_submit: dict, placeholder: Optional[str] = None) -> dict:
+        action: dict = {"type": "text_input", "prompt": prompt, "on_submit": on_submit}
+        if placeholder is not None:
+            action["placeholder"] = placeholder
+        return action
+
+
 class Emitter:
     """Emit commands to Plexi immediately (outside a render frame)."""
 
@@ -386,8 +448,8 @@ class Emitter:
         title: str,
         body: Optional[str] = None,
         urgency: str = "low",
-        action_type: str = "dismiss",
-        action_payload: Optional[dict] = None,
+        action: Optional[dict] = None,
+        run_id: Optional[str] = None,
         expires_at: Optional[int] = None,
         visible_after: Optional[int] = None,
     ):
@@ -395,8 +457,20 @@ class Emitter:
         Raise a notification to Plexi's notification log.
 
         urgency: "low" | "medium" | "high"
-        action_type: "dismiss" | "focus" | "confirm" | "text_input"
-        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+
+        action: structured NotificationAction dict (v2.0+). Use the helpers:
+            NotificationAction.focus(pane_id, fullscreen=False)
+            NotificationAction.resume_run(run_id)
+            NotificationAction.open_intent(open_intent_dict)
+            NotificationAction.run_command(app_id, command, args=[])
+            NotificationAction.external_url(url)
+            NotificationAction.confirm(confirm_text, cancel_text, on_confirm)
+            NotificationAction.text_input(prompt, placeholder=None, on_submit)
+            NotificationAction.dismiss()
+
+        run_id: associate this notification with a Run. Renders as a run card
+            in the palette with elapsed time and status pill.
+
         expires_at: unix timestamp (seconds); notification is dropped if already past
         visible_after: unix timestamp (seconds); defer display until this time
 
@@ -406,15 +480,17 @@ class Emitter:
         """
         cmd: dict = {
             "type": "notification",
+            "id": str(uuid.uuid4()),
             "title": title,
             "source_app": self._app_id,
             "urgency": urgency,
-            "action_type": action_type,
         }
         if body is not None:
             cmd["body"] = body
-        if action_payload is not None:
-            cmd["action_payload"] = action_payload
+        if action is not None:
+            cmd["action"] = action
+        if run_id is not None:
+            cmd["run_id"] = run_id
         if expires_at is not None:
             cmd["expires_at"] = expires_at
         if visible_after is not None:
@@ -1361,8 +1437,8 @@ class RenderContext:
         title: str,
         body: Optional[str] = None,
         urgency: str = "low",
-        action_type: str = "dismiss",
-        action_payload: Optional[dict] = None,
+        action: Optional[dict] = None,
+        run_id: Optional[str] = None,
         expires_at: Optional[int] = None,
         visible_after: Optional[int] = None,
     ):
@@ -1370,22 +1446,34 @@ class RenderContext:
         Raise a notification from inside a render frame.
 
         urgency: "low" | "medium" | "high"
-        action_type: "dismiss" | "focus" | "confirm" | "text_input"
-        action_payload: type-dependent dict; for "focus": {"pane_id": int, "fullscreen": bool}
+
+        action: structured NotificationAction dict (v2.0+). Use the helpers:
+            NotificationAction.focus(pane_id, fullscreen=False)
+            NotificationAction.resume_run(run_id)
+            NotificationAction.open_intent(open_intent_dict)
+            NotificationAction.run_command(app_id, command, args=[])
+            NotificationAction.external_url(url)
+            NotificationAction.confirm(confirm_text, cancel_text, on_confirm)
+            NotificationAction.text_input(prompt, placeholder=None, on_submit)
+            NotificationAction.dismiss()
+
+        run_id: associate this notification with a Run; renders as a run card.
         expires_at: unix timestamp (seconds); notification is dropped if already past
         visible_after: unix timestamp (seconds); defer display until this time
         """
         cmd: dict = {
             "type": "notification",
+            "id": str(uuid.uuid4()),
             "title": title,
             "source_app": self._app_id,
             "urgency": urgency,
-            "action_type": action_type,
         }
         if body is not None:
             cmd["body"] = body
-        if action_payload is not None:
-            cmd["action_payload"] = action_payload
+        if action is not None:
+            cmd["action"] = action
+        if run_id is not None:
+            cmd["run_id"] = run_id
         if expires_at is not None:
             cmd["expires_at"] = expires_at
         if visible_after is not None:

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -45,10 +45,6 @@ fn notification_default_urgency() -> String {
     "low".to_string()
 }
 
-fn notification_default_action_type() -> String {
-    "dismiss".to_string()
-}
-
 // ── Events sent FROM Plexi TO the app ────────────────────────────────────────
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -425,6 +421,8 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
+
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/notification_log.rs
+++ b/src/notification_log.rs
@@ -13,6 +13,7 @@
 /// styling, no dismissal persistence, no tray. See issue #74 for the full
 /// attention queue vision; this is the unblock-Parallax MVP.
 
+use crate::app_protocol::NotificationAction;
 use crate::config;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -23,16 +24,16 @@ fn default_urgency() -> String {
     "low".to_string()
 }
 
-fn default_action_type() -> String {
-    "dismiss".to_string()
-}
-
 /// A notification record.
 ///
 /// `timestamp` is UTC; `read` defaults to false and flips when the user clicks
 /// the notification in the palette. `read` is NOT persisted — on restart,
 /// reloaded notifications come back as read since the user has presumably
 /// already seen them in a previous session.
+///
+/// v2.0: `action` replaces the old `action_type`/`action_payload` string pair.
+/// Both fields are kept for backwards-compat deserialization of JSONL written
+/// by older builds; new code should read `action` first.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Notification {
     pub timestamp: chrono::DateTime<chrono::Utc>,
@@ -52,12 +53,18 @@ pub struct Notification {
     /// Unix timestamp (seconds). Defer rendering until this time has passed.
     #[serde(default)]
     pub visible_after: Option<i64>,
-    /// Action triggered when the user presses Enter on this notification.
-    /// Values: "focus" | "confirm" | "text_input" | "dismiss".
-    #[serde(default = "default_action_type")]
-    pub action_type: String,
-    /// Type-dependent payload for `action_type`.
-    /// For "focus": `{"pane_id": u64, "fullscreen": bool}`.
+    /// Run this notification is associated with. When set, the palette renders
+    /// this notification as a run card (head_task + elapsed + status pill).
+    #[serde(default)]
+    pub run_id: Option<String>,
+    /// Structured action (v2.0+). Supersedes `action_type`/`action_payload`.
+    #[serde(default)]
+    pub action: Option<NotificationAction>,
+    /// Legacy action type string — kept for JSONL round-trip compat.
+    /// Prefer `action` for new code.
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Legacy action payload — kept for JSONL round-trip compat.
     #[serde(default)]
     pub action_payload: Option<serde_json::Value>,
     /// Who emitted this notification: "app:<id>", "claude-code", "socket", etc.
@@ -189,8 +196,8 @@ pub fn record(
     urgency: String,
     expires_at: Option<i64>,
     visible_after: Option<i64>,
-    action_type: String,
-    action_payload: Option<serde_json::Value>,
+    run_id: Option<String>,
+    action: Option<NotificationAction>,
     source: Option<String>,
 ) {
     let n = Notification {
@@ -202,8 +209,10 @@ pub fn record(
         urgency,
         expires_at,
         visible_after,
-        action_type,
-        action_payload,
+        run_id,
+        action,
+        action_type: None,
+        action_payload: None,
         source,
     };
     match global().lock() {

--- a/src/notification_palette.rs
+++ b/src/notification_palette.rs
@@ -8,6 +8,7 @@
 use egui::{Align, Align2, Color32, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 
 use crate::app::PlexiApp;
+use crate::app_protocol::NotificationAction;
 use crate::notification_log::{self, Notification};
 use crate::overlays::MODAL_WIDTH;
 
@@ -150,9 +151,11 @@ impl PlexiApp {
                                         Color32::TRANSPARENT
                                     };
 
+                                    // Run-card notifications get taller rows.
+                                    let row_h = if n.run_id.is_some() { 58.0 } else { 42.0 };
                                     let row_rect = Rect::from_min_size(
                                         ui.cursor().min,
-                                        Vec2::new(MODAL_WIDTH, 42.0),
+                                        Vec2::new(MODAL_WIDTH, row_h),
                                     );
                                     ui.painter().rect_filled(row_rect, CornerRadius::same(4), fill);
 
@@ -167,13 +170,13 @@ impl PlexiApp {
                                         }
                                     };
                                     ui.painter().circle_filled(
-                                        egui::pos2(row_rect.min.x + 12.0, row_rect.center().y),
+                                        egui::pos2(row_rect.min.x + 12.0, row_rect.min.y + 21.0),
                                         4.0,
                                         dot_color,
                                     );
 
                                     ui.allocate_ui_with_layout(
-                                        Vec2::new(MODAL_WIDTH, 42.0),
+                                        Vec2::new(MODAL_WIDTH, row_h),
                                         Layout::left_to_right(Align::Center),
                                         |ui| {
                                             ui.add_space(24.0);
@@ -212,6 +215,33 @@ impl PlexiApp {
                                                         .size(9.0)
                                                         .color(self.colors.text_dim),
                                                 );
+                                                // Run card: show run_id pill when present.
+                                                if let Some(run_id) = &n.run_id {
+                                                    ui.add_space(2.0);
+                                                    ui.horizontal(|ui| {
+                                                        let run_label = format!("\u{25B6} run:{}", &run_id[..run_id.len().min(8)]);
+                                                        ui.label(
+                                                            RichText::new(run_label)
+                                                                .size(9.0)
+                                                                .color(Color32::from_rgb(0x6a, 0xb0, 0xf9))
+                                                                .monospace(),
+                                                        );
+                                                        // Action label for run-associated notifications.
+                                                        let action_label = match &n.action {
+                                                            Some(NotificationAction::ResumeRun { .. }) => Some("Resume"),
+                                                            Some(NotificationAction::OpenIntent { .. }) => Some("Open"),
+                                                            Some(NotificationAction::Focus { .. }) => Some("Focus"),
+                                                            _ => None,
+                                                        };
+                                                        if let Some(label) = action_label {
+                                                            ui.label(
+                                                                RichText::new(format!("· {label}"))
+                                                                    .size(9.0)
+                                                                    .color(self.colors.text_dim),
+                                                            );
+                                                        }
+                                                    });
+                                                }
                                             });
                                         },
                                     );
@@ -254,28 +284,7 @@ impl PlexiApp {
             Some(Action::ActivateSelected) => {
                 if self.notification_palette_selected < total {
                     let (log_idx, ref n) = ordered[self.notification_palette_selected];
-                    match n.action_type.as_str() {
-                        "focus" => {
-                            // Payload: {"pane_id": u64, "fullscreen": bool}
-                            let pane_id = n
-                                .action_payload
-                                .as_ref()
-                                .and_then(|p| p.get("pane_id"))
-                                .and_then(|v| v.as_u64());
-                            let fullscreen = n
-                                .action_payload
-                                .as_ref()
-                                .and_then(|p| p.get("fullscreen"))
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false);
-                            if let Some(pid) = pane_id {
-                                self.focus_pane_by_id(pid, fullscreen);
-                            }
-                        }
-                        // "confirm" and "text_input" degrade to mark-read + close
-                        // until inline sub-prompt UI is implemented.
-                        _ => {}
-                    }
+                    dispatch_notification_action(self, n);
                     if let Ok(mut log) = notification_log::global().lock() {
                         log.mark_read(log_idx);
                     }
@@ -283,6 +292,63 @@ impl PlexiApp {
                 }
             }
             None => {}
+        }
+    }
+}
+
+/// Dispatch the structured action on a notification. Called on Enter press or
+/// button click. Falls back to mark-read-only for action types that require
+/// additional UI (Confirm, TextInput) until inline sub-prompt UI is implemented.
+fn dispatch_notification_action(app: &mut PlexiApp, n: &Notification) {
+    // Resolve the effective action: prefer the v2.0 structured field; fall back
+    // to legacy action_type/action_payload for JSONL entries from older builds.
+    let effective_action: Option<NotificationAction> = n.action.clone().or_else(|| {
+        n.action_type.as_deref().and_then(|at| match at {
+            "focus" => {
+                let pane_id = n.action_payload.as_ref()?.get("pane_id")?.as_u64()?;
+                let fullscreen = n
+                    .action_payload
+                    .as_ref()
+                    .and_then(|p| p.get("fullscreen"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                Some(NotificationAction::Focus { pane_id, fullscreen })
+            }
+            _ => Some(NotificationAction::Dismiss),
+        })
+    });
+
+    match effective_action {
+        Some(NotificationAction::Focus { pane_id, fullscreen }) => {
+            app.focus_pane_by_id(pane_id, fullscreen);
+        }
+        Some(NotificationAction::ResumeRun { run_id }) => {
+            // TODO(#229): wire ResumeRun once run wakeup path is defined.
+            log::info!("notification_palette: ResumeRun {run_id} (wakeup path pending)");
+        }
+        Some(NotificationAction::OpenIntent { open_intent }) => {
+            // TODO(#229): wire OpenIntent dispatch once app-spawn-from-palette is implemented.
+            log::info!("notification_palette: OpenIntent {:?} (dispatch pending)", open_intent);
+        }
+        Some(NotificationAction::RunCommand { app_id, command, args }) => {
+            // TODO(#229): wire RunCommand once inter-app command channel exists.
+            log::info!(
+                "notification_palette: RunCommand app={app_id} cmd={command} args={args:?} (dispatch pending)"
+            );
+        }
+        Some(NotificationAction::ExternalUrl { url }) => {
+            log::info!("notification_palette: opening ExternalUrl {url}");
+            if let Err(e) = std::process::Command::new("open").arg(&url).spawn() {
+                log::warn!("notification_palette: failed to open URL {url}: {e}");
+            }
+        }
+        Some(NotificationAction::Confirm { .. }) | Some(NotificationAction::TextInput { .. }) => {
+            // TODO(#229): inline sub-prompt UI for Confirm/TextInput.
+            // For now, mark-read + close is the fallback (handled by caller).
+            log::debug!("notification_palette: Confirm/TextInput action deferred to future UI");
+        }
+        Some(NotificationAction::Dismiss) | None => {
+            // Nothing to do — caller marks read and closes.
         }
     }
 }

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -1284,7 +1284,6 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
-                protocol_version: self.protocol_version,
                 open_intent: self.open_intent.clone(),
                 protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
                 capability_manifest: None,
@@ -1388,19 +1387,6 @@ impl App for ProcessApp {
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| self.type_id.clone());
                     let source_tag = format!("app:{}", self.type_id);
-                    // Record to notification log with action payload extracted.
-                    let action_type = action.as_ref().map(|a| {
-                        match a {
-                            crate::app_protocol::NotificationAction::Focus { .. } => "focus",
-                            crate::app_protocol::NotificationAction::Confirm { .. } => "confirm",
-                            crate::app_protocol::NotificationAction::TextInput { .. } => "text_input",
-                            crate::app_protocol::NotificationAction::Dismiss => "dismiss",
-                            crate::app_protocol::NotificationAction::ResumeRun { .. } => "resume_run",
-                            crate::app_protocol::NotificationAction::OpenIntent { .. } => "open_intent",
-                            crate::app_protocol::NotificationAction::RunCommand { .. } => "run_command",
-                            crate::app_protocol::NotificationAction::ExternalUrl { .. } => "external_url",
-                        }.to_string()
-                    }).unwrap_or_else(|| "dismiss".to_string());
                     crate::notification_log::record(
                         title,
                         body,
@@ -1408,11 +1394,10 @@ impl App for ProcessApp {
                         urgency_str,
                         expires_at,
                         visible_after,
-                        action_type,
-                        None, // action_payload: structured action stored separately
+                        run_id,
+                        action,
                         Some(source_tag),
                     );
-                    let _ = (run_id, action); // wired into notification log above
                 }
                 DrawCommand::SetCursor { cursor } => {
                     let icon = match cursor.as_str() {


### PR DESCRIPTION
Closes #229. Supersedes #218, #219, #221.

## What changed

- **`notification_log::Notification`** gains `run_id: Option<String>` and `action: Option<NotificationAction>` (structured v2.0 field). Legacy `action_type`/`action_payload` kept as `Option<_>` for JSONL round-trip compat with older builds.
- **`notification_palette.rs`** dispatches all 8 `NotificationAction` variants via `dispatch_notification_action()`. `Focus` and `ExternalUrl` are fully wired. `ResumeRun`, `OpenIntent`, `RunCommand` log a TODO and no-op until host-side paths exist. `Confirm`/`TextInput` degrade gracefully to mark-read+close. Run cards render as taller rows with a run_id pill + action label when `run_id` is set.
- **`process_app.rs`** passes `run_id` and structured `action` through to `notification_log::record()` (drops the old action_type string extraction).
- **Python SDK** (`Emitter.notify()` + `RenderContext.notify()`): updated to emit structured `action: dict` + `run_id`. Added `NotificationAction` helper class with factory statics for all 8 variants.
- **`app_protocol.rs`**: removed dead `notification_default_action_type()` helper.

## Breaks if
Notification palette crashes on Enter with a notification that has `run_id` set.