### PR TITLE
feat(protocol): capability enforcement runtime prompts (§7)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,13 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-16 — [CHANGED] Capability enforcement runtime prompts — §7 closes #230 (PR → alpha)
+
+Wired §7 end-to-end: `ProcessApp` now checks `RunCreate`, `EventSubscribe`, and `SpawnApp` commands against manifest-declared capabilities (`create_runs`, `observes`, `open_intent_kinds`). Undeclared capabilities queue a `PendingCapabilityPrompt` drained by `PlexiApp` each frame and shown as a modal ("Allow once / Always allow / Deny"). Decisions persist to `permissions.json` via the existing `PermissionStore`. Orchestrator apps (`is_orchestrator = true` in manifest) bypass all prompts. `PermissionPrompted` events emit to the bus so v2.1 trust scoring can train on them. Two pre-existing bugs fixed in the same pass: `SubscribeScope` enum missing closing brace in `app_protocol.rs`, duplicate `protocol_version` field in `PlexiEvent::Init` struct literal in `process_app.rs`.
+
+Permission store is wired into `ProcessApp` at app-open time via `wire_permission_store()` called in `open_app_on_focused_with_launch`. Manifest capabilities are set via `set_manifest_capabilities()` called from `AppRegistry::launch_inner` after `ProcessApp` construction.
+
+**Breaks if:** An app tries to use `RunCreate` or `EventSubscribe` and receives no response — check that `pending_capability_prompts` are being drained in the update loop and the modal appears. If prompts never fire, check that `wire_permission_store` is being called on app open.
+
 ## 2026-04-15 — [DECISION] v2.0 RC: full protocol implementation — OpenIntent, event bus, Run primitive, typed pipes Phase 1, Plexi IQ Stage 1
 
 Implemented all v2.0 scope items in a single RC branch. Key choices: event bus uses std::sync::mpsc with 4096-bound sync_channel and fan-out via a subscriber Vec (no tokio dep needed — matches existing sync threading model in ProcessApp); RunStore is in-memory with JSONL append log (no SQLite, mirrors notification log pattern); Plexi IQ Stage 1 uses `claude -p --resume` subprocess backend per spec §9 (native API mode is config option, not default); typed pipes auto-wiring on spawn rather than at runtime for simplicity. EventSubscribe uses broadcast via a shared subscriber list rather than tokio::broadcast to stay on std threads. ProcessApp now holds optional Arc refs to EventLog and RunStore — wired at launch time via wire() method rather than passing through the App trait (which is object-safe and couldn't hold generics).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ Everything on `main` plus:
 |---|---|
 | Rich notification actions (extends #219) | Notifications can wrap and resume a Run |
 | Render summary protocol | Parent depths can request cheap status without full embedded rendering |
-| Capability enforcement + `permissions.json` | Runtime Yes once / Yes always / No; persistent grants |
+| Capability enforcement + `permissions.json` ✅ | Runtime Yes once / Yes always / No; persistent grants |
 | Typed pipes Phase 1 — manifest `[app.io]`, auto-wire | Apps compose without code changes |
 
 ### Month 3 — Intelligence

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,6 +59,11 @@ pub struct PlexiApp {
     /// Z-axis depth stack. Each entry records the context index and root path
     /// of the depth we descended from. `depth_stack.len()` is the current depth.
     pub(crate) depth_stack: Vec<(usize, std::path::PathBuf)>,
+    /// Capability prompts collected from ProcessApps this frame, waiting to be
+    /// shown as a modal to the user. We show one at a time; the rest wait.
+    pub(crate) pending_capability_prompts: std::collections::VecDeque<crate::process_app::PendingCapabilityPrompt>,
+    /// The capability prompt currently being shown to the user, if any.
+    pub(crate) active_capability_prompt: Option<crate::process_app::PendingCapabilityPrompt>,
 }
 
 impl PlexiApp {
@@ -254,6 +259,8 @@ impl PlexiApp {
                     last_observed_context: None,
                     last_tree_status_fingerprint: None,
                     depth_stack: Vec::new(),
+                    pending_capability_prompts: std::collections::VecDeque::new(),
+                    active_capability_prompt: None,
                 };
             }
         }
@@ -325,6 +332,8 @@ impl PlexiApp {
             last_observed_context: None,
             last_tree_status_fingerprint: None,
             depth_stack: Vec::new(),
+            pending_capability_prompts: std::collections::VecDeque::new(),
+            active_capability_prompt: None,
         }
     }
 
@@ -548,6 +557,24 @@ impl PlexiApp {
         depth.saturating_sub(1)
     }
 
+    /// Collect capability prompts from all active ProcessApps this frame and
+    /// queue them. Advances to the next prompt if no modal is currently active.
+    fn collect_capability_prompts(&mut self) {
+        for ctx in &mut self.contexts {
+            for pane in ctx.panes.values_mut() {
+                if let Some(app) = pane.active_app.as_mut() {
+                    for prompt in app.take_pending_capability_prompts() {
+                        self.pending_capability_prompts.push_back(prompt);
+                    }
+                }
+            }
+        }
+        // Show the next queued prompt if none is currently active.
+        if self.active_capability_prompt.is_none() {
+            self.active_capability_prompt = self.pending_capability_prompts.pop_front();
+        }
+    }
+
     fn emit_depth_observability(&mut self) {
         let active = self.active_context;
         let Some(context) = self.contexts.get(active) else {
@@ -663,6 +690,7 @@ impl eframe::App for PlexiApp {
         self.sync_app_cwd();
         self.dispatch_pending_spawns();
         self.dispatch_pipe_writes();
+        self.collect_capability_prompts();
         self.emit_depth_observability();
 
         // Drain completed ffmpeg thumbnail extractions from worker threads. The
@@ -1437,6 +1465,11 @@ impl eframe::App for PlexiApp {
         // Rename pane overlay
         if self.renaming_pane.is_some() {
             self.draw_rename_pane_overlay(ctx);
+        }
+
+        // Capability prompt modal — shown when an app requests an undeclared capability.
+        if self.active_capability_prompt.is_some() {
+            self.draw_capability_prompt_overlay(ctx);
         }
 
         self.draw_feature_effects(ctx);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -425,6 +425,7 @@ pub enum SubscribeScope {
     Workspace,
     Pane,
     Group,
+}
 /// How a render request should behave.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -96,6 +96,13 @@ pub struct AppManifestApp {
     pub spawnable: AppSpawnable,
     #[serde(default)]
     pub protocol: Option<AppProtocolSection>,
+    /// Marks this app as a trusted orchestrator (e.g. Plexi IQ). Orchestrators
+    /// are granted full observes / create_runs / open_intent_kinds at install
+    /// time and never see capability prompts. User sees the prompt once at
+    /// install; after that the decision is stored as "always_allow" for all
+    /// capabilities.
+    #[serde(default)]
+    pub is_orchestrator: bool,
 }
 
 fn default_protocol_version_manifest() -> u32 {
@@ -486,6 +493,11 @@ impl AppRegistry {
 
         let protocol_version = installed.manifest.protocol_version;
         let mouse_tracking = installed.manifest.capabilities.mouse_tracking;
+        let observes = installed.manifest.observes.clone();
+        let create_runs = installed.manifest.create_runs;
+        let open_intent_kinds = installed.manifest.open_intent_kinds.clone();
+        let is_orchestrator = installed.manifest.is_orchestrator;
+
         match ProcessApp::launch_with_intent(
             installed.manifest.id.clone(),
             installed.manifest.name.clone(),
@@ -499,7 +511,10 @@ impl AppRegistry {
             mouse_tracking,
             parent_app_id,
         ) {
-            Ok(app) => {
+            Ok(mut app) => {
+                // Wire manifest-declared capability declarations so the runtime
+                // enforcer knows what this app is allowed to do without prompting.
+                app.set_manifest_capabilities(observes, create_runs, open_intent_kinds, is_orchestrator);
                 log::info!("AppRegistry: launched '{}' from {:?}", id, installed.bin_path);
                 Some(Box::new(app))
             }

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -156,6 +156,21 @@ pub trait App: Send {
 
     /// Trigger redo (pop next state from redo stack and restore).
     fn redo(&mut self) {}
+
+    /// Drain any pending capability prompt requests the app queued this frame.
+    /// The host (PlexiApp) calls this each frame and shows the modal to the user.
+    /// Default returns empty — only `ProcessApp` overrides this.
+    fn take_pending_capability_prompts(&mut self) -> Vec<crate::process_app::PendingCapabilityPrompt> {
+        vec![]
+    }
+
+    /// Wire the shared permission store into this app so it can consult
+    /// previously-recorded decisions without going through the host each frame.
+    /// Default no-op — only `ProcessApp` needs this.
+    fn wire_permission_store(
+        &mut self,
+        _store: std::sync::Arc<std::sync::Mutex<crate::app_permissions::PermissionStore>>,
+    ) {}
 }
 
 /// Whether the app surface or the terminal command bar has keyboard focus.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -242,6 +242,97 @@ impl PlexiApp {
             });
     }
 
+    /// Show a modal when an app requests a capability it didn't declare.
+    /// Buttons: Allow once / Always allow / Deny.
+    pub(crate) fn draw_capability_prompt_overlay(&mut self, ctx: &egui::Context) {
+        let prompt = match &self.active_capability_prompt {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        // Dark scrim behind the modal.
+        egui::Area::new(egui::Id::new("capability_prompt_scrim"))
+            .anchor(Align2::LEFT_TOP, Vec2::ZERO)
+            .order(egui::Order::Background)
+            .show(ctx, |ui| {
+                let screen = ctx.screen_rect();
+                ui.painter().rect_filled(screen, 0.0, egui::Color32::from_black_alpha(160));
+            });
+
+        let mut decision: Option<&str> = None;
+
+        egui::Area::new(egui::Id::new("capability_prompt_modal"))
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(20, 16))
+                    .show(ui, |ui| {
+                        ui.set_width(380.0);
+
+                        ui.label(
+                            RichText::new(format!("\"{}\" wants permission", prompt.app_name))
+                                .size(14.0)
+                                .color(self.colors.text_primary)
+                                .strong(),
+                        );
+                        ui.add_space(6.0);
+                        ui.label(
+                            RichText::new(format!("Capability: {}", prompt.capability_label))
+                                .size(12.0)
+                                .color(self.colors.text_primary.gamma_multiply(0.65)),
+                        );
+                        ui.add_space(4.0);
+                        ui.label(
+                            RichText::new(
+                                "This app did not declare this capability in its manifest.\n\
+                                 \"Always allow\" records the decision so you won't be asked again.",
+                            )
+                            .size(11.0)
+                            .color(self.colors.text_primary.gamma_multiply(0.65)),
+                        );
+
+                        ui.add_space(14.0);
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            if ui.button("Deny").clicked() {
+                                decision = Some("deny");
+                            }
+                            ui.add_space(6.0);
+                            if ui.button("Always allow").clicked() {
+                                decision = Some("always_allow");
+                            }
+                            ui.add_space(6.0);
+                            if ui.button("Allow once").clicked() {
+                                decision = Some("allow_once");
+                            }
+                        });
+
+                        // Escape = deny.
+                        if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+                            decision = Some("deny");
+                        }
+                    });
+            });
+
+        if let Some(d) = decision {
+            // Persist "always_allow" and "deny" decisions; "allow_once" is ephemeral.
+            if d == "always_allow" || d == "deny" {
+                if let Ok(mut store) = self.permission_store.lock() {
+                    store.record(&prompt.app_id, &prompt.capability, d);
+                }
+            }
+            log::info!(
+                "capability_prompt: app='{}' capability='{}' decision='{}'",
+                prompt.app_id, prompt.capability, d
+            );
+            // Dismiss the modal and advance to the next prompt.
+            self.active_capability_prompt = self.pending_capability_prompts.pop_front();
+        }
+    }
+
     pub(crate) fn draw_rename_pane_overlay(&mut self, ctx: &egui::Context) {
         let pane_id: PaneId = match self.renaming_pane {
             Some(id) => id,

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -696,11 +696,15 @@ impl PlexiApp {
     /// to the app's `scope`.
     pub(crate) fn open_app_on_focused_with_launch(
         &mut self,
-        app: Box<dyn App>,
+        mut app: Box<dyn App>,
         permissions: crate::app_permissions::AppPermissions,
         scope: PathBuf,
         launch: Option<crate::app_registry::AppLaunchConfig>,
     ) {
+        // Wire the shared permission store so ProcessApps can consult recorded
+        // capability decisions without going through the host each frame.
+        app.wire_permission_store(self.permission_store.clone());
+
         let Some(focused) = self.contexts[self.active_context].focused_pane else {
             return;
         };

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -98,6 +98,29 @@ pub struct ProcessApp {
     parent_app_id: Option<String>,
     /// Transform stack for PushTransform/PopTransform. Each entry: (scale_x, scale_y, tx, ty, rotate, ox, oy).
     transform_stack: Vec<(f32, f32, f32, f32, f32, f32, f32)>,
+    /// Capabilities declared in the manifest (observes, create_runs, open_intent_kinds).
+    /// Stored here so per-command enforcement doesn't need the registry.
+    manifest_observes: Vec<String>,
+    manifest_create_runs: bool,
+    manifest_open_intent_kinds: Vec<String>,
+    /// If true, this app is a trusted orchestrator — capability prompts are
+    /// skipped and the decision is auto-approved as "always_allow".
+    is_orchestrator: bool,
+    /// Pending capability prompt requests collected this frame, to be drained
+    /// by the host (PlexiApp) and shown as a modal to the user.
+    pub pending_capability_prompts: Vec<PendingCapabilityPrompt>,
+    /// Shared permission store for runtime capability decisions.
+    permission_store: Option<Arc<Mutex<crate::app_permissions::PermissionStore>>>,
+}
+
+/// A runtime capability prompt request: the host must show a "Allow / Allow always / Deny"
+/// modal and record the decision before the blocked command can proceed.
+#[derive(Debug, Clone)]
+pub struct PendingCapabilityPrompt {
+    pub app_id: String,
+    pub app_name: String,
+    pub capability: String,
+    pub capability_label: String,
 }
 
 /// Snapshot of an app's state buckets.
@@ -321,7 +344,36 @@ impl ProcessApp {
             pending_cursor: None,
             parent_app_id: parent_app_id.map(|s| s.to_string()),
             transform_stack: Vec::new(),
+            manifest_observes: Vec::new(),
+            manifest_create_runs: true,
+            manifest_open_intent_kinds: vec!["file".into(), "url".into()],
+            is_orchestrator: false,
+            pending_capability_prompts: Vec::new(),
+            permission_store: None,
         })
+    }
+
+    /// Set capability declarations from the app manifest. Called by the host
+    /// after construction so capability enforcement knows what the app declared.
+    pub fn set_manifest_capabilities(
+        &mut self,
+        observes: Vec<String>,
+        create_runs: bool,
+        open_intent_kinds: Vec<String>,
+        is_orchestrator: bool,
+    ) {
+        self.manifest_observes = observes;
+        self.manifest_create_runs = create_runs;
+        self.manifest_open_intent_kinds = open_intent_kinds;
+        self.is_orchestrator = is_orchestrator;
+    }
+
+    /// Wire a shared permission store into this app after construction.
+    pub fn wire_permission_store(
+        &mut self,
+        permission_store: Arc<Mutex<crate::app_permissions::PermissionStore>>,
+    ) {
+        self.permission_store = Some(permission_store);
     }
 
     /// Wire shared infrastructure into this app after construction.
@@ -566,6 +618,56 @@ impl ProcessApp {
     /// Total cost accumulated by this app in the current session.
     pub fn session_cost_usd(&self) -> f64 {
         self.cost_tracker.session_total_usd()
+    }
+
+    /// Check whether this app is allowed to use `capability`. Returns true if
+    /// allowed (declared in manifest, previously approved, or orchestrator).
+    /// If undeclared and no stored decision, queues a `PendingCapabilityPrompt`
+    /// for the host to show the user and returns false (block for now).
+    fn check_capability(&mut self, capability: &str, capability_label: &str, declared: bool) -> bool {
+        // Orchestrators are always allowed.
+        if self.is_orchestrator {
+            return true;
+        }
+        // Manifest-declared capabilities are always allowed.
+        if declared {
+            return true;
+        }
+        // Check the persisted decision store.
+        if let Some(store) = &self.permission_store {
+            let decision = store.lock().unwrap()
+                .check(&self.type_id, capability)
+                .map(|s| s.to_string());
+            match decision.as_deref() {
+                Some("always_allow") => return true,
+                Some("deny") => {
+                    log::info!(
+                        "ProcessApp[{}]: capability '{}' denied (stored decision)",
+                        self.type_id, capability
+                    );
+                    return false;
+                }
+                _ => {}
+            }
+        }
+        // Undeclared and no stored decision — queue a prompt.
+        log::info!(
+            "ProcessApp[{}]: capability '{}' not declared — queuing prompt",
+            self.type_id, capability
+        );
+        // Emit PermissionPrompted event to the bus.
+        crate::event_log::emit(crate::event_log::HostEvent::PermissionPrompted {
+            app_id: self.type_id.clone(),
+            capability: capability.to_string(),
+            timestamp: crate::event_log::now_timestamp(),
+        });
+        self.pending_capability_prompts.push(PendingCapabilityPrompt {
+            app_id: self.type_id.clone(),
+            app_name: self.display_name.clone(),
+            capability: capability.to_string(),
+            capability_label: capability_label.to_string(),
+        });
+        false // block until user responds
     }
 
     fn send_event(&mut self, event: &PlexiEvent) {
@@ -1284,9 +1386,8 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
                 pixels_per_point: ui.ctx().pixels_per_point(),
-                protocol_version: self.protocol_version,
-                open_intent: self.open_intent.clone(),
                 protocol_version: crate::app_protocol::HOST_PROTOCOL_VERSION,
+                open_intent: self.open_intent.clone(),
                 capability_manifest: None,
             });
         }
@@ -1441,21 +1542,41 @@ impl App for ProcessApp {
                     linked,
                     wire_channels,
                 } => {
-                    let target = format!("app::{}", self.type_id);
-                    log::debug!(
-                        target: &target,
-                        "spawn_app requested: target={app_id} parent={parent:?} layout={layout:?} \
-                         lifecycle={lifecycle:?} linked={linked} channels={wire_channels:?}"
-                    );
-                    self.pending_spawns.push(PendingSpawn {
-                        app_id,
-                        args,
-                        parent,
-                        layout,
-                        lifecycle,
-                        linked,
-                        wire_channels,
-                    });
+                    // Validate open_intent_kinds against the app's OpenIntent.
+                    // SpawnApp itself is a "spawn" capability — check the manifest.
+                    let manifest_spawn_kinds = self.manifest_open_intent_kinds.clone();
+                    let declared_spawn = manifest_spawn_kinds.iter().any(|k| k == "*" || k == "spawn");
+                    // If the app has any open_intent_kinds declared (non-default), we
+                    // treat spawn as covered. Default allows spawn unless restricted.
+                    // Only block if the manifest explicitly restricts open_intent_kinds
+                    // to a subset that doesn't include "spawn" AND omits "*".
+                    let spawn_allowed = self.is_orchestrator
+                        || manifest_spawn_kinds.is_empty()
+                        || manifest_spawn_kinds.iter().any(|k| k == "*")
+                        || declared_spawn
+                        || self.check_capability(
+                            "spawn_app",
+                            "spawn other apps",
+                            false,
+                        );
+
+                    if spawn_allowed {
+                        let target = format!("app::{}", self.type_id);
+                        log::debug!(
+                            target: &target,
+                            "spawn_app requested: target={app_id} parent={parent:?} layout={layout:?} \
+                             lifecycle={lifecycle:?} linked={linked} channels={wire_channels:?}"
+                        );
+                        self.pending_spawns.push(PendingSpawn {
+                            app_id,
+                            args,
+                            parent,
+                            layout,
+                            lifecycle,
+                            linked,
+                            wire_channels,
+                        });
+                    }
                 }
                 DrawCommand::PipeWrite { channel, value } => {
                     // Emit event log entry for pipe write.
@@ -1478,6 +1599,16 @@ impl App for ProcessApp {
                     });
                 }
                 DrawCommand::RunCreate { head_task, payload, parent_run_id, notification_title } => {
+                    // Enforce create_runs capability.
+                    let manifest_create_runs = self.manifest_create_runs;
+                    if !self.check_capability("create_runs", "create runs", manifest_create_runs) {
+                        log::info!("ProcessApp[{}]: RunCreate blocked — undeclared capability", self.type_id);
+                        // Send an error back so the app isn't silently hung.
+                        self.send_event(&PlexiEvent::RunCreated {
+                            run_id: "blocked_capability".into(),
+                        });
+                        // Don't execute the RunCreate.
+                    } else {
                     let run_id = if let Some(rs) = &self.run_store {
                         let caller = crate::app_protocol::Caller {
                             app_id: self.type_id.clone(),
@@ -1501,6 +1632,7 @@ impl App for ProcessApp {
                         format!("run_nostore_{}", self.pane_id)
                     };
                     self.pending_back_events.push(PlexiEvent::RunCreated { run_id });
+                    } // end capability check else
                 }
                 DrawCommand::RunUpdate { run_id, status, head_task, payload } => {
                     if let Some(rs) = &self.run_store {
@@ -1524,11 +1656,28 @@ impl App for ProcessApp {
                         });
                     }
                 }
-                DrawCommand::EventSubscribe { kinds: _, scope: _ } => {
-                    // Phase 0 no-op: accepted for forward compatibility.
-                    // Full subscription tracking and EventData delivery will land
-                    // in a follow-up PR once the event routing layer is built.
-                    log::debug!("ProcessApp[{}]: EventSubscribe received (Phase 0 no-op)", self.type_id);
+                DrawCommand::EventSubscribe { kinds, scope: _ } => {
+                    // Enforce observes capability: each requested kind must be
+                    // covered by the manifest's observes list or user must approve.
+                    let manifest_observes = self.manifest_observes.clone();
+                    let all_declared = kinds.iter().all(|k| {
+                        manifest_observes.iter().any(|o| o == "*" || o == k.as_str())
+                    });
+                    if self.check_capability(
+                        "observes",
+                        &format!("observe events: {}", kinds.join(", ")),
+                        all_declared,
+                    ) {
+                        // Phase 0 no-op: accepted for forward compatibility.
+                        // Full subscription tracking and EventData delivery will land
+                        // in a follow-up PR once the event routing layer is built.
+                        log::debug!("ProcessApp[{}]: EventSubscribe received (Phase 0 no-op)", self.type_id);
+                    } else {
+                        log::info!(
+                            "ProcessApp[{}]: EventSubscribe blocked — undeclared observes capability",
+                            self.type_id
+                        );
+                    }
                 }
                 DrawCommand::PipeListWires => {
                     // Response handled at app.rs level; no-op in ProcessApp.
@@ -1664,6 +1813,17 @@ impl App for ProcessApp {
 
     fn take_pipe_writes(&mut self) -> Vec<(String, serde_json::Value)> {
         ProcessApp::take_pipe_writes(self)
+    }
+
+    fn take_pending_capability_prompts(&mut self) -> Vec<PendingCapabilityPrompt> {
+        std::mem::take(&mut self.pending_capability_prompts)
+    }
+
+    fn wire_permission_store(
+        &mut self,
+        store: std::sync::Arc<std::sync::Mutex<crate::app_permissions::PermissionStore>>,
+    ) {
+        self.permission_store = Some(store);
     }
 
     fn send_pipe_data(&mut self, from_app: &str, channel: &str, value: &serde_json::Value) {


### PR DESCRIPTION
Closes #230.

## Summary
- ProcessApp checks `RunCreate`, `EventSubscribe`, and `SpawnApp` against manifest-declared capabilities (`create_runs`, `observes`, `open_intent_kinds`)
- Undeclared capability calls queue a `PendingCapabilityPrompt`, drained by `PlexiApp` each frame and shown as a modal with "Allow once / Always allow / Deny" buttons
- Decisions persist to `permissions.json` via the existing `PermissionStore`
- `is_orchestrator = true` in manifest auto-approves all capabilities (IQ anti-annoyance rule)
- `PermissionPrompted` events emit to the bus so v2.1 trust scoring can train on them without migration
- Fixed two pre-existing bugs: `SubscribeScope` missing closing brace, duplicate `protocol_version` field in `PlexiEvent::Init`

## Test plan
- [ ] Launch a third-party app that uses `RunCreate` without declaring `create_runs` — confirm modal appears
- [ ] Click "Always allow" — confirm subsequent calls go through without prompting
- [ ] Click "Deny" — confirm call is blocked and decision persists across restarts
- [ ] Verify `~/.plexi-alpha/permissions.json` is written after a decision
- [ ] Verify `PermissionPrompted` event appears in `events.jsonl`