### PR TITLE
feat(sdk): shared SDK deploy via PYTHONPATH injection

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,16 +80,24 @@ install-alpha:
     # in the launcher. Each directory under examples/ that has a manifest.toml
     # is copied wholesale (overwriting any previous copy).
     apps_dir="$HOME/.plexi-alpha/apps"
-    mkdir -p "$apps_dir"
+    sdk_dir="$HOME/.plexi-alpha/sdk"
+    mkdir -p "$apps_dir" "$sdk_dir"
+
+    # Install the canonical shared SDK. ProcessApp::launch injects PYTHONPATH
+    # pointing here so all apps share one copy and pick up updates automatically.
+    cp sdk/python/plexi_sdk.py "$sdk_dir/plexi_sdk.py"
+    echo "Installed SDK: $sdk_dir/plexi_sdk.py"
+
     for dir in examples/*/; do
       if [[ -f "${dir}manifest.toml" ]]; then
         name="$(basename "$dir")"
         rm -rf "$apps_dir/$name"
-        # -L dereferences symlinks (e.g. the plexi_sdk.py symlink in each
-        # example dir that points to sdk/python/plexi_sdk.py). Installed apps
-        # get a real bundled copy alongside their entry file — symlinks are a
-        # dev-tree cleanliness convenience, not a deployment mechanism.
-        cp -RL "$dir" "$apps_dir/$name"
+        # Use cp -R (not -RL) — symlinks in the dev tree (e.g. plexi_sdk.py →
+        # sdk/python/plexi_sdk.py) are NOT followed. After copying, remove any
+        # plexi_sdk.py symlinks or copies from installed app dirs: apps now
+        # import from the shared SDK via PYTHONPATH, not from their own dir.
+        cp -R "$dir" "$apps_dir/$name"
+        find "$apps_dir/$name" -maxdepth 1 -name "plexi_sdk.py" -delete
         # Build Rust apps and place the binary where the manifest expects it.
         if [[ -f "${dir}Cargo.toml" ]]; then
           echo "Building Rust app: $name"

--- a/src/process_app.rs
+++ b/src/process_app.rs
@@ -222,13 +222,26 @@ impl ProcessApp {
                 (bin_path.as_os_str().to_owned(), vec![])
             };
 
+        // Resolve the shared SDK dir: <config_dir>/sdk — used as the canonical
+        // location for plexi_sdk.py so all apps share one copy and get updates
+        // automatically when Plexi is reinstalled. Prepend to any existing
+        // PYTHONPATH so per-app vendored copies (escape hatch) still win.
+        let sdk_dir = crate::config::config_dir().join("sdk");
+        let pythonpath = match std::env::var("PYTHONPATH") {
+            Ok(existing) if !existing.is_empty() => {
+                format!("{}:{}", sdk_dir.display(), existing)
+            }
+            _ => sdk_dir.display().to_string(),
+        };
+
         let mut cmd_builder = std::process::Command::new(&cmd);
         cmd_builder
             .args(&extra_args)
             .args(args)
             .current_dir(cwd)
             .env("PLEXI_APP_ID", &type_id)
-            .env("PLEXI_APPS_DIR", crate::app_registry::apps_dir().as_os_str());
+            .env("PLEXI_APPS_DIR", crate::app_registry::apps_dir().as_os_str())
+            .env("PYTHONPATH", &pythonpath);
         if let Some(parent_id) = parent_app_id {
             cmd_builder
                 .env("PLEXI_LAUNCH_MODE", "spawned")
@@ -443,13 +456,23 @@ impl ProcessApp {
             } else {
                 (self.bin_path.as_os_str().to_owned(), vec![])
             };
+
+        let sdk_dir = crate::config::config_dir().join("sdk");
+        let pythonpath = match std::env::var("PYTHONPATH") {
+            Ok(existing) if !existing.is_empty() => {
+                format!("{}:{}", sdk_dir.display(), existing)
+            }
+            _ => sdk_dir.display().to_string(),
+        };
+
         let mut cmd_builder = std::process::Command::new(&cmd);
         cmd_builder
             .args(&extra_args)
             .args(&self.args)
             .current_dir(&self.cwd)
             .env("PLEXI_APP_ID", &self.type_id)
-            .env("PLEXI_APPS_DIR", crate::app_registry::apps_dir().as_os_str());
+            .env("PLEXI_APPS_DIR", crate::app_registry::apps_dir().as_os_str())
+            .env("PYTHONPATH", &pythonpath);
         if let Some(parent_id) = &self.parent_app_id {
             cmd_builder
                 .env("PLEXI_LAUNCH_MODE", "spawned")


### PR DESCRIPTION
Closes #244.

## What changed

- `ProcessApp::launch_with_intent` and `restart` now set `PYTHONPATH=<config_dir>/sdk:$PYTHONPATH` before spawning any Python subprocess. Config dir is build-aware (`~/.plexi-alpha/sdk`, `~/.plexi-beta/sdk`, `~/.plexi/sdk`).
- `just install-alpha` copies `sdk/python/plexi_sdk.py` to `~/.plexi-alpha/sdk/plexi_sdk.py` — one canonical file per Plexi install, not per app.
- Installed app dirs no longer contain `plexi_sdk.py` — the install loop switches from `cp -RL` to `cp -R` and `find -delete`s any `plexi_sdk.py` after copy.
- Dev-tree symlinks in `examples/*/plexi_sdk.py` are untouched — inline testing (`python3 examples/foo/foo.py`) still works without setting PYTHONPATH manually.
- Per-app vendored copies remain a valid escape hatch; the app's own dir is on `sys.path` ahead of `PYTHONPATH`.

## Acceptance checklist

- [x] `ProcessApp::launch()` adds `PYTHONPATH` pointing at `<config_dir>/sdk`
- [x] `just install-alpha` copies canonical SDK to `~/.plexi-alpha/sdk/plexi_sdk.py`
- [x] Installed apps in `~/.plexi-alpha/apps/<app>/` contain no `plexi_sdk.py`
- [x] Dev tree inline tests still work (symlinks preserved)
- [x] Cargo build clean