### PR TITLE
feat(parallax): migrate to SecretGet API — closes #215

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,9 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-16 — [CHANGED] Parallax: migrate ANTHROPIC_API_KEY to SecretGet API — closes #215 (PR → alpha)
+Added `Emitter.get_secret(name)` to `parallax-app/plexi_sdk.py`: sends a `secret_get` draw command, blocks on stdin until `secret_response` arrives (stashes any intervening events). Added `App.on_init` decorator so apps can fetch secrets as soon as the PGAP pipe is active. Wired in `parallax.py` via `@app.on_init` which calls `emit.get_secret("ANTHROPIC_API_KEY")` and passes the result to `chat.set_anthropic_api_key()`. The dispatch subprocess in `chat.py._start_dispatch` now builds an explicit env dict with the resolved key, falling back to the inherited env var with a warning if not provisioned. `manifest.toml` declares `[app.secrets] required = ["ANTHROPIC_API_KEY"]`. One-time setup: `plexi secrets store ANTHROPIC_API_KEY <value>`.
+**Breaks if:** Parallax dispatches a render and `parallax CLI` errors with "ANTHROPIC_API_KEY not set" — check `plexi.log` for the SecretGet warning and confirm `plexi secrets store ANTHROPIC_API_KEY` was run.
+
 ## 2026-04-16 — [CHANGED] Capability enforcement runtime prompts — §7 closes #230 (PR → alpha)
 
 Wired §7 end-to-end: `ProcessApp` checks `RunCreate`, `EventSubscribe`, and `SpawnApp` against manifest-declared capabilities. Undeclared capabilities queue a `PendingCapabilityPrompt` shown as a modal ("Allow once / Always allow / Deny"). Decisions persist to `permissions.json`. `is_orchestrator = true` in manifest bypasses all prompts. `PermissionPrompted` events emitted to bus for future trust scoring.

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,9 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-16 — [CHANGED] Parallax: migrate ANTHROPIC_API_KEY to SecretGet API — closes #215 (PR → alpha)
+Added `Emitter.get_secret(name)` to `parallax-app/plexi_sdk.py`: sends a `secret_get` draw command, blocks on stdin until `secret_response` arrives (stashes any intervening events). Added `App.on_init` decorator so apps can fetch secrets as soon as the PGAP pipe is active. Wired in `parallax.py` via `@app.on_init` which calls `emit.get_secret("ANTHROPIC_API_KEY")` and passes the result to `chat.set_anthropic_api_key()`. The dispatch subprocess in `chat.py._start_dispatch` now builds an explicit env dict with the resolved key, falling back to the inherited env var with a warning if not provisioned. `manifest.toml` declares `[app.secrets] required = ["ANTHROPIC_API_KEY"]`. One-time setup: `plexi secrets store ANTHROPIC_API_KEY <value>`.
+**Breaks if:** Parallax dispatches a render and `parallax CLI` errors with "ANTHROPIC_API_KEY not set" — check `plexi.log` for the SecretGet warning and confirm `plexi secrets store ANTHROPIC_API_KEY` was run.
+
 ## 2026-04-16 — [CHANGED] Agent streaming + backlog→notification palette — closes #214, closes #234 (PR → alpha)
 
 **#214 (agent streaming):** Already fully implemented in `agent_llm.rs` + `agent_mode.rs` as of the RC commit. `call_claude()` parses stream-json line-by-line and emits `LlmResponse::Token` per `assistant` delta; `poll_llm()` clears the spinner on first token and appends each chunk to `pending_output`. No code changes needed — closed as complete.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,7 +182,7 @@ The Warp-style inline agent UI is live. `claude -p --resume` backend is wired wi
 | Senior-only routing (drop Junior, simplify) | **Done** | HoP routes footage_edit directly to SeniorEditor on Sonnet |
 | Parallax viewer app (companion pane in Plexi) | **Done** | Launched from command palette, companion pane |
 | Cost reporting via cost_report events | **Done** | 11+ `cost_report` calls across `head_of_production.py`, `cost_tracker.py`, `improvement_officer.py` |
-| SecretGet integration for API keys | Not started | Currently uses env vars — only Layer 3 item still pending |
+| SecretGet integration for API keys | **Done** (#215) | Emitter.get_secret + on_init hook; manifest declares [app.secrets] |
 
 ### Verification steps for Layer 3
 ```bash

--- a/TASKS.md
+++ b/TASKS.md
@@ -222,7 +222,7 @@ These are integration-layer issues. They require the protocol surface (Phase 1) 
   - Parallel with: #212, #214
   - Done looks like: `plexi open parallax` in a Parallax project opens the viewer pane alongside a linked terminal; the in-app chat UI is removed
 
-- [ ] #215 Parallax: migrate env-var secrets to SecretGet API
+- [x] #215 Parallax: migrate env-var secrets to SecretGet API
   - Blocks: nothing downstream
   - Parallel with: nothing in Phase 4 (depends on #247 in Phase 3, #113 above)
   - Done looks like: Parallax session starts without `ANTHROPIC_API_KEY` in the environment; it fetches the key via `SecretGet` at runtime; `.env` file is no longer required


### PR DESCRIPTION
Closes #215.

## What changed

Code changes are in `~/Documents/github/parallax-app` (external repo — separate git history). This PR carries the tracking artifacts: DEV_LOG entry, ROADMAP row flipped to Done, TASKS checkbox.

### parallax-app changes (committed to that repo separately)

- **`plexi_sdk.py`** — `Emitter.get_secret(name)` sends `secret_get` draw command and blocks on stdin until `secret_response` arrives; `App.on_init` decorator lets apps fetch secrets as soon as the PGAP pipe is live
- **`parallax.py`** — `@app.on_init` resolves `ANTHROPIC_API_KEY` via `emit.get_secret()`, passes it to `chat.set_anthropic_api_key()`; warns to `plexi.log` if not provisioned, falls back to env var
- **`chat.py`** — `_start_dispatch` builds an explicit env dict with the resolved key instead of relying on inherited env; warns to stderr if neither source has the key
- **`manifest.toml`** — adds `[app.secrets] required = ["ANTHROPIC_API_KEY"]`

## One-time setup

```
plexi secrets store ANTHROPIC_API_KEY <value>
```

## Smoke test

Launch Parallax, generate a scene. Verify render succeeds without `ANTHROPIC_API_KEY` in the shell environment.