### PR TITLE
refactor(pane): Pane ADT primitive — PR1 (wrapper variant)

### DIFF
--- a/examples/process-monitor/Cargo.lock
+++ b/examples/process-monitor/Cargo.lock
@@ -16,11 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "plexi-sdk"
-<<<<<<< HEAD
-version = "0.1.0"
-=======
 version = "0.3.0"
->>>>>>> origin/alpha
 dependencies = [
  "serde",
  "serde_json",

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use crate::config;
 use crate::context::Context;
 use crate::keys::{self, Action};
 use crate::media_cache::MediaCache;
-use crate::pane::TerminalPane;
+use crate::pane::{Pane, TerminalPane};
 use crate::shell;
 use crate::theme::{self, Colors};
 use crate::tiling::{PaneId, PlexiBehavior};
@@ -204,7 +204,7 @@ impl PlexiApp {
                                 }
                             }
                         }
-                        panes.insert(saved_pane.id, pane);
+                        panes.insert(saved_pane.id, Pane::Terminal(pane));
                     }
                 }
                 if panes.is_empty() {
@@ -280,7 +280,7 @@ impl PlexiApp {
         )
         .expect("failed to create initial terminal");
         let mut panes = HashMap::new();
-        panes.insert(0u64, pane);
+        panes.insert(0u64, Pane::Terminal(pane));
 
         let mut tiles = egui_tiles::Tiles::default();
         let root_tile = tiles.insert_pane(0u64);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::keys::Direction;
-use crate::pane::TerminalPane;
+use crate::pane::{Pane, TerminalPane};
 use crate::shell;
 use crate::tiling::PaneId;
 use egui_tiles::{Container, Tile, TileId, Tree};
@@ -18,7 +18,7 @@ pub struct Context {
     pub name: String,
     pub path: PathBuf,
     pub tree: Tree<PaneId>,
-    pub panes: HashMap<PaneId, TerminalPane>,
+    pub panes: HashMap<PaneId, Pane>,
     pub focused_pane: Option<TileId>,
     pub zoomed_pane: Option<TileId>,
 }
@@ -195,7 +195,7 @@ impl Context {
             _ => return None,
         };
         let pane = self.panes.get_mut(&pane_id)?;
-        Some((pane_id, pane))
+        Some((pane_id, pane.as_terminal_mut()?))
     }
 }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -30,6 +30,70 @@ pub struct TerminalPane {
     pub locked: bool,
 }
 
+/// Top-level pane primitive. A pane is one of several variants; this enum
+/// locks the ADT shape that later PRs will flesh out (AgentPane, AppPane).
+/// PR1: single variant wrapping the existing `TerminalPane` struct.
+pub enum Pane {
+    Terminal(TerminalPane),
+    // TODO(PR2): Agent(AgentPane),
+    // TODO(PR2): App(AppPane),
+}
+
+impl Pane {
+    #[inline]
+    pub fn as_terminal(&self) -> Option<&TerminalPane> {
+        match self {
+            Pane::Terminal(p) => Some(p),
+        }
+    }
+
+    #[inline]
+    pub fn as_terminal_mut(&mut self) -> Option<&mut TerminalPane> {
+        match self {
+            Pane::Terminal(p) => Some(p),
+        }
+    }
+
+    /// PR1 convenience: until sibling variants exist, every pane is a terminal.
+    /// Call sites can use this when they know the variant. In PR2, these
+    /// become fallible matches on specific variants.
+    #[inline]
+    pub fn terminal(&self) -> &TerminalPane {
+        match self {
+            Pane::Terminal(p) => p,
+        }
+    }
+
+    #[inline]
+    pub fn terminal_mut(&mut self) -> &mut TerminalPane {
+        match self {
+            Pane::Terminal(p) => p,
+        }
+    }
+}
+
+// TODO(PR2): remove Deref/DerefMut. They exist only to minimize PR1 call-site
+// churn while wrapping the single existing variant. When sibling variants
+// (Agent, App) land, callers must match the variant explicitly.
+impl std::ops::Deref for Pane {
+    type Target = TerminalPane;
+    #[inline]
+    fn deref(&self) -> &TerminalPane {
+        match self {
+            Pane::Terminal(p) => p,
+        }
+    }
+}
+
+impl std::ops::DerefMut for Pane {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut TerminalPane {
+        match self {
+            Pane::Terminal(p) => p,
+        }
+    }
+}
+
 impl TerminalPane {
     pub fn new(
         id: u64,

--- a/src/pane_ops.rs
+++ b/src/pane_ops.rs
@@ -1,6 +1,6 @@
 use crate::context::{replace_child, Context};
 use crate::keys::Direction;
-use crate::pane::TerminalPane;
+use crate::pane::{Pane, TerminalPane};
 use crate::shell;
 use crate::tiling::PaneId;
 use crate::workspace::WorkspaceFile;
@@ -16,7 +16,7 @@ impl PlexiApp {
     fn create_single_pane_tree(
         &mut self,
         cwd: Option<PathBuf>,
-    ) -> Option<(Tree<PaneId>, HashMap<PaneId, TerminalPane>, TileId)> {
+    ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.next_pane_id;
         self.next_pane_id += 1;
 
@@ -30,7 +30,7 @@ impl PlexiApp {
         )?;
 
         let mut panes = HashMap::new();
-        panes.insert(new_id, pane);
+        panes.insert(new_id, Pane::Terminal(pane));
 
         let mut tiles = egui_tiles::Tiles::default();
         let root_tile = tiles.insert_pane(new_id);
@@ -44,7 +44,7 @@ impl PlexiApp {
     fn create_split_pane_tree(
         &mut self,
         cwd: Option<PathBuf>,
-    ) -> Option<(Tree<PaneId>, HashMap<PaneId, TerminalPane>, TileId)> {
+    ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let id_left = self.next_pane_id;
         self.next_pane_id += 1;
         let id_right = self.next_pane_id;
@@ -69,8 +69,8 @@ impl PlexiApp {
         )?;
 
         let mut panes = HashMap::new();
-        panes.insert(id_left, pane_left);
-        panes.insert(id_right, pane_right);
+        panes.insert(id_left, Pane::Terminal(pane_left));
+        panes.insert(id_right, Pane::Terminal(pane_right));
 
         let mut tiles = egui_tiles::Tiles::default();
         let left_tile = tiles.insert_pane(id_left);
@@ -87,7 +87,7 @@ impl PlexiApp {
         &mut self,
         n: usize,
         cwd: Option<PathBuf>,
-    ) -> Option<(Tree<PaneId>, HashMap<PaneId, TerminalPane>, Vec<egui_tiles::TileId>)> {
+    ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, Vec<egui_tiles::TileId>)> {
         let count = n.max(1);
         let mut panes = HashMap::new();
         let mut tiles = egui_tiles::Tiles::default();
@@ -104,7 +104,7 @@ impl PlexiApp {
                 settings,
                 self.default_font_size,
             )?;
-            panes.insert(id, pane);
+            panes.insert(id, Pane::Terminal(pane));
             let tile = tiles.insert_pane(id);
             tile_ids.push(tile);
         }
@@ -144,7 +144,7 @@ impl PlexiApp {
         );
         self.contexts[self.active_context]
             .panes
-            .insert(new_id, pane);
+            .insert(new_id, Pane::Terminal(pane));
 
         let split_target = match self.contexts[self.active_context].find_ancestor_tabs(focused) {
             Some((tabs_id, _)) => tabs_id,
@@ -228,7 +228,7 @@ impl PlexiApp {
         log::info!("pane {new_id}: created as new tab");
         self.contexts[self.active_context]
             .panes
-            .insert(new_id, pane);
+            .insert(new_id, Pane::Terminal(pane));
 
         let ctx = &mut self.contexts[self.active_context];
         let new_tile = ctx.tree.tiles.insert_pane(new_id);
@@ -837,7 +837,7 @@ impl PlexiApp {
         }
         self.contexts[self.active_context]
             .panes
-            .insert(new_term_id, new_pane);
+            .insert(new_term_id, Pane::Terminal(new_pane));
 
         // Split using the exact same logic as split_focused (which works).
         let split_target = match self.contexts[self.active_context].find_ancestor_tabs(focused) {
@@ -1401,7 +1401,7 @@ impl PlexiApp {
         // 5. Insert pane into the panes map and create a tile.
         self.contexts[self.active_context]
             .panes
-            .insert(child_pane_id, child_pane);
+            .insert(child_pane_id, Pane::Terminal(child_pane));
         let new_tile = self.contexts[self.active_context]
             .tree
             .tiles

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -1,7 +1,7 @@
 use crate::agent_mode::AgentMode;
 use crate::app_trait::{AppRenderContext, SurfaceLayer, SurfaceMode, APP_DIM_OPACITY};
 use crate::media_cache::MediaCache;
-use crate::pane::TerminalPane;
+use crate::pane::Pane;
 use crate::theme::{self, Colors};
 use egui::{Color32, Stroke, Vec2};
 use egui_term::{BackendCommand, TerminalTheme, TerminalView};
@@ -37,7 +37,7 @@ pub(crate) fn paint_tab_dots(
 }
 
 pub struct PlexiBehavior<'a> {
-    pub panes: &'a mut HashMap<PaneId, TerminalPane>,
+    pub panes: &'a mut HashMap<PaneId, Pane>,
     pub focused_tile: Option<TileId>,
     pub theme: TerminalTheme,
     pub new_focused: Option<TileId>,


### PR DESCRIPTION
PR1 of the pane primitive refactor.

Wraps `TerminalPane` in a `Pane` enum with a single variant (`Pane::Terminal`). Migrates `Context::panes: HashMap<PaneId, TerminalPane>` → `HashMap<PaneId, Pane>`. Zero behavior change — every call site still works via a transitional `Deref`/`DerefMut` to `TerminalPane`.

TODO markers left for PR2 (extract `AgentPane` and `AppPane` sibling variants) and PR3 (delete SurfaceMode, collapse linkage systems).

**All four verification gates passed:**
- `cargo build` — zero errors (67 pre-existing warnings)
- `cargo build --release` — succeeds in 14.89s
- `just install-alpha` — succeeds, all apps installed
- App boots — PID alive after 6s wait, no crash

Locks the ADT shape so PR2 and PR3 become mechanical.