### PR TITLE
fix: Cmd+W on last pane resets context instead of destroying it

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,8 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-22 — [FIX] Cmd+W on last pane no longer destroys the context
+`Action::ClosePane` had an `else if self.contexts.len() > 1` branch that called `delete_context` — so pressing Cmd+W on the last pane in any context (except the very last context) would silently wipe the entire context from the sidebar. Removed that branch. Now when the last pane is closed via Cmd+W, the handler always falls through to `reset_active_context()` regardless of how many contexts exist. Context deletion remains exclusively the sidebar X button's responsibility.
+
 ## 2026-04-20 — [CHANGED] lava-opus app shipped (examples/lava-opus/)
 Buoyancy-driven blob simulation with fake-metaball blending via `DrawCommand::Circle` layering. Named "lava-opus" (not "lava-lamp") to avoid collision with a second lava app in flight. Physics: temperature-driven rise/fall, viscous drag, wall repulsion, soft bounce. Render: glow halo + solid core + specular highlight per blob; translucent bridge circles between nearby pairs fake the metaball merge look. Click to inject heat. Installed and verified at `~/.plexi-v3/apps/lava-opus/`.
 **Breaks if:** app registry fails to load `lava-opus` (id mismatch in manifest.toml — it must be `id = "lava-opus"`). Blobs teleport to top/bottom edge (bounds clamp regressed). Bridge circles disappear entirely between nearby blobs (MERGE_FACTOR or bridge alpha logic changed).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -606,8 +606,6 @@ impl eframe::App for PlexiApp {
                     let active_panes = self.contexts[self.active_context].panes.len();
                     if active_panes > 1 {
                         self.close_focused();
-                    } else if self.contexts.len() > 1 {
-                        self.delete_context(self.active_context);
                     } else {
                         self.reset_active_context();
                     }


### PR DESCRIPTION
## Summary
- Previously, Cmd+W with a single pane in a multi-context workspace would call `delete_context()`, removing the context from the sidebar
- Now always calls `reset_active_context()` when the last pane is closed, spawning a fresh blank terminal in the same context
- Context deletion via Cmd+W is no longer possible — only the sidebar X button removes a context

## Test plan
- [ ] Open Plexi with multiple contexts in the sidebar
- [ ] Focus a context that has only one pane, press Cmd+W
- [ ] Context should remain in sidebar with a fresh blank terminal — not disappear
- [ ] Open multiple panes in a context, Cmd+W them down to the last one — same reset behavior
- [ ] Sidebar X button still deletes a context as expected