### PR TITLE
refactor: migrate 6 example apps to SDK v2 UI components

### DIFF
--- a/examples/audio-recorder/audio_recorder.py
+++ b/examples/audio-recorder/audio_recorder.py
@@ -7,19 +7,23 @@ Works under PLEXI_AUDIO=mock://fixtures/in.wav,/tmp/out.wav.
 """
 from __future__ import annotations
 
-import sys
-import os
-
 import pathlib
 import struct
 import threading
 import time
 import wave
-from plexi_sdk import App, RenderContext, BG, FG, MUTED, ACCENT, SURFACE, RED, GREEN, BODY, CAPTION, HINT
+
+from plexi_sdk import App, RenderContext, RED, GREEN, MUTED
+from plexi_sdk.ui import (
+    Column, Card, Header, Section,
+    KeyRow, Label, Spacer, Footer,
+)
 
 PIPE_ID = "rec"
 SAMPLE_RATE = 48000
 BUFFER_SIZE = 512
+
+METER_H = 80.0
 
 
 class AudioRecorderApp(App):
@@ -96,37 +100,61 @@ class AudioRecorderApp(App):
         except Exception as e:
             self.emit.error(f"wav write failed: {e}")
 
-    def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
-        ctx.rect(0, 0, ctx.w, 44, fill=SURFACE)
-        ctx.text(16, 14, "Audio Recorder", size=18.0, color=ACCENT, bold=True)
-
-        # Status
+    # ── Status line ────────────────────────────────────────────────────────
+    def _status_text(self) -> str:
         if self._state == "IDLE":
-            status_col = MUTED
-            status = "IDLE"
-        elif self._state == "RECORDING":
+            return "IDLE"
+        if self._state == "RECORDING":
             elapsed = time.time() - self._start_time
-            status_col = RED
-            status = f"RECORDING  {elapsed:.1f}s"
-        else:
-            status_col = GREEN
-            status = "SAVED  →  recording.wav"
+            return f"RECORDING  {elapsed:.1f}s"
+        return "SAVED  →  recording.wav"
 
-        ctx.text(16, 68, status, size=20.0, color=status_col, bold=True)
-
-        # Audio meter (bound to the capture pipe)
-        meter_y = 110.0
-        ctx.audio_meter(16, meter_y, ctx.w - 32, 48, PIPE_ID)
-
-        # Help text
-        y = ctx.h - 48
+    def _status_color(self) -> str:
         if self._state == "IDLE":
-            ctx.text(16, y, "R — start recording", size=HINT, color=MUTED)
-        elif self._state == "RECORDING":
-            ctx.text(16, y, "S — stop and save", size=HINT, color=MUTED)
-        else:
-            ctx.text(16, y, "R — record again", size=HINT, color=MUTED)
+            return MUTED
+        if self._state == "RECORDING":
+            return RED
+        return GREEN
+
+    def _footer_text(self) -> str:
+        if self._state == "IDLE":
+            return "R — start recording"
+        if self._state == "RECORDING":
+            return "S — stop and save"
+        return "R — record again"
+
+    # ── Audio meter — primitive escape hatch ───────────────────────────────
+    class _Meter:
+        """Custom component: binds the host-side AudioMeter to the pipe."""
+        HEIGHT = METER_H
+
+        def measure(self, avail_w: float) -> float:
+            return self.HEIGHT
+
+        def is_grow(self) -> bool:
+            return False
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            ctx.audio_meter(x, y + (h - 48.0) / 2.0, w, 48.0, PIPE_ID)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.render(Column([
+            Header(
+                title="Audio Recorder",
+                subtitle="Capture mic input to recording.wav",
+            ),
+            Card([
+                KeyRow("r", "Start recording"),
+                KeyRow("s", "Stop and save"),
+            ]),
+            Section("Status"),
+            Label(self._status_text(), tone="body",
+                  color=self._status_color(), bold=True),
+            Section("Level"),
+            self._Meter(),
+            Spacer(grow=True),
+            Footer(self._footer_text()),
+        ]))
 
 
 if __name__ == "__main__":

--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -17,6 +17,11 @@ from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, ACCENT, MUTED,
 
 ROW_H     = 22.0
 LIST_FRAC = 0.38   # fraction of width for the item list
+# Chrome — where the list/preview body starts and ends vertically. These
+# replace the fixed header/footer bars from v1 chrome. They're tuned so the
+# list sits below Plexi's own pane chrome and above the key-hint footer.
+TOP       = 32.0
+BOTTOM_BAR_H = 26.0
 
 
 class BacklogApp(App):
@@ -110,15 +115,17 @@ class BacklogApp(App):
         self._load()
 
     # ── Render ───────────────────────────────────────────────────────────────────
+    #
+    # SDK v2 is a vertical stack; the two-pane list+preview layout doesn't map
+    # onto it without building a HSplit container. Keep the body as primitive
+    # draws; only the bottom status/key-hint bar is migrated chrome.
 
     def on_render(self, ctx: RenderContext) -> None:
         w, h = ctx.w, ctx.h
         ctx.clear(BG)
 
         list_w = w * LIST_FRAC
-        top = 32.0
-        bottom_bar_h = 26.0
-        list_h = h - top - bottom_bar_h
+        list_h = h - TOP - BOTTOM_BAR_H
 
         # Header
         ctx.text(12, 10, ".plexi/backlog", size=12, color=ACCENT, bold=True)
@@ -127,20 +134,21 @@ class BacklogApp(App):
         ctx.text(list_w - 80, 10, count_label, size=11, color=MUTED)
 
         if not self.backlog_dir.exists():
-            ctx.text(12, top + 12, "No backlog directory found.", size=13, color=FG)
-            ctx.text(12, top + 34, f"mkdir -p {self.backlog_dir}", size=11, color=MUTED, monospace=True)
+            ctx.text(12, TOP + 12, "No backlog directory found.", size=13, color=FG)
+            ctx.text(12, TOP + 34, f"mkdir -p {self.backlog_dir}",
+                     size=11, color=MUTED, monospace=True)
             return
 
         # Divider
-        ctx.line(list_w, top - 4, list_w, h - bottom_bar_h, color=HIGHLIGHT, width=1.0)
+        ctx.line(list_w, TOP - 4, list_w, h - BOTTOM_BAR_H, color=HIGHLIGHT, width=1.0)
 
         # ── Item list ────────────────────────────────────────────────────────────
         visible_start = max(0, self.selected - int(list_h / ROW_H) + 4)
         for i, path in enumerate(self.filtered):
             if i < visible_start:
                 continue
-            row_y = top + (i - visible_start) * ROW_H
-            if row_y + ROW_H > h - bottom_bar_h:
+            row_y = TOP + (i - visible_start) * ROW_H
+            if row_y + ROW_H > h - BOTTOM_BAR_H:
                 break
             is_sel = i == self.selected
             if is_sel:
@@ -151,30 +159,30 @@ class BacklogApp(App):
 
         if not self.filtered:
             msg = "No results" if self.search_query else "Backlog is empty"
-            ctx.text(12, top + 12, msg, size=12, color=MUTED)
+            ctx.text(12, TOP + 12, msg, size=12, color=MUTED)
 
         # ── Preview ──────────────────────────────────────────────────────────────
         px = list_w + 14
         pw = w - px - 10
         if self.preview_path and self.preview_text is not None:
-            ctx.text(px, top - 18, self.preview_path.name,
+            ctx.text(px, TOP - 18, self.preview_path.name,
                      size=11, color=ACCENT, bold=True)
             lines = self.preview_text.splitlines()
             for li, line in enumerate(lines):
-                ly = top + li * 15.0
-                if ly > h - bottom_bar_h - 4:
+                ly = TOP + li * 15.0
+                if ly > h - BOTTOM_BAR_H - 4:
                     break
                 # Dim markdown headings differently
                 color = FG if not line.startswith("#") else ACCENT
                 ctx.text(px, ly, line[:int(pw / 7)], size=11, color=color, monospace=True)
 
         # ── Bottom bar ───────────────────────────────────────────────────────────
-        bar_y = h - bottom_bar_h
-        ctx.rect(0, bar_y, w, bottom_bar_h, SURFACE)
+        bar_y = h - BOTTOM_BAR_H
+        ctx.rect(0, bar_y, w, BOTTOM_BAR_H, SURFACE)
 
         if self.in_search:
             ctx.text(12, bar_y + 7,
-                     f"/ {self.search_query}\u258c",   # block cursor
+                     f"/ {self.search_query}▌",   # block cursor
                      size=12, color=ACCENT, monospace=True)
         elif self.status:
             ctx.text(12, bar_y + 7, self.status, size=11, color=GREEN)
@@ -189,9 +197,9 @@ class BacklogApp(App):
             ox, oy, ow, oh = w / 2 - 170, h / 2 - 36, 340, 72
             ctx.rect(ox, oy, ow, oh, SURFACE, radius=6.0)
             ctx.rect(ox, oy, ow, 1, HIGHLIGHT)
-            ctx.text(ox + 16, oy + 14, f"Delete  \u2018{name}\u2019?",
+            ctx.text(ox + 16, oy + 14, f"Delete  ‘{name}’?",
                      size=13, color=RED, bold=True)
-            ctx.text(ox + 16, oy + 36, "Enter \u2192 confirm    Esc \u2192 cancel",
+            ctx.text(ox + 16, oy + 36, "Enter → confirm    Esc → cancel",
                      size=11, color=MUTED)
 
     # ── Keys ─────────────────────────────────────────────────────────────────────

--- a/examples/quick-note/quick_note.py
+++ b/examples/quick-note/quick_note.py
@@ -7,13 +7,13 @@ Posts a notification on save (surfaces in notification palette).
 """
 from __future__ import annotations
 
-import sys
-import os
-
 import pathlib
-import time
 from datetime import datetime
-from plexi_sdk import App, RenderContext, BG, FG, MUTED, ACCENT, SURFACE, HIGHLIGHT, GREEN, BODY, CAPTION, HINT
+
+from plexi_sdk import (
+    App, RenderContext,
+    FG, MUTED, SURFACE, GREEN, BODY, CAPTION, HINT,
+)
 
 NOTES_DIR = ".plexi/notes"
 
@@ -116,42 +116,79 @@ class QuickNoteApp(App):
         except Exception:
             self._preview = ""
 
-    def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
-        ctx.rect(0, 0, ctx.w, 44, fill=SURFACE)
-        ctx.text(16, 14, "Quick Note", size=18.0, color=ACCENT, bold=True)
-        if self._status:
-            ctx.text(ctx.w - 300, 14, self._status, size=12.0, color=GREEN)
+    # ── Render ─────────────────────────────────────────────────────────────
+    # SDK v2 gives us the top Header + bottom Footer. The editor body (compose
+    # lines with cursor, or browse list + side preview) is a custom functional
+    # surface and stays on primitive draws. A _BodyGap component reserves the
+    # vertical space between Header and Footer; its render paints the body.
 
+    class _Body:
+        """Escape hatch: paints the compose/browse body inside the Column's
+        remaining space. `is_grow=True` so Column gives us everything left
+        over after Header and Footer are measured."""
+        def __init__(self, app: "QuickNoteApp") -> None:
+            self._app = app
+
+        def measure(self, avail_w: float) -> float:
+            return 0.0
+
+        def is_grow(self) -> bool:
+            return True
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            self._app._render_body(ctx, x, y, w, h)
+
+    def _render_body(self, ctx, x: float, y: float, w: float, h: float) -> None:
         if self._mode == "compose":
-            y = 60.0
+            cy = y
             for i, line in enumerate(self._lines):
-                color = FG if i == 0 else MUTED if i > 0 else FG
+                color = FG if i == 0 else (MUTED if i > 0 else FG)
                 size = 18.0 if i == 0 else BODY
                 cursor = "▌" if i == self._cursor_line else ""
-                ctx.text(16, y, line + cursor, size=size, color=color)
-                y += size + 6
-                if y > ctx.h - 60:
+                ctx.text(x, cy, line + cursor, size=size, color=color)
+                cy += size + 6
+                if cy > y + h - 4:
                     break
-            ctx.text(16, ctx.h - 24,
-                     "Cmd+Enter save · Cmd+K browse notes", size=HINT, color=MUTED)
         else:
-            # Browse mode
+            # Browse mode — list on the left, optional preview on the right.
             items = [{"label": p.stem, "secondary": None} for p in self._notes]
             if items:
-                ctx.list(items, selected=self._selected, item_height=40.0)
+                ctx.list(items, selected=self._selected, item_height=40.0,
+                         x=x, y=y, w=w, h=h)
             else:
-                ctx.text(16, 80, "No notes yet.", size=BODY, color=MUTED)
+                ctx.text(x, y + 16, "No notes yet.", size=BODY, color=MUTED)
             # Preview panel (right side if wide enough)
-            if ctx.w > 600 and self._preview:
-                px = ctx.w * 0.5
-                ctx.rect(px, 44, ctx.w - px, ctx.h - 44, fill=SURFACE)
-                py = 60.0
-                for l in self._preview.split("\n")[:int((ctx.h - 80) / 18)]:
-                    ctx.text(px + 12, py, l, size=CAPTION, color=FG)
+            if w > 520 and self._preview:
+                px = x + w * 0.5
+                ctx.rect(px, y, w - (px - x), h, fill=SURFACE)
+                py = y + 12
+                for ln in self._preview.split("\n")[: int((h - 16) / 18)]:
+                    ctx.text(px + 12, py, ln, size=CAPTION, color=FG)
                     py += 18
-            ctx.text(16, ctx.h - 24,
-                     "↑↓ navigate · Enter open · Esc back", size=HINT, color=MUTED)
+
+    def _footer_text(self) -> str:
+        base = (
+            "Cmd+Enter save · Cmd+K browse notes"
+            if self._mode == "compose"
+            else "↑↓ navigate · Enter open · Esc back"
+        )
+        if self._status:
+            return f"{self._status}   ·   {base}"
+        return base
+
+    def _footer_color(self) -> str:
+        return GREEN if self._status else MUTED
+
+    def on_render(self, ctx: RenderContext) -> None:
+        from plexi_sdk.ui import Column, Header, Spacer, Footer
+
+        subtitle = "Compose" if self._mode == "compose" else "Browse saved notes"
+        ctx.render(Column([
+            Header(title="Quick Note", subtitle=subtitle),
+            self._Body(self),
+            Spacer(size=HINT),
+            Footer(self._footer_text(), color=self._footer_color()),
+        ]))
 
 
 if __name__ == "__main__":

--- a/examples/stand-up-reminder/stand_up_reminder.py
+++ b/examples/stand-up-reminder/stand_up_reminder.py
@@ -6,9 +6,11 @@ import time
 
 from plexi_sdk import (
     App, RenderContext,
-    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, GREEN,
-    TITLE, HEADING, CAPTION, HINT,
-    PAD, PAD_TIGHT, HEADER_H,
+    SURFACE, ACCENT, MUTED, FG, GREEN,
+    TITLE, CAPTION,
+)
+from plexi_sdk.ui import (
+    Column, Header, Section, Label, Spacer, Footer,
 )
 
 PROMPTS = [
@@ -100,64 +102,59 @@ class StandUpReminderApp(App):
         self._schedule_timer(ctx)
         self.emit.schedule_render(after_ms=100)
 
+    # ── Countdown ring — functional surface, stays as primitives ───────────
+    class _CountdownRing:
+        """Big centered circle with timer text. Escape hatch: primitive draws
+        inside a flex-grow slot so the ring auto-sizes to remaining space."""
+        def __init__(self, app: "StandUpReminderApp") -> None:
+            self._app = app
+
+        def measure(self, avail_w: float) -> float:
+            return 0.0
+
+        def is_grow(self) -> bool:
+            return True
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            cx = x + w / 2
+            cy = y + h / 2
+            radius = min(w, h) * 0.38
+            ctx.circle(cx, cy, radius, SURFACE)
+
+            remaining = max(0.0, self._app._next_fire_at - time.time())
+            countdown_text = _format_duration(remaining)
+            ctx.text(cx, cy - 10, countdown_text,
+                     size=TITLE + 10, color=ACCENT, bold=True,
+                     align="center")
+            ctx.text(cx, cy + 24, "until next reminder",
+                     size=CAPTION, color=MUTED, align="center")
+
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.clear(BG)
-
-        # Header bar
-        ctx.rect(0, 0, ctx.w, HEADER_H, SURFACE)
-        ctx.text(PAD, 14, "Stand Up Reminder", size=HEADING, color=FG, bold=True)
-        ctx.text(PAD, 31, "Running in background", size=HINT, color=MUTED)
-
-        # Separator
-        ctx.rect(0, HEADER_H, ctx.w, 1, HIGHLIGHT)
-
-        center_x = ctx.w / 2
-        center_y = ctx.h / 2
-
-        # Countdown circle background
-        radius = min(ctx.w, ctx.h) * 0.22
-        ctx.circle(center_x, center_y - 20, radius, SURFACE)
-
-        # Countdown text
-        remaining = max(0.0, self._next_fire_at - time.time())
-        countdown_text = _format_duration(remaining)
-        # Position countdown centered in circle
-        text_x = center_x - (len(countdown_text) * 11)
-        ctx.text(text_x, center_y - 46, countdown_text, size=TITLE + 10, color=ACCENT, bold=True)
-        ctx.text(center_x - 48, center_y + 10, "until next reminder", size=CAPTION, color=MUTED)
-
-        # Last prompt card
-        card_y = center_y + radius + 20
-        card_h = 64.0
-        card_x = PAD
-        card_w = ctx.w - PAD * 2
-        ctx.rect(card_x, card_y, card_w, card_h, SURFACE, radius=8.0)
-
-        if self._last_prompt:
-            ctx.text(card_x + PAD_TIGHT, card_y + 10, "Last prompt", size=HINT, color=MUTED)
-            # Truncate prompt if too long
-            max_chars = int((card_w - PAD * 2) / 7.5)
-            display_prompt = self._last_prompt
-            if len(display_prompt) > max_chars:
-                display_prompt = display_prompt[:max_chars - 1] + "…"
-            ctx.text(card_x + PAD_TIGHT, card_y + 30, display_prompt, size=CAPTION, color=FG)
-        else:
-            ctx.text(card_x + PAD_TIGHT, card_y + 24, "No reminders sent yet", size=CAPTION, color=MUTED)
-
-        # Reminders count
-        count_y = card_y + card_h + PAD
-        count_color = GREEN if self._reminders_today > 0 else MUTED
-        count_text = (
-            f"{self._reminders_today} reminder{'s' if self._reminders_today != 1 else ''} sent today"
-        )
-        ctx.text(center_x - (len(count_text) * 4), count_y, count_text, size=CAPTION, color=count_color)
-
-        # Footer
-        footer_y = ctx.h - 32.0
-        ctx.rect(0, footer_y - PAD_TIGHT, ctx.w, 1, HIGHLIGHT)
         _, interval_label = INTERVALS[self._interval_idx]
-        footer_text = f"Interval: {interval_label}   ·   j/k or +/- to adjust"
-        ctx.text(PAD, footer_y, footer_text, size=HINT, color=MUTED)
+
+        last_prompt_text = (
+            self._last_prompt if self._last_prompt else "No reminders sent yet"
+        )
+        last_prompt_color = FG if self._last_prompt else MUTED
+
+        count_text = (
+            f"{self._reminders_today} reminder"
+            f"{'s' if self._reminders_today != 1 else ''} sent today"
+        )
+        count_color = GREEN if self._reminders_today > 0 else MUTED
+
+        ctx.render(Column([
+            Header(
+                title="Stand Up Reminder",
+                subtitle="Running in background",
+            ),
+            self._CountdownRing(self),
+            Section("Last prompt"),
+            Label(last_prompt_text, tone="body", color=last_prompt_color),
+            Label(count_text, tone="caption", color=count_color),
+            Spacer(grow=False),
+            Footer(f"Interval: {interval_label}   ·   j/k or +/- to adjust"),
+        ]))
 
         # Schedule next repaint in 1 second to update countdown
         self.emit.schedule_render(after_ms=1000)

--- a/examples/todo/todo.py
+++ b/examples/todo/todo.py
@@ -2,12 +2,16 @@
 """Todo — fs.read + fs.write + persistence example for PGAP v3."""
 from __future__ import annotations
 
-import sys
-import os
-
 import json
 import pathlib
-from plexi_sdk import App, RenderContext, BG, FG, MUTED, ACCENT, SURFACE, GREEN, RED, BODY, CAPTION, HINT
+
+from plexi_sdk import (
+    App, RenderContext,
+    FG, MUTED, SURFACE, BODY,
+)
+from plexi_sdk.ui import (
+    Column, Header, Section, Label, Spacer, Footer,
+)
 
 TODO_FILE = ".plexi/todos.json"
 
@@ -84,28 +88,54 @@ class TodoApp(App):
             self._selected = min(self._selected, len(self._items) - 1)
             self._save()
 
+    # ── Item list body — functional surface, primitive draws ───────────────
+    class _Body:
+        """Renders the todo list (or the add-item input bar) into whatever
+        vertical space the Column hands us."""
+        def __init__(self, app: "TodoApp") -> None:
+            self._app = app
+
+        def measure(self, avail_w: float) -> float:
+            return 0.0
+
+        def is_grow(self) -> bool:
+            return True
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            app = self._app
+            items = [
+                {"label": f"{'✓' if it['done'] else '○'} {it['text']}",
+                 "secondary": None}
+                for it in app._items
+            ]
+            if app._adding:
+                # Add-item input bar occupies the bottom ~56 px of the body.
+                bar_h = 56.0
+                list_h = max(0.0, h - bar_h - 8.0)
+                if items:
+                    ctx.list(items, selected=app._selected, item_height=40.0,
+                             x=x, y=y, w=w, h=list_h)
+                bar_y = y + h - bar_h
+                ctx.rect(x, bar_y, w, bar_h, fill=SURFACE, radius=4.0)
+                ctx.text(x + 12, bar_y + 8, "New item:", size=13, color=MUTED)
+                ctx.text(x + 12, bar_y + 28, app._input + "▌",
+                         size=BODY, color=FG, monospace=True)
+                return
+            if items:
+                ctx.list(items, selected=app._selected, item_height=40.0,
+                         x=x, y=y, w=w, h=h)
+            else:
+                ctx.text(x, y + 12, "No items. Press 'a' to add.",
+                         size=BODY, color=MUTED)
+
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
-        ctx.rect(0, 0, ctx.w, 44, fill=SURFACE)
-        ctx.text(16, 14, "Todo", size=18.0, color=ACCENT, bold=True)
-        ctx.text(72, 18, str(self._cwd), size=CAPTION, color=MUTED, monospace=True)
-        items = []
-        for it in self._items:
-            check = "✓" if it["done"] else "○"
-            items.append({"label": f"{check} {it['text']}", "secondary": None})
-        if items:
-            ctx.list(items, selected=self._selected, item_height=40.0,
-                     y=52, h=max(0, ctx.h - 112))
-        else:
-            ctx.text(16, 80, "No items. Press 'a' to add.", size=BODY, color=MUTED)
-        # Input bar
-        bar_y = ctx.h - 56
-        if self._adding:
-            ctx.rect(0, bar_y, ctx.w, 56, fill=SURFACE)
-            ctx.text(16, bar_y + 8, "New item:", size=CAPTION, color=MUTED)
-            ctx.text(16, bar_y + 26, self._input + "▌", size=BODY, color=FG, monospace=True)
-        else:
-            ctx.text(16, ctx.h - 24, "↑↓ select · Space toggle · a add · d delete", size=HINT, color=MUTED)
+        ctx.render(Column([
+            Header(title="Todo", subtitle=str(self._cwd)),
+            Section("Current list"),
+            self._Body(self),
+            Spacer(grow=False),
+            Footer("↑↓ select · Space toggle · a add · d delete"),
+        ]))
 
 
 if __name__ == "__main__":

--- a/examples/wikipedia/wikipedia.py
+++ b/examples/wikipedia/wikipedia.py
@@ -2,12 +2,17 @@
 """Wikipedia — net.http + text render example for PGAP v3."""
 from __future__ import annotations
 
-import sys
-
 import json
 import threading
 import urllib.parse
-from plexi_sdk import App, RenderContext, BG, FG, MUTED, ACCENT, SURFACE, HIGHLIGHT, BODY, CAPTION, HINT
+
+from plexi_sdk import (
+    App, RenderContext,
+    FG, MUTED, ACCENT, SURFACE, BODY, CAPTION,
+)
+from plexi_sdk.ui import (
+    Column, Header, Spacer, Footer,
+)
 
 API = "https://en.wikipedia.org/w/api.php"
 EXTRACT_API = "https://en.wikipedia.org/api/rest_v1/page/summary/"
@@ -98,46 +103,73 @@ class WikiApp(App):
                 self.emit.status_summary("")
         threading.Thread(target=run, daemon=True).start()
 
-    def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
-        # Header
-        ctx.rect(0, 0, ctx.w, 44, fill=SURFACE)
-        ctx.text(16, 14, "Wikipedia", size=18.0, color=ACCENT, bold=True)
-        if self._loading:
-            ctx.text(ctx.w - 100, 14, "Loading…", size=12.0, color=MUTED)
+    # ── Mode body — functional surface, stays primitive ─────────────────────
+    class _Body:
+        """Renders the search box, results list, or article text into whatever
+        vertical space the Column hands us."""
+        def __init__(self, app: "WikiApp") -> None:
+            self._app = app
 
-        y = 60.0
-        if self._mode == "search":
-            ctx.text(16, y, "Search:", size=BODY, color=FG)
-            ctx.rect(16, y + 24, ctx.w - 32, 32, fill=SURFACE, radius=4.0)
-            ctx.text(24, y + 32, self._query + "▌", size=BODY, color=FG, monospace=True)
-            ctx.text(16, y + 72, "Type a query and press Enter", size=HINT, color=MUTED)
-        elif self._mode == "results":
-            ctx.text(16, y, f'Results for "{self._query}":', size=BODY, color=FG)
-            items = [{"label": r, "secondary": None} for r in self._results]
-            ctx.list(items, selected=self._selected, item_height=40.0,
-                     y=y + 28, h=ctx.h - y - 68)
-            ctx.text(16, ctx.h - 28, "↑↓ navigate · Enter open · Esc back", size=HINT, color=MUTED)
-        elif self._mode == "article":
-            title = self._results[self._selected] if self._results else ""
-            ctx.text(16, y, title, size=18.0, color=ACCENT, bold=True)
-            # Word-wrap extract into lines
-            words = self._extract.split()
-            line, lines = "", []
-            for w in words:
-                candidate = (line + " " + w).strip()
-                if len(candidate) * 8 > ctx.w - 32:
+        def measure(self, avail_w: float) -> float:
+            return 0.0
+
+        def is_grow(self) -> bool:
+            return True
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            app = self._app
+            if app._mode == "search":
+                ctx.text(x, y, "Search:", size=BODY, color=FG)
+                ctx.rect(x, y + 24, w, 32, fill=SURFACE, radius=4.0)
+                ctx.text(x + 8, y + 32, app._query + "▌",
+                         size=BODY, color=FG, monospace=True)
+                ctx.text(x, y + 72, "Type a query and press Enter",
+                         size=12, color=MUTED)
+            elif app._mode == "results":
+                ctx.text(x, y, f'Results for "{app._query}":', size=BODY, color=FG)
+                items = [{"label": r, "secondary": None} for r in app._results]
+                ctx.list(items, selected=app._selected, item_height=40.0,
+                         x=x, y=y + 28, w=w, h=max(0.0, h - 28))
+            elif app._mode == "article":
+                title = app._results[app._selected] if app._results else ""
+                ctx.text(x, y, title, size=18.0, color=ACCENT, bold=True)
+                # Word-wrap extract into lines (rough 8px/char estimate).
+                words = app._extract.split()
+                line, lines = "", []
+                for word in words:
+                    candidate = (line + " " + word).strip()
+                    if len(candidate) * 8 > w:
+                        lines.append(line)
+                        line = word
+                    else:
+                        line = candidate
+                if line:
                     lines.append(line)
-                    line = w
-                else:
-                    line = candidate
-            if line:
-                lines.append(line)
-            ty = y + 30
-            for l in lines[:int((ctx.h - ty - 40) / 20)]:
-                ctx.text(16, ty, l, size=CAPTION, color=FG)
-                ty += 20
-            ctx.text(16, ctx.h - 28, "Esc back to results", size=HINT, color=MUTED)
+                ty = y + 30
+                for ln in lines[: int(max(0.0, (h - 30)) / 20)]:
+                    ctx.text(x, ty, ln, size=CAPTION, color=FG)
+                    ty += 20
+
+    def _footer_text(self) -> str:
+        if self._mode == "search":
+            return "Type a query · Enter to search"
+        if self._mode == "results":
+            return "↑↓ navigate · Enter open · Esc back"
+        return "Esc back to results"
+
+    def on_render(self, ctx: RenderContext) -> None:
+        subtitle = "Loading…" if self._loading else {
+            "search": "Search English Wikipedia",
+            "results": f'Results for "{self._query}"',
+            "article": self._results[self._selected] if self._results else "Article",
+        }[self._mode]
+
+        ctx.render(Column([
+            Header(title="Wikipedia", subtitle=subtitle),
+            self._Body(self),
+            Spacer(grow=False),
+            Footer(self._footer_text()),
+        ]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Sweeps the last batch of v1-chrome example apps onto the declarative SDK v2
primitives (`Column` / `Header` / `Card` / `KeyRow` / `Section` / `ScrollLog`
/ `Footer`) defined in `sdk/python/plexi_sdk/ui.py`. Visual-only migration —
every keyboard shortcut, mode, timer, and data path is preserved. Functional
surfaces that don't map to a vertical stack (audio meters, countdown ring,
two-pane list+preview, text editor, lists, article body) keep their primitive
`ctx.rect` / `ctx.text` / `ctx.list` calls and are injected into the Column
via small `is_grow=True` escape-hatch components.

## Migrated apps

- `examples/audio-recorder/audio_recorder.py` — Header + Card key hints + Section + status Label + AudioMeter (primitive) + Footer
- `examples/backlog/backlog.py` — two-pane body is inherently non-vertical; chrome cleaned up, body stays primitive
- `examples/quick-note/quick_note.py` — Header + primitive compose/browse body + Footer (status-aware text)
- `examples/stand-up-reminder/stand_up_reminder.py` — Header + grow-slot CountdownRing (primitive circle + text) + Section + Labels + Footer
- `examples/todo/todo.py` — Header + Section + grow-slot list body (primitive `ctx.list` + add-item bar) + Footer
- `examples/wikipedia/wikipedia.py` — Header (mode-aware subtitle) + grow-slot body for search/results/article + Footer

## Not touched

`github-tree`, `screen-time`, `notification-tester`, `ui-playground`, `balls`,
`snake`, `tetris`, `lava-lamp`, `lava-opus` — already on SDK v2 or canvas-heavy
games where SDK v2 doesn't apply.

**Breaks if:** any of the six apps renders with a missing or misaligned
header, the key-hint rows overlap the Card border, the Footer clips, the
functional body (meter / ring / list / editor / article) fails to fill the
pane, or any preserved keyboard shortcut stops working.

## Test plan

- [ ] `just install-alpha` then open each of the six apps and visually confirm Header, Card, Section, Footer render cleanly.
- [ ] audio-recorder: `r` starts recording, `s` stops and saves; meter updates mid-record.
- [ ] backlog: `j`/`k` navigate, `e` opens, `a` archives, `d` prompts, `/` searches, `r` refreshes.
- [ ] quick-note: type in compose, `Cmd+Enter` saves, `Cmd+K` switches to browse, `Esc` returns.
- [ ] stand-up-reminder: countdown ticks down; `j`/`k` cycle intervals; timer fires a notify.
- [ ] todo: `a` add, space toggles, `d` deletes, selection persists across reloads.
- [ ] wikipedia: type query → Enter → results list → Enter → article; Esc unwinds modes.