### PR TITLE
Migrate palette/rename overlays to FocusLayer pattern

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,13 +11,15 @@ mod sync;
 /// which runs before the drain and is always live.
 ///
 /// New overlays should push their layer on open and pop on close to inherit
-/// input capture. Today the notification modal and confirm-close use the
-/// layer — command palette, run palette, and rename still have legacy
-/// per-handler input paths (tracked in `.plexi/backlog`).
+/// input capture. All keyboard-owning overlays live here: notification modal,
+/// confirm-close, command palette, run palette, and rename-pane.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum FocusLayer {
     NotificationModal,
     ConfirmClose,
+    CommandPalette,
+    RunPalette,
+    RenamePane,
 }
 
 #[derive(Clone)]
@@ -515,13 +517,17 @@ impl eframe::App for PlexiApp {
         // `input_captured_by_overlay()` answers correctly this frame.
         self.sync_notification_modal_focus();
         self.sync_confirm_close_focus();
+        self.sync_command_palette_focus();
+        self.sync_run_palette_focus();
+        self.sync_rename_pane_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
-        // notification modal's TextEdit for the `input` kind) can read
-        // keystrokes before we drain. Then drain the keyboard buffer so
-        // downstream readers — focused app (`dispatch_app_key_events`),
-        // terminal backends, `keys::poll_actions` — see only the global
-        // allowlist (Cmd+Q, Cmd+W, Cmd+Shift+A, Cmd+]/Cmd+[).
+        // notification modal's TextEdit for the `input` kind, the palette's
+        // search field, the rename input) can read keystrokes before we
+        // drain. Then drain the keyboard buffer so downstream readers —
+        // focused app (`dispatch_app_key_events`), terminal backends,
+        // `keys::poll_actions` — see only the global allowlist (Cmd+Q,
+        // Cmd+W, Cmd+Shift+A, Cmd+]/Cmd+[).
         let mut early_modal_cmds: Vec<crate::app_trait::AppCommand> = Vec::new();
         if self.input_captured_by_overlay() {
             match self.focus_stack.last() {
@@ -531,14 +537,27 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::ConfirmClose) => {
                     self.draw_confirm_close(ctx);
                 }
+                Some(FocusLayer::CommandPalette) => {
+                    self.draw_command_palette(ctx);
+                }
+                Some(FocusLayer::RunPalette) => {
+                    self.draw_run_palette(ctx);
+                }
+                Some(FocusLayer::RenamePane) => {
+                    self.draw_rename_pane_overlay(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
-            // The overlay may have self-closed (notification queue drained, or
-            // confirm-close confirmed/cancelled). Re-sync so the layer is
-            // accurate for the rest of this frame.
+            // The overlay may have self-closed (notification queue drained,
+            // confirm-close confirmed/cancelled, palette picked an entry,
+            // rename committed). Re-sync so the layer is accurate for the
+            // rest of this frame.
             self.sync_notification_modal_focus();
             self.sync_confirm_close_focus();
+            self.sync_command_palette_focus();
+            self.sync_run_palette_focus();
+            self.sync_rename_pane_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -1219,33 +1238,14 @@ impl eframe::App for PlexiApp {
             self.draw_shortcuts_overlay(ctx);
         }
 
-        // Command palette overlay
-        if self.show_command_palette {
-            self.draw_command_palette(ctx);
-        }
-
-        // Run palette overlay (Cmd+R)
-        if self.show_run_palette {
-            self.draw_run_palette(ctx);
-        }
-
-        // Notification modal — rendered in the EARLY phase of `update()` (see
-        // `input_captured_by_overlay` branch up top) so its input handling
-        // runs before panes. Nothing to render here; just keep the visibility
-        // flag honest if the queue has drained since the frame started.
+        // Command palette, run palette, rename-pane overlay, notification
+        // modal, and confirm-close are all drawn by the early input-capture
+        // path at the top of `update()` — they own a `FocusLayer` and render
+        // their own keystrokes before the drain. Drawing again here would
+        // double-dispatch Enter/Escape after keys have been drained.
         if self.pending_notifications.is_empty() {
             self.show_notification_modal = false;
         }
-
-        // Rename pane overlay
-        if self.renaming_pane.is_some() {
-            self.draw_rename_pane_overlay(ctx);
-        }
-
-        // Close-pane confirmation is drawn by the early input-capture path at
-        // the top of `update()` (it owns `FocusLayer::ConfirmClose`). Drawing
-        // it again here would run the Enter/Escape consumers a second time,
-        // after keys have already been drained.
 
         // Quit confirmation overlay
         if self.quit_confirm_required && self.quit_press_count > 0 {
@@ -1275,7 +1275,11 @@ impl PlexiApp {
     pub(crate) fn input_captured_by_overlay(&self) -> bool {
         matches!(
             self.focus_stack.last(),
-            Some(FocusLayer::NotificationModal) | Some(FocusLayer::ConfirmClose)
+            Some(FocusLayer::NotificationModal)
+                | Some(FocusLayer::ConfirmClose)
+                | Some(FocusLayer::CommandPalette)
+                | Some(FocusLayer::RunPalette)
+                | Some(FocusLayer::RenamePane)
         )
     }
 
@@ -1327,6 +1331,50 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::NotificationModal);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::NotificationModal);
+        }
+    }
+
+    /// Reconcile the command-palette focus layer with `show_command_palette`.
+    /// Same pattern as the notification modal: boolean visibility flag is the
+    /// source of truth, focus stack follows it deterministically each frame.
+    pub(crate) fn sync_command_palette_focus(&mut self) {
+        let should_own = self.show_command_palette;
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::CommandPalette);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::CommandPalette);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::CommandPalette);
+        }
+    }
+
+    /// Reconcile the run-palette focus layer with `show_run_palette`.
+    pub(crate) fn sync_run_palette_focus(&mut self) {
+        let should_own = self.show_run_palette;
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::RunPalette);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::RunPalette);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::RunPalette);
+        }
+    }
+
+    /// Reconcile the rename-pane focus layer with `renaming_pane`.
+    pub(crate) fn sync_rename_pane_focus(&mut self) {
+        let should_own = self.renaming_pane.is_some();
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::RenamePane);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::RenamePane);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::RenamePane);
         }
     }
 

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -120,6 +120,12 @@ impl PlexiApp {
             if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
                 self.show_command_palette = false;
             }
+            // Cmd+P toggles the palette closed without re-dispatching through
+            // `poll_actions` (which runs after the keyboard drain). Consuming
+            // here keeps open→close symmetric with the open keybind.
+            if input.consume_key(egui::Modifiers::COMMAND, egui::Key::P) {
+                self.show_command_palette = false;
+            }
             if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
                 && total > 0
                 && self.palette_selected < total - 1

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -167,6 +167,15 @@ impl PlexiApp {
             None => return,
         };
 
+        // Consume Enter/Escape at the context level so they cannot bleed into
+        // the focused pane this frame. Pairs with `FocusLayer::RenamePane` —
+        // the overlay owns its own commit/cancel keys.
+        let (commit, cancel) = ctx.input_mut(|i| {
+            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            (enter, esc)
+        });
+
         egui::Area::new(egui::Id::new("rename_pane_overlay"))
             .anchor(Align2::CENTER_TOP, Vec2::new(0.0, 80.0))
             .order(egui::Order::Foreground)
@@ -195,32 +204,6 @@ impl PlexiApp {
                                 .font(egui::TextStyle::Body),
                         );
 
-                        if te.lost_focus() {
-                            if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-                                self.renaming_pane = None;
-                            } else {
-                                // Apply rename
-                                let new_name = self.rename_buffer.trim().to_string();
-                                if let Some(pane) =
-                                    self.contexts[self.active_context].panes.get_mut(&pane_id)
-                                {
-                                    if let Some(t) = pane.as_terminal_mut() {
-                                        t.name = if new_name.is_empty() {
-                                            None
-                                        } else {
-                                            Some(new_name)
-                                        };
-                                    }
-                                }
-                                self.renaming_pane = None;
-                            }
-                            // Consume Enter/Escape
-                            ui.input_mut(|i| {
-                                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-                                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-                            });
-                        }
-
                         // Auto-focus and select all
                         if !te.has_focus() {
                             te.request_focus();
@@ -236,6 +219,24 @@ impl PlexiApp {
                         }
                     });
             });
+
+        if cancel {
+            self.renaming_pane = None;
+        } else if commit {
+            let new_name = self.rename_buffer.trim().to_string();
+            if let Some(pane) =
+                self.contexts[self.active_context].panes.get_mut(&pane_id)
+            {
+                if let Some(t) = pane.as_terminal_mut() {
+                    t.name = if new_name.is_empty() {
+                        None
+                    } else {
+                        Some(new_name)
+                    };
+                }
+            }
+            self.renaming_pane = None;
+        }
     }
 
     pub(crate) fn draw_quit_confirm_overlay(&self, ctx: &egui::Context) {
@@ -391,12 +392,21 @@ impl PlexiApp {
     /// Run palette overlay (Cmd+R). Shows active runs across all panes; BlockedOnUser
     /// runs get a [!] badge and an inline text input for unblocking.
     pub(crate) fn draw_run_palette(&mut self, ctx: &egui::Context) {
+        // Consume Escape / Cmd+R at the context level so the key can't bleed
+        // through to the focused pane or trigger `poll_actions` a second
+        // time. Pairs with `FocusLayer::RunPalette` — the overlay owns its
+        // own dismissal keys.
+        let mut close = ctx.input_mut(|i| {
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            let toggle = i.consume_key(egui::Modifiers::COMMAND, egui::Key::R);
+            esc || toggle
+        });
+
         // Collect all active runs from every app pane in every context.
         // Clone needed because we hold &self across the window render.
         let all_runs: Vec<(String, String, String, Option<String>)> = Vec::new(); // (run_id, app_id, status, blocked_prompt)
         for _context in &self.contexts {}
 
-        let mut close = false;
         egui::Window::new("Active Runs")
             .collapsible(false)
             .resizable(true)
@@ -432,10 +442,6 @@ impl PlexiApp {
             });
 
         if close {
-            self.show_run_palette = false;
-        }
-        // Also close on Escape.
-        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
             self.show_run_palette = false;
         }
     }


### PR DESCRIPTION
## Summary

Migrate command palette, run palette, and rename-pane overlays to the existing `FocusLayer` pattern that notification modal and confirm-close already use. Fixes keyboard bleed-through where Enter/Escape in an overlay would also fire on the pane/app underneath.

## Why

Previously these overlays read keystrokes via non-consuming `ui.input(|i| i.key_pressed(...))`. The event stayed in `ctx.input` and was re-read by focused app/terminal/`poll_actions` the same frame. Symptoms:
- Pressing Enter on a palette row would also open a selected item in the app behind it
- Pressing Esc to close an overlay would also dismiss an app surface
- Rename commit via Enter could trigger terminal handling

The `FocusLayer` pattern solves this at the host level: overlays own a layer, render during the early-capture phase before the drain, and consume their own keys via `ctx.input_mut(|i| i.consume_key(...))`. Any key not consumed by the overlay gets filtered by `drain_captured_keyboard_input` before any pane or `poll_actions` sees it.

## Changes

- `src/app/mod.rs`
  - Added `FocusLayer::CommandPalette`, `FocusLayer::RunPalette`, `FocusLayer::RenamePane`
  - Added `sync_command_palette_focus`, `sync_run_palette_focus`, `sync_rename_pane_focus`
  - Extended `input_captured_by_overlay` to recognize the three new layers
  - Early-capture block now dispatches to the new overlay draw functions based on the top focus layer
  - Removed late-render `draw_command_palette` / `draw_run_palette` / `draw_rename_pane_overlay` calls to avoid double-dispatch of Enter/Escape

- `src/command_palette.rs`
  - Added `Cmd+P` close via `consume_key` so the toggle key doesn't leak to `poll_actions` post-drain (Esc/Arrows/Enter already used `consume_key`)

- `src/overlays.rs`
  - `draw_run_palette`: Esc and `Cmd+R` now consume at context level instead of the previous read-only `i.key_pressed(Escape)`
  - `draw_rename_pane_overlay`: Enter/Esc consume at context level, commit/cancel decisions made from those booleans instead of the brittle `lost_focus`-gated branch

Visual styling, sizes, colors, anchors, and scrim behavior unchanged.

## Test plan

- [x] `cargo build --release` clean, zero warnings
- [x] `just install-alpha` succeeds
- [ ] Cmd+P opens/closes command palette cleanly; Enter on a row jumps/launches without firing in the underlying app
- [ ] Cmd+R opens/closes run palette; Esc closes without reaching pane
- [ ] Cmd+Shift+R opens rename overlay; Enter commits, Esc cancels, neither bleeds to terminal
- [ ] Notification modal and confirm-close still behave identically (pre-existing FocusLayer consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)