### PR TITLE
fix(terminal): URL hyperlink detection across hard-wrapped rows

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -575,16 +575,132 @@ impl TerminalBackend {
 
     /// Based on alacritty/src/display/hint.rs > regex_match_at
     /// Retrieve the match, if the specified point is inside the content matching the regex.
+    ///
+    /// If the match terminates at the right edge of a row that is NOT marked
+    /// `WRAPLINE` (i.e. a client-wrapped row produced by tools like Claude Code,
+    /// git, bat, etc. that emit a literal `\n` at their own `$COLUMNS` boundary),
+    /// extend the match across the visual wrap so URLs stay clickable as a
+    /// single unit. See `extend_url_match_across_client_wraps`.
     fn regex_match_at(
         &self,
         terminal: &Term<EventProxy>,
         point: Point,
         regex: &mut RegexSearch,
     ) -> Option<Match> {
-        let x = visible_regex_match_iter(terminal, regex)
-            .find(|rm| rm.contains(&point));
-        x
+        let m = visible_regex_match_iter(terminal, regex)
+            .find(|rm| rm.contains(&point))?;
+        Some(extend_url_match_across_client_wraps(terminal, m))
     }
+}
+
+/// Return true if `c` is in the URL character set used by `url_regex` —
+/// i.e. it would be accepted by `[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩\`]`.
+/// Keep this in exact sync with the regex in `TerminalBackend::new`.
+///
+/// Note: inside a regex character class, `{-}` parses as the inclusive range
+/// `{` (U+007B) .. `}` (U+007D), which covers `{`, `|`, `}` — NOT a literal
+/// `-`. That is why plain hyphens ARE valid URL chars (e.g. `foo-bar.com`).
+fn is_url_char(c: char) -> bool {
+    // C0 / DEL / C1 control ranges.
+    if ('\u{0000}'..='\u{001F}').contains(&c)
+        || ('\u{007F}'..='\u{009F}').contains(&c)
+    {
+        return false;
+    }
+    // Explicit terminators from the regex char class.
+    // `{-}` in the class is the range `{`..=`}` = `{`, `|`, `}`.
+    if matches!(c, '<' | '>' | '"' | '{' | '|' | '}' | '^' | '⟨' | '⟩' | '`') {
+        return false;
+    }
+    // All whitespace (regex `\s`).
+    if c.is_whitespace() {
+        return false;
+    }
+    true
+}
+
+/// Extend a URL match across a "client-wrapped" visual boundary.
+///
+/// Many CLI tools (Claude Code, git, bat, etc.) wrap long lines themselves at
+/// `$COLUMNS` and emit a literal `\n`. Our backend correctly ingests that as a
+/// hard newline, so the cell at the right edge of the wrapped row does NOT
+/// carry `CellFlags::WRAPLINE`. Alacritty's `RegexIter` therefore stops the
+/// match at the newline and the URL is truncated.
+///
+/// This helper detects that specific pattern and walks the match end rightward
+/// across subsequent rows, appending cells as long as:
+///   * the row on which the match currently ends is at the terminal's right
+///     edge (`last_column`) AND does NOT have `WRAPLINE` set (so we're looking
+///     at a client wrap, not a normal soft wrap — alacritty already handles
+///     soft wraps internally via `line_search_right`),
+///   * the next row begins with a char accepted by the URL char class,
+///   * and we haven't yet hit a whitespace or URL-terminating character.
+///
+/// The heuristic is deliberately conservative: if any condition fails we stop
+/// extending. A false negative is just "link not clickable across the break",
+/// which is identical to today's behavior; a false positive would attach
+/// unrelated adjacent text to the URL.
+fn extend_url_match_across_client_wraps(
+    terminal: &Term<EventProxy>,
+    m: Match,
+) -> Match {
+    let grid = terminal.grid();
+    let last_col = terminal.last_column();
+    let bottom = terminal.bottommost_line();
+
+    let start = *m.start();
+    let mut end = *m.end();
+
+    loop {
+        // The match must currently end at the right edge of its row.
+        if end.column != last_col {
+            break;
+        }
+        // And the row's last cell must NOT be alacritty-soft-wrapped (if it
+        // were, alacritty's own `line_search_right` would have already
+        // followed it and the match would already span the join).
+        let end_cell: &Cell = &grid[end];
+        if end_cell.flags.contains(CellFlags::WRAPLINE) {
+            break;
+        }
+        // Don't walk past the last visible/scrollback row we can index.
+        let next_line = end.line + 1;
+        if next_line > bottom {
+            break;
+        }
+
+        // Peek the first cell of the next row. Only bridge if it looks like a
+        // direct continuation of the URL — i.e. a non-whitespace URL-valid
+        // character sits at column 0.
+        let first_point = Point::new(next_line, Column(0));
+        let first_cell: &Cell = &grid[first_point];
+        if !is_url_char(first_cell.c) {
+            break;
+        }
+
+        // Commit the bridge: advance end to (next_line, 0), then walk right
+        // along the new row until the URL char class breaks or we hit the
+        // right edge.
+        end = first_point;
+        let mut col = Column(0);
+        while col < last_col {
+            let peek = Column(col.0 + 1);
+            let peek_cell: &Cell = &grid[Point::new(next_line, peek)];
+            if !is_url_char(peek_cell.c) {
+                break;
+            }
+            col = peek;
+        }
+        end.column = col;
+
+        // If we stopped before the right edge, the URL has genuinely ended.
+        if col != last_col {
+            break;
+        }
+        // Otherwise loop: another client-wrap may continue the URL further.
+    }
+
+    start..=end
 }
 
 /// Copied from alacritty/src/display/hint.rs:
@@ -662,5 +778,36 @@ pub struct EventProxy(mpsc::Sender<Event>);
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {
         let _ = self.0.send(event.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_url_char;
+
+    /// The URL char predicate must mirror the negated class in `url_regex`:
+    /// `[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩\`]`.
+    /// If these diverge, the cross-wrap extension will either stop too early
+    /// or swallow non-URL text — regression-guard the obvious cases here.
+    #[test]
+    fn is_url_char_accepts_typical_url_bytes() {
+        // `-` is a valid URL char (e.g. `foo-bar.com`); see the note in
+        // `is_url_char` about `{-}` actually meaning the range `{`..=`}`.
+        for c in [
+            'a', 'Z', '0', '/', ':', '.', '?', '=', '&', '%', '#', '_', '+',
+            '[', ']', '(', ')', '~', '-',
+        ] {
+            assert!(is_url_char(c), "expected {c:?} to be a URL char");
+        }
+    }
+
+    #[test]
+    fn is_url_char_rejects_terminators_and_whitespace() {
+        for c in [
+            ' ', '\t', '\n', '\r', '<', '>', '"', '{', '|', '}', '^', '⟨',
+            '⟩', '`', '\u{0000}', '\u{001F}', '\u{007F}', '\u{0085}',
+        ] {
+            assert!(!is_url_char(c), "expected {c:?} to NOT be a URL char");
+        }
     }
 }


### PR DESCRIPTION
## Symptom

In a Plexi terminal pane, a long URL that gets hard-wrapped across two display rows (Claude Code Frame.io links, long `git`/`bat` output, etc.) only detects the first row as clickable. The hover underline stops at the right edge of row 1, Cmd+click opens only the first half of the URL, and row 2 has no hover hit-test.

## Root cause

URL detection uses `alacritty_terminal`'s `RegexIter`, which walks *logical* lines spanned via `line_search_left`/`line_search_right`. Those routines follow the `CellFlags::WRAPLINE` marker — they cross into the next row only when the terminal itself soft-wrapped it.

Many CLI tools (Claude Code, `git`, `bat`, …) do their own column-width wrapping at `$COLUMNS` and emit a literal `\n` at the wrap point. Our backend correctly ingests that as a hard newline, so `WRAPLINE` is never set. `RegexIter` stops at the newline, the URL match terminates at the first row's right edge, and the render path in `view.rs` only underlines cells inside that truncated match.

Soft-wrapped URLs (where the terminal itself wrapped) already worked — this bug is specifically about the "client-wrapped" case.

## What this patch does

`regex_match_at` now extends any match that terminates at the right edge of a non-`WRAPLINE` row, provided the next row begins with a URL-valid character. The extension walks rightward cell-by-cell using the same char set as the URL regex (shared via a new `is_url_char` predicate), stopping the moment a whitespace or URL-terminator is hit. If the extended row also fills its right edge without `WRAPLINE`, it keeps going — multi-wrap URLs are handled.

The heuristic is deliberately conservative:
- bridges only when (row ends at `last_column`) AND (no `WRAPLINE`) AND (next row's col 0 is URL-valid)
- stops at the first non-URL char on the continuation row
- walks row-by-row without pulling from arbitrary grid positions

A false negative ("link not clickable across wrap") is identical to today's behavior; a false positive would wrongly glue adjacent text onto a URL — so we prefer to under-bridge.

The extended `RangeInclusive<Point>` works with the existing render code in `view.rs` (row-by-row `display_iter` with `r.contains(&point)` — `Point`'s `Ord` is `(line, column)` lexicographic, so a range whose `start` and `end` sit on different rows correctly covers every wrapped cell) and with `open_link`'s `grid.iter_from(*start)` loop (which already walks across rows to `end`). No changes were needed to either.

## What this patch does NOT do

- **Does not touch `selectable_content()` or any copy-path code.** Copy-with-newlines across client-wrapped rows is a separate concern tracked as #301 and explicitly out of scope for this PR.
- **Does not change the URL regex itself.** The `is_url_char` helper mirrors the existing regex's negated character class; both live in `backend/mod.rs` with a comment noting they must stay in sync. (Worth noting for reviewers: `{-}` inside the regex class parses as the range `{`..=`}` = `{`, `|`, `}` — NOT a literal hyphen. Hyphens are valid URL chars, which is why `foo-bar.com` works today.)

## Tests

Added two unit tests for `is_url_char` covering accepted URL bytes and rejected terminators/whitespace. A full end-to-end test against a live `Term<EventProxy>` would require significant test-harness scaffolding that doesn't exist in this crate yet; skipped per the spec guidance.

## Verification

- `cargo build --release` — clean, no new warnings
- `cargo test --release -p egui_term` — 2 passed
- `just install-alpha` — succeeded

**Manual check (for the reviewer):** open a long URL in Claude Code output inside a Plexi Alpha terminal pane such that it wraps across two display rows. Hover and confirm the underline + hit-box covers both rows. Cmd+click and confirm the full URL opens (not the truncated first half).

Relates to #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)