### PR TITLE
feat(ui): migrate all shortcut hints to key_chip primitive

### DIFF
--- a/examples/github-tree/commit_graph.py
+++ b/examples/github-tree/commit_graph.py
@@ -769,32 +769,24 @@ class CommitGraphApp(App):
     # ── Help overlay ──────────────────────────────────────────────────────────
 
     def _draw_help(self, ctx: RenderContext) -> None:
-        help_items = [
-            ("[ ]",  "go to older / newer week"),
-            ("t",    "jump to today"),
-            ("j / k", "select next / previous commit"),
-            ("h / l", "select commit in left / right lane"),
-            ("g / G", "first / last commit"),
-            ("c",    "copy commit hash (shown in status bar)"),
-            ("o",    "open on GitHub (shown in status bar)"),
-            ("r",    "force refresh"),
-            ("?",    "toggle this help"),
+        help_rows = [
+            (["[", "]"],  "go to older / newer week"),
+            (["t"],       "jump to today"),
+            (["j", "/", "k"], "select next / previous commit"),
+            (["h", "/", "l"], "select commit in left / right lane"),
+            (["g", "/", "G"], "first / last commit"),
+            (["c"],       "copy hash (shown in status bar)"),
+            (["o"],       "open on GitHub (shown in status bar)"),
+            (["r"],       "force refresh"),
+            (["?"],       "toggle this help"),
         ]
-        W = min(380.0, ctx.w - 48.0)
-        ROW = 22.0
-        H = ROW * len(help_items) + 24.0
+        from plexi_sdk.ui import Column, Card, KeyRow, SPACE_MD
+        W = min(400.0, ctx.w - 48.0)
+        card = Card([KeyRow(keys, desc) for keys, desc in help_rows])
+        card_h = card.measure(W)
         bx = (ctx.w - W) / 2
-        by = (ctx.h - H) / 2
-
-        ctx.rect(bx - 1, by - 1, W + 2, H + 2, fill=HIGHLIGHT, radius=9.0)
-        ctx.rect(bx, by, W, H, fill=SURFACE, radius=8.0)
-
-        ty = by + 12.0
-        for key_str, desc in help_items:
-            ctx.text(bx + 12.0, ty, key_str, size=TEXT_CAPTION,
-                     color=ACCENT, monospace=True)
-            ctx.text(bx + 80.0, ty, desc, size=TEXT_CAPTION, color=FG)
-            ty += ROW
+        by = max(8.0, (ctx.h - card_h) / 2)
+        card.render(ctx, bx, by, W, card_h)
 
     # ── Utilities ─────────────────────────────────────────────────────────────
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -38,7 +38,7 @@ below the minimum pane size, or use `ScrollLog` for variable content.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 
 # ── Style tokens ──────────────────────────────────────────────────────────
 # Keep these in sync with Rust's src/style.rs. Adding a token here without
@@ -346,42 +346,86 @@ class Section(Component):
 
 @dataclass
 class KeyRow(Component):
-    """A `[k]` key badge followed by a description, left-aligned. The badge
-    uses a monospace glyph on an elevated background so single keys and
-    chords (⌘K, ⎋) all look tidy. Description text is proportional.
+    """A keycap chip (or a chord of chips) followed by a description, left-aligned.
 
-    Layout math: the badge and description text are both vertically centered
-    within the row's HEIGHT. Text is drawn with LEFT_TOP anchor, so we
-    compute `top = y + (HEIGHT - font_size) / 2`.
+    `key` accepts either a single string (e.g. `"m"`) or a list of strings
+    forming a chord (e.g. `["⌘", "K"]`). Each element is rendered as a
+    distinct rounded-rect chip, matching the host-side `key_chip` primitive.
+
+    Layout:  [⌘][K]  Description text
+             ↑ chips  ↑ proportional label, vertically centred
+
+    Visual spec (mirrors src/widgets.rs key_chip):
+      - chip fill:   HIGHLIGHT
+      - chip border: drawn as a 1px rect outline in MUTED
+      - key text:    monospace, TEXT_HINT, MUTED
+      - corner r:    3px
+      - padding:     5px h / 1px v inside each chip
+      - min chip w:  16px
+      - gap between chips in a chord: 2px
     """
-    key: str
+    key: Union[str, List[str]]
     description: str
-    badge_color: str = HIGHLIGHT
-    key_color: str = ACCENT
 
-    HEIGHT = 34.0
-    BADGE_H = 26.0
-    BADGE_W = 44.0  # wide enough for 2–3 glyph chords like "⌘K" / "Esc"
+    HEIGHT = 28.0
+    CHIP_PAD_H = 5.0
+    CHIP_PAD_V = 1.0
+    CHIP_MIN_W = 16.0
+    CHIP_CORNER_R = 3.0
+    CHIP_GAP = 2.0       # gap between chips in a chord
+    DESC_GAP = 10.0      # gap between last chip and description text
+
+    def _keys(self) -> List[str]:
+        """Normalise key to a list."""
+        if isinstance(self.key, list):
+            return self.key
+        return [self.key]
+
+    def _chip_w(self, label: str) -> float:
+        """Approximate chip width for a given label."""
+        char_w = _char_px(TEXT_HINT, mono=True)
+        text_w = len(label) * char_w
+        return max(self.CHIP_MIN_W, text_w + self.CHIP_PAD_H * 2)
+
+    def _total_chips_w(self) -> float:
+        keys = self._keys()
+        total = sum(self._chip_w(k) for k in keys)
+        total += self.CHIP_GAP * max(0, len(keys) - 1)
+        return total
 
     def measure(self, avail_w: float) -> float:
         return self.HEIGHT
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        badge_y = y + (self.HEIGHT - self.BADGE_H) / 2.0
-        ctx.rect(x, badge_y, self.BADGE_W, self.BADGE_H, self.badge_color,
-                 radius=RADIUS_MD)
-        # Both the badge glyph and the description use host-side anchors so
-        # real font metrics drive the centering — no Python-side char-width
-        # approximation that falls apart on narrow glyphs like `i`.
-        glyph = self.key[:3]
-        ctx.text(
-            x + self.BADGE_W / 2.0,
-            badge_y + self.BADGE_H / 2.0,
-            glyph,
-            size=TEXT_BODY, color=self.key_color,
-            bold=True, monospace=True, align="center",
-        )
-        desc_x = x + self.BADGE_W + SPACE_MD
+        chip_h = TEXT_HINT + self.CHIP_PAD_V * 2
+        chip_y = y + (self.HEIGHT - chip_h) / 2.0
+
+        cursor_x = x
+        for i, label in enumerate(self._keys()):
+            if i > 0:
+                cursor_x += self.CHIP_GAP
+            cw = self._chip_w(label)
+            # Chip background
+            ctx.rect(
+                cursor_x, chip_y, cw, chip_h,
+                HIGHLIGHT, radius=self.CHIP_CORNER_R,
+            )
+            # Chip border (1px outline approximated as four thin rects)
+            ctx.rect(cursor_x, chip_y, cw, 1.0, MUTED)
+            ctx.rect(cursor_x, chip_y + chip_h - 1.0, cw, 1.0, MUTED)
+            ctx.rect(cursor_x, chip_y, 1.0, chip_h, MUTED)
+            ctx.rect(cursor_x + cw - 1.0, chip_y, 1.0, chip_h, MUTED)
+            # Key label, centred inside chip
+            ctx.text(
+                cursor_x + cw / 2.0,
+                chip_y + chip_h / 2.0,
+                label,
+                size=TEXT_HINT, color=MUTED,
+                monospace=True, align="center",
+            )
+            cursor_x += cw
+
+        desc_x = cursor_x + self.DESC_GAP
         desc_avail = w - (desc_x - x)
         desc_text = _truncate_to_width(self.description, desc_avail, TEXT_BODY)
         ctx.text(

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -108,6 +108,10 @@ impl PlexiApp {
     }
 
     pub(crate) fn draw_shortcuts_overlay(&self, ctx: &egui::Context) {
+        // Each row: (combo chips, description).
+        // Multi-key combos are expressed as slices; single-key as a one-element slice.
+        // Rows that cover two related combos (e.g. ]/[) are represented as a
+        // key_combo_list with two combos and a combined description.
         egui::Area::new(egui::Id::new("shortcuts_overlay"))
             .anchor(Align2::RIGHT_TOP, Vec2::new(-16.0, 44.0))
             .show(ctx, |ui| {
@@ -117,7 +121,7 @@ impl PlexiApp {
                     .corner_radius(R6)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
-                        ui.set_width(240.0);
+                        ui.set_width(280.0);
                         ui.label(
                             RichText::new("Keyboard Shortcuts")
                                 .size(13.0)
@@ -126,37 +130,60 @@ impl PlexiApp {
                         );
                         ui.add_space(8.0);
 
-                        let shortcuts = [
-                            ("\u{2318}P", "Command palette"),
-                            ("\u{2318}\u{21E7}R", "Rename pane"),
-                            ("\u{2318}T", "New tab"),
-                            ("\u{2318}]/[", "Next/prev tab"),
-                            ("\u{2318}D", "Split right"),
-                            ("\u{2318}\u{21E7}D", "Split down"),
-                            ("\u{2318}W", "Close pane"),
-                            ("\u{2318}B", "Toggle sidebar"),
-                            ("\u{2318}H/J/K/L", "Focus pane"),
-                            ("\u{2318}\u{21A9}", "Zoom pane"),
-                            ("\u{2318}N", "New context"),
-                            ("\u{2318}1-9", "Switch context"),
-                            ("\u{2318}/", "This help"),
-                            ("\u{2318}Q", "Quit"),
-                        ];
+                        // Two-column grid: fixed-width left column holds chips,
+                        // right column holds the description.
+                        egui::Grid::new("shortcuts_grid")
+                            .num_columns(2)
+                            .spacing([style::SPACE_SM, 4.0])
+                            .show(ui, |ui| {
+                                let colors = &self.colors;
 
-                        for (key, desc) in shortcuts {
-                            ui.horizontal(|ui| {
-                                ui.label(
-                                    RichText::new(key)
-                                        .size(11.0)
-                                        .color(self.colors.accent)
-                                        .family(egui::FontFamily::Monospace),
-                                );
-                                ui.add_space(8.0);
-                                ui.label(
-                                    RichText::new(desc).size(11.0).color(self.colors.text_dim),
-                                );
+                                // Single-combo rows: (&[key parts], description)
+                                let rows: &[(&[&str], &str)] = &[
+                                    (&["\u{2318}", "P"], "Command palette"),
+                                    (&["\u{2318}", "\u{21E7}", "R"], "Rename pane"),
+                                    (&["\u{2318}", "T"], "New tab"),
+                                    (&["\u{2318}", "D"], "Split right"),
+                                    (&["\u{2318}", "\u{21E7}", "D"], "Split down"),
+                                    (&["\u{2318}", "W"], "Close pane"),
+                                    (&["\u{2318}", "B"], "Toggle sidebar"),
+                                    (&["\u{2318}", "\u{21A9}"], "Zoom pane"),
+                                    (&["\u{2318}", "N"], "New context"),
+                                    (&["\u{2318}", "/"], "This help"),
+                                    (&["\u{2318}", "Q"], "Quit"),
+                                ];
+                                for (keys, desc) in rows {
+                                    crate::widgets::key_combo(ui, keys, colors);
+                                    ui.label(
+                                        RichText::new(*desc)
+                                            .size(style::TEXT_HINT)
+                                            .color(colors.text_dim),
+                                    );
+                                    ui.end_row();
+                                }
+
+                                // Two-combo rows rendered with key_combo_list.
+                                let two_combo_rows: &[(&[&str], &[&str], &str)] = &[
+                                    (&["\u{2318}", "]"], &["\u{2318}", "["], "Next/prev tab"),
+                                    (&["\u{2318}", "H"], &["\u{2318}", "L"], "Focus pane ←/→"),
+                                    (&["\u{2318}", "J"], &["\u{2318}", "K"], "Focus pane ↓/↑"),
+                                    (&["\u{2318}", "1"], &["\u{2318}", "9"], "Switch context 1–9"),
+                                ];
+                                for (keys_a, keys_b, desc) in two_combo_rows {
+                                    crate::widgets::key_combo_list(
+                                        ui,
+                                        &[keys_a, keys_b],
+                                        None,
+                                        colors,
+                                    );
+                                    ui.label(
+                                        RichText::new(*desc)
+                                            .size(style::TEXT_HINT)
+                                            .color(colors.text_dim),
+                                    );
+                                    ui.end_row();
+                                }
                             });
-                        }
                     });
             });
     }
@@ -372,9 +399,17 @@ impl PlexiApp {
                                 cancelled = true;
                             }
                             ui.add_space(12.0);
+                            crate::widgets::key_chip(ui, "Enter", &self.colors);
                             ui.label(
-                                RichText::new("Enter  confirm   Esc  cancel")
-                                    .size(10.0)
+                                RichText::new("confirm")
+                                    .size(style::TEXT_HINT)
+                                    .color(self.colors.text_dim),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            crate::widgets::key_chip(ui, "Esc", &self.colors);
+                            ui.label(
+                                RichText::new("cancel")
+                                    .size(style::TEXT_HINT)
                                     .color(self.colors.text_dim),
                             );
                         });
@@ -436,9 +471,14 @@ impl PlexiApp {
                     }
                 }
                 ui.add_space(8.0);
-                if ui.button("Close  [Cmd+R]").clicked() {
-                    close = true;
-                }
+                ui.horizontal(|ui| {
+                    if ui.button("Close").clicked() {
+                        close = true;
+                    }
+                    crate::widgets::key_combo_list(
+                        ui, &[&["\u{2318}", "R"]], None, &self.colors,
+                    );
+                });
             });
 
         if close {
@@ -812,35 +852,97 @@ impl PlexiApp {
                             ui.add_space(style::SPACE_MD);
                         }
 
-                        let hint = match notif.kind {
-                            NotifyKind::Message => {
-                                if notif.required {
-                                    "Enter / Space to acknowledge"
-                                } else {
-                                    "Enter / Space  ·  Esc to dismiss"
-                                }
-                            }
-                            NotifyKind::Choice => {
-                                if notif.required {
-                                    "↑↓ or j/k  ·  Enter  ·  1-9"
-                                } else {
-                                    "↑↓ or j/k  ·  Enter  ·  1-9  ·  Esc to dismiss"
-                                }
-                            }
-                            NotifyKind::Input => {
-                                if notif.required {
-                                    "Enter for newline  ·  \u{2318}\u{21B5} to submit"
-                                } else {
-                                    "Enter for newline  ·  \u{2318}\u{21B5} to submit  ·  Esc to dismiss"
-                                }
-                            }
-                        };
+                        // Footer keyboard hint — chips + inline labels per action.
                         ui.vertical_centered(|ui| {
-                            ui.label(
-                                RichText::new(hint)
-                                    .size(style::TEXT_HINT)
-                                    .color(self.colors.text_dim),
-                            );
+                            ui.horizontal_wrapped(|ui| {
+                                ui.spacing_mut().item_spacing.x = 4.0;
+                                match notif.kind {
+                                    NotifyKind::Message => {
+                                        crate::widgets::key_chip(ui, "Enter", &self.colors);
+                                        crate::widgets::key_chip(ui, "Space", &self.colors);
+                                        ui.label(
+                                            RichText::new("acknowledge")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        if !notif.required {
+                                            ui.label(
+                                                RichText::new("·")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                            crate::widgets::key_chip(ui, "Esc", &self.colors);
+                                            ui.label(
+                                                RichText::new("dismiss")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                        }
+                                    }
+                                    NotifyKind::Choice => {
+                                        crate::widgets::key_chip(ui, "↑↓", &self.colors);
+                                        crate::widgets::key_chip(ui, "j/k", &self.colors);
+                                        ui.label(
+                                            RichText::new("·")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        crate::widgets::key_chip(ui, "Enter", &self.colors);
+                                        ui.label(
+                                            RichText::new("·")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        crate::widgets::key_chip(ui, "1-9", &self.colors);
+                                        if !notif.required {
+                                            ui.label(
+                                                RichText::new("·")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                            crate::widgets::key_chip(ui, "Esc", &self.colors);
+                                            ui.label(
+                                                RichText::new("dismiss")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                        }
+                                    }
+                                    NotifyKind::Input => {
+                                        crate::widgets::key_chip(ui, "Enter", &self.colors);
+                                        ui.label(
+                                            RichText::new("newline")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        ui.label(
+                                            RichText::new("·")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        crate::widgets::key_chip(ui, "\u{2318}", &self.colors);
+                                        crate::widgets::key_chip(ui, "\u{21B5}", &self.colors);
+                                        ui.label(
+                                            RichText::new("submit")
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                        if !notif.required {
+                                            ui.label(
+                                                RichText::new("·")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                            crate::widgets::key_chip(ui, "Esc", &self.colors);
+                                            ui.label(
+                                                RichText::new("dismiss")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                        }
+                                    }
+                                }
+                            });
                         });
                     });
             });

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -114,5 +114,54 @@ pub(crate) fn key_chip(ui: &mut egui::Ui, label: &str, colors: &Colors) -> egui:
     response
 }
 
-// Combo/list wrappers will be added when the help modal migration lands.
-// Keeping the surface minimal until a second consumer exists.
+/// Gap between chips within a single combo (e.g. ⌘ + [).
+const INTRA_COMBO_GAP: f32 = 2.0;
+/// Gap between separate combos in a list (e.g. ⌘[ vs ⌘]).
+const INTER_COMBO_GAP: f32 = 10.0;
+/// Gap between the last combo/chip and the trailing description text.
+const TRAILING_GAP: f32 = 10.0;
+
+/// Render several chips forming a single key combo (e.g. ["⌘", "["]).
+/// Chips are laid out left-to-right with `INTRA_COMBO_GAP` between them.
+pub(crate) fn key_combo(ui: &mut egui::Ui, keys: &[&str], colors: &Colors) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = INTRA_COMBO_GAP;
+        for key in keys {
+            key_chip(ui, key, colors);
+        }
+    });
+}
+
+/// Render multiple combos inline with an optional trailing description label.
+///
+/// Layout:    [⌘][[] ··inter·· [⌘][] ··trailing·· "cycle"
+pub(crate) fn key_combo_list(
+    ui: &mut egui::Ui,
+    combos: &[&[&str]],
+    trailing: Option<&str>,
+    colors: &Colors,
+) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        for (i, keys) in combos.iter().enumerate() {
+            if i > 0 {
+                ui.add_space(INTER_COMBO_GAP);
+            }
+            // Chips within a combo sit INTRA_COMBO_GAP apart.
+            for (j, key) in keys.iter().enumerate() {
+                if j > 0 {
+                    ui.add_space(INTRA_COMBO_GAP);
+                }
+                key_chip(ui, key, colors);
+            }
+        }
+        if let Some(text) = trailing {
+            ui.add_space(TRAILING_GAP);
+            ui.label(
+                egui::RichText::new(text)
+                    .size(style::TEXT_HINT)
+                    .color(colors.text_dim),
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Summary

- **`src/widgets.rs`**: Added `key_combo` and `key_combo_list` wrappers on top of the existing `key_chip` primitive. Intra-combo gap = 2px, inter-combo = 10px, trailing-text = 10px — matching the spec.
- **`src/overlays.rs`**: Four surfaces migrated:
  - `draw_shortcuts_overlay` — rewritten as a two-column `egui::Grid`; each row uses `key_combo` (single combo) or `key_combo_list` (paired combos like ]/[). Width expanded 240→280 to accommodate chips.
  - `draw_confirm_close` footer — `"Enter  confirm   Esc  cancel"` flat text replaced with `key_chip("Enter")` + label + `key_chip("Esc")` + label inline.
  - `draw_run_palette` close button — `"Close  [Cmd+R]"` button label separated: plain Close button + `key_combo_list` chip aside it.
  - `draw_notification_modal` hint row — the `let hint = match ...` flat string block replaced with `horizontal_wrapped` chip+label pairs per action, conditioned on `notif.required`.
- **`sdk/python/plexi_sdk/ui.py`**: `KeyRow.key` now accepts `Union[str, List[str]]`. Single-string case is unchanged (no breakage). Chord case renders each element as a distinct chip (HIGHLIGHT fill, MUTED 1px border, monospace TEXT_HINT, corner r=3). `Union` import added.
- **`examples/github-tree/commit_graph.py`**: `_draw_help` overlay migrated from manual rect+text rows to a `KeyRow` `Card`. Footer prose strings (`"[ ] week  t today  j k commit…"`) left as-is — they are narrative status-line text, not a lookup table.

## Surfaces deliberately left as prose

- All `Footer(...)` strings in `commit_graph.py` and other example apps — compact, multi-key run-on strings used as status line copy, not shortcut tables.
- `draw_rename_pane_overlay` — no hint text exists (silent Enter/Esc); nothing to migrate.
- `draw_quit_confirm_overlay` — message is informational prose ("⌘Q pressed N of 3…"), not a shortcut hint.
- Notification modal `input` kind `.hint_text("Type. Enter for newline, ⌘↵ to submit.")` — this is a TextEdit placeholder, not a separate hint row. The hint row below it was migrated.

## Test plan

- [x] `cargo build --release` — clean, zero warnings
- [x] `cargo test --release` — green
- [x] `pytest examples/github-tree/tests/ -q` — 10 passed
- [x] `just install-alpha` — clean (16 apps synced)
- [ ] Visual smoke: open Plexi Alpha → `?` shows grid of chips → confirm-close shows `Enter`/`Esc` chips → notification modal footer shows chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)