### PR TITLE
fix: background app cross-context tick for Global notifications

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,21 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-24 — [GOTCHA] `wtp add` always branches from main, not the active worktree
+
+`wtp add -b <name>` picks up the repo's default branch (main) as the base, not the worktree you're currently sitting in. Running it from the alpha worktree still produced a branch off main — 14 commits behind. Fix: after every `wtp add`, immediately run `git log --oneline -1` in the new worktree. If it doesn't match alpha HEAD, `git reset --hard alpha` before touching any files.
+
+## 2026-04-24 — [GOTCHA] `vertical_centered` + `horizontal_wrapped` doesn't actually center content
+
+In egui, `horizontal_wrapped` fills the full available width and wraps left-to-right, so wrapping a it in `vertical_centered` only centers the outer widget block — the chips/labels inside still left-align. Fix: use `horizontal` (no wrap) when the content is short enough to fit on one line. The notification modal's keyboard hint row had this bug; switching to `horizontal` centered it correctly.
+
+## 2026-04-24 — [GOTCHA] Custom Component subclasses crash if they don't inherit `Component`
+
+`Column` calls `child._render_clipped()` on every child. Inner classes used as layout children (`_CountdownRing` in stand-up-reminder, `_Body` in quick-note/todo/wikipedia) that implement `measure/is_grow/render` but don't inherit `Component` will crash at render time with `AttributeError: object has no attribute '_render_clipped'`. Rule: any object placed inside a `Column` or `Card` must be a `Component` subclass.
+
+## 2026-04-24 — [FIX] App code corrupted during AppBar migration — not caught until smoke test
+
+The Header→AppBar migration in this session produced silent corruption in two apps: `screen-time`'s `_chrome_tree` had the MODE_CLOCK branch reduced to a dangling `%B %-d')}")` fragment (the subtitle f-string was deleted but a closing fragment remained), and `notification-tester`'s `AppBar(title=...)` call had extra words appended after the string close, making it a syntax error. Both were only discovered by opening the apps and seeing them crash. The Scrollable.render method was also found outside the class body (orphaned past a `return`). These are syntax-level bugs — the right safeguard is `python3 -m py_compile` on every modified app file before committing.
+
 ## 2026-04-23 — [CHANGED] Host-measured text layout primitives (issue #312, PR → alpha)
 Python SDK estimated text widths with `font_size × ratio` heuristics; the host renders with real egui font metrics. This produced mis-sized badge pills, wrongly-clipped keychips, and truncation that cut at the wrong character count.
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -46,10 +46,17 @@ impl PlexiApp {
         // looked up from the registry by type_id, and we can't hold a
         // mutable borrow on contexts + a shared borrow on the registry at
         // the same time during the match below.
+        let active = self.active_context;
         let mut per_pane: Vec<(usize, u64, String, Vec<AppCommand>)> = Vec::new();
         for (ctx_idx, context) in self.contexts.iter_mut().enumerate() {
             for (pane_id, pane) in context.panes.iter_mut() {
                 let Some(app_pane) = pane.as_app_mut() else { continue };
+                // Active-context panes are already fully updated by ui() this frame.
+                // Non-active panes need a headless tick so their timer/async events
+                // reach the subprocess and control commands (notifications, etc.) flow out.
+                if ctx_idx != active {
+                    app_pane.runtime.background_tick();
+                }
                 let type_id = app_pane.runtime.type_id().to_string();
                 let cmds = app_pane.runtime.take_pending_commands();
                 if !cmds.is_empty() {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -833,7 +833,7 @@ impl PlexiApp {
                             }
                         }
 
-                        ui.add_space(style::SPACE_XL);
+                        ui.add_space(style::SPACE_MD);
 
                         // Footer: primary action for message kind, plus a
                         // centered hint row describing keyboard shortcuts.
@@ -843,7 +843,7 @@ impl PlexiApp {
                                     ui,
                                     "Acknowledge",
                                     &self.colors,
-                                    220.0,
+                                    180.0,
                                 );
                                 if resp.clicked() {
                                     action_cmd = Some(AppCommand::DeliverNotifyAction {
@@ -859,7 +859,7 @@ impl PlexiApp {
 
                         // Footer keyboard hint — chips + inline labels per action.
                         ui.vertical_centered(|ui| {
-                            ui.horizontal_wrapped(|ui| {
+                            ui.horizontal(|ui| {
                                 ui.spacing_mut().item_spacing.x = 4.0;
                                 match notif.kind {
                                     NotifyKind::Message => {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -177,6 +177,14 @@ impl AppRuntime {
             AppRuntime::Builtin(app) => app.serialize_state(),
         }
     }
+
+    /// Pump event I/O for a pane not in the active context. No-op for builtins.
+    pub fn background_tick(&mut self) {
+        match self {
+            AppRuntime::Process(app) => app.background_tick(),
+            AppRuntime::Builtin(_) => {}
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -321,6 +321,60 @@ impl ProcessApp {
         }
         cmds
     }
+
+    /// Pump event I/O for a pane that is not currently rendered.
+    ///
+    /// Active-context panes are fully updated by `ui()` each frame. Non-active
+    /// panes never get `ui()` called, so `http_rx` (where timer events land) is
+    /// never drained and the Python process never receives those events — timers
+    /// stall and notifications never fire.
+    ///
+    /// This does the minimal work to keep background apps alive:
+    /// 1. Drain `http_rx` → `outbound_events`
+    /// 2. Flush `outbound_events` → Python stdin
+    /// 3. Drain `draw_rx` → route control commands (timers, notifications, etc.)
+    ///
+    /// Visual draw commands are discarded — there is no pane to render into.
+    pub(crate) fn background_tick(&mut self) {
+        while let Ok(event) = self.http_rx.try_recv() {
+            self.outbound_events.push_back(event);
+        }
+        self.flush_outbound_events();
+        for cmd in self.drain_draw_commands() {
+            match cmd {
+                DrawCommand::Log { level, message } => {
+                    let target = format!("app::{}", self.type_id);
+                    match level.as_str() {
+                        "error" => log::error!(target: &target, "{message}"),
+                        "warn"  => log::warn!(target: &target, "{message}"),
+                        "debug" => log::debug!(target: &target, "{message}"),
+                        _       => log::info!(target: &target, "{message}"),
+                    }
+                }
+                cmd @ (DrawCommand::CapabilityRequest { .. }
+                | DrawCommand::SecretGet { .. }
+                | DrawCommand::RunGet { .. }
+                | DrawCommand::RunComplete { .. }
+                | DrawCommand::Notify { .. }
+                | DrawCommand::PipeOpen { .. }
+                | DrawCommand::PipeSend { .. }
+                | DrawCommand::StatusSummary { .. }
+                | DrawCommand::SpawnApp { .. }
+                | DrawCommand::HttpRequest { .. }
+                | DrawCommand::LlmRequest { .. }
+                | DrawCommand::AudioPlay { .. }
+                | DrawCommand::AudioCapture { .. }
+                | DrawCommand::CdRequest { .. }
+                | DrawCommand::SetTimer { .. }
+                | DrawCommand::CancelTimer { .. }) => {
+                    self.route_command(cmd);
+                }
+                // Visual commands, FrameDone, Ready, MeasureText, ScheduleRender
+                // are discarded — no pane to render into.
+                _ => {}
+            }
+        }
+    }
 }
 
 impl App for ProcessApp {


### PR DESCRIPTION
## Summary

- Non-active context panes never had `ui()` called, so `http_rx` (where timer thread fires land) was never drained — timers stalled and `ctx.notify()` never fired for apps in any context other than the active one
- `stand-up-reminder` manifest already had `default_notification_scope = \"global\"` — the protocol infrastructure was complete, the event delivery loop was the gap
- New `ProcessApp::background_tick()` does the minimal headless update each frame: drain `http_rx` → stdin, drain `draw_rx` for control commands only (timers, notifications, pipes), discard visual commands
- `drain_all_app_commands()` calls `background_tick()` on every non-active pane before `take_pending_commands()`

## Idle cost

One non-blocking `try_recv()` per non-active pane per frame. No actual I/O unless a timer fires.

## Breaks if

Stand-up reminder (or any timer-based app) in a non-active context fires its timer and no notification modal appears in the active context.