### PR TITLE
docs: squash-merge contract + milestone-cumulation rule + check off #312

### DIFF
--- a/.claude/iteration-cycle.md
+++ b/.claude/iteration-cycle.md
@@ -15,7 +15,7 @@ Hotfixes are the only main-direct work — branch from `main`, PR to `main`, che
 - Alpha (active): `just install-alpha`
 - Stable (only when promoting beta → main): `just install`
 
-After every code change, install for the active branch before reporting done. The user installs alpha after every merge to verify.
+After every code change, install for the active branch before reporting done. **Orchestrator runs `just install-alpha` after every squash-merge** — the user does not have to.
 
 ## Smoke test (required before claiming done)
 ```
@@ -53,8 +53,8 @@ Per release:
 2. Group by file overlap — same-file issues serialize, others parallelize.
 3. Dispatch one sub-agent per issue via `Agent` with `isolation: "worktree"`, `run_in_background: true`.
 4. Review diffs (not summaries) when agents report done.
-5. Pull worktree, run smoke test, merge to `alpha` if clean.
-6. **User runs human-verification checklist on alpha build.** Green → next dispatch in this theme. Red → revert + new dispatch with diagnosis.
+5. Pull worktree, run smoke test, **squash-merge** to `alpha` if clean (`gh pr merge <N> --squash --delete-branch` — never `--merge` or `--rebase`; squash so each PR is one revertible commit).
+6. **Orchestrator runs `just install-alpha` immediately after merge**, then pings user with the human-verification checklist. Green → next dispatch. Red → `git revert <squash-sha>` on alpha + new dispatch with diagnosis.
 7. After all PRs in milestone merged + verified: run release-level checklist from `docs/specs/releases/v3.x.md`.
 8. After alpha contains v3.5 (or whenever user calls it): batch-promote alpha → beta, soak, → main.
 

--- a/docs/specs/process/release-orchestration.md
+++ b/docs/specs/process/release-orchestration.md
@@ -43,7 +43,8 @@ v3.5 PRN → alpha → user verifies on alpha build
 - The user can choose to cut a beta partway (e.g. after v3.2) if they want a "stable enough" snapshot — but it's a deliberate decision, not a per-release ritual.
 
 **Hard rules:**
-- Sub-agent worktrees branch from `alpha`, PR back to `alpha`. Never to `beta` or `main`.
+- Sub-agent worktrees branch from **current `alpha` HEAD** (not from where the previous milestone started). Each new milestone's first sub-agent therefore inherits every previously squash-merged PR — milestones cumulate on alpha, they don't fan out from a fixed base.
+- All sub-agent PRs target `alpha`. Never `beta` or `main`.
 - `beta` only moves when the user explicitly says "promote alpha."
 - `main` only moves when `beta` has soaked successfully.
 - Hotfixes for `main` are the only exception — those branch from `main`, PR to `main`, and cherry-pick back to `alpha`.
@@ -93,17 +94,19 @@ Spawn one sub-agent per issue (or per serial group) via `Agent` with `isolation:
 When an agent reports done:
 - Orchestrator reviews the diff (not the summary).
 - Pulls the worktree, runs smoke test locally.
-- If clean: merge to `alpha`.
+- If clean: **squash-merge to `alpha`** via `gh pr merge <N> --squash --delete-branch`. Squash is mandatory — every PR lands as a single revertible commit on alpha so a bad PR can be ejected with `git revert <sha>` without unwinding others. Never use `--merge` or `--rebase`.
 - If stub (`todo!()`, missing test, smoke-test failure): reject with tightened brief, re-dispatch.
 - After 3 rejections on the same issue, orchestrator takes it directly.
 
-### 5. Human verification on alpha
-After every merge to alpha:
-1. User pulls latest alpha and runs `just install-alpha`.
-2. User runs the **Human verification** checklist from the PR description.
-3. Reports back: ✅ → next PR can dispatch; ❌ → revert merge, file regression issue, re-dispatch with diagnosis.
+### 5. Install + human verification on alpha
+After every squash-merge to alpha:
+1. **Orchestrator runs `just install-alpha`** on the alpha worktree (no longer waits for the user to do it). Verify the install succeeded (binary present, smoke test passes).
+2. Orchestrator pings the user with the PR's **Human verification** checklist + a one-line summary of what to look at.
+3. User runs the checklist. Reports back: ✅ → next PR dispatches; ❌ → orchestrator runs `git revert <squash-sha>` on alpha, files regression issue with the diagnosis, re-dispatches with tightened brief.
 
-This step is non-optional. A merged PR that hasn't been human-verified blocks the next dispatch in the same theme. Other themes' PRs can continue in parallel.
+This step is non-optional. A merged-but-unverified PR blocks the next dispatch in the same theme. Other themes' PRs can continue in parallel.
+
+**Cherry-pick endgame:** once v4 planning starts, alpha will not be merged into the v4 branch wholesale. The squash-per-PR history makes it cheap to cherry-pick the keepers (`git cherry-pick <sha>`) into v4 and drop the dead-end PRs from v3.x. This is why every PR must be one commit.
 
 ### 6. Release-level checklist
 When all PRs in a milestone are merged + human-verified, run the release-level checklist in `docs/specs/releases/v3.x.md`. This is the rolled-up smoke test for the theme — proves the release as a whole works, not just the individual PRs. Examples:

--- a/docs/specs/releases/v3.1.md
+++ b/docs/specs/releases/v3.1.md
@@ -5,7 +5,7 @@
 **Milestone:** [v3.1](https://github.com/ianjamesburke/PLEXI/milestone/1)
 
 ## Issues
-- [ ] #312 — Host-measured text layout primitives + SDK migration (P1, headline)
+- [x] #312 — Host-measured text layout primitives + SDK migration (P1, headline) — shipped via PR #313
 - [ ] #314 — Bounded paint regions + Scrollable SDK primitive (P1)
 - [ ] #316 — Observable app lifecycle — surface every failure mode in-pane (P1)
 - [ ] #317 — Single-source-of-geometry — explicit `pane_rect` everywhere (P2)


### PR DESCRIPTION
## Summary
- Orchestrator squash-merges every sub-agent PR (\`gh pr merge --squash --delete-branch\`) so each PR is a single revertible commit on alpha. Never \`--merge\` or \`--rebase\`. Cherry-pick keepers into v4 later; revert dead-ends with one command.
- Orchestrator runs \`just install-alpha\` after every merge (no longer waiting on the user to install). User then runs the PR's Human verification checklist on the installed alpha build.
- Each new milestone branches from **current alpha HEAD** — milestones cumulate on alpha rather than fanning out from a fixed base. v3.2 sub-agents inherit all v3.1 PRs automatically.
- v3.1 spec checks off #312 (host-measured text) — already shipped via PR #313 / commit \`fedfacc\` on 2026-04-23. Closing the issue manually.

## Why
User authorized me to merge sub-agent PRs unilaterally on alpha on the condition that every merge is squash so it's a single revertible commit. The point: keep the alpha train moving without a human-merge bottleneck while preserving clean revert granularity.

## Breaks if
- Any sub-agent PR is merged with \`--merge\` or \`--rebase\` (multiple commits per PR breaks the cherry-pick endgame).
- Orchestrator skips \`just install-alpha\` after a merge (user can't verify against the built binary).
- A new milestone's sub-agents are dispatched from a stale alpha base instead of current HEAD.

## Test plan
- [ ] \`grep "squash-merge" docs/specs/process/release-orchestration.md\` returns the contract.
- [ ] \`grep "current alpha HEAD" docs/specs/process/release-orchestration.md\` returns the milestone-cumulation rule.
- [ ] \`docs/specs/releases/v3.1.md\` shows #312 ticked with the PR #313 reference.
- [ ] \`.claude/iteration-cycle.md\` step 5 says orchestrator runs \`install-alpha\` after merge, not the user.