### PR TITLE
feat(host): observable app lifecycle pill (#316)

### DIFF
--- a/src/process_app/lifecycle.rs
+++ b/src/process_app/lifecycle.rs
@@ -1,0 +1,488 @@
+//! Observable app lifecycle (issue #316).
+//!
+//! `LifecycleTracker` is a thread-safe view of an app's health that the
+//! background readers (stdout, stderr, `try_wait` poller) write to and the
+//! UI thread reads from each frame to render the in-pane status pill.
+//!
+//! Five distinguishable states:
+//!
+//! - `Booting`       — process spawned, no FrameDone yet. Faint pill.
+//! - `Running`       — last FrameDone within `RUNNING_FRESH_WINDOW`. No pill.
+//! - `Hung`          — process alive, no FrameDone in `HUNG_FRAME_GAP`,
+//!                     AND user input observed in that window.
+//! - `Crashed`       — subprocess exited / stderr matched `Traceback`/`PANIC` /
+//!                     stdout closed.
+//! - `ProtocolError` — stdout JSON parse failures exceeded
+//!                     `PROTOCOL_ERROR_THRESHOLD` within
+//!                     `PROTOCOL_ERROR_WINDOW`.
+//!
+//! Once a state is *terminal* (Crashed / ProtocolError) it never transitions
+//! back to a healthier state — those are sticky. `Hung` may transition to
+//! `Running` again when a fresh FrameDone arrives.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::time::{Duration, Instant};
+
+/// Five lifecycle states for an app process.
+///
+/// Wire encoding is the discriminant value — kept stable so the atomic
+/// load/store round-trip stays cheap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LifecycleState {
+    Booting = 0,
+    Running = 1,
+    Hung = 2,
+    Crashed = 3,
+    ProtocolError = 4,
+}
+
+impl LifecycleState {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Booting,
+            1 => Self::Running,
+            2 => Self::Hung,
+            3 => Self::Crashed,
+            4 => Self::ProtocolError,
+            // Unknown discriminants degrade to Booting — better than panicking.
+            _ => Self::Booting,
+        }
+    }
+
+    /// Terminal states never transition back to a healthier state.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Crashed | Self::ProtocolError)
+    }
+}
+
+// Tunables. `HUNG_FRAME_GAP` is the spec's 5s stall threshold. The
+// protocol-error counter ticks N=3 within M=10s — three malformed lines
+// from an app is catastrophic regardless of why; show the user something
+// is wrong.
+pub const HUNG_FRAME_GAP: Duration = Duration::from_secs(5);
+pub const PROTOCOL_ERROR_THRESHOLD: u32 = 3;
+pub const PROTOCOL_ERROR_WINDOW: Duration = Duration::from_secs(10);
+
+/// Thread-safe lifecycle state shared between the stdout reader,
+/// stderr reader, the `try_wait` poller, and the UI thread.
+///
+/// All counters use a fixed monotonic origin (`launched_at: Instant`) so we
+/// can store millisecond offsets in `AtomicU64` instead of locking around an
+/// `Instant`. Two reads from different threads can observe slightly stale
+/// values; that's fine — the pill only updates per frame anyway.
+pub struct LifecycleTracker {
+    state: AtomicU8,
+    /// Origin instant. Captured once at construction.
+    launched_at: Instant,
+    /// Milliseconds since `launched_at` of the most recent FrameDone.
+    /// Zero means "no frame yet" — distinguishable from any real timestamp
+    /// because frame 0 lands at least one tick after launch.
+    last_frame_done_ms: AtomicU64,
+    /// Milliseconds since `launched_at` of the most recent observed user
+    /// input on this pane. Zero means "never interacted".
+    last_input_ms: AtomicU64,
+    /// Sliding-window protocol-error counter.
+    parse_error_count: AtomicU32,
+    /// Window start (ms since `launched_at`) for the parse-error counter.
+    parse_error_window_start_ms: AtomicU64,
+}
+
+impl LifecycleTracker {
+    pub fn new() -> Self {
+        Self {
+            state: AtomicU8::new(LifecycleState::Booting as u8),
+            launched_at: Instant::now(),
+            last_frame_done_ms: AtomicU64::new(0),
+            last_input_ms: AtomicU64::new(0),
+            parse_error_count: AtomicU32::new(0),
+            parse_error_window_start_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Test-only ctor that pins `launched_at` so tests can inject deterministic
+    /// timestamps without sleeping.
+    #[cfg(test)]
+    fn with_origin(origin: Instant) -> Self {
+        Self {
+            state: AtomicU8::new(LifecycleState::Booting as u8),
+            launched_at: origin,
+            last_frame_done_ms: AtomicU64::new(0),
+            last_input_ms: AtomicU64::new(0),
+            parse_error_count: AtomicU32::new(0),
+            parse_error_window_start_ms: AtomicU64::new(0),
+        }
+    }
+
+    pub fn state(&self) -> LifecycleState {
+        LifecycleState::from_u8(self.state.load(Ordering::Acquire))
+    }
+
+    /// Set state unless we're already in a terminal (sticky) state.
+    /// Returns the state that's actually in effect after the call.
+    fn set_state(&self, new: LifecycleState) -> LifecycleState {
+        let current = self.state();
+        if current.is_terminal() && new != current {
+            return current;
+        }
+        self.state.store(new as u8, Ordering::Release);
+        new
+    }
+
+    /// Force-set a terminal state. Sticky — overrides any prior state.
+    fn set_terminal(&self, new: LifecycleState) {
+        debug_assert!(new.is_terminal());
+        self.state.store(new as u8, Ordering::Release);
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        // Saturate on Instant subtraction so we never panic on backwards clocks.
+        self.launched_at.elapsed().as_millis() as u64
+    }
+
+    /// Called by the stdout reader thread on every successful FrameDone.
+    /// Sets state to Running (unless terminal).
+    pub fn on_frame_done(&self) {
+        self.last_frame_done_ms
+            .store(self.elapsed_ms().max(1), Ordering::Release);
+        self.set_state(LifecycleState::Running);
+    }
+
+    /// Called by the host UI thread when egui reports input events on this
+    /// pane. Used to gate the Hung detection — a stalled app that the user
+    /// isn't poking is just idle, not hung.
+    pub fn on_user_input(&self) {
+        self.last_input_ms
+            .store(self.elapsed_ms().max(1), Ordering::Release);
+    }
+
+    /// Called when `process.try_wait()` returns `Some(_)` — i.e. the
+    /// subprocess has exited. Sticky: Crashed.
+    pub fn on_process_exited(&self) {
+        self.set_terminal(LifecycleState::Crashed);
+    }
+
+    /// Called when the stdout reader thread observes a closed pipe
+    /// (EOF on stdout). Sticky: Crashed.
+    pub fn on_stdout_closed(&self) {
+        self.set_terminal(LifecycleState::Crashed);
+    }
+
+    /// Called by the stderr reader thread on every captured line.
+    /// Recognises Python `Traceback` and Rust `PANIC` patterns and
+    /// flips state to Crashed if found.
+    pub fn observe_stderr_line(&self, line: &str) {
+        if line.contains("Traceback") || line.contains("PANIC") || line.contains("panicked at") {
+            self.set_terminal(LifecycleState::Crashed);
+        }
+    }
+
+    /// Called by the stdout reader thread on a malformed JSON line.
+    /// Returns `true` if the threshold was crossed *on this call* (caller
+    /// can log a one-shot diagnostic).
+    pub fn on_parse_error(&self) -> bool {
+        let now = self.elapsed_ms();
+        let window_start = self.parse_error_window_start_ms.load(Ordering::Acquire);
+        let window_ms = PROTOCOL_ERROR_WINDOW.as_millis() as u64;
+
+        // If the previous window has expired (or this is the first error),
+        // reset the count and start a fresh window.
+        if window_start == 0 || now.saturating_sub(window_start) > window_ms {
+            self.parse_error_window_start_ms
+                .store(now, Ordering::Release);
+            self.parse_error_count.store(1, Ordering::Release);
+            return false;
+        }
+
+        let prior = self.parse_error_count.fetch_add(1, Ordering::AcqRel);
+        let count = prior + 1;
+        if count >= PROTOCOL_ERROR_THRESHOLD {
+            self.set_terminal(LifecycleState::ProtocolError);
+            return true;
+        }
+        false
+    }
+
+    /// Called once per UI frame. Performs the time-based Hung check that
+    /// can't be driven by an event-arrival callback. Returns the resulting
+    /// state for caller convenience.
+    ///
+    /// Hung iff:
+    ///   - current state is Booting or Running (not terminal, not already Hung),
+    ///   - we've seen a FrameDone (`last_frame_done_ms != 0`),
+    ///   - the gap since that FrameDone exceeds `HUNG_FRAME_GAP`,
+    ///   - AND user input was observed within that gap (otherwise the
+    ///     app is just idle, which is fine).
+    pub fn tick_check_hung(&self) -> LifecycleState {
+        let current = self.state();
+        if current.is_terminal() || current == LifecycleState::Hung {
+            return current;
+        }
+        let last_frame = self.last_frame_done_ms.load(Ordering::Acquire);
+        if last_frame == 0 {
+            // Still booting — Hung doesn't apply until we've at least seen
+            // one frame land.
+            return current;
+        }
+        let now = self.elapsed_ms();
+        let gap_ms = now.saturating_sub(last_frame);
+        if gap_ms < HUNG_FRAME_GAP.as_millis() as u64 {
+            return current;
+        }
+        let last_input = self.last_input_ms.load(Ordering::Acquire);
+        if last_input == 0 || last_input < last_frame {
+            // No interaction since the last frame — just idle.
+            return current;
+        }
+        self.set_state(LifecycleState::Hung)
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn tracker() -> LifecycleTracker {
+        // Origin 60s ago so elapsed_ms() returns deterministic large values
+        // without us actually sleeping in the test.
+        LifecycleTracker::with_origin(Instant::now() - Duration::from_secs(60))
+    }
+
+    #[test]
+    fn starts_booting() {
+        let t = LifecycleTracker::new();
+        assert_eq!(t.state(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn frame_done_transitions_to_running() {
+        let t = tracker();
+        t.on_frame_done();
+        assert_eq!(t.state(), LifecycleState::Running);
+    }
+
+    #[test]
+    fn process_exit_is_sticky_crashed() {
+        let t = tracker();
+        t.on_process_exited();
+        assert_eq!(t.state(), LifecycleState::Crashed);
+        // Subsequent FrameDone (rogue thread) must not unstick Crashed.
+        t.on_frame_done();
+        assert_eq!(t.state(), LifecycleState::Crashed);
+    }
+
+    #[test]
+    fn stderr_traceback_marks_crashed() {
+        let t = tracker();
+        t.observe_stderr_line("Traceback (most recent call last):");
+        assert_eq!(t.state(), LifecycleState::Crashed);
+    }
+
+    #[test]
+    fn stderr_rust_panic_marks_crashed() {
+        let t = tracker();
+        t.observe_stderr_line("thread 'main' panicked at src/foo.rs:1:1");
+        assert_eq!(t.state(), LifecycleState::Crashed);
+    }
+
+    #[test]
+    fn stderr_normal_line_is_ignored() {
+        let t = tracker();
+        t.observe_stderr_line("debug: starting up");
+        assert_eq!(t.state(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn parse_errors_under_threshold_do_not_trip_protocol_error() {
+        let t = tracker();
+        assert!(!t.on_parse_error());
+        assert!(!t.on_parse_error());
+        assert_eq!(t.state(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn parse_errors_at_threshold_trip_protocol_error() {
+        let t = tracker();
+        assert!(!t.on_parse_error());
+        assert!(!t.on_parse_error());
+        assert!(t.on_parse_error());
+        assert_eq!(t.state(), LifecycleState::ProtocolError);
+    }
+
+    #[test]
+    fn protocol_error_is_sticky() {
+        let t = tracker();
+        for _ in 0..3 {
+            t.on_parse_error();
+        }
+        assert_eq!(t.state(), LifecycleState::ProtocolError);
+        // FrameDone must not unstick ProtocolError.
+        t.on_frame_done();
+        assert_eq!(t.state(), LifecycleState::ProtocolError);
+    }
+
+    #[test]
+    fn parse_errors_outside_window_reset_counter() {
+        // Origin far in the past so the simulated "first error" is far
+        // enough back that the second error window has already expired.
+        let origin = Instant::now() - Duration::from_secs(60);
+        let t = LifecycleTracker::with_origin(origin);
+        // Force two errors then rewind the window-start so the next
+        // error counts as "in a fresh window".
+        t.on_parse_error();
+        t.on_parse_error();
+        // Manually mark the window start as expired by setting it to 0.
+        // (Equivalent to the natural M=10s gap passing.)
+        t.parse_error_window_start_ms.store(0, Ordering::Release);
+        assert!(!t.on_parse_error());
+        assert_eq!(t.state(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn hung_requires_a_frame_already_landed() {
+        let t = tracker();
+        // No FrameDone ever — Hung must not trigger.
+        t.on_user_input();
+        assert_eq!(t.tick_check_hung(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn hung_requires_user_input_during_stall() {
+        // Frame at t=launch+10ms (since `tracker()` rewinds origin 60s),
+        // no input at all → idle, not hung.
+        let t = tracker();
+        t.on_frame_done();
+        // Far future check (the 60s rewind makes elapsed_ms() ~60_000).
+        assert_eq!(t.tick_check_hung(), LifecycleState::Running);
+    }
+
+    #[test]
+    fn hung_triggers_when_input_observed_after_stale_frame() {
+        let origin = Instant::now() - Duration::from_secs(60);
+        let t = LifecycleTracker::with_origin(origin);
+        // Frame landed 30s after launch, input at 50s (still 60s after origin
+        // total elapsed when we tick). Gap 30s+ since frame, input post-frame.
+        t.last_frame_done_ms.store(30_000, Ordering::Release);
+        t.set_state(LifecycleState::Running);
+        t.last_input_ms.store(50_000, Ordering::Release);
+        assert_eq!(t.tick_check_hung(), LifecycleState::Hung);
+    }
+
+    #[test]
+    fn hung_does_not_overwrite_terminal() {
+        let origin = Instant::now() - Duration::from_secs(60);
+        let t = LifecycleTracker::with_origin(origin);
+        t.last_frame_done_ms.store(1_000, Ordering::Release);
+        t.last_input_ms.store(50_000, Ordering::Release);
+        t.set_terminal(LifecycleState::Crashed);
+        assert_eq!(t.tick_check_hung(), LifecycleState::Crashed);
+    }
+
+    #[test]
+    fn from_u8_round_trips_known_values() {
+        for s in [
+            LifecycleState::Booting,
+            LifecycleState::Running,
+            LifecycleState::Hung,
+            LifecycleState::Crashed,
+            LifecycleState::ProtocolError,
+        ] {
+            assert_eq!(LifecycleState::from_u8(s as u8), s);
+        }
+    }
+
+    #[test]
+    fn from_u8_unknown_degrades_to_booting() {
+        assert_eq!(LifecycleState::from_u8(99), LifecycleState::Booting);
+    }
+}
+
+/// Integration test: spawn a real subprocess that exits with a Python
+/// `Traceback`, drive it through `ProcessApp::launch`, and assert the
+/// lifecycle reaches Crashed within 1s.
+///
+/// Lives in this file (not a `tests/` directory) to keep crate-private
+/// access to `ProcessApp` internals — same pattern as the unit tests above.
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::process_app::ProcessApp;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    /// Find a usable shell on the host. Tests skip gracefully if none is
+    /// available (the CI smoke-test always runs on macOS where `/bin/sh`
+    /// exists).
+    fn find_shell() -> Option<PathBuf> {
+        for candidate in ["/bin/sh", "/usr/bin/sh"] {
+            let p = PathBuf::from(candidate);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn crashing_subprocess_reaches_crashed_within_1s() {
+        let Some(sh) = find_shell() else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        // tmpdir as workspace_root — must be absolute + existing.
+        let workspace_root = std::env::temp_dir();
+        // Script that prints a Python-style Traceback to stderr and exits.
+        let args = vec![
+            "-c".to_string(),
+            "echo 'Traceback (most recent call last):' >&2; exit 1".to_string(),
+        ];
+        let app = ProcessApp::launch(
+            "test_crashing_app",
+            "Test Crashing App",
+            &sh,
+            &workspace_root,
+            &args,
+            workspace_root.clone(),
+            HashSet::new(),
+            false,
+        )
+        .expect("launch crashing app");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            // The stderr-reader thread observes the Traceback line; the
+            // stdout-reader thread observes EOF when the process exits.
+            // Either path flips us to Crashed. We *don't* call try_wait()
+            // here — that's the host UI thread's job — but stdout EOF is
+            // detected by the background reader.
+            app.lifecycle.observe_stderr_lines_drain_for_test();
+            if app.lifecycle.state() == LifecycleState::Crashed {
+                return;
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "expected Crashed within 1s, got {:?}",
+                    app.lifecycle.state()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+// ── Test-only helper exposed on LifecycleTracker ──────────────────────────────
+//
+// The integration test above polls without a UI thread, so it has nowhere
+// for the stderr-reader-thread's writes to "land" except directly on the
+// tracker. This no-op exists purely to make the polling loop's intent
+// explicit. The real stderr thread already calls `observe_stderr_line` per
+// line; the test's only job is to wait.
+#[cfg(test)]
+impl LifecycleTracker {
+    fn observe_stderr_lines_drain_for_test(&self) {
+        // Intentionally empty — the stderr reader thread does the work.
+    }
+}

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -11,9 +11,12 @@
 //! - `render.rs`   — `render_draw_commands()`: paint committed frames into egui
 //! - `prompts.rs`  — `show_prompt_modal()`: capability/secret grant UI
 
+mod lifecycle;
 mod prompts;
 mod render;
 mod routing;
+
+pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 
 use crate::app_permissions::{AppPermissions, Capability};
 use crate::app_protocol::{DrawCommand, Modifiers, PlexiEvent};
@@ -97,6 +100,13 @@ pub struct ProcessApp {
     http_rx: Receiver<PlexiEvent>,
     /// Cancel flags for pending timers. Key = timer_id, value = Arc<AtomicBool> set to true to cancel.
     pub(crate) pending_timers: HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Observable lifecycle state (issue #316). Written by the stdout/stderr
+    /// reader threads and the UI thread's per-frame `try_wait` poll; read
+    /// by the UI thread to render the in-pane pill.
+    pub(crate) lifecycle: Arc<LifecycleTracker>,
+    /// When true, the click-to-reveal stderr overlay is displayed in the
+    /// pane. Toggled by clicking a non-Running lifecycle pill.
+    show_stderr_overlay: bool,
 }
 
 impl ProcessApp {
@@ -171,12 +181,16 @@ impl ProcessApp {
         let stdout: ChildStdout = child.stdout.take().expect("stdout piped");
         let stderr = child.stderr.take().expect("stderr piped");
 
-        // Background thread: forward subprocess stderr to Plexi's logger
-        // AND capture into the recent-stderr ring buffer used by the
-        // in-pane error fallback.
+        // Background thread: forward subprocess stderr to Plexi's logger,
+        // capture into the recent-stderr ring buffer used by the in-pane
+        // error fallback, AND scan each line for `Traceback` / `PANIC` /
+        // `panicked at` so the lifecycle pill flips to Crashed without
+        // waiting for `try_wait` to observe the eventual exit.
         let stderr_type_id = type_id.clone();
         let recent_stderr_capture = Arc::new(Mutex::new(VecDeque::<String>::new()));
         let recent_stderr_thread = Arc::clone(&recent_stderr_capture);
+        let lifecycle_tracker = Arc::new(LifecycleTracker::new());
+        let lifecycle_stderr = Arc::clone(&lifecycle_tracker);
         thread::spawn(move || {
             const STDERR_RING_CAP: usize = 32;
             let reader = std::io::BufReader::new(stderr);
@@ -185,6 +199,7 @@ impl ProcessApp {
                     Ok(l) if !l.trim().is_empty() => {
                         let target = format!("app::{stderr_type_id}");
                         log::warn!(target: &target, "stderr: {l}");
+                        lifecycle_stderr.observe_stderr_line(&l);
                         if let Ok(mut buf) = recent_stderr_thread.lock() {
                             if buf.len() >= STDERR_RING_CAP {
                                 buf.pop_front();
@@ -199,7 +214,12 @@ impl ProcessApp {
         });
 
         // Background thread: read draw commands line-by-line and forward via channel.
+        // Also feeds the lifecycle tracker:
+        //   - Malformed JSON → on_parse_error() (counts toward ProtocolError).
+        //   - Stdout EOF / read error → on_stdout_closed() (sticky Crashed).
         let (draw_tx, draw_rx) = mpsc::channel::<DrawCommand>();
+        let lifecycle_stdout = Arc::clone(&lifecycle_tracker);
+        let stdout_type_id = type_id.clone();
         thread::spawn(move || {
             let reader = BufReader::new(stdout);
             for line in reader.lines() {
@@ -212,17 +232,29 @@ impl ProcessApp {
                                 }
                             }
                             Err(e) => {
-                                log::warn!("ProcessApp: malformed draw command: {e} — line: {l}");
+                                log::warn!(
+                                    "ProcessApp[{stdout_type_id}]: malformed draw command: {e} — line: {l}"
+                                );
+                                if lifecycle_stdout.on_parse_error() {
+                                    log::error!(
+                                        "ProcessApp[{stdout_type_id}]: protocol-error threshold reached — flipping pane state"
+                                    );
+                                }
                             }
                         }
                     }
                     Err(e) => {
-                        log::debug!("ProcessApp stdout closed: {e}");
+                        log::debug!("ProcessApp[{stdout_type_id}] stdout closed: {e}");
+                        lifecycle_stdout.on_stdout_closed();
                         break;
                     }
                     _ => {}
                 }
             }
+            // Natural EOF (loop exit without an Err) also signals the
+            // subprocess closed its stdout — flip Crashed unless already
+            // terminal.
+            lifecycle_stdout.on_stdout_closed();
         });
 
         let permissions = AppPermissions {
@@ -268,6 +300,8 @@ impl ProcessApp {
             http_tx,
             http_rx,
             pending_timers: HashMap::new(),
+            lifecycle: lifecycle_tracker,
+            show_stderr_overlay: false,
         })
     }
 
@@ -320,6 +354,77 @@ impl ProcessApp {
             }
         }
         cmds
+    }
+
+    /// Draw the lifecycle pill in the top-right corner of `pane_rect` and
+    /// return its interaction response. Returns `None` for `Running` —
+    /// the healthy state is intentionally invisible.
+    ///
+    /// Colour rules:
+    /// - Booting        — faint blue/grey
+    /// - Hung           — yellow
+    /// - Crashed        — red
+    /// - ProtocolError  — red
+    fn draw_lifecycle_pill(
+        &self,
+        ui: &mut egui::Ui,
+        pane_rect: egui::Rect,
+        state: LifecycleState,
+    ) -> Option<egui::Response> {
+        let (label, fill_hex, fg_hex) = match state {
+            LifecycleState::Running => return None,
+            LifecycleState::Booting => ("starting", "#3a4a5a", "#cfd6e0"),
+            LifecycleState::Hung => ("hung", "#d4a017", "#1e1e2e"),
+            LifecycleState::Crashed => ("crashed", "#cc3838", "#ffffff"),
+            LifecycleState::ProtocolError => ("protocol error", "#cc3838", "#ffffff"),
+        };
+
+        // Anchor the pill to the top-right corner with a small inset so it
+        // doesn't sit flush against the pane edge. We measure the label
+        // width with the same font metrics `render_badge` uses, then
+        // position the pill's *left edge* such that its right edge lands
+        // at `pane_rect.max.x - inset`.
+        let font_size = 11.0;
+        let radius = 6.0;
+        let inset = 8.0;
+        let font_id = egui::FontId::proportional(font_size);
+        let galley = ui.fonts(|f| f.layout_no_wrap(label.to_string(), font_id, egui::Color32::BLACK));
+        let text_w = galley.size().x;
+        let text_h = galley.size().y;
+        let pill_w = (text_w + crate::style::BADGE_PAD_H * 2.0).max(crate::style::BADGE_MIN_W);
+        let pill_h = text_h + crate::style::BADGE_PAD_V * 2.0;
+        let pill_x_abs = pane_rect.max.x - inset - pill_w;
+        let pill_y_center_abs = pane_rect.min.y + inset + pill_h / 2.0;
+
+        // render_badge expects pane-relative `x` (left edge) and `y_center`,
+        // and adds `origin` itself. Pass `pane_rect.min` as origin so the
+        // helper paints inside the pane.
+        let origin = pane_rect.min;
+        let x_rel = pill_x_abs - origin.x;
+        let y_center_rel = pill_y_center_abs - origin.y;
+        // Clip to the pane rect so a pill near a tight pane edge doesn't
+        // bleed into a neighbouring pane.
+        render::render_badge(
+            ui,
+            origin,
+            pane_rect,
+            x_rel,
+            y_center_rel,
+            label,
+            fill_hex,
+            fg_hex,
+            font_size,
+            radius,
+        );
+
+        let pill_rect = egui::Rect::from_min_size(
+            egui::pos2(pill_x_abs, pill_y_center_abs - pill_h / 2.0),
+            egui::vec2(pill_w, pill_h),
+        );
+        // Stable id so toggling state across frames doesn't rebuild the
+        // interaction widget. type_id is unique-per-pane in practice.
+        let id = ui.id().with(("lifecycle_pill", &self.type_id));
+        Some(ui.interact(pill_rect, id, egui::Sense::click()))
     }
 
     /// Pump event I/O for a pane that is not currently rendered.
@@ -399,6 +504,42 @@ impl App for ProcessApp {
 
         self.flush_outbound_events();
 
+        // Lifecycle: per-frame try_wait poll. `try_wait` is non-blocking on
+        // macOS — `Ok(Some(_))` means the child has exited; `Ok(None)` means
+        // still running; `Err(_)` is fatal-for-this-process and treated as
+        // "we can't observe it any more, assume crashed". Exited child is
+        // sticky Crashed.
+        if let Some(child) = self.process.as_mut() {
+            match child.try_wait() {
+                Ok(Some(_status)) => self.lifecycle.on_process_exited(),
+                Ok(None) => {}
+                Err(e) => {
+                    log::warn!(
+                        "ProcessApp[{}]: try_wait failed: {e} — marking Crashed",
+                        self.type_id
+                    );
+                    self.lifecycle.on_process_exited();
+                }
+            }
+        }
+
+        // Lifecycle: track user-input recency on this pane. Only required
+        // for the Hung detector — we just need a "did the user touch this
+        // window in the last N seconds" signal, not a per-event log. egui's
+        // per-frame input snapshot exposes that directly.
+        let had_input = ui.input(|i| {
+            !i.events.is_empty()
+                || i.pointer.any_pressed()
+                || i.pointer.any_down()
+                || i.pointer.is_moving()
+        });
+        if had_input {
+            self.lifecycle.on_user_input();
+        }
+
+        // Lifecycle: drive the time-based Hung check once per frame.
+        self.lifecycle.tick_check_hung();
+
         if !self.initialized {
             self.initialized = true;
             self.last_size = size;
@@ -459,6 +600,8 @@ impl App for ProcessApp {
                     }
                     std::mem::swap(&mut self.frame, &mut self.pending_frame);
                     self.pending_frame.clear();
+                    // Lifecycle: a frame just landed → Running (unless terminal).
+                    self.lifecycle.on_frame_done();
                 }
                 DrawCommand::Log { level, message } => {
                     let target = format!("app::{}", self.type_id);
@@ -563,12 +706,21 @@ impl App for ProcessApp {
         render::render_draw_commands(ui, pane_rect, &frame_clone, ctx.colors);
 
         // ── Error fallback ──────────────────────────────────────────────────
-        // If the app emitted no draw commands (crashed during init, threw an
-        // unhandled exception in on_render, or just never started rendering),
-        // surface its recent stderr in the pane instead of a silent blank
-        // screen. Apps that render normally never see this — empty frame +
-        // empty stderr means "still starting up", not "broken".
-        if frame_clone.is_empty() {
+        // Surface recent stderr in the pane when:
+        //   1. The app emitted no draw commands at all (still booting / never
+        //      started rendering), OR
+        //   2. The lifecycle says Crashed or Hung — overlays even if the app
+        //      had previously committed a frame, so a kill -9 of an app
+        //      mid-run shows the failure rather than a frozen last frame.
+        //   3. The user clicked the lifecycle pill (show_stderr_overlay).
+        let lifecycle_state = self.lifecycle.state();
+        let stderr_overlay_active = self.show_stderr_overlay
+            || frame_clone.is_empty()
+            || matches!(
+                lifecycle_state,
+                LifecycleState::Crashed | LifecycleState::Hung | LifecycleState::ProtocolError
+            );
+        if stderr_overlay_active {
             let stderr_lines: Vec<String> = self
                 .recent_stderr
                 .lock()
@@ -577,10 +729,18 @@ impl App for ProcessApp {
             if !stderr_lines.is_empty() {
                 let painter = ui.painter();
                 let title_pos = pane_rect.min + egui::vec2(16.0, 16.0);
+                let header = match lifecycle_state {
+                    LifecycleState::Crashed => format!("⚠  {} crashed — recent stderr:", self.type_id),
+                    LifecycleState::Hung => format!("⚠  {} hung — recent stderr:", self.type_id),
+                    LifecycleState::ProtocolError => {
+                        format!("⚠  {} protocol error — recent stderr:", self.type_id)
+                    }
+                    _ => format!("⚠  {} emitted no frames — recent stderr:", self.type_id),
+                };
                 painter.text(
                     title_pos,
                     egui::Align2::LEFT_TOP,
-                    format!("⚠  {} emitted no frames — recent stderr:", self.type_id),
+                    header,
                     egui::FontId::proportional(13.0),
                     egui::Color32::from_rgb(0xff, 0x55, 0x55),
                 );
@@ -602,21 +762,39 @@ impl App for ProcessApp {
             }
         }
 
+        // ── Lifecycle pill ──────────────────────────────────────────────────
+        // Top-right corner. Hidden in Running. Click toggles the stderr
+        // overlay (in addition to the auto-overlay rules above).
+        let pill_response = self.draw_lifecycle_pill(ui, pane_rect, lifecycle_state);
+        let pill_consumed_click = if let Some(response) = pill_response {
+            if response.clicked() {
+                self.show_stderr_overlay = !self.show_stderr_overlay;
+            }
+            // Even hover/down over the pill suppresses the pane click —
+            // we don't want a click that targeted the pill to ALSO get
+            // forwarded as a PlexiEvent::Click into the app behind it.
+            response.clicked() || response.is_pointer_button_down_on()
+        } else {
+            false
+        };
+
         // Detect clicks over the pane and forward them as PlexiEvent::Click.
         let click_response = ui.interact(pane_rect, ui.id(), egui::Sense::click());
-        if let Some(pos) = click_response.interact_pointer_pos() {
-            let origin = pane_rect.min;
-            let button = if click_response.secondary_clicked() {
-                crate::app_protocol::MouseButton::Secondary
-            } else {
-                crate::app_protocol::MouseButton::Primary
-            };
-            if click_response.clicked() || click_response.secondary_clicked() {
-                self.send_event(&PlexiEvent::Click {
-                    x: pos.x - origin.x,
-                    y: pos.y - origin.y,
-                    button,
-                });
+        if !pill_consumed_click {
+            if let Some(pos) = click_response.interact_pointer_pos() {
+                let origin = pane_rect.min;
+                let button = if click_response.secondary_clicked() {
+                    crate::app_protocol::MouseButton::Secondary
+                } else {
+                    crate::app_protocol::MouseButton::Primary
+                };
+                if click_response.clicked() || click_response.secondary_clicked() {
+                    self.send_event(&PlexiEvent::Click {
+                        x: pos.x - origin.x,
+                        y: pos.y - origin.y,
+                        button,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Closes #316

## What changed

Adds a five-state lifecycle tracker (`Booting` / `Running` / `Hung` / `Crashed` / `ProtocolError`) for every `ProcessApp`, surfaced as a top-right corner pill rendered with the existing `render_badge` helper. Detection signals: per-frame `process.try_wait()` poll, stderr `Traceback` / `PANIC` / `panicked at` pattern match, stdout EOF, and a sliding-window protocol-error counter (3+ malformed JSON lines within 10s) on the stdout reader thread. The Hung state additionally requires user input observed during the stall window — idle apps are not flagged. Terminal states (`Crashed`, `ProtocolError`) are sticky. Click on a non-Running pill toggles an inline stderr overlay; the existing empty-frame stderr fallback (commit `6ec880c`) is extended so Crashed / Hung / ProtocolError overlay stderr regardless of frame state. All cross-thread state lives on `Arc<LifecycleTracker>` with atomic counters — no locks on the reader threads.

## Breaks if

- A normally rendering app (e.g. `snake`) shows any pill — `Running` must be invisible.
- `kill -9 <pid>` of a running app's subprocess produces no in-pane signal — pane just goes blank or shows a frozen last frame.
- A Python app with `raise RuntimeError("boom")` in init takes longer than 1s to flip the pill red, or never overlays the traceback.
- Clicking the pill forwards a `PlexiEvent::Click` into the app behind it.

## Human verification

- [ ] Open `Plexi Alpha.app`. Spawn `examples/snake` (or any healthy app). Pane renders, no pill visible.
- [ ] Drop in a one-line crashy app (e.g. copy `~/.plexi-alpha/apps/snake/snake.py` and replace its body with `raise RuntimeError("boom")`). Spawn it. Within 1s the pill is red `crashed`, the stderr traceback overlays the pane, and clicking the pill toggles the overlay.
- [ ] With a healthy app running, `kill -9 $(pgrep -f <app>.py)`. Pane shows red `crashed` pill within 1s. Host stays alive.
- [ ] Spawn an app whose `on_render` is `while True: pass`. Move the mouse / type into the pane during the stall. After ~5s the pill turns yellow `hung`.
- [ ] Spawn an app that prints `{not-json` repeatedly to stdout. Within ~3 lines the pill turns red `protocol error`.

## Test added

- `src/process_app/lifecycle.rs::tests` — 16 unit tests covering every state transition, sticky-terminal invariants, parse-error windowing, and the Hung gating rules. Failing-then-green: drove the design before the implementation.
- `src/process_app/lifecycle.rs::integration_tests::crashing_subprocess_reaches_crashed_within_1s` — spawns a real `/bin/sh` subprocess via `ProcessApp::launch` that emits a Python-style Traceback line on stderr and exits, asserts the lifecycle reaches `Crashed` within 1s through the live stderr-reader thread.