### PR TITLE
feat(examples): secrets-routing-tester POC for #322

### DIFF
--- a/examples/secrets-routing-tester/manifest.toml
+++ b/examples/secrets-routing-tester/manifest.toml
@@ -1,0 +1,17 @@
+[app]
+id = "secrets-routing-tester"
+name = "Secrets Routing Tester"
+version = "0.1.0"
+description = "POC for #322 — resolves declared canonical secrets via .plexi/secrets.toml routing and shows masked previews."
+entry = "secrets_routing_tester.py"
+default_notification_scope = "context"
+
+[app.capabilities]
+capabilities = ["secrets.get"]
+
+[secrets]
+OPENAI_API_KEY = { required = true, description = "Demo: workspace-routed key" }
+GITHUB_TOKEN = { required = false, description = "Demo: optional fallback-routed key" }
+
+[launch]
+background = false

--- a/examples/secrets-routing-tester/secrets_routing_tester.py
+++ b/examples/secrets-routing-tester/secrets_routing_tester.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Secrets Routing Tester — POC for #322.
+
+Declares two canonical secrets in manifest.toml and lets the user fetch each
+via ctx.get_secret(...). The host resolves them through the workspace
+.plexi/secrets.toml router. Values are masked in the UI (first 8 chars + "…")
+and never logged.
+
+Keys:
+  o — Fetch OPENAI_API_KEY (required)
+  g — Fetch GITHUB_TOKEN (optional)
+  r — Refresh both
+"""
+from __future__ import annotations
+
+import threading
+
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    AppBar,
+    Card,
+    Column,
+    Footer,
+    KeyRow,
+    Label,
+    Section,
+    Spacer,
+)
+
+
+CANONICAL_SECRETS = ("OPENAI_API_KEY", "GITHUB_TOKEN")
+
+
+def _mask(value: str) -> str:
+    """Mask a secret for display. Show first 8 chars + ellipsis if long enough,
+    otherwise show middle-dots so we never reveal a short value's content."""
+    if not value:
+        return "(empty)"
+    if len(value) > 8:
+        return value[:8] + "…"
+    return "·" * len(value)
+
+
+class SecretsRoutingTesterApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        # status[name] is one of:
+        #   None         — not yet fetched
+        #   "fetching"   — request in flight
+        #   ("ok", masked_preview)
+        #   ("missing",) — host returned None (denied / hard-missing / prompt)
+        self._status: dict[str, object] = {n: None for n in CANONICAL_SECRETS}
+        self._workspace_root = ctx.workspace_root or ""
+        ctx.status_summary("Secrets Routing Demo — ready")
+        self.emit.info("Secrets Routing Tester started")
+
+    def _fetch(self, name: str) -> None:
+        """Background-thread fetch so the blocking secret_get doesn't stall
+        the render loop. Never logs the resolved value."""
+        self._status[name] = "fetching"
+        self.emit.schedule_render(after_ms=20)
+
+        def runner() -> None:
+            try:
+                value = self.emit.get_secret(name)
+            except Exception as e:
+                self.emit.error(f"get_secret({name}) raised: {e}")
+                self._status[name] = ("missing",)
+                self.emit.schedule_render(after_ms=20)
+                return
+            if value is None:
+                self._status[name] = ("missing",)
+                self.emit.info(f"{name}: missing (denied / hard-missing / prompt)")
+            else:
+                self._status[name] = ("ok", _mask(value))
+                # NB: we deliberately log only the length, never the value.
+                self.emit.info(f"{name}: resolved (len={len(value)})")
+            self.emit.schedule_render(after_ms=20)
+
+        threading.Thread(target=runner, daemon=True).start()
+
+    def _refresh_all(self) -> None:
+        for name in CANONICAL_SECRETS:
+            self._fetch(name)
+
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+        k = key.lower()
+        if k == "o":
+            self._fetch("OPENAI_API_KEY")
+        elif k == "g":
+            self._fetch("GITHUB_TOKEN")
+        elif k == "r":
+            self._refresh_all()
+
+    def _row_status_text(self, name: str) -> str:
+        st = self._status[name]
+        if st is None:
+            return "not fetched"
+        if st == "fetching":
+            return "fetching…"
+        if isinstance(st, tuple) and st and st[0] == "ok":
+            return f"value: {st[1]}"
+        if isinstance(st, tuple) and st and st[0] == "missing":
+            return "missing — check .plexi/secrets.toml route or Keychain entry"
+        return "unknown"
+
+    def on_render(self, ctx: RenderContext) -> None:
+        footer_ws = self._workspace_root or "(no workspace)"
+        ctx.render(Column([
+            AppBar(title="Secrets Routing Demo"),
+            Label("Resolves declared secrets via .plexi/secrets.toml routing."),
+            Section("Declared secrets"),
+            Card([
+                KeyRow("o", "Fetch OPENAI_API_KEY (required)"),
+                Label(f"  → {self._row_status_text('OPENAI_API_KEY')}"),
+                KeyRow("g", "Fetch GITHUB_TOKEN (optional)"),
+                Label(f"  → {self._row_status_text('GITHUB_TOKEN')}"),
+            ]),
+            Section("Actions"),
+            Card([
+                KeyRow("r", "Refresh both (re-resolve after editing secrets.toml)"),
+            ]),
+            Spacer(grow=True),
+            Footer(f"workspace: {footer_ws}"),
+        ]))
+
+
+SecretsRoutingTesterApp().run()


### PR DESCRIPTION
## What changed
Adds `examples/secrets-routing-tester/` — a one-pane POC app that exercises the workspace secret routing landed in #322. Two declared canonical secrets (`OPENAI_API_KEY` required, `GITHUB_TOKEN` optional), Fetch buttons, masked value preview, workspace UUID footer.

## Why this PR
Retroactive POC for #322 — the original brief predated the "every user-visible feature ships a POC app" rule (commit `192c995`). Closes the gap tracked in `docs/specs/releases/pending-verification.md` under "POC test app gaps".

## Breaks if
- App fails to load with a manifest deserialization error referencing `[secrets]`.
- "Fetch" button on `OPENAI_API_KEY` always returns the same value across two workspaces with different routes.
- Secret values appear unmasked in the UI or in `~/.plexi-alpha/plexi.log`.

## Human verification
- [ ] `plexi-alpha workspace init` in `~/work-test/`. Edit `.plexi/secrets.toml` to route `OPENAI_API_KEY` for `secrets-routing-tester` to a friendly name. `plexi-alpha secret set <friendly>` to set the value.
- [ ] Launch Plexi from `~/work-test/`, open secrets-routing-tester, click Fetch on OPENAI_API_KEY. Masked value appears. Workspace UUID in footer matches `.plexi/workspace.toml`.
- [ ] Repeat in `~/personal-test/` with a different value. Same app, different value resolved.
- [ ] In a workspace with `fallback = false` and no route for OPENAI_API_KEY: Fetch shows clear missing-secret state, not a fall-through value.
- [ ] Logs (`~/.plexi-alpha/plexi.log`) do NOT contain the full secret values.

## Test added
- *(POC app — no new test code; existing #322 tests cover the routing logic.)*