### PR TITLE
feat(agent-as-app): manifest type field + protocol variants + broker widening (#285 part 1)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,29 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-25 — [CHANGED] Agent-as-app foundation — manifest type field + protocol variants + broker widening (#285 part 1 → alpha)
+
+First slice of #285 (v3.3 P1 headline "Agent-as-app"). Lands the wire and schema additions that the host integration in part 2 will consume; does NOT yet spawn subprocess agents into `Pane::Agent` or ship the SDK Agent class. Scoped down deliberately to keep the PR reviewable — the host integration ripples through `process_app/routing.rs`, `agent_pane.rs`, `pane.rs`, and the SDK simultaneously, and is its own commit.
+
+**Manifest schema (`src/app_registry.rs`)** — required `[app] type = "app" | "agent"` field on every manifest. Discipline matches `schema_version` (#308 Phase 2): no `serde(default)`, no fallback to `"app"`, missing field → loud parse error. New `ManifestType` enum (`App` | `Agent`). Optional `[launch] system_prompt: Option<String>` for agent manifests; the host forwards it to the agent subprocess via `PlexiEvent::AgentInit` once the host integration lands. All 18 example manifests migrated to add `type = "app"`. Inline manifest fixtures in `src/install.rs` test helpers also migrated.
+
+**Protocol additions (`src/app_protocol.rs`)** — three new variants, all required-field shape, no `serde(default)`:
+  - `PlexiEvent::AgentInit { system_prompt: Option<String> }` — sent once at agent startup with the manifest's `system_prompt`. Only delivered to `type = "agent"` panes. `Option` is explicit on the wire (`null` for unset).
+  - `PlexiEvent::UserMessage { text }` — sent when the user submits text in the host-rendered conversation input box. Only delivered to agent panes.
+  - `DrawCommand::AppendConversation { role, content }` — agent emits one per logical turn; host renders into the conversation history surface. `role` accepted as a string (`"user" | "assistant" | "tool" | "system"`) for forward-compat with future role kinds; unknown roles render as plain text.
+
+**Broker widening (`src/plexi_iq/{broker,loop,backend/{mod,anthropic_api}}.rs`)** — lifted the `flatten_messages` stop-gap from #284. `LlmRequest` now carries `messages: Vec<IqMessage>` directly (the structured Anthropic Messages shape) plus `system: String`. `AnthropicApiBackend::stream_native` translates each `IqMessage` to a `MessageBuilder`-built `Message` with the matching `MessageRole`; empty `messages` is a loud error (`"LlmRequest.messages is empty"`), unknown role values likewise. `turn_loop::run_turn` widened: `messages: Vec<IqMessage>` instead of `prompt: impl Into<String>`. Multi-turn agent conversations now flow natively — no more `[assistant previously]:` prefix joining.
+
+**Out of scope deliberately (filed as follow-up):**
+  - Host integration: spawning subprocess agents into `Pane::Agent` with conversation UI scaffolding from `agent_pane.rs` backed by subprocess `AppendConversation` events (vs. the legacy hardcoded `agent_turn` loop).
+  - SDK `Agent` base class with the `on_user_message(text) -> str` callback pattern.
+  - POC `examples/agent-tester/` end-to-end agent.
+  - `plexi app new --type agent` scaffolder.
+  - Deletion of `agent_turn.rs` / `agent_pane.rs` legacy in-pane turn loop.
+
+Test-first: 11 new tests across `app_protocol::tests` (5), `app_registry::tests` (5), `plexi_iq::broker::tests` (1, replacing the deleted `flatten_messages_joins_user_turns`). All 114 pass; clean `cargo build --release`.
+
+**Breaks if:** any existing manifest loads after this PR without `type = "app"` set; `cargo test --bin plexi` reports any test in `app_protocol::tests::user_message_*`, `agent_init_*`, `append_conversation_*`, or `app_registry::tests::manifest_with_type_*` failing; `LlmRequest.messages` empty no longer surfaces a stream error containing `"messages is empty"`; or an agent manifest's `[launch].system_prompt` field is silently ignored at load (verify by checking `~/.plexi-alpha/plexi.log` — every `launching '<id>'` line should now also log `type=...` and `system_prompt=...`).
+
 ## 2026-04-26 — [CHANGED] `iq.query` brokered capability — first v3.3 milestone PR (#284 → alpha)
 
 Opens the v3.3 milestone (Agents as First-Class Citizens). Three new wire types in `src/app_protocol.rs`: `DrawCommand::IqQuery { request_id, model_tier, system, messages, tools }`, `PlexiEvent::IqResponse { request_id, content, tokens_in, tokens_out, error }`, and the `ModelTier` enum (`low | medium | high`). All fields required — no `serde(default)`. Adds `IqQuery` to the `Capability` enum (string `"iq.query"`); manifest validator and `from_capability_strings` recognise it.

--- a/examples/app-store/manifest.toml
+++ b/examples/app-store/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "app-store"
+type = "app"
 name = "App Store"
 version = "1.0.0"
 description = "Browse, install, update, and export Plexi apps. Phase 3 of #308."

--- a/examples/backlog/manifest.toml
+++ b/examples/backlog/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "backlog"
+type = "app"
 name = "Backlog"
 version = "0.1.0"
 description = "Browse, preview, open, archive, and delete .plexi/backlog items."

--- a/examples/balls/manifest.toml
+++ b/examples/balls/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "balls"
+type = "app"
 name = "Balls"
 version = "0.1.0"
 description = "Physics simulation — elastic circle collisions demonstrating DrawCommand::Circle."

--- a/examples/clipboard-test/manifest.toml
+++ b/examples/clipboard-test/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "clipboard-test"
+type = "app"
 name = "Clipboard Demo"
 version = "0.1.0"
 description = "Exercises clipboard write, paste, and selectable text (#200, #146)."

--- a/examples/github-tree/manifest.toml
+++ b/examples/github-tree/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "github-tree"
+type = "app"
 name = "Commit Graph"
 version = "0.3.0"
 description = "Subway-style git commit history for the pane's repo."

--- a/examples/iq-query-denied-test/manifest.toml
+++ b/examples/iq-query-denied-test/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "iq-query-denied-test"
+type = "app"
 name = "IQ Query Denied Test"
 version = "0.1.0"
 description = "POC for #284 — proves the iq.query capability gate. This app does NOT declare iq.query, so every call returns capability_denied."

--- a/examples/iq-query-test/manifest.toml
+++ b/examples/iq-query-test/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "iq-query-test"
+type = "app"
 name = "IQ Query Test"
 version = "0.1.0"
 description = "POC for #284 — exercises the iq.query broker across all three model tiers (Haiku / Sonnet / Opus)."

--- a/examples/notification-tester/manifest.toml
+++ b/examples/notification-tester/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "notification-tester"
+type = "app"
 name = "Notification Tester"
 version = "0.1.0"
 description = "Fires each Notify kind (message / choice / input) on demand. Proof-of-concept playground for the notification modal."

--- a/examples/quick-note/manifest.toml
+++ b/examples/quick-note/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "quick-note"
+type = "app"
 name = "Quick Note"
 version = "0.1.0"
 description = "Markdown note composer and browser. Notes saved to <workspace_root>/.plexi/notes/."

--- a/examples/screen-time/manifest.toml
+++ b/examples/screen-time/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "screen-time"
+type = "app"
 name = "Screen Time"
 version = "0.1.0"
 description = "Pie chart of macOS app usage from the last 7 days."

--- a/examples/secrets-routing-tester/manifest.toml
+++ b/examples/secrets-routing-tester/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "secrets-routing-tester"
+type = "app"
 name = "Secrets Routing Tester"
 version = "0.1.0"
 description = "POC for #322 — resolves declared canonical secrets via .plexi/secrets.toml routing and shows masked previews."

--- a/examples/snake/manifest.toml
+++ b/examples/snake/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "snake"
+type = "app"
 name = "Snake"
 version = "0.1.0"
 description = "Classic snake game — proves input + draw primitives."

--- a/examples/stand-up-reminder/manifest.toml
+++ b/examples/stand-up-reminder/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "stand-up-reminder"
+type = "app"
 name = "Stand Up Reminder"
 version = "0.1.0"
 description = "Background app: notifies every 15 min with a random movement prompt."

--- a/examples/tetris/manifest.toml
+++ b/examples/tetris/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "tetris"
+type = "app"
 name = "Tetris"
 version = "0.1.0"
 description = "Classic Tetris — demonstrates ScheduleRender game loop at 60 fps."

--- a/examples/todo/manifest.toml
+++ b/examples/todo/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "todo"
+type = "app"
 name = "Todo"
 version = "0.1.0"
 description = "Simple todo list persisted to <workspace_root>/.plexi/todos.json."

--- a/examples/ui-playground/manifest.toml
+++ b/examples/ui-playground/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "ui-playground"
+type = "app"
 name = "UI Playground"
 version = "0.1.0"
 description = "Every SDK v2 component rendered side-by-side. Reference app for building clean UIs."

--- a/examples/wikipedia/manifest.toml
+++ b/examples/wikipedia/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "wikipedia"
+type = "app"
 name = "Wikipedia"
 version = "0.1.0"
 description = "Search Wikipedia and browse article summaries."

--- a/examples/workspace-config-tester/manifest.toml
+++ b/examples/workspace-config-tester/manifest.toml
@@ -2,6 +2,7 @@ schema_version = 1
 
 [app]
 id = "workspace-config-tester"
+type = "app"
 name = "Workspace Config Tester"
 version = "0.1.0"
 description = "POC for #308 Phase 1 — shows the resolved workspace root, workspace UUID, and demonstrates global → project config.toml merge."

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -165,6 +165,27 @@ pub enum PlexiEvent {
     /// buffer for `id` after emitting this event so the field is empty for
     /// the next input.
     TextSubmitted { id: String, value: String },
+    /// Sent once at agent startup to deliver the manifest's `[launch].system_prompt`.
+    ///
+    /// Only delivered to apps whose manifest declares `[app] type = "agent"`. Apps
+    /// of `type = "app"` will never receive this event. The agent decides how to
+    /// use the prompt — typically by passing it as the `system` field on the
+    /// first `iq.query` call. Apps that don't need a system prompt may simply
+    /// ignore the event.
+    ///
+    /// `system_prompt` is `None` when the manifest omits the `[launch].system_prompt`
+    /// field; the host serialises it as JSON `null` so the value is explicit on
+    /// the wire. Agents must handle the `None` case (no prompt set).
+    AgentInit { system_prompt: Option<String> },
+    /// User submitted text in the host-rendered conversation input box of an
+    /// agent pane.
+    ///
+    /// Only delivered to apps whose manifest declares `[app] type = "agent"`.
+    /// The agent receives the raw user text and decides how to respond
+    /// (typically by appending it to its conversation history and dispatching
+    /// an `iq.query`). The host owns the input widget; the agent owns the
+    /// conversation logic.
+    UserMessage { text: String },
     /// Clipboard paste forwarded into the focused app pane.
     ///
     /// Emitted whenever the host observes `egui::Event::Paste(text)` while an
@@ -668,6 +689,23 @@ pub enum DrawCommand {
     /// app already controls when it fires (key handler, button, etc.).
     CopyToClipboard { text: String },
 
+    /// Append a row to the host-owned conversation history of an agent pane.
+    ///
+    /// Only meaningful for panes whose manifest declares `[app] type = "agent"`.
+    /// The host renders the conversation history as the pane's primary surface;
+    /// the agent emits one of these per logical turn boundary (user echo,
+    /// assistant reply, tool result, system note).
+    ///
+    /// `role` is one of `"user"` | `"assistant"` | `"tool"` | `"system"`. Other
+    /// values are accepted at the wire level (forward-compatibility) but the
+    /// host renders unknown roles as plain text. Required field — no
+    /// `serde(default)`.
+    ///
+    /// `content` is the plain-text body of the row. Required field. Empty
+    /// strings are valid (e.g. a placeholder turn while a stream is in flight)
+    /// but discouraged — emit on completion, not on dispatch.
+    AppendConversation { role: String, content: String },
+
     /// Single-line text input field (host-owned buffer, submit-only).
     ///
     /// Emitted by the app each frame at `(x, y)` with width `w`. The host
@@ -957,6 +995,103 @@ mod tests {
             }
             other => panic!("expected IqResponse, got {other:?}"),
         }
+    }
+
+    // ── v3.3 agent-as-app wire shape (#285) ──────────────────────────────
+    // Pin the on-the-wire shape for the three new variants. All fields are
+    // required — no `serde(default)`.
+
+    #[test]
+    fn user_message_event_round_trips_serde() {
+        let json = r#"{"type":"user_message","text":"tell me a joke"}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::UserMessage { text } => assert_eq!(text, "tell me a joke"),
+            other => panic!("expected UserMessage, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"user_message""#),
+            "wire tag missing: {serialised}"
+        );
+        assert!(
+            serialised.contains(r#""text":"tell me a joke""#),
+            "text missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn user_message_missing_text_fails_deserialise() {
+        // No `text` field — must fail because the field is required (no
+        // `serde(default)`).
+        let json = r#"{"type":"user_message"}"#;
+        let result: Result<PlexiEvent, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "deserialise should fail without `text` field"
+        );
+    }
+
+    #[test]
+    fn agent_init_event_round_trips_serde() {
+        // With a system prompt set.
+        let json = r#"{"type":"agent_init","system_prompt":"You are helpful."}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::AgentInit { system_prompt } => {
+                assert_eq!(system_prompt.as_deref(), Some("You are helpful."));
+            }
+            other => panic!("expected AgentInit, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"agent_init""#),
+            "wire tag missing: {serialised}"
+        );
+
+        // Null system_prompt — agent manifests without a `[launch].system_prompt`.
+        let json = r#"{"type":"agent_init","system_prompt":null}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::AgentInit { system_prompt } => {
+                assert!(system_prompt.is_none(), "system_prompt must be None");
+            }
+            other => panic!("expected AgentInit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_conversation_drawcommand_round_trips() {
+        let json =
+            r#"{"type":"append_conversation","role":"assistant","content":"Hello!"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::AppendConversation { role, content } => {
+                assert_eq!(role, "assistant");
+                assert_eq!(content, "Hello!");
+            }
+            other => panic!("expected AppendConversation, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"append_conversation""#),
+            "wire tag missing: {serialised}"
+        );
+        assert!(
+            serialised.contains(r#""role":"assistant""#),
+            "role missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn append_conversation_missing_content_fails_deserialise() {
+        // No `content` field — must fail. Required.
+        let json = r#"{"type":"append_conversation","role":"user"}"#;
+        let result: Result<DrawCommand, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "deserialise should fail without `content` field"
+        );
     }
 
     #[test]

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -79,6 +79,21 @@ pub struct AppManifestApp {
     pub id: String,
     pub name: String,
     pub entry: String,
+    /// Required. Selects host rendering / pane behaviour:
+    ///
+    /// - `App` (`type = "app"`): the host renders the app's draw canvas. The
+    ///   default for nearly every Plexi app — UI is freeform, the app emits
+    ///   `Rect`/`Text`/etc.
+    /// - `Agent` (`type = "agent"`): the host renders a conversation UI
+    ///   (history scrollback + input box), and the agent subprocess emits
+    ///   `AppendConversation` rows in response to `UserMessage` events. The
+    ///   manifest may also declare `[launch].system_prompt` which the host
+    ///   forwards via `AgentInit` at startup.
+    ///
+    /// No `serde(default)` — every manifest must declare its type explicitly.
+    /// Discipline matches `schema_version` (issue #308 Phase 2).
+    #[serde(rename = "type")]
+    pub manifest_type: ManifestType,
     #[serde(default)]
     pub version: String,
     #[serde(default)]
@@ -91,6 +106,18 @@ pub struct AppManifestApp {
     /// the user regardless of which context is active (e.g. stand-up-reminder).
     #[serde(default)]
     pub default_notification_scope: DefaultNotifyScope,
+}
+
+/// Manifest `[app] type` field — chooses the host rendering surface for
+/// the pane. Required; no `serde(default)`.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ManifestType {
+    /// Standard draw-canvas app. Host renders whatever the app draws.
+    App,
+    /// Conversation agent. Host renders a chat UI; agent subprocess emits
+    /// `AppendConversation` and reads `UserMessage` / `AgentInit`.
+    Agent,
 }
 
 /// Newtype for the manifest `default_notification_scope` field so it
@@ -155,6 +182,12 @@ pub struct LaunchSection {
     /// instead it parks the process in a background registry keyed by app_id.
     #[serde(default)]
     pub background: bool,
+    /// Agent system prompt — only meaningful when `[app] type = "agent"`.
+    /// Forwarded to the agent subprocess via `PlexiEvent::AgentInit` once at
+    /// startup. The agent decides how to use it (typically as the `system`
+    /// field on `iq.query`). Optional — `None` when the manifest omits it.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 /// Structured layout hint. `side` ∈ {`"right"`, `"below"`, `"overlay"`}.
@@ -458,6 +491,21 @@ impl AppRegistry {
         let keyboard_capture = installed.launch.keyboard_capture;
         let default_scope = self.default_notification_scope_for(id);
 
+        // Log manifest type + system_prompt presence for observability. The
+        // host integration that consumes these to switch pane rendering and
+        // forward `AgentInit` lands in the follow-up to #285; logging here
+        // makes the manifest contract visible from day one.
+        log::info!(
+            "AppRegistry: launching '{id}' as type={:?}, system_prompt={}",
+            installed.manifest.manifest_type,
+            installed
+                .launch
+                .system_prompt
+                .as_deref()
+                .map(|s| format!("set ({} chars)", s.len()))
+                .unwrap_or_else(|| "unset".to_string()),
+        );
+
         // Issue #322: log declared-but-routed status for visibility. The
         // missing-secret prompt fires lazily on first `ctx.secret(...)` call —
         // this just makes the manifest's contract observable in the host log.
@@ -566,11 +614,16 @@ mod tests {
     /// Create a manifest + executable entry under `dir/<id>/`.
     /// `name` is what shows up in the manifest's `[app].name` so tests can
     /// distinguish two entries with the same id but different content.
+    /// Defaults to `type = "app"` — use `write_app_with_type` for agents.
     fn write_app(dir: &Path, id: &str, name: &str) {
+        write_app_with_type(dir, id, name, "app");
+    }
+
+    fn write_app_with_type(dir: &Path, id: &str, name: &str, manifest_type: &str) {
         let app_dir = dir.join(id);
         fs::create_dir_all(&app_dir).unwrap();
         let manifest = format!(
-            "schema_version = 1\n\n[app]\nid = \"{id}\"\nname = \"{name}\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n"
+            "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"{manifest_type}\"\nname = \"{name}\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n"
         );
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
@@ -666,7 +719,7 @@ mod tests {
         let app_dir = global.path().join("future-app");
         fs::create_dir_all(&app_dir).unwrap();
         let manifest = format!(
-            "schema_version = {}\n\n[app]\nid = \"future-app\"\nname = \"Future\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n",
+            "schema_version = {}\n\n[app]\nid = \"future-app\"\ntype = \"app\"\nname = \"Future\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n",
             MANIFEST_SCHEMA_VERSION + 1
         );
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
@@ -702,6 +755,116 @@ entry = "run.sh"
         assert!(
             parsed.is_err(),
             "manifest missing schema_version must be rejected, got: {parsed:?}"
+        );
+    }
+
+    // ── v3.3 agent-as-app manifest type field (#285) ─────────────────────
+
+    #[test]
+    fn manifest_with_type_app_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_type(global.path(), "regular-app", "Regular", "app");
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let entry = registry
+            .get("regular-app")
+            .expect("type=app manifest should load");
+        assert_eq!(entry.manifest.manifest_type, ManifestType::App);
+    }
+
+    #[test]
+    fn manifest_with_type_agent_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_type(global.path(), "research-agent", "Research", "agent");
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let entry = registry
+            .get("research-agent")
+            .expect("type=agent manifest should load");
+        assert_eq!(entry.manifest.manifest_type, ManifestType::Agent);
+    }
+
+    #[test]
+    fn manifest_missing_type_field_errors() {
+        // No `type` field — must fail to parse. Required field, no
+        // `serde(default)`. Discipline matches `schema_version`.
+        let raw = r#"
+schema_version = 1
+
+[app]
+id = "no-type"
+name = "No Type"
+version = "0.0.1"
+entry = "run.sh"
+"#;
+        let parsed: Result<AppManifest, _> = toml::from_str(raw);
+        assert!(
+            parsed.is_err(),
+            "manifest missing `type` must be rejected, got: {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_with_unknown_type_errors() {
+        // `type = "wizard"` — must fail to parse. Only `app` and `agent` are
+        // valid; unknown values should not silently fall back.
+        let raw = r#"
+schema_version = 1
+
+[app]
+id = "unknown-type"
+type = "wizard"
+name = "Wizard"
+version = "0.0.1"
+entry = "run.sh"
+"#;
+        let parsed: Result<AppManifest, _> = toml::from_str(raw);
+        assert!(
+            parsed.is_err(),
+            "manifest with unknown type variant must be rejected, got: {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn agent_manifest_with_system_prompt_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("prompted-agent");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"prompted-agent\"
+type = \"agent\"
+name = \"Prompted\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+system_prompt = \"You are terse.\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        let entry = app_dir.join("run.sh");
+        fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&entry).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&entry, perms).unwrap();
+        }
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let agent = registry
+            .get("prompted-agent")
+            .expect("agent manifest should load");
+        assert_eq!(agent.manifest.manifest_type, ManifestType::Agent);
+        assert_eq!(
+            agent.launch.system_prompt.as_deref(),
+            Some("You are terse."),
+            "system_prompt must round-trip from manifest"
         );
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -720,7 +720,7 @@ pub(crate) mod test_support {
                 .cloned()
                 .unwrap_or_else(|| {
                     format!(
-                        "schema_version = 1\n\n[app]\nid = \"{id}\"\nname = \"{id}\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n"
+                        "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n"
                     )
                 });
             std::fs::write(target_dir.join("manifest.toml"), manifest)
@@ -810,7 +810,7 @@ mod install_tests {
     fn install_with_future_schema_refuses() {
         let target = tmp();
         let manifest = format!(
-            "schema_version = {}\n\n[app]\nid = \"future\"\nname = \"Future\"\nversion = \"0.1.0\"\nentry = \"run.sh\"\n",
+            "schema_version = {}\n\n[app]\nid = \"future\"\ntype = \"app\"\nname = \"Future\"\nversion = \"0.1.0\"\nentry = \"run.sh\"\n",
             MANIFEST_SCHEMA_VERSION + 1
         );
         let cloner =
@@ -937,7 +937,7 @@ mod pack_export_tests {
         std::fs::write(
             dir.join("manifest.toml"),
             format!(
-                "schema_version = 1\n\n[app]\nid = \"{id}\"\nname = \"{id}\"\nversion = \"{version}\"\nentry = \"run.sh\"\n"
+                "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\nversion = \"{version}\"\nentry = \"run.sh\"\n"
             ),
         )
         .unwrap();
@@ -1005,7 +1005,7 @@ mod pack_export_tests {
         let target = tempfile::tempdir().unwrap();
         let dir = target.path().join("foo");
         std::fs::create_dir_all(&dir).unwrap();
-        let manifest_text = "schema_version = 1\n\n[app]\nid = \"foo\"\nname = \"Foo\"\nversion = \"0.3.0\"\nentry = \"run.sh\"\n";
+        let manifest_text = "schema_version = 1\n\n[app]\nid = \"foo\"\ntype = \"app\"\nname = \"Foo\"\nversion = \"0.3.0\"\nentry = \"run.sh\"\n";
         let manifest: AppManifest = toml::from_str(manifest_text).unwrap();
         let (source, version) = infer_source_and_version(&dir, &manifest);
         assert_eq!(source, "local:foo");

--- a/src/plexi_iq/backend/anthropic_api.rs
+++ b/src/plexi_iq/backend/anthropic_api.rs
@@ -95,19 +95,45 @@ async fn stream_native(
 
     let client = async_anthropic::Client::from_api_key(api_key);
 
-    let user_msg = match MessageBuilder::default()
-        .role(MessageRole::User)
-        .content(request.prompt.as_str())
-        .build()
-    {
-        Ok(m) => m,
-        Err(e) => {
-            let _ = tx.send(StreamEvent::Error(format!(
-                "failed to build user message: {e}"
-            )));
-            return;
-        }
-    };
+    // Translate the structured `IqMessage` array directly to the Anthropic
+    // SDK's `Message` shape. Empty array is a programmer error; surface it
+    // loudly rather than silently calling the API with no messages.
+    if request.messages.is_empty() {
+        let _ = tx.send(StreamEvent::Error(
+            "LlmRequest.messages is empty — backend requires at least one message"
+                .to_string(),
+        ));
+        return;
+    }
+
+    let mut api_messages = Vec::with_capacity(request.messages.len());
+    for m in &request.messages {
+        let role = match m.role.as_str() {
+            "user" => MessageRole::User,
+            "assistant" => MessageRole::Assistant,
+            other => {
+                let _ = tx.send(StreamEvent::Error(format!(
+                    "unsupported message role '{other}' (expected 'user' or 'assistant')"
+                )));
+                return;
+            }
+        };
+        let built = match MessageBuilder::default()
+            .role(role)
+            .content(m.content.as_str())
+            .build()
+        {
+            Ok(msg) => msg,
+            Err(e) => {
+                let _ = tx.send(StreamEvent::Error(format!(
+                    "failed to build message (role={}): {e}",
+                    m.role
+                )));
+                return;
+            }
+        };
+        api_messages.push(built);
+    }
 
     // Build the request. The system prompt field takes `&str`, so we keep a
     // local binding for the string value before starting the builder chain.
@@ -115,7 +141,7 @@ async fn stream_native(
     let api_request = {
         let mut b = CreateMessagesRequestBuilder::default();
         b.model(model);
-        b.messages(vec![user_msg]);
+        b.messages(api_messages);
         if !system_str.is_empty() {
             b.system(system_str.as_str());
         }

--- a/src/plexi_iq/backend/mod.rs
+++ b/src/plexi_iq/backend/mod.rs
@@ -39,10 +39,20 @@ pub enum StreamEvent {
 }
 
 /// Conversation turn passed to `LlmBackend::stream_to_channel`.
+///
+/// `messages` carries the full conversation history as a structured array —
+/// the same shape the Anthropic Messages API uses. Each entry has `role` ∈
+/// {`"user"`, `"assistant"`} and a plain-text `content`. Backends MUST honour
+/// the array (no flattening to a single prompt string) so multi-turn agent
+/// conversations work correctly.
+///
+/// `system` is the system prompt; injected on every call. Empty string =
+/// no system prompt.
 #[derive(Debug, Clone, Default)]
 pub struct LlmRequest {
-    /// User message for this turn.
-    pub prompt: String,
+    /// Full structured conversation history. Wire shape mirrors the Anthropic
+    /// Messages API — see `app_protocol::IqMessage`.
+    pub messages: Vec<crate::app_protocol::IqMessage>,
     /// System prompt (injected on every call for the native API).
     pub system: String,
 }

--- a/src/plexi_iq/broker.rs
+++ b/src/plexi_iq/broker.rs
@@ -134,9 +134,15 @@ impl IqBroker for LiveIqBroker {
 
         let backend = AnthropicApiBackend::with_model(api_key, model_id.clone());
 
-        let (prompt, system) = flatten_messages(&request.messages, &request.system);
-
-        let turn = turn_loop::run_turn(&backend, prompt, system, |_| {});
+        // Multi-turn conversations flow natively now — `LlmRequest` carries
+        // the structured `Vec<IqMessage>` and the backend translates each
+        // entry directly to the Anthropic Messages API. No flattening.
+        let turn = turn_loop::run_turn(
+            &backend,
+            request.messages.clone(),
+            request.system.clone(),
+            |_| {},
+        );
 
         match turn {
             Ok(result) => {
@@ -193,27 +199,6 @@ pub fn resolve_model_id(tier: ModelTier) -> String {
     }
 }
 
-/// Flatten an `IqMessage` array into the (single user prompt, system) shape
-/// the existing `LlmBackend::stream_to_channel` accepts. Until the backend
-/// trait grows native multi-turn message support, the broker collapses the
-/// conversation by joining every user message with `\n\n`. Assistant turns
-/// are kept in a labelled prefix so the model still sees the prior context.
-///
-/// This is a deliberate stop-gap; a future PR will widen `LlmRequest` to
-/// carry the structured array directly.
-fn flatten_messages(messages: &[IqMessage], system: &str) -> (String, String) {
-    let mut prompt_parts: Vec<String> = Vec::with_capacity(messages.len());
-    for m in messages {
-        match m.role.as_str() {
-            "user" => prompt_parts.push(m.content.clone()),
-            "assistant" => prompt_parts.push(format!("[assistant previously]: {}", m.content)),
-            other => prompt_parts.push(format!("[{other}]: {}", m.content)),
-        }
-    }
-    let prompt = prompt_parts.join("\n\n");
-    (prompt, system.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,8 +234,13 @@ mod tests {
     }
 
     #[test]
-    fn flatten_messages_joins_user_turns() {
-        let msgs = vec![
+    fn broker_accepts_structured_messages_after_widening() {
+        // Multi-turn conversations now flow as a structured `Vec<IqMessage>`
+        // through the broker — no flattening into a single prompt. This test
+        // pins the contract: the broker hands the full message array to the
+        // backend and `IqBrokerRequest` accepts the structured form unchanged.
+        let broker = CannedBroker::ok("response");
+        let messages = vec![
             IqMessage {
                 role: "user".to_string(),
                 content: "first".to_string(),
@@ -264,14 +254,20 @@ mod tests {
                 content: "second".to_string(),
             },
         ];
-        let (prompt, system) = flatten_messages(&msgs, "be helpful");
-        assert_eq!(system, "be helpful");
-        assert!(prompt.contains("first"), "prompt missing first turn: {prompt}");
-        assert!(prompt.contains("second"), "prompt missing second turn: {prompt}");
-        assert!(
-            prompt.contains("[assistant previously]: ok"),
-            "prompt must label prior assistant turn: {prompt}"
-        );
+        let resp = broker.dispatch(IqBrokerRequest {
+            app_id: "test".to_string(),
+            model_tier: ModelTier::Low,
+            system: "be helpful".to_string(),
+            messages: messages.clone(),
+            tools: vec![],
+        });
+        assert_eq!(resp.content.as_deref(), Some("response"));
+        // The broker must have received the structured array verbatim — no
+        // flattening, no "[assistant previously]" prefix, no joining.
+        let seen = broker.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "broker should have seen exactly one request");
+        assert_eq!(seen[0].messages, messages, "messages must round-trip unchanged");
+        assert_eq!(seen[0].system, "be helpful");
     }
 
     #[test]

--- a/src/plexi_iq/loop.rs
+++ b/src/plexi_iq/loop.rs
@@ -16,6 +16,7 @@
 
 use std::sync::mpsc;
 
+use crate::app_protocol::IqMessage;
 use crate::plexi_iq::backend::{LlmBackend, LlmError, LlmRequest, StreamEvent};
 
 /// Outcome of a completed turn.
@@ -54,16 +55,20 @@ impl std::fmt::Display for TurnError {
 /// Synchronous — blocks until the backend delivers `StreamEvent::Done` or
 /// `StreamEvent::Error`. For UI use, call from a dedicated worker thread.
 ///
+/// `messages` is the full structured conversation history (Anthropic shape:
+/// alternating user/assistant turns). Multi-turn conversations now flow
+/// natively through this path — no flattening at the broker.
+///
 /// `on_token` is called with each text chunk as it arrives. Pass a no-op
 /// closure if streaming is not needed (e.g. in tests).
 pub fn run_turn(
     backend: &dyn LlmBackend,
-    prompt: impl Into<String>,
+    messages: Vec<IqMessage>,
     system: impl Into<String>,
     mut on_token: impl FnMut(&str),
 ) -> Result<TurnResult, TurnError> {
     let request = LlmRequest {
-        prompt: prompt.into(),
+        messages,
         system: system.into(),
     };
 

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -382,7 +382,13 @@ pub(super) fn render_draw_commands(
             | DrawCommand::ScheduleRender { .. }
             | DrawCommand::SetTimer { .. }
             | DrawCommand::CancelTimer { .. }
-            | DrawCommand::CopyToClipboard { .. } => {}
+            | DrawCommand::CopyToClipboard { .. }
+            // AppendConversation is consumed by the host's agent-pane conversation
+            // history surface (issue #285); it never paints into the draw canvas.
+            // The host integration (forthcoming follow-up PR) drains it from the
+            // command stream before this painter sees it; this arm is the safety
+            // net for the wire-only landing.
+            | DrawCommand::AppendConversation { .. } => {}
         }
     }
 


### PR DESCRIPTION
First slice of #285 (v3.3 P1 headline "Agent-as-app"). Lands the wire and schema additions plus broker plumbing that the host integration in part 2 will consume. Does **not** yet spawn subprocess agents into `Pane::Agent` or ship the SDK Agent class — those changes ripple through `process_app/routing.rs`, `agent_pane.rs`, `pane.rs`, and the SDK simultaneously and are tracked as follow-ups.

Closes #285 partially. Host integration tracked in #338; legacy `agent_turn.rs` cleanup tracked in #339.

## What changed

- **Manifest schema (`src/app_registry.rs`)** — required `[app] type = "app" | "agent"` field on every manifest (no `serde(default)`, missing field = loud parse error). New `ManifestType` enum (`App` | `Agent`). Optional `[launch] system_prompt: Option<String>` for agent manifests. All 18 example manifests + 4 inline manifest fixtures in `src/install.rs` migrated.
- **Protocol (`src/app_protocol.rs`)** — three new variants:
  - `PlexiEvent::AgentInit { system_prompt: Option<String> }` — fires once at agent startup with the manifest's `system_prompt`.
  - `PlexiEvent::UserMessage { text }` — fires when the user submits text in the host-rendered conversation input.
  - `DrawCommand::AppendConversation { role, content }` — agent emits one per logical turn; host renders into the conversation history surface.
- **Broker widening (`src/plexi_iq/{broker,loop,backend/{mod,anthropic_api}}.rs`)** — lifted the `flatten_messages` stop-gap from #284. `LlmRequest` now carries `messages: Vec<IqMessage>` directly (the structured Anthropic Messages shape). `AnthropicApiBackend` translates each entry to a real `Message`; empty array = loud error; unknown role = loud error. `turn_loop::run_turn` widened. Multi-turn agent conversations now flow natively.

## Out of scope (filed as follow-ups)

- Host integration: spawning subprocess agents into `Pane::Agent` backed by `AppendConversation` events — #338.
- SDK `Agent` base class with the `on_user_message(text) -> str` callback pattern — #338.
- POC `examples/agent-tester/` end-to-end agent — #338.
- `plexi app new --type agent` scaffolder — #338 (defer further if non-trivial).
- Deletion of `agent_turn.rs` / `agent_pane.rs` legacy in-pane turn loop — #339.

## Breaks if

Any existing manifest loads after this PR without `type = "app"` set; `cargo test --bin plexi` reports any test in `app_protocol::tests::user_message_*`, `agent_init_*`, `append_conversation_*`, or `app_registry::tests::manifest_with_type_*` failing; `LlmRequest.messages = []` no longer surfaces a stream error containing `"messages is empty"`; or an agent manifest's `[launch].system_prompt` field is silently ignored at load (verify in `~/.plexi-alpha/plexi.log` — every `launching '<id>'` line should now also log `type=...` and `system_prompt=...`).

## Human verification

- [ ] `just install-alpha` succeeds, smoke test (manual launch + 2s scan) shows no panics in `~/.plexi-alpha/plexi.log`.
- [ ] After launching Plexi Alpha, every `AppRegistry: launching '<id>'` line in the log includes `type=App, system_prompt=unset`. (Confirms manifest fields are read at runtime, not just parsed.)
- [ ] `cargo test --bin plexi` is green: 114 tests pass, 0 fail.
- [ ] Existing apps with `type = "app"` still launch normally (no regression on iq-query-test, todo, snake, etc.).

## Test added

11 new tests, all required-field discipline (no `serde(default)`):
- `src/app_protocol.rs::tests` (5):
  - `user_message_event_round_trips_serde` / `user_message_missing_text_fails_deserialise`
  - `agent_init_event_round_trips_serde`
  - `append_conversation_drawcommand_round_trips` / `append_conversation_missing_content_fails_deserialise`
- `src/app_registry.rs::tests` (5):
  - `manifest_with_type_app_loads` / `manifest_with_type_agent_loads`
  - `manifest_missing_type_field_errors` / `manifest_with_unknown_type_errors`
  - `agent_manifest_with_system_prompt_loads`
- `src/plexi_iq/broker.rs::tests` (1):
  - `broker_accepts_structured_messages_after_widening` — replaces the deleted `flatten_messages_joins_user_turns` and asserts the structured `Vec<IqMessage>` round-trips through the broker unchanged.