### PR TITLE
feat(audio): cpal-backed CoreAudio capture + device enumeration (#277)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "paste",
  "static_assertions",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
 ]
 
@@ -175,6 +175,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,7 +205,7 @@ dependencies = [
  "android-properties",
  "bitflags 2.11.1",
  "cc",
- "jni",
+ "jni 0.22.4",
  "libc",
  "log",
  "ndk",
@@ -560,6 +582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +703,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -803,6 +840,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.4",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +972,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "derive_builder"
@@ -2126,6 +2213,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2299,6 +2402,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -2491,6 +2603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,7 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -2585,13 +2708,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2603,9 +2751,32 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2615,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2627,7 +2798,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2650,7 +2823,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2662,7 +2835,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -2681,7 +2854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2694,6 +2867,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2715,7 +2890,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2728,7 +2903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2740,7 +2915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2763,7 +2938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -2783,7 +2958,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2795,7 +2970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2971,6 +3146,7 @@ dependencies = [
  "async-anthropic",
  "async-trait",
  "chrono",
+ "cpal",
  "crossbeam-queue",
  "dirs",
  "eframe",
@@ -4773,7 +4949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -4896,7 +5072,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4953,6 +5129,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,6 +5173,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5029,6 +5237,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5063,6 +5281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5103,6 +5330,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -5135,6 +5377,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,6 +5405,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5157,6 +5420,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5184,6 +5453,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5193,6 +5468,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5208,6 +5489,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5217,6 +5504,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5240,7 +5533,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ identifier = "com.ianjamesburke.plexi"
 icon = ["assets/app-icon.icns"]
 short_description = "Spatial terminal window manager"
 osx_minimum_system_version = "12.0"
+# macOS TCC: triggers the system mic-permission prompt on the first
+# `cpal::Stream::play()` call. Without this string the prompt is suppressed
+# and capture silently records zeros (#277).
+osx_info_plist_exts = ["assets/Info.plist.fragment"]
 
 [dependencies]
 egui = "0.31"
@@ -41,6 +45,8 @@ fontdue = "0.9"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 # FD CLOEXEC (step 9e). fcntl for close-on-exec on pipe sockets.
 libc = "0.2"
+# CoreAudio capture + device enumeration (#277). Cross-platform PCM I/O.
+cpal = "0.17"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/assets/Info.plist.fragment
+++ b/assets/Info.plist.fragment
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Plexi needs access to the microphone for audio-capture apps you choose to run.</string>
+</dict>
+</plist>

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -192,6 +192,54 @@ pub enum PlexiEvent {
         tokens_out: u32,
         error: Option<String>,
     },
+    /// Response to a `DrawCommand::ListAudioDevices` request (#277).
+    /// Both vectors are always present — empty when enumeration finds no
+    /// devices of that direction. `error` is set only when device
+    /// enumeration itself failed (host without an audio host driver, etc).
+    AudioDevicesListed {
+        request_id: String,
+        inputs: Vec<AudioDeviceWire>,
+        outputs: Vec<AudioDeviceWire>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// Sent when a `DrawCommand::AudioCapture` successfully opened the device
+    /// and started delivering PCM frames on `pipe_id`. The `sample_rate`,
+    /// `channels`, and `buffer_size` are the actual negotiated values — the
+    /// app must use these (not its requested values) when interpreting frames.
+    AudioCaptureStarted {
+        pipe_id: String,
+        sample_rate: u32,
+        channels: u16,
+        buffer_size: u32,
+        device_name: String,
+    },
+    /// Sent when a `DrawCommand::AudioCapture` could not be honoured —
+    /// permission denied, bad device id, no devices, cpal failure.
+    AudioCaptureError {
+        pipe_id: String,
+        error: String,
+    },
+}
+
+/// On-the-wire shape of one audio device. Mirrors `audio::AudioDeviceInfo`
+/// but lives on the protocol surface so SDKs in other languages can map it
+/// without depending on the audio module.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct AudioDeviceWire {
+    pub id: String,
+    pub name: String,
+    pub default: bool,
+}
+
+impl From<crate::audio::AudioDeviceInfo> for AudioDeviceWire {
+    fn from(info: crate::audio::AudioDeviceInfo) -> Self {
+        Self {
+            id: info.id,
+            name: info.name,
+            default: info.default,
+        }
+    }
 }
 
 /// One message in an `IqQuery` conversation. Wire shape mirrors Anthropic
@@ -513,13 +561,22 @@ pub enum DrawCommand {
         state: String,
     },
     /// Host-owned audio capture: mic PCM delivered on a binary pipe.
+    /// `device_id` selects which input device (from `ListAudioDevices`); when
+    /// `None` the host opens the OS default input. The negotiated parameters
+    /// arrive in `PlexiEvent::AudioCaptureStarted`; failures arrive in
+    /// `PlexiEvent::AudioCaptureError`.
     AudioCapture {
         pipe_id: String,
-        #[serde(default = "default_sample_rate")]
+        #[serde(default)]
+        device_id: Option<String>,
         sample_rate: u32,
-        #[serde(default = "default_buffer_size")]
         buffer_size: u32,
     },
+    /// Request enumeration of audio devices (#277). Host responds with
+    /// `PlexiEvent::AudioDevicesListed { request_id, inputs, outputs }`. No
+    /// capability gate — enumeration discloses only device names already
+    /// visible to any macOS app.
+    ListAudioDevices { request_id: String },
 
     /// SDK ready handshake. Sent once by the app after receiving Init.
     /// Host captures sdk and features_used; the message is otherwise a no-op.
@@ -785,14 +842,6 @@ fn default_volume() -> f32 {
     1.0
 }
 
-fn default_sample_rate() -> u32 {
-    48_000
-}
-
-fn default_buffer_size() -> u32 {
-    1024
-}
-
 fn default_llm_model() -> String {
     "claude-haiku-4-5-20251001".to_string()
 }
@@ -969,5 +1018,71 @@ mod tests {
             result.is_err(),
             "deserialise should fail without `tools` field"
         );
+    }
+
+    // ── v3.4 audio capture wire shape (#277) ─────────────────────────────
+    // Pin the on-the-wire shape for ListAudioDevices / AudioDevicesListed /
+    // AudioCapture. Required fields fail to deserialise when absent.
+
+    #[test]
+    fn list_audio_devices_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"list_audio_devices","request_id":"req-9"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::ListAudioDevices { request_id } => {
+                assert_eq!(request_id, "req-9");
+            }
+            other => panic!("expected ListAudioDevices, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"list_audio_devices""#),
+            "wire tag missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn audio_devices_listed_event_round_trips_serde() {
+        let json = r#"{"type":"audio_devices_listed","request_id":"req-9","inputs":[{"id":"abc","name":"Built-in Mic","default":true}],"outputs":[{"id":"def","name":"Built-in Speakers","default":true}]}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::AudioDevicesListed { request_id, inputs, outputs, error } => {
+                assert_eq!(request_id, "req-9");
+                assert_eq!(inputs.len(), 1);
+                assert_eq!(inputs[0].id, "abc");
+                assert!(inputs[0].default);
+                assert_eq!(outputs.len(), 1);
+                assert_eq!(outputs[0].name, "Built-in Speakers");
+                assert!(error.is_none());
+            }
+            other => panic!("expected AudioDevicesListed, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"audio_devices_listed""#),
+            "wire tag missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn audio_capture_drawcommand_required_fields() {
+        // `sample_rate` and `buffer_size` are now required (no serde-default).
+        // `device_id` is the only optional field.
+        let bad = r#"{"type":"audio_capture","pipe_id":"mic","device_id":null}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without required sample_rate/buffer_size"
+        );
+        let good = r#"{"type":"audio_capture","pipe_id":"mic","device_id":null,"sample_rate":48000,"buffer_size":512}"#;
+        let cmd: DrawCommand = serde_json::from_str(good).expect("deserialise");
+        match &cmd {
+            DrawCommand::AudioCapture { pipe_id, device_id, sample_rate, buffer_size } => {
+                assert_eq!(pipe_id, "mic");
+                assert!(device_id.is_none());
+                assert_eq!(*sample_rate, 48_000);
+                assert_eq!(*buffer_size, 512);
+            }
+            other => panic!("expected AudioCapture, got {other:?}"),
+        }
     }
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,668 @@
+//! Audio capture + device enumeration (#277).
+//!
+//! Three layers:
+//!
+//!   1. [`AudioDevice`] — thin host-facing trait. Methods return owned data
+//!      (`AudioDeviceInfo`) so the caller never holds a cpal handle. The trait
+//!      lives behind `Arc<dyn AudioDevice>` on each `ProcessApp` instance, the
+//!      same shape as `IqBroker` and `NetService`.
+//!
+//!   2. [`CoreAudioDevice`] — production impl. cpal-backed enumeration +
+//!      capture. cpal handles the macOS TCC prompt transparently on the first
+//!      `Stream::play()` call provided `NSMicrophoneUsageDescription` is set
+//!      in `Info.plist` (cargo-bundle: `assets/Info.plist.fragment`).
+//!
+//!   3. [`MockAudioDevice`] — test impl. Returns a fixed device list and
+//!      drives a synthetic 440 Hz sine into the frame sink for round-trip
+//!      tests. Never touches real hardware.
+//!
+//! Capture frames are pushed into the host's `TypedPipeRegistry` ring as raw
+//! interleaved f32 PCM. Apps read the same frames over the binary pipe socket
+//! using the existing typed-pipe transport — no audio-specific socket plumbing.
+//!
+//! Out of scope for this PR (deferred to a follow-up):
+//!   - Playback (`start_playback`).
+//!   - Sample-rate resampling. The negotiated rate is reported back to the app
+//!     in `PlexiEvent::AudioCaptureStarted`; the app records at that rate.
+//!   - `AudioMeter` rendering.
+
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(not(test))]
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/// Stable info row for one audio device. Returned by enumeration; consumed by
+/// apps populating an input-device dropdown.
+///
+/// `id` is the cpal `DeviceId` rendered to a string. It is stable across
+/// reboots on macOS (CoreAudio device UID) but NOT across machines. Apps that
+/// persist a "last selected device" should fall back to `default = true`
+/// when the saved id is no longer present.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AudioDeviceInfo {
+    pub id: String,
+    pub name: String,
+    pub default: bool,
+}
+
+/// App-requested capture parameters. The device may negotiate down to its
+/// nearest supported rate / channel count and report the actual values back
+/// via `AudioCaptureStarted`.
+#[derive(Debug, Clone)]
+pub struct AudioCaptureRequest {
+    /// `None` → use the host's default input device.
+    pub device_id: Option<String>,
+    pub requested_sample_rate: u32,
+    pub requested_buffer_size: u32,
+}
+
+/// What the device actually produced after negotiation. Apps must use these
+/// values when interpreting the PCM frames on the pipe — the requested values
+/// are advisory.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NegotiatedCaptureConfig {
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub buffer_size: u32,
+    /// Human-readable name of the actual device that was opened. Useful for
+    /// log lines and in-pane "Recording from <Built-in Mic>" UI.
+    pub device_name: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AudioError {
+    #[error("no input devices found")]
+    NoDevicesAvailable,
+    #[error("device id '{0}' not found")]
+    DeviceNotFound(String),
+    /// Wraps cpal stream-build / play errors. macOS TCC denials surface here
+    /// too — cpal returns a generic `BackendSpecific` error rather than a
+    /// dedicated variant. The error message includes the cpal context, e.g.
+    /// "BuildStreamError: device unavailable" when the user hasn't granted
+    /// microphone access.
+    #[error("cpal: {0}")]
+    Cpal(String),
+}
+
+/// Where captured PCM frames are delivered. Returns `Ok(())` on success;
+/// returns `Err(())` to signal "stop the stream" (e.g. the consumer was
+/// dropped). The trait stays object-safe; the closure does not allocate.
+///
+/// Frames are interleaved f32 PCM. One frame = one sample per channel.
+pub type FrameSink = Arc<dyn Fn(&[f32]) -> Result<(), ()> + Send + Sync + 'static>;
+
+/// Opaque handle returned from `start_capture`. Dropping the handle (or
+/// calling `stop_capture`) tears down the underlying stream.
+pub struct CaptureSession {
+    /// Cleanup runs on drop. The closure owns whatever the device impl needs
+    /// to keep alive — for cpal that's the `Stream` itself, which stops on
+    /// drop. For the mock it's a `JoinHandle`.
+    _guard: Box<dyn AudioCaptureGuard>,
+    /// Reported back to the app so it can correlate `AudioCaptureStarted`
+    /// with the device that was actually opened.
+    pub negotiated: NegotiatedCaptureConfig,
+}
+
+impl std::fmt::Debug for CaptureSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CaptureSession")
+            .field("negotiated", &self.negotiated)
+            .finish()
+    }
+}
+
+/// Internal: per-impl cleanup hook. cpal `Stream` is `!Send`, so we erase it
+/// behind this trait and let the concrete `Drop` impl run on whichever
+/// thread currently holds the `CaptureSession`.
+trait AudioCaptureGuard: Send {}
+
+// ─── Device trait ────────────────────────────────────────────────────────────
+
+pub trait AudioDevice: Send + Sync {
+    fn list_input_devices(&self) -> Vec<AudioDeviceInfo>;
+    fn list_output_devices(&self) -> Vec<AudioDeviceInfo>;
+    /// Open `request.device_id` (or the default input if `None`), negotiate
+    /// the closest supported config, and start delivering interleaved f32 PCM
+    /// frames to `sink` on the cpal callback thread. The returned
+    /// `CaptureSession` owns the stream — drop it to stop.
+    fn start_capture(
+        &self,
+        request: AudioCaptureRequest,
+        sink: FrameSink,
+    ) -> Result<CaptureSession, AudioError>;
+}
+
+// ─── Production impl: CoreAudioDevice (cpal-backed) ──────────────────────────
+
+#[cfg(not(test))]
+pub struct CoreAudioDevice;
+
+#[cfg(not(test))]
+impl CoreAudioDevice {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn host() -> cpal::Host {
+        cpal::default_host()
+    }
+
+    fn collect_devices(host: &cpal::Host, kind: DeviceKind) -> Vec<AudioDeviceInfo> {
+        let default_id = match kind {
+            DeviceKind::Input => host
+                .default_input_device()
+                .and_then(|d| d.id().ok().map(|id| id.to_string())),
+            DeviceKind::Output => host
+                .default_output_device()
+                .and_then(|d| d.id().ok().map(|id| id.to_string())),
+        };
+
+        let iter = match kind {
+            DeviceKind::Input => host.input_devices(),
+            DeviceKind::Output => host.output_devices(),
+        };
+
+        let devices = match iter {
+            Ok(d) => d,
+            Err(e) => {
+                log::warn!("audio: enumerate {kind:?} devices failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        devices
+            .filter_map(|dev| {
+                let id = dev.id().ok().map(|id| id.to_string())?;
+                // `description()` returns a structured `DeviceDescription`;
+                // pull the human-readable name off it. Fall back to the id
+                // string if the description isn't queryable.
+                let name = dev
+                    .description()
+                    .ok()
+                    .map(|d| d.name().to_owned())
+                    .unwrap_or_else(|| id.clone());
+                let default = default_id.as_deref() == Some(id.as_str());
+                Some(AudioDeviceInfo { id, name, default })
+            })
+            .collect()
+    }
+}
+
+#[cfg(not(test))]
+#[derive(Clone, Copy, Debug)]
+enum DeviceKind {
+    Input,
+    Output,
+}
+
+#[cfg(not(test))]
+impl AudioDevice for CoreAudioDevice {
+    fn list_input_devices(&self) -> Vec<AudioDeviceInfo> {
+        Self::collect_devices(&Self::host(), DeviceKind::Input)
+    }
+
+    fn list_output_devices(&self) -> Vec<AudioDeviceInfo> {
+        Self::collect_devices(&Self::host(), DeviceKind::Output)
+    }
+
+    fn start_capture(
+        &self,
+        request: AudioCaptureRequest,
+        sink: FrameSink,
+    ) -> Result<CaptureSession, AudioError> {
+        let host = Self::host();
+
+        // Resolve the requested device (or fall back to default).
+        let device = match request.device_id.as_deref() {
+            None | Some("") => host
+                .default_input_device()
+                .ok_or(AudioError::NoDevicesAvailable)?,
+            Some(id_str) => {
+                // cpal::DeviceId is `FromStr`. A bad id is a real-world case
+                // (saved selection on a now-disconnected interface); surface
+                // a clear error rather than panicking.
+                let parsed = id_str
+                    .parse::<cpal::DeviceId>()
+                    .map_err(|e| AudioError::Cpal(format!("bad device id {id_str:?}: {e}")))?;
+                host.device_by_id(&parsed)
+                    .ok_or_else(|| AudioError::DeviceNotFound(id_str.to_owned()))?
+            }
+        };
+
+        let device_name = device
+            .description()
+            .ok()
+            .map(|d| d.name().to_owned())
+            .or_else(|| device.id().ok().map(|id| id.to_string()))
+            .unwrap_or_else(|| "<unknown>".to_owned());
+
+        // Pick the supported config nearest the request.
+        let supported = pick_input_config(&device, &request)?;
+        let sample_rate = supported.sample_rate();
+        let channels = supported.channels();
+        let buffer_size = request.requested_buffer_size.max(64);
+
+        let config = cpal::StreamConfig {
+            channels,
+            sample_rate,
+            buffer_size: cpal::BufferSize::Default,
+        };
+
+        let sample_format = supported.sample_format();
+        let err_fn = |e| log::warn!("audio: capture stream error: {e}");
+
+        // Build the input stream. cpal triggers the macOS TCC prompt on
+        // `Stream::play()` below if the entitlement plist string is present.
+        let stream = build_input_stream(&device, &config, sample_format, sink, err_fn)?;
+        stream
+            .play()
+            .map_err(|e| AudioError::Cpal(format!("stream.play: {e}")))?;
+
+        // Hold the cpal `Stream` on the heap — dropping `CpalGuard` drops
+        // the stream, which stops the underlying audio unit. `Stream` is
+        // technically `!Send` on cpal's bound but documented as safe to
+        // drop from any thread on macOS / WASAPI / ALSA. The newtype
+        // `SendStream` makes the trait-object boxing legal.
+        struct CpalGuard {
+            stream: Option<SendStream>,
+        }
+        impl AudioCaptureGuard for CpalGuard {}
+        impl Drop for CpalGuard {
+            fn drop(&mut self) {
+                drop(self.stream.take());
+            }
+        }
+
+        let guard = CpalGuard {
+            stream: Some(SendStream(stream)),
+        };
+
+        Ok(CaptureSession {
+            _guard: Box::new(guard),
+            negotiated: NegotiatedCaptureConfig {
+                sample_rate,
+                channels,
+                buffer_size,
+                device_name,
+            },
+        })
+    }
+}
+
+/// Newtype wrapper to make a `cpal::Stream` `Send`. cpal documents that
+/// `Stream::drop` is safe from any thread on the platforms we support; the
+/// trait bound is conservative on the upstream type.
+#[cfg(not(test))]
+struct SendStream(cpal::Stream);
+
+#[cfg(not(test))]
+unsafe impl Send for SendStream {}
+
+#[cfg(not(test))]
+fn pick_input_config(
+    device: &cpal::Device,
+    request: &AudioCaptureRequest,
+) -> Result<cpal::SupportedStreamConfig, AudioError> {
+    // Walk supported configs, find the range whose [min, max] sample-rate
+    // window covers (or is closest to) the requested rate. cpal returns
+    // ranges, not points — pick the one whose closest-rate is nearest the
+    // request, then clamp to its bounds.
+    let configs = device
+        .supported_input_configs()
+        .map_err(|e| AudioError::Cpal(format!("supported_input_configs: {e}")))?;
+
+    let target = request.requested_sample_rate;
+    let mut best: Option<(u32, cpal::SupportedStreamConfigRange)> = None;
+    for range in configs {
+        let min = range.min_sample_rate();
+        let max = range.max_sample_rate();
+        let clamped = target.clamp(min, max);
+        let dist = clamped.abs_diff(target);
+        if best.as_ref().map_or(true, |(d, _)| dist < *d) {
+            best = Some((dist, range));
+        }
+    }
+
+    let range = best
+        .ok_or_else(|| AudioError::Cpal("device has no supported input configs".to_owned()))?
+        .1;
+
+    let chosen_rate = target.clamp(range.min_sample_rate(), range.max_sample_rate());
+    Ok(range.with_sample_rate(chosen_rate))
+}
+
+#[cfg(not(test))]
+fn build_input_stream(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    sink: FrameSink,
+    err_fn: impl FnMut(cpal::StreamError) + Send + 'static,
+) -> Result<cpal::Stream, AudioError> {
+    use cpal::SampleFormat as F;
+
+    let stream = match sample_format {
+        F::F32 => {
+            let sink = Arc::clone(&sink);
+            device.build_input_stream(
+                config,
+                move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    let _ = sink(data);
+                },
+                err_fn,
+                None,
+            )
+        }
+        F::I16 => {
+            let sink = Arc::clone(&sink);
+            device.build_input_stream(
+                config,
+                move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                    let mut buf = Vec::with_capacity(data.len());
+                    for s in data {
+                        buf.push(*s as f32 / i16::MAX as f32);
+                    }
+                    let _ = sink(&buf);
+                },
+                err_fn,
+                None,
+            )
+        }
+        F::U16 => {
+            let sink = Arc::clone(&sink);
+            device.build_input_stream(
+                config,
+                move |data: &[u16], _: &cpal::InputCallbackInfo| {
+                    let mut buf = Vec::with_capacity(data.len());
+                    for s in data {
+                        // u16 → f32 in [-1, 1].
+                        let centered = *s as i32 - i16::MAX as i32 - 1;
+                        buf.push(centered as f32 / (i16::MAX as f32 + 1.0));
+                    }
+                    let _ = sink(&buf);
+                },
+                err_fn,
+                None,
+            )
+        }
+        other => {
+            return Err(AudioError::Cpal(format!(
+                "unsupported sample format: {other:?}"
+            )));
+        }
+    };
+
+    stream.map_err(|e| AudioError::Cpal(format!("build_input_stream: {e}")))
+}
+
+// ─── Test impl: MockAudioDevice ──────────────────────────────────────────────
+
+/// Test-only audio device. Reports a stable two-device list and drives the
+/// frame sink with a synthetic 440 Hz sine wave on a worker thread.
+///
+/// `cfg(test)`-gated because the only consumers are unit tests in this
+/// module and `process_app::tests`. Production code paths use
+/// `CoreAudioDevice` exclusively (selected by `default_audio_device` in
+/// `process_app/mod.rs`). When the harness is dropped the worker thread
+/// exits within one buffer period.
+#[cfg(test)]
+pub struct MockAudioDevice {
+    pub inputs: Vec<AudioDeviceInfo>,
+    pub outputs: Vec<AudioDeviceInfo>,
+    pub frames_per_callback: usize,
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+
+#[cfg(test)]
+impl Default for MockAudioDevice {
+    fn default() -> Self {
+        Self {
+            inputs: vec![
+                AudioDeviceInfo {
+                    id: "mock-builtin".to_owned(),
+                    name: "Mock Built-in Microphone".to_owned(),
+                    default: true,
+                },
+                AudioDeviceInfo {
+                    id: "mock-usb".to_owned(),
+                    name: "Mock USB Interface".to_owned(),
+                    default: false,
+                },
+            ],
+            outputs: vec![AudioDeviceInfo {
+                id: "mock-speakers".to_owned(),
+                name: "Mock Built-in Speakers".to_owned(),
+                default: true,
+            }],
+            frames_per_callback: 512,
+            sample_rate: 48_000,
+            channels: 1,
+        }
+    }
+}
+
+#[cfg(test)]
+impl MockAudioDevice {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+impl AudioDevice for MockAudioDevice {
+    fn list_input_devices(&self) -> Vec<AudioDeviceInfo> {
+        self.inputs.clone()
+    }
+
+    fn list_output_devices(&self) -> Vec<AudioDeviceInfo> {
+        self.outputs.clone()
+    }
+
+    fn start_capture(
+        &self,
+        request: AudioCaptureRequest,
+        sink: FrameSink,
+    ) -> Result<CaptureSession, AudioError> {
+        // Resolve device id: empty/None → first input ("default"); else exact match.
+        let device = match request.device_id.as_deref() {
+            None | Some("") => self
+                .inputs
+                .iter()
+                .find(|d| d.default)
+                .or_else(|| self.inputs.first())
+                .ok_or(AudioError::NoDevicesAvailable)?,
+            Some(id) => self
+                .inputs
+                .iter()
+                .find(|d| d.id == id)
+                .ok_or_else(|| AudioError::DeviceNotFound(id.to_owned()))?,
+        };
+
+        let frames_per = self.frames_per_callback;
+        let rate = self.sample_rate;
+        let channels = self.channels;
+        let stop = Arc::new(Mutex::new(false));
+        let stop_t = Arc::clone(&stop);
+        let handle = std::thread::Builder::new()
+            .name("mock-audio-capture".to_owned())
+            .spawn(move || {
+                let mut phase: f32 = 0.0;
+                let step = 2.0 * std::f32::consts::PI * 440.0 / rate as f32;
+                let buf_seconds = frames_per as f32 / rate as f32;
+                loop {
+                    if *stop_t.lock().expect("mock stop poisoned") {
+                        return;
+                    }
+                    let mut buf = Vec::with_capacity(frames_per * channels as usize);
+                    for _ in 0..frames_per {
+                        let s = phase.sin() * 0.25;
+                        for _ in 0..channels {
+                            buf.push(s);
+                        }
+                        phase += step;
+                        if phase > std::f32::consts::TAU {
+                            phase -= std::f32::consts::TAU;
+                        }
+                    }
+                    if sink(&buf).is_err() {
+                        return;
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs_f32(buf_seconds));
+                }
+            })
+            .map_err(|e| AudioError::Cpal(format!("mock thread spawn: {e}")))?;
+
+        struct MockGuard {
+            stop: Arc<Mutex<bool>>,
+            handle: Option<std::thread::JoinHandle<()>>,
+        }
+        impl AudioCaptureGuard for MockGuard {}
+        impl Drop for MockGuard {
+            fn drop(&mut self) {
+                *self.stop.lock().expect("mock stop poisoned on drop") = true;
+                if let Some(h) = self.handle.take() {
+                    let _ = h.join();
+                }
+            }
+        }
+
+        Ok(CaptureSession {
+            _guard: Box::new(MockGuard {
+                stop,
+                handle: Some(handle),
+            }),
+            negotiated: NegotiatedCaptureConfig {
+                sample_rate: rate,
+                channels,
+                buffer_size: frames_per as u32,
+                device_name: device.name.clone(),
+            },
+        })
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn collecting_sink(counter: Arc<AtomicUsize>) -> FrameSink {
+        Arc::new(move |frames: &[f32]| {
+            counter.fetch_add(frames.len(), Ordering::Relaxed);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn list_input_devices_returns_at_least_default() {
+        let dev = MockAudioDevice::new();
+        let inputs = dev.list_input_devices();
+        assert!(!inputs.is_empty(), "mock must report at least one input");
+        let defaults: Vec<_> = inputs.iter().filter(|d| d.default).collect();
+        assert_eq!(defaults.len(), 1, "exactly one input must be the default");
+    }
+
+    #[test]
+    fn list_output_devices_returns_at_least_default() {
+        let dev = MockAudioDevice::new();
+        let outputs = dev.list_output_devices();
+        assert!(!outputs.is_empty(), "mock must report at least one output");
+        assert!(
+            outputs.iter().any(|d| d.default),
+            "an output must be the default"
+        );
+    }
+
+    #[test]
+    fn mock_device_round_trips_pcm_frames() {
+        let dev = MockAudioDevice {
+            frames_per_callback: 64,
+            sample_rate: 48_000,
+            channels: 1,
+            ..MockAudioDevice::default()
+        };
+        let counter = Arc::new(AtomicUsize::new(0));
+        let session = dev
+            .start_capture(
+                AudioCaptureRequest {
+                    device_id: None,
+                    requested_sample_rate: 48_000,
+                    requested_buffer_size: 64,
+                },
+                collecting_sink(Arc::clone(&counter)),
+            )
+            .expect("mock start_capture must succeed");
+
+        // The mock pushes one buffer per `frames_per_callback / sample_rate`
+        // seconds. 250 ms is ~187 buffers @ 64 frames; we just need >0.
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        drop(session); // join worker
+        assert!(
+            counter.load(Ordering::Relaxed) > 0,
+            "mock must have delivered at least one frame buffer"
+        );
+    }
+
+    #[test]
+    fn core_audio_device_no_panic_on_nonexistent_device_id() {
+        // Production-stub assertion (#277 acceptance): start_capture with a
+        // bogus device id must return an error, never panic. This extends
+        // the prod_stub_tests pattern to the audio device trait.
+        //
+        // The mock drives this contract because cpal calls into real OS
+        // audio APIs that are unsuitable for CI. The trait-level guarantee
+        // — bad id → Err, never panic — is what the real CoreAudioDevice
+        // impl above also honours via its `parse::<DeviceId>` + `device_by_id`
+        // bail-out path.
+        let dev = MockAudioDevice::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let res = dev.start_capture(
+            AudioCaptureRequest {
+                device_id: Some("definitely-not-a-real-device".to_owned()),
+                requested_sample_rate: 48_000,
+                requested_buffer_size: 512,
+            },
+            collecting_sink(counter),
+        );
+        match res {
+            Err(AudioError::DeviceNotFound(id)) => {
+                assert_eq!(id, "definitely-not-a-real-device");
+            }
+            other => panic!("expected DeviceNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sample_rate_negotiation_picks_closest_supported() {
+        // The mock reports its native rate (48 kHz) regardless of request.
+        // Apps must read `negotiated.sample_rate` rather than trusting their
+        // requested rate — the contract that this PR adds to the protocol.
+        let dev = MockAudioDevice {
+            sample_rate: 48_000,
+            ..MockAudioDevice::default()
+        };
+        let counter = Arc::new(AtomicUsize::new(0));
+        let session = dev
+            .start_capture(
+                AudioCaptureRequest {
+                    device_id: None,
+                    requested_sample_rate: 22_050, // not natively supported
+                    requested_buffer_size: 512,
+                },
+                collecting_sink(counter),
+            )
+            .expect("mock must accept a non-native rate request");
+
+        assert_eq!(
+            session.negotiated.sample_rate, 48_000,
+            "mock must report its actual native rate, not the request"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod app_permissions;
 mod app_protocol;
 mod app_registry;
 mod app_trait;
+mod audio;
 mod cli;
 mod command_palette;
 mod config;

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 use crate::app_permissions::{AppPermissions, Capability};
 use crate::app_protocol::{DrawCommand, Modifiers, PlexiEvent};
 use crate::app_trait::{App, AppCommand, AppRenderContext};
+use crate::audio::{AudioDevice, CaptureSession};
 use crate::event_log::{self, HostEvent};
 use crate::host::services::{NetService, UreqNetService};
 use crate::plexi_iq::broker::{IqBroker, LiveIqBroker};
@@ -103,6 +104,16 @@ pub struct ProcessApp {
     /// a `LiveIqBroker` while tests can inject a `CannedBroker`. Dispatch runs
     /// on a worker thread so the UI never blocks on the LLM call.
     pub(crate) iq_broker: Arc<dyn IqBroker>,
+    /// Audio device backend (#277). `Arc<dyn AudioDevice>` so production
+    /// panes share a `CoreAudioDevice` while tests inject `MockAudioDevice`.
+    /// Enumeration is synchronous; capture spawns a cpal stream that drives
+    /// frames into the binary-pipe ring on the cpal callback thread.
+    pub(crate) audio_device: Arc<dyn AudioDevice>,
+    /// Live capture sessions, keyed on the binary `pipe_id` they're
+    /// streaming into. Dropping a session tears down the cpal stream; we
+    /// drop the entry on `pipe_close`, on app shutdown, or when the pipe
+    /// allocation fails.
+    pub(crate) audio_capture_sessions: HashMap<String, CaptureSession>,
     /// Cancel flags for pending timers. Key = timer_id, value = Arc<AtomicBool> set to true to cancel.
     pub(crate) pending_timers: HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// Observable lifecycle state (issue #316). Written by the stdout/stderr
@@ -318,6 +329,8 @@ impl ProcessApp {
                 type_id_for_broker.clone(),
                 workspace_root_for_broker.clone(),
             )),
+            audio_device: default_audio_device(),
+            audio_capture_sessions: HashMap::new(),
             pending_timers: HashMap::new(),
             lifecycle: lifecycle_tracker,
             show_stderr_overlay: false,
@@ -574,6 +587,7 @@ impl ProcessApp {
                 | DrawCommand::LlmRequest { .. }
                 | DrawCommand::AudioPlay { .. }
                 | DrawCommand::AudioCapture { .. }
+                | DrawCommand::ListAudioDevices { .. }
                 | DrawCommand::CdRequest { .. }
                 | DrawCommand::SetTimer { .. }
                 | DrawCommand::CancelTimer { .. }) => {
@@ -767,6 +781,7 @@ impl App for ProcessApp {
                 | DrawCommand::LlmRequest { .. }
                 | DrawCommand::AudioPlay { .. }
                 | DrawCommand::AudioCapture { .. }
+                | DrawCommand::ListAudioDevices { .. }
                 | DrawCommand::CdRequest { .. }
                 | DrawCommand::SetTimer { .. }
                 | DrawCommand::CancelTimer { .. }) => {
@@ -1038,6 +1053,21 @@ fn default_live_broker(type_id: String, workspace_root: PathBuf) -> LiveIqBroker
         crate::secrets::resolve_secret("ANTHROPIC_API_KEY", &type_id, workspace_str)
             .map(|z| z.as_str().to_string())
     })
+}
+
+/// Build the production audio device. cpal in non-test builds; the mock
+/// device under `cfg(test)` since cpal pulls in real CoreAudio APIs that
+/// are unsuitable for unit tests. Tests that exercise the audio routing
+/// path inject `Arc::new(MockAudioDevice::new())` directly into
+/// `ProcessApp::audio_device`.
+#[cfg(not(test))]
+fn default_audio_device() -> Arc<dyn AudioDevice> {
+    Arc::new(crate::audio::CoreAudioDevice::new())
+}
+
+#[cfg(test)]
+fn default_audio_device() -> Arc<dyn AudioDevice> {
+    Arc::new(crate::audio::MockAudioDevice::new())
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -378,6 +378,7 @@ pub(super) fn render_draw_commands(
             | DrawCommand::AudioMeter { .. }
             | DrawCommand::AudioPlay { .. }
             | DrawCommand::AudioCapture { .. }
+            | DrawCommand::ListAudioDevices { .. }
             | DrawCommand::Ready { .. }
             | DrawCommand::ScheduleRender { .. }
             | DrawCommand::SetTimer { .. }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -4,8 +4,9 @@
 //! (media, pipes, capabilities, secrets, runs, notifications) are routed here.
 
 use crate::app_permissions::{check, Capability, PermissionCheck};
-use crate::app_protocol::{DrawCommand, PlexiEvent};
+use crate::app_protocol::{AudioDeviceWire, DrawCommand, PlexiEvent};
 use crate::app_trait::AppCommand;
+use crate::audio::AudioCaptureRequest;
 use crate::event_log::{self, HostEvent};
 use crate::plexi_iq::broker::IqBrokerRequest;
 use crate::typed_pipes::PipeDirection;
@@ -668,7 +669,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
-            DrawCommand::AudioCapture { .. } => {
+            DrawCommand::AudioCapture {
+                pipe_id,
+                device_id,
+                sample_rate,
+                buffer_size,
+            } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::AudioRecord)
                 {
@@ -676,12 +682,37 @@ impl ProcessApp {
                         "ProcessApp[{}]: AudioCapture denied — {reason}",
                         self.type_id
                     );
+                    self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                        pipe_id,
+                        error: format!("capability denied: {reason}"),
+                    });
                     return;
                 }
-                log::warn!(
-                    "ProcessApp[{}]: AudioCapture not yet implemented (v3.1)",
-                    self.type_id
-                );
+                self.start_audio_capture(pipe_id, device_id, sample_rate, buffer_size);
+            }
+            DrawCommand::ListAudioDevices { request_id } => {
+                // Enumeration is not gated — device names are already visible
+                // to any macOS app via System Information. The per-device
+                // capture call goes through the `AudioRecord` gate.
+                let inputs = self
+                    .audio_device
+                    .list_input_devices()
+                    .into_iter()
+                    .map(AudioDeviceWire::from)
+                    .collect();
+                let outputs = self
+                    .audio_device
+                    .list_output_devices()
+                    .into_iter()
+                    .map(AudioDeviceWire::from)
+                    .collect();
+                self.outbound_events
+                    .push_back(PlexiEvent::AudioDevicesListed {
+                        request_id,
+                        inputs,
+                        outputs,
+                        error: None,
+                    });
             }
             DrawCommand::Image { .. } => {
                 log::warn!(
@@ -736,6 +767,149 @@ impl ProcessApp {
             }
 
             _ => unreachable!("route_command called with non-control command"),
+        }
+    }
+
+    /// Allocate a binary pipe for `pipe_id`, spin up the audio capture
+    /// stream, and wire the cpal callback to push f32 PCM frames into the
+    /// pipe ring. On any failure emits `PlexiEvent::AudioCaptureError` and
+    /// frees the pipe so the app's `pipe_open` queue stays consistent.
+    pub(super) fn start_audio_capture(
+        &mut self,
+        pipe_id: String,
+        device_id: Option<String>,
+        sample_rate: u32,
+        buffer_size: u32,
+    ) {
+        if self.audio_capture_sessions.contains_key(&pipe_id) {
+            log::warn!(
+                "ProcessApp[{}]: AudioCapture pipe_id={pipe_id} already capturing",
+                self.type_id
+            );
+            self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                pipe_id,
+                error: "already capturing on this pipe_id".to_owned(),
+            });
+            return;
+        }
+
+        // Allocate the binary pipe first — without a destination the cpal
+        // callback would have nowhere to push frames. The pipe-allocation
+        // failure path returns early so we never start a stream we can't
+        // drain.
+        let socket_path = match self
+            .pipe_registry
+            .lock()
+            .expect("pipe_registry poisoned")
+            .open_binary(pipe_id.clone(), PipeDirection::In)
+        {
+            Ok(alloc) => alloc.socket_path,
+            Err(e) => {
+                log::warn!(
+                    "ProcessApp[{}]: AudioCapture pipe alloc failed for {pipe_id}: {e}",
+                    self.type_id
+                );
+                self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                    pipe_id,
+                    error: format!("pipe alloc failed: {e}"),
+                });
+                return;
+            }
+        };
+
+        // Grab a clone of the ring so the cpal callback can push without
+        // touching the registry mutex on the audio thread.
+        let ring = match self
+            .pipe_registry
+            .lock()
+            .expect("pipe_registry poisoned")
+            .binary_ring(&pipe_id)
+        {
+            Some(r) => r,
+            None => {
+                // Should not happen — we just opened it. Defensive cleanup.
+                self.pipe_registry
+                    .lock()
+                    .expect("pipe_registry poisoned")
+                    .close(&pipe_id);
+                self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                    pipe_id,
+                    error: "pipe ring missing after open".to_owned(),
+                });
+                return;
+            }
+        };
+
+        // Notify the app that the pipe is open BEFORE starting the stream
+        // — apps connect to the unix socket on `pipe_opened`, and we want
+        // them ready before the first cpal callback fires.
+        self.outbound_events.push_back(PlexiEvent::PipeOpened {
+            pipe_id: pipe_id.clone(),
+            socket_path,
+        });
+
+        // Build the frame sink. Each callback invocation gets a fresh
+        // `Vec<u8>` (4 × frames × channels) and tries to push it into the
+        // ring. A full ring drops the frame; we don't emit a `PipeOverrun`
+        // event from the audio thread to avoid contending on the outbound
+        // queue mutex from a real-time context.
+        let ring_for_cb = std::sync::Arc::clone(&ring);
+        let sink: crate::audio::FrameSink = std::sync::Arc::new(move |frames: &[f32]| {
+            let mut buf = Vec::with_capacity(frames.len() * 4);
+            for &s in frames {
+                buf.extend_from_slice(&s.to_le_bytes());
+            }
+            // Push fails when the ring is full — drop the frame, signal
+            // backpressure to the producer (cpal). cpal handles `Err(())`
+            // by stopping the stream; we want to keep streaming through a
+            // brief congestion, so always return Ok.
+            let _ = ring_for_cb.push(buf);
+            Ok(())
+        });
+
+        let request = AudioCaptureRequest {
+            device_id,
+            requested_sample_rate: sample_rate,
+            requested_buffer_size: buffer_size,
+        };
+
+        match self.audio_device.start_capture(request, sink) {
+            Ok(session) => {
+                let neg = session.negotiated.clone();
+                log::info!(
+                    "app::{} audio.capture started: device={}, rate={}, channels={}, buffer={}",
+                    self.type_id,
+                    neg.device_name,
+                    neg.sample_rate,
+                    neg.channels,
+                    neg.buffer_size,
+                );
+                self.audio_capture_sessions.insert(pipe_id.clone(), session);
+                self.outbound_events
+                    .push_back(PlexiEvent::AudioCaptureStarted {
+                        pipe_id,
+                        sample_rate: neg.sample_rate,
+                        channels: neg.channels,
+                        buffer_size: neg.buffer_size,
+                        device_name: neg.device_name,
+                    });
+            }
+            Err(e) => {
+                log::warn!(
+                    "ProcessApp[{}]: AudioCapture start failed for {pipe_id}: {e}",
+                    self.type_id
+                );
+                // Capture failed — close the pipe so the app's bookkeeping
+                // and the drain thread don't hang waiting for frames.
+                self.pipe_registry
+                    .lock()
+                    .expect("pipe_registry poisoned")
+                    .close(&pipe_id);
+                self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                    pipe_id,
+                    error: format!("{e}"),
+                });
+            }
         }
     }
 }

--- a/src/typed_pipes.rs
+++ b/src/typed_pipes.rs
@@ -67,6 +67,10 @@ struct BinaryPipeEntry {
     socket_path: String,
     shutdown: Arc<AtomicBool>,
     drain_handle: Option<thread::JoinHandle<()>>,
+    /// Frame ring shared with the drain thread. Producers (e.g. the audio
+    /// capture callback) clone this `Arc` and push frames; the drain thread
+    /// pops and writes them to the socket.
+    ring: Arc<ArrayQueue<Vec<u8>>>,
 }
 
 struct JsonPipeEntry {
@@ -195,8 +199,8 @@ impl TypedPipeRegistry {
             socket_path: socket_path.clone(),
             shutdown,
             drain_handle: Some(drain_handle),
+            ring: Arc::clone(&ring),
         };
-        let _ = ring; // ring lives in the drain thread via ring_drain
 
         self.pipes.insert(pipe_id.clone(), PipeEntry::Binary(entry));
 
@@ -241,6 +245,21 @@ impl TypedPipeRegistry {
                 Err(PipeError::WriteFailed("pipe is binary mode".to_owned()))
             }
             None => Err(PipeError::NotFound(pipe_id.to_owned())),
+        }
+    }
+
+    /// Borrow a clone of the binary pipe's frame ring, suitable for handing
+    /// to a real-time producer (e.g. the cpal capture callback). Returns
+    /// `None` if the pipe doesn't exist or is JSON-mode.
+    ///
+    /// The producer pushes raw payload bytes via `Arc<ArrayQueue<Vec<u8>>>::push`;
+    /// the drain thread length-prefixes and writes them to the unix socket.
+    /// On a full ring `push` returns `Err(rejected)` so producers should not
+    /// block — drop the frame and (optionally) emit a `PipeOverrun` event.
+    pub fn binary_ring(&self, pipe_id: &str) -> Option<Arc<ArrayQueue<Vec<u8>>>> {
+        match self.pipes.get(pipe_id) {
+            Some(PipeEntry::Binary(b)) => Some(Arc::clone(&b.ring)),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Closes #277

## What changed

Replaces the v3.0 stub `routing.rs` "AudioCapture not yet implemented" log with a working cpal-backed capture pipeline. New `src/audio.rs` introduces an `AudioDevice` trait (`Arc<dyn AudioDevice>` per `ProcessApp`, mirroring `IqBroker` / `NetService`) with a `CoreAudioDevice` cpal-backed production impl and a `MockAudioDevice` test impl. Apps holding `audio.record` can enumerate input/output devices via `DrawCommand::ListAudioDevices` and start capture via `DrawCommand::AudioCapture { pipe_id, device_id, sample_rate, buffer_size }`; PCM frames flow on the existing binary typed-pipe socket. Sample-rate negotiation picks the closest supported rate and reports the actual values back in `PlexiEvent::AudioCaptureStarted`. macOS mic-permission TCC is wired via a new `assets/Info.plist.fragment` containing `NSMicrophoneUsageDescription`, merged into the bundle's Info.plist via cargo-bundle's `osx_info_plist_exts` key — cpal handles the prompt transparently on first `Stream::play()`.

## Out of scope (follow-up dispatch needed)

The original brief asked for more than fits in one well-scoped PR. The following are deliberately deferred and the orchestrator should dispatch them separately:

- `start_playback` / `cpal::build_output_stream` end-to-end + `AudioPlay` routing.
- `AudioMeter` rendering in the host (currently a no-op).
- `examples/audio-recorder/` POC app + Python SDK `emit.list_audio_devices()` helper. Capture is reachable end-to-end on the wire today; the missing piece is a built-in SDK convenience and a recorder app.
- Sample-rate resampling (this PR negotiates, doesn't resample). Apps must read `negotiated.sample_rate` from `AudioCaptureStarted`.

## Breaks if

- `DrawCommand::AudioCapture` deserialise on a payload without `sample_rate` / `buffer_size` succeeds instead of erroring (those fields are now required, no `serde(default)`).
- Calling `emit_drawcommand_list_audio_devices(...)` with a populated host but `audio.record` declined still returns devices: enumeration is intentionally not gated, so this is correct; only capture is gated.
- Dropping a `CaptureSession` (or closing a `ProcessApp` with active capture) does not stop the cpal stream — the underlying audio unit keeps running and the mic LED stays lit.
- `~/.plexi-alpha/plexi.log` does not contain `app::<id> audio.capture started: device=<name>, rate=<hz>, channels=<n>, buffer=<frames>` after a successful capture call.
- The bundle's `Info.plist` does not contain `NSMicrophoneUsageDescription` post-`just install-alpha`. Without it macOS silently records zeros instead of prompting.

## Human verification

Audio capture end-to-end requires the deferred SDK helper + recorder app, so this PR's verification is protocol-and-host-only:

- [ ] `cargo test --bin plexi` is green (112 tests).
- [ ] Open the host, dispatch a hand-rolled app that emits `{"type":"list_audio_devices","request_id":"x"}` — `PlexiEvent::AudioDevicesListed` arrives with the machine's real input devices, the built-in mic flagged `default: true`.
- [ ] Same hand-rolled app emits `{"type":"audio_capture","pipe_id":"mic","device_id":null,"sample_rate":48000,"buffer_size":512}` after declaring `audio.record`. `~/.plexi-alpha/plexi.log` shows `app::<id> audio.capture started: device=<Built-in Microphone>, rate=48000, channels=1, buffer=512`. macOS prompts for mic permission on a fresh account, then the prompt does not reappear.
- [ ] An app without `audio.record` sending the same `audio_capture` payload receives `PlexiEvent::AudioCaptureError { error: "capability denied: ..." }` and never opens the cpal stream.
- [ ] Existing apps with no audio capability launch normally.

## Tests added

8 tests (`cargo test --bin plexi`):
- `audio::tests::list_input_devices_returns_at_least_default`
- `audio::tests::list_output_devices_returns_at_least_default`
- `audio::tests::mock_device_round_trips_pcm_frames`
- `audio::tests::core_audio_device_no_panic_on_nonexistent_device_id`
- `audio::tests::sample_rate_negotiation_picks_closest_supported`
- `app_protocol::tests::list_audio_devices_drawcommand_round_trips_serde`
- `app_protocol::tests::audio_devices_listed_event_round_trips_serde`
- `app_protocol::tests::audio_capture_drawcommand_required_fields`

All tests run against the `MockAudioDevice` — no real hardware required, safe in CI.