### PR TITLE
feat(agent-as-app): host integration + SDK Agent class (#338, part 2 of #285)

### DIFF
--- a/examples/agent-tester/agent_tester.py
+++ b/examples/agent-tester/agent_tester.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Agent Tester — POC for #338 (agent-as-app, part 2 of #285).
+
+Demonstrates the full agent-as-app loop end-to-end without writing
+turn-loop boilerplate. The Plexi host renders the conversation UI;
+this app receives `PlexiEvent::AgentInit` (system prompt) once at
+startup and `PlexiEvent::UserMessage` per submit, then replies via
+the `iq.query` broker.
+
+Build: ~10 lines of substance. The `Agent` SDK base class handles
+history mirroring, append helpers, and event wiring.
+"""
+from __future__ import annotations
+
+from plexi_sdk import Agent
+
+
+class AgentTester(Agent):
+    def respond(self, text: str) -> str:
+        # `self.history` is auto-populated by `append_user_message` (called
+        # by the SDK before this override runs). `system_prompt` is set by
+        # the host's AgentInit forwarded from the manifest.
+        del text  # captured by `self.history[-1]`
+        response = self.emit.iq_query(
+            model_tier="medium",
+            system=self.system_prompt or "",
+            messages=self.history,
+        )
+        return response.content
+
+
+if __name__ == "__main__":
+    AgentTester().run()

--- a/examples/agent-tester/manifest.toml
+++ b/examples/agent-tester/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "agent-tester"
+type = "agent"
+name = "Agent Tester"
+version = "0.1.0"
+description = "POC for #338 — agent-as-app: subprocess-backed conversation pane driven by iq.query."
+entry = "agent_tester.py"
+
+[app.capabilities]
+capabilities = ["iq.query"]
+
+[launch]
+system_prompt = "You are a focused, terse assistant. Reply in one or two sentences."

--- a/examples/agent-tester/tests/test_agent.py
+++ b/examples/agent-tester/tests/test_agent.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+"""Unit tests for the v3.3 SDK `Agent` base class (issue #338, part 2 of #285).
+
+Covers:
+  1. AgentInit handler stores the system prompt on `self.system_prompt`.
+  2. UserMessage handler appends a user row, calls `respond()`, then
+     auto-appends the returned assistant string.
+  3. `respond() -> None` skips the auto-append (manual mode).
+  4. `append_*` helpers emit `append_conversation` DrawCommands with the
+     correct shape and mirror history correctly.
+
+We don't run the full PGAP event loop — we drive the SDK's event-handler
+branches directly, which is exactly what `App.run()` does internally.
+This keeps the tests deterministic and dependency-free.
+"""
+
+import io
+import json
+import os
+import sys
+
+# Allow importing plexi_sdk from the source tree without install.
+# Path: examples/agent-tester/tests/ → repo_root/sdk/python.
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "sdk", "python"),
+)
+
+from plexi_sdk import Agent  # noqa: E402
+
+
+def _capture_stdout():
+    saved = sys.stdout
+    buf = io.StringIO()
+    sys.stdout = buf
+    return saved, buf
+
+
+def _restore(saved):
+    sys.stdout = saved
+
+
+def _decoded(buf: io.StringIO) -> list[dict]:
+    out = []
+    for line in buf.getvalue().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+def test_agent_class_stores_system_prompt_from_agent_init():
+    """The host emits AgentInit once at startup with the manifest's
+    `[launch].system_prompt`. The Agent base class must store it on
+    `self.system_prompt` so subclasses can pass it to `iq.query`."""
+    saved, _buf = _capture_stdout()
+    try:
+        agent = Agent()
+        assert agent.system_prompt is None, "fresh agent has no prompt"
+        agent.on_agent_init("You are terse.")
+    finally:
+        _restore(saved)
+
+    assert agent.system_prompt == "You are terse."
+
+    # `None` from the host means the manifest omitted the field — must
+    # round-trip cleanly.
+    saved, _buf = _capture_stdout()
+    try:
+        agent2 = Agent()
+        agent2.on_agent_init(None)
+    finally:
+        _restore(saved)
+    assert agent2.system_prompt is None
+
+
+def test_agent_class_appends_user_message_on_user_event():
+    """When the host emits UserMessage, the Agent base class must:
+    (1) append a "user" row to history,
+    (2) emit an `append_conversation` DrawCommand with role=user."""
+
+    class TestAgent(Agent):
+        def respond(self, _text: str) -> str:
+            return "noop"  # required to satisfy NotImplementedError
+
+    saved, buf = _capture_stdout()
+    try:
+        agent = TestAgent()
+        ctx = agent._make_ctx()
+        agent.on_user_message(ctx, "hello agent")
+        cmds = _decoded(buf)
+    finally:
+        _restore(saved)
+
+    # Exactly two append_conversation commands: user input, then assistant reply.
+    appends = [c for c in cmds if c.get("type") == "append_conversation"]
+    assert len(appends) == 2, f"expected 2 appends, got {appends}"
+    assert appends[0] == {
+        "type": "append_conversation",
+        "role": "user",
+        "content": "hello agent",
+    }
+    # History reflects both turns.
+    assert agent.history == [
+        {"role": "user", "content": "hello agent"},
+        {"role": "assistant", "content": "noop"},
+    ]
+
+
+def test_agent_class_calls_on_user_message_override():
+    """`respond()` is called once per user_message event with the raw text.
+    `self.history` already contains the user turn before respond() runs so
+    the override can pass it straight to `iq.query`."""
+
+    captured: dict = {}
+
+    class TestAgent(Agent):
+        def respond(self, text: str) -> str:
+            captured["text"] = text
+            captured["history_len_at_respond"] = len(self.history)
+            captured["last_role"] = self.history[-1]["role"]
+            return "ack"
+
+    saved, _buf = _capture_stdout()
+    try:
+        agent = TestAgent()
+        ctx = agent._make_ctx()
+        agent.on_user_message(ctx, "ping")
+    finally:
+        _restore(saved)
+
+    assert captured["text"] == "ping"
+    # When respond() runs, history has the user turn (length 1).
+    assert captured["history_len_at_respond"] == 1
+    assert captured["last_role"] == "user"
+
+
+def test_agent_class_appends_assistant_message_after_override_returns():
+    """A non-None return from `respond` auto-emits the assistant turn.
+    A `None` return means the override appended manually — no auto-append."""
+
+    class AutoAgent(Agent):
+        def respond(self, _text: str) -> str:
+            return "auto reply"
+
+    saved, buf = _capture_stdout()
+    try:
+        agent = AutoAgent()
+        ctx = agent._make_ctx()
+        agent.on_user_message(ctx, "hi")
+        cmds = _decoded(buf)
+    finally:
+        _restore(saved)
+    assistant = [c for c in cmds if c.get("role") == "assistant"]
+    assert len(assistant) == 1
+    assert assistant[0]["content"] == "auto reply"
+
+    # Now the manual-mode path: respond() returns None, override calls
+    # append_* helpers itself.
+    class ManualAgent(Agent):
+        def respond(self, _text: str):
+            self.append_tool_message("looking it up")
+            self.append_assistant_message("manual reply")
+            return None
+
+    saved, buf = _capture_stdout()
+    try:
+        agent = ManualAgent()
+        ctx = agent._make_ctx()
+        agent.on_user_message(ctx, "hello")
+        cmds = _decoded(buf)
+    finally:
+        _restore(saved)
+
+    appends = [c for c in cmds if c.get("type") == "append_conversation"]
+    # user + tool + assistant = 3 (NOT a fourth auto-assistant)
+    assert len(appends) == 3, f"expected 3 (user/tool/assistant), got {appends}"
+    roles = [c["role"] for c in appends]
+    assert roles == ["user", "tool", "assistant"]
+    # Tool messages are NOT mirrored into history.
+    assert agent.history == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "manual reply"},
+    ]

--- a/packs/core.toml
+++ b/packs/core.toml
@@ -48,3 +48,12 @@ version = "bundled"
 id      = "app-store"
 source  = "local:app-store"
 version = "1.0.0"
+
+# Agent-as-app POC (#338, part 2 of #285). Demonstrates the
+# `type = "agent"` manifest path: subprocess-backed conversation
+# pane driven by `iq.query`. Requires ANTHROPIC_API_KEY in the
+# Plexi secrets store at first launch.
+[[app]]
+id      = "agent-tester"
+source  = "local:agent-tester"
+version = "0.1.0"

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1226,6 +1226,11 @@ class App:
     def on_inject(self, _ctx: RenderContext, _payload: Any) -> None: pass
     def on_app_spawned(self, _pane_id: int, _type_id: str) -> None: pass
     def on_timer(self, _ctx: "RenderContext", _timer_id: str) -> None: pass
+    # ── Agent-as-app hooks (#338, type = "agent" manifests only) ────────────
+    # `Agent` subclass wires these. Plain `App` subclasses get no-op defaults
+    # so a misclassified manifest doesn't crash on the host's emit.
+    def on_agent_init(self, _system_prompt: "str | None") -> None: pass
+    def on_user_message(self, _ctx: "RenderContext", _text: str) -> None: pass
     def on_suspend(self) -> None: pass
     def on_resume(self) -> None: pass
     def on_shutdown(self) -> None: pass
@@ -1410,6 +1415,26 @@ class App:
                     else:
                         q.put(action_label or "acknowledge")
 
+            elif t == "agent_init":
+                # v3.3 agent-as-app (#338): the host forwards the manifest's
+                # `[launch].system_prompt` once at startup. Apps that subclass
+                # `Agent` consume this in `_on_agent_init`; plain App
+                # subclasses can override `on_agent_init` to receive it.
+                try:
+                    self.on_agent_init(ev.get("system_prompt"))
+                except Exception as e:
+                    sys.stderr.write(f"on_agent_init handler raised: {e}\n")
+
+            elif t == "user_message":
+                # v3.3 agent-as-app (#338): the user submitted text in the
+                # host-rendered conversation input box. Forwarded to
+                # `on_user_message`. Only delivered to type=agent panes.
+                ctx = self._make_ctx()
+                try:
+                    self.on_user_message(ctx, ev.get("text", ""))
+                except Exception as e:
+                    sys.stderr.write(f"on_user_message handler raised: {e}\n")
+
             elif t == "text_submitted":
                 # Host-owned text input: the user pressed Enter on a
                 # `DrawCommand::TextInput` field. Stash the value keyed
@@ -1441,3 +1466,104 @@ class App:
         # Ensure all pipes are closed cleanly
         for p in self._pipes.values():
             p.close()
+
+
+# ── Agent base class (issue #338) ────────────────────────────────────────────
+
+class Agent(App):
+    """Subclass for `type = "agent"` manifests. Wires the conversation loop.
+
+    The host renders the conversation UI (history scrollback + input box).
+    The agent owns the dialogue logic. The contract is symmetric:
+
+        Host → Agent      PlexiEvent::AgentInit  { system_prompt }   (once)
+        Host → Agent      PlexiEvent::UserMessage { text }            (per submit)
+        Agent → Host      DrawCommand::AppendConversation { role, content }
+
+    Author writes a single `on_user_message(text) -> str | None` callback.
+    Returning a string auto-emits an assistant `AppendConversation`. Returning
+    `None` means "I'll append manually" — useful for agents that emit
+    multiple rows per turn (tool use, partial replies).
+
+    Conversation history (`self.history`) is auto-built from `append_*`
+    helpers — pass it directly to `emit.iq_query(...)` for multi-turn.
+
+    Example:
+
+        class JokeAgent(Agent):
+            def on_user_message(self, text: str) -> str:
+                resp = self.emit.iq_query(
+                    model_tier="medium",
+                    system=self.system_prompt or "",
+                    messages=self.history,
+                )
+                return resp.content
+
+        if __name__ == "__main__":
+            JokeAgent().run()
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Populated by AgentInit. None until the host emits it (or forever
+        # if the manifest omits `[launch].system_prompt`).
+        self.system_prompt: "str | None" = None
+        # Conversation history in Anthropic Messages shape — built by the
+        # `append_*` helpers and passed straight to `emit.iq_query`.
+        self.history: list = []
+
+    # ── Wire-up (do not override) ───────────────────────────────────────────
+    def on_agent_init(self, system_prompt: "str | None") -> None:  # type: ignore[override]
+        self.system_prompt = system_prompt
+        self.emit.info(
+            f"agent: AgentInit received (system_prompt={'set' if system_prompt else 'unset'})"
+        )
+
+    def on_user_message(self, ctx: "RenderContext", text: str) -> None:  # type: ignore[override]
+        # Append the user turn before invoking the override so `self.history`
+        # already contains it when the override calls `emit.iq_query`.
+        self.append_user_message(text)
+        try:
+            reply = self.respond(text)
+        except Exception as e:
+            self.emit.error(f"agent: respond() raised: {e}")
+            self.append_system_message(f"Error: {e}")
+            return
+        # `None` means "I'll handle appends myself" — common for agents that
+        # stream multiple rows (tool use, partial replies). A returned string
+        # is the conventional one-shot reply path.
+        if reply is not None:
+            self.append_assistant_message(reply)
+
+    # ── User override ───────────────────────────────────────────────────────
+    def respond(self, _text: str) -> "str | None":
+        """Override this. Called once per `user_message` event.
+
+        Return a string to auto-append as the assistant turn. Return `None`
+        if you've already called `append_assistant_message` (or other
+        `append_*` helpers) yourself — useful for tool-use loops.
+        """
+        raise NotImplementedError(
+            "Agent subclasses must override `respond(text) -> str | None`"
+        )
+
+    # ── Conversation surface ────────────────────────────────────────────────
+    def append_user_message(self, text: str) -> None:
+        """Append a user row to the transcript. Updates `self.history` so the
+        next `emit.iq_query` call sees the turn."""
+        self.history.append({"role": "user", "content": text})
+        _emit({"type": "append_conversation", "role": "user", "content": text})
+
+    def append_assistant_message(self, text: str) -> None:
+        """Append an assistant row. Mirrors into `self.history`."""
+        self.history.append({"role": "assistant", "content": text})
+        _emit({"type": "append_conversation", "role": "assistant", "content": text})
+
+    def append_tool_message(self, text: str) -> None:
+        """Append a tool-use status row. Tool messages are NOT mirrored into
+        `self.history` (they're not part of the LLM-visible conversation)."""
+        _emit({"type": "append_conversation", "role": "tool", "content": text})
+
+    def append_system_message(self, text: str) -> None:
+        """Append a system / error status row. NOT mirrored into history."""
+        _emit({"type": "append_conversation", "role": "system", "content": text})

--- a/src/agent_pane.rs
+++ b/src/agent_pane.rs
@@ -1,4 +1,5 @@
-/// Agent pane: chats with `claude -p` using streaming JSON for real-time output.
+/// Agent pane: conversation UI scaffolding (header / transcript / input)
+/// backed by one of two interchangeable backends (issue #338, part 2 of #285).
 ///
 /// Layout (top→bottom):
 ///   Header: "IQ  workspace-name"
@@ -6,12 +7,30 @@
 ///   Transcript: scrollable, sticks to bottom
 ///   Input: multiline — Enter sends, Shift+Enter inserts newline (no hint shown)
 ///
+/// `AgentBackend` discriminates *who produces messages*. The render path is
+/// identical for both — both backends own a `transcript: Vec<String>` and an
+/// `in_flight: bool`, surfaced through `AgentPane::transcript()` /
+/// `AgentPane::in_flight()`. Adding a new backend means one match arm in
+/// `submit_input` / `drain_results` plus a new state struct.
+///
+///   - `InProcess` — legacy `claude -p --output-format stream-json` worker
+///     thread. Ships unchanged; deletion tracked in #339. Used by Cmd+I.
+///   - `Subprocess` — agent-as-app: a `ProcessApp` running an external binary
+///     that speaks PGAP. Receives `PlexiEvent::AgentInit` once at startup,
+///     `PlexiEvent::UserMessage` on every submit, and emits
+///     `DrawCommand::AppendConversation` rows that the host appends to the
+///     transcript.
+///
 /// Interruption: submitting while in-flight kills the subprocess and dispatches
 /// the new message immediately. The cancelled turn is discarded silently.
+/// (In-process backend only — subprocess backend has no concept of "kill the
+/// turn", because the agent decides when its turn ends.)
 ///
 /// Large pastes (>300 chars or multiline) appear collapsed in the transcript as
 /// "You: [pasted text — N chars]" — the full text is still sent to the agent.
 use crate::agent_turn::{self, WorkerEvent};
+use crate::app_protocol::PlexiEvent;
+use crate::process_app::ProcessApp;
 use crate::theme::Colors;
 use crate::tiling::PaneId;
 use std::path::{Path, PathBuf};
@@ -110,7 +129,25 @@ fn save_session_file(iq_dir: &Path, pane_id: PaneId, file: &SessionFile) {
     }
 }
 
-// ── AgentPane ────────────────────────────────────────────────────────────────
+// ── Display helpers ──────────────────────────────────────────────────────────
+
+/// Render a user-typed message into a transcript line, collapsing oversized /
+/// multiline pastes per the spec. Shared by both backends so the UI stays
+/// consistent.
+fn format_user_message(message: &str) -> String {
+    if message.len() > 300 || message.contains('\n') {
+        let lines = message.lines().count();
+        if lines > 1 {
+            format!("You: [pasted text — {lines} lines, {} chars]", message.len())
+        } else {
+            format!("You: [pasted text — {} chars]", message.len())
+        }
+    } else {
+        format!("You: {message}")
+    }
+}
+
+// ── In-process backend (legacy `claude -p` turn loop) ────────────────────────
 
 struct WorkerMsg {
     session_id: String,
@@ -119,16 +156,12 @@ struct WorkerMsg {
     cwd: PathBuf,
 }
 
-pub struct AgentPane {
-    pub id: PaneId,
+/// Backend that drives the legacy `agent_turn::run_turn` loop on a worker
+/// thread. Used by the Cmd+I "open agent pane" path. Will be retired in #339.
+pub struct InProcessAgent {
     pub session_id: String,
-    pub transcript: Vec<String>,
-    pub input_buf: String,
-    pub in_flight: bool,
     pub cwd: PathBuf,
     iq_dir: Option<PathBuf>,
-    pub font_size: f32,
-    needs_focus: bool,
     /// Message queued to send immediately after current turn completes.
     pending_message: Option<String>,
     /// True when the last transcript line is the live streaming agent response.
@@ -142,8 +175,8 @@ pub struct AgentPane {
     event_rx: mpsc::Receiver<WorkerEvent>,
 }
 
-impl AgentPane {
-    pub fn new(id: PaneId, cwd: PathBuf) -> Self {
+impl InProcessAgent {
+    fn new(id: PaneId, cwd: PathBuf) -> (Self, Vec<String>) {
         let iq_dir = find_iq_dir(&cwd);
 
         let (session_id, transcript) = if let Some(ref dir) = iq_dir {
@@ -178,65 +211,18 @@ impl AgentPane {
             })
             .unwrap_or_else(|e| panic!("failed to spawn agent worker: {e}"));
 
-        Self {
-            id,
+        let agent = Self {
             session_id,
-            transcript,
-            input_buf: String::new(),
-            in_flight: false,
             cwd,
             iq_dir,
-            font_size: 13.0,
-            needs_focus: true,
             pending_message: None,
             streaming_active: false,
             interrupting: false,
             child_slot,
             turn_tx: Some(turn_tx),
             event_rx,
-        }
-    }
-
-    fn dispatch(&mut self, message: String) {
-        log::info!("agent_pane {}: submit {:?}", self.id, message);
-
-        // Show large/multiline pastes collapsed — full text still sent to the agent.
-        let display = if message.len() > 300 || message.contains('\n') {
-            let lines = message.lines().count();
-            if lines > 1 {
-                format!("You: [pasted text — {lines} lines, {} chars]", message.len())
-            } else {
-                format!("You: [pasted text — {} chars]", message.len())
-            }
-        } else {
-            format!("You: {message}")
         };
-        self.transcript.push(display);
-
-        let soul_context = if self.session_id.is_empty() {
-            self.iq_dir.as_deref().map(load_soul_context)
-        } else {
-            None
-        };
-
-        let msg = WorkerMsg {
-            session_id: self.session_id.clone(),
-            soul_context,
-            message,
-            cwd: self.cwd.clone(),
-        };
-        if let Some(tx) = &self.turn_tx {
-            match tx.try_send(msg) {
-                Ok(_) => {
-                    self.in_flight = true;
-                    self.streaming_active = false;
-                }
-                Err(e) => {
-                    log::error!("agent_pane {}: channel send failed: {e}", self.id);
-                    self.transcript.push("Error: failed to dispatch turn".into());
-                }
-            }
-        }
+        (agent, transcript)
     }
 
     /// Kill the current subprocess. Done(Err) will arrive; `interrupting` suppresses
@@ -249,6 +235,206 @@ impl AgentPane {
             }
         }
     }
+}
+
+// ── Subprocess backend (PGAP-speaking external agent — issue #338) ───────────
+
+/// Backend that wraps a `ProcessApp` running a `type = "agent"` manifest. The
+/// host renders the conversation UI; the agent subprocess decides what to say
+/// by emitting `DrawCommand::AppendConversation` rows in response to
+/// `PlexiEvent::UserMessage` events the host forwards from the input box.
+pub struct SubprocessAgent {
+    pub process: Box<ProcessApp>,
+    pub system_prompt: Option<String>,
+    pub manifest_id: String,
+    /// `true` once `AgentInit` has been forwarded to the subprocess. Sending
+    /// happens lazily on the first drain after the subprocess marks Ready —
+    /// the launch path doesn't have a synchronous "Ready" handshake.
+    init_sent: bool,
+    /// Tracks whether a turn is currently in flight (a UserMessage was sent
+    /// and we're awaiting at least one AppendConversation back). Cleared
+    /// when an assistant row arrives.
+    in_flight: bool,
+}
+
+impl SubprocessAgent {
+    pub fn new(process: Box<ProcessApp>, system_prompt: Option<String>, manifest_id: String) -> Self {
+        Self {
+            process,
+            system_prompt,
+            manifest_id,
+            init_sent: false,
+            in_flight: false,
+        }
+    }
+
+    /// Send `PlexiEvent::AgentInit` if the subprocess has finished Init/Ready
+    /// and we haven't already. Idempotent — safe to call every drain.
+    fn maybe_send_init(&mut self) {
+        if self.init_sent {
+            return;
+        }
+        if !self.process.is_ready_for_agent_init() {
+            return;
+        }
+        let event = PlexiEvent::AgentInit {
+            system_prompt: self.system_prompt.clone(),
+        };
+        log::info!(
+            "agent_pane[{}]: sending AgentInit (system_prompt={})",
+            self.manifest_id,
+            self.system_prompt
+                .as_deref()
+                .map(|s| format!("{} chars", s.len()))
+                .unwrap_or_else(|| "unset".to_string())
+        );
+        self.process.queue_outbound_event_direct(event);
+        self.init_sent = true;
+    }
+}
+
+// ── AgentBackend ─────────────────────────────────────────────────────────────
+
+/// Discriminates which backend produces messages on the conversation surface.
+/// Both backends share the transcript/input rendering on `AgentPane`. Adding a
+/// backend means one match arm in `submit_input` and `drain_results`.
+pub enum AgentBackend {
+    /// Legacy in-process turn loop (Cmd+I path). Calls `claude -p` directly.
+    InProcess(InProcessAgent),
+    /// Subprocess agent (manifest `type = "agent"` path, issue #338). Speaks
+    /// PGAP, receives `UserMessage` / `AgentInit`, emits `AppendConversation`.
+    Subprocess(SubprocessAgent),
+}
+
+// ── AgentPane ────────────────────────────────────────────────────────────────
+
+pub struct AgentPane {
+    pub id: PaneId,
+    pub transcript: Vec<String>,
+    pub input_buf: String,
+    pub in_flight: bool,
+    pub font_size: f32,
+    needs_focus: bool,
+
+    pub backend: AgentBackend,
+}
+
+impl AgentPane {
+    /// Construct an in-process (Cmd+I) agent pane. Spawns the worker thread
+    /// and loads any persisted session for this `id`.
+    pub fn new(id: PaneId, cwd: PathBuf) -> Self {
+        let (agent, transcript) = InProcessAgent::new(id, cwd);
+        Self {
+            id,
+            transcript,
+            input_buf: String::new(),
+            in_flight: false,
+            font_size: 13.0,
+            needs_focus: true,
+            backend: AgentBackend::InProcess(agent),
+        }
+    }
+
+    /// Construct a subprocess-backed agent pane (#338). The `process` is a
+    /// freshly launched `type = "agent"` ProcessApp; the host owns its
+    /// lifetime and pumps it via `agent_tick` on every render.
+    pub fn new_subprocess(
+        id: PaneId,
+        process: Box<ProcessApp>,
+        system_prompt: Option<String>,
+        manifest_id: String,
+    ) -> Self {
+        Self {
+            id,
+            transcript: Vec::new(),
+            input_buf: String::new(),
+            in_flight: false,
+            font_size: 13.0,
+            needs_focus: true,
+            backend: AgentBackend::Subprocess(SubprocessAgent::new(
+                process,
+                system_prompt,
+                manifest_id,
+            )),
+        }
+    }
+
+    /// Workspace `cwd` for this pane. In-process backend tracks the workspace
+    /// dir explicitly (it loads SOUL/MEMORY relative to it); subprocess
+    /// backend uses the `ProcessApp`'s `workspace_root`. Used by workspace
+    /// persistence to round-trip the pane.
+    pub fn cwd(&self) -> PathBuf {
+        match &self.backend {
+            AgentBackend::InProcess(a) => a.cwd.clone(),
+            AgentBackend::Subprocess(a) => a.process.workspace_root.clone(),
+        }
+    }
+
+    /// `cwd` is only meaningful for the in-process backend (it points at the
+    /// workspace whose `.plexi/agents/iq/` we persist sessions into). Returned
+    /// here for the header's workspace label; subprocess panes return `None`.
+    pub fn iq_dir(&self) -> Option<&Path> {
+        match &self.backend {
+            AgentBackend::InProcess(a) => a.iq_dir.as_deref(),
+            AgentBackend::Subprocess(_) => None,
+        }
+    }
+
+    pub fn pending_message_present(&self) -> bool {
+        match &self.backend {
+            AgentBackend::InProcess(a) => a.pending_message.is_some(),
+            AgentBackend::Subprocess(_) => false,
+        }
+    }
+
+    fn dispatch_in_process(&mut self, message: String) {
+        log::info!("agent_pane {}: submit {:?}", self.id, message);
+
+        let display = format_user_message(&message);
+        self.transcript.push(display);
+
+        let AgentBackend::InProcess(agent) = &mut self.backend else {
+            return;
+        };
+
+        let soul_context = if agent.session_id.is_empty() {
+            agent.iq_dir.as_deref().map(load_soul_context)
+        } else {
+            None
+        };
+
+        let msg = WorkerMsg {
+            session_id: agent.session_id.clone(),
+            soul_context,
+            message,
+            cwd: agent.cwd.clone(),
+        };
+        if let Some(tx) = &agent.turn_tx {
+            match tx.try_send(msg) {
+                Ok(_) => {
+                    self.in_flight = true;
+                    agent.streaming_active = false;
+                }
+                Err(e) => {
+                    log::error!("agent_pane {}: channel send failed: {e}", self.id);
+                    self.transcript.push("Error: failed to dispatch turn".into());
+                }
+            }
+        }
+    }
+
+    fn dispatch_subprocess(&mut self, message: String) {
+        log::info!("agent_pane {}: submit (subprocess) {:?}", self.id, message);
+        self.transcript.push(format_user_message(&message));
+        let AgentBackend::Subprocess(agent) = &mut self.backend else {
+            return;
+        };
+        agent
+            .process
+            .queue_outbound_event_direct(PlexiEvent::UserMessage { text: message });
+        agent.in_flight = true;
+        self.in_flight = true;
+    }
 
     pub fn submit_input(&mut self) {
         let message = self.input_buf.trim().to_string();
@@ -257,30 +443,56 @@ impl AgentPane {
         }
         self.input_buf.clear();
 
-        if self.in_flight {
-            // Interrupt current turn, queue new message — dispatches when Done arrives.
-            self.cancel_current_turn();
-            self.pending_message = Some(message);
-        } else {
-            self.dispatch(message);
+        match &mut self.backend {
+            AgentBackend::InProcess(agent) => {
+                if self.in_flight {
+                    // Interrupt current turn, queue new message — dispatches when Done arrives.
+                    agent.cancel_current_turn();
+                    agent.pending_message = Some(message);
+                } else {
+                    self.dispatch_in_process(message);
+                }
+            }
+            AgentBackend::Subprocess(_) => {
+                // Subprocess agents don't support interruption today — the
+                // agent owns the turn boundary. Submitting while in_flight
+                // simply queues another UserMessage; the agent decides how
+                // to handle concurrent turns. Kept simple deliberately;
+                // streaming + interruption are tracked under v3.3.5+.
+                self.dispatch_subprocess(message);
+            }
         }
     }
 
-    /// Drain streaming events. Returns true if caller should request a repaint.
+    /// Drain backend events into the transcript. Returns true if caller should
+    /// request a repaint (events arrived OR a turn is still running).
     pub fn drain_results(&mut self) -> bool {
-        let mut changed = false;
+        match &mut self.backend {
+            AgentBackend::InProcess(_) => self.drain_in_process(),
+            AgentBackend::Subprocess(_) => self.drain_subprocess(),
+        }
+    }
 
-        while let Ok(event) = self.event_rx.try_recv() {
+    fn drain_in_process(&mut self) -> bool {
+        let mut changed = false;
+        // Captured outside the loop so we can release the `&mut self.backend`
+        // borrow before calling `dispatch_in_process` (which needs `&mut self`).
+        let mut to_dispatch: Option<String> = None;
+        let AgentBackend::InProcess(agent) = &mut self.backend else {
+            return false;
+        };
+
+        while let Ok(event) = agent.event_rx.try_recv() {
             changed = true;
             match event {
                 WorkerEvent::Chunk(text) => {
-                    if self.streaming_active {
+                    if agent.streaming_active {
                         if let Some(last) = self.transcript.last_mut() {
                             *last = format!("Agent: {text}");
                         }
                     } else {
                         self.transcript.push(format!("Agent: {text}"));
-                        self.streaming_active = true;
+                        agent.streaming_active = true;
                     }
                 }
                 WorkerEvent::ToolUse { name, input_preview } => {
@@ -290,7 +502,7 @@ impl AgentPane {
                         format!("  ↳ {name}: {input_preview}")
                     };
                     // Insert before the streaming response so tools stay above reply text.
-                    if self.streaming_active {
+                    if agent.streaming_active {
                         let idx = self.transcript.len().saturating_sub(1);
                         self.transcript.insert(idx, label);
                     } else {
@@ -299,11 +511,11 @@ impl AgentPane {
                 }
                 WorkerEvent::Done(result) => {
                     self.in_flight = false;
-                    self.streaming_active = false;
+                    agent.streaming_active = false;
                     self.needs_focus = true;
 
-                    let was_interrupting = self.interrupting;
-                    self.interrupting = false;
+                    let was_interrupting = agent.interrupting;
+                    agent.interrupting = false;
 
                     match result {
                         Ok(turn) => {
@@ -311,8 +523,8 @@ impl AgentPane {
                                 "agent_pane {}: turn ok, session={:?}",
                                 self.id, turn.session_id
                             );
-                            if !turn.session_id.is_empty() && self.session_id != turn.session_id {
-                                self.session_id = turn.session_id.clone();
+                            if !turn.session_id.is_empty() && agent.session_id != turn.session_id {
+                                agent.session_id = turn.session_id.clone();
                             }
                             // Push response text if no chunks arrived (e.g. very short reply).
                             if !self.transcript.last().map(|l| l.starts_with("Agent:")).unwrap_or(false) {
@@ -320,9 +532,9 @@ impl AgentPane {
                                     self.transcript.push(format!("Agent: {}", turn.response));
                                 }
                             }
-                            if let Some(ref dir) = self.iq_dir {
+                            if let Some(ref dir) = agent.iq_dir {
                                 save_session_file(dir, self.id, &SessionFile {
-                                    session_id: self.session_id.clone(),
+                                    session_id: agent.session_id.clone(),
                                     transcript: self.transcript.clone(),
                                 });
                             }
@@ -338,14 +550,62 @@ impl AgentPane {
                     }
 
                     // Auto-send queued message (from pending or interrupt).
-                    if let Some(pending) = self.pending_message.take() {
-                        self.dispatch(pending);
+                    // Stage outside the loop so we can drop the borrow on
+                    // `agent` before calling `dispatch_in_process` (which
+                    // re-borrows `self`).
+                    if let Some(pending) = agent.pending_message.take() {
+                        to_dispatch = Some(pending);
                     }
                 }
             }
         }
 
+        // Borrow on `agent` released — safe to dispatch.
+        if let Some(message) = to_dispatch {
+            self.dispatch_in_process(message);
+        }
+
         changed || self.in_flight
+    }
+
+    fn drain_subprocess(&mut self) -> bool {
+        let AgentBackend::Subprocess(agent) = &mut self.backend else {
+            return false;
+        };
+
+        // 1. Forward AgentInit lazily once the subprocess is Ready.
+        agent.maybe_send_init();
+
+        // 2. Pump I/O + collect AppendConversation rows.
+        let new_rows = agent.process.agent_tick();
+        let changed = !new_rows.is_empty();
+        for (role, content) in new_rows {
+            // The agent finished a turn (or part of one) — clear in-flight on
+            // any assistant row. Tool / system rows don't toggle the flag.
+            if role == "assistant" {
+                agent.in_flight = false;
+                self.in_flight = false;
+                self.needs_focus = true;
+            }
+            self.transcript.push(format_conversation_row(&role, &content));
+        }
+
+        // Repaint while a turn is in progress so the working indicator animates.
+        changed || self.in_flight
+    }
+}
+
+/// Render a `(role, content)` pair from `AppendConversation` into a transcript
+/// line that the existing UI styling matches on (You:/Agent:/  ↳ /Error:).
+/// Unknown roles fall through as plain text per the spec — forward-compat for
+/// future role kinds.
+fn format_conversation_row(role: &str, content: &str) -> String {
+    match role {
+        "user" => format_user_message(content),
+        "assistant" => format!("Agent: {content}"),
+        "tool" => format!("  ↳ {content}"),
+        "system" => format!("Error: {content}"),
+        _ => content.to_string(),
     }
 }
 
@@ -366,7 +626,7 @@ pub fn render(ui: &mut egui::Ui, pane: &mut AgentPane, colors: &Colors) {
             // ── Header ──────────────────────────────────────────────────────
             ui.horizontal(|ui| {
                 ui.label(egui::RichText::new("IQ").size(11.0).color(accent));
-                if let Some(ref dir) = pane.iq_dir {
+                if let Some(dir) = pane.iq_dir() {
                     if let Some(ws) = dir.parent().and_then(|p| p.parent()).and_then(|p| p.file_name()) {
                         ui.label(
                             egui::RichText::new(format!("  {}", ws.to_string_lossy()))
@@ -374,6 +634,14 @@ pub fn render(ui: &mut egui::Ui, pane: &mut AgentPane, colors: &Colors) {
                                 .color(dim_color),
                         );
                     }
+                } else if let AgentBackend::Subprocess(agent) = &pane.backend {
+                    // Subprocess agents have no .plexi/ session dir — show the
+                    // manifest id instead so the user knows which agent this is.
+                    ui.label(
+                        egui::RichText::new(format!("  {}", agent.manifest_id))
+                            .size(10.0)
+                            .color(dim_color),
+                    );
                 }
             });
 
@@ -392,7 +660,7 @@ pub fn render(ui: &mut egui::Ui, pane: &mut AgentPane, colors: &Colors) {
                             .italics()
                             .color(dim_color),
                     );
-                    if pane.pending_message.is_some() {
+                    if pane.pending_message_present() {
                         ui.label(
                             egui::RichText::new("· next queued")
                                 .size(10.0)
@@ -484,4 +752,146 @@ pub fn render_and_drain(ui: &mut egui::Ui, pane: &mut AgentPane, colors: &Colors
     let needs_repaint = pane.drain_results();
     render(ui, pane, colors);
     needs_repaint
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! Behavioural tests for the AgentBackend enum (issue #338, part 2 of #285).
+    //!
+    //! In-process backend regression: existing Cmd+I flow constructs an
+    //! `AgentPane` with `AgentBackend::InProcess` and never panics during
+    //! drain on a quiet event_rx.
+    //!
+    //! Subprocess backend (the new path):
+    //!   - `dispatch_subprocess` appends a "You: ..." row and queues a
+    //!     `PlexiEvent::UserMessage` on the wrapped `ProcessApp`.
+    //!   - When the subprocess emits an `AppendConversation` row, the host
+    //!     extracts it via `agent_tick()` and appends to the transcript.
+    //!
+    //! Tests don't exercise the renderer (egui isn't easy to drive headless);
+    //! we drive the data layer directly.
+    use super::*;
+    use crate::app_protocol::DrawCommand;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    /// Spawn `/bin/sh -c "sleep 1"` so the lifecycle threads are happy. We
+    /// never actually exchange real PGAP traffic with this child — every test
+    /// drives the data structures directly.
+    fn make_process_app(type_id: &str) -> Option<Box<ProcessApp>> {
+        let sh = ["/bin/sh", "/usr/bin/sh"]
+            .iter()
+            .find(|p| std::path::Path::new(p).exists())
+            .map(PathBuf::from)?;
+        let workspace_root = std::env::temp_dir();
+        let app = ProcessApp::launch(
+            type_id,
+            "Agent Test",
+            &sh,
+            &workspace_root,
+            &["-c".to_string(), "sleep 1".to_string()],
+            workspace_root.clone(),
+            HashSet::new(),
+            false,
+        )
+        .ok()?;
+        Some(Box::new(app))
+    }
+
+    #[test]
+    fn subprocess_backend_appends_conversation_on_event() {
+        // Given a subprocess-backed AgentPane, when an AppendConversation
+        // row lands in the ProcessApp's pending_frame it should surface on
+        // the transcript via `drain_results`.
+        let Some(process) = make_process_app("agent_test_append") else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        let mut pane = AgentPane::new_subprocess(
+            42,
+            process,
+            Some("You are terse.".to_string()),
+            "agent-test".to_string(),
+        );
+        // Inject the row directly into the test seam. `agent_tick()` will
+        // pull it into the transcript on the next drain.
+        if let AgentBackend::Subprocess(agent) = &mut pane.backend {
+            agent.process.test_inject_draw_command(DrawCommand::AppendConversation {
+                role: "assistant".to_string(),
+                content: "Hello!".to_string(),
+            });
+        } else {
+            panic!("expected Subprocess backend");
+        }
+
+        pane.drain_results();
+
+        assert!(
+            pane.transcript.iter().any(|line| line.contains("Hello!")),
+            "transcript must include the appended assistant content; got: {:?}",
+            pane.transcript
+        );
+        assert!(
+            pane.transcript.last().unwrap().starts_with("Agent: "),
+            "assistant row must render with the 'Agent: ' prefix"
+        );
+    }
+
+    #[test]
+    fn subprocess_backend_forwards_user_message_to_subprocess() {
+        // Given a subprocess-backed AgentPane, when the user submits text in
+        // the input box, `submit_input` must (1) append a "You: ..." row to
+        // the local transcript AND (2) queue a `PlexiEvent::UserMessage` on
+        // the ProcessApp's outbound event queue so the host writes it to the
+        // subprocess's stdin on the next flush.
+        let Some(process) = make_process_app("agent_test_user_msg") else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        let mut pane = AgentPane::new_subprocess(7, process, None, "agent-test".to_string());
+
+        pane.input_buf = "Tell me a joke.".to_string();
+        pane.submit_input();
+
+        assert!(
+            pane.transcript
+                .iter()
+                .any(|line| line == "You: Tell me a joke."),
+            "transcript must include the user message"
+        );
+        assert!(pane.in_flight, "subprocess pane must be in_flight after submit");
+        assert_eq!(pane.input_buf, "", "input buffer must clear after submit");
+
+        // Inspect the outbound event queue on the underlying ProcessApp.
+        let AgentBackend::Subprocess(agent) = &pane.backend else {
+            panic!("expected Subprocess backend");
+        };
+        let outbound = agent.process.test_outbound_events();
+        let queued: Vec<&PlexiEvent> = outbound
+            .into_iter()
+            .filter(|e| matches!(e, PlexiEvent::UserMessage { .. }))
+            .collect();
+        assert_eq!(queued.len(), 1, "exactly one UserMessage must be queued");
+        match queued[0] {
+            PlexiEvent::UserMessage { text } => assert_eq!(text, "Tell me a joke."),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn in_process_backend_unchanged_path_still_works() {
+        // Regression guard: the legacy Cmd+I flow constructs an AgentPane
+        // via `AgentPane::new(id, cwd)` and the backend must be the
+        // `InProcess` variant. `drain_results` must be safe to call on a
+        // freshly constructed pane that has done nothing yet (empty event_rx).
+        let pane = AgentPane::new(99, std::env::temp_dir());
+        assert!(matches!(pane.backend, AgentBackend::InProcess(_)));
+        // empty drain — just confirm we don't panic
+        let mut pane = pane;
+        let _ = pane.drain_results();
+        assert!(!pane.in_flight, "no turn submitted → no in_flight");
+        assert!(pane.transcript.is_empty() || pane.transcript.iter().all(|l| !l.is_empty()));
+    }
 }

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -470,6 +470,25 @@ impl AppRegistry {
             .map(|h| h.split)
     }
 
+    /// Return the manifest `[app] type` for an installed app, or `None` when
+    /// no app with this id is registered. Lets the launch path branch on
+    /// agent-vs-app rendering without re-reading the manifest from disk.
+    pub fn manifest_type(&self, app_id: &str) -> Option<ManifestType> {
+        self.apps
+            .get(app_id)
+            .map(|a| a.manifest.manifest_type)
+    }
+
+    /// Return the manifest-declared `[launch].system_prompt` for an installed
+    /// agent. Returns `None` for `type = "app"` manifests OR for agent
+    /// manifests that omit the field — both cases are forwarded as
+    /// `PlexiEvent::AgentInit { system_prompt: None }`.
+    pub fn system_prompt_for(&self, app_id: &str) -> Option<String> {
+        self.apps
+            .get(app_id)
+            .and_then(|a| a.launch.system_prompt.clone())
+    }
+
     /// Return the manifest-declared default notification scope for an app.
     /// Used by operators and the host to understand the app's intent;
     /// the actual scope is set per-notification by the app via the SDK.

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -350,6 +350,9 @@ impl PlexiApp {
     ///   "split_v" (default) — vertical split, new pane below
     ///   "split_h"           — horizontal split, new pane to the right
     ///   "overlay"           — full pane, no terminal split
+    ///
+    /// Manifests declaring `[app] type = "agent"` (#338) bypass the normal
+    /// app-canvas pane and land in `Pane::Agent` with the subprocess backend.
     pub(crate) fn launch_app_by_id_with_layout(
         &mut self,
         id: &str,
@@ -364,6 +367,26 @@ impl PlexiApp {
         let group = self.registry.group_for(id);
         let hint = layout.or_else(|| self.registry.layout_hint_for(id));
 
+        // Agent path (#338) — manifest type=agent gets the conversation UI
+        // backed by the subprocess. Background re-attach is intentionally
+        // not supported for agents in this PR (parking + resume of an
+        // active conversation is its own design problem; tracked under
+        // v3.3.5+).
+        if matches!(
+            self.registry.manifest_type(id),
+            Some(crate::app_registry::ManifestType::Agent)
+        ) {
+            if let Some(process) = self.registry.launch_process(id, &cwd, args) {
+                let system_prompt = self.registry.system_prompt_for(id);
+                self.open_subprocess_agent_pane(id, process, system_prompt);
+            } else {
+                log::warn!(
+                    "launch_app_by_id: agent '{id}' not found or failed to launch"
+                );
+            }
+            return;
+        }
+
         // Re-attach a parked background app if one is waiting
         if let Some(mut parked) = self.background_apps.remove(id) {
             log::info!("re-attaching background app '{id}'");
@@ -377,6 +400,32 @@ impl PlexiApp {
         } else {
             log::warn!("launch_app_by_id: app '{id}' not found or failed to launch");
         }
+    }
+
+    /// Open a `Pane::Agent` whose backend is the freshly launched subprocess
+    /// (#338). Vertical 1:1 split alongside the focused pane — same default as
+    /// `open_agent_pane` (Cmd+I path) for now; layout hints are deferred to
+    /// v3.3.5+ so the agent UI lands in a predictable place every time.
+    fn open_subprocess_agent_pane(
+        &mut self,
+        manifest_id: &str,
+        mut process: crate::process_app::ProcessApp,
+        system_prompt: Option<String>,
+    ) {
+        let active = self.active_context;
+        let new_id = self.host.alloc_pane_id();
+        process.set_pane_id(new_id);
+        let pane = crate::agent_pane::AgentPane::new_subprocess(
+            new_id,
+            Box::new(process),
+            system_prompt,
+            manifest_id.to_string(),
+        );
+        self.contexts[active]
+            .panes
+            .insert(new_id, Pane::Agent(Box::new(pane)));
+        let share = ShareRatio::new(1.0, 1.0).expect("1:1 is valid");
+        let _ = self.split_with_new_pane(new_id, true, share, false);
     }
 
     /// Open a new agent (Plexi IQ) pane alongside the focused terminal (Cmd+I).

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -112,7 +112,7 @@ impl PlexiApp {
                     saved_panes.push(crate::workspace::SavedPane {
                         id,
                         kind: crate::workspace::SavedPaneKind::Agent,
-                        cwd: ag.cwd.clone(),
+                        cwd: ag.cwd(),
                         name: None,
                         app_id: None,
                         app_state: None,

--- a/src/process_app/agent.rs
+++ b/src/process_app/agent.rs
@@ -1,0 +1,336 @@
+//! Agent-pane support on `ProcessApp` (issue #338, part 2 of #285).
+//!
+//! When a manifest declares `[app] type = "agent"`, the host wraps the
+//! resulting `ProcessApp` in `Pane::Agent` instead of `Pane::App`. The
+//! conversation UI in `agent_pane::render` does the rendering; this module
+//! exposes the I/O surface the agent pane needs to talk to its subprocess:
+//!
+//!   - `agent_tick()` — drain the subprocess's stdout, route any control
+//!     commands (timers, secret_get, iq.query, etc.), discard visual draw
+//!     commands (the agent pane has no canvas), and return any
+//!     `AppendConversation` rows so the pane can append them to the
+//!     transcript.
+//!   - `is_ready_for_agent_init()` — true once the subprocess has emitted
+//!     its `Ready` reply to the initial `Init` event. The pane uses this
+//!     to forward `PlexiEvent::AgentInit` exactly once at the right time.
+//!   - `queue_outbound_event_direct()` / `test_outbound_events` /
+//!     `test_inject_draw_command` — small surface for the host to push
+//!     events onto the outbound queue and for unit tests to drive the
+//!     paths deterministically without spinning up a real subprocess.
+
+use crate::app_protocol::{DrawCommand, PlexiEvent};
+
+use super::ProcessApp;
+
+#[cfg(test)]
+mod agent_tests {
+    //! Behavioural tests for the agent path on `ProcessApp` (#338).
+    //!
+    //! 1. `agent_tick` extracts `AppendConversation` rows out of the draw
+    //!    stream and returns them — they don't go through `route_command`
+    //!    or `pending_frame` (the agent pane has no canvas).
+    //! 2. The agent pane's lazy `AgentInit` send fires once `Ready` arrives,
+    //!    not before — verified via `is_ready_for_agent_init`.
+    //!
+    //! These tests bypass the real subprocess pipeline by calling
+    //! `test_inject_draw_command` to seed the draw stream. The lifecycle
+    //! / I/O threads spawned by `ProcessApp::launch` against `/bin/sh`
+    //! are inert because we never write real PGAP traffic to the child
+    //! and discard its stderr.
+    use super::*;
+    use crate::app_protocol::DrawCommand;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    fn make_app(type_id: &str) -> Option<ProcessApp> {
+        let sh = ["/bin/sh", "/usr/bin/sh"]
+            .iter()
+            .find(|p| std::path::Path::new(p).exists())
+            .map(PathBuf::from)?;
+        let workspace_root = std::env::temp_dir();
+        ProcessApp::launch(
+            type_id,
+            "Agent Test",
+            &sh,
+            &workspace_root,
+            &["-c".to_string(), "sleep 1".to_string()],
+            workspace_root.clone(),
+            HashSet::new(),
+            false,
+        )
+        .ok()
+    }
+
+    #[test]
+    fn type_agent_manifest_routes_to_subprocess_pane() {
+        // The host-level "type=agent → AgentBackend::Subprocess" wiring is
+        // exercised by the agent_pane unit tests
+        // (subprocess_backend_appends_conversation_on_event /
+        // subprocess_backend_forwards_user_message_to_subprocess), which
+        // construct a Pane with `AgentPane::new_subprocess` and prove that
+        // the data flows correctly. This test pins the contract on the
+        // ProcessApp side: a `type=agent` ProcessApp's `agent_tick` must
+        // surface AppendConversation rows on the conversation channel,
+        // not on the visual draw frame.
+        let Some(mut app) = make_app("agent_routes_test") else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        app.test_inject_draw_command(DrawCommand::AppendConversation {
+            role: "assistant".to_string(),
+            content: "ack".to_string(),
+        });
+
+        let rows = app.agent_tick();
+
+        assert_eq!(rows.len(), 1, "AppendConversation must surface as a row");
+        assert_eq!(rows[0].0, "assistant");
+        assert_eq!(rows[0].1, "ack");
+        // Must NOT have leaked into pending_frame (visual surface).
+        let leaked = app
+            .pending_frame
+            .iter()
+            .any(|c| matches!(c, DrawCommand::AppendConversation { .. }));
+        assert!(
+            !leaked,
+            "AppendConversation must not appear on the draw frame"
+        );
+    }
+
+    #[test]
+    fn agent_init_event_emitted_with_system_prompt() {
+        // Once the subprocess emits `Ready`, the `is_ready_for_agent_init`
+        // gate flips. The agent pane uses this to forward AgentInit. We
+        // verify the gate semantics directly here so changes to the
+        // readiness signal break this test instead of leaking into
+        // production.
+        let Some(mut app) = make_app("agent_init_test") else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        assert!(
+            !app.is_ready_for_agent_init(),
+            "fresh subprocess must NOT be ready for AgentInit"
+        );
+
+        app.test_inject_draw_command(DrawCommand::Ready {
+            sdk: "test".to_string(),
+            features_used: vec![],
+        });
+        // First tick processes the Ready and flips the gate.
+        let _ = app.agent_tick();
+        assert!(
+            app.is_ready_for_agent_init(),
+            "after Ready arrives, the subprocess must be ready for AgentInit"
+        );
+
+        // Direct verification that AgentInit serialises with the prompt
+        // intact. (Wire round-trip is already covered in `app_protocol::tests`.)
+        let event = PlexiEvent::AgentInit {
+            system_prompt: Some("You are terse.".to_string()),
+        };
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(
+            serialised.contains(r#""system_prompt":"You are terse.""#),
+            "AgentInit must carry the manifest's system_prompt verbatim: {serialised}"
+        );
+    }
+}
+
+impl ProcessApp {
+    /// True once the subprocess has emitted its `Ready` reply. The
+    /// `sdk` field on `ProcessApp` is set when `DrawCommand::Ready`
+    /// arrives — same signal `ui()` uses indirectly.
+    pub(crate) fn is_ready_for_agent_init(&self) -> bool {
+        self.sdk.is_some()
+    }
+
+    /// Push an event onto the outbound queue. Mirrors `App::queue_outbound_event`
+    /// but keeps the call ergonomic for code paths that hold the `ProcessApp`
+    /// directly (the agent pane does — it never goes through the `App` trait).
+    pub(crate) fn queue_outbound_event_direct(&mut self, event: PlexiEvent) {
+        self.outbound_events.push_back(event);
+    }
+
+    /// Pump one tick of agent I/O.
+    ///
+    /// Conceptually identical to `background_tick()` — drains responses, sends
+    /// queued events, drains draw commands — but with two differences:
+    ///   1. Sends `Init` lazily on the first call (subprocess agents never go
+    ///      through `ui()`, which normally owns the Init handshake).
+    ///   2. Filters `AppendConversation` out of the routing pass and returns
+    ///      them as `(role, content)` pairs so `AgentPane` can append rows.
+    ///
+    /// Returns the list of conversation rows the subprocess emitted on this
+    /// tick. Empty vec is normal — only signals "no new rows", not an error.
+    pub(crate) fn agent_tick(&mut self) -> Vec<(String, String)> {
+        // STEP-1: lazy Init. Subprocess agents don't go through `ui()` so the
+        // initialised gate that lives there never fires. Send it once here.
+        if !self.initialized {
+            self.initialized = true;
+            let cap_strings: Vec<String> = self
+                .permissions
+                .capabilities
+                .iter()
+                .map(|c| c.to_string())
+                .collect();
+            self.send_event(&PlexiEvent::Init {
+                protocol: "pgap/3".to_string(),
+                app_id: self.type_id.clone(),
+                workspace_root: self.workspace_root.clone(),
+                capabilities: cap_strings,
+                feature_flags: vec!["pane_groups_v1".into()],
+            });
+        }
+
+        // STEP-2: drain async HTTP responses from background request threads
+        // (timers land here too). Same as `ui()` does each frame.
+        while let Ok(event) = self.http_rx.try_recv() {
+            self.outbound_events.push_back(event);
+        }
+        self.flush_outbound_events_pub();
+
+        // STEP-3: drain draw commands. Pull AppendConversation rows out for
+        // return; route control commands; discard visual primitives.
+        let mut rows: Vec<(String, String)> = Vec::new();
+        for cmd in self.drain_draw_commands_pub() {
+            match cmd {
+                DrawCommand::AppendConversation { role, content } => {
+                    rows.push((role, content));
+                }
+                DrawCommand::Ready { sdk, features_used } => {
+                    self.sdk = Some(sdk);
+                    self.features_used = features_used;
+                }
+                DrawCommand::Log { level, message } => {
+                    let target = format!("app::{}", self.type_id);
+                    match level.as_str() {
+                        "error" => log::error!(target: &target, "{message}"),
+                        "warn" => log::warn!(target: &target, "{message}"),
+                        "debug" => log::debug!(target: &target, "{message}"),
+                        _ => log::info!(target: &target, "{message}"),
+                    }
+                }
+                cmd @ (DrawCommand::CapabilityRequest { .. }
+                | DrawCommand::SecretGet { .. }
+                | DrawCommand::RunGet { .. }
+                | DrawCommand::RunComplete { .. }
+                | DrawCommand::Notify { .. }
+                | DrawCommand::PipeOpen { .. }
+                | DrawCommand::PipeSend { .. }
+                | DrawCommand::StatusSummary { .. }
+                | DrawCommand::SpawnApp { .. }
+                | DrawCommand::HttpRequest { .. }
+                | DrawCommand::LlmRequest { .. }
+                | DrawCommand::IqQuery { .. }
+                | DrawCommand::AudioPlay { .. }
+                | DrawCommand::AudioCapture { .. }
+                | DrawCommand::CdRequest { .. }
+                | DrawCommand::SetTimer { .. }
+                | DrawCommand::CancelTimer { .. }) => {
+                    self.route_command(cmd);
+                }
+                // FrameDone, ScheduleRender, MeasureText, CopyToClipboard, and
+                // every visual primitive (Rect/Text/etc.) are silently
+                // discarded — agent panes have no canvas. CopyToClipboard
+                // would need a UI context anyway; if an agent ever needs it,
+                // surface a separate route.
+                _ => {}
+            }
+        }
+
+        // STEP-4: per-frame try_wait poll for lifecycle (Crashed detection).
+        // Mirrors what `ui()` does on the App-pane path.
+        if let Some(child) = self.process.as_mut() {
+            match child.try_wait() {
+                Ok(Some(_status)) => self.lifecycle.on_process_exited(),
+                Ok(None) => {}
+                Err(e) => {
+                    log::warn!(
+                        "ProcessApp[{}]: agent_tick try_wait failed: {e} — marking Crashed",
+                        self.type_id
+                    );
+                    self.lifecycle.on_process_exited();
+                }
+            }
+        }
+
+        rows
+    }
+
+    // Test seam. Inserts a synthetic DrawCommand into a channel `agent_tick`
+    // will consume, so unit tests can drive the routing layer without a real
+    // subprocess emitting bytes.
+    #[cfg(test)]
+    pub(crate) fn test_inject_draw_command(&mut self, cmd: DrawCommand) {
+        // Use the existing draw_tx → draw_rx channel by stealing the rx,
+        // creating a fresh channel, sending the command, then merging.
+        // Simpler: keep a side queue the tick reads first if non-empty.
+        // We piggyback on the existing `pending_frame` field by routing
+        // through a dedicated test queue would require a new field.
+        //
+        // Cleanest: just push directly onto a test-only side queue we add
+        // to `ProcessApp`. But adding a field for tests-only is wasteful.
+        // Instead, send through draw_tx via a tiny ephemeral plumbing —
+        // we don't have draw_tx visible here. So use a hidden field.
+        self.test_injected_commands
+            .lock()
+            .unwrap()
+            .push_back(cmd);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_outbound_events(&self) -> Vec<&PlexiEvent> {
+        self.outbound_events.iter().collect()
+    }
+}
+
+// Helpers exposing the existing private mod.rs methods to this submodule.
+// Both methods already exist on `ProcessApp` but are private to mod.rs;
+// re-exposing them here as `pub(crate)` thin shims keeps the public API
+// minimal and the existing internal helpers untouched.
+impl ProcessApp {
+    pub(crate) fn flush_outbound_events_pub(&mut self) {
+        // Drain outbound queue → stdin. Inlined — `flush_outbound_events`
+        // is `fn` (private) in mod.rs and we want a single source of truth,
+        // but Rust doesn't let one impl block call another module's private
+        // methods. The body is identical to mod.rs's `flush_outbound_events`.
+        while let Some(event) = self.outbound_events.pop_front() {
+            self.send_event(&event);
+        }
+    }
+
+    pub(crate) fn drain_draw_commands_pub(&mut self) -> Vec<DrawCommand> {
+        // First, take any test-injected commands. Always returns empty in
+        // production builds (the field is `#[cfg(test)]`-gated to keep its
+        // memory footprint zero in release).
+        #[cfg(test)]
+        let mut cmds: Vec<DrawCommand> = self
+            .test_injected_commands
+            .lock()
+            .unwrap()
+            .drain(..)
+            .collect();
+        #[cfg(not(test))]
+        let mut cmds: Vec<DrawCommand> = Vec::new();
+
+        let Some(rx) = self.draw_rx.as_ref() else {
+            return cmds;
+        };
+        loop {
+            match rx.try_recv() {
+                Ok(cmd) => cmds.push(cmd),
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    log::debug!(
+                        "ProcessApp[{}]: subprocess stdout closed during agent_tick",
+                        self.type_id
+                    );
+                    self.draw_rx = None;
+                    break;
+                }
+            }
+        }
+        cmds
+    }
+}

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -11,6 +11,7 @@
 //! - `render.rs`   — `render_draw_commands()`: paint committed frames into egui
 //! - `prompts.rs`  — `show_prompt_modal()`: capability/secret grant UI
 
+mod agent;
 mod lifecycle;
 mod prompts;
 mod render;
@@ -118,6 +119,11 @@ pub struct ProcessApp {
     /// `PlexiEvent::TextSubmitted`. Cleared on submit; the whole map is
     /// dropped when the `ProcessApp` is dropped (app close).
     pub(crate) text_input_buffers: HashMap<String, String>,
+    /// Test-only seam used by `process_app::agent` unit tests to inject
+    /// `DrawCommand`s without spinning up a real subprocess pipeline.
+    /// Drained on every `agent_tick` (and thus invisible in production).
+    #[cfg(test)]
+    pub(crate) test_injected_commands: Arc<Mutex<VecDeque<DrawCommand>>>,
 }
 
 impl ProcessApp {
@@ -322,6 +328,8 @@ impl ProcessApp {
             lifecycle: lifecycle_tracker,
             show_stderr_overlay: false,
             text_input_buffers: HashMap::new(),
+            #[cfg(test)]
+            test_injected_commands: Arc::new(Mutex::new(VecDeque::new())),
         })
     }
 


### PR DESCRIPTION
Closes #338

Builds on PR #337 (#285 part 1 — wire/schema). Legacy turn-loop deletion remains in #339.

## What changed

Lights up the `type = "agent"` manifest path end-to-end. New `AgentBackend` enum on `AgentPane` (`InProcess` legacy / `Subprocess` new); `launch_app_by_id_with_layout` branches on manifest type; `ProcessApp::agent_tick()` drains the subprocess for agent panes (control commands routed, `AppendConversation` rows surfaced, visual primitives discarded); `AgentInit` forwarded once after Ready with the manifest's `[launch].system_prompt`; `UserMessage` queued on every submit. New SDK `Agent` base class subclasses `App` and provides `append_*` helpers + auto-mirroring `self.history` for `emit.iq_query`. POC `examples/agent-tester/` (~10 lines of user code) added to `packs/core.toml`.

## Breaks if

- Manifests declaring `[app] type = "agent"` open a draw-canvas pane instead of the conversation UI (would mean the registry branch in `launch_app_by_id_with_layout` regressed).
- `AppendConversation` events from the subprocess never appear in the transcript (would mean `agent_tick` lost the row-extraction step or the pane stopped calling `drain_results`).
- The `system_prompt` from the manifest never reaches the subprocess (verify via the `agent: AgentInit received (system_prompt=set)` log line — its absence on first turn is the symptom).
- Existing apps with `type = "app"` route into `Pane::Agent` (regression — they'd render with the chat UI instead of the canvas).
- Cmd+I no longer opens the legacy in-process IQ pane (regression — the `InProcess` backend path is untouched and must continue working).

## Human verification

- [ ] Open Plexi Alpha. Run `agent-tester` from the palette. The pane opens in conversation UI mode (header `IQ  agent-tester`, message input box at bottom — no draw canvas).
- [ ] Type "Tell me a joke." into the input → press Enter. Within a few seconds, an "Agent: ..." reply appears in the transcript.
- [ ] Continue: "Now tell another." → reply uses prior context (i.e. the LLM saw the multi-turn history).
- [ ] Existing apps with `type = "app"` (e.g. `iq-query-test`, `notification-tester`, `todo`) still render normally — no regression.
- [ ] Cmd+I (or whichever keybind opens the legacy IQ pane) still works in-process — same behaviour as before this PR. Reads `~/<workspace>/.plexi/agents/iq/SOUL.md`, calls `claude -p`.
- [ ] Drop `examples/agent-tester/manifest.toml` into `~/work-test/.plexi/agents/agent-tester/`. Launch Plexi from `~/work-test/`. The agent appears in the palette as a workspace agent. Lifecycle log (`~/.plexi-alpha/plexi.log`) shows `app::agent-tester` entries.

## Test added

- `agent_pane::tests::subprocess_backend_appends_conversation_on_event` — `AppendConversation` from the subprocess surfaces on the transcript.
- `agent_pane::tests::subprocess_backend_forwards_user_message_to_subprocess` — `submit_input` queues a `PlexiEvent::UserMessage` on the wrapped `ProcessApp`.
- `agent_pane::tests::in_process_backend_unchanged_path_still_works` — Cmd+I regression guard.
- `process_app::agent::agent_tests::type_agent_manifest_routes_to_subprocess_pane` — `agent_tick` extracts `AppendConversation` rows out of the draw stream (not into `pending_frame`).
- `process_app::agent::agent_tests::agent_init_event_emitted_with_system_prompt` — `is_ready_for_agent_init` flips after `Ready`; `AgentInit` round-trips the prompt.
- `examples/agent-tester/tests/test_agent.py::test_agent_class_stores_system_prompt_from_agent_init`
- `examples/agent-tester/tests/test_agent.py::test_agent_class_appends_user_message_on_user_event`
- `examples/agent-tester/tests/test_agent.py::test_agent_class_calls_on_user_message_override`
- `examples/agent-tester/tests/test_agent.py::test_agent_class_appends_assistant_message_after_override_returns`

`cargo test --bin plexi`: 119 passing (was 114). All 4 Python tests pass.

## Out of scope (deferred)

- Tool-calling from agents (broker rejects `tools`; substrate is in place).
- Streaming responses inside the conversation UI (single response per turn).
- Conversation history persistence across restarts.
- Multi-pane shared agent context.
- Legacy IQ pane migration to subprocess (#339).
- `plexi app new --type agent` scaffolder. The existing `plexi app init` is broken on its own (writes manifests without `schema_version` or `type`); orthogonal bug, separate issue.