### PR TITLE
feat(agents): roster + inter-agent directed pipes (#286)

### DIFF
--- a/examples/agent-coordinator/agent_coordinator.py
+++ b/examples/agent-coordinator/agent_coordinator.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Agent Coordinator — POC for #286 (agent roster + inter-agent pipes).
+
+Demonstrates the full delegation loop end-to-end:
+
+  1. User submits a message in the coordinator's pane.
+  2. Coordinator calls `list_agents()` to find a `agent-worker` peer.
+  3. Coordinator opens a directed JSON pipe to the worker's pane.
+  4. Coordinator sends `{ request_id, prompt }` over the pipe.
+  5. Worker receives it, calls `iq.query`, replies on the same pipe.
+  6. Coordinator's `on_pipe_message` handler unblocks the waiting queue;
+     the response surfaces in the coordinator's conversation history.
+
+Both panes log the exchange in their own surfaces — open them side by
+side to watch the round-trip happen.
+
+The delegation runs on a background thread so the SDK's stdin event
+loop stays free to dispatch the worker's `pipe_message` reply back into
+`on_pipe_message`. `respond` returns `None` (manual append mode) and
+the worker thread does the final `append_assistant_message` itself.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+import uuid
+
+from plexi_sdk import Agent
+
+
+WORKER_APP_ID = "agent-worker"
+PIPE_REPLY_TIMEOUT_S = 30.0
+
+
+class AgentCoordinator(Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        # Open pipe handles keyed on pipe_id so we can re-use one channel
+        # across multiple delegations to the same worker.
+        self._open_pipes: dict[str, object] = {}
+        # Pending replies keyed on (pipe_id, request_id) — the worker
+        # echoes our request_id back so we correlate concurrent
+        # delegations on the same pipe.
+        self._pending_replies: dict[tuple[str, str], queue.Queue] = {}
+
+    # ── Delegation core ─────────────────────────────────────────────────────
+    def respond(self, text: str) -> str | None:
+        # Run the full delegation off the stdin loop so `on_pipe_message`
+        # callbacks can fire while we wait for the worker's reply.
+        threading.Thread(
+            target=self._delegate, args=(text,), daemon=True
+        ).start()
+        # Manual-append mode — the thread will append the assistant row.
+        return None
+
+    def _delegate(self, text: str) -> None:
+        try:
+            roster = self.list_agents()
+            worker = next((a for a in roster if a.app_id == WORKER_APP_ID), None)
+            if worker is None:
+                self.append_tool_message(
+                    f"no '{WORKER_APP_ID}' in roster — open one in another pane and try again. "
+                    f"roster={[a.app_id for a in roster]}"
+                )
+                self.append_assistant_message(
+                    f"I couldn't find an `{WORKER_APP_ID}` agent in the workspace. "
+                    f"Open one in another pane and try again."
+                )
+                return
+
+            self.append_tool_message(
+                f"found {worker.app_id} on pane {worker.pane_id} — opening directed pipe"
+            )
+
+            pipe_id = f"coord-{worker.pane_id}"
+            if pipe_id not in self._open_pipes:
+                self._open_pipes[pipe_id] = self.open_pipe_to(
+                    worker.pane_id, pipe_id=pipe_id
+                )
+                self.append_tool_message(f"opened pipe '{pipe_id}'")
+
+            request_id = str(uuid.uuid4())
+            reply_q: queue.Queue = queue.Queue()
+            self._pending_replies[(pipe_id, request_id)] = reply_q
+
+            self._open_pipes[pipe_id].send(  # type: ignore[attr-defined]
+                {"request_id": request_id, "prompt": text}
+            )
+            self.append_tool_message(f"delegated to {worker.app_id}: {text[:80]}")
+
+            try:
+                content = reply_q.get(timeout=PIPE_REPLY_TIMEOUT_S)
+            except queue.Empty:
+                self._pending_replies.pop((pipe_id, request_id), None)
+                self.append_assistant_message(
+                    f"Worker timed out after {PIPE_REPLY_TIMEOUT_S:.0f}s."
+                )
+                return
+
+            self.append_assistant_message(f"Worker replied: {content}")
+        except Exception as e:  # noqa: BLE001
+            self.append_system_message(f"Coordinator: delegation failed: {e}")
+
+    # ── Wire-up ─────────────────────────────────────────────────────────────
+    def on_pipe_message(self, ctx, pipe_id: str, payload):  # noqa: ANN001
+        del ctx
+        if not isinstance(payload, dict):
+            self.append_system_message(
+                f"Coordinator: ignoring non-dict payload on pipe '{pipe_id}'"
+            )
+            return
+        request_id = str(payload.get("request_id", ""))
+        content = str(payload.get("content", ""))
+        q = self._pending_replies.pop((pipe_id, request_id), None)
+        if q is not None:
+            q.put(content)
+        else:
+            self.append_system_message(
+                f"Coordinator: stray pipe message on '{pipe_id}' "
+                f"(request_id={request_id!r}, no waiter)"
+            )
+
+
+if __name__ == "__main__":
+    AgentCoordinator().run()

--- a/examples/agent-coordinator/manifest.toml
+++ b/examples/agent-coordinator/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "agent-coordinator"
+type = "agent"
+name = "Agent Coordinator"
+version = "0.1.0"
+description = "POC for #286 — coordinator agent that discovers worker agents via the roster and delegates over inter-agent pipes."
+entry = "agent_coordinator.py"
+
+[app.capabilities]
+capabilities = ["iq.query", "pipe.open", "agents.list"]
+
+[launch]
+system_prompt = "You coordinate work across other agents. When the user asks you to delegate, use the agent roster to find a worker agent and open a pipe to it. Reply concisely after collecting the worker's response."

--- a/examples/agent-worker/agent_worker.py
+++ b/examples/agent-worker/agent_worker.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Agent Worker — POC for #286 (agent roster + inter-agent pipes).
+
+A simple worker agent that listens for delegated requests on a directed
+JSON pipe opened by a coordinator agent. The worker:
+
+  1. Receives `PipeMessage { request_id, prompt }` on the pipe.
+  2. Calls `iq.query` with the prompt as the user message.
+  3. Sends `{ request_id, content }` back on the same pipe.
+  4. Logs the exchange in its own conversation history surface so the
+     user sees the round-trip happen.
+
+Both pipe-receive and direct-user paths run their `iq.query` calls on
+a background thread so the SDK stdin loop stays free.
+"""
+from __future__ import annotations
+
+import threading
+
+from plexi_sdk import Agent
+
+
+class AgentWorker(Agent):
+    def respond(self, text: str) -> str | None:
+        # Direct user messages — handle off the stdin loop.
+        del text  # captured by self.history[-1]
+
+        def runner() -> None:
+            try:
+                response = self.emit.iq_query(
+                    model_tier="low",
+                    system=self.system_prompt or "",
+                    messages=self.history,
+                )
+                self.append_assistant_message(response.content)
+            except Exception as e:  # noqa: BLE001
+                self.append_system_message(f"Worker iq_query failed: {e}")
+
+        threading.Thread(target=runner, daemon=True).start()
+        return None  # Manual-append mode.
+
+    def on_pipe_message(self, ctx, pipe_id: str, payload):  # noqa: ANN001
+        del ctx
+        if not isinstance(payload, dict):
+            self.append_system_message(
+                f"Worker: ignoring non-dict payload on pipe '{pipe_id}'"
+            )
+            return
+        request_id = str(payload.get("request_id", ""))
+        prompt = str(payload.get("prompt", ""))
+        if not prompt:
+            self.append_system_message(
+                f"Worker: empty prompt on pipe '{pipe_id}' — ignoring"
+            )
+            return
+        self.append_tool_message(f"received delegated request: {prompt[:80]}")
+
+        # Run the iq.query off the stdin loop so further pipe messages can
+        # land while we're waiting on the LLM. The reply goes back on the
+        # same pipe — host's directed-pipe table scopes the route.
+        def runner() -> None:
+            try:
+                response = self.emit.iq_query(
+                    model_tier="low",
+                    system=self.system_prompt or "",
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                self.append_assistant_message(response.content)
+                self.emit.pipe_send(pipe_id, {
+                    "request_id": request_id,
+                    "content": response.content,
+                })
+            except Exception as e:  # noqa: BLE001
+                self.append_system_message(f"Worker iq_query failed: {e}")
+
+        threading.Thread(target=runner, daemon=True).start()
+
+
+if __name__ == "__main__":
+    AgentWorker().run()

--- a/examples/agent-worker/manifest.toml
+++ b/examples/agent-worker/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "agent-worker"
+type = "agent"
+name = "Agent Worker"
+version = "0.1.0"
+description = "POC for #286 — focused worker agent that replies to delegated requests over inter-agent pipes."
+entry = "agent_worker.py"
+
+[app.capabilities]
+capabilities = ["iq.query", "pipe.open"]
+
+[launch]
+system_prompt = "You are a focused, terse worker agent. You receive delegated requests from a coordinator agent over a JSON pipe. Reply in one sentence, plain text only."

--- a/packs/core.toml
+++ b/packs/core.toml
@@ -57,3 +57,17 @@ version = "1.0.0"
 id      = "agent-tester"
 source  = "local:agent-tester"
 version = "0.1.0"
+
+# Agent roster + inter-agent pipes POCs (#286 / v3.3 P2). Open both
+# panes, ask the coordinator to delegate to the worker, and watch the
+# round-trip surface in both conversation histories. Requires
+# ANTHROPIC_API_KEY in the Plexi secrets store.
+[[app]]
+id      = "agent-coordinator"
+source  = "local:agent-coordinator"
+version = "0.1.0"
+
+[[app]]
+id      = "agent-worker"
+source  = "local:agent-worker"
+version = "0.1.0"

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -428,6 +428,22 @@ class MidiDeviceList:
     inputs: list[MidiPortInfo]
     outputs: list[MidiPortInfo]
 
+
+# ── agents.list (#286) types ──────────────────────────────────────────────────
+
+@dataclass
+class AgentInfo:
+    """One row of the agent roster returned by `Emitter.agent_roster`.
+
+    `pane_id` is the host's stable id for the agent pane; pass it to
+    `Emitter.pipe_open_directed(pipe_id, pane_id)` to wire an inter-agent
+    channel. `app_id` is the manifest id for subprocess agents (or the
+    sentinel `"iq"` for the legacy in-process Cmd+I agent backend).
+    """
+    pane_id: int
+    app_id: str
+    name: str
+
 # ── Theme constants ───────────────────────────────────────────────────────────
 TITLE   = 22.0; HEADING = 18.0; BODY = 15.0; CAPTION = 13.0; HINT = 12.0
 MONO_BODY = 14.0; MONO_SMALL = 12.0
@@ -860,6 +876,66 @@ class Emitter:
         _emit({"type": "pipe_open", "pipe_id": pipe_id,
                "mode": mode, "direction": direction})
         return p
+
+    def pipe_open_directed(self, pipe_id: str, target_pane_id: int) -> "Pipe":
+        """Open a *directed* JSON pipe to one specific target pane (#286).
+
+        Mirrors `pipe_open` but the host scopes `PipeMessage` delivery so
+        only the caller and `target_pane_id` see traffic on `pipe_id` —
+        peers that coincidentally `pipe_open` the same id stay isolated.
+        Always JSON-mode duplex; `pipe.send(payload)` is symmetric on
+        either end. Used to wire inter-agent channels after discovering
+        a target via `emit.agent_roster()`.
+
+        Capability: `pipe.open` (same as `pipe_open`). The target pane
+        does NOT need `agents.list` to be subscribed — only to be
+        addressable via the roster.
+        """
+        p = Pipe(pipe_id=pipe_id, mode="json", direction="duplex", app=self._app)
+        self._app._pipes[pipe_id] = p
+        _emit({
+            "type": "pipe_open_directed",
+            "pipe_id": pipe_id,
+            "target_pane_id": int(target_pane_id),
+        })
+        return p
+
+    def pipe_send(self, pipe_id: str, payload: Any) -> None:
+        """Send a JSON payload on an already-open pipe by id (#286).
+
+        Use this when you don't own a `Pipe` handle locally — for example
+        when replying on a directed pipe a *peer* opened (you're the target;
+        the host subscribed you, but the SDK doesn't auto-build a handle).
+        Sends a `pipe_send` DrawCommand; the host routes per the existing
+        directed-pipe pair table.
+        """
+        _emit({"type": "pipe_send", "pipe_id": pipe_id, "payload": payload})
+
+    def agent_roster(self) -> "list[AgentInfo]":
+        """Blocking query for live agent panes in the workspace (#286).
+
+        Returns a list of `AgentInfo` rows sorted by `pane_id` ascending.
+        Each row carries `pane_id`, `app_id`, and `name`. Pass the
+        `pane_id` back to `pipe_open_directed(...)` to address an
+        inter-agent pipe.
+
+        Capability: `agents.list`. Apps without it receive an EMPTY
+        list (NOT an error) — the host returns an empty roster on the
+        wire so the caller can't probe the workspace via this surface.
+        """
+        req_id = str(uuid.uuid4())
+        q: "queue.Queue[list[dict]]" = queue.Queue()
+        self._app._pending_agent_roster[req_id] = q
+        _emit({"type": "agent_roster_get", "request_id": req_id})
+        rows = q.get()
+        return [
+            AgentInfo(
+                pane_id=int(r.get("pane_id", 0)),
+                app_id=str(r.get("app_id", "")),
+                name=str(r.get("name", "")),
+            )
+            for r in rows
+        ]
 
 
 # ── Pipe ──────────────────────────────────────────────────────────────────────
@@ -1316,6 +1392,9 @@ class App:
         # v3.4 CoreMIDI (#320): blocks on PlexiEvent::MidiDevicesListed keyed
         # on request_id. Each entry is consumed by a single list_midi_devices().
         self._pending_midi_devices: dict[str, queue.Queue] = {}
+        # v3.3 P2 agents.list (#286): blocks on PlexiEvent::AgentRoster keyed
+        # on request_id. Each entry is consumed by a single agent_roster() call.
+        self._pending_agent_roster: dict[str, queue.Queue] = {}
         self._pending_notify: dict[str, queue.Queue] = {}
         self._pipes: dict[str, Pipe] = {}
         self._last_render_time: float | None = None
@@ -1563,6 +1642,17 @@ class App:
                     f"error={ev.get('error')}"
                 )
 
+            elif t == "agent_roster":
+                # v3.3 P2 agents.list (#286). The `agents` field is always
+                # a list (empty when the app lacks the `agents.list`
+                # capability — the host returns an empty roster, not an
+                # error). Forwarded as-is to the queue waiting in
+                # `Emitter.agent_roster`.
+                req_id = ev.get("request_id", "")
+                q = self._pending_agent_roster.pop(req_id, None)
+                if q:
+                    q.put(ev.get("agents", []) or [])
+
             elif t == "notify_action":
                 # notify_choice / notify_input: put the value back.
                 # notify / notify_and_wait: put action_label back.
@@ -1731,3 +1821,38 @@ class Agent(App):
     def append_system_message(self, text: str) -> None:
         """Append a system / error status row. NOT mirrored into history."""
         _emit({"type": "append_conversation", "role": "system", "content": text})
+
+    # ── Inter-agent helpers (#286) ──────────────────────────────────────────
+    def list_agents(self) -> "list[AgentInfo]":
+        """Blocking helper — returns the workspace's live agent roster.
+
+        Thin wrapper around `self.emit.agent_roster()`. Apps without the
+        `agents.list` capability receive an EMPTY list (not an error).
+
+        Pass an entry's `pane_id` to `open_pipe_to(pane_id, ...)` to start
+        an inter-agent channel.
+        """
+        return self.emit.agent_roster()
+
+    def open_pipe_to(self, pane_id: int, pipe_id: "str | None" = None) -> Pipe:
+        """Open a duplex JSON pipe to another agent pane (#286).
+
+        `pipe_id` defaults to a fresh uuid4 — pass an explicit id only when
+        both ends agreed on one out-of-band. The pipe is duplex; either
+        side calls `pipe.send(payload)` and the other receives it via
+        `on_pipe_message(ctx, pipe_id, payload)`.
+
+        Capability: `pipe.open`.
+        """
+        pid = pipe_id or f"agent-{uuid.uuid4()}"
+        return self.emit.pipe_open_directed(pid, int(pane_id))
+
+    def on_pipe_message(self, ctx: RenderContext, pipe_id: str, payload: Any) -> None:
+        """Override to receive directed inter-agent messages.
+
+        The default `App.on_pipe_message` is a no-op. Override on `Agent`
+        subclasses that act as workers / fan-out targets to handle
+        delegated requests.
+        """
+        # Same default as App.on_pipe_message — overridable by subclasses.
+        del ctx, pipe_id, payload

--- a/src/agent_pane.rs
+++ b/src/agent_pane.rs
@@ -29,7 +29,8 @@
 /// Large pastes (>300 chars or multiline) appear collapsed in the transcript as
 /// "You: [pasted text — N chars]" — the full text is still sent to the agent.
 use crate::agent_turn::{self, WorkerEvent};
-use crate::app_protocol::PlexiEvent;
+use crate::app_protocol::{AgentInfo, PlexiEvent};
+use crate::pane::Pane;
 use crate::process_app::ProcessApp;
 use crate::theme::Colors;
 use crate::tiling::PaneId;
@@ -754,6 +755,43 @@ pub fn render_and_drain(ui: &mut egui::Ui, pane: &mut AgentPane, colors: &Colors
     needs_repaint
 }
 
+// ── Roster enumeration (#286) ────────────────────────────────────────────────
+
+/// Walk a workspace's pane container and surface every `Pane::Agent` as an
+/// `AgentInfo` row. Used by `DrawCommand::AgentRosterGet` routing.
+///
+/// `name` resolves to the agent's manifest id for `Subprocess` backends and
+/// to a stable `"iq"` string for the legacy `InProcess` (Cmd+I) backend, which
+/// has no manifest. The legacy backend is intentionally included — agents
+/// can still address it via directed pipes.
+///
+/// Output ordering is `pane_id` ascending so the snapshot is reproducible
+/// across calls (and across test runs).
+pub fn enumerate_agents<'a, I>(panes: I) -> Vec<AgentInfo>
+where
+    I: IntoIterator<Item = &'a Pane>,
+{
+    let mut rows: Vec<AgentInfo> = panes
+        .into_iter()
+        .filter_map(|pane| pane.as_agent())
+        .map(|agent| {
+            let (app_id, name) = match &agent.backend {
+                AgentBackend::InProcess(_) => ("iq".to_string(), "IQ".to_string()),
+                AgentBackend::Subprocess(sub) => {
+                    (sub.manifest_id.clone(), sub.manifest_id.clone())
+                }
+            };
+            AgentInfo {
+                pane_id: agent.id,
+                app_id,
+                name,
+            }
+        })
+        .collect();
+    rows.sort_by_key(|a| a.pane_id);
+    rows
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -878,6 +916,49 @@ mod tests {
             PlexiEvent::UserMessage { text } => assert_eq!(text, "Tell me a joke."),
             _ => unreachable!(),
         }
+    }
+
+    // ── Roster enumeration (#286) ────────────────────────────────────────
+
+    #[test]
+    fn enumerate_agents_walks_pane_tree() {
+        // Construct a mixed pane container: one agent + (notionally) some
+        // non-agent panes. `enumerate_agents` must skip the non-agents and
+        // surface only the `Pane::Agent` entries with stable name/app_id.
+        // We can't easily construct a `Pane::Terminal` or `Pane::App` here
+        // without a full host harness, so we test with two agents and
+        // assert the right shape (and rely on the `as_agent()` filter to
+        // skip non-agents in production).
+        let pane1 = Pane::Agent(Box::new(AgentPane::new(11, std::env::temp_dir())));
+        let pane2 = Pane::Agent(Box::new(AgentPane::new(7, std::env::temp_dir())));
+        let panes = vec![pane1, pane2];
+        let roster = enumerate_agents(panes.iter());
+        assert_eq!(roster.len(), 2, "roster should include both agents");
+        // Both are InProcess legacy panes — same name/app_id pair.
+        for row in &roster {
+            assert_eq!(row.app_id, "iq");
+            assert_eq!(row.name, "IQ");
+        }
+    }
+
+    #[test]
+    fn enumerate_agents_returns_stable_order() {
+        // Insertion-order independence — roster must be sorted by pane_id
+        // ascending so consumers can rely on a deterministic snapshot.
+        let pane_a = Pane::Agent(Box::new(AgentPane::new(99, std::env::temp_dir())));
+        let pane_b = Pane::Agent(Box::new(AgentPane::new(2, std::env::temp_dir())));
+        let pane_c = Pane::Agent(Box::new(AgentPane::new(50, std::env::temp_dir())));
+        let panes = vec![pane_a, pane_b, pane_c];
+        let roster = enumerate_agents(panes.iter());
+        let ids: Vec<u64> = roster.iter().map(|r| r.pane_id).collect();
+        assert_eq!(ids, vec![2, 50, 99], "roster must sort by pane_id ascending");
+    }
+
+    #[test]
+    fn enumerate_agents_empty_when_no_agents() {
+        let panes: Vec<Pane> = vec![];
+        let roster = enumerate_agents(panes.iter());
+        assert!(roster.is_empty(), "no agents → empty roster");
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -50,17 +50,35 @@ impl PlexiApp {
         let mut per_pane: Vec<(usize, u64, String, Vec<AppCommand>)> = Vec::new();
         for (ctx_idx, context) in self.contexts.iter_mut().enumerate() {
             for (pane_id, pane) in context.panes.iter_mut() {
-                let Some(app_pane) = pane.as_app_mut() else { continue };
-                // Active-context panes are already fully updated by ui() this frame.
-                // Non-active panes need a headless tick so their timer/async events
-                // reach the subprocess and control commands (notifications, etc.) flow out.
-                if ctx_idx != active {
-                    app_pane.runtime.background_tick();
+                if let Some(app_pane) = pane.as_app_mut() {
+                    // Active-context panes are already fully updated by ui()
+                    // this frame. Non-active panes need a headless tick so
+                    // timer/async events reach the subprocess and control
+                    // commands flow out.
+                    if ctx_idx != active {
+                        app_pane.runtime.background_tick();
+                    }
+                    let type_id = app_pane.runtime.type_id().to_string();
+                    let cmds = app_pane.runtime.take_pending_commands();
+                    if !cmds.is_empty() {
+                        per_pane.push((ctx_idx, *pane_id, type_id, cmds));
+                    }
+                    continue;
                 }
-                let type_id = app_pane.runtime.type_id().to_string();
-                let cmds = app_pane.runtime.take_pending_commands();
-                if !cmds.is_empty() {
-                    per_pane.push((ctx_idx, *pane_id, type_id, cmds));
+                // Subprocess agent panes (#286) — the agent emits AppCommands
+                // (e.g. AgentRosterGet, OpenDirectedPipe, DeliverPipeMessage)
+                // through its inner ProcessApp. Drain those here so the host
+                // dispatch loop sees them.
+                if let Some(agent_pane) = pane.as_agent_mut() {
+                    if let crate::agent_pane::AgentBackend::Subprocess(sub) =
+                        &mut agent_pane.backend
+                    {
+                        let type_id = sub.manifest_id.clone();
+                        let cmds = std::mem::take(&mut sub.process.pending_commands);
+                        if !cmds.is_empty() {
+                            per_pane.push((ctx_idx, *pane_id, type_id, cmds));
+                        }
+                    }
                 }
             }
         }
@@ -78,6 +96,8 @@ impl PlexiApp {
                 match cmd {
                     AppCommand::SpawnApp { .. }
                     | AppCommand::DeliverPipeMessage { .. }
+                    | AppCommand::OpenDirectedPipe { .. }
+                    | AppCommand::AgentRosterGet { .. }
                     | AppCommand::DeliverRunUpdate { .. } => deferred.push(cmd),
                     AppCommand::CdRequest { cwd, .. } => {
                         deferred.push(AppCommand::CdRequest { cwd, sender_pane_id: pane_id });

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -127,6 +127,12 @@ pub struct PlexiApp {
     /// Parked background ProcessApps — kept alive when their pane is closed.
     /// Keyed by app type_id. Re-attached by B3 when the app is reopened.
     pub(crate) background_apps: HashMap<String, Box<crate::process_app::ProcessApp>>,
+    /// Directed inter-agent / inter-app pipes (#286). Keyed by `pipe_id`,
+    /// value is the `(sender_pane_id, target_pane_id)` pair the host must
+    /// scope `PipeMessage` deliveries to. `DeliverPipeMessage` consults this
+    /// map first: hits route ONLY to the non-sender member of the pair;
+    /// misses fall back to the legacy peer-broadcast (`has_reader`) path.
+    pub(crate) directed_pipes: HashMap<String, (u64, u64)>,
 }
 
 impl PlexiApp {
@@ -366,6 +372,7 @@ impl PlexiApp {
                     host,
                     host_services: crate::host::services::HostServices::new(),
                     background_apps: HashMap::new(),
+                    directed_pipes: HashMap::new(),
                 };
             }
         }
@@ -438,6 +445,7 @@ impl PlexiApp {
             host: crate::host::model::HostModel::new(),
             host_services: crate::host::services::HostServices::new(),
             background_apps: HashMap::new(),
+            directed_pipes: HashMap::new(),
         }
     }
 
@@ -869,6 +877,41 @@ impl eframe::App for PlexiApp {
                 }
                 AppCommand::DeliverPipeMessage { sender_pane_id, pipe_id, payload } => {
                     let active = self.active_context;
+                    // Directed pipe (#286) — only the non-sender member of
+                    // the pair receives. Falls through to the legacy peer
+                    // broadcast when the pipe was not opened directed.
+                    if let Some(&(a, b)) = self.directed_pipes.get(&pipe_id) {
+                        let target_pid = if sender_pane_id == a {
+                            Some(b)
+                        } else if sender_pane_id == b {
+                            Some(a)
+                        } else {
+                            // Neither side — wire mismatch. Log + drop.
+                            log::warn!(
+                                "DeliverPipeMessage: directed pipe '{pipe_id}' \
+                                 sender {sender_pane_id} not in pair ({a}, {b}); dropping"
+                            );
+                            None
+                        };
+                        if let Some(tid) = target_pid {
+                            if let Some(pane) = self.contexts[active].panes.get_mut(&tid) {
+                                let event = crate::app_protocol::PlexiEvent::PipeMessage {
+                                    pipe_id: pipe_id.clone(),
+                                    payload: payload.clone(),
+                                };
+                                if let Some(app) = pane.as_app_mut() {
+                                    app.runtime.queue_outbound_event(event);
+                                } else if let Some(agent) = pane.as_agent_mut() {
+                                    if let crate::agent_pane::AgentBackend::Subprocess(sub) =
+                                        &mut agent.backend
+                                    {
+                                        sub.process.queue_outbound_event_direct(event);
+                                    }
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     let pane_ids: Vec<_> = self.contexts[active].panes.keys().copied().collect();
                     for pid in pane_ids {
                         if pid == sender_pane_id {
@@ -895,6 +938,78 @@ impl eframe::App for PlexiApp {
                                         },
                                     );
                                 }
+                            }
+                        }
+                    }
+                }
+                AppCommand::OpenDirectedPipe {
+                    sender_pane_id,
+                    pipe_id,
+                    target_pane_id,
+                } => {
+                    // Subscribe both sides + record the pair so subsequent
+                    // `DeliverPipeMessage` for this pipe routes ONLY between
+                    // them (#286). The sender already registered the pipe
+                    // locally inside its own ProcessApp; we need to register
+                    // it on the target so its `has_reader` returns true and
+                    // its SDK has a Pipe handle if it sends in reverse.
+                    let active = self.active_context;
+                    let target_kind = self.contexts[active]
+                        .panes
+                        .get(&target_pane_id)
+                        .map(|p| match p {
+                            crate::pane::Pane::Agent(_) => "agent",
+                            crate::pane::Pane::App(_) => "app",
+                            crate::pane::Pane::Terminal(_) => "terminal",
+                        });
+                    match target_kind {
+                        Some("agent") | Some("app") => {
+                            // Register pipe on target's registry so it can
+                            // PipeSend back through the same id.
+                            let registered = if let Some(pane) =
+                                self.contexts[active].panes.get_mut(&target_pane_id)
+                            {
+                                register_directed_pipe_on_target(pane, &pipe_id)
+                            } else {
+                                false
+                            };
+                            if !registered {
+                                log::warn!(
+                                    "OpenDirectedPipe: failed to register '{pipe_id}' on target {target_pane_id}"
+                                );
+                                continue;
+                            }
+                            self.directed_pipes
+                                .insert(pipe_id.clone(), (sender_pane_id, target_pane_id));
+                            log::info!(
+                                "OpenDirectedPipe: '{pipe_id}' subscribed pane {sender_pane_id} ↔ pane {target_pane_id}"
+                            );
+                        }
+                        Some(other) => log::warn!(
+                            "OpenDirectedPipe: target {target_pane_id} is a {other}; expected agent/app — pipe '{pipe_id}' not subscribed"
+                        ),
+                        None => log::warn!(
+                            "OpenDirectedPipe: target pane {target_pane_id} not found; pipe '{pipe_id}' dropped"
+                        ),
+                    }
+                }
+                AppCommand::AgentRosterGet { sender_pane_id, request_id } => {
+                    let active = self.active_context;
+                    let agents = crate::agent_pane::enumerate_agents(
+                        self.contexts[active].panes.values(),
+                    );
+                    let event = crate::app_protocol::PlexiEvent::AgentRoster {
+                        request_id,
+                        agents,
+                    };
+                    if let Some(pane) = self.contexts[active].panes.get_mut(&sender_pane_id) {
+                        if let Some(app) = pane.as_app_mut() {
+                            app.runtime.queue_outbound_event(event);
+                        } else if let Some(agent) = pane.as_agent_mut() {
+                            if let crate::agent_pane::AgentBackend::Subprocess(sub) =
+                                &mut agent.backend
+                            {
+                                sub.process.queue_outbound_event_direct(event);
                             }
                         }
                     }
@@ -1725,6 +1840,47 @@ impl PlexiApp {
             }
         } else {
             raw
+        }
+    }
+}
+
+// ── Directed pipe helpers (#286) ─────────────────────────────────────────────
+
+/// Register a duplex JSON pipe on the target pane's typed-pipe registry so
+/// `has_reader` returns `true` and the SDK can `pipe_send` back through the
+/// same id. Returns `true` on success, `false` if the target pane has no
+/// process-app registry to register against (terminals — should never reach
+/// this path; logged at the call site).
+fn register_directed_pipe_on_target(pane: &mut crate::pane::Pane, pipe_id: &str) -> bool {
+    use crate::typed_pipes::PipeDirection;
+    let registry = match pane {
+        crate::pane::Pane::App(app) => match &app.runtime {
+            crate::pane::AppRuntime::Process(pa) => Some(pa.pipe_registry.clone()),
+            crate::pane::AppRuntime::Builtin(_) => None,
+        },
+        crate::pane::Pane::Agent(agent) => match &agent.backend {
+            crate::agent_pane::AgentBackend::Subprocess(sub) => {
+                Some(sub.process.pipe_registry.clone())
+            }
+            crate::agent_pane::AgentBackend::InProcess(_) => None,
+        },
+        crate::pane::Pane::Terminal(_) => None,
+    };
+    let Some(registry) = registry else {
+        return false;
+    };
+    let result = registry
+        .lock()
+        .unwrap()
+        .open_json(pipe_id.to_string(), PipeDirection::Duplex);
+    match result {
+        Ok(()) => true,
+        // Already open is acceptable — agents may have called `pipe_open` or
+        // received a prior directed pipe with the same id; treat as success.
+        Err(crate::typed_pipes::PipeError::AlreadyOpen(_)) => true,
+        Err(e) => {
+            log::warn!("register_directed_pipe_on_target: open_json failed: {e}");
+            false
         }
     }
 }

--- a/src/app_permissions.rs
+++ b/src/app_permissions.rs
@@ -51,6 +51,11 @@ pub enum Capability {
     /// host CoreMIDI broker (#320). Per-port; the SendMidi dispatch validates
     /// the gate.
     MidiOut,
+    /// Query the workspace-scoped agent roster (`agents.list`, #286). Allows an
+    /// app to discover other live agent panes via `DrawCommand::AgentRosterGet`.
+    /// Apps without this capability receive an EMPTY roster (per spec) — not
+    /// a denial error. Pair with `pipe.open` to open directed inter-agent pipes.
+    AgentsList,
 }
 
 impl fmt::Display for Capability {
@@ -76,6 +81,7 @@ impl Capability {
             Self::IqQuery => "iq.query",
             Self::MidiIn => "midi.in",
             Self::MidiOut => "midi.out",
+            Self::AgentsList => "agents.list",
         }
     }
 }
@@ -113,6 +119,7 @@ impl<'a> TryFrom<&'a str> for Capability {
             "iq.query" => Ok(Self::IqQuery),
             "midi.in" => Ok(Self::MidiIn),
             "midi.out" => Ok(Self::MidiOut),
+            "agents.list" => Ok(Self::AgentsList),
             other => Err(UnknownCapability(other.to_string())),
         }
     }
@@ -222,6 +229,29 @@ mod tests {
         );
         assert!(matches!(
             check(&perms, Capability::IqQuery),
+            PermissionCheck::Allowed
+        ));
+    }
+
+    #[test]
+    fn agents_list_capability_recognized() {
+        // The new v3.3 P2 capability (#286) must round-trip through
+        // `Capability::try_from` / `as_str` and end up in the granted set
+        // when declared. Note: the *runtime* contract for an undeclared
+        // `agents.list` is "empty roster" (not denial) — that is enforced
+        // in the routing layer, not here. This test pins only the parser
+        // layer recognising the capability string.
+        let parsed = Capability::try_from("agents.list").expect("agents.list must parse");
+        assert_eq!(parsed, Capability::AgentsList);
+        assert_eq!(parsed.as_str(), "agents.list");
+
+        let perms = AppPermissions::from_capability_strings(&["agents.list".to_string()]);
+        assert!(
+            perms.capabilities.contains(&Capability::AgentsList),
+            "agents.list must end up in granted capabilities"
+        );
+        assert!(matches!(
+            check(&perms, Capability::AgentsList),
             PermissionCheck::Allowed
         ));
     }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -273,6 +273,17 @@ pub enum PlexiEvent {
         port_id: String,
         error: String,
     },
+    /// Response to `DrawCommand::AgentRosterGet` (#286). Lists every live
+    /// `Pane::Agent` in the same workspace context.
+    ///
+    /// `agents` is sorted by `pane_id` ascending so the snapshot is
+    /// reproducible across calls. An app without the `agents.list`
+    /// capability receives an empty `agents` vec — NOT an error. This
+    /// matches the spec: "agents.list" is gated on visibility, not access.
+    AgentRoster {
+        request_id: String,
+        agents: Vec<AgentInfo>,
+    },
 }
 
 /// On-the-wire shape of one MIDI port. Mirrors `midi::MidiPortInfo` but lives
@@ -293,6 +304,18 @@ impl From<crate::midi::MidiPortInfo> for MidiPortWire {
             default: info.default,
         }
     }
+}
+
+/// One live agent pane on the wire. Returned by `AgentRoster` (#286).
+///
+/// `pane_id` matches the host's internal `PaneId` (`u64`); pass it back
+/// to the host as `target_pane_id` on `PipeOpenDirected` to address
+/// inter-agent pipes.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct AgentInfo {
+    pub pane_id: u64,
+    pub app_id: String,
+    pub name: String,
 }
 
 /// On-the-wire shape of one audio device. Mirrors `audio::AudioDeviceInfo`
@@ -541,11 +564,38 @@ pub enum DrawCommand {
         /// One of: "in" | "out" | "duplex"
         direction: String,
     },
+    /// Open a *directed* JSON pipe to a specific target pane (#286).
+    ///
+    /// Mirrors `PipeOpen` but the host scopes `PipeMessage` delivery so only
+    /// the caller pane and the pane identified by `target_pane_id` can
+    /// receive messages on this pipe — peer apps are NOT subscribed even
+    /// if they call `pipe_open` with the same `pipe_id`.
+    ///
+    /// Created bidirectionally: both panes receive the other's `PipeSend`
+    /// payloads as `PlexiEvent::PipeMessage`. Either side can close.
+    ///
+    /// Capability gate: caller needs `pipe.open` (the same as `PipeOpen`).
+    /// The target does NOT need `agents.list` — it just needs to be
+    /// addressable. The target also doesn't need to opt in; the host
+    /// subscribes it on this pipe id.
+    ///
+    /// Direction is always `duplex` on directed pipes — there's no use case
+    /// for a one-way agent-to-agent channel today, so the field is omitted.
+    /// Mode is always `json`; binary directed pipes are out of scope until
+    /// a real use case arrives.
+    PipeOpenDirected {
+        pipe_id: String,
+        target_pane_id: u64,
+    },
     /// Send a JSON-mode pipe message (not for binary pipes).
     PipeSend {
         pipe_id: String,
         payload: serde_json::Value,
     },
+    /// Query the live agent roster (#286). Requires `agents.list` capability;
+    /// callers without it receive an empty `agents` vec on the response — not
+    /// an error. The response is `PlexiEvent::AgentRoster { request_id, agents }`.
+    AgentRosterGet { request_id: String },
     /// Update the status text shown in the parent pane chrome.
     StatusSummary { text: String },
 
@@ -1354,6 +1404,82 @@ mod tests {
         assert!(
             serde_json::from_str::<DrawCommand>(bad).is_err(),
             "must fail without required `bytes` field"
+        );
+    }
+
+    // ── v3.3 P2 agent roster + directed pipes (#286) ────────────────────
+    // Pin the on-the-wire shape for the roster query/event and the directed
+    // pipe DrawCommand. All fields required — no `#[serde(default)]`.
+
+    #[test]
+    fn agent_roster_get_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"agent_roster_get","request_id":"req-7"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::AgentRosterGet { request_id } => {
+                assert_eq!(request_id, "req-7");
+            }
+            other => panic!("expected AgentRosterGet, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"agent_roster_get""#),
+            "wire tag missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn agent_roster_event_round_trips_serde() {
+        let json = r#"{"type":"agent_roster","request_id":"req-7","agents":[{"pane_id":3,"app_id":"agent-worker","name":"Worker"},{"pane_id":7,"app_id":"agent-coordinator","name":"Coordinator"}]}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::AgentRoster { request_id, agents } => {
+                assert_eq!(request_id, "req-7");
+                assert_eq!(agents.len(), 2);
+                assert_eq!(agents[0].pane_id, 3);
+                assert_eq!(agents[0].app_id, "agent-worker");
+                assert_eq!(agents[0].name, "Worker");
+                assert_eq!(agents[1].pane_id, 7);
+            }
+            other => panic!("expected AgentRoster, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"agent_roster""#),
+            "wire tag missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn pipe_open_directed_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"pipe_open_directed","pipe_id":"coord-to-worker","target_pane_id":42}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::PipeOpenDirected { pipe_id, target_pane_id } => {
+                assert_eq!(pipe_id, "coord-to-worker");
+                assert_eq!(*target_pane_id, 42);
+            }
+            other => panic!("expected PipeOpenDirected, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"pipe_open_directed""#),
+            "wire tag missing: {serialised}"
+        );
+        assert!(
+            serialised.contains(r#""target_pane_id":42"#),
+            "target_pane_id missing: {serialised}"
+        );
+    }
+
+    #[test]
+    fn pipe_open_directed_missing_target_pane_id_fails_deserialise() {
+        // No `target_pane_id` — must fail. Required.
+        let json = r#"{"type":"pipe_open_directed","pipe_id":"x"}"#;
+        let result: Result<DrawCommand, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "deserialise should fail without `target_pane_id` field"
         );
     }
 

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -27,6 +27,23 @@ pub enum AppCommand {
         pipe_id: String,
         payload: serde_json::Value,
     },
+    /// Open a *directed* JSON pipe (#286) — only the sender and the named
+    /// target pane subscribe to subsequent `PipeMessage` deliveries.
+    /// Routed by the host because the target pane lives outside the sender's
+    /// process and the sender has no other way to subscribe peers.
+    OpenDirectedPipe {
+        sender_pane_id: u64,
+        pipe_id: String,
+        target_pane_id: u64,
+    },
+    /// Query the workspace agent roster (#286). The host enumerates every
+    /// `Pane::Agent` and emits `PlexiEvent::AgentRoster { request_id, agents }`
+    /// back to `sender_pane_id`. Apps without `agents.list` get an empty
+    /// roster (NOT an error) — see `app_permissions.rs::Capability::AgentsList`.
+    AgentRosterGet {
+        sender_pane_id: u64,
+        request_id: String,
+    },
     /// Deliver a RunUpdate event to the pane that originally issued the run,
     /// identified by its type_id.
     DeliverRunUpdate {

--- a/src/process_app/agent.rs
+++ b/src/process_app/agent.rs
@@ -217,7 +217,9 @@ impl ProcessApp {
                 | DrawCommand::RunComplete { .. }
                 | DrawCommand::Notify { .. }
                 | DrawCommand::PipeOpen { .. }
+                | DrawCommand::PipeOpenDirected { .. }
                 | DrawCommand::PipeSend { .. }
+                | DrawCommand::AgentRosterGet { .. }
                 | DrawCommand::StatusSummary { .. }
                 | DrawCommand::SpawnApp { .. }
                 | DrawCommand::HttpRequest { .. }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -603,7 +603,9 @@ impl ProcessApp {
                 | DrawCommand::RunComplete { .. }
                 | DrawCommand::Notify { .. }
                 | DrawCommand::PipeOpen { .. }
+                | DrawCommand::PipeOpenDirected { .. }
                 | DrawCommand::PipeSend { .. }
+                | DrawCommand::AgentRosterGet { .. }
                 | DrawCommand::StatusSummary { .. }
                 | DrawCommand::SpawnApp { .. }
                 | DrawCommand::HttpRequest { .. }
@@ -801,7 +803,9 @@ impl App for ProcessApp {
                 | DrawCommand::RunComplete { .. }
                 | DrawCommand::Notify { .. }
                 | DrawCommand::PipeOpen { .. }
+                | DrawCommand::PipeOpenDirected { .. }
                 | DrawCommand::PipeSend { .. }
+                | DrawCommand::AgentRosterGet { .. }
                 | DrawCommand::StatusSummary { .. }
                 | DrawCommand::SpawnApp { .. }
                 | DrawCommand::HttpRequest { .. }
@@ -1767,5 +1771,179 @@ mod midi_tests {
             .expect("mock-output-1 entries must exist after SendMidi");
         assert_eq!(entries.len(), 1, "exactly one send dispatched");
         assert_eq!(entries[0], vec![0x90u8, 0x3C, 0x64]);
+    }
+}
+
+#[cfg(test)]
+mod roster_tests {
+    //! Routing-layer tests for the v3.3 P2 agent roster (#286).
+    //!
+    //! These verify the capability-gate behaviour at the route_command level:
+    //!
+    //!   - An app WITH the `agents.list` capability emits an
+    //!     `AppCommand::AgentRosterGet` for the host to fulfil — no
+    //!     synchronous response on `outbound_events`. The host (one layer up)
+    //!     enumerates agents and sends back `PlexiEvent::AgentRoster`.
+    //!
+    //!   - An app WITHOUT the capability gets an EMPTY `AgentRoster` event
+    //!     synchronously on `outbound_events` — NOT a denial error. This is
+    //!     the unusual "empty roster on denial" rule from the v3.1 spec.
+    use super::*;
+    use crate::app_permissions::Capability;
+    use crate::app_protocol::{DrawCommand, PlexiEvent};
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    fn make_app(caps: HashSet<Capability>) -> Option<ProcessApp> {
+        let sh = ["/bin/sh", "/usr/bin/sh"]
+            .iter()
+            .find(|p| std::path::Path::new(p).exists())
+            .map(PathBuf::from)?;
+        let workspace_root = std::env::temp_dir();
+        ProcessApp::launch(
+            "test_roster",
+            "Test Roster",
+            &sh,
+            &workspace_root,
+            &["-c".to_string(), "sleep 1".to_string()],
+            workspace_root.clone(),
+            caps,
+            false,
+        )
+        .ok()
+    }
+
+    #[test]
+    fn granted_app_gets_full_roster() {
+        // App with `agents.list` declared: route_command emits a
+        // pending AppCommand::AgentRosterGet — the host routes the
+        // enumeration. No synchronous outbound event yet.
+        let mut caps = HashSet::new();
+        caps.insert(Capability::AgentsList);
+        let Some(mut app) = make_app(caps) else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        app.route_command(DrawCommand::AgentRosterGet {
+            request_id: "req-roster".to_string(),
+        });
+        let saw_roster_event = app
+            .outbound_events
+            .iter()
+            .any(|e| matches!(e, PlexiEvent::AgentRoster { .. }));
+        assert!(
+            !saw_roster_event,
+            "granted path must defer to host — no synchronous roster event"
+        );
+        let saw_pending = app
+            .pending_commands
+            .iter()
+            .any(|c| matches!(c, AppCommand::AgentRosterGet { .. }));
+        assert!(
+            saw_pending,
+            "granted path must enqueue an AppCommand::AgentRosterGet for the host"
+        );
+    }
+
+    #[test]
+    fn pipe_open_directed_enqueues_open_directed_pipe_command() {
+        // Sender path: an app calls `PipeOpenDirected { pipe_id, target_pane_id }`.
+        // route_command must (1) pass the `pipe.open` cap check, (2) register
+        // the pipe locally as JSON duplex (so `has_reader` returns true and the
+        // SDK's `pipe_send` works), (3) enqueue an
+        // `AppCommand::OpenDirectedPipe` carrying the pair so the host can
+        // scope delivery on it.
+        let mut caps = HashSet::new();
+        caps.insert(Capability::PipeOpen);
+        let Some(mut app) = make_app(caps) else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        app.pane_id = 11;
+
+        app.route_command(DrawCommand::PipeOpenDirected {
+            pipe_id: "coord-to-worker".to_string(),
+            target_pane_id: 42,
+        });
+
+        assert!(
+            app.pipe_registry.lock().unwrap().has_reader("coord-to-worker"),
+            "directed pipe must be registered on caller side as duplex"
+        );
+
+        let pending = app
+            .pending_commands
+            .iter()
+            .find_map(|c| match c {
+                AppCommand::OpenDirectedPipe {
+                    sender_pane_id,
+                    pipe_id,
+                    target_pane_id,
+                } => Some((*sender_pane_id, pipe_id.clone(), *target_pane_id)),
+                _ => None,
+            })
+            .expect("AppCommand::OpenDirectedPipe must be enqueued");
+        assert_eq!(pending.0, 11);
+        assert_eq!(pending.1, "coord-to-worker");
+        assert_eq!(pending.2, 42);
+    }
+
+    #[test]
+    fn pipe_open_directed_denied_without_pipe_open_capability() {
+        let Some(mut app) = make_app(HashSet::new()) else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        app.route_command(DrawCommand::PipeOpenDirected {
+            pipe_id: "x".to_string(),
+            target_pane_id: 99,
+        });
+        assert!(
+            !app.pipe_registry.lock().unwrap().has_reader("x"),
+            "denied path must not register the pipe"
+        );
+        assert!(
+            !app.pending_commands
+                .iter()
+                .any(|c| matches!(c, AppCommand::OpenDirectedPipe { .. })),
+            "denied path must not enqueue host command"
+        );
+    }
+
+    #[test]
+    fn ungranted_app_gets_empty_roster_not_error() {
+        // App without `agents.list`: route_command emits an EMPTY
+        // AgentRoster event synchronously — never a denial error.
+        let Some(mut app) = make_app(HashSet::new()) else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+        app.route_command(DrawCommand::AgentRosterGet {
+            request_id: "req-empty".to_string(),
+        });
+        let event = app
+            .outbound_events
+            .iter()
+            .find(|e| matches!(e, PlexiEvent::AgentRoster { .. }))
+            .expect("ungranted path must emit AgentRoster synchronously");
+        match event {
+            PlexiEvent::AgentRoster { request_id, agents } => {
+                assert_eq!(request_id, "req-empty");
+                assert!(
+                    agents.is_empty(),
+                    "ungranted roster must be empty (not error): got {agents:?}"
+                );
+            }
+            other => panic!("expected AgentRoster, got {other:?}"),
+        }
+        // No pending command should be enqueued — the gate short-circuits.
+        let saw_pending = app
+            .pending_commands
+            .iter()
+            .any(|c| matches!(c, AppCommand::AgentRosterGet { .. }));
+        assert!(
+            !saw_pending,
+            "ungranted path must NOT enqueue AppCommand::AgentRosterGet"
+        );
     }
 }

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -393,7 +393,13 @@ pub(super) fn render_draw_commands(
             // The host integration (forthcoming follow-up PR) drains it from the
             // command stream before this painter sees it; this arm is the safety
             // net for the wire-only landing.
-            | DrawCommand::AppendConversation { .. } => {}
+            | DrawCommand::AppendConversation { .. }
+            // PipeOpenDirected and AgentRosterGet are control commands routed
+            // by `route_command`; they never paint and the painter sees them
+            // only as a safety net (the dispatcher should already have peeled
+            // them off via the routing path).
+            | DrawCommand::PipeOpenDirected { .. }
+            | DrawCommand::AgentRosterGet { .. } => {}
         }
     }
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -417,6 +417,79 @@ impl ProcessApp {
                 }
             }
 
+            // ── Pipe open (directed) — #286 ────────────────────────────────
+            // Inter-agent (or app↔agent) channel. Caller needs `pipe.open`
+            // (same gate as undirected `PipeOpen`). Resolution lives in
+            // `app/mod.rs::AppCommand::OpenDirectedPipe` because the target
+            // pane is not in this process and has to be subscribed by the
+            // host. We register the JSON pipe locally so subsequent
+            // `PipeSend` calls succeed; `has_reader` returns true for the
+            // sender side because the direction is duplex.
+            DrawCommand::PipeOpenDirected {
+                pipe_id,
+                target_pane_id,
+            } => {
+                if let PermissionCheck::Denied(reason) =
+                    check(&self.permissions, Capability::PipeOpen)
+                {
+                    log::warn!(
+                        "ProcessApp[{}]: PipeOpenDirected denied — {reason}",
+                        self.type_id
+                    );
+                    return;
+                }
+                match self
+                    .pipe_registry
+                    .lock()
+                    .unwrap()
+                    .open_json(pipe_id.clone(), PipeDirection::Duplex)
+                {
+                    Ok(()) => {
+                        log::info!(
+                            "ProcessApp[{}]: opened directed JSON pipe '{pipe_id}' → pane {target_pane_id}",
+                            self.type_id
+                        );
+                        event_log::emit_pipe_opened(&self.type_id, &pipe_id, "json");
+                        self.pending_commands.push(AppCommand::OpenDirectedPipe {
+                            sender_pane_id: self.pane_id,
+                            pipe_id,
+                            target_pane_id,
+                        });
+                    }
+                    Err(e) => log::warn!(
+                        "ProcessApp[{}]: PipeOpenDirected failed: {e}",
+                        self.type_id
+                    ),
+                }
+            }
+
+            // ── Agent roster query — #286 ─────────────────────────────────
+            // Capability gate is unusual: an undeclared `agents.list` does
+            // NOT return an error — it returns an empty roster. The check
+            // happens here (loud log) but we still defer to the host to
+            // emit the response so the wire shape is identical regardless.
+            DrawCommand::AgentRosterGet { request_id } => {
+                if let PermissionCheck::Denied(_) =
+                    check(&self.permissions, Capability::AgentsList)
+                {
+                    // Per-spec: undeclared → empty roster, not an error.
+                    log::debug!(
+                        "ProcessApp[{}]: AgentRosterGet without agents.list — empty roster",
+                        self.type_id
+                    );
+                    self.outbound_events
+                        .push_back(PlexiEvent::AgentRoster {
+                            request_id,
+                            agents: Vec::new(),
+                        });
+                    return;
+                }
+                self.pending_commands.push(AppCommand::AgentRosterGet {
+                    sender_pane_id: self.pane_id,
+                    request_id,
+                });
+            }
+
             // ── Pipe send ──────────────────────────────────────────────────
             DrawCommand::PipeSend { pipe_id, payload } => {
                 if let PermissionCheck::Denied(reason) =

--- a/src/typed_pipes.rs
+++ b/src/typed_pipes.rs
@@ -308,3 +308,65 @@ fn write_eos(writer: &mut impl Write) -> std::io::Result<()> {
 
 // ---------------------------------------------------------------------------
 // Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the typed-pipe registry primitives that the directed
+    //! inter-agent pipe routing (#286) builds on.
+    use super::*;
+
+    #[test]
+    fn directed_pipe_routes_to_target_pane_only() {
+        // Two panes' registries are independent. The sender pane registers
+        // a JSON duplex pipe under id "x"; the target pane registers the
+        // same id under its own registry. Each registry's `has_reader`
+        // reflects only its own subscribers — they do NOT collide.
+        //
+        // This is the substrate for `directed_pipes` scoping in
+        // `app/mod.rs`: the host maintains a `(sender, target)` pair keyed
+        // on pipe_id, and `DeliverPipeMessage` consults that pair to route
+        // ONLY to the target — never broadcasting to other panes that
+        // coincidentally opened the same id. The registry's job is simply
+        // to track per-pane subscription state; the scoping is upstream.
+        let mut sender_reg = TypedPipeRegistry::new();
+        let mut target_reg = TypedPipeRegistry::new();
+
+        sender_reg
+            .open_json("coord-to-worker".to_string(), PipeDirection::Duplex)
+            .expect("sender opens JSON pipe");
+        target_reg
+            .open_json("coord-to-worker".to_string(), PipeDirection::Duplex)
+            .expect("target opens same id on its independent registry");
+
+        assert!(
+            sender_reg.has_reader("coord-to-worker"),
+            "sender side has_reader true (duplex)"
+        );
+        assert!(
+            target_reg.has_reader("coord-to-worker"),
+            "target side has_reader true (duplex)"
+        );
+
+        // A third bystander registry without the pipe must NOT read.
+        let bystander_reg = TypedPipeRegistry::new();
+        assert!(
+            !bystander_reg.has_reader("coord-to-worker"),
+            "bystander pane never opted in — has_reader must be false"
+        );
+    }
+
+    #[test]
+    fn open_json_rejects_duplicate_pipe_id_on_same_registry() {
+        // A single registry must reject opening the same pipe id twice —
+        // this is what the host's `register_directed_pipe_on_target`
+        // helper has to handle gracefully when the target pane has
+        // independently opened the pipe (treats AlreadyOpen as success).
+        let mut reg = TypedPipeRegistry::new();
+        reg.open_json("dup".to_string(), PipeDirection::Duplex).unwrap();
+        let err = reg
+            .open_json("dup".to_string(), PipeDirection::Duplex)
+            .unwrap_err();
+        assert!(matches!(err, PipeError::AlreadyOpen(_)));
+    }
+}


### PR DESCRIPTION
Closes #286

## What changed

v3.3 P2 — adds the workspace-scoped agent roster and inter-agent directed pipes.

- New capability `agents.list` (`Capability::AgentsList`) with the unusual "empty roster on denial" rule (per spec): apps without the capability receive `AgentRoster { agents: [] }` synchronously, NOT a denial error.
- New `DrawCommand::AgentRosterGet { request_id }` + `PlexiEvent::AgentRoster { request_id, agents: Vec<AgentInfo> }`. `AgentInfo { pane_id, app_id, name }` is sorted by `pane_id` ascending for reproducibility.
- New `DrawCommand::PipeOpenDirected { pipe_id, target_pane_id }` (option B from the brief — separate variant, no migration burden on existing `PipeOpen` callers). Always JSON / duplex; the host registers the pipe on both panes' typed-pipe registries and records `(sender, target)` in a new `directed_pipes: HashMap` on `PlexiApp`. `DeliverPipeMessage` consults this map first — directed pipes route ONLY between the pair; misses fall through to the legacy peer-broadcast path.
- `enumerate_agents(panes)` helper on `agent_pane.rs` walks the pane container, surfaces both `Subprocess` and `InProcess` agent backends, sorts ascending.
- Subprocess agents now emit `pending_commands` through `dispatch.rs` alongside `Pane::App` so agent-originated `AgentRosterGet` / `OpenDirectedPipe` / `DeliverPipeMessage` reach the host.
- Python SDK: `AgentInfo` dataclass, `Emitter.agent_roster()` (blocking), `Emitter.pipe_open_directed()`, `Emitter.pipe_send()` (raw fire-and-forget for directed-pipe receivers without a local handle), `Agent.list_agents()`, `Agent.open_pipe_to(pane_id)`, `Agent.on_pipe_message` overridable.
- POC pair `examples/agent-coordinator/` + `examples/agent-worker/` shipped in the bundled core pack. Both agents run their `iq.query` calls on background threads so the SDK stdin loop stays free for `pipe_message` callbacks.

## Breaks if

- An agent declaring `agents.list` calls `emit.agent_roster()` and gets back an empty list when other agent panes are open (host enumeration broken).
- An agent without `agents.list` calls `emit.agent_roster()` and gets `CapabilityDeniedError` instead of an empty list (the "empty on denial" rule regressed).
- A `PipeOpenDirected` from agent A to agent B delivers a `PipeMessage` to a *third* agent C that coincidentally opened the same `pipe_id` (directed-pipe scoping regressed; broadcast path fired).
- Two agents on different workspaces appear in each other's roster (cross-workspace leakage — currently scoped to active context per spec).
- Existing `agent-tester` (no roster usage) breaks — would mean a regression in the agent-as-app substrate from #338.

## Human verification
- [ ] Open Plexi Alpha. Run `agent-coordinator` and `agent-worker` in two panes (Cmd+T then App pick).
- [ ] In the coordinator pane: type `ask the worker what 2+2 is` and submit. Coordinator's history shows: `found agent-worker on pane N — opening directed pipe` → `delegated to agent-worker: …` → `Worker replied: …` (the worker's actual answer).
- [ ] Worker's history shows the incoming `received delegated request` and its assistant reply.
- [ ] Spawn `agent-tester` in a third pane (no `agents.list` declared). Calling `agent_roster()` from a quick test app returns an empty list (no error). [Optional manual verify only — agent-tester doesn't currently call agent_roster.]
- [ ] Existing `agent-tester` still runs normally — no regression in the agent-as-app substrate.

## Test added
14 tests added across `app_permissions::tests` (1), `app_protocol::tests` (4), `agent_pane::tests` (3), `process_app::roster_tests` (4), `typed_pipes::tests` (2). All 156 pass on `cargo test --bin plexi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)