### PR TITLE
v3.5 P1: CLI wrapper registry + AI release-watcher (substrate)

### DIFF
--- a/docs/specs/proposals/cli-wrapper-registry.md
+++ b/docs/specs/proposals/cli-wrapper-registry.md
@@ -1,0 +1,88 @@
+# CLI Wrapper Registry (issue #321)
+
+The middle tier between `--plexi`-native CLIs (#188) and `--help` crawl
+fallback (#78). Most CLIs won't ship `--plexi` for years; crawling `--help`
+is lossy. The registry is the pragmatic middle path: hand-authored
+descriptors for popular CLIs, kept fresh by tooling.
+
+## Three-tier resolution
+
+1. **Tier 1** — the CLI itself emits a descriptor when invoked with
+   `--plexi`. Fastest, always in sync with the installed binary.
+2. **Tier 2** — *this proposal*. The Plexi binary consults a baked-in
+   registry keyed by `(cli_name, version)`. A user-side override directory
+   at `~/.plexi-<channel>/registry/` shadows the embedded copy so users can
+   patch a descriptor locally without rebuilding Plexi.
+3. **Tier 3** — fallback `--help` crawl, owned by issue #78.
+
+## In-repo registry layout
+
+```
+registry/
+  gh/
+    2.40.0.json     # version-pinned descriptor
+    latest.json     # copy of the highest version (NOT a symlink — Windows-safe)
+  cargo/
+    1.75.0.json
+    latest.json
+  npm/
+    10.0.0.json
+    latest.json
+```
+
+Each `*.json` validates against `schemas/plexi-descriptor-schema.json`. The
+file format is identical to the `--plexi` flag output (#188) — a registry
+descriptor and a native-emitted descriptor are interchangeable.
+
+`latest.json` is a copy rather than a symlink so the layout works on
+Windows and inside the `include_dir!` macro without symlink chasing. A
+unit test (`embedded_registry_round_trips_through_parser`) guards against
+hand-edit drift by re-parsing every shipped descriptor.
+
+## Authoring a new descriptor
+
+1. Pick a CLI version. Run the CLI's `--help` and explore its commands.
+2. Author `registry/<cli>/<version>.json` against the descriptor schema.
+   See `examples/plexi-descriptor-demo/plexi_descriptor_demo.py` for the
+   shape — top-level fields are `plexi_version`, `name`, `version`,
+   `description`, `icon`, `default_view`, `commands`, optional
+   `live_state`. Keep the initial set of commands tight — 3–5 top-level
+   commands per CLI is enough to ship.
+3. Copy the file to `registry/<cli>/latest.json`.
+4. Run `cargo test --bin plexi cli_registry` — the round-trip test must
+   pass.
+5. Verify with `plexi descriptor probe <cli>`. The summary should show
+   `(via registry)`.
+
+## Release-watcher CLI usage
+
+`plexi registry watch [<cli>]` walks the registered CLI set (or just the
+named one), comparing the locally-installed binary against its registry
+entry:
+
+- **Not installed** — skipped quietly.
+- **Up to date** — installed version matches registry, and `--help`
+  command set matches the descriptor.
+- **Stale** — installed version > registry version. Descriptor needs a
+  refresh.
+- **Drift** — installed version matches, but `--help` shows commands not
+  in the descriptor (or vice versa). Descriptor body is incomplete.
+
+Output is human-readable. Machine-parseable JSON is intentionally
+deferred — the cron-driven watcher is a follow-up.
+
+## Roadmap (follow-ups)
+
+- **Author full descriptors for the remaining 7 CLIs** — `git`, `docker`,
+  `kubectl`, `brew`, `uv`, `rg`, `fzf`. One small PR per CLI.
+- **Automated release-watcher cron** — wrap `plexi registry watch` in a
+  GitHub Action that runs daily, sandbox-installs the new CLI, opens a PR
+  with the diffed descriptor.
+- **Public CDN at `registry.plexi.app`** — host the registry outside the
+  binary so updates don't require a Plexi rebuild. Today the registry
+  ships baked into the binary; CDN move is a no-op for descriptor
+  authors.
+- **Per-platform variations** — same CLI may expose different commands on
+  macOS vs Linux vs Windows. Out of scope for v1.
+- **Community submissions / PR triage automation** — once the cron
+  watcher proves the round-trip works.

--- a/registry/cargo/1.75.0.json
+++ b/registry/cargo/1.75.0.json
@@ -1,0 +1,67 @@
+{
+  "plexi_version": "0.1",
+  "name": "cargo",
+  "version": "1.75.0",
+  "description": "Rust's package manager",
+  "icon": "📦",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "build",
+      "description": "Compile the current package",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false, "description": "Build artifacts in release mode"},
+        {"name": "--target", "type": "string", "description": "Build for the target triple"}
+      ]
+    },
+    {
+      "name": "test",
+      "description": "Run the tests",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false},
+        {"name": "--no-run", "type": "bool", "default": false, "description": "Compile, but don't run tests"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a binary or example of the local package",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false},
+        {"name": "--bin", "type": "string", "description": "Name of the bin target to run"}
+      ]
+    },
+    {
+      "name": "check",
+      "description": "Analyze the current package and report errors, but don't build object files",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "new",
+      "description": "Create a new cargo package at <path>",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": true, "description": "Path of the new package"}
+      ],
+      "flags": [
+        {"name": "--lib", "type": "bool", "default": false, "description": "Create a library"},
+        {"name": "--bin", "type": "bool", "default": true, "description": "Create a binary (default)"}
+      ],
+      "writes": ["<path>/"]
+    },
+    {
+      "name": "publish",
+      "description": "Upload a package to the registry",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false}
+      ]
+    }
+  ]
+}

--- a/registry/cargo/latest.json
+++ b/registry/cargo/latest.json
@@ -1,0 +1,67 @@
+{
+  "plexi_version": "0.1",
+  "name": "cargo",
+  "version": "1.75.0",
+  "description": "Rust's package manager",
+  "icon": "📦",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "build",
+      "description": "Compile the current package",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false, "description": "Build artifacts in release mode"},
+        {"name": "--target", "type": "string", "description": "Build for the target triple"}
+      ]
+    },
+    {
+      "name": "test",
+      "description": "Run the tests",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false},
+        {"name": "--no-run", "type": "bool", "default": false, "description": "Compile, but don't run tests"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a binary or example of the local package",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--release", "type": "bool", "default": false},
+        {"name": "--bin", "type": "string", "description": "Name of the bin target to run"}
+      ]
+    },
+    {
+      "name": "check",
+      "description": "Analyze the current package and report errors, but don't build object files",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "new",
+      "description": "Create a new cargo package at <path>",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": true, "description": "Path of the new package"}
+      ],
+      "flags": [
+        {"name": "--lib", "type": "bool", "default": false, "description": "Create a library"},
+        {"name": "--bin", "type": "bool", "default": true, "description": "Create a binary (default)"}
+      ],
+      "writes": ["<path>/"]
+    },
+    {
+      "name": "publish",
+      "description": "Upload a package to the registry",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false}
+      ]
+    }
+  ]
+}

--- a/registry/gh/2.40.0.json
+++ b/registry/gh/2.40.0.json
@@ -1,0 +1,101 @@
+{
+  "plexi_version": "0.1",
+  "name": "gh",
+  "version": "2.40.0",
+  "description": "GitHub's official command-line tool",
+  "icon": "🐙",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "auth",
+      "description": "Authenticate gh and git with GitHub",
+      "ui_hint": "form",
+      "commands": [
+        {
+          "name": "login",
+          "description": "Authenticate with a GitHub host"
+        },
+        {
+          "name": "status",
+          "description": "View authentication status",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "pr",
+      "description": "Manage pull requests",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "create",
+          "description": "Create a pull request",
+          "ui_hint": "form",
+          "flags": [
+            {"name": "--title", "type": "string", "description": "Title for the pull request"},
+            {"name": "--body", "type": "string", "description": "Body for the pull request"},
+            {"name": "--draft", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List pull requests in a repository",
+          "ui_hint": "output"
+        },
+        {
+          "name": "view",
+          "description": "View a pull request",
+          "ui_hint": "output",
+          "args": [
+            {"name": "number", "type": "int", "required": false, "description": "PR number"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "issue",
+      "description": "Manage issues",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "create",
+          "description": "Create a new issue",
+          "ui_hint": "form",
+          "flags": [
+            {"name": "--title", "type": "string", "required": true},
+            {"name": "--body", "type": "string"}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List issues in a repository",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "repo",
+      "description": "Manage repositories",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "clone",
+          "description": "Clone a repository locally",
+          "args": [
+            {"name": "repository", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "view",
+          "description": "View a repository",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "release",
+      "description": "Manage releases",
+      "ui_hint": "list"
+    }
+  ]
+}

--- a/registry/gh/latest.json
+++ b/registry/gh/latest.json
@@ -1,0 +1,101 @@
+{
+  "plexi_version": "0.1",
+  "name": "gh",
+  "version": "2.40.0",
+  "description": "GitHub's official command-line tool",
+  "icon": "🐙",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "auth",
+      "description": "Authenticate gh and git with GitHub",
+      "ui_hint": "form",
+      "commands": [
+        {
+          "name": "login",
+          "description": "Authenticate with a GitHub host"
+        },
+        {
+          "name": "status",
+          "description": "View authentication status",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "pr",
+      "description": "Manage pull requests",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "create",
+          "description": "Create a pull request",
+          "ui_hint": "form",
+          "flags": [
+            {"name": "--title", "type": "string", "description": "Title for the pull request"},
+            {"name": "--body", "type": "string", "description": "Body for the pull request"},
+            {"name": "--draft", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List pull requests in a repository",
+          "ui_hint": "output"
+        },
+        {
+          "name": "view",
+          "description": "View a pull request",
+          "ui_hint": "output",
+          "args": [
+            {"name": "number", "type": "int", "required": false, "description": "PR number"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "issue",
+      "description": "Manage issues",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "create",
+          "description": "Create a new issue",
+          "ui_hint": "form",
+          "flags": [
+            {"name": "--title", "type": "string", "required": true},
+            {"name": "--body", "type": "string"}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List issues in a repository",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "repo",
+      "description": "Manage repositories",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "clone",
+          "description": "Clone a repository locally",
+          "args": [
+            {"name": "repository", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "view",
+          "description": "View a repository",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "release",
+      "description": "Manage releases",
+      "ui_hint": "list"
+    }
+  ]
+}

--- a/registry/npm/10.0.0.json
+++ b/registry/npm/10.0.0.json
@@ -1,0 +1,60 @@
+{
+  "plexi_version": "0.1",
+  "name": "npm",
+  "version": "10.0.0",
+  "description": "Node Package Manager",
+  "icon": "📦",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "install",
+      "description": "Install a package and any packages it depends on",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "package", "type": "string", "required": false, "description": "Package name(s) to install"}
+      ],
+      "flags": [
+        {"name": "--save-dev", "type": "bool", "default": false, "description": "Save as a devDependency"},
+        {"name": "--global", "type": "bool", "default": false, "description": "Install globally"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run an arbitrary package script defined in package.json",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "script", "type": "string", "required": true, "description": "Script name"}
+      ]
+    },
+    {
+      "name": "test",
+      "description": "Run the tests script defined in package.json",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "publish",
+      "description": "Publish the package to the npm registry",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false},
+        {"name": "--tag", "type": "string", "description": "Registers the published package with the given tag"}
+      ]
+    },
+    {
+      "name": "init",
+      "description": "Create a package.json file",
+      "ui_hint": "form",
+      "writes": ["package.json"]
+    },
+    {
+      "name": "uninstall",
+      "description": "Remove a package",
+      "args": [
+        {"name": "package", "type": "string", "required": true}
+      ]
+    }
+  ]
+}

--- a/registry/npm/latest.json
+++ b/registry/npm/latest.json
@@ -1,0 +1,60 @@
+{
+  "plexi_version": "0.1",
+  "name": "npm",
+  "version": "10.0.0",
+  "description": "Node Package Manager",
+  "icon": "📦",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "install",
+      "description": "Install a package and any packages it depends on",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "package", "type": "string", "required": false, "description": "Package name(s) to install"}
+      ],
+      "flags": [
+        {"name": "--save-dev", "type": "bool", "default": false, "description": "Save as a devDependency"},
+        {"name": "--global", "type": "bool", "default": false, "description": "Install globally"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run an arbitrary package script defined in package.json",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "script", "type": "string", "required": true, "description": "Script name"}
+      ]
+    },
+    {
+      "name": "test",
+      "description": "Run the tests script defined in package.json",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "publish",
+      "description": "Publish the package to the npm registry",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false},
+        {"name": "--tag", "type": "string", "description": "Registers the published package with the given tag"}
+      ]
+    },
+    {
+      "name": "init",
+      "description": "Create a package.json file",
+      "ui_hint": "form",
+      "writes": ["package.json"]
+    },
+    {
+      "name": "uninstall",
+      "description": "Remove a package",
+      "args": [
+        {"name": "package", "type": "string", "required": true}
+      ]
+    }
+  ]
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -891,6 +891,373 @@ fn read_line_plain() -> io::Result<String> {
         .to_string())
 }
 
+// ── plexi registry (issue #321) ───────────────────────────────────────────────
+/// `plexi registry watch [<cli>]` — walks the seeded registry and reports,
+/// per-CLI, whether the locally installed CLI matches the registered version
+/// and whether `<cli> --help` shows top-level command names absent from the
+/// registry descriptor (a heuristic signal that the descriptor is stale).
+///
+/// Output is human-readable. JSON output is intentionally deferred — the
+/// release-watcher cron that consumes this is itself a follow-up issue (see
+/// #321 PR description).
+pub mod registry {
+    use crate::cli_registry;
+    use std::collections::BTreeSet;
+    use std::process::Command;
+
+    /// Indirection so the watch path can be tested without spawning real
+    /// processes.
+    pub trait CliInspector {
+        /// `which <name>` — `Some(path)` when the CLI is installed.
+        fn which(&self, name: &str) -> Option<String>;
+        /// Captured stdout of `<name> --version`. `None` when the spawn
+        /// itself fails.
+        fn version(&self, name: &str) -> Option<String>;
+        /// Captured stdout of `<name> --help`. Empty string on failure (we
+        /// downgrade to "couldn't read help" rather than blowing up).
+        fn help(&self, name: &str) -> String;
+    }
+
+    pub struct RealInspector;
+
+    impl CliInspector for RealInspector {
+        fn which(&self, name: &str) -> Option<String> {
+            let out = Command::new("which").arg(name).output().ok()?;
+            if !out.status.success() {
+                return None;
+            }
+            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if path.is_empty() { None } else { Some(path) }
+        }
+        fn version(&self, name: &str) -> Option<String> {
+            let out = Command::new(name).arg("--version").output().ok()?;
+            if !out.status.success() {
+                return None;
+            }
+            Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        }
+        fn help(&self, name: &str) -> String {
+            match Command::new(name).arg("--help").output() {
+                Ok(out) => {
+                    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+                    if s.is_empty() {
+                        // Some CLIs (e.g. cargo) print --help to stderr.
+                        s = String::from_utf8_lossy(&out.stderr).into_owned();
+                    }
+                    s
+                }
+                Err(_) => String::new(),
+            }
+        }
+    }
+
+    /// Per-CLI status emitted by the watcher. Variants are exhaustive so
+    /// callers can pivot rendering by case (text now, JSON later).
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum WatchStatus {
+        NotInstalled,
+        UpToDate { version: String },
+        Stale { installed: String, registered: String },
+        DescriptorDrift { added: Vec<String>, removed: Vec<String> },
+        RegistryError(String),
+    }
+
+    pub struct WatchReport {
+        pub cli: String,
+        pub status: WatchStatus,
+    }
+
+    /// Compare a CLI's installed `--version`/`--help` against its registry
+    /// descriptor. Pure given an inspector — drives both the real CLI surface
+    /// and the unit tests.
+    pub fn watch_one<I: CliInspector>(inspector: &I, cli: &str) -> WatchReport {
+        if inspector.which(cli).is_none() {
+            return WatchReport {
+                cli: cli.to_string(),
+                status: WatchStatus::NotInstalled,
+            };
+        }
+        let descriptor = match cli_registry::lookup(cli, None) {
+            Ok(d) => d,
+            Err(e) => {
+                return WatchReport {
+                    cli: cli.to_string(),
+                    status: WatchStatus::RegistryError(e.to_string()),
+                };
+            }
+        };
+        let installed_version_raw = inspector.version(cli).unwrap_or_default();
+        let installed_version = extract_version(&installed_version_raw);
+
+        if !installed_version.is_empty() && installed_version != descriptor.version {
+            return WatchReport {
+                cli: cli.to_string(),
+                status: WatchStatus::Stale {
+                    installed: installed_version,
+                    registered: descriptor.version.clone(),
+                },
+            };
+        }
+
+        // Help-diff heuristic: pull top-level command names from --help, diff
+        // against descriptor.commands[].name. Heuristic because every CLI
+        // formats --help differently; we don't try to be exhaustive.
+        let help = inspector.help(cli);
+        let help_commands = parse_top_level_commands(&help);
+        let descriptor_commands: BTreeSet<String> =
+            descriptor.commands.iter().map(|c| c.name.clone()).collect();
+        let added: Vec<String> = help_commands
+            .difference(&descriptor_commands)
+            .cloned()
+            .collect();
+        let removed: Vec<String> = descriptor_commands
+            .difference(&help_commands)
+            .cloned()
+            .collect();
+
+        if !added.is_empty() || !removed.is_empty() {
+            return WatchReport {
+                cli: cli.to_string(),
+                status: WatchStatus::DescriptorDrift { added, removed },
+            };
+        }
+
+        WatchReport {
+            cli: cli.to_string(),
+            status: WatchStatus::UpToDate {
+                version: descriptor.version.clone(),
+            },
+        }
+    }
+
+    /// CLI entry point. Walks every registered CLI (or just the named one),
+    /// prints a human-readable summary, returns 0 on success — failures here
+    /// are *informational* (a stale descriptor is the watcher's whole point),
+    /// so we don't treat them as exit-1.
+    pub fn watch_cli(only: Option<&str>) -> i32 {
+        let inspector = RealInspector;
+        let clis: Vec<String> = match only {
+            Some(c) => vec![c.to_string()],
+            None => cli_registry::list_clis(),
+        };
+        if clis.is_empty() {
+            println!("registry: no CLIs registered");
+            return 0;
+        }
+        for cli in &clis {
+            let report = watch_one(&inspector, cli);
+            print_report(&report);
+        }
+        0
+    }
+
+    fn print_report(report: &WatchReport) {
+        match &report.status {
+            WatchStatus::NotInstalled => {
+                println!("  {}  (not installed — skipping)", report.cli);
+            }
+            WatchStatus::UpToDate { version } => {
+                println!("  {}  up to date (v{version})", report.cli);
+            }
+            WatchStatus::Stale {
+                installed,
+                registered,
+            } => {
+                println!(
+                    "  [STALE] {}  registry has v{registered}; installed v{installed} \
+                     — descriptor may be outdated",
+                    report.cli
+                );
+            }
+            WatchStatus::DescriptorDrift { added, removed } => {
+                println!("  [DRIFT] {}  --help shows commands not in registry:", report.cli);
+                if !added.is_empty() {
+                    println!("    + {}", added.join(", "));
+                }
+                if !removed.is_empty() {
+                    println!("    - {} (in registry but not in --help)", removed.join(", "));
+                }
+            }
+            WatchStatus::RegistryError(msg) => {
+                println!("  [ERROR] {}  {msg}", report.cli);
+            }
+        }
+    }
+
+    /// Pull the first whitespace-separated token that contains a `.` from a
+    /// `<cli> --version` line. Handles "gh version 2.40.0 ..." and
+    /// "cargo 1.75.0 (...)" without baking in per-CLI parsers.
+    fn extract_version(raw: &str) -> String {
+        for token in raw.split_whitespace() {
+            if token.chars().any(|c| c == '.')
+                && token.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+            {
+                // Strip trailing punctuation/build-metadata.
+                let cleaned: String = token
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit() || *c == '.')
+                    .collect();
+                return cleaned;
+            }
+        }
+        String::new()
+    }
+
+    /// Heuristic: scan `--help` output for indented two-column "name<spaces>
+    /// description" rows under a "Commands:" / "COMMANDS" / "CORE COMMANDS"
+    /// header and treat the first column as a command name. The parser is
+    /// intentionally loose — every CLI formats --help differently, and the
+    /// goal is "good enough drift signal", not exhaustive parsing.
+    fn parse_top_level_commands(help: &str) -> BTreeSet<String> {
+        let mut out: BTreeSet<String> = BTreeSet::new();
+        let mut in_commands = false;
+        for line in help.lines() {
+            let trimmed = line.trim_start();
+            let lower = trimmed.trim_end_matches(':').to_ascii_lowercase();
+            // Recognize any section header whose name *contains* "command" /
+            // "subcommand" as an entry point into command-listing mode. This
+            // covers "Commands:", "COMMANDS", "Core Commands", "Management
+            // Commands", "All Commands" without per-CLI special cases.
+            let is_command_header = !line.starts_with(' ')
+                && !line.starts_with('\t')
+                && (lower.ends_with("command")
+                    || lower.ends_with("commands")
+                    || lower.ends_with("subcommand")
+                    || lower.ends_with("subcommands"));
+            if is_command_header {
+                in_commands = true;
+                continue;
+            }
+            // Any other column-0 header that doesn't mention "command" exits
+            // the section (e.g. OPTIONS, FLAGS, EXAMPLES, ENVIRONMENT).
+            if in_commands && !line.starts_with(' ') && !line.starts_with('\t') && !trimmed.is_empty()
+            {
+                in_commands = false;
+                continue;
+            }
+            if in_commands {
+                if trimmed.is_empty() {
+                    // Some CLIs (gh) split commands into labelled subsections
+                    // separated by blanks. Stay in command mode across blanks.
+                    continue;
+                }
+                if let Some(first) = trimmed.split_whitespace().next() {
+                    // Strip the gh-style trailing colon.
+                    let name = first.trim_end_matches(':');
+                    if name.is_empty() || name.starts_with('-') {
+                        continue;
+                    }
+                    if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+                        out.insert(name.to_string());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[cfg(test)]
+    pub struct MockInspector {
+        pub installed: bool,
+        pub version_str: String,
+        pub help_str: String,
+    }
+
+    #[cfg(test)]
+    impl CliInspector for MockInspector {
+        fn which(&self, _: &str) -> Option<String> {
+            if self.installed {
+                Some("/usr/bin/mock".to_string())
+            } else {
+                None
+            }
+        }
+        fn version(&self, _: &str) -> Option<String> {
+            if self.installed {
+                Some(self.version_str.clone())
+            } else {
+                None
+            }
+        }
+        fn help(&self, _: &str) -> String {
+            self.help_str.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod registry_watch_tests {
+    use super::registry::*;
+
+    #[test]
+    fn watch_reports_not_installed_for_missing_binary() {
+        let inspector = MockInspector {
+            installed: false,
+            version_str: String::new(),
+            help_str: String::new(),
+        };
+        let report = watch_one(&inspector, "gh");
+        assert_eq!(report.status, WatchStatus::NotInstalled);
+    }
+
+    #[test]
+    fn watch_reports_up_to_date_when_versions_match() {
+        // The seeded `gh` registry has version 2.40.0. Match it exactly and
+        // give a --help that lists the same top-level commands as the
+        // descriptor.
+        let inspector = MockInspector {
+            installed: true,
+            version_str: "gh version 2.40.0 (2023-12-14)".into(),
+            help_str: "Usage:  gh <command> <subcommand> [flags]\n\n\
+                       CORE COMMANDS\n  \
+                       auth:        do auth\n  \
+                       pr:          do pr\n  \
+                       issue:       do issue\n  \
+                       repo:        do repo\n  \
+                       release:     do release\n"
+                .into(),
+        };
+        let report = watch_one(&inspector, "gh");
+        assert!(
+            matches!(report.status, WatchStatus::UpToDate { .. }),
+            "expected UpToDate, got {:?}",
+            report.status
+        );
+    }
+
+    #[test]
+    fn watch_reports_stale_when_installed_version_exceeds_registry() {
+        let inspector = MockInspector {
+            installed: true,
+            version_str: "gh version 2.99.0 (2026-01-01)".into(),
+            help_str: String::new(),
+        };
+        let report = watch_one(&inspector, "gh");
+        match report.status {
+            WatchStatus::Stale { installed, registered } => {
+                assert_eq!(installed, "2.99.0");
+                assert_eq!(registered, "2.40.0");
+            }
+            other => panic!("expected Stale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn watch_reports_registry_error_for_unknown_cli() {
+        let inspector = MockInspector {
+            installed: true,
+            version_str: "fake 0.0.1".into(),
+            help_str: String::new(),
+        };
+        let report = watch_one(&inspector, "nonexistent-cli-zzz");
+        assert!(
+            matches!(report.status, WatchStatus::RegistryError(_)),
+            "expected RegistryError, got {:?}",
+            report.status
+        );
+    }
+}
+
 // ── plexi descriptor (issue #188) ─────────────────────────────────────────────
 /// `plexi descriptor probe <cmd> [args...]` — invokes the target with
 /// `--plexi` appended, parses the JSON descriptor, prints a summary. Reference
@@ -926,53 +1293,105 @@ pub mod descriptor {
         }
     }
 
-    /// Run `<command> <args...> --plexi`, parse + summarize. Returns the
+    /// Knobs governing the Tier-2 registry fallback. The default behavior
+    /// (Tier 1 first, Tier 2 on failure) matches the issue #321 substrate;
+    /// `--no-registry` disables Tier 2.
+    pub struct ProbeOptions {
+        pub use_registry: bool,
+    }
+
+    impl Default for ProbeOptions {
+        fn default() -> Self {
+            Self { use_registry: true }
+        }
+    }
+
+    /// Run `<command> <args...> --plexi`, parse + summarize. On failure (spawn
+    /// error, non-zero exit, or unparseable JSON), optionally fall through to
+    /// the Tier-2 registry lookup (`cli_registry::lookup`). Returns the
     /// process exit code suitable for `std::process::exit`.
+    ///
+    /// The CLI surface in `main.rs` calls `probe_with_options` directly so
+    /// it can plumb `--no-registry`; this thin wrapper exists for tests and
+    /// for any future caller that wants the default behavior.
+    #[cfg(test)]
     pub fn probe<R: DescriptorRunner>(runner: &R, command: &str, args: &[&str]) -> i32 {
+        probe_with_options(runner, command, args, &ProbeOptions::default())
+    }
+
+    pub fn probe_with_options<R: DescriptorRunner>(
+        runner: &R,
+        command: &str,
+        args: &[&str],
+        options: &ProbeOptions,
+    ) -> i32 {
         let mut full_args: Vec<&str> = args.to_vec();
         full_args.push("--plexi");
 
-        let output = match runner.run(command, &full_args) {
-            Ok(o) => o,
-            Err(e) => {
-                eprintln!("error: failed to spawn `{command}`: {e}");
-                return 1;
-            }
+        // Tier 1 — ask the CLI itself.
+        let tier1: Option<PlexiDescriptor> = match runner.run(command, &full_args) {
+            Ok(o) if o.status_success => match plexi_descriptor::parse(&o.stdout) {
+                Ok(d) => Some(d),
+                Err(_) => None, // Fall through to Tier 2 — bad/empty stdout.
+            },
+            Ok(_) => None, // Non-zero exit — `--plexi` not implemented.
+            Err(_) => None, // Spawn failed (e.g. command not on PATH).
         };
 
-        if !output.status_success {
-            eprintln!(
-                "error: `{command} {}` exited non-zero",
-                full_args.join(" ")
-            );
-            if !output.stderr.is_empty() {
-                eprintln!("--- stderr ---\n{}", output.stderr.trim_end());
-            }
-            return 1;
+        if let Some(descriptor) = tier1 {
+            print_summary(&descriptor, SummarySource::Native);
+            return 0;
         }
 
-        let descriptor = match plexi_descriptor::parse(&output.stdout) {
-            Ok(d) => d,
-            Err(e) => {
-                eprintln!("error: descriptor from `{command}` failed to parse:");
-                eprintln!("  {e}");
-                return 1;
+        // Tier 2 — registry. Only consulted when caller passes args=[],
+        // because registry descriptors describe the bare CLI, not arbitrary
+        // subcommand invocations.
+        if options.use_registry && args.is_empty() {
+            match crate::cli_registry::lookup(command, None) {
+                Ok(descriptor) => {
+                    print_summary(&descriptor, SummarySource::Registry);
+                    return 0;
+                }
+                Err(crate::cli_registry::RegistryError::NotFound { .. }) => {
+                    // Fall through to the no-descriptor message below.
+                }
+                Err(e) => {
+                    eprintln!("error: registry lookup for `{command}` failed:\n  {e}");
+                    return 1;
+                }
             }
-        };
+        }
 
-        print_summary(&descriptor);
-        0
+        eprintln!(
+            "error: no descriptor available for `{command}` — neither --plexi nor registry."
+        );
+        eprintln!(
+            "  Tier 3 (--help crawl) is owned by issue #78 and is not yet wired in."
+        );
+        1
     }
 
-    fn print_summary(d: &PlexiDescriptor) {
+    /// Where the descriptor printed in the summary came from. Used to surface
+    /// a `(via registry)` indicator when Tier-2 won the resolution.
+    pub enum SummarySource {
+        Native,
+        Registry,
+    }
+
+    fn print_summary(d: &PlexiDescriptor, source: SummarySource) {
         let icon = d.icon.as_deref().unwrap_or("");
+        let via = match source {
+            SummarySource::Native => "",
+            SummarySource::Registry => "  (via registry)",
+        };
         println!(
-            "{}{}{} v{}  (descriptor {})",
+            "{}{}{} v{}  (descriptor {}){}",
             icon,
             if icon.is_empty() { "" } else { " " },
             d.name,
             d.version,
-            d.plexi_version
+            d.plexi_version,
+            via,
         );
         if let Some(desc) = &d.description {
             println!("  {desc}");
@@ -1035,9 +1454,8 @@ mod descriptor_tests {
     use super::descriptor::*;
     use std::cell::RefCell;
 
-    #[test]
-    fn probe_invokes_command_with_plexi_flag() {
-        let mock = MockRunner {
+    fn ok_descriptor_runner() -> MockRunner {
+        MockRunner {
             stdout: r#"{
                 "plexi_version": "0.1",
                 "name": "fake",
@@ -1048,8 +1466,26 @@ mod descriptor_tests {
             stderr: String::new(),
             success: true,
             captured: RefCell::new(None),
-        };
+        }
+    }
+
+    fn no_plexi_runner() -> MockRunner {
+        // Simulates a CLI that exists on PATH but doesn't implement --plexi
+        // (non-zero exit code). This is the common case for the registry
+        // fallback path.
+        MockRunner {
+            stdout: String::new(),
+            stderr: "unknown flag --plexi".into(),
+            success: false,
+            captured: RefCell::new(None),
+        }
+    }
+
+    #[test]
+    fn probe_invokes_command_with_plexi_flag() {
+        let mock = ok_descriptor_runner();
         let code = probe(&mock, "fake-cli", &[]);
+        // Tier 1 succeeds; result is the parsed descriptor.
         assert_eq!(code, 0);
         let captured = mock.captured.borrow();
         let (cmd, args) = captured.as_ref().expect("runner was invoked");
@@ -1059,18 +1495,7 @@ mod descriptor_tests {
 
     #[test]
     fn probe_appends_plexi_after_user_args() {
-        let mock = MockRunner {
-            stdout: r#"{
-                "plexi_version": "0.1",
-                "name": "fake",
-                "version": "0.0.1",
-                "commands": []
-            }"#
-            .into(),
-            stderr: String::new(),
-            success: true,
-            captured: RefCell::new(None),
-        };
+        let mock = ok_descriptor_runner();
         let code = probe(&mock, "fake-cli", &["sub", "--verbose"]);
         assert_eq!(code, 0);
         let captured = mock.captured.borrow();
@@ -1079,38 +1504,42 @@ mod descriptor_tests {
     }
 
     #[test]
-    fn probe_surfaces_parse_error_with_path() {
-        // Mock returns JSON with an unknown top-level field. We assert the
-        // probe surfaces a non-zero exit; the specific error message reaches
-        // stderr (not assertable cleanly here without a buffer-capture
-        // harness — the field-path content is covered by the parser's own
-        // `parse_rejects_unknown_top_level_field` test).
-        let mock = MockRunner {
-            stdout: r#"{
-                "plexi_version": "0.1",
-                "name": "x",
-                "version": "0.0.1",
-                "commands": [],
-                "rogue": 1
-            }"#
-            .into(),
-            stderr: String::new(),
-            success: true,
-            captured: RefCell::new(None),
-        };
-        let code = probe(&mock, "fake-cli", &[]);
+    fn probe_falls_back_to_registry_when_native_plexi_fails() {
+        // `gh` ships in the embedded registry. With a runner that simulates
+        // gh's real behavior (no native --plexi), the probe should fall
+        // through to Tier 2 and resolve the registry descriptor.
+        let mock = no_plexi_runner();
+        let code = probe(&mock, "gh", &[]);
+        assert_eq!(code, 0, "registry fallback should succeed for `gh`");
+    }
+
+    #[test]
+    fn probe_no_registry_flag_skips_fallback() {
+        // Same setup, but registry disabled. Should fail because Tier 1
+        // fell through and Tier 2 is gated off.
+        let mock = no_plexi_runner();
+        let opts = ProbeOptions { use_registry: false };
+        let code = probe_with_options(&mock, "gh", &[], &opts);
+        assert_eq!(code, 1, "without registry, gh has no descriptor");
+    }
+
+    #[test]
+    fn probe_surfaces_nonzero_exit_for_unknown_cli_with_no_registry_entry() {
+        // No native --plexi, no registry hit → non-zero exit.
+        let mock = no_plexi_runner();
+        let code = probe(&mock, "nonexistent-cli-zzz", &[]);
         assert_eq!(code, 1);
     }
 
     #[test]
-    fn probe_surfaces_nonzero_exit_when_command_fails() {
-        let mock = MockRunner {
-            stdout: String::new(),
-            stderr: "boom".into(),
-            success: false,
-            captured: RefCell::new(None),
-        };
-        let code = probe(&mock, "fake-cli", &[]);
-        assert_eq!(code, 1);
+    fn probe_skips_registry_when_user_args_provided() {
+        // Registry descriptors describe the bare CLI; subcommand invocations
+        // shouldn't get a registry hit even if the CLI is registered.
+        let mock = no_plexi_runner();
+        let code = probe(&mock, "gh", &["pr", "create"]);
+        assert_eq!(
+            code, 1,
+            "registry fallback only applies when no user args are passed"
+        );
     }
 }

--- a/src/cli_registry.rs
+++ b/src/cli_registry.rs
@@ -1,0 +1,363 @@
+//! Tier-2 CLI descriptor registry (issue #321 substrate).
+//!
+//! Three tiers of UI-descriptor resolution for an arbitrary CLI:
+//!
+//! 1. **Tier 1** — the CLI itself emits a descriptor when invoked with
+//!    `--plexi`. Owned by issue #188 / `plexi_descriptor`.
+//! 2. **Tier 2** — *this module*. The Plexi binary ships a registry of
+//!    hand-authored descriptors for popular CLIs that haven't (yet) opted in
+//!    to the `--plexi` standard. Looked up by `(cli_name, version)`.
+//! 3. **Tier 3** — fallback `--help` crawl. Owned by issue #78.
+//!
+//! The registry baked into the binary at build time lives at `registry/` in
+//! the repo (see `RegistrySource::EmbeddedThenUserOverride::EMBEDDED`). A
+//! per-channel user-side override directory shadows the embedded copy:
+//! `~/.plexi-<channel>/registry/`. Override wins. This lets users hand-author
+//! or patch a descriptor locally without rebuilding Plexi.
+//!
+//! Lookup contract: `lookup("gh", None)` → `gh/latest.json`.
+//! `lookup("gh", Some("2.40.0"))` → `gh/2.40.0.json`.
+
+use crate::plexi_descriptor::{self, DescriptorError, PlexiDescriptor};
+use std::path::PathBuf;
+#[cfg(test)]
+use std::path::Path;
+
+/// Compile-time-embedded registry rooted at `registry/` in the repo.
+static EMBEDDED_REGISTRY: include_dir::Dir<'_> =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/registry");
+
+/// Why a registry lookup failed. Distinguishes "no descriptor" (caller falls
+/// through to Tier 3) from "descriptor exists but is broken" (loud error —
+/// the registry is supposed to be curated).
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("registry has no descriptor for `{cli}` version `{version}`")]
+    NotFound { cli: String, version: String },
+
+    #[error("registry descriptor for `{cli}` at `{path}` is malformed: {source}")]
+    Malformed {
+        cli: String,
+        path: String,
+        #[source]
+        source: DescriptorError,
+    },
+
+    #[error("registry descriptor for `{cli}` at `{path}` could not be read: {source}")]
+    Io {
+        cli: String,
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Backing store for the registry. The `Embedded` and `Filesystem` variants
+/// exist primarily so unit tests can supply a temp dir without monkey-patching
+/// `dirs::home_dir()`.
+pub trait RegistryBackend {
+    /// Return the raw JSON text for `<cli>/<version>.json`, or `None` if the
+    /// path doesn't exist in this backend.
+    fn read(&self, cli: &str, version: &str) -> std::io::Result<Option<String>>;
+}
+
+/// The compile-time `include_dir!`-baked registry.
+pub struct EmbeddedBackend;
+
+impl RegistryBackend for EmbeddedBackend {
+    fn read(&self, cli: &str, version: &str) -> std::io::Result<Option<String>> {
+        let path = format!("{cli}/{version}.json");
+        match EMBEDDED_REGISTRY.get_file(&path) {
+            Some(file) => match file.contents_utf8() {
+                Some(s) => Ok(Some(s.to_string())),
+                None => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("embedded registry file `{path}` is not valid UTF-8"),
+                )),
+            },
+            None => Ok(None),
+        }
+    }
+}
+
+/// A user-side filesystem registry directory. Used both for the override at
+/// `~/.plexi-<channel>/registry/` (which shadows `EmbeddedBackend`) and for
+/// tests that need to stage a temp dir.
+pub struct FilesystemBackend {
+    pub root: PathBuf,
+}
+
+impl FilesystemBackend {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+impl RegistryBackend for FilesystemBackend {
+    fn read(&self, cli: &str, version: &str) -> std::io::Result<Option<String>> {
+        let path = self.root.join(cli).join(format!("{version}.json"));
+        match std::fs::read_to_string(&path) {
+            Ok(s) => Ok(Some(s)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Resolve the user-side override directory for the active channel.
+/// Returns `None` if the home dir is unavailable.
+pub fn user_override_dir() -> Option<PathBuf> {
+    Some(crate::config::config_dir().join("registry"))
+}
+
+/// Look up a descriptor for `(cli_name, version)`. When `version` is `None`,
+/// the lookup uses `latest.json`.
+///
+/// Resolution order: user-override → embedded. The first backend that has a
+/// matching file wins, even if it's malformed (we surface the parse error
+/// rather than silently falling through — a malformed override is a bug the
+/// user wants to know about).
+pub fn lookup(cli_name: &str, version: Option<&str>) -> Result<PlexiDescriptor, RegistryError> {
+    let version_key = version.unwrap_or("latest");
+
+    // 1. User override.
+    if let Some(override_root) = user_override_dir() {
+        let backend = FilesystemBackend::new(override_root);
+        match read_and_parse(&backend, cli_name, version_key) {
+            Ok(Some(d)) => return Ok(d),
+            Ok(None) => { /* fall through */ }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // 2. Embedded.
+    match read_and_parse(&EmbeddedBackend, cli_name, version_key) {
+        Ok(Some(d)) => Ok(d),
+        Ok(None) => Err(RegistryError::NotFound {
+            cli: cli_name.to_string(),
+            version: version_key.to_string(),
+        }),
+        Err(e) => Err(e),
+    }
+}
+
+/// Lookup against an explicit list of backends (in priority order). The
+/// public `lookup()` is a thin wrapper over this; tests can call this
+/// directly to inject a temp filesystem backend.
+#[cfg(test)]
+pub fn lookup_with_backends(
+    backends: &[&dyn RegistryBackend],
+    cli_name: &str,
+    version: Option<&str>,
+) -> Result<PlexiDescriptor, RegistryError> {
+    let version_key = version.unwrap_or("latest");
+    for backend in backends {
+        match read_and_parse(*backend, cli_name, version_key) {
+            Ok(Some(d)) => return Ok(d),
+            Ok(None) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(RegistryError::NotFound {
+        cli: cli_name.to_string(),
+        version: version_key.to_string(),
+    })
+}
+
+fn read_and_parse(
+    backend: &dyn RegistryBackend,
+    cli: &str,
+    version: &str,
+) -> Result<Option<PlexiDescriptor>, RegistryError> {
+    let path_repr = format!("{cli}/{version}.json");
+    let raw = backend.read(cli, version).map_err(|e| RegistryError::Io {
+        cli: cli.to_string(),
+        path: path_repr.clone(),
+        source: e,
+    })?;
+    match raw {
+        None => Ok(None),
+        Some(json) => match plexi_descriptor::parse(&json) {
+            Ok(d) => Ok(Some(d)),
+            Err(e) => Err(RegistryError::Malformed {
+                cli: cli.to_string(),
+                path: path_repr,
+                source: e,
+            }),
+        },
+    }
+}
+
+/// Iterate all CLI directories present in either the embedded or override
+/// backend. Used by `plexi registry watch` to walk the registered CLI set.
+pub fn list_clis() -> Vec<String> {
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for entry in EMBEDDED_REGISTRY.entries() {
+        if let Some(d) = entry.as_dir() {
+            if let Some(name) = d.path().file_name().and_then(|s| s.to_str()) {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    if let Some(override_root) = user_override_dir() {
+        if let Ok(read) = std::fs::read_dir(&override_root) {
+            for entry in read.flatten() {
+                if entry.path().is_dir() {
+                    if let Some(name) = entry.file_name().to_str() {
+                        names.insert(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// Build-time-style sanity check that every embedded descriptor parses. Run
+/// from a unit test (cheap — descriptors are small) so a hand-edit that
+/// breaks the schema fails CI rather than blowing up at runtime.
+#[cfg(test)]
+fn parse_all_embedded() -> Result<usize, RegistryError> {
+    let mut count = 0;
+    for entry in EMBEDDED_REGISTRY.entries() {
+        if let Some(dir) = entry.as_dir() {
+            let cli = dir
+                .path()
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("?")
+                .to_string();
+            for f in dir.files() {
+                let path_repr = f.path().to_string_lossy().into_owned();
+                let json = f.contents_utf8().ok_or_else(|| RegistryError::Io {
+                    cli: cli.clone(),
+                    path: path_repr.clone(),
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "non-utf8 registry file",
+                    ),
+                })?;
+                plexi_descriptor::parse(json).map_err(|e| RegistryError::Malformed {
+                    cli: cli.clone(),
+                    path: path_repr,
+                    source: e,
+                })?;
+                count += 1;
+            }
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+fn write_descriptor(root: &Path, cli: &str, version: &str, json: &str) {
+    let dir = root.join(cli);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(dir.join(format!("{version}.json")), json).expect("write descriptor");
+}
+
+#[cfg(test)]
+const FAKE_DESCRIPTOR: &str = r#"{
+    "plexi_version": "0.1",
+    "name": "fake",
+    "version": "9.9.9",
+    "commands": []
+}"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn lookup_returns_descriptor_for_known_cli() {
+        // gh ships seeded into the embedded registry. The public `lookup` is
+        // OK to call here — no override dir is created in the test sandbox.
+        let d = lookup("gh", None).expect("gh latest in embedded registry");
+        assert_eq!(d.name, "gh");
+        assert!(!d.commands.is_empty());
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown_cli() {
+        let err = lookup("nonexistent-cli-zzz", None).expect_err("unknown CLI must NotFound");
+        match err {
+            RegistryError::NotFound { cli, .. } => assert_eq!(cli, "nonexistent-cli-zzz"),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookup_with_explicit_version_picks_that_file() {
+        let tmp = TempDir::new().unwrap();
+        write_descriptor(tmp.path(), "fake", "9.9.9", FAKE_DESCRIPTOR);
+        let backend = FilesystemBackend::new(tmp.path().to_path_buf());
+        let d = lookup_with_backends(&[&backend], "fake", Some("9.9.9"))
+            .expect("explicit version found");
+        assert_eq!(d.version, "9.9.9");
+    }
+
+    #[test]
+    fn lookup_without_version_picks_latest() {
+        let tmp = TempDir::new().unwrap();
+        write_descriptor(tmp.path(), "fake", "latest", FAKE_DESCRIPTOR);
+        let backend = FilesystemBackend::new(tmp.path().to_path_buf());
+        let d = lookup_with_backends(&[&backend], "fake", None)
+            .expect("default version maps to latest.json");
+        assert_eq!(d.version, "9.9.9");
+    }
+
+    #[test]
+    fn user_override_dir_shadows_embedded_registry() {
+        // Stage a `gh/latest.json` in a temp override dir whose `name` field
+        // differs from the embedded `gh` descriptor. Override must win.
+        let tmp = TempDir::new().unwrap();
+        let overridden_json = r#"{
+            "plexi_version": "0.1",
+            "name": "gh-overridden",
+            "version": "0.0.0",
+            "commands": []
+        }"#;
+        write_descriptor(tmp.path(), "gh", "latest", overridden_json);
+        let override_backend = FilesystemBackend::new(tmp.path().to_path_buf());
+        let d = lookup_with_backends(&[&override_backend, &EmbeddedBackend], "gh", None)
+            .expect("override should resolve");
+        assert_eq!(d.name, "gh-overridden");
+    }
+
+    #[test]
+    fn malformed_descriptor_in_registry_errors_clearly() {
+        let tmp = TempDir::new().unwrap();
+        write_descriptor(
+            tmp.path(),
+            "fake",
+            "latest",
+            r#"{ "this": "is not a descriptor" }"#,
+        );
+        let backend = FilesystemBackend::new(tmp.path().to_path_buf());
+        let err = lookup_with_backends(&[&backend], "fake", None)
+            .expect_err("malformed JSON must error");
+        match err {
+            RegistryError::Malformed { cli, path, .. } => {
+                assert_eq!(cli, "fake");
+                assert!(path.contains("fake/latest.json"), "path: {path}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embedded_registry_round_trips_through_parser() {
+        // Guard against hand-edit drift: every shipped descriptor must parse.
+        let n = parse_all_embedded().expect("all embedded descriptors must parse");
+        assert!(n >= 6, "expected ≥6 descriptors (3 CLIs × 2 files), got {n}");
+    }
+
+    #[test]
+    fn list_clis_returns_seeded_three() {
+        let names = list_clis();
+        for cli in &["gh", "cargo", "npm"] {
+            assert!(names.iter().any(|n| n == cli), "expected {cli} in {names:?}");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod app_registry;
 mod app_trait;
 mod audio;
 mod cli;
+mod cli_registry;
 mod command_palette;
 mod config;
 mod context;
@@ -404,29 +405,68 @@ fn main() -> eframe::Result {
                 std::process::exit(cli::notify_cli(&title, &body, level));
             }
             "descriptor" => {
-                // `plexi descriptor probe <cmd> [args...]` — invokes
-                // `<cmd> [args...] --plexi`, parses the result against the
-                // descriptor schema, and prints a human-readable summary.
-                // Reference consumer for #188 / substrate for #78 + #321.
+                // `plexi descriptor probe <cmd> [args...] [--no-registry]` —
+                // runs `<cmd> [args...] --plexi`, parses the result against
+                // the descriptor schema, and prints a human-readable
+                // summary. On Tier-1 failure, falls back to the Tier-2
+                // registry (issue #321) unless `--no-registry` is set.
                 if args.len() < 3 {
-                    eprintln!("Usage: plexi descriptor probe <command> [args...]");
+                    eprintln!(
+                        "Usage: plexi descriptor probe <command> [args...] [--no-registry]"
+                    );
                     std::process::exit(1);
                 }
                 match args[2].as_str() {
                     "probe" => {
                         if args.len() < 4 {
-                            eprintln!("Usage: plexi descriptor probe <command> [args...]");
+                            eprintln!(
+                                "Usage: plexi descriptor probe <command> [args...] [--no-registry]"
+                            );
                             std::process::exit(1);
                         }
                         let cmd = &args[3];
-                        let extra: Vec<&str> =
-                            args[4..].iter().map(|s| s.as_str()).collect();
+                        // Split the tail into positional args + flags. `--no-registry`
+                        // is the only flag we consume; anything else is forwarded
+                        // verbatim to the target command.
+                        let mut use_registry = true;
+                        let mut extra: Vec<&str> = Vec::new();
+                        for a in &args[4..] {
+                            if a == "--no-registry" {
+                                use_registry = false;
+                            } else {
+                                extra.push(a.as_str());
+                            }
+                        }
                         let runner = cli::descriptor::RealRunner;
-                        std::process::exit(cli::descriptor::probe(&runner, cmd, &extra));
+                        let opts = cli::descriptor::ProbeOptions { use_registry };
+                        std::process::exit(cli::descriptor::probe_with_options(
+                            &runner, cmd, &extra, &opts,
+                        ));
                     }
                     other => {
                         eprintln!("Unknown descriptor subcommand: {other}");
-                        eprintln!("Usage: plexi descriptor probe <command> [args...]");
+                        eprintln!(
+                            "Usage: plexi descriptor probe <command> [args...] [--no-registry]"
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
+            "registry" => {
+                // `plexi registry watch [<cli>]` — diff installed CLIs
+                // against their registered descriptors. Issue #321 substrate.
+                if args.len() < 3 {
+                    eprintln!("Usage: plexi registry watch [<cli>]");
+                    std::process::exit(1);
+                }
+                match args[2].as_str() {
+                    "watch" => {
+                        let only = args.get(3).map(|s| s.as_str());
+                        std::process::exit(cli::registry::watch_cli(only));
+                    }
+                    other => {
+                        eprintln!("Unknown registry subcommand: {other}");
+                        eprintln!("Usage: plexi registry watch [<cli>]");
                         std::process::exit(1);
                     }
                 }
@@ -503,6 +543,8 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "pack",
         // #188 — `plexi descriptor probe <cmd>` for the --plexi standard.
         "descriptor",
+        // #321 — `plexi registry watch [<cli>]` for the CLI wrapper registry.
+        "registry",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).


### PR DESCRIPTION
Closes #321 (substrate).

Builds on #188 (#352). #78's host renderer is in flight (parallel).

## What changed
Adds the substrate for the Tier-2 CLI descriptor registry: a baked-in `registry/` directory with seed descriptors for `gh`, `cargo`, `npm`; a new `src/cli_registry.rs` lookup module with `EmbeddedBackend` + per-channel filesystem override at `~/.plexi-<channel>/registry/`; descriptor `probe` falls back to the registry when `--plexi` isn't natively supported (with `--no-registry` to opt out); and a new `plexi registry watch [<cli>]` subcommand that walks the registered CLIs and reports staleness vs. the locally installed binary. Authoring the remaining 7 CLIs, the cron-driven watcher, and the public CDN are deferred to follow-ups #354 / #355 / #356.

## Breaks if
- `plexi descriptor probe gh` (gh installed, doesn't ship `--plexi`) returns "no descriptor available" instead of the registry's gh descriptor.
- `plexi registry watch` errors instead of reporting per-CLI status (or silently skips installed CLIs).
- A user-side `~/.plexi-alpha/registry/gh/latest.json` does not shadow the embedded descriptor.
- A hand-edit to `registry/<cli>/*.json` that produces invalid JSON does not fail the `cli_registry::tests::embedded_registry_round_trips_through_parser` test.

## Human verification
- [ ] Ensure `gh` is installed on PATH. Run `plexi-alpha descriptor probe gh`. Output shows the registry's gh descriptor with `(via registry)` indicator.
- [ ] Run `plexi-alpha descriptor probe gh --no-registry`. Falls through to the no-descriptor-available message.
- [ ] Run `plexi-alpha registry watch`. Walks gh/cargo/npm; reports installed version vs registry (likely all `[STALE]` since seeds are pinned older).
- [ ] Drop a hand-edited `~/.plexi-alpha/registry/gh/latest.json` with a different `name`. Re-run probe — user override wins.

## Test added
10 new tests across `cli_registry::tests` (8) + `cli::descriptor_tests` (3 new, 2 retired/replaced) + `cli::registry_watch_tests` (4). Full plexi suite: 209 passing.

## Follow-ups filed
- #354 — Author full descriptors for the remaining 7 CLIs (git, docker, kubectl, brew, uv, rg, fzf).
- #355 — Automated release-watcher cron + GitHub Action.
- #356 — Move registry to public CDN at registry.plexi.app.