### PR TITLE
v3.4 P2: GUI↔Terminal media bridge — file browser routes media to in-app players (#79)

### DIFF
--- a/examples/audio-bridge-test/audio_bridge_test.py
+++ b/examples/audio-bridge-test/audio_bridge_test.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Audio Bridge Test — POC for #79 (GUI↔Terminal media bridge).
+
+End-to-end demo of the v3.4 release-level checklist item:
+"Run the GUI↔terminal media bridge demo: terminal plays an audio file,
+the canvas pane visualizes the waveform in real time."
+
+Mirror of the goal but driven by mic capture so the demo is self-
+contained — no test asset needed:
+  - Records: starts mic capture (#277), reads f32 PCM frames from the
+    binary pipe, computes peak meters per ~50 ms window, and paints
+    them across the pane.
+  - Echoes the equivalent ffmpeg command through a linked terminal
+    so the user sees how to do the same thing from CLI.
+
+Capabilities: ``audio.record`` (#277) + ``terminal.bindings`` (#78).
+
+Keys:
+  r - Record (start capture + echo ffmpeg command)
+  s - Stop (end capture + echo "# capture stopped")
+  c - Clear waveform
+"""
+from __future__ import annotations
+
+import struct
+import threading
+import time
+
+from plexi_sdk import App, RenderContext, CapabilityDeniedError
+
+
+PIPE_ID = "audio-bridge-mic"
+SAMPLE_RATE = 48000
+BUFFER_SIZE = 512
+# Last ~5 s of peak data, one peak per ~50 ms window. 5000 / 50 = 100.
+MAX_PEAKS = 100
+PEAK_WINDOW_MS = 50
+
+# Equivalent CLI: macOS avfoundation default mic, 5s capture, 48 kHz wav.
+FFMPEG_CAPTURE = (
+    "ffmpeg -f avfoundation -i :0 -t 5 -ar 48000 capture.wav"
+)
+
+
+class AudioBridgeTestApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._terminal_pane_id: int = 0
+        self._capturing: bool = False
+        self._reader_thread: "threading.Thread | None" = None
+        self._reader_stop = threading.Event()
+        self._pipe = None
+        # Rolling window of recent peaks. Each value is the peak |sample|
+        # in the last PEAK_WINDOW_MS window, clamped to [0, 1].
+        self._peaks: list[float] = []
+        self._peaks_lock = threading.Lock()
+        # Running window state.
+        self._window_peak: float = 0.0
+        self._window_samples: int = 0
+        self._frames_seen: int = 0
+
+        ctx.status_summary("Audio Bridge Test — press r to record")
+        self.emit.info("audio-bridge-test starting")
+        try:
+            self._terminal_pane_id = self.emit.request_linked_terminal(
+                cwd=None,
+                label="audio bridge",
+            )
+            self.emit.info(f"linked terminal pane #{self._terminal_pane_id}")
+        except CapabilityDeniedError as e:
+            self.emit.error(str(e))
+
+    # -- Bridge ---------------------------------------------------------
+
+    def _emit_cli(self, command: str, *, echo: bool = True) -> None:
+        if self._terminal_pane_id == 0:
+            return
+        self.emit.run_in_linked_terminal(
+            self._terminal_pane_id, command, echo=echo,
+        )
+
+    # -- Capture --------------------------------------------------------
+
+    def _start(self) -> None:
+        if self._capturing:
+            return
+        self._capturing = True
+        self._reader_stop.clear()
+        try:
+            self._pipe = self.emit.audio_capture(
+                pipe_id=PIPE_ID,
+                sample_rate=SAMPLE_RATE,
+                buffer_size=BUFFER_SIZE,
+            )
+        except CapabilityDeniedError as e:
+            self._capturing = False
+            self.emit.error(str(e))
+            return
+        self._emit_cli(FFMPEG_CAPTURE, echo=True)
+        self._reader_thread = threading.Thread(
+            target=self._reader, daemon=True
+        )
+        self._reader_thread.start()
+        self.emit.schedule_render(after_ms=20)
+
+    def _stop(self) -> None:
+        if not self._capturing:
+            return
+        self._capturing = False
+        self._reader_stop.set()
+        # Comment-only — doesn't run anything destructive.
+        self._emit_cli("# capture stopped", echo=True)
+        self.emit.schedule_render(after_ms=20)
+
+    def _reader(self) -> None:
+        """Pull f32 PCM packets from the binary pipe and accumulate the
+        rolling peak window. Each packet is a tightly-packed array of
+        f32 samples (interleaved if multi-channel — we treat them as a
+        flat stream for the waveform, which over-counts per-frame width
+        but doesn't matter for a peak meter)."""
+        if self._pipe is None:
+            return
+        if not self._pipe.connect(timeout=5.0):
+            self.emit.warn("audio-bridge-test: pipe connect timed out")
+            return
+        window_samples_target = int(SAMPLE_RATE * PEAK_WINDOW_MS / 1000)
+        while not self._reader_stop.is_set():
+            frame = self._pipe.read_frame()
+            if frame is None:
+                break
+            self._frames_seen += 1
+            # Decode f32 little-endian samples. Slice in 4-byte chunks
+            # without an explicit numpy dep so the SDK install stays
+            # vanilla.
+            count = len(frame) // 4
+            if count == 0:
+                continue
+            samples = struct.unpack_from(f"<{count}f", frame)
+            for s in samples:
+                a = abs(s)
+                if a > self._window_peak:
+                    self._window_peak = a
+                self._window_samples += 1
+                if self._window_samples >= window_samples_target:
+                    with self._peaks_lock:
+                        self._peaks.append(min(1.0, self._window_peak))
+                        if len(self._peaks) > MAX_PEAKS:
+                            del self._peaks[: len(self._peaks) - MAX_PEAKS]
+                    self._window_peak = 0.0
+                    self._window_samples = 0
+            # Repaint at most ~20 fps.
+            if self._frames_seen % 4 == 0:
+                self.emit.schedule_render(after_ms=20)
+
+    # -- Input ----------------------------------------------------------
+
+    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+        k = key.lower()
+        if k == "r":
+            self._start()
+        elif k == "s":
+            self._stop()
+        elif k == "c":
+            with self._peaks_lock:
+                self._peaks.clear()
+            ctx.schedule_render(after_ms=16)
+
+    # -- Render ---------------------------------------------------------
+
+    def on_render(self, ctx: RenderContext) -> None:
+        w, h = ctx.w, ctx.h
+
+        bg = "#0e0e10"
+        fg = "#e2e8f0"
+        muted = "#64748b"
+        accent = "#34d399"
+        red = "#ef4444"
+        ctx.rect(0, 0, w, h, bg)
+
+        # Header.
+        ctx.text(x=24, y=24, text="audio bridge test",
+                 size=22.0, color=fg, bold=True)
+        if self._terminal_pane_id == 0:
+            sub = "no linked terminal — manifest missing terminal.bindings"
+            sub_col = red
+        else:
+            sub = f"linked terminal #{self._terminal_pane_id}  ·  r record  ·  s stop  ·  c clear"
+            sub_col = muted
+        ctx.text(x=24, y=58, text=sub, size=12.0, color=sub_col)
+
+        # State badge.
+        state_text = "RECORDING" if self._capturing else "idle"
+        state_col = red if self._capturing else muted
+        ctx.text(x=24, y=86, text=state_text, size=14.0, color=state_col,
+                 monospace=True, bold=True)
+
+        # Waveform area.
+        wf_x = 24
+        wf_y = 110
+        wf_w = max(w - 48, 200)
+        wf_h = max(h - wf_y - 80, 80)
+        ctx.rect(wf_x, wf_y, wf_w, wf_h, "#1a1a1f", radius=6.0)
+        midline = wf_y + wf_h / 2
+        ctx.line(wf_x, midline, wf_x + wf_w, midline, muted, width=1.0)
+
+        with self._peaks_lock:
+            peaks = list(self._peaks)
+        if peaks:
+            bar_w = max(1.0, wf_w / MAX_PEAKS)
+            offset = wf_w - len(peaks) * bar_w  # right-align (newest on right)
+            for i, p in enumerate(peaks):
+                bar_h = p * (wf_h / 2 - 4)
+                x = wf_x + offset + i * bar_w
+                ctx.rect(x, midline - bar_h, bar_w * 0.85, bar_h * 2,
+                         accent)
+        else:
+            ctx.text(x=wf_x + 12, y=midline, text="(no audio yet — press r)",
+                     size=12.0, color=muted, align="left_center")
+
+        # Footer: equivalent CLI.
+        ctx.text(x=24, y=h - 48,
+                 text="equivalent CLI (echoed in terminal on record):",
+                 size=11.0, color=muted)
+        ctx.text(x=24, y=h - 26, text=f"$ {FFMPEG_CAPTURE}",
+                 size=12.0, color=fg, monospace=True,
+                 max_width=w - 48, elide=True)
+
+
+if __name__ == "__main__":
+    AudioBridgeTestApp().run()

--- a/examples/audio-bridge-test/manifest.toml
+++ b/examples/audio-bridge-test/manifest.toml
@@ -1,0 +1,17 @@
+schema_version = 1
+
+[app]
+id = "audio-bridge-test"
+type = "app"
+name = "Audio Bridge Test"
+version = "0.1.0"
+description = "POC for #79 — exercises the GUI↔Terminal media bridge end-to-end. Captures mic PCM via #277, paints a live waveform of the last 5s, and echoes the equivalent ffmpeg command into a linked terminal whenever the user starts/stops capture."
+entry = "audio_bridge_test.py"
+default_notification_scope = "context"
+layout_hint = "split_h"
+
+[app.capabilities]
+capabilities = ["audio.record", "terminal.bindings"]
+
+[launch]
+background = false

--- a/examples/audio-player/audio_player.py
+++ b/examples/audio-player/audio_player.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Audio Player — POC for #79 (GUI↔Terminal media bridge, v3.4 P2).
+
+Spawned by the file browser when the user opens an audio file. The path
+arrives as ``sys.argv[1]``. v3.4 scope is the bridge surface: every
+transport action emits an explicit ``RunInLinkedTerminal`` with the
+equivalent ``ffplay`` / ``ffmpeg`` invocation, so the user can copy any
+GUI action as a plain CLI command.
+
+Decode-in-app via ``audio.rs`` is NOT in scope for this POC — #277 ships
+capture only, playback is on the v3.5+ roadmap. Until then, "play" is
+the bridge primitive: the linked terminal does the actual playing via
+``ffplay``. Apps lacking ``ffplay`` see the command echoed but it errors
+in the terminal — surface, not a crash.
+
+Capabilities: ``terminal.bindings`` (#78).
+
+Keys:
+  o - Open the file via ffplay (run in linked terminal)
+  p - Pause (echo equivalent ffplay pause; ffplay reads stdin keys)
+  r - Resume play (re-issue ffplay)
+  [ - Seek -5s (ffmpeg -ss helper)
+  ] - Seek +5s
+  i - ffprobe info dump
+  c - Clear log
+"""
+from __future__ import annotations
+
+import shlex
+import sys
+import threading
+import time
+
+from plexi_sdk import App, RenderContext, CapabilityDeniedError
+from plexi_sdk.ui import (
+    AppBar,
+    Card,
+    Column,
+    Footer,
+    KeyRow,
+    Label,
+    ScrollLog,
+    Section,
+    Spacer,
+)
+
+
+SEEK_STEP_MS = 5_000
+MAX_LOG_LINES = 200
+
+
+def _path_from_argv() -> str:
+    """The file browser passes the audio path as argv[1]. When launched
+    standalone (e.g. command palette), argv is empty — surface that as a
+    clear in-pane error instead of crashing."""
+    if len(sys.argv) >= 2 and sys.argv[1]:
+        return sys.argv[1]
+    return ""
+
+
+class AudioPlayerApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._path: str = _path_from_argv()
+        self._terminal_pane_id: int = 0
+        self._state: str = "(closed)"
+        self._position_ms: int = 0
+        self._log_lines: list[str] = []
+        self._log_lock = threading.Lock()
+
+        if not self._path:
+            ctx.status_summary("Audio Player — no file (launch with a path arg)")
+            self.emit.warn("audio-player: no path argument; launch via file browser or pass argv[1]")
+            return
+
+        ctx.status_summary(f"Audio Player — {self._path}")
+        self.emit.info(f"audio-player: opening {self._path}")
+
+        # Open a linked terminal so every transport action is also a
+        # visible CLI command. This is the bridge contract from #79.
+        try:
+            self._terminal_pane_id = self.emit.request_linked_terminal(
+                cwd=None,
+                label="audio bridge",
+            )
+            self._append_log(f"linked terminal pane #{self._terminal_pane_id}")
+        except CapabilityDeniedError as e:
+            self.emit.error(str(e))
+            self._append_log(f"capability denied: {e}")
+
+    # -- Bridge helpers --------------------------------------------------
+
+    def _emit_cli(self, command: str, *, echo: bool = True) -> None:
+        """Fire-and-forget the equivalent CLI through the linked
+        terminal. No-op if the terminal isn't open."""
+        if self._terminal_pane_id == 0:
+            self._append_log("(no linked terminal — drop command)")
+            return
+        self.emit.run_in_linked_terminal(
+            self._terminal_pane_id, command, echo=echo,
+        )
+        self._append_log(f"$ {command}")
+
+    def _quoted_path(self) -> str:
+        return shlex.quote(self._path)
+
+    # -- Transport actions ----------------------------------------------
+
+    def _open(self) -> None:
+        if not self._path:
+            self._append_log("no file — relaunch with a path argument")
+            return
+        self._state = "play"
+        self._position_ms = 0
+        self._emit_cli(f"ffplay -autoexit -nodisp {self._quoted_path()}")
+
+    def _pause(self) -> None:
+        # ffplay reads `space` from stdin to toggle pause. We can't drive
+        # its stdin directly through RunInLinkedTerminal (it injects a
+        # newline-terminated command into the shell, not the running
+        # process). Echo the equivalent for the user to repro manually.
+        self._state = "pause"
+        self._emit_cli("# ffplay: press SPACE in the terminal to toggle pause", echo=False)
+
+    def _resume(self) -> None:
+        self._state = "play"
+        self._emit_cli("# ffplay: press SPACE to resume (or re-run with -ss)", echo=False)
+
+    def _seek(self, delta_ms: int) -> None:
+        self._position_ms = max(0, self._position_ms + delta_ms)
+        seconds = self._position_ms / 1000.0
+        self._emit_cli(
+            f"ffplay -autoexit -nodisp -ss {seconds:.3f} {self._quoted_path()}"
+        )
+
+    def _probe(self) -> None:
+        self._emit_cli(
+            f"ffprobe -hide_banner -show_format -show_streams {self._quoted_path()}"
+        )
+
+    # -- Logging ---------------------------------------------------------
+
+    def _append_log(self, line: str) -> None:
+        ts = time.strftime("%H:%M:%S")
+        with self._log_lock:
+            self._log_lines.append(f"{ts} {line}")
+            if len(self._log_lines) > MAX_LOG_LINES:
+                del self._log_lines[: len(self._log_lines) - MAX_LOG_LINES]
+
+    # -- Input -----------------------------------------------------------
+
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+        k = key.lower()
+        if k == "o":
+            self._open()
+        elif k == "p":
+            self._pause()
+        elif k == "r":
+            self._resume()
+        elif key == "[" or k == "[":
+            self._seek(-SEEK_STEP_MS)
+        elif key == "]" or k == "]":
+            self._seek(SEEK_STEP_MS)
+        elif k == "i":
+            self._probe()
+        elif k == "c":
+            with self._log_lock:
+                self._log_lines.clear()
+        self.emit.schedule_render(after_ms=20)
+
+    # -- Render ----------------------------------------------------------
+
+    def _status_card(self) -> Card:
+        rows: list = [Section("Status")]
+        if not self._path:
+            rows.append(Label("(no file — launch via file browser or pass argv[1])"))
+        else:
+            rows.append(Label(f"  path     {self._path}"))
+            rows.append(Label(f"  state    {self._state}"))
+            rows.append(Label(f"  position {self._position_ms} ms"))
+            rows.append(Label(f"  terminal #{self._terminal_pane_id}"))
+        return Card(rows)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        with self._log_lock:
+            log_snapshot = list(self._log_lines)
+
+        children: list = [
+            AppBar(title="Audio Player"),
+            Label("v3.4 GUI↔Terminal media bridge POC (#79)"),
+            Label("Every transport action emits the equivalent CLI in the linked terminal."),
+            self._status_card(),
+            Section("Keys"),
+            Card([
+                KeyRow("o", "Open via ffplay"),
+                KeyRow("p", "Pause (echo: SPACE in terminal)"),
+                KeyRow("r", "Resume"),
+                KeyRow("[", f"Seek -{SEEK_STEP_MS} ms (ffplay -ss)"),
+                KeyRow("]", f"Seek +{SEEK_STEP_MS} ms"),
+                KeyRow("i", "ffprobe info dump"),
+                KeyRow("c", "Clear log"),
+            ]),
+            Section(f"CLI bridge log ({len(log_snapshot)})"),
+            Spacer(grow=True),
+            ScrollLog(lines=log_snapshot, empty_text="(no actions yet — press o to play)"),
+            Footer("ffplay required for actual playback. CoreAudio in-app decode lands v3.5+."),
+        ]
+        ctx.render(Column(children))
+
+
+if __name__ == "__main__":
+    AudioPlayerApp().run()

--- a/examples/audio-player/manifest.toml
+++ b/examples/audio-player/manifest.toml
@@ -1,0 +1,17 @@
+schema_version = 1
+
+[app]
+id = "audio-player"
+type = "app"
+name = "Audio Player"
+version = "0.1.0"
+description = "GUI↔Terminal media bridge POC (#79). Spawned by the file browser when the user opens an audio file (mp3/wav/flac/m4a/aac/ogg/opus). v3.4 path: requests a linked terminal and emits the equivalent ffplay/ffmpeg command for every transport action — actual decode is shelled. CoreAudio playback is on the v3.5+ roadmap."
+entry = "audio_player.py"
+default_notification_scope = "context"
+layout_hint = "split_h"
+
+[app.capabilities]
+capabilities = ["terminal.bindings"]
+
+[launch]
+background = false

--- a/examples/video-player/manifest.toml
+++ b/examples/video-player/manifest.toml
@@ -5,12 +5,13 @@ id = "video-player"
 type = "app"
 name = "Video Player"
 version = "0.1.0"
-description = "POC for #345 - exercises the video substrate via the procedural mock decoder. Set PLEXI_VIDEO=mock://gradient before launching the host. Play / Pause / Seek work; frame counter increments at the configured fps."
+description = "POC for #345 + #79 — exercises the video substrate via mock or AVFoundation AND echoes the equivalent ffplay/ffmpeg CLI through a linked terminal (GUI↔Terminal media bridge). Set PLEXI_VIDEO=mock://gradient, set PLEXI_VIDEO_PATH for a real H.264 file, or pass a path as argv[1] (the file browser does this for mp4/mov/mkv files)."
 entry = "video_player.py"
 default_notification_scope = "context"
+layout_hint = "split_h"
 
 [app.capabilities]
-capabilities = ["video.playback"]
+capabilities = ["video.playback", "terminal.bindings"]
 
 [launch]
 background = false

--- a/examples/video-player/video_player.py
+++ b/examples/video-player/video_player.py
@@ -36,6 +36,8 @@ CapabilityDeniedError immediately and the app surfaces it in the log.
 from __future__ import annotations
 
 import os
+import shlex
+import sys
 import threading
 import time
 
@@ -54,7 +56,12 @@ from plexi_sdk.ui import (
 
 
 MOCK_SOURCE = "mock://gradient"
-FILE_SOURCE = os.environ.get("PLEXI_VIDEO_PATH", "")
+# Source resolution priority (most specific wins):
+#   1. argv[1]                 — file browser passes the path (#79).
+#   2. PLEXI_VIDEO_PATH env    — pre-#79 launch path (kept for the mock harness).
+#   3. mock://gradient         — fallback for the substrate POC (#345).
+ARGV_SOURCE = sys.argv[1] if len(sys.argv) >= 2 and sys.argv[1] else ""
+FILE_SOURCE = ARGV_SOURCE or os.environ.get("PLEXI_VIDEO_PATH", "")
 PIPE_ID = "video-stream"
 SEEK_STEP_MS = 5_000
 MAX_LOG_LINES = 200
@@ -67,25 +74,66 @@ class VideoPlayerApp(App):
         self._last_frame_bytes: int = 0
         self._position_ms: int = 0
         self._state: str = "(closed)"
-        self._source: str = MOCK_SOURCE
+        # If the file browser launched us with argv[1], default to that
+        # source so the user doesn't have to press `f` first. Otherwise
+        # the substrate-POC default (mock://gradient) holds.
+        self._source: str = FILE_SOURCE if ARGV_SOURCE else MOCK_SOURCE
         self._log_lines: list[str] = []
         self._log_lock = threading.Lock()
         self._reader_stop = threading.Event()
         self._reader_thread: threading.Thread | None = None
+        # GUI↔Terminal media bridge (#79): every transport action also
+        # emits the equivalent ffplay/ffmpeg invocation through a linked
+        # terminal so the user can copy any GUI action as a CLI command.
+        self._terminal_pane_id: int = 0
         ctx.status_summary("Video Player - press o to open, f to toggle file/mock, p/r pause/resume, [/] seek")
         self.emit.info("Video Player started")
-        if FILE_SOURCE:
+        if ARGV_SOURCE:
+            self.emit.info(f"argv path: {ARGV_SOURCE} (file browser handoff)")
+        elif FILE_SOURCE:
             self.emit.info(f"PLEXI_VIDEO_PATH={FILE_SOURCE} - press f to switch to it")
         else:
             self.emit.info("PLEXI_VIDEO_PATH not set - mock://gradient only. Set it to drive AVFoundation.")
+        try:
+            self._terminal_pane_id = self.emit.request_linked_terminal(
+                cwd=None,
+                label="video bridge",
+            )
+            self.emit.info(f"linked terminal pane #{self._terminal_pane_id}")
+        except CapabilityDeniedError as e:
+            self.emit.warn(f"terminal.bindings denied — CLI bridge disabled: {e}")
 
     # -- Open / close ----------------------------------------------------------
+
+    # -- CLI bridge (#79) ------------------------------------------------
+
+    def _emit_cli(self, command: str, *, echo: bool = False) -> None:
+        """Echo the equivalent CLI through the linked terminal. We use
+        ``echo=False`` for the per-action mirror so it doesn't actually
+        run alongside the in-app decode — the in-app player IS doing the
+        playback. The user sees the command in the terminal as a copy-
+        ready primitive. No-op when no terminal is linked."""
+        if self._terminal_pane_id == 0:
+            return
+        # echo=False is observational only — the host always writes
+        # command+\n to the PTY (PTY-level echo is shell-controlled);
+        # we send a comment line so the user sees the equivalent without
+        # actually running ffplay alongside the in-app decode.
+        line = command if echo else f"# {command}"
+        self.emit.run_in_linked_terminal(self._terminal_pane_id, line, echo=False)
+
+    def _quoted_source(self) -> str:
+        # mock:// URLs are fine to pass verbatim to ffplay — it'll
+        # error, but the bridge contract is "the equivalent command",
+        # not "a command that will succeed".
+        return shlex.quote(self._source)
 
     def _open(self) -> None:
         if self._handle is not None:
             self._append_log("already open - close (x) first")
             return
         self._append_log(f"opening {self._source} ...")
+        self._emit_cli(f"ffplay -autoexit {self._quoted_source()}")
 
         def runner() -> None:
             try:
@@ -147,6 +195,7 @@ class VideoPlayerApp(App):
         self._reader_stop.set()
         self.emit.close_video(h.handle_id)
         self._append_log(f"closed handle_id={h.handle_id}")
+        self._emit_cli("ffplay teardown")
         self._handle = None
         self._state = "(closed)"
         self.emit.schedule_render(after_ms=20)
@@ -165,9 +214,17 @@ class VideoPlayerApp(App):
             # after a seek.
             self._frames_seen = int((position_ms / 1000.0) * self._handle.fps)
             self._append_log(f"seek -> {position_ms} ms")
+            seconds = position_ms / 1000.0
+            self._emit_cli(
+                f"ffplay -autoexit -ss {seconds:.3f} {self._quoted_source()}"
+            )
         else:
             self._state = state
             self._append_log(f"state -> {state}")
+            if state == "pause":
+                self._emit_cli("ffplay: press SPACE to toggle pause")
+            elif state == "play":
+                self._emit_cli(f"ffplay -autoexit {self._quoted_source()}")
         self.emit.schedule_render(after_ms=20)
 
     # -- Logging ---------------------------------------------------------------

--- a/packs/core.toml
+++ b/packs/core.toml
@@ -89,3 +89,20 @@ version = "0.1.0"
 id      = "canvas-terminal-bindings-test"
 source  = "local:canvas-terminal-bindings-test"
 version = "0.1.0"
+
+# GUI↔Terminal media bridge (#79 / v3.4 P2). Spawned by the file
+# browser when the user opens an audio file. Echoes the equivalent
+# ffplay/ffmpeg command into a linked terminal for every transport
+# action. Capabilities: `terminal.bindings`.
+[[app]]
+id      = "audio-player"
+source  = "local:audio-player"
+version = "0.1.0"
+
+# Audio bridge demo (#79 / v3.4 P2). Mic capture + live waveform +
+# linked-terminal echo of the equivalent ffmpeg command. Capabilities:
+# `audio.record`, `terminal.bindings`.
+[[app]]
+id      = "audio-bridge-test"
+source  = "local:audio-bridge-test"
+version = "0.1.0"

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1182,6 +1182,40 @@ class Emitter:
         the decoder and drains the binary pipe. No response event."""
         _emit({"type": "close_video", "handle_id": int(handle_id)})
 
+    def audio_capture(
+        self,
+        pipe_id: str,
+        sample_rate: int = 48000,
+        buffer_size: int = 512,
+        device_id: "str | None" = None,
+    ) -> "Pipe":
+        """Start mic capture (#277). PCM frames stream as raw f32 PCM on
+        a binary pipe — interleaved per-channel, ``sample_rate`` per
+        channel per second.
+
+        Returns the binary Pipe immediately (negotiated values arrive
+        async via ``PlexiEvent::AudioCaptureStarted`` and the host log;
+        the app reads ``handle.read_frame()`` once it connects). Failure
+        arrives as ``PlexiEvent::AudioCaptureError``.
+
+        Requires ``audio.in`` capability. Raises ``CapabilityDeniedError``
+        only when the gate fires synchronously at the wire layer; the
+        usual TCC mic-permission denial surfaces async on the first frame
+        attempt as an ``AudioCaptureError`` event.
+        """
+        # Open the binary pipe FIRST so PipeOpened can attach when it
+        # arrives — same shape as ``open_video``.
+        pipe = Pipe(pipe_id=pipe_id, mode="binary", direction="in", app=self._app)
+        self._app._pipes[pipe_id] = pipe
+        _emit({
+            "type": "audio_capture",
+            "pipe_id": pipe_id,
+            "device_id": device_id,
+            "sample_rate": int(sample_rate),
+            "buffer_size": int(buffer_size),
+        })
+        return pipe
+
     def set_timer(self, timer_id: str, after_ms: int) -> None:
         """Fire PlexiEvent::Timer after after_ms milliseconds. Requires timer capability."""
         _emit({"type": "set_timer", "timer_id": timer_id, "after_ms": after_ms})

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -1,4 +1,53 @@
+use std::path::Path;
 use std::time::SystemTime;
+
+/// Routing classification for a file the user wants to open. Drives the
+/// GUI↔terminal media bridge (#79): video/audio files spawn the in-app
+/// player examples; everything else falls through to the system default
+/// (`open` / `xdg-open`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MediaKind {
+    Video,
+    Audio,
+    Other,
+}
+
+impl MediaKind {
+    /// Classify a path by extension. Case-insensitive. Paths with no
+    /// extension or unrecognised extensions return `Other`.
+    pub(crate) fn for_path(path: &Path) -> Self {
+        let Some(ext) = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+        else {
+            return Self::Other;
+        };
+        match ext.as_str() {
+            // Common video container formats. AVFoundation handles the
+            // big three on macOS (#346); the rest still route to the
+            // in-app player so it can surface a decoder error rather
+            // than the user double-clicking into QuickTime.
+            "mp4" | "mov" | "m4v" | "mkv" | "webm" | "avi" => Self::Video,
+            // Common audio formats. v3.4 audio-player is a
+            // command-bridge POC — actual decode is shelled to `ffplay`
+            // via `RunInLinkedTerminal`. All recognised extensions route
+            // identically.
+            "mp3" | "wav" | "flac" | "m4a" | "aac" | "ogg" | "opus" => Self::Audio,
+            _ => Self::Other,
+        }
+    }
+
+    /// Manifest id of the in-app player for this media kind. `None`
+    /// means "fall through to the system default opener".
+    pub(crate) fn player_app_id(self) -> Option<&'static str> {
+        match self {
+            Self::Video => Some("video-player"),
+            Self::Audio => Some("audio-player"),
+            Self::Other => None,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct Entry {
@@ -54,5 +103,74 @@ pub(crate) fn format_modified(modified: Option<SystemTime>) -> String {
         format!("{}w ago", secs / (86400 * 7))
     } else {
         format!("{}mo ago", secs / (86400 * 30))
+    }
+}
+
+#[cfg(test)]
+mod media_bridge_tests {
+    //! GUI↔Terminal media bridge routing (#79). The file browser opens
+    //! recognised media in the in-app players instead of shelling out to
+    //! the system default — these tests pin the classifier so a renamed
+    //! manifest id or a dropped extension surfaces here, not in a smoke
+    //! test halfway through release.
+    use super::MediaKind;
+    use std::path::PathBuf;
+
+    #[test]
+    fn open_video_file_routes_to_video_player_app() {
+        for ext in &["mp4", "MP4", "mov", "mkv", "webm", "m4v", "avi"] {
+            let p = PathBuf::from(format!("/tmp/clip.{ext}"));
+            assert_eq!(
+                MediaKind::for_path(&p),
+                MediaKind::Video,
+                "extension {ext} should classify as Video"
+            );
+            assert_eq!(
+                MediaKind::for_path(&p).player_app_id(),
+                Some("video-player"),
+                "video routes to video-player app"
+            );
+        }
+    }
+
+    #[test]
+    fn open_audio_file_routes_to_audio_player_app() {
+        for ext in &["mp3", "MP3", "wav", "flac", "m4a", "aac", "ogg", "opus"] {
+            let p = PathBuf::from(format!("/tmp/song.{ext}"));
+            assert_eq!(
+                MediaKind::for_path(&p),
+                MediaKind::Audio,
+                "extension {ext} should classify as Audio"
+            );
+            assert_eq!(
+                MediaKind::for_path(&p).player_app_id(),
+                Some("audio-player"),
+                "audio routes to audio-player app"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecognized_extension_falls_back_to_system_open() {
+        for path in &[
+            "/tmp/notes.txt",
+            "/tmp/photo.tiff",
+            "/tmp/archive.zip",
+            "/tmp/Makefile",
+            "/tmp/.dotfile",
+            "/tmp/no-extension",
+        ] {
+            let p = PathBuf::from(path);
+            assert_eq!(
+                MediaKind::for_path(&p),
+                MediaKind::Other,
+                "{path} should fall through to system default"
+            );
+            assert_eq!(
+                MediaKind::for_path(&p).player_app_id(),
+                None,
+                "{path} should not route to an in-app player"
+            );
+        }
     }
 }

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -8,7 +8,7 @@ use image::imageops::FilterType;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use helpers::{format_modified, format_size, DirStats, Entry, SortMode};
+use helpers::{format_modified, format_size, DirStats, Entry, MediaKind, SortMode};
 use icons::paint_entry_icon;
 
 const ROW_HEIGHT: f32 = 58.0;
@@ -145,6 +145,57 @@ impl FileBrowserApp {
             cwd: self.cwd.to_string_lossy().to_string(),
             sender_pane_id: 0, // dispatch.rs stamps the real pane_id
         });
+    }
+
+    /// Open a file the user activated (Enter, double-click, search-Enter).
+    /// GUI↔Terminal media bridge (#79): recognised video/audio extensions
+    /// route to the in-app players (`video-player` / `audio-player`) so
+    /// the user stays inside the canvas. Everything else falls through
+    /// to the system default opener (`open` on macOS, `xdg-open` on
+    /// Linux). Failures to spawn the system opener are logged and
+    /// silently swallowed — they're not user-recoverable from the file
+    /// browser.
+    fn open_file(&mut self, path: &Path) {
+        let kind = MediaKind::for_path(path);
+        if let Some(app_id) = kind.player_app_id() {
+            log::info!(
+                "file_browser: routing {kind:?} file '{}' to in-app player '{app_id}'",
+                path.display()
+            );
+            self.pending_cmds.push(AppCommand::SpawnApp {
+                type_id: app_id.to_string(),
+                layout: None, // respect the player's manifest layout_hint
+                args: vec![path.to_string_lossy().to_string()],
+            });
+            return;
+        }
+        match std::process::Command::new(Self::system_opener()).arg(path).spawn() {
+            Ok(_) => log::debug!("file_browser: system-open spawned for {}", path.display()),
+            Err(e) => log::error!(
+                "file_browser: system-open failed for {}: {e}",
+                path.display()
+            ),
+        }
+    }
+
+    /// Platform-appropriate fallback opener. macOS / Linux only — Windows
+    /// callers fall through to a no-op since the media-bridge surface is
+    /// unix-first for v3.4 (mirrors `canvas_bindings::shell_open`).
+    fn system_opener() -> &'static str {
+        #[cfg(target_os = "macos")]
+        {
+            "open"
+        }
+        #[cfg(target_os = "linux")]
+        {
+            "xdg-open"
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            // The Command will fail to spawn; the error log makes the
+            // platform gap visible without panicking.
+            "open"
+        }
     }
 
     fn navigate_up(&mut self) {
@@ -657,7 +708,7 @@ impl App for FileBrowserApp {
                     if is_dir {
                         self.navigate_into(path);
                     } else {
-                        let _ = std::process::Command::new("open").arg(&path).spawn();
+                        self.open_file(&path);
                     }
                 }
             });
@@ -682,7 +733,7 @@ impl App for FileBrowserApp {
                         self.exit_search();
                         self.navigate_into(entry.path);
                     } else {
-                        let _ = std::process::Command::new("open").arg(&entry.path).spawn();
+                        self.open_file(&entry.path);
                         self.exit_search();
                     }
                 }
@@ -777,7 +828,7 @@ impl App for FileBrowserApp {
                 if entry.is_dir {
                     self.navigate_into(entry.path);
                 } else {
-                    let _ = std::process::Command::new("open").arg(&entry.path).spawn();
+                    self.open_file(&entry.path);
                 }
             }
             consumed = true;


### PR DESCRIPTION
Closes #79

## What changed

GUI↔Terminal media bridge for v3.4. The file browser previously shelled out to `open` for every non-directory entry, dumping users into QuickTime / system audio players when they double-clicked media files. This PR redirects recognised video extensions (mp4/mov/m4v/mkv/webm/avi) to the in-app `video-player` and recognised audio extensions (mp3/wav/flac/m4a/aac/ogg/opus) to a new `audio-player`, both passing the path via `args=[path]` through the existing `AppCommand::SpawnApp` plumbing — no new wire types. Unrecognised extensions still fall through to the system default opener (`open` / `xdg-open`).

Two new POC apps:
- **`examples/audio-player/`** — spawned by the file browser when the user opens an audio file. Reads path from `argv[1]`, requests a linked terminal, emits the equivalent `ffplay`/`ffprobe` command for every transport action via `RunInLinkedTerminal`. v3.4 scope is the bridge surface — actual CoreAudio in-app decode is on the v3.5+ roadmap (audio.rs ships capture only per #277).
- **`examples/audio-bridge-test/`** — end-to-end demo of v3.4's release-level checklist item ("terminal plays an audio file, canvas pane visualizes the waveform in real time"). Mic capture (#277) + live waveform of the last 5 s + ffmpeg-equivalent CLI echo into a linked terminal on record/stop. New thin `Emitter.audio_capture()` SDK helper to keep the wire shape clean.

`examples/video-player/` extended: now also accepts `argv[1]` (file-browser handoff alongside the existing `PLEXI_VIDEO_PATH` env var) AND requests a linked terminal at startup, emitting equivalent `ffplay -ss …` / `ffplay -autoexit …` invocations on play/pause/seek/close as observational comments. The in-app decode path (#345/#346) is unchanged — the CLI bridge is purely additive.

The v3.4 release-level demo is now self-contained: open `audio-bridge-test`, press `r` — the linked terminal shows the equivalent `ffmpeg -f avfoundation -i :0 -t 5 -ar 48000 capture.wav`, the canvas paints peaks of the last 5 s, press `s` and the comment `# capture stopped` appears in the terminal.

Out of scope (file as follow-ups): full DAW/NLE workflow, unified `.plexi/project.toml`, cross-platform decode beyond AVFoundation, audio mixing/effects, job tracking for renders, in-app CoreAudio playback (lifts to v3.5+ after #277's deferred follow-up #341).

## Breaks if
- Double-clicking a `.mp4` in the file browser opens QuickTime / VLC instead of the `video-player` pane.
- Same for `.mp3` → `audio-player`. The "loaded global entry 'audio-player'" log line on host startup is the proof point.
- `audio-bridge-test` capture button doesn't echo `ffmpeg -f avfoundation -i :0 -t 5 -ar 48000 capture.wav` into the linked terminal.
- A `.tiff` / `.txt` / `.zip` no longer falls through to the system default opener (visible: `open` is not invoked, file_browser pending_cmds doesn't get a SpawnApp either — file just doesn't open).
- `video-player`'s play button does NOT echo `ffplay -autoexit <path>` as a comment in its linked terminal.

## Human verification
1. `just install-alpha`. Open `Plexi Alpha.app`. Drop an mp4 into a workspace, navigate to it in the file browser, hit Enter — the `video-player` pane opens (not QuickTime).
2. Same for an mp3 → `audio-player` pane opens with the path visible, linked terminal alongside.
3. Press `o` in `audio-player` — the linked terminal shows `ffplay -autoexit -nodisp '<path>'`.
4. Run `audio-bridge-test` (e.g. via command palette). A linked terminal pane appears. Click/key Record — peaks paint, `ffmpeg -f avfoundation -i :0 -t 5 -ar 48000 capture.wav` echoes into the terminal. Press Stop — `# capture stopped` echoes.
5. In `video-player`, press `o` — the linked terminal shows `# ffplay -autoexit '<source>'` as a comment.
6. System fallback: select a `.tiff` (unrecognized) → falls through to `open` (system default).

## Test added
- `src/file_browser/helpers.rs::media_bridge_tests::open_video_file_routes_to_video_player_app` — every video extension classifies to `MediaKind::Video` + routes to `video-player` manifest id.
- `src/file_browser/helpers.rs::media_bridge_tests::open_audio_file_routes_to_audio_player_app` — every audio extension → `audio-player`.
- `src/file_browser/helpers.rs::media_bridge_tests::unrecognized_extension_falls_back_to_system_open` — `.txt`, `.tiff`, `.zip`, dotfiles, and no-extension paths all classify as `Other` with `player_app_id() == None`.

`cargo test --bin plexi`: 247 passed (244 → 247).

## Surprises noted

1. **The issue body's premise was off.** It claims `OpenVideoFile` / `OpenAudioFile` DrawCommands exist and shell out to system players today. They do not — `grep -rn "OpenVideoFile\|OpenAudioFile" src/` returns nothing. The actual delegation lives as three direct `std::process::Command::new("open").arg(&path).spawn()` sites in `src/file_browser/mod.rs` (Enter, ArrowRight/L, search-Enter, double-click). I implemented the spirit of #79 by routing those three sites through a new `MediaKind` classifier — no new DrawCommand variant needed. `OpenArtifact::OpenWithDefault` (added in #78) still shells out to `open` for non-media files; redirecting that path is left as a follow-up since the issue's headline scenario is the file browser, not OpenArtifact callers.

2. **`audio.rs` is capture-only (#277).** No file-decode-from-disk path exists yet — playback + resampling were deferred to follow-up #341. The audio-player POC therefore can't decode in-app yet; v3.4 makes it a *bridge-surface* POC where actual playback happens via `ffplay` in the linked terminal. The user-visible value is the same (one-click play from the file browser, copy-as-CLI for free) without committing to the full CoreAudio playback stack ahead of #341.

3. **Capability string is `audio.record`, not `audio.in`.** The orchestrator brief said `audio.in`, but `src/app_permissions.rs` defines the capability as `audio.record`. The audio-bridge-test manifest uses the actual string.