### PR TITLE
feat: descriptor-renderer defaults to bundled sample.json

### DIFF
--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -46,6 +46,10 @@ def _parse_descriptor_path(argv: list[str]) -> str | None:
     for arg in argv:
         if not arg.startswith("-"):
             return arg
+    # Default: sample.json bundled alongside this script
+    sample = Path(__file__).parent / "sample.json"
+    if sample.exists():
+        return str(sample)
     return None
 
 

--- a/examples/descriptor-renderer/sample.json
+++ b/examples/descriptor-renderer/sample.json
@@ -1,0 +1,68 @@
+{
+  "plexi_version": "0.1",
+  "name": "parallax",
+  "version": "0.1.0",
+  "description": "Video agent pipeline CLI (descriptor demo)",
+  "icon": "\ud83c\udfac",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "run",
+      "description": "Kick off a footage_edit run in cwd",
+      "icon": "\u25b6",
+      "ui_hint": "form",
+      "args": [
+        {
+          "name": "brief",
+          "type": "string",
+          "required": true,
+          "description": "What you want the agent to create",
+          "placeholder": "western cowboy scene, 8 seconds"
+        }
+      ],
+      "flags": [
+        {
+          "name": "--test-mode",
+          "type": "bool",
+          "default": false
+        }
+      ],
+      "writes": [
+        ".parallax/"
+      ],
+      "streaming": true
+    },
+    {
+      "name": "status",
+      "description": "Print manifest stats",
+      "ui_hint": "output",
+      "args": [],
+      "output_format": "yaml"
+    },
+    {
+      "name": "project",
+      "description": "Project management",
+      "commands": [
+        {
+          "name": "new",
+          "args": [
+            {
+              "name": "name",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list"
+        }
+      ]
+    }
+  ],
+  "live_state": {
+    "source": "file",
+    "path": ".parallax/manifest.yaml",
+    "poll_ms": 1000,
+    "format": "yaml"
+  }
+}


### PR DESCRIPTION
Falls back to `sample.json` bundled alongside the script when no `--descriptor` path is given. Test with a single command:\n\n```\nplexi-alpha launch descriptor-renderer\n```