### PR TITLE
feat: empty context welcome screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,19 @@ Try-catch on all I/O, network, external API calls, and anything that can reasona
 - **Fallback chain audit:** When a value looks correct on the surface but behavior is stale, enumerate every fallback source in priority order (cookies, env vars, caches, defaults). Fix the chain, not the surface.
 - **Model ID verification:** Never guess versioned model IDs. Use only confirmed-current family IDs. A 400/404 surfaces only at call time.
 
+## Host UI Systems — Reuse Before Rolling Your Own
+
+Before writing any keyboard shortcut display, badge, chip, or inline label widget, check `src/widgets.rs` and `src/style.rs`. These modules contain the canonical, already-tested implementations. Re-rolling them inline produces visual inconsistency and duplicated sizing logic.
+
+**`src/style.rs`** — design tokens: spacing scale (`SPACE_SM/MD/XL`), typography scale (`TEXT_HINT/CAPTION/BODY/TITLE_XL`), corner radii (`RADIUS_MD/LG`), modal widths, button heights, overlay chrome. Use these constants everywhere — never hard-code magic numbers.
+
+**`src/widgets.rs`** — reusable egui widgets:
+- `key_chip(ui, label, colors)` — renders a single keyboard key as a styled rounded-rect chip (`bg_active` fill, `border` stroke, `TEXT_HINT`-size monospace text).
+- `key_combo(ui, keys, colors)` — renders a sequence of `key_chip`s with `INTRA_COMBO_GAP` between them (e.g. `["⌘", "N"]` → `[⌘][N]`).
+- `key_combo_list(ui, combos, trailing, colors)` — renders multiple combos inline with `INTER_COMBO_GAP` between them and an optional dim description label at the end. This is the standard pattern for keyboard shortcut hint rows.
+
+**Use `key_combo_list` for any shortcut hint row.** Do not render key shortcuts as plain `Label` text — it produces a visually inconsistent result that requires a separate pass to fix.
+
 ## General Rules
 
 - Before SSH/networking setup, ask if machines are on the same LAN or remote. Before any multi-step infra task, clarify topology first.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1298,40 +1298,52 @@ impl PlexiApp {
 
     pub(crate) fn draw_welcome_screen(&self, ui: &mut egui::Ui) {
         let colors = self.colors;
-        let available_height = ui.available_height();
-        ui.add_space(available_height * 0.28);
-        ui.vertical_centered(|ui| {
-            ui.label(
-                RichText::new("PLEXI")
-                    .size(36.0)
-                    .color(colors.text_primary)
-                    .strong(),
-            );
+        let center = ui.max_rect().center();
+        let box_rect = egui::Rect::from_center_size(center, egui::vec2(480.0, 400.0));
 
-            ui.add_space(32.0);
+        ui.allocate_ui_at_rect(box_rect, |ui| {
+            egui::Frame::new()
+                .fill(colors.bg_sidebar)
+                .stroke(Stroke::new(1.0, colors.border))
+                .corner_radius(style::RADIUS_MD)
+                .inner_margin(egui::Margin::symmetric(
+                    style::MODAL_PADDING_H,
+                    style::MODAL_PADDING_V,
+                ))
+                .show(ui, |ui| {
+                    ui.vertical_centered(|ui| {
+                        ui.label(
+                            RichText::new("PLEXI")
+                                .size(style::TEXT_TITLE_XL)
+                                .color(colors.text_primary)
+                                .strong(),
+                        );
+                    });
+                    ui.add_space(style::SPACE_XL);
 
-            let hint_color = colors.text_dim;
-            let key_color = colors.text_primary;
+                    // Each entry: (chip groups for one combo, description).
+                    // Every modifier/key is a separate chip — no combined strings.
+                    let shortcuts: &[(&[&str], &str)] = &[
+                        (&["⌘", "H", "J", "K", "L"], "move between panes"),
+                        (&["⌘", "⇧", "H", "J", "K", "L"], "move between windows"),
+                        (&["⌘", "N"], "open a terminal"),
+                        (&["⌘", "⇧", "N"], "new context"),
+                        (&["⌘", "/"], "keyboard shortcuts"),
+                    ];
 
-            let hints: &[(&str, &str)] = &[
-                ("HJK", "move between panes"),
-                ("Cmd + HJKL", "move between windows"),
-                ("Cmd + Shift + HJKL", "navigate to / create a window"),
-                ("Cmd + N", "open a terminal"),
-            ];
-
-            for (keys, desc) in hints {
-                ui.horizontal(|ui| {
-                    ui.add_sized(
-                        [200.0, 20.0],
-                        egui::Label::new(
-                            RichText::new(*keys).size(12.0).color(key_color).monospace(),
-                        ),
-                    );
-                    ui.label(RichText::new(*desc).size(12.0).color(hint_color));
+                    for (keys, desc) in shortcuts {
+                        ui.horizontal(|ui| {
+                            crate::widgets::key_combo(ui, keys, &colors);
+                            ui.add_space(style::SPACE_SM);
+                            ui.label(
+                                RichText::new(*desc)
+                                    .size(style::TEXT_BODY)
+                                    .color(colors.text_dim),
+                            );
+                        });
+                        ui.add_space(style::SPACE_SM);
+                    }
                 });
-                ui.add_space(6.0);
-            }
         });
     }
 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -321,6 +321,29 @@ impl PlexiApp {
     }
 
     pub(crate) fn new_tab(&mut self) {
+        // Empty context (welcome screen): create the first pane as tree root.
+        if self.contexts[self.active_context].panes.is_empty() {
+            let new_id = self.host.alloc_pane_id();
+            let settings = Self::make_backend_settings(None, &self.colors);
+            let Some(pane) = TerminalPane::new(
+                new_id,
+                self.ctx.clone(),
+                self.pty_event_tx.clone(),
+                settings,
+                self.default_font_size,
+            ) else {
+                log::error!("Failed to create first terminal pane in empty context");
+                return;
+            };
+            let ctx = &mut self.contexts[self.active_context];
+            ctx.panes.insert(new_id, Pane::Terminal(Box::new(pane)));
+            let pane_tile = ctx.tree.tiles.insert_pane(new_id);
+            let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![pane_tile]);
+            ctx.tree.root = Some(tab_tile);
+            ctx.focused_pane = Some(pane_tile);
+            return;
+        }
+
         let Some(focused) = self.contexts[self.active_context].focused_pane else {
             return;
         };
@@ -659,12 +682,8 @@ impl PlexiApp {
     /// (blank canvas) so the user can create a new spatial page with Cmd+N.
     pub(crate) fn execute_close_pane(&mut self) -> bool {
         self.contexts[self.active_context].zoomed_pane = None;
-        let active_panes = self.contexts[self.active_context].panes.len();
-        if active_panes > 1 {
+        if !self.contexts[self.active_context].panes.is_empty() {
             self.close_focused();
-        } else {
-            // Last pane in this window: close the window (context).
-            self.delete_context(self.active_context);
         }
         false
     }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -78,17 +78,17 @@ pub(crate) fn selectable_row<R>(
 //     key_combo_list(ui, &[["⌘", "["], ["⌘", "]"]], colors, "to cycle");
 
 /// Padding around the key label text inside the chip.
-const KEYCAP_PAD_H: f32 = 5.0;
-const KEYCAP_PAD_V: f32 = 1.0;
+const KEYCAP_PAD_H: f32 = 6.0;
+const KEYCAP_PAD_V: f32 = 3.0;
 /// Minimum chip width — keeps single-char keys like `[` from looking cramped.
-const KEYCAP_MIN_W: f32 = 16.0;
+const KEYCAP_MIN_W: f32 = 18.0;
 
 /// Render a single keycap chip. Allocates its own exact-size rect and
 /// returns the egui Response so callers can compose with other widgets.
 pub(crate) fn key_chip(ui: &mut egui::Ui, label: &str, colors: &Colors) -> egui::Response {
-    let font_id = egui::FontId::monospace(style::TEXT_HINT);
+    let font_id = egui::FontId::monospace(style::TEXT_CAPTION);
     let galley = ui
-        .fonts(|f| f.layout_no_wrap(label.to_string(), font_id, colors.text_dim));
+        .fonts(|f| f.layout_no_wrap(label.to_string(), font_id, colors.text_primary));
     let text_w = galley.size().x;
     let text_h = galley.size().y;
     let chip_w = (text_w + KEYCAP_PAD_H * 2.0).max(KEYCAP_MIN_W);
@@ -105,12 +105,11 @@ pub(crate) fn key_chip(ui: &mut egui::Ui, label: &str, colors: &Colors) -> egui:
         Stroke::new(1.0, colors.border),
         StrokeKind::Inside,
     );
-    // Centre the text horizontally inside the chip.
     let text_pos = Pos2::new(
         rect.center().x - text_w / 2.0,
         rect.min.y + KEYCAP_PAD_V,
     );
-    painter.galley(text_pos, galley, colors.text_dim);
+    painter.galley(text_pos, galley, colors.text_primary);
     response
 }
 


### PR DESCRIPTION
## Summary

- Cmd+W on the last pane now leaves the context empty (welcome screen) instead of being blocked or silently deleting the context
- Cmd+N from the welcome screen creates the first terminal pane
- Welcome screen: centered box using existing `key_chip`/`key_combo` widgets — correct shortcuts, all modifiers/keys as separate chips
- `key_chip`: `text_dim` → `text_primary`, `TEXT_HINT` → `TEXT_CAPTION`, vertical padding 1px → 3px — more readable everywhere
- `CLAUDE.md`: adds Host UI Systems section documenting `key_chip`, `key_combo`, `key_combo_list`, and style tokens so future sessions reach for existing widgets instead of re-rolling shortcut rendering

**Breaks if:** Cmd+W on the last pane in a context quits the app or does nothing instead of showing the welcome screen, or Cmd+N from the welcome screen doesn't open a terminal.

## Test plan

- [ ] Cmd+W down to last pane — welcome screen appears
- [ ] Cmd+N from welcome screen — terminal opens
- [ ] Cmd+W with multiple panes still closes normally
- [ ] Key chips in notification modal still render correctly (brighter/taller is fine)