### PR TITLE
fix: button description text missing align=left_center

### DIFF
--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -257,7 +257,8 @@ class DescriptorRendererApp(App):
                      size=BODY, color=FG, bold=True, align="left_center")
             if desc_text:
                 ctx.text(x=PAD + 14, y=by + BTN_H * 0.72, text=desc_text,
-                         size=HINT, color=MUTED, max_width=btn_w - 28, elide=True)
+                         size=HINT, color=MUTED, align="left_center",
+                         max_width=btn_w - 28, elide=True)
 
         total_h = len(commands) * row_h
         visible_h = ctx.h - y


### PR DESCRIPTION
Description lines in list-view buttons were missing `align="left_center"`, so y was interpreted as the top of the text rather than the center — pushing the subtitle flush against the button's bottom edge.