### PR TITLE
feat: add Move to Bottom to context right-click menu

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ pub(crate) enum ContextMenuAction {
     MoveToTop,
     MoveUp,
     MoveDown,
+    MoveToBottom,
     Delete,
 }
 

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -238,9 +238,15 @@ impl PlexiApp {
                                 ui.close_menu();
                             }
                         }
-                        if i < num_workspaces - 1 && ui.button("Move Down").clicked() {
-                            menu_action = Some((i, ContextMenuAction::MoveDown));
-                            ui.close_menu();
+                        if i < num_workspaces - 1 {
+                            if ui.button("Move Down").clicked() {
+                                menu_action = Some((i, ContextMenuAction::MoveDown));
+                                ui.close_menu();
+                            }
+                            if ui.button("Move to Bottom").clicked() {
+                                menu_action = Some((i, ContextMenuAction::MoveToBottom));
+                                ui.close_menu();
+                            }
                         }
                         if num_workspaces > 1 {
                             ui.separator();
@@ -288,6 +294,16 @@ impl PlexiApp {
                         self.active_context = i + 1;
                     } else if self.active_context == i + 1 {
                         self.active_context = i;
+                    }
+                }
+                ContextMenuAction::MoveToBottom => {
+                    let last = num_workspaces - 1;
+                    let ctx = self.contexts.remove(i);
+                    self.contexts.push(ctx);
+                    if self.active_context == i {
+                        self.active_context = last;
+                    } else if self.active_context > i {
+                        self.active_context -= 1;
                     }
                 }
                 ContextMenuAction::Delete => {


### PR DESCRIPTION
## Summary
- Adds **Move to Bottom** option to the sidebar context right-click menu, symmetric with the existing **Move to Top**
- Only shown when the context is not already at the bottom (same guard as Move Down)
- Active context index tracks correctly when moved

## Test plan
- [ ] Right-click a context that is not last — "Move to Bottom" should appear below "Move Down"
- [ ] Right-click the last context — "Move Down" and "Move to Bottom" should not appear
- [ ] Moving the active context to bottom keeps it selected
- [ ] Moving a non-active context to bottom does not change the selection unexpectedly