### PR TITLE
fix: welcome screen Cmd/Shift labels + CLAUDE.md done-cycle rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ If `CHANGELOG.md` doesn't exist yet, create it with a header comment and the fir
 - `alpha` → `just install-alpha` (run from inside `worktrees/alpha/`, not the repo root — the recipe builds from CWD, so running from the wrong directory installs from the wrong branch)
 - `main` → `just install`
 
+**Never claim a task complete based on an install from a feature worktree.** `just install-alpha` builds from source files in CWD — uncommitted changes compile and install successfully, making the task appear done when nothing has been committed. Installing from a feature worktree is only valid during development iteration. The full done cycle is: commit → push → PR → merge to alpha → pull alpha → `just install-alpha` from `worktrees/alpha/`.
+
 ## Logging
 
 Build-specific log file:

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1324,11 +1324,11 @@ impl PlexiApp {
                     // Each entry: (chip groups for one combo, description).
                     // Every modifier/key is a separate chip — no combined strings.
                     let shortcuts: &[(&[&str], &str)] = &[
-                        (&["⌘", "H", "J", "K", "L"], "move between panes"),
-                        (&["⌘", "⇧", "H", "J", "K", "L"], "move between windows"),
-                        (&["⌘", "N"], "open a terminal"),
-                        (&["⌘", "⇧", "N"], "new context"),
-                        (&["⌘", "/"], "keyboard shortcuts"),
+                        (&["Cmd", "H", "J", "K", "L"], "move between panes"),
+                        (&["Cmd", "Shift", "H", "J", "K", "L"], "move between windows"),
+                        (&["Cmd", "N"], "open a terminal"),
+                        (&["Cmd", "Shift", "N"], "new context"),
+                        (&["Cmd", "/"], "keyboard shortcuts"),
                     ];
 
                     for (keys, desc) in shortcuts {


### PR DESCRIPTION
## Summary

- Welcome screen shortcuts now read [Cmd][H][J][K][L] instead of [⌘][H][J][K][L] — legible to users who don't immediately recognize the ⌘ symbol
- CLAUDE.md: adds explicit rule that installing from a feature worktree is not the "done" verification step — the full cycle is commit → PR → merge → pull alpha → install from alpha

**Breaks if:** Welcome screen still shows ⌘ symbol chips instead of "Cmd"/"Shift" text chips.