### PR TITLE
fix: revert welcome screen chips to ⌘/⇧ symbols

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1324,11 +1324,11 @@ impl PlexiApp {
                     // Each entry: (chip groups for one combo, description).
                     // Every modifier/key is a separate chip — no combined strings.
                     let shortcuts: &[(&[&str], &str)] = &[
-                        (&["Cmd", "H", "J", "K", "L"], "move between panes"),
-                        (&["Cmd", "Shift", "H", "J", "K", "L"], "move between windows"),
-                        (&["Cmd", "N"], "open a terminal"),
-                        (&["Cmd", "Shift", "N"], "new context"),
-                        (&["Cmd", "/"], "keyboard shortcuts"),
+                        (&["⌘", "H", "J", "K", "L"], "move between panes"),
+                        (&["⌘", "⇧", "H", "J", "K", "L"], "move between windows"),
+                        (&["⌘", "N"], "open a terminal"),
+                        (&["⌘", "⇧", "N"], "new context"),
+                        (&["⌘", "/"], "keyboard shortcuts"),
                     ];
 
                     for (keys, desc) in shortcuts {


### PR DESCRIPTION
Reverts Cmd/Shift text labels back to ⌘/⇧ symbols. The symbol chips were correct; the text change was an over-interpretation of feedback.