### PR TITLE
fix: sidebar move handlers operate on workspaces not contexts

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -272,38 +272,38 @@ impl PlexiApp {
                     self.rename_buffer = self.workspaces[i].name.clone();
                 }
                 ContextMenuAction::MoveToTop => {
-                    let ctx = self.contexts.remove(i);
-                    self.contexts.insert(0, ctx);
-                    if self.active_context == i {
-                        self.active_context = 0;
-                    } else if self.active_context < i {
-                        self.active_context += 1;
+                    let ws = self.workspaces.remove(i);
+                    self.workspaces.insert(0, ws);
+                    if self.active_workspace == i {
+                        self.active_workspace = 0;
+                    } else if self.active_workspace < i {
+                        self.active_workspace += 1;
                     }
                 }
                 ContextMenuAction::MoveUp => {
-                    self.contexts.swap(i, i - 1);
-                    if self.active_context == i {
-                        self.active_context = i - 1;
-                    } else if self.active_context == i - 1 {
-                        self.active_context = i;
+                    self.workspaces.swap(i, i - 1);
+                    if self.active_workspace == i {
+                        self.active_workspace = i - 1;
+                    } else if self.active_workspace == i - 1 {
+                        self.active_workspace = i;
                     }
                 }
                 ContextMenuAction::MoveDown => {
-                    self.contexts.swap(i, i + 1);
-                    if self.active_context == i {
-                        self.active_context = i + 1;
-                    } else if self.active_context == i + 1 {
-                        self.active_context = i;
+                    self.workspaces.swap(i, i + 1);
+                    if self.active_workspace == i {
+                        self.active_workspace = i + 1;
+                    } else if self.active_workspace == i + 1 {
+                        self.active_workspace = i;
                     }
                 }
                 ContextMenuAction::MoveToBottom => {
                     let last = num_workspaces - 1;
-                    let ctx = self.contexts.remove(i);
-                    self.contexts.push(ctx);
-                    if self.active_context == i {
-                        self.active_context = last;
-                    } else if self.active_context > i {
-                        self.active_context -= 1;
+                    let ws = self.workspaces.remove(i);
+                    self.workspaces.push(ws);
+                    if self.active_workspace == i {
+                        self.active_workspace = last;
+                    } else if self.active_workspace > i {
+                        self.active_workspace -= 1;
                     }
                 }
                 ContextMenuAction::Delete => {


### PR DESCRIPTION
## Summary
The workspace refactor (22308d6) updated the sidebar loop to iterate `self.workspaces` / `self.active_workspace`, but left all four move handlers (MoveToTop, MoveUp, MoveDown, MoveToBottom) still touching `self.contexts` / `self.active_context` — the wrong array.

Result: clicking any move option in the right-click menu did nothing visually (workspaces never moved), and could panic if workspace and context counts diverged.

Fix: all four handlers now operate on `self.workspaces` and track `active_workspace`. The `contexts` array and `active_context` don't need to change — contexts are identified by `workspace_id`, not by position in the array.

## Test plan
- [ ] Right-click a workspace → Move to Top — should reorder in sidebar, active workspace follows
- [ ] Move Up / Move Down — should step one position, active follows
- [ ] Move to Bottom — should move to last position, active follows
- [ ] Moving a non-active workspace does not change which workspace is active