### PR TITLE
fix: TextInput auto-focus + multiline support (#404)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1611,8 +1611,9 @@ class RenderContext:
                "item_height": item_height})
 
     def text_input(self, id: str, x: float, y: float, w: float,
-                   placeholder: str = "") -> "str | None":
-        """Single-line text input — host-owned buffer, submit-only.
+                   placeholder: str = "",
+                   multiline: bool = False) -> "str | None":
+        """Text input — host-owned buffer, submit-only.
 
         Emits a `DrawCommand::TextInput` and returns the most recently
         submitted value for `id` if any landed since the previous frame,
@@ -1620,6 +1621,13 @@ class RenderContext:
         characters never reach the app between keystrokes. On Enter the
         host emits `PlexiEvent::TextSubmitted { id, value }` and clears
         its buffer.
+
+        The host auto-focuses the widget on its first visible frame so
+        the user can type immediately without clicking.
+
+        When `multiline=True`, Enter submits and Shift+Enter inserts a
+        newline. When `multiline=False` (default), Enter submits
+        immediately.
 
         Pattern (poll on every frame)::
 
@@ -1629,11 +1637,10 @@ class RenderContext:
                 save_note(submitted)
 
         Real-time validation (per-keystroke access) is out of scope —
-        see issue #283. Use `TextArea` for multi-line app-managed
-        editors instead.
+        see issue #283.
         """
         _emit({"type": "text_input", "id": id, "x": x, "y": y, "w": w,
-               "placeholder": placeholder})
+               "placeholder": placeholder, "multiline": multiline})
         return self._app._take_text_submission(id)
 
     # Logging helpers (in-frame, forwarded to host logger)

--- a/sdk/python/plexi_sdk/widgets/text_input.py
+++ b/sdk/python/plexi_sdk/widgets/text_input.py
@@ -1,14 +1,21 @@
-"""TextInput widget — host-owned single-line text entry primitive.
+"""TextInput widget — host-owned text entry primitive.
 
 This is the v3.1 PGAP `TextInput` / `TextSubmitted` pair (issue #283). The
 host owns the underlying buffer entirely — the app emits a `TextInput`
 DrawCommand each frame (placeholder, position, width) and gets exactly
 one `PlexiEvent::TextSubmitted` back when the user presses Enter.
 
+When `multiline=True`, the host renders a multi-line editor; Enter submits
+and Shift+Enter inserts a newline. When `multiline=False` (the default),
+the host renders a single-line editor and Enter submits.
+
+The host auto-focuses the widget on the first frame it appears, so the user
+can type immediately without clicking.
+
 Distinct from `TextArea` in the same package. `TextArea` is a multi-line
 app-managed editor (apps own the buffer, render it as Rect+Text
-primitives). `TextInput` is single-line and submit-only, with the host
-owning state — apps cannot inspect the typed value between keystrokes.
+primitives). `TextInput` is submit-only, with the host owning state —
+apps cannot inspect the typed value between keystrokes.
 
 Real-time validation (per-keystroke value access) is intentionally out
 of scope for v3.1 — see issue #283 option A.
@@ -29,17 +36,29 @@ def _emit(obj: dict) -> None:
         sys.stdout.flush()
 
 
-def emit_text_input(id: str, x: float, y: float, w: float, placeholder: str) -> None:
+def emit_text_input(
+    id: str,
+    x: float,
+    y: float,
+    w: float,
+    placeholder: str,
+    multiline: bool = False,
+) -> None:
     """Emit a single-frame `DrawCommand::TextInput`.
 
     Apps should call this on every frame they want the input visible —
     omitting it on a frame removes the field. The host renders an
-    `egui::TextEdit::singleline` at `(x, y)` with width `w` and the
-    given placeholder; the buffer state lives on the host, keyed on
-    `id`.
+    `egui::TextEdit` at `(x, y)` with width `w` and the given placeholder;
+    the buffer state lives on the host, keyed on `id`.
 
-    On Enter, the host sends `PlexiEvent::TextSubmitted { id, value }`
-    and clears its buffer. The next frame's emit starts empty.
+    The host auto-focuses the widget on its first visible frame so the user
+    can type immediately without clicking.
+
+    When `multiline=True`, Enter submits and Shift+Enter inserts a newline.
+    When `multiline=False` (default), Enter submits immediately.
+
+    On submit, the host sends `PlexiEvent::TextSubmitted { id, value }` and
+    clears its buffer. The next frame's emit starts empty.
     """
     _emit({
         "type": "text_input",
@@ -48,4 +67,5 @@ def emit_text_input(id: str, x: float, y: float, w: float, placeholder: str) -> 
         "y": y,
         "w": w,
         "placeholder": placeholder,
+        "multiline": multiline,
     })

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -970,12 +970,17 @@ pub enum DrawCommand {
     /// but discouraged — emit on completion, not on dispatch.
     AppendConversation { role: String, content: String },
 
-    /// Single-line text input field (host-owned buffer, submit-only).
+    /// Text input field (host-owned buffer, submit-only).
     ///
     /// Emitted by the app each frame at `(x, y)` with width `w`. The host
     /// owns the underlying buffer keyed on `id` — typed characters never
     /// reach the app between frames. On Enter the host emits
     /// `PlexiEvent::TextSubmitted { id, value }` and clears its buffer.
+    ///
+    /// When `multiline` is `false` (the default), the host renders a
+    /// single-line `TextEdit` and Enter submits. When `multiline` is `true`,
+    /// the host renders a multi-line `TextEdit`; Enter still submits but
+    /// Shift+Enter inserts a newline.
     ///
     /// Real-time validation (per-keystroke value access) is intentionally
     /// out of scope — see issue #283 option A. Apps that need it must
@@ -986,6 +991,11 @@ pub enum DrawCommand {
         y: f32,
         w: f32,
         placeholder: String,
+        /// When `true`, render as a multi-line editor. Enter submits;
+        /// Shift+Enter inserts a newline. Defaults to `false` so existing
+        /// draw commands without this field continue to work.
+        #[serde(default)]
+        multiline: bool,
     },
 
     // ── Canvas Terminal Binding Primitives (#78) ─────────────────────────

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -187,6 +187,11 @@ pub struct ProcessApp {
     /// `PlexiEvent::TextSubmitted`. Cleared on submit; the whole map is
     /// dropped when the `ProcessApp` is dropped (app close).
     pub(crate) text_input_buffers: HashMap<String, String>,
+    /// IDs of `TextInput` widgets that were visible in the most recently
+    /// rendered frame. Used by `render_text_inputs` to detect newly-visible
+    /// inputs and call `request_focus()` on them so the user can type
+    /// immediately without clicking.
+    text_input_visible_prev: std::collections::HashSet<String>,
     /// Test-only seam used by `process_app::agent` unit tests to inject
     /// `DrawCommand`s without spinning up a real subprocess pipeline.
     /// Drained on every `agent_tick` (and thus invisible in production).
@@ -448,6 +453,7 @@ impl ProcessApp {
             lifecycle: lifecycle_tracker,
             show_stderr_overlay: false,
             text_input_buffers: HashMap::new(),
+            text_input_visible_prev: std::collections::HashSet::new(),
             #[cfg(test)]
             test_injected_commands: Arc::new(Mutex::new(VecDeque::new())),
         })
@@ -594,12 +600,16 @@ impl ProcessApp {
     }
 
     /// Render every `DrawCommand::TextInput` in `frame` as a real egui
-    /// `TextEdit::singleline`, owning the buffer state on `self`. Submits
+    /// `TextEdit`, owning the buffer state on `self`. Submits
     /// (Enter while focused) emit `PlexiEvent::TextSubmitted { id, value }`
     /// and clear the buffer.
     ///
     /// Buffer survives across frames and pane resizes because it lives on
     /// `self.text_input_buffers`, not in egui memory.
+    ///
+    /// Auto-focus: when a `TextInput` id appears for the first time in a
+    /// frame (i.e. it was absent last frame), `request_focus()` is called so
+    /// the user can type immediately without clicking.
     pub(crate) fn render_text_inputs(
         &mut self,
         ui: &mut egui::Ui,
@@ -611,6 +621,10 @@ impl ProcessApp {
         // borrow on `text_input_buffers` while pushing onto
         // `outbound_events` — both live on `self`.
         let mut submitted: Vec<String> = Vec::new();
+        // Track which IDs are visible this frame so we can update
+        // `text_input_visible_prev` after the loop.
+        let mut visible_this_frame: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         for cmd in frame {
             let DrawCommand::TextInput {
@@ -619,14 +633,20 @@ impl ProcessApp {
                 y,
                 w,
                 placeholder,
+                multiline,
             } = cmd
             else {
                 continue;
             };
 
+            visible_this_frame.insert(id.clone());
+            let newly_visible = !self.text_input_visible_prev.contains(id.as_str());
+
             // Single-line height tuned to read as a proper input row
             // rather than a hairline — matches the SDK's BODY size + a
-            // sensible vertical margin.
+            // sensible vertical margin. Multiline widgets use the app's
+            // declared height (derived from `w`/layout), but we keep the
+            // same 24px minimum so a zero-height rect doesn't collapse.
             let height = 24.0;
             let widget_rect = egui::Rect::from_min_size(
                 egui::pos2(origin.x + x, origin.y + y),
@@ -645,21 +665,57 @@ impl ProcessApp {
                         .max_rect(widget_rect)
                         .id_salt(widget_id),
                 );
-                let edit = egui::TextEdit::singleline(buffer)
-                    .id(widget_id)
-                    .desired_width(*w)
-                    .hint_text(placeholder.as_str())
-                    .frame(true);
-                child.add(edit)
+                let edit = if *multiline {
+                    egui::TextEdit::multiline(buffer)
+                        .id(widget_id)
+                        .desired_width(*w)
+                        .hint_text(placeholder.as_str())
+                        .frame(true)
+                } else {
+                    egui::TextEdit::singleline(buffer)
+                        .id(widget_id)
+                        .desired_width(*w)
+                        .hint_text(placeholder.as_str())
+                        .frame(true)
+                };
+                let r = child.add(edit);
+                // Auto-focus newly-visible inputs so the user can type
+                // immediately without clicking.
+                if newly_visible {
+                    r.request_focus();
+                }
+                r
             };
 
-            // Submit on Enter while focused. The egui idiom for
-            // singleline submit is `lost_focus() && key_pressed(Enter)`
-            // — `lost_focus` alone fires on tab-out / click-away too.
-            if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                submitted.push(id.clone());
+            if *multiline {
+                // Multiline: Enter submits, Shift+Enter inserts newline.
+                // We check for Enter *without* Shift while the widget is
+                // focused. egui does not consume Enter for multiline edits
+                // (it inserts a newline), so we have to intercept it here.
+                if resp.has_focus()
+                    && ui.input(|i| {
+                        i.key_pressed(egui::Key::Enter) && !i.modifiers.shift
+                    })
+                {
+                    // Strip the newline egui already inserted before we submit.
+                    if let Some(buf) = self.text_input_buffers.get_mut(id.as_str()) {
+                        if buf.ends_with('\n') {
+                            buf.pop();
+                        }
+                    }
+                    submitted.push(id.clone());
+                }
+            } else {
+                // Submit on Enter while focused. The egui idiom for
+                // singleline submit is `lost_focus() && key_pressed(Enter)`
+                // — `lost_focus` alone fires on tab-out / click-away too.
+                if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    submitted.push(id.clone());
+                }
             }
         }
+
+        self.text_input_visible_prev = visible_this_frame;
 
         for id in submitted {
             self.submit_text_input(&id);


### PR DESCRIPTION
## Summary

- **Auto-focus:** `ProcessApp` now tracks which `TextInput` IDs were visible in the previous frame (`text_input_visible_prev: HashSet<String>`). On the first frame a widget appears, `response.request_focus()` is called — user can type immediately without clicking.
- **Multiline:** Added `multiline: bool` (`#[serde(default)]`) to `DrawCommand::TextInput`. When true, the host renders `TextEdit::multiline`; Enter submits (stripping the trailing newline egui auto-inserts), Shift+Enter inserts a newline. Singleline behaviour is unchanged.
- **Python SDK:** `multiline` threaded through `RenderContext.text_input()` and `emit_text_input()` in the widgets module.

## Test plan

- [ ] Open any app that emits a `TextInput` — input should be focused on first appearance, no click required
- [ ] Confirm existing singleline Enter-to-submit still works
- [ ] Test a `multiline=True` input: Enter submits, Shift+Enter inserts newline, submitted value has no trailing newline
- [ ] Verify mind-map rename (`r`/`F2`) auto-focuses immediately
- [ ] `cargo test` green