### PR TITLE
fix: restore empty context on launch — welcome screen instead of default terminal

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -432,7 +432,11 @@ impl PlexiApp {
                         panes.insert(saved_pane.id, pane);
                     }
                 }
-                if panes.is_empty() {
+                // Skip only if there were saved panes that all failed to restore
+                // (corrupted state). An empty saved pane list means the user
+                // intentionally closed all panes — restore the empty context so
+                // the welcome screen appears on next launch.
+                if !saved_ctx.panes.is_empty() && panes.is_empty() {
                     continue;
                 }
                 contexts.push(Context {


### PR DESCRIPTION
## What
On startup, a saved context with zero panes was silently dropped by the restore loop, leaving `contexts` empty. The empty-contexts guard then fell through to the default-terminal creation path, opening a new terminal pane instead of the welcome screen.

## Root cause
`src/app/mod.rs` line 435:
```rust
if panes.is_empty() {
    continue;  // skipped ALL empty contexts, including intentionally empty ones
}
```
An empty context is valid state — it means the user closed all panes before quitting and should see the welcome screen on relaunch. The guard was conflating two different cases: intentionally empty (no panes in saved file) and corrupted (panes were in the saved file but all failed to restore).

## Fix
Only skip a context if it had saved panes that all failed to restore. An empty `saved_ctx.panes` list is intentional — push the context through so the welcome screen appears.

## Test plan
- [ ] Close all panes in alpha (welcome screen appears)
- [ ] Quit Plexi Alpha
- [ ] Relaunch Plexi Alpha — welcome screen should appear instead of a default terminal

**Breaks if:** Relaunch after closing all panes opens a terminal instead of the welcome screen.