### PR TITLE
feat(welcome): empty context on first launch + Cmd+N first + key separators

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -537,22 +537,9 @@ impl PlexiApp {
             }
         }
 
-        // Default: single context with single pane
-        let settings = Self::make_backend_settings(None, &colors);
-        let pane = TerminalPane::new(
-            0,
-            cc.egui_ctx.clone(),
-            tx.clone(),
-            settings,
-            default_font_size,
-        )
-        .expect("failed to create initial terminal");
-        let mut panes = HashMap::new();
-        panes.insert(0u64, Pane::Terminal(Box::new(pane)));
-
-        let mut tiles = egui_tiles::Tiles::default();
-        let root_tile = tiles.insert_pane(0u64);
-        let tree = Tree::new("plexi", root_tile, tiles);
+        // Default: empty context — welcome screen is shown until the user creates a pane.
+        let panes: HashMap<u64, Pane> = HashMap::new();
+        let tree = Tree::empty("plexi");
 
         let path = std::env::current_dir()
             .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
@@ -574,7 +561,7 @@ impl PlexiApp {
                 path,
                 tree,
                 panes,
-                focused_pane: Some(root_tile),
+                focused_pane: None,
                 zoomed_pane: None,
                 grid_x: 0,
                 grid_y: 0,

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1324,10 +1324,10 @@ impl PlexiApp {
                     // Each entry: (chip groups for one combo, description).
                     // Every modifier/key is a separate chip — no combined strings.
                     let shortcuts: &[(&[&str], &str)] = &[
+                        (&["⌘", "N"], "new terminal"),
+                        (&["⌘", "⇧", "N"], "new context"),
                         (&["⌘", "H", "J", "K", "L"], "move between panes"),
                         (&["⌘", "⇧", "H", "J", "K", "L"], "move between windows"),
-                        (&["⌘", "N"], "open a terminal"),
-                        (&["⌘", "⇧", "N"], "new context"),
                         (&["⌘", "/"], "keyboard shortcuts"),
                     ];
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -121,11 +121,18 @@ const INTER_COMBO_GAP: f32 = 10.0;
 const TRAILING_GAP: f32 = 10.0;
 
 /// Render several chips forming a single key combo (e.g. ["⌘", "["]).
-/// Chips are laid out left-to-right with `INTRA_COMBO_GAP` between them.
+/// Chips are separated by a "+" label between each pair.
 pub(crate) fn key_combo(ui: &mut egui::Ui, keys: &[&str], colors: &Colors) {
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = INTRA_COMBO_GAP;
-        for key in keys {
+        for (i, key) in keys.iter().enumerate() {
+            if i > 0 {
+                ui.label(
+                    egui::RichText::new("+")
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+            }
             key_chip(ui, key, colors);
         }
     });


### PR DESCRIPTION
## Summary

- **Empty first launch**: no longer auto-creates a terminal pane on first boot. The welcome screen appears immediately and the user presses Cmd+N to get started.
- **Shortcut order**: Cmd+N moved to the top of the welcome-screen shortcut list (was third), labelled "new terminal". Cmd+Shift+N follows as "new context".
- **Key separators**: `key_combo` widget now renders a "+" between each key chip — shortcuts display as `[⌘]+[N]` instead of `[⌘][N]`.

## Test plan

- [ ] Delete `~/.plexi-alpha/workspace.json` (or move it aside), launch alpha — welcome screen should appear with no terminal
- [ ] Press Cmd+N — terminal opens, welcome screen disappears
- [ ] Welcome screen shows Cmd+N at the top with "new terminal"
- [ ] Key chips show "+" between them (e.g. `[⌘]+[N]`, `[⌘]+[H][J][K][L]`)
- [ ] Press Cmd+/ — full shortcuts overlay also uses new "+" format

**Breaks if:** welcome screen never appears on fresh launch (empty workspace.json), or Cmd+N no longer opens a terminal from the welcome screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)