### PR TITLE
fix: Cmd+N on empty welcome context populates in-place

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1644,7 +1644,11 @@ impl eframe::App for PlexiApp {
                     self.force_reload_focused_app();
                 }
                 Action::NewPageRight => {
-                    self.new_page_right();
+                    if self.contexts[self.active_context].panes.is_empty() {
+                        self.reset_active_context();
+                    } else {
+                        self.new_page_right();
+                    }
                 }
                 Action::NewContext => {
                     self.new_context();


### PR DESCRIPTION
## Summary
- When the active context has no panes (welcome screen), `NewPageRight` was calling `new_page_right()` which created a second context at grid_x=1 alongside the empty placeholder at grid_x=0 — two cells on the minimap, one blank ghost
- Fix: check `panes.is_empty()` before dispatching; if empty, call `reset_active_context()` which populates the existing slot with a terminal instead of spawning a sibling

## Test plan
- [ ] Delete `~/.plexi-alpha/workspace.json`, relaunch — welcome screen appears
- [ ] Press Cmd+N — single terminal opens, minimap stays hidden (no ghost page)
- [ ] Press Cmd+N again from an existing terminal — new page created to the right, minimap shows 2 cells (correct behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)