### PR TITLE
fix: copy selection spanning scrollback boundary

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -285,7 +285,14 @@ impl TerminalBackend {
         if let Some(range) = content.selectable_range {
             let mut prev_line: Option<Line> = None;
             let last_col = content.grid.last_column();
-            for indexed in content.grid.display_iter() {
+            // iter_from(range.start) instead of display_iter() — display_iter
+            // only covers the current viewport, so a selection that starts in
+            // scrollback but ends at the live view would silently drop all cells
+            // above the visible top.
+            for indexed in content.grid.iter_from(range.start) {
+                if indexed.point > range.end {
+                    break;
+                }
                 if range.contains(indexed.point) {
                     if let Some(prev) = prev_line {
                         if prev != indexed.point.line {


### PR DESCRIPTION
## Summary
- `selectable_content()` used `display_iter()` which only iterates the current viewport
- A selection that starts in scrollback and ends at the live view (or vice versa) would silently drop all cells outside the visible area — user only got the on-screen text
- Fix: replace `display_iter()` with `iter_from(range.start)` + early-exit at `range.end`, covering the full selection regardless of scroll position

## Root cause
`display_iter()` is defined as iterating exactly `screen_lines` rows anchored at the current `display_offset`. When you scroll back up to start a selection, then drag (auto-scrolling) to the live view, `display_offset` drops to 0 and the scrollback lines leave `display_iter()`'s range entirely.

## Test plan
- [ ] Run `seq 1 200` to fill scrollback
- [ ] Scroll up ~50 lines
- [ ] Drag-select from scrollback across the scroll boundary to the live view
- [ ] Cmd+C, paste — should include all selected lines, not just what was on screen at time of copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)