### PR TITLE
feat(pgap): nav stack protocol — PushNav/PopNav + NavBack (Rust host) (#392)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1503,7 +1503,39 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::ClosePane => {
-                    if self.confirm_close() {
+                    // If the focused app pane has declared internal navigation
+                    // depth (via PushNav), Escape routes NavBack to the app
+                    // instead of closing the pane.
+                    let nav_pane_id = {
+                        let active_ctx = &self.contexts[self.active_context];
+                        active_ctx.focused_pane.and_then(|tile_id| {
+                            if let Some(egui_tiles::Tile::Pane(pane_id)) =
+                                active_ctx.tree.tiles.get(tile_id)
+                            {
+                                active_ctx.panes.get(pane_id).and_then(|pane| {
+                                    pane.as_app().and_then(|app| {
+                                        if app.runtime.nav_stack_depth() > 0 {
+                                            Some(*pane_id)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                    };
+                    if let Some(pane_id) = nav_pane_id {
+                        let active = self.active_context;
+                        if let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) {
+                            if let Some(app) = pane.as_app_mut() {
+                                app.runtime.queue_outbound_event(
+                                    crate::app_protocol::PlexiEvent::NavBack {},
+                                );
+                            }
+                        }
+                    } else if self.confirm_close() {
                         self.pending_close = true;
                     } else if self.execute_close_pane() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -328,6 +328,10 @@ pub enum PlexiEvent {
         command: String,
         would_run_in_cwd: String,
     },
+    /// Emitted by host to app when Escape is pressed and the app's nav stack
+    /// depth is > 0. The app handles this by popping its own internal view
+    /// and emitting `DrawCommand::PopNav` to decrement the host counter.
+    NavBack {},
 }
 
 /// On-the-wire shape of one MIDI port. Mirrors `midi::MidiPortInfo` but lives
@@ -1092,6 +1096,18 @@ pub enum DrawCommand {
     ///
     /// Capability: `terminal.bindings`. All fields required.
     OpenArtifact { path: String, mode: ArtifactOpenMode },
+
+    // ── Navigation stack ─────────────────────────────────────────────────
+    /// App signals it has pushed a navigation level. The host increments its
+    /// per-pane nav stack depth counter. While depth > 0, pressing Escape
+    /// emits `PlexiEvent::NavBack` to the app instead of closing the pane.
+    ///
+    /// The optional `title` is reserved for future breadcrumb rendering and
+    /// is ignored by the host in this version.
+    PushNav { title: String },
+    /// App signals it has popped a navigation level. The host decrements its
+    /// per-pane nav stack depth counter (saturating — never below 0).
+    PopNav {},
 }
 
 /// Replace-vs-append behaviour for `DrawCommand::InsertPathToken`.

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -206,6 +206,15 @@ impl AppRuntime {
             AppRuntime::Builtin(_) => {}
         }
     }
+
+    /// Current nav stack depth as reported by the app via `PushNav`/`PopNav`.
+    /// Always 0 for builtin apps — they manage their own internal navigation.
+    pub fn nav_stack_depth(&self) -> usize {
+        match self {
+            AppRuntime::Process(app) => app.nav_stack_depth(),
+            AppRuntime::Builtin(_) => 0,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/process_app/agent.rs
+++ b/src/process_app/agent.rs
@@ -229,7 +229,9 @@ impl ProcessApp {
                 | DrawCommand::AudioCapture { .. }
                 | DrawCommand::CdRequest { .. }
                 | DrawCommand::SetTimer { .. }
-                | DrawCommand::CancelTimer { .. }) => {
+                | DrawCommand::CancelTimer { .. }
+                | DrawCommand::PushNav { .. }
+                | DrawCommand::PopNav { .. }) => {
                     self.route_command(cmd);
                 }
                 // FrameDone, ScheduleRender, MeasureText, CopyToClipboard, and

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -116,6 +116,10 @@ pub struct ProcessApp {
     pub(crate) run_registry: RunRegistry,
     pub(crate) pending_prompts: VecDeque<PendingPrompt>,
     pub(crate) status_summary: Option<String>,
+    /// Current navigation stack depth as reported by the app via
+    /// `DrawCommand::PushNav` / `DrawCommand::PopNav`. When > 0, Escape emits
+    /// `PlexiEvent::NavBack` to the app instead of closing the pane.
+    pub(crate) nav_stack_depth: usize,
     pub(crate) outbound_events: VecDeque<PlexiEvent>,
     pub(crate) secret_input_buf: String,
     /// Recent stderr lines from the subprocess. Capped at the last
@@ -430,6 +434,7 @@ impl ProcessApp {
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
             status_summary: None,
+            nav_stack_depth: 0,
             outbound_events: VecDeque::new(),
             secret_input_buf: String::new(),
             recent_stderr: Arc::clone(&recent_stderr_capture),
@@ -464,6 +469,12 @@ impl ProcessApp {
     /// exclude the sending pane.
     pub fn set_pane_id(&mut self, id: u64) {
         self.pane_id = id;
+    }
+
+    /// Current nav stack depth as tracked by `PushNav`/`PopNav` commands.
+    /// Returns 0 for Builtin apps that never emit these commands.
+    pub fn nav_stack_depth(&self) -> usize {
+        self.nav_stack_depth
     }
 
     pub(crate) fn send_event(&mut self, event: &PlexiEvent) {
@@ -791,7 +802,9 @@ impl ProcessApp {
                 | DrawCommand::RunInLinkedTerminal { .. }
                 | DrawCommand::InsertPathToken { .. }
                 | DrawCommand::RequestCommandPreview { .. }
-                | DrawCommand::OpenArtifact { .. }) => {
+                | DrawCommand::OpenArtifact { .. }
+                | DrawCommand::PushNav { .. }
+                | DrawCommand::PopNav { .. }) => {
                     self.route_command(cmd);
                 }
                 // Visual commands, FrameDone, Ready, MeasureText, ScheduleRender
@@ -997,7 +1010,9 @@ impl App for ProcessApp {
                 | DrawCommand::RunInLinkedTerminal { .. }
                 | DrawCommand::InsertPathToken { .. }
                 | DrawCommand::RequestCommandPreview { .. }
-                | DrawCommand::OpenArtifact { .. }) => {
+                | DrawCommand::OpenArtifact { .. }
+                | DrawCommand::PushNav { .. }
+                | DrawCommand::PopNav { .. }) => {
                     self.route_command(cmd);
                 }
                 other => self.pending_frame.push(other),

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -410,7 +410,12 @@ pub(super) fn render_draw_commands(
             | DrawCommand::RunInLinkedTerminal { .. }
             | DrawCommand::InsertPathToken { .. }
             | DrawCommand::RequestCommandPreview { .. }
-            | DrawCommand::OpenArtifact { .. } => {}
+            | DrawCommand::OpenArtifact { .. }
+            // Navigation stack commands are handled by route_command; the
+            // painter never sees them in the normal path — this arm is the
+            // safety net for any stray commands that leak through.
+            | DrawCommand::PushNav { .. }
+            | DrawCommand::PopNav { .. } => {}
         }
     }
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -537,6 +537,24 @@ impl ProcessApp {
                 self.status_summary = Some(text);
             }
 
+            // ── Navigation stack ───────────────────────────────────────────
+            DrawCommand::PushNav { title: _ } => {
+                self.nav_stack_depth = self.nav_stack_depth.saturating_add(1);
+                log::debug!(
+                    "ProcessApp[{}]: PushNav → depth={}",
+                    self.type_id,
+                    self.nav_stack_depth
+                );
+            }
+            DrawCommand::PopNav {} => {
+                self.nav_stack_depth = self.nav_stack_depth.saturating_sub(1);
+                log::debug!(
+                    "ProcessApp[{}]: PopNav → depth={}",
+                    self.type_id,
+                    self.nav_stack_depth
+                );
+            }
+
             // ── Spawn app ──────────────────────────────────────────────────
             DrawCommand::SpawnApp {
                 type_id,


### PR DESCRIPTION
## Summary

- Adds `DrawCommand::PushNav { title: String }` and `DrawCommand::PopNav {}` — apps emit these to increment/decrement the host's per-pane nav stack depth counter
- Adds `PlexiEvent::NavBack {}` — emitted by the host to the app when Escape is pressed and `nav_stack_depth > 0`, giving the app a chance to pop its own internal view
- `nav_stack_depth` lives on `ProcessApp` (same layer as `status_summary`), exposed via `ProcessApp::nav_stack_depth()` and `AppRuntime::nav_stack_depth()`
- `Action::ClosePane` (Escape) now checks the focused pane's depth first: if > 0, routes `NavBack` to the app; otherwise falls through to the existing confirm-close / execute-close path
- Builtin apps always return depth 0 — they manage their own navigation

## Files changed

- `src/app_protocol.rs` — `PushNav`, `PopNav` on `DrawCommand`; `NavBack` on `PlexiEvent`
- `src/pane.rs` — `AppRuntime::nav_stack_depth()` method
- `src/process_app/mod.rs` — `nav_stack_depth: usize` field + initializer + `ProcessApp::nav_stack_depth()` + routing arms
- `src/process_app/routing.rs` — `PushNav`/`PopNav` handlers (saturating inc/dec with debug log)
- `src/process_app/render.rs` — safety-net no-op arms for `PushNav`/`PopNav`
- `src/process_app/agent.rs` — route arms so agent panes can also use nav stack
- `src/app/mod.rs` — `Action::ClosePane` intercepts when `nav_stack_depth > 0`

## Out of scope (follow-up)

Python SDK surface (`ctx.push_nav`, `ctx.pop_nav`, `on_nav_back` hook) is tracked separately against the asyncio SDK rewrite.

## Test plan

- [ ] `cargo build` passes clean (verified locally)
- [ ] Open an app pane, emit `PushNav`, press Escape — confirm pane stays open
- [ ] After `PopNav` (depth back to 0), press Escape — confirm pane closes normally
- [ ] Open a non-app pane (terminal), press Escape — closes as before

**Breaks if:** Escape on an app pane that emitted `PushNav` closes the pane instead of sending `NavBack` to the app process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)