### PR TITLE
fix(pyright): zero errors across examples and SDK

### DIFF
--- a/examples/app-store/app_store.py
+++ b/examples/app-store/app_store.py
@@ -812,7 +812,7 @@ class AppStoreApp(App):
             "app-store-url",
             x=20.0,
             y=input_y,
-            w=ctx.width - 40.0 if hasattr(ctx, "width") else 600.0,
+            w=ctx.w - 40.0,
             placeholder="github:owner/repo[@ref]  or  git+https://…  (Enter to install)",
         )
         if submitted is not None:

--- a/examples/audio-bridge-test/audio_bridge_test.py
+++ b/examples/audio-bridge-test/audio_bridge_test.py
@@ -162,7 +162,7 @@ class AudioBridgeTestApp(App):
         elif k == "c":
             with self._peaks_lock:
                 self._peaks.clear()
-            ctx.schedule_render(after_ms=16)
+            self.emit.schedule_render(after_ms=16)
 
     # -- Render ---------------------------------------------------------
 

--- a/examples/canvas-terminal-bindings-test/canvas_terminal_bindings_test.py
+++ b/examples/canvas-terminal-bindings-test/canvas_terminal_bindings_test.py
@@ -142,7 +142,7 @@ class CanvasTerminalBindingsTestApp(App):
             self._open_desktop()
         elif key == "5":
             self._reveal_home()
-        ctx.schedule_render(after_ms=16)
+        self.emit.schedule_render(after_ms=16)
 
     def on_click(
         self,
@@ -165,7 +165,7 @@ class CanvasTerminalBindingsTestApp(App):
                 self._reveal_home,
             ]
             handlers[idx]()
-        ctx.schedule_render(after_ms=16)
+        self.emit.schedule_render(after_ms=16)
 
     # ── Primitive dispatchers ──────────────────────────────────────────
 

--- a/examples/iq-query-denied-test/iq_query_denied_test.py
+++ b/examples/iq-query-denied-test/iq_query_denied_test.py
@@ -32,7 +32,7 @@ class IqQueryDeniedTestApp(App):
         #   ("denied", str)  — got CapabilityDeniedError (the happy path here)
         #   ("ok", str)      — unexpected; the gate should have blocked us
         #   ("err", str)     — some other error
-        self._state: object = None
+        self._state: "str | tuple[str, str] | None" = None
         ctx.status_summary("IQ Query Denied — press `s` to verify the gate")
         self.emit.info("IQ Query Denied Test started")
 

--- a/examples/iq-query-test/iq_query_test.py
+++ b/examples/iq-query-test/iq_query_test.py
@@ -120,8 +120,7 @@ class IqQueryTestApp(App):
         ])
 
     def on_render(self, ctx: RenderContext) -> None:
-        rect = ctx.rect
-        ox, oy, ow, _oh = rect["x"], rect["y"], rect["w"], rect["h"]
+        ox, oy, ow = ctx.x, ctx.y, ctx.w
 
         # Single-line text input, host-owned buffer. Submit (Enter) sends to
         # Low tier by default — buttons l/m/h pick a specific tier explicitly.

--- a/examples/mind-map/mind_map.py
+++ b/examples/mind-map/mind_map.py
@@ -191,7 +191,9 @@ class MindMapApp(App):
 
         elif key in ("Backspace", "Delete"):
             if self._selected != self._root:
-                parent_id = node.parent
+                # Non-root nodes always have a parent; assert to narrow the type.
+                assert node.parent is not None
+                parent_id: int = node.parent
                 # Find a reasonable node to select after deletion
                 siblings = self._nodes[parent_id].children
                 idx = siblings.index(self._selected)

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1563,6 +1563,10 @@ class RenderContext:
             # events expected mid-frame). A full async approach would require
             # a separate thread; apps that need that should use DrawCommand::MeasureText
             # with an explicit NotifyAction-style async pattern instead.
+        # stdin closed without a matching TextMeasured response.
+        raise RuntimeError(
+            f"measure_text: host closed stdin before responding to request_id={request_id!r}"
+        )
 
     def push_clip(self, x: float, y: float, w: float, h: float) -> None:
         """Push a clip rect onto the host's clip stack.


### PR DESCRIPTION
## Summary

- `iq_query_test.py`: `ctx.rect` was being used as a subscriptable dict — it's a draw method. Replaced with `ctx.x`, `ctx.y`, `ctx.w`.
- `app_store.py`: `ctx.width` doesn't exist on `RenderContext`; replaced with `ctx.w`. Also removed the `hasattr` guard — `ctx.w` is always present.
- `audio_bridge_test.py`, `canvas_terminal_bindings_test.py`: `ctx.schedule_render()` doesn't exist; `schedule_render` lives on `Emitter`. Fixed to `self.emit.schedule_render()`.
- `iq_query_denied_test.py`: `_state` was typed as `object`, making subscripting and unpacking invalid. Replaced with the correct union `str | tuple[str, str] | None`.
- `mind_map.py`: `node.parent` is `int | None`; added `assert node.parent is not None` before use (the enclosing `if self._selected != self._root` guard makes this invariant true, the assert narrows the type).
- `sdk/python/plexi_sdk/__init__.py`: `measure_text()` was missing a return path when stdin closes before a matching `TextMeasured` response arrives; added `raise RuntimeError(...)` so Pyright sees all paths return.

**Breaks if:** `pyright` (run from the repo root) reports errors on `examples/` or `sdk/python/`.

## Test plan
- [ ] `pyright` from repo root: 0 errors, 0 warnings