### PR TITLE
feat(install): detect and append missing config sections on install

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,17 @@ install:
     cp target/release/bundle/osx/Plexi.app/Contents/MacOS/plexi /usr/local/bin/plexi
     rm -rf /Applications/Plexi.app
     cp -r target/release/bundle/osx/Plexi.app /Applications/Plexi.app
+    @bash scripts/migrate-config.sh "$HOME/.plexi/config.toml"
+
+# Append any missing config sections to a Plexi config.toml. Idempotent.
+migrate-config-alpha:
+    @bash scripts/migrate-config.sh "$HOME/.plexi-alpha/config.toml"
+
+migrate-config-beta:
+    @bash scripts/migrate-config.sh "$HOME/.plexi-beta/config.toml"
+
+migrate-config-v3:
+    @bash scripts/migrate-config.sh "$HOME/.plexi-v3/config.toml"
 
 # ── Versions — full lifecycle for parallel .app installs + worktrees ─────────
 #
@@ -298,6 +309,7 @@ install-alpha:
     echo "CLI binary: /usr/local/bin/plexi-alpha"
     echo "Config dir: ~/.plexi-alpha/"
     echo "Apps: $(ls ~/.plexi-alpha/apps | wc -l | tr -d ' ') synced from examples/"
+    bash scripts/migrate-config.sh "$HOME/.plexi-alpha/config.toml"
 
 install-v3:
     #!/usr/bin/env bash
@@ -362,6 +374,7 @@ install-v3:
     echo "CLI binary: /usr/local/bin/plexi-v3"
     echo "Config dir: ~/.plexi-v3/"
     echo "Apps: $(ls ~/.plexi-v3/apps | wc -l | tr -d ' ') installed"
+    bash scripts/migrate-config.sh "$HOME/.plexi-v3/config.toml"
 
 install-beta:
     #!/usr/bin/env bash
@@ -426,6 +439,7 @@ install-beta:
     echo "CLI binary: /usr/local/bin/plexi-beta"
     echo "Config dir: ~/.plexi-beta/"
     echo "Apps: $(ls ~/.plexi-beta/apps | wc -l | tr -d ' ') synced from examples/"
+    bash scripts/migrate-config.sh "$HOME/.plexi-beta/config.toml"
 
 # Wipe a channel's installed apps directory. The install-* recipes use
 # `cp -R` (sync, not mirror), so apps deleted from `examples/` persist in

--- a/scripts/migrate-config.sh
+++ b/scripts/migrate-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# migrate-config.sh — Append missing config sections to a Plexi config.toml.
+#
+# Usage: migrate-config.sh <config-path>
+# Example: migrate-config.sh ~/.plexi-alpha/config.toml
+#
+# Idempotent: running twice never duplicates sections.
+# Only appends — never modifies or removes existing values.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: migrate-config.sh <config-path>" >&2
+  exit 1
+fi
+
+CONFIG="$1"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "config: no config.toml found at $CONFIG — skipping migration"
+  exit 0
+fi
+
+ADDED=0
+
+# Check for [ai] section (also accepts legacy [iq] from before #429 rename).
+# Users with [iq] already have equivalent config — don't duplicate.
+if ! grep -q '^\[ai\]' "$CONFIG" && ! grep -q '^\[iq\]' "$CONFIG"; then
+  cat >> "$CONFIG" << 'BLOCK'
+
+# Added by installer — Plexi AI backend config
+# Set OPENROUTER_API_KEY in your environment to use OpenRouter
+[ai]
+backend = "openrouter"
+
+[ai.openrouter]
+api_key_env = "OPENROUTER_API_KEY"
+model_low    = "google/gemini-2.0-flash-001"
+model_medium = "anthropic/claude-sonnet-4-6"
+model_high   = "anthropic/claude-opus-4-7"
+
+[ai.ollama]
+host = "http://localhost:11434"
+model_low    = "llama3.2:3b"
+model_medium = "llama3.3:70b"
+model_high   = "qwq:32b"
+BLOCK
+  echo "config: added [ai] section to $CONFIG"
+  ADDED=$((ADDED + 1))
+fi
+
+# Add more section checks here as new required sections are introduced.
+
+if [[ $ADDED -eq 0 ]]; then
+  echo "config: up to date — no sections added"
+fi


### PR DESCRIPTION
Closes #425

## Summary
- `scripts/migrate-config.sh` accepts a config path argument and appends any missing sections with defaults and comments
- Checks for both `[ai]` and legacy `[iq]` — users who already upgraded via #429 don't get a duplicate section
- `just install-alpha`, `install-beta`, `install-v3`, and `install` all call the script for their respective config paths
- Standalone `migrate-config-alpha`, `migrate-config-beta`, `migrate-config-v3` recipes for manual invocation
- Script is idempotent — running twice prints "up to date — no sections added"
- Silently skips if no config.toml exists yet (first install)

## Test plan
- [ ] Remove `[iq]`/`[ai]` section from `~/.plexi-alpha/config.toml`, run `just install-alpha`, verify `[ai]` section is appended with correct defaults
- [ ] Run `just install-alpha` again — "up to date — no sections added" printed, no duplicate section
- [ ] With existing `[iq]` section present — "up to date" printed, no `[ai]` section added
- [ ] `cargo build` passes clean

🤖 Generated with Claude Code