### PR TITLE
fix(layout): show welcome screen on all empty contexts

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1785,13 +1785,8 @@ impl eframe::App for PlexiApp {
                 ..Default::default()
             })
             .show(ctx, |ui| {
-                // Safety net: show the welcome screen when the sole remaining
-                // context is empty. Primary removal of empty non-last contexts
-                // happens in execute_close_pane; by the time we reach here
-                // there should never be more than one context left.
                 let active = self.active_context;
-                let is_last = self.contexts.len() == 1;
-                if is_last && self.contexts[active].panes.is_empty() {
+                if self.contexts[active].panes.is_empty() {
                     self.draw_welcome_screen(ui);
                     return;
                 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -677,21 +677,12 @@ impl PlexiApp {
     /// Execute the close-pane action (called directly when confirm_close is false,
     /// or from the confirm-close dialog when the user confirms).
     ///
-    /// After closing the last pane in a context, the context itself is removed
-    /// unless it is the sole remaining context at grid position (0,0) — in that
-    /// case the welcome screen is shown instead.
+    /// After closing the last pane in a context the context remains open and
+    /// the welcome screen is shown in its place.
     pub(crate) fn execute_close_pane(&mut self) -> bool {
         self.contexts[self.active_context].zoomed_pane = None;
         if !self.contexts[self.active_context].panes.is_empty() {
             self.close_focused();
-        }
-
-        // If closing the last pane emptied this context and it isn't the only
-        // one left, remove it. Keeping at least one context avoids UI panics
-        // and preserves the welcome-screen slot.
-        let active = self.active_context;
-        if self.contexts[active].panes.is_empty() && self.contexts.len() > 1 {
-            self.delete_context(active);
         }
 
         false


### PR DESCRIPTION
Reverts the context auto-deletion behavior added in #406 (#405).

The previous behavior deleted empty non-last contexts and only showed the welcome screen at grid 0-0. The desired behavior is: every empty context shows the welcome screen regardless of how many contexts exist.

**Changes:**
- `execute_close_pane` no longer calls `delete_context` when the last pane closes in a multi-context workspace
- Welcome screen guard changed from `is_last && panes.is_empty()` back to just `panes.is_empty()`

🤖 Generated with Claude Code