### PR TITLE
refactor: rename WorkspaceMeta→Context, Context→Window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Try-catch on all I/O, network, external API calls, and anything that can reasona
 
 ## PlexiApp State
 
-`PlexiApp` fields are declared in `src/app/mod.rs`. There are exactly two struct-literal initialization blocks — both contain `renaming_context: None` and are the only places new fields need to be initialized.
+`PlexiApp` fields are declared in `src/app/mod.rs`. There are exactly two struct-literal initialization blocks — both contain `renaming_window: None` and are the only places new fields need to be initialized.
 
 ## Host UI Systems — Reuse Before Rolling Your Own
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,10 @@ Try-catch on all I/O, network, external API calls, and anything that can reasona
 - **Fallback chain audit:** When a value looks correct on the surface but behavior is stale, enumerate every fallback source in priority order (cookies, env vars, caches, defaults). Fix the chain, not the surface.
 - **Model ID verification:** Never guess versioned model IDs. Use only confirmed-current family IDs. A 400/404 surfaces only at call time.
 
+## PlexiApp State
+
+`PlexiApp` fields are declared in `src/app/mod.rs`. There are exactly two struct-literal initialization blocks — both contain `renaming_context: None` and are the only places new fields need to be initialized.
+
 ## Host UI Systems — Reuse Before Rolling Your Own
 
 Before writing any keyboard shortcut display, badge, chip, or inline label widget, check `src/widgets.rs` and `src/style.rs`. These modules contain the canonical, already-tested implementations. Re-rolling them inline produces visual inconsistency and duplicated sizing logic.

--- a/src/agent_workspace_modal.rs
+++ b/src/agent_workspace_modal.rs
@@ -115,12 +115,12 @@ impl crate::app::PlexiApp {
         if self.agent_workspace_modal.is_some() {
             return;
         }
-        let default_cwd: Option<PathBuf> = self.contexts[self.active_context]
+        let default_cwd: Option<PathBuf> = self.windows[self.active_window]
             .focused_pane
             .and_then(|fp| {
-                self.contexts[self.active_context].get_focused_pane_cwd(fp)
+                self.windows[self.active_window].get_focused_pane_cwd(fp)
             })
-            .or_else(|| Some(self.contexts[self.active_context].path.clone()));
+            .or_else(|| Some(self.windows[self.active_window].path.clone()));
 
         let modal = AgentWorkspaceModal::open(&self.last_cli_map, default_cwd.as_deref());
         self.agent_workspace_modal = Some(modal);

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -29,11 +29,11 @@ impl PlexiApp {
         request_id: String,
         cwd: Option<String>,
     ) {
-        let active = self.active_context;
+        let active = self.active_window;
 
         // Resolve cwd: explicit > sender's workspace_root > home.
         let workspace_root = self
-            .contexts[active]
+            .windows[active]
             .panes
             .get(&sender_pane_id)
             .and_then(|p| p.as_app())
@@ -46,7 +46,7 @@ impl PlexiApp {
         // Find the sender's tile so we can split next to it. Without the
         // tile we have no anchor for the split — bail out and notify the
         // app so the blocking helper unblocks instead of hanging.
-        let Some(sender_tile) = find_tile_for_pane(&self.contexts[active].tree, sender_pane_id)
+        let Some(sender_tile) = find_tile_for_pane(&self.windows[active].tree, sender_pane_id)
         else {
             log::warn!(
                 "RequestLinkedTerminal: sender pane {sender_pane_id} not in tree; \
@@ -84,7 +84,7 @@ impl PlexiApp {
             );
             return;
         };
-        self.contexts[active]
+        self.windows[active]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(term)));
 
@@ -94,18 +94,18 @@ impl PlexiApp {
         // then restore focus afterwards. Side-by-side (vertical=true) on
         // the right: feels right for a Canvas-app-on-left, terminal-on-
         // right layout, which is the common case.
-        let prev_focus = self.contexts[active].focused_pane;
-        self.contexts[active].focused_pane = Some(sender_tile);
+        let prev_focus = self.windows[active].focused_pane;
+        self.windows[active].focused_pane = Some(sender_tile);
         let share = crate::host::command::ShareRatio::new(1.0, 1.0)
             .expect("1:1 is a valid ShareRatio");
         let _ = self.split_with_new_pane(new_id, true, share, false);
         // Don't snap focus to the new terminal — the user clicked a button
         // in the Canvas app and would lose keyboard focus mid-flow.
-        self.contexts[active].focused_pane = prev_focus;
+        self.windows[active].focused_pane = prev_focus;
 
         // Update the sender's linked_pane_id so legacy CdRequest also
         // routes to this terminal.
-        if let Some(pane) = self.contexts[active].panes.get_mut(&sender_pane_id) {
+        if let Some(pane) = self.windows[active].panes.get_mut(&sender_pane_id) {
             if let Some(app) = pane.as_app_mut() {
                 app.linked_pane_id = Some(new_id);
             }
@@ -136,8 +136,8 @@ impl PlexiApp {
         command: String,
         echo: bool,
     ) {
-        let active = self.active_context;
-        let Some(term) = self.contexts[active]
+        let active = self.active_window;
+        let Some(term) = self.windows[active]
             .panes
             .get_mut(&terminal_pane_id)
             .and_then(|p| p.as_terminal_mut())
@@ -164,8 +164,8 @@ impl PlexiApp {
         path: String,
         mode: PathTokenMode,
     ) {
-        let active = self.active_context;
-        let Some(term) = self.contexts[active]
+        let active = self.active_window;
+        let Some(term) = self.windows[active]
             .panes
             .get_mut(&terminal_pane_id)
             .and_then(|p| p.as_terminal_mut())
@@ -198,8 +198,8 @@ impl PlexiApp {
         terminal_pane_id: PaneId,
         command: String,
     ) {
-        let active = self.active_context;
-        let cwd = self.contexts[active]
+        let active = self.active_window;
+        let cwd = self.windows[active]
             .panes
             .get(&terminal_pane_id)
             .and_then(|p| p.as_terminal())
@@ -254,8 +254,8 @@ impl PlexiApp {
     /// pending dispatch — the user closed the canvas app between request
     /// and response).
     fn queue_event_to_pane(&mut self, pane_id: PaneId, event: PlexiEvent) {
-        let active = self.active_context;
-        if let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) {
+        let active = self.active_window;
+        if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
             if let Some(app) = pane.as_app_mut() {
                 app.runtime.queue_outbound_event(event);
             } else if let Some(agent) = pane.as_agent_mut() {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -11,17 +11,17 @@ impl PlexiApp {
     /// apps can surface notifications and other commands while the
     /// focused pane is something else (or while a modal holds focus).
     pub(super) fn dispatch_app_key_events(&mut self, ctx: &egui::Context) {
-        let active = self.active_context;
-        let Some(focused_tile) = self.contexts[active].focused_pane else {
+        let active = self.active_window;
+        let Some(focused_tile) = self.windows[active].focused_pane else {
             return;
         };
         let Some(egui_tiles::Tile::Pane(pane_id)) =
-            self.contexts[active].tree.tiles.get(focused_tile)
+            self.windows[active].tree.tiles.get(focused_tile)
         else {
             return;
         };
         let pane_id = *pane_id;
-        let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) else {
+        let Some(pane) = self.windows[active].panes.get_mut(&pane_id) else {
             return;
         };
         let Some(app_pane) = pane.as_app_mut() else {
@@ -46,9 +46,9 @@ impl PlexiApp {
         // looked up from the registry by type_id, and we can't hold a
         // mutable borrow on contexts + a shared borrow on the registry at
         // the same time during the match below.
-        let active = self.active_context;
+        let active = self.active_window;
         let mut per_pane: Vec<(usize, u64, String, Vec<AppCommand>)> = Vec::new();
-        for (ctx_idx, context) in self.contexts.iter_mut().enumerate() {
+        for (ctx_idx, context) in self.windows.iter_mut().enumerate() {
             for (pane_id, pane) in context.panes.iter_mut() {
                 if let Some(app_pane) = pane.as_app_mut() {
                     // Active-context panes are already fully updated by ui()
@@ -126,8 +126,8 @@ impl PlexiApp {
                         image_pipe_id,
                         ..
                     } => {
-                        let ws_idx = self.contexts.get(ctx_idx)
-                            .and_then(|c| self.workspaces.iter().position(|w| w.context_id == c.workspace_id))
+                        let ws_idx = self.windows.get(ctx_idx)
+                            .and_then(|w| self.contexts.iter().position(|c| c.context_id == w.context_id))
                             .unwrap_or(0);
                         deferred.push(AppCommand::ShowNotification {
                             notify_id,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -75,7 +75,7 @@ pub(crate) enum NotificationImageState {
 use crate::agent_workspace::MergeOutcome;
 use crate::app_registry::AppRegistry;
 use crate::config;
-use crate::context::Context;
+use crate::context::{Context, Window};
 use crate::keys::{self, Action};
 use crate::pane::{Pane, TerminalPane};
 use crate::shell;
@@ -97,10 +97,10 @@ pub struct PlexiApp {
     pub(crate) colors: Colors,
     pub(crate) default_font_size: f32,
     pub(crate) ctx: egui::Context,
-    pub(crate) workspaces: Vec<crate::context::WorkspaceMeta>,
     pub(crate) contexts: Vec<Context>,
+    pub(crate) windows: Vec<Window>,
+    pub(crate) active_window: usize,
     pub(crate) active_context: usize,
-    pub(crate) active_workspace: usize,
     pub(crate) sidebar_visible: bool,
     pub(crate) show_shortcuts: bool,
     pub(crate) quitting: bool,
@@ -110,7 +110,7 @@ pub struct PlexiApp {
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
-    pub(crate) renaming_context: Option<usize>,
+    pub(crate) renaming_window: Option<usize>,
     pub(crate) rename_buffer: String,
     pub(crate) drag_context: Option<usize>,
     pub(crate) registry: AppRegistry,
@@ -195,15 +195,15 @@ pub struct PlexiApp {
     /// consult this to land on the most recently accessed page in the target
     /// row rather than the spatially closest one.
     pub(crate) last_page_x_per_row: HashMap<u32, u32>,
-    /// workspace_id → last active context_id for that workspace.
-    pub(crate) workspace_active_window: HashMap<u64, u64>,
-    /// Per-workspace minimap visibility. Saved on workspace switch so each
-    /// workspace remembers its own minimap state across context changes.
-    /// Absent entry = first visit; defaults to `true` iff workspace has > 1 page.
-    pub(crate) minimap_visible_per_workspace: HashMap<u64, bool>,
-    /// Monotonically increasing counter. Assigned to each new `Context` as its
-    /// stable `context_id`. Never reused — only increments.
-    pub(crate) next_context_id: u64,
+    /// context_id → last active window_id for that context.
+    pub(crate) context_active_window: HashMap<u64, u64>,
+    /// Per-context minimap visibility. Saved on context switch so each
+    /// context remembers its own minimap state across window changes.
+    /// Absent entry = first visit; defaults to `true` iff context has > 1 page.
+    pub(crate) minimap_visible_per_context: HashMap<u64, bool>,
+    /// Monotonically increasing counter. Assigned to each new `Window` as its
+    /// stable `window_id`. Never reused — only increments.
+    pub(crate) next_window_id: u64,
 }
 
 impl PlexiApp {
@@ -265,14 +265,14 @@ impl PlexiApp {
 
         // Try to load saved workspace
         if let Some(ws) = WorkspaceFile::load() {
-            let mut contexts = Vec::new();
-            for saved_ctx in ws.contexts {
+            let mut windows = Vec::new();
+            for saved_win in ws.windows {
                 let mut panes = HashMap::new();
-                for saved_pane in &saved_ctx.panes {
+                for saved_pane in &saved_win.panes {
                     let cwd = if saved_pane.cwd.is_dir() {
                         Some(saved_pane.cwd.clone())
-                    } else if saved_ctx.path.is_dir() {
-                        Some(saved_ctx.path.clone())
+                    } else if saved_win.path.is_dir() {
+                        Some(saved_win.path.clone())
                     } else {
                         dirs::home_dir()
                     };
@@ -438,50 +438,50 @@ impl PlexiApp {
                 }
                 // Skip only if there were saved panes that all failed to restore
                 // (corrupted state). An empty saved pane list means the user
-                // intentionally closed all panes — restore the empty context so
+                // intentionally closed all panes — restore the empty window so
                 // the welcome screen appears on next launch.
-                if !saved_ctx.panes.is_empty() && panes.is_empty() {
+                if !saved_win.panes.is_empty() && panes.is_empty() {
                     continue;
                 }
-                contexts.push(Context {
-                    name: saved_ctx.name,
-                    path: saved_ctx.path,
-                    tree: saved_ctx.tree,
+                windows.push(Window {
+                    name: saved_win.name,
+                    path: saved_win.path,
+                    tree: saved_win.tree,
                     panes,
-                    focused_pane: saved_ctx.focused_pane,
+                    focused_pane: saved_win.focused_pane,
                     zoomed_pane: None,
-                    grid_x: saved_ctx.grid_x,
-                    grid_y: saved_ctx.grid_y,
-                    context_id: saved_ctx.context_id,
-                    workspace_id: saved_ctx.workspace_id,
+                    grid_x: saved_win.grid_x,
+                    grid_y: saved_win.grid_y,
+                    window_id: saved_win.window_id,
+                    context_id: saved_win.context_id,
                 });
             }
-            if !contexts.is_empty() {
-                // Repair context_ids: old workspace files have context_id=0.
-                // Assign sequential IDs so every context has a stable unique ID.
+            if !windows.is_empty() {
+                // Repair window_ids: old workspace files have window_id=0.
+                // Assign sequential IDs so every window has a stable unique ID.
                 let mut next_id: u64 = 1;
-                for ctx in &mut contexts {
-                    if ctx.context_id == 0 {
-                        ctx.context_id = next_id;
+                for win in &mut windows {
+                    if win.window_id == 0 {
+                        win.window_id = next_id;
                         next_id += 1;
                     } else {
-                        next_id = next_id.max(ctx.context_id + 1);
+                        next_id = next_id.max(win.window_id + 1);
                     }
                 }
-                let mut workspaces = Vec::new();
-                for saved_ws in ws.workspaces {
-                    workspaces.push(crate::context::WorkspaceMeta {
-                        name: saved_ws.name,
-                        path: saved_ws.path,
-                        context_id: saved_ws.context_id,
+                let mut contexts = Vec::new();
+                for saved_ctx in ws.contexts {
+                    contexts.push(crate::context::Context {
+                        name: saved_ctx.name,
+                        path: saved_ctx.path,
+                        context_id: saved_ctx.context_id,
                     });
                 }
-                let active_ws = ws.active_workspace.min(workspaces.len().saturating_sub(1));
-                let active_ws_id = workspaces[active_ws].context_id;
-                let active = ws.workspace_active_window.get(&active_ws_id)
-                    .and_then(|ctx_id| contexts.iter().position(|c| c.context_id == *ctx_id))
+                let active_ctx = ws.active_context.min(contexts.len().saturating_sub(1));
+                let active_ctx_id = contexts[active_ctx].context_id;
+                let active = ws.context_active_window.get(&active_ctx_id)
+                    .and_then(|win_id| windows.iter().position(|w| w.window_id == *win_id))
                     .unwrap_or(0);
-                let window_count = contexts.iter().filter(|c| c.workspace_id == active_ws_id).count();
+                let window_count = windows.iter().filter(|w| w.context_id == active_ctx_id).count();
                 let mut host = crate::host::model::HostModel::new();
                 host.seed_next_pane_id(ws.next_pane_id);
                 return Self {
@@ -492,9 +492,9 @@ impl PlexiApp {
                     default_font_size,
                     ctx: cc.egui_ctx.clone(),
                     contexts,
-                    workspaces,
-                    active_context: active,
-                    active_workspace: active_ws,
+                    windows,
+                    active_window: active,
+                    active_context: active_ctx,
                     sidebar_visible: ws.sidebar_visible,
                     show_shortcuts: false,
                     quitting: false,
@@ -502,7 +502,7 @@ impl PlexiApp {
                     quit_last_press: None,
                     config: config.clone(),
                     pending_close: false,
-                    renaming_context: None,
+                    renaming_window: None,
                     rename_buffer: String::new(),
                     drag_context: None,
                     show_command_palette: false,
@@ -535,9 +535,9 @@ impl PlexiApp {
                     last_cli_map: crate::agent_workspace::persistence::load(),
                     minimap: crate::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
-                    workspace_active_window: ws.workspace_active_window,
-                    minimap_visible_per_workspace: HashMap::new(),
-                    next_context_id: next_id,
+                    context_active_window: ws.context_active_window,
+                    minimap_visible_per_context: HashMap::new(),
+                    next_window_id: next_id,
                 };
             }
         }
@@ -556,12 +556,12 @@ impl PlexiApp {
             colors,
             default_font_size,
             ctx: cc.egui_ctx.clone(),
-            workspaces: vec![crate::context::WorkspaceMeta {
+            contexts: vec![crate::context::Context {
                 name: "Default".into(),
                 path: path.clone(),
                 context_id: 1,
             }],
-            contexts: vec![Context {
+            windows: vec![Window {
                 name: "Default".into(),
                 path,
                 tree,
@@ -570,9 +570,10 @@ impl PlexiApp {
                 zoomed_pane: None,
                 grid_x: 0,
                 grid_y: 0,
+                window_id: 1,
                 context_id: 1,
-                workspace_id: 1,
             }],
+            active_window: 0,
             active_context: 0,
             sidebar_visible: true,
             show_shortcuts: false,
@@ -581,7 +582,7 @@ impl PlexiApp {
             quit_last_press: None,
             config,
             pending_close: false,
-            renaming_context: None,
+            renaming_window: None,
             rename_buffer: String::new(),
             drag_context: None,
             show_command_palette: false,
@@ -614,10 +615,9 @@ impl PlexiApp {
             last_cli_map: crate::agent_workspace::persistence::load(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
-            workspace_active_window: HashMap::new(),
-            minimap_visible_per_workspace: HashMap::new(),
-            active_workspace: 0,
-            next_context_id: 2,
+            context_active_window: HashMap::new(),
+            minimap_visible_per_context: HashMap::new(),
+            next_window_id: 2,
         }
     }
 
@@ -675,7 +675,7 @@ impl PlexiApp {
                 sender_pane_id: 0,
                 // Host-originated notifications are global (they originate
                 // outside any context) and always visible.
-                source_context: self.active_workspace,
+                source_context: self.active_context,
                 scope: crate::app_protocol::NotifyScope::Global,
                 level,
                 title,
@@ -711,8 +711,8 @@ impl PlexiApp {
             // Forward Wakeup / ChildExit to AgentWorkspace status heuristics
             // (#349). Other panes ignore these — only the agent workspace
             // tracks activity timing.
-            for context in &mut self.contexts {
-                if let Some(pane) = context.panes.get_mut(&id) {
+            for win in &mut self.windows {
+                if let Some(pane) = win.panes.get_mut(&id) {
                     if let Some(workspace) = pane.as_agent_workspace_mut() {
                         workspace.record_pty_activity(&event, now);
                     }
@@ -721,8 +721,8 @@ impl PlexiApp {
             }
             match &event {
                 PtyEvent::Exit => {
-                    for context in &mut self.contexts {
-                        if let Some(pane) = context.panes.get_mut(&id) {
+                    for win in &mut self.windows {
+                        if let Some(pane) = win.panes.get_mut(&id) {
                             if let Some(t) = pane.as_terminal_mut() {
                                 t.exited = true;
                             }
@@ -759,14 +759,14 @@ impl PlexiApp {
     // push order (we never reorder the Vec; dismissal removes by id).
     //
     // Visibility: Context-scoped notifications are only visible when
-    // `source_context == self.active_workspace`. Global notifications are
+    // `source_context == self.active_context`. Global notifications are
     // always visible. The raw `pending_notifications` Vec stays flat;
     // only the *view* changes with the active workspace.
 
     /// True when this notification should appear in the current workspace view.
     pub(crate) fn notification_is_visible(&self, n: &PendingNotification) -> bool {
         matches!(n.scope, crate::app_protocol::NotifyScope::Global)
-            || n.source_context == self.active_workspace
+            || n.source_context == self.active_context
     }
 
     /// Return ids of all *visible* notifications (for the current context),
@@ -860,8 +860,8 @@ impl PlexiApp {
         let now = std::time::Instant::now();
         let mut conflict_surfaces: Vec<(String, Vec<String>)> = Vec::new();
         let mut merge_failures: Vec<(String, String)> = Vec::new();
-        for context in &mut self.contexts {
-            for pane in context.panes.values_mut() {
+        for win in &mut self.windows {
+            for pane in win.panes.values_mut() {
                 let Some(workspace) = pane.as_agent_workspace_mut() else {
                     continue;
                 };
@@ -939,7 +939,7 @@ impl PlexiApp {
         self.pending_notifications.push(PendingNotification {
             notify_id: internal_id.clone(),
             sender_pane_id: 0,
-            source_context: self.active_workspace,
+            source_context: self.active_context,
             scope: crate::app_protocol::NotifyScope::Global,
             level,
             title,
@@ -1050,10 +1050,10 @@ impl eframe::App for PlexiApp {
                     args,
                 } => {
                     // Capture requesting pane before launch changes focused_pane.
-                    let active = self.active_context;
-                    let requesting_pane_id = self.contexts[active]
+                    let active = self.active_window;
+                    let requesting_pane_id = self.windows[active]
                         .focused_pane
-                        .and_then(|tile| self.contexts[active].tree.tiles.get(tile))
+                        .and_then(|tile| self.windows[active].tree.tiles.get(tile))
                         .and_then(|tile| {
                             if let egui_tiles::Tile::Pane(pid) = tile {
                                 Some(*pid)
@@ -1067,8 +1067,8 @@ impl eframe::App for PlexiApp {
 
                     // Confirm back to the requesting app.
                     if let Some(req_pane_id) = requesting_pane_id {
-                        let active = self.active_context;
-                        if let Some(pane) = self.contexts[active].panes.get_mut(&req_pane_id) {
+                        let active = self.active_window;
+                        if let Some(pane) = self.windows[active].panes.get_mut(&req_pane_id) {
                             let event = crate::app_protocol::PlexiEvent::AppSpawned {
                                 pane_id: new_pane_id,
                                 type_id: type_id.clone(),
@@ -1080,16 +1080,16 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::CdRequest { cwd, sender_pane_id } => {
-                    let active = self.active_context;
+                    let active = self.active_window;
                     let escaped = cwd.replace('\'', "'\\''");
                     let cd_cmd = format!("cd '{}'\n", escaped);
-                    let linked_id = self.contexts[active]
+                    let linked_id = self.windows[active]
                         .panes
                         .get(&sender_pane_id)
                         .and_then(|p| p.as_app())
                         .and_then(|a| a.linked_pane_id);
                     if let Some(tid) = linked_id {
-                        if let Some(t) = self.contexts[active]
+                        if let Some(t) = self.windows[active]
                             .panes
                             .get_mut(&tid)
                             .and_then(|p| p.as_terminal_mut())
@@ -1151,7 +1151,7 @@ impl eframe::App for PlexiApp {
                     //      "note saved".
                     // If any gate fails, the notification still queues
                     // (badge ticks) but the modal doesn't pop.
-                    let is_visible = is_global || notif_source_ctx == self.active_context;
+                    let is_visible = is_global || notif_source_ctx == self.active_window;
                     let should_auto_open = is_visible
                         && !self.notifications_focus_mode
                         && priority >= self.notifications_interrupt_threshold;
@@ -1169,8 +1169,8 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } => {
-                    let active = self.active_context;
-                    if let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) {
+                    let active = self.active_window;
+                    if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
                         if let Some(app) = pane.as_app_mut() {
                             app.runtime.queue_outbound_event(
                                 crate::app_protocol::PlexiEvent::NotifyAction {
@@ -1183,7 +1183,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::DeliverPipeMessage { sender_pane_id, pipe_id, payload } => {
-                    let active = self.active_context;
+                    let active = self.active_window;
                     // Directed pipe (#286) — only the non-sender member of
                     // the pair receives. Falls through to the legacy peer
                     // broadcast when the pipe was not opened directed.
@@ -1201,7 +1201,7 @@ impl eframe::App for PlexiApp {
                             None
                         };
                         if let Some(tid) = target_pid {
-                            if let Some(pane) = self.contexts[active].panes.get_mut(&tid) {
+                            if let Some(pane) = self.windows[active].panes.get_mut(&tid) {
                                 let event = crate::app_protocol::PlexiEvent::PipeMessage {
                                     pipe_id: pipe_id.clone(),
                                     payload: payload.clone(),
@@ -1217,12 +1217,12 @@ impl eframe::App for PlexiApp {
                         }
                         continue;
                     }
-                    let pane_ids: Vec<_> = self.contexts[active].panes.keys().copied().collect();
+                    let pane_ids: Vec<_> = self.windows[active].panes.keys().copied().collect();
                     for pid in pane_ids {
                         if pid == sender_pane_id {
                             continue; // don't echo back to sender
                         }
-                        let is_reader = self.contexts[active]
+                        let is_reader = self.windows[active]
                             .panes
                             .get(&pid)
                             .and_then(|p| p.as_app())
@@ -1234,7 +1234,7 @@ impl eframe::App for PlexiApp {
                             })
                             .unwrap_or(false);
                         if is_reader {
-                            if let Some(pane) = self.contexts[active].panes.get_mut(&pid) {
+                            if let Some(pane) = self.windows[active].panes.get_mut(&pid) {
                                 if let Some(app) = pane.as_app_mut() {
                                     app.runtime.queue_outbound_event(
                                         crate::app_protocol::PlexiEvent::PipeMessage {
@@ -1258,8 +1258,8 @@ impl eframe::App for PlexiApp {
                     // locally inside its own ProcessApp; we need to register
                     // it on the target so its `has_reader` returns true and
                     // its SDK has a Pipe handle if it sends in reverse.
-                    let active = self.active_context;
-                    let target_kind = self.contexts[active]
+                    let active = self.active_window;
+                    let target_kind = self.windows[active]
                         .panes
                         .get(&target_pane_id)
                         .map(|p| match p {
@@ -1273,7 +1273,7 @@ impl eframe::App for PlexiApp {
                             // Register pipe on target's registry so it can
                             // PipeSend back through the same id.
                             let registered = if let Some(pane) =
-                                self.contexts[active].panes.get_mut(&target_pane_id)
+                                self.windows[active].panes.get_mut(&target_pane_id)
                             {
                                 register_directed_pipe_on_target(pane, &pipe_id)
                             } else {
@@ -1300,15 +1300,15 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::AgentRosterGet { sender_pane_id, request_id } => {
-                    let active = self.active_context;
+                    let active = self.active_window;
                     let agents = crate::agent_pane::enumerate_agents(
-                        self.contexts[active].panes.values(),
+                        self.windows[active].panes.values(),
                     );
                     let event = crate::app_protocol::PlexiEvent::AgentRoster {
                         request_id,
                         agents,
                     };
-                    if let Some(pane) = self.contexts[active].panes.get_mut(&sender_pane_id) {
+                    if let Some(pane) = self.windows[active].panes.get_mut(&sender_pane_id) {
                         if let Some(app) = pane.as_app_mut() {
                             app.runtime.queue_outbound_event(event);
                         } else if let Some(agent) = pane.as_agent_mut() {
@@ -1357,11 +1357,11 @@ impl eframe::App for PlexiApp {
                     self.dispatch_open_artifact(path, mode);
                 }
                 AppCommand::DeliverRunUpdate { originator_type_id, event } => {
-                    let active = self.active_context;
-                    let pane_ids: Vec<_> = self.contexts[active].panes.keys().copied().collect();
+                    let active = self.active_window;
+                    let pane_ids: Vec<_> = self.windows[active].panes.keys().copied().collect();
                     let mut delivered = false;
                     for pid in pane_ids {
-                        let matches = self.contexts[active]
+                        let matches = self.windows[active]
                             .panes
                             .get(&pid)
                             .and_then(|p| p.as_app())
@@ -1373,7 +1373,7 @@ impl eframe::App for PlexiApp {
                             })
                             .unwrap_or(false);
                         if matches {
-                            if let Some(pane) = self.contexts[active].panes.get_mut(&pid) {
+                            if let Some(pane) = self.windows[active].panes.get_mut(&pid) {
                                 if let Some(app) = pane.as_app_mut() {
                                     app.runtime.queue_outbound_event(event.clone());
                                     delivered = true;
@@ -1393,7 +1393,7 @@ impl eframe::App for PlexiApp {
 
         // Check if the focused app wants to close itself (e.g. after saving).
         {
-            let ctx_ref = &self.contexts[self.active_context];
+            let ctx_ref = &self.windows[self.active_window];
             let should_close = ctx_ref
                 .focused_pane
                 .and_then(|tile| ctx_ref.tree.tiles.get(tile))
@@ -1418,7 +1418,7 @@ impl eframe::App for PlexiApp {
 
         // Update window title to reflect active pane — readable by AppleScript / OS scripts
         {
-            let context = &self.contexts[self.active_context];
+            let context = &self.windows[self.active_window];
             let pane_name = context
                 .focused_pane
                 .and_then(|tile_id| context.tree.tiles.get(tile_id))
@@ -1436,9 +1436,9 @@ impl eframe::App for PlexiApp {
                         pane.as_app().map(|a| a.name.clone())
                     }
                 });
-            let ws = &self.workspaces[self.active_workspace];
+            let ws = &self.contexts[self.active_context];
             let ws_id = ws.context_id;
-            let window_count = self.contexts.iter().filter(|c| c.workspace_id == ws_id).count();
+            let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
             let context_label = if window_count > 1 {
                 format!("{} ({},{})", ws.name, context.grid_x, context.grid_y)
             } else {
@@ -1454,7 +1454,7 @@ impl eframe::App for PlexiApp {
         // Determine if the focused pane has an active app surface, and whether
         // that app has declared keyboard_capture mode.
         let (app_active, keyboard_capture_active) = {
-            let context = &self.contexts[self.active_context];
+            let context = &self.windows[self.active_window];
             let focused_pane = context.focused_pane.and_then(|tile_id| {
                 if let Some(egui_tiles::Tile::Pane(pane_id)) = context.tree.tiles.get(tile_id) {
                     context.panes.get(pane_id)
@@ -1481,27 +1481,27 @@ impl eframe::App for PlexiApp {
         for action in keys::poll_actions(ctx, app_active, keyboard_capture_active, modal_open) {
             match action {
                 Action::SplitHorizontal => {
-                    self.contexts[self.active_context].zoomed_pane = None;
+                    self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused(false);
                 }
                 Action::SplitVertical => {
-                    self.contexts[self.active_context].zoomed_pane = None;
+                    self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused(true);
                 }
                 Action::SplitRight => {
-                    self.contexts[self.active_context].zoomed_pane = None;
+                    self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused_mirror(crate::host::command::Placement::Right);
                 }
                 Action::SplitDown => {
-                    self.contexts[self.active_context].zoomed_pane = None;
+                    self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused_mirror(crate::host::command::Placement::Below);
                 }
                 Action::Navigate(dir) => {
-                    let was_zoomed = self.contexts[self.active_context].zoomed_pane.is_some();
+                    let was_zoomed = self.windows[self.active_window].zoomed_pane.is_some();
                     self.navigate(dir);
                     if was_zoomed {
-                        self.contexts[self.active_context].zoomed_pane =
-                            self.contexts[self.active_context].focused_pane;
+                        self.windows[self.active_window].zoomed_pane =
+                            self.windows[self.active_window].focused_pane;
                     }
                 }
                 Action::ClosePane => {
@@ -1509,7 +1509,7 @@ impl eframe::App for PlexiApp {
                     // depth (via PushNav), Escape routes NavBack to the app
                     // instead of closing the pane.
                     let nav_pane_id = {
-                        let active_ctx = &self.contexts[self.active_context];
+                        let active_ctx = &self.windows[self.active_window];
                         active_ctx.focused_pane.and_then(|tile_id| {
                             if let Some(egui_tiles::Tile::Pane(pane_id)) =
                                 active_ctx.tree.tiles.get(tile_id)
@@ -1529,8 +1529,8 @@ impl eframe::App for PlexiApp {
                         })
                     };
                     if let Some(pane_id) = nav_pane_id {
-                        let active = self.active_context;
-                        if let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) {
+                        let active = self.active_window;
+                        if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
                             if let Some(app) = pane.as_app_mut() {
                                 app.runtime.queue_outbound_event(
                                     crate::app_protocol::PlexiEvent::NavBack {},
@@ -1545,7 +1545,7 @@ impl eframe::App for PlexiApp {
                 }
                 Action::NewTab => self.new_tab(),
                 Action::ToggleZoom => {
-                    let ctx = &mut self.contexts[self.active_context];
+                    let ctx = &mut self.windows[self.active_window];
                     if let Some(focused) = ctx.focused_pane {
                         if ctx.zoomed_pane == Some(focused) {
                             ctx.zoomed_pane = None;
@@ -1589,7 +1589,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::RenamePane => {
-                    let active_ctx = &self.contexts[self.active_context];
+                    let active_ctx = &self.windows[self.active_window];
                     if let Some(focused_tile) = active_ctx.focused_pane {
                         if let Some(Tile::Pane(pane_id)) = active_ctx.tree.tiles.get(focused_tile) {
                             let pane_id = *pane_id;
@@ -1604,7 +1604,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SwitchContext(n) => {
-                    if n < self.workspaces.len() {
+                    if n < self.contexts.len() {
                         self.switch_workspace(n);
                     }
                 }
@@ -1678,7 +1678,7 @@ impl eframe::App for PlexiApp {
                     self.force_reload_focused_app();
                 }
                 Action::NewPageRight => {
-                    if self.contexts[self.active_context].panes.is_empty() {
+                    if self.windows[self.active_window].panes.is_empty() {
                         self.reset_active_context();
                     } else {
                         self.new_page_right();
@@ -1787,13 +1787,13 @@ impl eframe::App for PlexiApp {
                 ..Default::default()
             })
             .show(ctx, |ui| {
-                let active = self.active_context;
-                if self.contexts[active].panes.is_empty() {
+                let active = self.active_window;
+                if self.windows[active].panes.is_empty() {
                     self.draw_welcome_screen(ui);
                     return;
                 }
 
-                let ctx = &mut self.contexts[self.active_context];
+                let ctx = &mut self.windows[self.active_window];
 
                 // Resolve focused_pane if simplifier moved the tile
                 if let Some(fp) = ctx.focused_pane {
@@ -1816,7 +1816,7 @@ impl eframe::App for PlexiApp {
                     .iter()
                     .filter_map(|(&id, p)| p.as_terminal()?.name.as_ref().map(|n| (id, n.clone())))
                     .collect();
-                let suppress_focus = self.renaming_context.is_some()
+                let suppress_focus = self.renaming_window.is_some()
                     || self.show_command_palette
                     || self.renaming_pane.is_some();
 
@@ -2000,8 +2000,8 @@ impl eframe::App for PlexiApp {
         }
 
         // Minimap overlay — auto-hidden when current workspace has <2 windows.
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let window_count = self.contexts.iter().filter(|c| c.workspace_id == ws_id).count();
+        let ws_id = self.contexts[self.active_context].context_id;
+        let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
         if window_count >= 2 {
             self.draw_minimap_overlay(ctx);
         } else {
@@ -2261,8 +2261,8 @@ impl PlexiApp {
         use crate::app_trait::AppCommand;
         for cmd in cmds {
             if let AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } = cmd {
-                let active = self.active_context;
-                if let Some(pane) = self.contexts[active].panes.get_mut(&pane_id) {
+                let active = self.active_window;
+                if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
                     if let Some(app) = pane.as_app_mut() {
                         app.runtime.queue_outbound_event(
                             crate::app_protocol::PlexiEvent::NotifyAction {

--- a/src/app/notification_image.rs
+++ b/src/app/notification_image.rs
@@ -155,7 +155,7 @@ fn drain_pipe_frame(
     // Walk every context's panes — the sender pane id is unique across the
     // workspace, so a linear scan is fine for the small N (single-digit
     // contexts × low-double-digit panes).
-    for ctx in &app.contexts {
+    for ctx in &app.windows {
         let Some(pane) = ctx.panes.get(&sender_pane_id) else {
             continue;
         };

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -9,11 +9,11 @@ impl PlexiApp {
     /// in the active context. This way PathChanged fires even when an app pane
     /// (like the file browser) is the egui-focused tile.
     pub(super) fn sync_app_cwd(&mut self) {
-        let active = self.active_context;
+        let active = self.active_window;
 
         // First try: focused pane if it's a terminal.
         let terminal_cwd = {
-            let ctx = &self.contexts[active];
+            let ctx = &self.windows[active];
             let focused_terminal_cwd = ctx.focused_pane.and_then(|tile| {
                 let pane_id = match ctx.tree.tiles.get(tile)? {
                     egui_tiles::Tile::Pane(id) => *id,
@@ -38,7 +38,7 @@ impl PlexiApp {
             return;
         };
 
-        let app_ids: Vec<_> = self.contexts[active]
+        let app_ids: Vec<_> = self.windows[active]
             .panes
             .iter()
             .filter_map(|(&id, pane)| {
@@ -52,7 +52,7 @@ impl PlexiApp {
             .collect();
 
         for id in app_ids {
-            if let Some(pane) = self.contexts[active].panes.get_mut(&id) {
+            if let Some(pane) = self.windows[active].panes.get_mut(&id) {
                 if let Some(app) = pane.as_app_mut() {
                     if app.workspace_root != new_cwd {
                         app.workspace_root = new_cwd.clone();

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -28,42 +28,42 @@ impl PlexiApp {
     pub(crate) fn draw_command_palette(&mut self, ctx: &egui::Context) {
         let query = self.palette_query.to_lowercase();
 
-        // ── Context entries (active context first, then by visit recency) ──
-        let active_ctx_id = self.contexts[self.active_context].context_id;
+        // ── Window entries (active window first, then by visit recency) ──
+        let active_win_id = self.windows[self.active_window].window_id;
 
-        let rank_of = |context_id: u64| -> usize {
-            if context_id == active_ctx_id {
+        let rank_of = |win_id: u64| -> usize {
+            if win_id == active_win_id {
                 return 0;
             }
             self.context_visit_history
                 .iter()
-                .position(|&id| id == context_id)
+                .position(|&id| id == win_id)
                 .map(|p| p + 1)
                 .unwrap_or(usize::MAX)
         };
 
         let mut entries: Vec<PaletteEntry> = {
             let mut ctx_entries: Vec<PaletteEntry> = self
-                .contexts
+                .windows
                 .iter()
                 .enumerate()
-                .filter_map(|(ci, c)| {
-                    let ws_name = self
-                        .workspaces
+                .filter_map(|(ci, w)| {
+                    let ctx_name = self
+                        .contexts
                         .iter()
-                        .find(|w| w.context_id == c.workspace_id)
-                        .map(|w| w.name.clone())
+                        .find(|c| c.context_id == w.context_id)
+                        .map(|c| c.name.clone())
                         .unwrap_or_default();
 
                     if query.is_empty()
-                        || c.name.to_lowercase().contains(&query)
-                        || ws_name.to_lowercase().contains(&query)
+                        || w.name.to_lowercase().contains(&query)
+                        || ctx_name.to_lowercase().contains(&query)
                     {
                         Some(PaletteEntry::Context {
                             ctx_idx: ci,
-                            context_id: c.context_id,
-                            name: c.name.clone(),
-                            workspace_name: ws_name,
+                            context_id: w.window_id,
+                            name: w.name.clone(),
+                            workspace_name: ctx_name,
                         })
                     } else {
                         None
@@ -300,7 +300,7 @@ impl PlexiApp {
                                             name,
                                             workspace_name,
                                         } => {
-                                            let is_active = *context_id == active_ctx_id;
+                                            let is_active = *context_id == active_win_id;
                                             let name_color = if is_active {
                                                 colors.accent
                                             } else {
@@ -480,26 +480,26 @@ impl PlexiApp {
             });
     }
 
-    /// Jump to a context by index, switching workspace if necessary.
-    fn jump_to_context(&mut self, ctx_idx: usize, context_id: u64) {
-        let target_ws_id = self.contexts[ctx_idx].workspace_id;
-        if let Some(ws_idx) = self
-            .workspaces
+    /// Jump to a window by index, switching context if necessary.
+    fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64) {
+        let target_ctx_id = self.windows[ctx_idx].context_id;
+        if let Some(ctx_idx_sidebar) = self
+            .contexts
             .iter()
-            .position(|w| w.context_id == target_ws_id)
+            .position(|c| c.context_id == target_ctx_id)
         {
-            if ws_idx != self.active_workspace {
+            if ctx_idx_sidebar != self.active_context {
                 // switch_workspace → pick_active_context_from_workspace sets
-                // active_context based on workspace_active_window. We override it
+                // active_window based on context_active_window. We override it
                 // immediately below.
-                self.switch_workspace(ws_idx);
+                self.switch_workspace(ctx_idx_sidebar);
             }
         }
-        self.active_context = ctx_idx;
-        self.contexts[ctx_idx].zoomed_pane = None;
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        self.workspace_active_window.insert(ws_id, context_id);
-        self.record_context_visit(context_id);
+        self.active_window = ctx_idx;
+        self.windows[ctx_idx].zoomed_pane = None;
+        let ctx_id = self.contexts[self.active_context].context_id;
+        self.context_active_window.insert(ctx_id, win_id);
+        self.record_context_visit(win_id);
     }
 
     /// Dispatch a static palette action. Adding a new action means

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use egui_tiles::{Container, Tile, TileId, Tree};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-pub(crate) enum ContextMenuAction {
+pub(crate) enum WindowMenuAction {
     Rename,
     MoveToTop,
     MoveUp,
@@ -15,37 +15,37 @@ pub(crate) enum ContextMenuAction {
     Delete,
 }
 
-/// A workspace is a sidebar item — a project or directory scope.
-/// It does not own panes directly; pane layouts live in `Context` windows
-/// that reference this workspace via `workspace_id`.
-pub struct WorkspaceMeta {
+/// A context is a sidebar item — a project or directory scope.
+/// It does not own panes directly; pane layouts live in `Window` pages
+/// that reference this context via `context_id`.
+pub struct Context {
     pub name: String,
     pub path: PathBuf,
     /// Stable unique ID, assigned at creation and never reused.
     pub context_id: u64,
 }
 
-/// A context is a single window — a pane layout with focus and zoom state.
-/// Every context belongs to a workspace (`workspace_id`).
-pub struct Context {
+/// A window is a single spatial grid page — a pane layout with focus and zoom state.
+/// Every window belongs to a context (`context_id`).
+pub struct Window {
     pub name: String,
     pub path: PathBuf,
     pub tree: Tree<PaneId>,
     pub panes: HashMap<PaneId, Pane>,
     pub focused_pane: Option<TileId>,
     pub zoomed_pane: Option<TileId>,
-    /// Spatial grid coordinates within the workspace's window grid.
+    /// Spatial grid coordinates within the context's window grid.
     /// `(0, 0)` is the origin (top-left). `grid_x` grows rightward,
     /// `grid_y` grows downward.
     pub grid_x: u32,
     pub grid_y: u32,
-    /// Stable unique ID for this context (window), assigned at creation.
+    /// Stable unique ID for this window, assigned at creation.
+    pub window_id: u64,
+    /// The context this window belongs to.
     pub context_id: u64,
-    /// The workspace this window belongs to.
-    pub workspace_id: u64,
 }
 
-impl Context {
+impl Window {
     pub(crate) fn find_ancestor_tabs(&self, tile_id: TileId) -> Option<(TileId, TileId)> {
         let mut current = tile_id;
         loop {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,11 +3,11 @@
 // Cmd+D / Cmd+Shift+D       — split horizontal / vertical (terminal)
 // Cmd+\                       — split focused pane to the right (mirror type)
 // Cmd+Shift+\                 — split focused pane below (mirror type)
-// Cmd+N                       — new page to the right on the current grid row
-// Cmd+Shift+N                 — new sidebar context
+// Cmd+N                       — new window to the right on the current grid row
+// Cmd+Shift+N                 — new context (sidebar item)
 // Cmd+W                       — close pane
 // Cmd+H/J/K/L                 — navigate panes
-// Cmd+Shift+H/J/K/L           — navigate to adjacent page (spatial grid)
+// Cmd+Shift+H/J/K/L           — navigate to adjacent window (spatial grid)
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
 // Cmd+] / Cmd+[               — cycle tabs
@@ -21,7 +21,7 @@
 // Cmd+= / Cmd+-               — font size
 // Cmd+E                       — file browser
 // Cmd+0                       — quick note
-// Cmd+1–9                     — switch context
+// Cmd+1–9                     — switch context (sidebar)
 // Escape (app active)         — close app
 // Tab (app active)            — navigate to linked terminal
 //
@@ -93,13 +93,13 @@ pub enum Action {
     /// Option (Alt) modifier is the next free chord. No-op when the
     /// focused pane isn't a process-backed app.
     ForceReloadApp,
-    /// Create a new page (context) to the right of the active one on the same
+    /// Create a new window to the right of the active one on the same
     /// grid row. Bound to Cmd+N.
     NewPageRight,
-    /// Create a new sidebar context and immediately open the rename modal.
+    /// Create a new context (sidebar item) and immediately open the rename modal.
     /// Bound to Cmd+Shift+N.
     NewContext,
-    /// Navigate to the adjacent page in the spatial grid. Bound to
+    /// Navigate to the adjacent window in the spatial grid. Bound to
     /// Cmd+Shift+H/J/K/L (left/down/up/right).
     PageLeft,
     PageDown,

--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -4,7 +4,7 @@
 //! active workspace. Empty rows are collapsed so the grid is always compact.
 //! The active window is highlighted; clicking a cell switches to it.
 
-use crate::context::Context;
+use crate::context::Window;
 use crate::theme::Colors;
 
 /// Runtime state for the minimap overlay.
@@ -38,18 +38,18 @@ const NAME_FONT_SIZE: f32 = 12.0;
 pub fn render_minimap(
     ui: &mut egui::Ui,
     content_rect: egui::Rect,
-    contexts: &[Context],
-    active_context: usize,
+    windows: &[Window],
+    active_window: usize,
     last_visited: &std::collections::HashMap<u32, u32>,
     colors: &Colors,
     workspace_id: u64,
     workspace_name: &str,
 ) -> Option<usize> {
     // Only windows belonging to the current workspace.
-    let visible: Vec<(usize, &Context)> = contexts
+    let visible: Vec<(usize, &Window)> = windows
         .iter()
         .enumerate()
-        .filter(|(_, c)| c.workspace_id == workspace_id)
+        .filter(|(_, c)| c.context_id == workspace_id)
         .collect();
 
     if visible.is_empty() {
@@ -138,7 +138,7 @@ pub fn render_minimap(
             egui::Vec2::new(CELL_W, CELL_H),
         );
 
-        let is_active = idx == active_context;
+        let is_active = idx == active_window;
         let is_trail = !is_active
             && last_visited.get(&ctx.grid_y).copied() == Some(ctx.grid_x);
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -12,10 +12,10 @@ const R6: CornerRadius = CornerRadius::same(6);
 impl PlexiApp {
     pub(crate) fn draw_toolbar(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
-            let active_ctx = &self.contexts[self.active_context];
+            let active_ctx = &self.windows[self.active_window];
 
             // Workspace dots
-            let sidebar_contexts: Vec<usize> = (0..self.workspaces.len()).collect();
+            let sidebar_contexts: Vec<usize> = (0..self.contexts.len()).collect();
             if sidebar_contexts.len() > 1 {
                 let dot_radius = 3.5;
                 let dot_spacing = 10.0;
@@ -28,7 +28,7 @@ impl PlexiApp {
                 let start_x = rect.left() + dot_radius;
                 for (dot_i, ctx_i) in sidebar_contexts.iter().enumerate() {
                     let cx = start_x + (dot_i as f32) * dot_spacing;
-                    let color = if *ctx_i == self.active_workspace {
+                    let color = if *ctx_i == self.active_context {
                         self.colors.accent
                     } else {
                         self.colors.bg_active
@@ -41,9 +41,9 @@ impl PlexiApp {
 
             // Title: "Workspace (x,y)" when multiple windows exist,
             // otherwise just the workspace name.
-            let ws = &self.workspaces[self.active_workspace];
+            let ws = &self.contexts[self.active_context];
             let ws_id = ws.context_id;
-            let window_count = self.contexts.iter().filter(|c| c.workspace_id == ws_id).count();
+            let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
             let title = if window_count > 1 {
                 format!(
                     "{} ({},{})",
@@ -251,7 +251,7 @@ impl PlexiApp {
         } else if commit {
             let new_name = self.rename_buffer.trim().to_string();
             if let Some(pane) =
-                self.contexts[self.active_context].panes.get_mut(&pane_id)
+                self.windows[self.active_window].panes.get_mut(&pane_id)
             {
                 if let Some(t) = pane.as_terminal_mut() {
                     t.name = if new_name.is_empty() {
@@ -441,7 +441,7 @@ impl PlexiApp {
         // Collect all active runs from every app pane in every context.
         // Clone needed because we hold &self across the window render.
         let all_runs: Vec<(String, String, String, Option<String>)> = Vec::new(); // (run_id, app_id, status, blocked_prompt)
-        for _context in &self.contexts {}
+        for _win in &self.windows {}
 
         egui::Window::new("Active Runs")
             .collapsible(false)
@@ -1266,10 +1266,10 @@ impl PlexiApp {
         }
 
         let content_rect = ctx.screen_rect();
-        let active_context = self.active_context;
+        let active_context = self.active_window;
         let colors = self.colors;
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let ws_name = self.workspaces[self.active_workspace].name.clone();
+        let ws_id = self.contexts[self.active_context].context_id;
+        let ws_name = self.contexts[self.active_context].name.clone();
 
         egui::Area::new(egui::Id::new("minimap_overlay"))
             .order(egui::Order::Foreground)
@@ -1279,19 +1279,19 @@ impl PlexiApp {
                 if let Some(clicked_idx) = crate::minimap::render_minimap(
                     ui,
                     content_rect,
-                    &self.contexts,
+                    &self.windows,
                     active_context,
                     &self.last_page_x_per_row,
                     &colors,
                     ws_id,
                     &ws_name,
                 ) {
-                    let old = &self.contexts[self.active_context];
+                    let old = &self.windows[self.active_window];
                     self.last_page_x_per_row.insert(old.grid_y, old.grid_x);
-                    self.active_context = clicked_idx;
-                    let new = &self.contexts[clicked_idx];
+                    self.active_window = clicked_idx;
+                    let new = &self.windows[clicked_idx];
                     self.last_page_x_per_row.insert(new.grid_y, new.grid_x);
-                    self.workspace_active_window.insert(ws_id, new.context_id);
+                    self.context_active_window.insert(ws_id, new.window_id);
                 }
             });
     }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -35,7 +35,7 @@ impl PlexiApp {
     /// Used to record which terminal an app was spawned alongside, so CdRequest can
     /// route directly to it without a tile-tree walk.
     fn focused_terminal_id(&self, active: usize) -> Option<PaneId> {
-        let ctx = &self.contexts[active];
+        let ctx = &self.windows[active];
         let tile_id = ctx.focused_pane?;
         let pane_id = match ctx.tree.tiles.get(tile_id) {
             Some(egui_tiles::Tile::Pane(id)) => *id,
@@ -109,7 +109,7 @@ impl PlexiApp {
         group: Option<String>,
         hint: Option<&str>,
     ) {
-        let active = self.active_context;
+        let active = self.active_window;
         let new_app_pane = |id: PaneId,
                             process: crate::process_app::ProcessApp,
                             workspace_root: PathBuf,
@@ -130,24 +130,24 @@ impl PlexiApp {
         };
 
         if matches!(hint, Some("overlay")) {
-            let Some(focused_tile) = self.contexts[active].focused_pane else {
+            let Some(focused_tile) = self.windows[active].focused_pane else {
                 return;
             };
             let Some(Tile::Pane(focused_pane_id)) =
-                self.contexts[active].tree.tiles.get(focused_tile)
+                self.windows[active].tree.tiles.get(focused_tile)
             else {
                 return;
             };
             let pane_id = *focused_pane_id;
-            let Some(replaced_pane) = self.contexts[active].panes.remove(&pane_id) else {
+            let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
                 return;
             };
             process.set_pane_id(pane_id);
-            self.contexts[active].panes.insert(
+            self.windows[active].panes.insert(
                 pane_id,
                 new_app_pane(pane_id, process, workspace_root, group, None, Some(Box::new(replaced_pane))),
             );
-            self.contexts[active].focused_pane = Some(focused_tile);
+            self.windows[active].focused_pane = Some(focused_tile);
             return;
         }
 
@@ -157,7 +157,7 @@ impl PlexiApp {
         let (new_id, share, vertical, new_pane_first) =
             self.open_pane_layout(app_id, group.clone(), hint, share);
         process.set_pane_id(new_id);
-        self.contexts[active].panes.insert(
+        self.windows[active].panes.insert(
             new_id,
             new_app_pane(new_id, process, workspace_root, group, linked_pane_id, None),
         );
@@ -190,8 +190,8 @@ impl PlexiApp {
     /// process-backed AppPane). Returns false otherwise (pane gone, not an
     /// app pane, or builtin runtime).
     pub(crate) fn reload_app_pane(&mut self, pane_id: PaneId, reason: &str) -> bool {
-        let active = self.active_context;
-        let ctx = &self.contexts[active];
+        let active = self.active_window;
+        let ctx = &self.windows[active];
         let Some(app_pane) = ctx.panes.get(&pane_id).and_then(|p| p.as_app()) else {
             log::debug!("reload_app_pane({pane_id}): not an app pane — ignoring");
             return false;
@@ -220,7 +220,7 @@ impl PlexiApp {
 
         // Swap the runtime. The old `ProcessApp` drops at end-of-scope —
         // its `Drop` impl sends `Shutdown` and waits/kills the child.
-        let ctx_mut = &mut self.contexts[active];
+        let ctx_mut = &mut self.windows[active];
         if let Some(pane) = ctx_mut.panes.get_mut(&pane_id) {
             if let Some(app_pane) = pane.as_app_mut() {
                 let new_perms = new_process.permissions.clone();
@@ -252,11 +252,11 @@ impl PlexiApp {
     /// Force-reload the focused app pane (manual trigger via Cmd+Option+R).
     /// No-op when the focused pane isn't a process-backed AppPane.
     pub(crate) fn force_reload_focused_app(&mut self) {
-        let active = self.active_context;
-        let Some(focused_tile) = self.contexts[active].focused_pane else {
+        let active = self.active_window;
+        let Some(focused_tile) = self.windows[active].focused_pane else {
             return;
         };
-        let Some(Tile::Pane(pane_id)) = self.contexts[active].tree.tiles.get(focused_tile) else {
+        let Some(Tile::Pane(pane_id)) = self.windows[active].tree.tiles.get(focused_tile) else {
             return;
         };
         let pane_id = *pane_id;
@@ -272,7 +272,7 @@ impl PlexiApp {
         hint: Option<&str>,
         share: Option<f32>,
     ) {
-        let active = self.active_context;
+        let active = self.active_window;
         let app_type_id = app.type_id().to_string();
         let app_name = app.display_name();
         let new_app_pane = |id: PaneId,
@@ -295,23 +295,23 @@ impl PlexiApp {
         };
 
         if matches!(hint, Some("overlay")) {
-            let Some(focused_tile) = self.contexts[active].focused_pane else {
+            let Some(focused_tile) = self.windows[active].focused_pane else {
                 return;
             };
             let Some(Tile::Pane(focused_pane_id)) =
-                self.contexts[active].tree.tiles.get(focused_tile)
+                self.windows[active].tree.tiles.get(focused_tile)
             else {
                 return;
             };
             let pane_id = *focused_pane_id;
-            let Some(replaced_pane) = self.contexts[active].panes.remove(&pane_id) else {
+            let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
                 return;
             };
-            self.contexts[active].panes.insert(
+            self.windows[active].panes.insert(
                 pane_id,
                 new_app_pane(pane_id, app, workspace_root, group, None, Some(Box::new(replaced_pane))),
             );
-            self.contexts[active].focused_pane = Some(focused_tile);
+            self.windows[active].focused_pane = Some(focused_tile);
             return;
         }
 
@@ -323,7 +323,7 @@ impl PlexiApp {
         );
         let (new_id, share, vertical, new_pane_first) =
             self.open_pane_layout(&app_type_id, group.clone(), hint, share);
-        self.contexts[active].panes.insert(
+        self.windows[active].panes.insert(
             new_id,
             new_app_pane(new_id, app, workspace_root, group, linked_pane_id, None),
         );
@@ -361,7 +361,7 @@ impl PlexiApp {
     pub(crate) fn open_file_browser(&mut self) {
         // Check if the focused pane (or its linked app pane above) already has
         // a file browser open. If so, close it.
-        let ctx = &self.contexts[self.active_context];
+        let ctx = &self.windows[self.active_window];
         if let Some(focused) = ctx.focused_pane {
             if let Some(egui_tiles::Tile::Pane(pane_id)) = ctx.tree.tiles.get(focused) {
                 let pane_id = *pane_id;
@@ -377,7 +377,7 @@ impl PlexiApp {
         }
 
         let cwd = {
-            let ctx = &self.contexts[self.active_context];
+            let ctx = &self.windows[self.active_window];
             ctx.focused_pane
                 .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
                 .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
@@ -404,7 +404,7 @@ impl PlexiApp {
     /// Open the quick note app (full pane, no terminal split).
     pub(crate) fn open_quick_note(&mut self) {
         let cwd = {
-            let ctx = &self.contexts[self.active_context];
+            let ctx = &self.windows[self.active_window];
             ctx.focused_pane
                 .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
                 .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
@@ -457,9 +457,9 @@ impl PlexiApp {
         layout: Option<String>,
         args: &[String],
     ) {
-        let cwd = self.contexts[self.active_context]
+        let cwd = self.windows[self.active_window]
             .focused_pane
-            .and_then(|fp| self.contexts[self.active_context].get_focused_pane_cwd(fp))
+            .and_then(|fp| self.windows[self.active_window].get_focused_pane_cwd(fp))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
         let group = self.registry.group_for(id);
@@ -510,7 +510,7 @@ impl PlexiApp {
         mut process: crate::process_app::ProcessApp,
         system_prompt: Option<String>,
     ) {
-        let active = self.active_context;
+        let active = self.active_window;
         let new_id = self.host.alloc_pane_id();
         process.set_pane_id(new_id);
         let pane = crate::agent_pane::AgentPane::new_subprocess(
@@ -519,7 +519,7 @@ impl PlexiApp {
             system_prompt,
             manifest_id.to_string(),
         );
-        self.contexts[active]
+        self.windows[active]
             .panes
             .insert(new_id, Pane::Agent(Box::new(pane)));
         let share = ShareRatio::new(1.0, 1.0).expect("1:1 is valid");
@@ -546,10 +546,10 @@ impl PlexiApp {
         cli: crate::agent_workspace::AgentCli,
         task_label: String,
     ) -> Result<(), crate::agent_workspace::AgentWorkspaceError> {
-        let active = self.active_context;
-        let cwd = self.contexts[active]
+        let active = self.active_window;
+        let cwd = self.windows[active]
             .focused_pane
-            .and_then(|fp| self.contexts[active].get_focused_pane_cwd(fp))
+            .and_then(|fp| self.windows[active].get_focused_pane_cwd(fp))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
         let repo_root = crate::agent_workspace::find_git_repo_root(&cwd).ok_or_else(|| {
@@ -568,7 +568,7 @@ impl PlexiApp {
         repo_root: PathBuf,
         task_label: String,
     ) -> Result<(), crate::agent_workspace::AgentWorkspaceError> {
-        let active = self.active_context;
+        let active = self.active_window;
         let new_id = self.host.alloc_pane_id();
         let env = crate::shell::build_env();
         let dynamic_colors = crate::theme::terminal_dynamic_colors(&self.colors);
@@ -584,7 +584,7 @@ impl PlexiApp {
             self.default_font_size,
         )?;
 
-        self.contexts[active]
+        self.windows[active]
             .panes
             .insert(new_id, Pane::AgentWorkspace(Box::new(pane)));
         let share = crate::host::command::ShareRatio::new(1.0, 1.0).expect("1:1 is valid");
@@ -595,7 +595,7 @@ impl PlexiApp {
     /// Open the secrets manager (read-only vault viewer, full pane, no terminal split).
     pub(crate) fn open_secrets_manager(&mut self) {
         // Toggle: if already open, close it.
-        let ctx = &self.contexts[self.active_context];
+        let ctx = &self.windows[self.active_window];
         if let Some(focused) = ctx.focused_pane {
             if let Some(egui_tiles::Tile::Pane(pane_id)) = ctx.tree.tiles.get(focused) {
                 if let Some(pane) = ctx.panes.get(pane_id) {
@@ -610,7 +610,7 @@ impl PlexiApp {
         }
 
         let cwd = {
-            let ctx = &self.contexts[self.active_context];
+            let ctx = &self.windows[self.active_window];
             ctx.focused_pane
                 .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
                 .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -2,7 +2,7 @@
 //! zoom-free tree manipulation, font size, scroll.
 
 use crate::app::PlexiApp;
-use crate::context::{replace_child, Context};
+use crate::context::{replace_child, Window};
 use crate::host::command::{HostCommand, Placement};
 use crate::host::effect::HostEffect;
 use crate::keys::Direction;
@@ -53,13 +53,13 @@ impl PlexiApp {
         share: crate::host::command::ShareRatio,
         new_pane_first: bool,
     ) -> Option<egui_tiles::TileId> {
-        let focused = self.contexts[self.active_context].focused_pane?;
-        let split_target = match self.contexts[self.active_context].find_ancestor_tabs(focused) {
+        let focused = self.windows[self.active_window].focused_pane?;
+        let split_target = match self.windows[self.active_window].find_ancestor_tabs(focused) {
             Some((tabs_id, _)) => tabs_id,
             None => focused,
         };
 
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         let parent = ctx.tree.tiles.parent_of(split_target);
         let new_tile = ctx.tree.tiles.insert_pane(new_pane_id);
 
@@ -133,24 +133,24 @@ impl PlexiApp {
     ///
     /// If no pane is focused, falls back to creating a full-size terminal.
     pub(crate) fn split_focused_mirror(&mut self, placement: Placement) {
-        let active = self.active_context;
-        let Some(focused_tile) = self.contexts[active].focused_pane else {
+        let active = self.active_window;
+        let Some(focused_tile) = self.windows[active].focused_pane else {
             // No focused pane → create a full-size terminal in the active context.
             // The empty-context path: if the context has no panes at all, replace
             // the tree. If it has panes but none focused (rare), drop into the
             // standard terminal split path which will no-op for now.
-            if self.contexts[active].panes.is_empty() {
+            if self.windows[active].panes.is_empty() {
                 if let Some((tree, panes, root_tile)) = self.create_single_pane_tree(None) {
-                    self.contexts[active].tree = tree;
-                    self.contexts[active].panes = panes;
-                    self.contexts[active].focused_pane = Some(root_tile);
+                    self.windows[active].tree = tree;
+                    self.windows[active].panes = panes;
+                    self.windows[active].focused_pane = Some(root_tile);
                 }
             }
             return;
         };
 
         let Some(Tile::Pane(focused_pane_id)) =
-            self.contexts[active].tree.tiles.get(focused_tile)
+            self.windows[active].tree.tiles.get(focused_tile)
         else {
             return;
         };
@@ -169,7 +169,7 @@ impl PlexiApp {
             /// would be confusing, so we fall back to a plain terminal split.
             AgentWorkspace,
         }
-        let kind = match self.contexts[active].panes.get(&focused_pane_id) {
+        let kind = match self.windows[active].panes.get(&focused_pane_id) {
             Some(Pane::Terminal(_)) => Kind::Terminal,
             Some(Pane::App(a)) => Kind::App(a.manifest_id.clone()),
             Some(Pane::Agent(_)) => Kind::Agent,
@@ -215,7 +215,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn split_focused(&mut self, vertical: bool) {
-        let Some(focused) = self.contexts[self.active_context].focused_pane else {
+        let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
 
@@ -236,7 +236,7 @@ impl PlexiApp {
             })
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
-        let cwd = self.contexts[self.active_context].get_focused_pane_cwd(focused);
+        let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
         let settings = Self::make_backend_settings(cwd, &self.colors);
         let Some(pane) = TerminalPane::new(
             new_id,
@@ -248,16 +248,16 @@ impl PlexiApp {
             log::error!("Failed to create new terminal pane");
             return;
         };
-        self.contexts[self.active_context]
+        self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
 
-        let split_target = match self.contexts[self.active_context].find_ancestor_tabs(focused) {
+        let split_target = match self.windows[self.active_window].find_ancestor_tabs(focused) {
             Some((tabs_id, _)) => tabs_id,
             None => focused,
         };
 
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         let parent = ctx.tree.tiles.parent_of(split_target);
         let new_tile = ctx.tree.tiles.insert_pane(new_id);
 
@@ -313,7 +313,7 @@ impl PlexiApp {
 
     pub(crate) fn new_tab(&mut self) {
         // Empty context (welcome screen): create the first pane as tree root.
-        if self.contexts[self.active_context].panes.is_empty() {
+        if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
             let settings = Self::make_backend_settings(None, &self.colors);
             let Some(pane) = TerminalPane::new(
@@ -326,7 +326,7 @@ impl PlexiApp {
                 log::error!("Failed to create first terminal pane in empty context");
                 return;
             };
-            let ctx = &mut self.contexts[self.active_context];
+            let ctx = &mut self.windows[self.active_window];
             ctx.panes.insert(new_id, Pane::Terminal(Box::new(pane)));
             let pane_tile = ctx.tree.tiles.insert_pane(new_id);
             let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![pane_tile]);
@@ -335,13 +335,13 @@ impl PlexiApp {
             return;
         }
 
-        let Some(focused) = self.contexts[self.active_context].focused_pane else {
+        let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
 
         let new_id = self.host.alloc_pane_id();
 
-        let cwd = self.contexts[self.active_context].get_focused_pane_cwd(focused);
+        let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
         let settings = Self::make_backend_settings(cwd, &self.colors);
         let Some(pane) = TerminalPane::new(
             new_id,
@@ -353,11 +353,11 @@ impl PlexiApp {
             log::error!("Failed to create new terminal pane");
             return;
         };
-        self.contexts[self.active_context]
+        self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
 
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         let new_tile = ctx.tree.tiles.insert_pane(new_id);
 
         if let Some((tabs_id, _)) = ctx.find_ancestor_tabs(focused) {
@@ -388,7 +388,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn cycle_tab(&mut self, forward: bool) {
-        let ctx = &self.contexts[self.active_context];
+        let ctx = &self.windows[self.active_window];
         let Some(focused) = ctx.focused_pane else {
             return;
         };
@@ -418,7 +418,7 @@ impl PlexiApp {
         };
         let target = children[new_idx];
 
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(tabs_id) {
             tabs.set_active(target);
         }
@@ -432,11 +432,11 @@ impl PlexiApp {
     }
 
     pub(crate) fn close_focused(&mut self) {
-        let focused = match self.contexts[self.active_context].focused_pane {
+        let focused = match self.windows[self.active_window].focused_pane {
             Some(f) => f,
             None => return,
         };
-        let focused_pane_id = self.contexts[self.active_context]
+        let focused_pane_id = self.windows[self.active_window]
             .tree
             .tiles
             .get(focused)
@@ -445,22 +445,22 @@ impl PlexiApp {
                 _ => None,
             });
         if let Some(pane_id) = focused_pane_id {
-            if restore_overlay_replacement(&mut self.contexts[self.active_context].panes, pane_id) {
+            if restore_overlay_replacement(&mut self.windows[self.active_window].panes, pane_id) {
                 return;
             }
         }
 
         let effects = self.submit(HostCommand::CloseFocusedPane);
         log::debug!("close_focused effects: {:?}", effects);
-        self.close_tile(self.active_context, focused);
+        self.close_tile(self.active_window, focused);
     }
 
     /// Close a specific pane by its PaneId (the u64 backend ID, not the TileId).
     /// Searches all contexts to find the tile containing this pane.
     pub(crate) fn close_pane_by_id(&mut self, pane_id: PaneId) {
         // Find which context and tile owns this pane_id.
-        for ctx_idx in 0..self.contexts.len() {
-            if let Some(tile_id) = self.contexts[ctx_idx].tree.tiles.find_pane(&pane_id) {
+        for ctx_idx in 0..self.windows.len() {
+            if let Some(tile_id) = self.windows[ctx_idx].tree.tiles.find_pane(&pane_id) {
                 self.close_tile(ctx_idx, tile_id);
                 return;
             }
@@ -471,11 +471,11 @@ impl PlexiApp {
     /// transfer, container cleanup, and pane removal.
     pub(super) fn close_tile(&mut self, ctx_idx: usize, tile_id: TileId) {
         // Phase 1: Read-only — determine sibling and container type
-        let parent_info = self.contexts[ctx_idx].find_logical_parent(tile_id);
+        let parent_info = self.windows[ctx_idx].find_logical_parent(tile_id);
 
         let next = if let Some((parent_id, child_in_parent)) = parent_info {
             let sibling_info = {
-                let ctx: &Context = &self.contexts[ctx_idx];
+                let ctx: &Window = &self.windows[ctx_idx];
                 if let Some(Tile::Container(container)) = ctx.tree.tiles.get(parent_id) {
                     let children: Vec<TileId> = container.children().copied().collect();
                     children
@@ -498,7 +498,7 @@ impl PlexiApp {
 
             if let Some((sibling, is_tabs, is_linear, all_children)) = sibling_info {
                 // Phase 2: Mutable — update container state
-                let ctx = &mut self.contexts[ctx_idx];
+                let ctx = &mut self.windows[ctx_idx];
                 if is_tabs {
                     if let Some(Tile::Container(Container::Tabs(tabs))) =
                         ctx.tree.tiles.get_mut(parent_id)
@@ -516,17 +516,17 @@ impl PlexiApp {
                     }
                 }
 
-                self.contexts[ctx_idx].find_first_pane_in(sibling)
+                self.windows[ctx_idx].find_first_pane_in(sibling)
             } else {
-                self.contexts[ctx_idx].find_next_focus(tile_id)
+                self.windows[ctx_idx].find_next_focus(tile_id)
             }
         } else {
-            self.contexts[ctx_idx].find_next_focus(tile_id)
+            self.windows[ctx_idx].find_next_focus(tile_id)
         };
 
         // Phase 3: Remove tile and extract pane — defer drop so background apps can be parked.
         let removed_pane = {
-            let ctx = &mut self.contexts[ctx_idx];
+            let ctx = &mut self.windows[ctx_idx];
             if let Some(parent_id) = ctx.tree.tiles.parent_of(tile_id) {
                 if let Some(Tile::Container(parent)) = ctx.tree.tiles.get_mut(parent_id) {
                     parent.remove_child(tile_id);
@@ -592,16 +592,16 @@ impl PlexiApp {
         let effects = self.submit(HostCommand::Navigate(dir));
         log::debug!("navigate({:?}) effects: {:?}", dir, effects);
 
-        let ctx = &self.contexts[self.active_context];
+        let ctx = &self.windows[self.active_window];
         if let Some(focused) = ctx.focused_pane {
             if let Some(target) = ctx.find_pane_in_direction_from(focused, dir) {
-                self.contexts[self.active_context].focused_pane = Some(target);
+                self.windows[self.active_window].focused_pane = Some(target);
             }
         }
     }
 
     pub(crate) fn scroll_focused_pane(&mut self, lines: i32) {
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         let Some(focused_tile) = ctx.focused_pane else {
             return;
         };
@@ -617,7 +617,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn adjust_focused_pane_font_size(&mut self, delta: f32) {
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         let Some(focused_tile) = ctx.focused_pane else {
             return;
         };
@@ -636,11 +636,11 @@ impl PlexiApp {
 
     /// Close the focused app pane.
     pub(crate) fn close_focused_app(&mut self) {
-        let active = self.active_context;
-        let Some(focused_tile) = self.contexts[active].focused_pane else {
+        let active = self.active_window;
+        let Some(focused_tile) = self.windows[active].focused_pane else {
             return;
         };
-        let Some(pane_id) = self.contexts[active]
+        let Some(pane_id) = self.windows[active]
             .tree
             .tiles
             .get(focused_tile)
@@ -651,11 +651,11 @@ impl PlexiApp {
         else {
             return;
         };
-        if restore_overlay_replacement(&mut self.contexts[active].panes, pane_id) {
+        if restore_overlay_replacement(&mut self.windows[active].panes, pane_id) {
             return;
         }
 
-        let is_app = self.contexts[active]
+        let is_app = self.windows[active]
             .panes
             .get(&pane_id)
             .and_then(|p| p.as_app())
@@ -671,8 +671,8 @@ impl PlexiApp {
     /// After closing the last pane in a context the context remains open and
     /// the welcome screen is shown in its place.
     pub(crate) fn execute_close_pane(&mut self) -> bool {
-        self.contexts[self.active_context].zoomed_pane = None;
-        if !self.contexts[self.active_context].panes.is_empty() {
+        self.windows[self.active_window].zoomed_pane = None;
+        if !self.windows[self.active_window].panes.is_empty() {
             self.close_focused();
         }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -2,7 +2,7 @@
 //! and on-disk workspace save.
 
 use crate::app::PlexiApp;
-use crate::context::Context;
+use crate::context::Window;
 use crate::shell;
 use crate::workspace::WorkspaceFile;
 use std::path::PathBuf;
@@ -16,18 +16,18 @@ impl PlexiApp {
             return;
         };
 
-        let ws_id = self.next_context_id;
-        self.next_context_id += 1;
-        let ctx_id = self.next_context_id;
-        self.next_context_id += 1;
+        let ctx_id = self.next_window_id;
+        self.next_window_id += 1;
+        let win_id = self.next_window_id;
+        self.next_window_id += 1;
 
-        let name = format!("Context {}", self.workspaces.len() + 1);
-        self.workspaces.push(crate::context::WorkspaceMeta {
+        let name = format!("Context {}", self.contexts.len() + 1);
+        self.contexts.push(crate::context::Context {
             name: name.clone(),
             path: home.clone(),
-            context_id: ws_id,
+            context_id: ctx_id,
         });
-        self.contexts.push(Context {
+        self.windows.push(Window {
             name,
             path: home,
             tree,
@@ -36,27 +36,27 @@ impl PlexiApp {
             zoomed_pane: None,
             grid_x: 0,
             grid_y: 0,
+            window_id: win_id,
             context_id: ctx_id,
-            workspace_id: ws_id,
         });
-        self.active_workspace = self.workspaces.len() - 1;
         self.active_context = self.contexts.len() - 1;
-        self.workspace_active_window.insert(ws_id, ctx_id);
+        self.active_window = self.windows.len() - 1;
+        self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = false;
 
         // Auto-open inline rename so the user can name the context immediately.
-        let new_ws_idx = self.workspaces.len() - 1;
-        self.renaming_context = Some(new_ws_idx);
-        self.rename_buffer = self.workspaces[new_ws_idx].name.clone();
+        let new_ctx_idx = self.contexts.len() - 1;
+        self.renaming_window = Some(new_ctx_idx);
+        self.rename_buffer = self.contexts[new_ctx_idx].name.clone();
     }
 
     /// Create a new page immediately to the right of the active page on the
     /// same grid row, then switch to it.
     pub(crate) fn new_page_right(&mut self) {
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let active_y = self.contexts[self.active_context].grid_y;
-        let max_x = self.contexts.iter()
-            .filter(|c| c.workspace_id == ws_id && c.grid_y == active_y)
+        let ws_id = self.contexts[self.active_context].context_id;
+        let active_y = self.windows[self.active_window].grid_y;
+        let max_x = self.windows.iter()
+            .filter(|c| c.context_id == ws_id && c.grid_y == active_y)
             .map(|c| c.grid_x)
             .max();
         let new_x = match max_x {
@@ -76,10 +76,10 @@ impl PlexiApp {
             return;
         };
         let name = format!("Page {},{}", grid_x, grid_y);
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let ctx_id = self.next_context_id;
-        self.next_context_id += 1;
-        self.contexts.push(Context {
+        let ctx_id = self.contexts[self.active_context].context_id;
+        let win_id = self.next_window_id;
+        self.next_window_id += 1;
+        self.windows.push(Window {
             name,
             path: home,
             tree,
@@ -88,11 +88,11 @@ impl PlexiApp {
             zoomed_pane: None,
             grid_x,
             grid_y,
+            window_id: win_id,
             context_id: ctx_id,
-            workspace_id: ws_id,
         });
-        self.active_context = self.contexts.len() - 1;
-        self.workspace_active_window.insert(ws_id, ctx_id);
+        self.active_window = self.windows.len() - 1;
+        self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = true;
     }
 
@@ -104,7 +104,7 @@ impl PlexiApp {
             return;
         };
 
-        let ctx = &mut self.contexts[self.active_context];
+        let ctx = &mut self.windows[self.active_window];
         ctx.tree = tree;
         ctx.panes = panes;
         ctx.focused_pane = Some(root_tile);
@@ -112,20 +112,20 @@ impl PlexiApp {
     }
 
     pub(crate) fn delete_workspace(&mut self, ws_index: usize) {
-        if self.workspaces.len() <= 1 {
+        if self.contexts.len() <= 1 {
             return;
         }
-        let ws_id = self.workspaces[ws_index].context_id;
+        let ws_id = self.contexts[ws_index].context_id;
 
         // Remove all contexts belonging to this workspace.
-        self.contexts.retain(|c| c.workspace_id != ws_id);
-        self.workspaces.remove(ws_index);
+        self.windows.retain(|c| c.context_id != ws_id);
+        self.contexts.remove(ws_index);
 
         // Fix active indices.
-        if self.active_workspace >= self.workspaces.len() {
-            self.active_workspace = self.workspaces.len().saturating_sub(1);
-        } else if self.active_workspace > ws_index {
-            self.active_workspace -= 1;
+        if self.active_context >= self.contexts.len() {
+            self.active_context = self.contexts.len().saturating_sub(1);
+        } else if self.active_context > ws_index {
+            self.active_context -= 1;
         }
         // Pick a valid active_context in the new active workspace.
         self.pick_active_context_from_workspace();
@@ -143,58 +143,58 @@ impl PlexiApp {
         }
 
         // Restore minimap state for the workspace we landed on.
-        let new_ws_id = self.workspaces[self.active_workspace].context_id;
-        let page_count = self.contexts.iter().filter(|c| c.workspace_id == new_ws_id).count();
+        let new_ws_id = self.contexts[self.active_context].context_id;
+        let page_count = self.windows.iter().filter(|c| c.context_id == new_ws_id).count();
         self.minimap.visible = self
-            .minimap_visible_per_workspace
+            .minimap_visible_per_context
             .get(&new_ws_id)
             .copied()
             .unwrap_or(page_count > 1);
     }
 
     pub(crate) fn delete_context(&mut self, index: usize) {
-        if self.contexts.len() <= 1 {
+        if self.windows.len() <= 1 {
             return;
         }
-        let removed_ws_id = self.contexts[index].workspace_id;
-        let was_active = self.active_context == index;
-        let removed_x = self.contexts[index].grid_x;
-        let removed_y = self.contexts[index].grid_y;
+        let removed_ws_id = self.windows[index].context_id;
+        let was_active = self.active_window == index;
+        let removed_x = self.windows[index].grid_x;
+        let removed_y = self.windows[index].grid_y;
 
-        self.contexts.remove(index);
+        self.windows.remove(index);
 
         // If workspace now has no windows, remove it too.
-        let ws_has_windows = self.contexts.iter().any(|c| c.workspace_id == removed_ws_id);
+        let ws_has_windows = self.windows.iter().any(|c| c.context_id == removed_ws_id);
         if !ws_has_windows {
-            if let Some(ws_idx) = self.workspaces.iter().position(|w| w.context_id == removed_ws_id) {
-                self.workspaces.remove(ws_idx);
-                if self.active_workspace >= self.workspaces.len() {
-                    self.active_workspace = self.workspaces.len().saturating_sub(1);
-                } else if self.active_workspace > ws_idx {
-                    self.active_workspace -= 1;
+            if let Some(ws_idx) = self.contexts.iter().position(|w| w.context_id == removed_ws_id) {
+                self.contexts.remove(ws_idx);
+                if self.active_context >= self.contexts.len() {
+                    self.active_context = self.contexts.len().saturating_sub(1);
+                } else if self.active_context > ws_idx {
+                    self.active_context -= 1;
                 }
             }
         }
 
         if was_active {
-            self.active_context = self.nearest_context_after_delete(removed_x, removed_y);
-            // Sync workspace to the new active context.
-            let new_ws_id = self.contexts[self.active_context].workspace_id;
-            if let Some(ws_idx) = self.workspaces.iter().position(|w| w.context_id == new_ws_id) {
-                self.active_workspace = ws_idx;
-                self.workspace_active_window.insert(new_ws_id, self.contexts[self.active_context].context_id);
+            self.active_window = self.nearest_context_after_delete(removed_x, removed_y);
+            // Sync context to the new active window.
+            let new_ctx_id = self.windows[self.active_window].context_id;
+            if let Some(ctx_idx) = self.contexts.iter().position(|w| w.context_id == new_ctx_id) {
+                self.active_context = ctx_idx;
+                self.context_active_window.insert(new_ctx_id, self.windows[self.active_window].window_id);
             }
-        } else if self.active_context >= self.contexts.len() {
-            self.active_context = self.contexts.len() - 1;
-        } else if self.active_context > index {
-            self.active_context -= 1;
+        } else if self.active_window >= self.windows.len() {
+            self.active_window = self.windows.len() - 1;
+        } else if self.active_window > index {
+            self.active_window -= 1;
         }
 
-        if self.renaming_context == Some(index) {
-            self.renaming_context = None;
-        } else if let Some(r) = self.renaming_context {
+        if self.renaming_window == Some(index) {
+            self.renaming_window = None;
+        } else if let Some(r) = self.renaming_window {
             if r > index {
-                self.renaming_context = Some(r - 1);
+                self.renaming_window = Some(r - 1);
             }
         }
 
@@ -202,10 +202,10 @@ impl PlexiApp {
         self.compact_workspace_grid(removed_ws_id);
 
         // Restore minimap state for the workspace we landed on.
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let page_count = self.contexts.iter().filter(|c| c.workspace_id == ws_id).count();
+        let ws_id = self.contexts[self.active_context].context_id;
+        let page_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
         self.minimap.visible = self
-            .minimap_visible_per_workspace
+            .minimap_visible_per_context
             .get(&ws_id)
             .copied()
             .unwrap_or(page_count > 1);
@@ -214,35 +214,35 @@ impl PlexiApp {
     /// After a deletion, compact each row independently: within each row,
     /// shift windows left to close any gaps in grid_x. This ensures that
     /// deleting the left-most window in a row causes the rest to slide over.
-    fn compact_workspace_grid(&mut self, ws_id: u64) {
-        // Collect positions: (context_id, grid_y, grid_x)
-        let entries: Vec<(u64, u32, u32)> = self.contexts.iter()
-            .filter(|c| c.workspace_id == ws_id)
-            .map(|c| (c.context_id, c.grid_y, c.grid_x))
+    fn compact_workspace_grid(&mut self, ctx_id: u64) {
+        // Collect positions: (window_id, grid_y, grid_x) for windows in the given context.
+        let entries: Vec<(u64, u32, u32)> = self.windows.iter()
+            .filter(|w| w.context_id == ctx_id)
+            .map(|w| (w.window_id, w.grid_y, w.grid_x))
             .collect();
 
         // Group by row (grid_y)
         let mut by_row: std::collections::HashMap<u32, Vec<(u64, u32)>> = std::collections::HashMap::new();
-        for (ctx_id, y, x) in entries {
-            by_row.entry(y).or_default().push((ctx_id, x));
+        for (win_id, y, x) in entries {
+            by_row.entry(y).or_default().push((win_id, x));
         }
 
         // For each row, sort by x and assign sequential new_x = 0,1,2,...
         let mut updates: Vec<(u64, u32)> = Vec::new();
         for (_, mut items) in by_row {
             items.sort_by_key(|(_, x)| *x);
-            for (new_x, (ctx_id, _)) in items.iter().enumerate() {
-                updates.push((*ctx_id, new_x as u32));
+            for (new_x, (win_id, _)) in items.iter().enumerate() {
+                updates.push((*win_id, new_x as u32));
             }
         }
 
         // Apply updates
         let mut old_to_new: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
-        for ctx in self.contexts.iter_mut() {
-            if let Some(&(_, new_x)) = updates.iter().find(|(id, _)| *id == ctx.context_id) {
-                if ctx.grid_x != new_x {
-                    old_to_new.insert(ctx.grid_x, new_x);
-                    ctx.grid_x = new_x;
+        for win in self.windows.iter_mut() {
+            if let Some(&(_, new_x)) = updates.iter().find(|(id, _)| *id == win.window_id) {
+                if win.grid_x != new_x {
+                    old_to_new.insert(win.grid_x, new_x);
+                    win.grid_x = new_x;
                 }
             }
         }
@@ -262,68 +262,68 @@ impl PlexiApp {
     /// This is the **only** place workspace switching should be performed —
     /// do not inline `active_workspace = i` + `pick_active_context_from_workspace`
     /// elsewhere, as that bypasses the save/restore.
-    pub(crate) fn switch_workspace(&mut self, new_ws_idx: usize) {
-        // Save current workspace's active window + minimap state.
-        let old_ws_id = self.workspaces[self.active_workspace].context_id;
-        self.workspace_active_window
-            .insert(old_ws_id, self.contexts[self.active_context].context_id);
-        self.minimap_visible_per_workspace
-            .insert(old_ws_id, self.minimap.visible);
+    pub(crate) fn switch_workspace(&mut self, new_ctx_idx: usize) {
+        // Save current context's active window + minimap state.
+        let old_ctx_id = self.contexts[self.active_context].context_id;
+        self.context_active_window
+            .insert(old_ctx_id, self.windows[self.active_window].window_id);
+        self.minimap_visible_per_context
+            .insert(old_ctx_id, self.minimap.visible);
 
-        self.active_workspace = new_ws_idx;
+        self.active_context = new_ctx_idx;
         self.pick_active_context_from_workspace();
 
-        // Restore minimap state for the new workspace.
-        let new_ws_id = self.workspaces[self.active_workspace].context_id;
+        // Restore minimap state for the new context.
+        let new_ctx_id = self.contexts[self.active_context].context_id;
         let page_count = self
-            .contexts
+            .windows
             .iter()
-            .filter(|c| c.workspace_id == new_ws_id)
+            .filter(|w| w.context_id == new_ctx_id)
             .count();
         self.minimap.visible = self
-            .minimap_visible_per_workspace
-            .get(&new_ws_id)
+            .minimap_visible_per_context
+            .get(&new_ctx_id)
             .copied()
             .unwrap_or(page_count > 1);
     }
 
     pub(crate) fn pick_active_context_from_workspace(&mut self) {
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        let preferred = self.workspace_active_window.get(&ws_id).copied();
-        if let Some(ctx_id) = preferred {
-            if let Some(idx) = self.contexts.iter().position(|c| c.context_id == ctx_id && c.workspace_id == ws_id) {
-                self.active_context = idx;
-                self.record_context_visit(ctx_id);
+        let ctx_id = self.contexts[self.active_context].context_id;
+        let preferred = self.context_active_window.get(&ctx_id).copied();
+        if let Some(win_id) = preferred {
+            if let Some(idx) = self.windows.iter().position(|w| w.window_id == win_id && w.context_id == ctx_id) {
+                self.active_window = idx;
+                self.record_context_visit(win_id);
                 return;
             }
         }
-        if let Some(idx) = self.contexts.iter().position(|c| c.workspace_id == ws_id) {
-            self.active_context = idx;
-            let cid = self.contexts[idx].context_id;
-            self.workspace_active_window.insert(ws_id, cid);
-            self.record_context_visit(cid);
+        if let Some(idx) = self.windows.iter().position(|w| w.context_id == ctx_id) {
+            self.active_window = idx;
+            let wid = self.windows[idx].window_id;
+            self.context_active_window.insert(ctx_id, wid);
+            self.record_context_visit(wid);
         }
     }
 
     pub(crate) fn save_workspace(&self) {
-        let mut saved_workspaces = Vec::new();
         let mut saved_contexts = Vec::new();
+        let mut saved_windows = Vec::new();
 
-        for ws in &self.workspaces {
-            saved_workspaces.push(crate::workspace::SavedWorkspaceMeta {
-                name: ws.name.clone(),
-                path: ws.path.clone(),
-                context_id: ws.context_id,
+        for ctx in &self.contexts {
+            saved_contexts.push(crate::workspace::SavedContext {
+                name: ctx.name.clone(),
+                path: ctx.path.clone(),
+                context_id: ctx.context_id,
             });
         }
 
-        for context in &self.contexts {
+        for win in &self.windows {
             let mut saved_panes = Vec::new();
-            for (&id, pane) in &context.panes {
+            for (&id, pane) in &win.panes {
                 debug_assert_eq!(pane.id(), id);
                 if let Some(t) = pane.as_terminal() {
                     let cwd = shell::get_pid_cwd(t.backend.child_pid())
-                        .unwrap_or_else(|| context.path.clone());
+                        .unwrap_or_else(|| win.path.clone());
                     saved_panes.push(crate::workspace::SavedPane {
                         id,
                         kind: crate::workspace::SavedPaneKind::Terminal,
@@ -371,27 +371,27 @@ impl PlexiApp {
                     });
                 }
             }
-            saved_contexts.push(crate::workspace::SavedContext {
-                name: context.name.clone(),
-                path: context.path.clone(),
-                tree: context.tree.clone(),
+            saved_windows.push(crate::workspace::SavedWindow {
+                name: win.name.clone(),
+                path: win.path.clone(),
+                tree: win.tree.clone(),
                 panes: saved_panes,
-                focused_pane: context.focused_pane,
-                grid_x: context.grid_x,
-                grid_y: context.grid_y,
-                context_id: context.context_id,
-                workspace_id: context.workspace_id,
+                focused_pane: win.focused_pane,
+                grid_x: win.grid_x,
+                grid_y: win.grid_y,
+                window_id: win.window_id,
+                context_id: win.context_id,
             });
         }
 
         let ws = WorkspaceFile {
             version: 2,
-            active_workspace: self.active_workspace,
+            active_context: self.active_context,
             sidebar_visible: self.sidebar_visible,
             next_pane_id: self.host.next_pane_id(),
-            workspaces: saved_workspaces,
             contexts: saved_contexts,
-            workspace_active_window: self.workspace_active_window.clone(),
+            windows: saved_windows,
+            context_active_window: self.context_active_window.clone(),
         };
 
         if let Err(e) = ws.save() {

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::context::ContextMenuAction;
+use crate::context::WindowMenuAction;
 use egui::{Align, Color32, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 
 use crate::app::PlexiApp;
@@ -74,16 +74,16 @@ impl PlexiApp {
         ui.add_space(4.0);
 
         // Workspace list
-        let num_workspaces = self.workspaces.len();
+        let num_contexts = self.contexts.len();
         let mut clicked_workspace: Option<usize> = None;
-        let mut delete_workspace: Option<usize> = None;
-        let mut menu_action: Option<(usize, ContextMenuAction)> = None;
-        let mut row_rects: Vec<Rect> = Vec::with_capacity(num_workspaces);
+        let mut delete_context: Option<usize> = None;
+        let mut menu_action: Option<(usize, WindowMenuAction)> = None;
+        let mut row_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
         let mut drag_released = false;
 
-        for i in 0..num_workspaces {
-            let is_active = i == self.active_workspace;
-            let is_renaming = self.renaming_context == Some(i);
+        for i in 0..num_contexts {
+            let is_active = i == self.active_context;
+            let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
 
             let row_rect = ui.cursor();
@@ -169,13 +169,13 @@ impl PlexiApp {
                         );
                         if te.lost_focus() {
                             if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-                                self.renaming_context = None;
+                                self.renaming_window = None;
                             } else {
                                 let new_name = self.rename_buffer.trim().to_string();
                                 if !new_name.is_empty() {
-                                    self.workspaces[i].name = new_name;
+                                    self.contexts[i].name = new_name;
                                 }
-                                self.renaming_context = None;
+                                self.renaming_window = None;
                             }
                             ui.input_mut(|i| {
                                 i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
@@ -215,7 +215,7 @@ impl PlexiApp {
                         }
                         ui.add(
                             egui::Label::new(
-                                RichText::new(&self.workspaces[i].name)
+                                RichText::new(&self.contexts[i].name)
                                     .size(12.0)
                                     .color(text_color),
                             )
@@ -248,7 +248,7 @@ impl PlexiApp {
                         }
 
                         // Delete button on hover when 2+ contexts (suppress during drag)
-                        if hover && num_workspaces > 1 && self.drag_context.is_none() {
+                        if hover && num_contexts > 1 && self.drag_context.is_none() {
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                 ui.add_space(8.0);
                                 let x_btn = ui
@@ -263,7 +263,7 @@ impl PlexiApp {
                                     .on_hover_cursor(egui::CursorIcon::PointingHand)
                                     .on_hover_text("Delete context");
                                 if x_btn.clicked() {
-                                    delete_workspace = Some(i);
+                                    delete_context = Some(i);
                                 }
                             });
                         }
@@ -272,37 +272,37 @@ impl PlexiApp {
             );
 
             if !is_renaming {
-                if delete_workspace.is_none() {
+                if delete_context.is_none() {
                     row_response.context_menu(|ui| {
                         if ui.button("Rename").clicked() {
-                            menu_action = Some((i, ContextMenuAction::Rename));
+                            menu_action = Some((i, WindowMenuAction::Rename));
                             ui.close_menu();
                         }
                         ui.separator();
                         if i > 0 {
                             if ui.button("Move to Top").clicked() {
-                                menu_action = Some((i, ContextMenuAction::MoveToTop));
+                                menu_action = Some((i, WindowMenuAction::MoveToTop));
                                 ui.close_menu();
                             }
                             if ui.button("Move Up").clicked() {
-                                menu_action = Some((i, ContextMenuAction::MoveUp));
+                                menu_action = Some((i, WindowMenuAction::MoveUp));
                                 ui.close_menu();
                             }
                         }
-                        if i < num_workspaces - 1 {
+                        if i < num_contexts - 1 {
                             if ui.button("Move Down").clicked() {
-                                menu_action = Some((i, ContextMenuAction::MoveDown));
+                                menu_action = Some((i, WindowMenuAction::MoveDown));
                                 ui.close_menu();
                             }
                             if ui.button("Move to Bottom").clicked() {
-                                menu_action = Some((i, ContextMenuAction::MoveToBottom));
+                                menu_action = Some((i, WindowMenuAction::MoveToBottom));
                                 ui.close_menu();
                             }
                         }
-                        if num_workspaces > 1 {
+                        if num_contexts > 1 {
                             ui.separator();
                             if ui.button("Delete").clicked() {
-                                menu_action = Some((i, ContextMenuAction::Delete));
+                                menu_action = Some((i, WindowMenuAction::Delete));
                                 ui.close_menu();
                             }
                         }
@@ -330,14 +330,14 @@ impl PlexiApp {
             if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
                 if dst != src && dst != src + 1 {
                     let effective_dst = if dst > src { dst - 1 } else { dst };
-                    let ws = self.workspaces.remove(src);
-                    self.workspaces.insert(effective_dst, ws);
-                    if self.active_workspace == src {
-                        self.active_workspace = effective_dst;
-                    } else if src < self.active_workspace && effective_dst >= self.active_workspace {
-                        self.active_workspace -= 1;
-                    } else if src > self.active_workspace && effective_dst <= self.active_workspace {
-                        self.active_workspace += 1;
+                    let ctx = self.contexts.remove(src);
+                    self.contexts.insert(effective_dst, ctx);
+                    if self.active_context == src {
+                        self.active_context = effective_dst;
+                    } else if src < self.active_context && effective_dst >= self.active_context {
+                        self.active_context -= 1;
+                    } else if src > self.active_context && effective_dst <= self.active_context {
+                        self.active_context += 1;
                     }
                 }
             }
@@ -365,50 +365,50 @@ impl PlexiApp {
         // Handle collected actions after the loop
         if let Some((i, action)) = menu_action {
             match action {
-                ContextMenuAction::Rename => {
-                    self.renaming_context = Some(i);
-                    self.rename_buffer = self.workspaces[i].name.clone();
+                WindowMenuAction::Rename => {
+                    self.renaming_window = Some(i);
+                    self.rename_buffer = self.contexts[i].name.clone();
                 }
-                ContextMenuAction::MoveToTop => {
-                    let ws = self.workspaces.remove(i);
-                    self.workspaces.insert(0, ws);
-                    if self.active_workspace == i {
-                        self.active_workspace = 0;
-                    } else if self.active_workspace < i {
-                        self.active_workspace += 1;
+                WindowMenuAction::MoveToTop => {
+                    let ctx = self.contexts.remove(i);
+                    self.contexts.insert(0, ctx);
+                    if self.active_context == i {
+                        self.active_context = 0;
+                    } else if self.active_context < i {
+                        self.active_context += 1;
                     }
                 }
-                ContextMenuAction::MoveUp => {
-                    self.workspaces.swap(i, i - 1);
-                    if self.active_workspace == i {
-                        self.active_workspace = i - 1;
-                    } else if self.active_workspace == i - 1 {
-                        self.active_workspace = i;
+                WindowMenuAction::MoveUp => {
+                    self.contexts.swap(i, i - 1);
+                    if self.active_context == i {
+                        self.active_context = i - 1;
+                    } else if self.active_context == i - 1 {
+                        self.active_context = i;
                     }
                 }
-                ContextMenuAction::MoveDown => {
-                    self.workspaces.swap(i, i + 1);
-                    if self.active_workspace == i {
-                        self.active_workspace = i + 1;
-                    } else if self.active_workspace == i + 1 {
-                        self.active_workspace = i;
+                WindowMenuAction::MoveDown => {
+                    self.contexts.swap(i, i + 1);
+                    if self.active_context == i {
+                        self.active_context = i + 1;
+                    } else if self.active_context == i + 1 {
+                        self.active_context = i;
                     }
                 }
-                ContextMenuAction::MoveToBottom => {
-                    let last = num_workspaces - 1;
-                    let ws = self.workspaces.remove(i);
-                    self.workspaces.push(ws);
-                    if self.active_workspace == i {
-                        self.active_workspace = last;
-                    } else if self.active_workspace > i {
-                        self.active_workspace -= 1;
+                WindowMenuAction::MoveToBottom => {
+                    let last = num_contexts - 1;
+                    let ctx = self.contexts.remove(i);
+                    self.contexts.push(ctx);
+                    if self.active_context == i {
+                        self.active_context = last;
+                    } else if self.active_context > i {
+                        self.active_context -= 1;
                     }
                 }
-                ContextMenuAction::Delete => {
+                WindowMenuAction::Delete => {
                     self.delete_workspace(i);
                 }
             }
-        } else if let Some(i) = delete_workspace {
+        } else if let Some(i) = delete_context {
             self.delete_workspace(i);
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -81,14 +81,14 @@ impl PlexiApp {
     /// Does **not** create pages. For create-if-missing behaviour see
     /// [`navigate_or_create_page`].
     pub(crate) fn navigate_page(&mut self, dx: i32, dy: i32) {
-        let cur_x = self.contexts[self.active_context].grid_x;
-        let cur_y = self.contexts[self.active_context].grid_y;
-        let ws_id = self.workspaces[self.active_workspace].context_id;
+        let cur_x = self.windows[self.active_window].grid_x;
+        let cur_y = self.windows[self.active_window].grid_y;
+        let ws_id = self.contexts[self.active_context].context_id;
 
         let pages: Vec<(u32, u32, u64)> = self
-            .contexts
+            .windows
             .iter()
-            .map(|c| (c.grid_x, c.grid_y, c.workspace_id))
+            .map(|w| (w.grid_x, w.grid_y, w.context_id))
             .collect();
 
         // Record the current column before leaving this row so that returning
@@ -102,12 +102,12 @@ impl PlexiApp {
             find_navigation_target(&pages, ws_id, cur_x, cur_y, dx, dy, &self.last_page_x_per_row);
 
         if let Some(idx) = new_idx {
-            self.active_context = idx;
-            let c = &self.contexts[idx];
-            self.last_page_x_per_row.insert(c.grid_y, c.grid_x);
-            self.workspace_active_window.insert(ws_id, c.context_id);
-            let cid = c.context_id;
-            self.record_context_visit(cid);
+            self.active_window = idx;
+            let w = &self.windows[idx];
+            self.last_page_x_per_row.insert(w.grid_y, w.grid_x);
+            self.context_active_window.insert(ws_id, w.window_id);
+            let wid = w.window_id;
+            self.record_context_visit(wid);
         }
     }
 
@@ -117,8 +117,8 @@ impl PlexiApp {
     /// Creation policy: vertical moves start new rows at **column 0**;
     /// horizontal moves extend the current row at the adjacent column.
     pub(crate) fn navigate_or_create_page(&mut self, dx: i32, dy: i32) {
-        let cur_x = self.contexts[self.active_context].grid_x;
-        let cur_y = self.contexts[self.active_context].grid_y;
+        let cur_x = self.windows[self.active_window].grid_x;
+        let cur_y = self.windows[self.active_window].grid_y;
 
         let tx = cur_x as i32 + dx;
         let ty = cur_y as i32 + dy;
@@ -126,9 +126,9 @@ impl PlexiApp {
             return;
         }
 
-        let before = self.active_context;
+        let before = self.active_window;
         self.navigate_page(dx, dy);
-        if self.active_context == before {
+        if self.active_window == before {
             // Vertical: new rows always start at column 0.
             // Horizontal: extend the current row at the adjacent column.
             let create_x = if dy != 0 { 0 } else { tx as u32 };
@@ -149,11 +149,11 @@ impl PlexiApp {
         removed_x: u32,
         removed_y: u32,
     ) -> usize {
-        let ws_id = self.workspaces[self.active_workspace].context_id;
-        self.contexts
+        let ws_id = self.contexts[self.active_context].context_id;
+        self.windows
             .iter()
             .enumerate()
-            .filter(|(_, c)| c.workspace_id == ws_id)
+            .filter(|(_, c)| c.context_id == ws_id)
             .min_by_key(|(_, c)| {
                 let dx = (c.grid_x as i64 - removed_x as i64).unsigned_abs();
                 let dy = (c.grid_y as i64 - removed_y as i64).unsigned_abs();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -9,26 +9,26 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize)]
 pub struct WorkspaceFile {
     pub version: u32,
-    /// Active workspace index (sidebar context).
-    pub active_workspace: usize,
+    /// Active context index (sidebar item).
+    pub active_context: usize,
     pub sidebar_visible: bool,
     pub next_pane_id: u64,
-    pub workspaces: Vec<SavedWorkspaceMeta>,
     pub contexts: Vec<SavedContext>,
-    /// workspace_id → last active context_id for that workspace.
+    pub windows: Vec<SavedWindow>,
+    /// context_id → last active window_id for that context.
     #[serde(default)]
-    pub workspace_active_window: HashMap<u64, u64>,
+    pub context_active_window: HashMap<u64, u64>,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct SavedWorkspaceMeta {
+pub struct SavedContext {
     pub name: String,
     pub path: PathBuf,
     pub context_id: u64,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct SavedContext {
+pub struct SavedWindow {
     pub name: String,
     pub path: PathBuf,
     pub tree: Tree<PaneId>,
@@ -39,9 +39,9 @@ pub struct SavedContext {
     #[serde(default)]
     pub grid_y: u32,
     #[serde(default)]
-    pub context_id: u64,
+    pub window_id: u64,
     #[serde(default)]
-    pub workspace_id: u64,
+    pub context_id: u64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(aw.task_label, "fix the auth bug");
     }
 
-    /// SavedContext omits `grid_x` / `grid_y` defaults cleanly.
+    /// SavedWindow omits `grid_x` / `grid_y` defaults cleanly.
     #[test]
     fn grid_coords_default_to_zero_on_load() {
         use egui_tiles::Tree;
@@ -227,8 +227,8 @@ mod tests {
             tree_json
         );
 
-        let restored: SavedContext = serde_json::from_str(&json)
-            .expect("SavedContext without grid_x/grid_y must deserialize");
+        let restored: SavedWindow = serde_json::from_str(&json)
+            .expect("SavedWindow without grid_x/grid_y must deserialize");
         assert_eq!(restored.grid_x, 0, "grid_x must default to 0");
         assert_eq!(restored.grid_y, 0, "grid_y must default to 0");
     }


### PR DESCRIPTION
## Summary

Establishes the shared terminology agreed on in conversation:

- **Context** = sidebar project scope (`WorkspaceMeta` → `Context`)
- **Window** = spatial grid page (`Context` → `Window`, created by Cmd+N)
- **Pane** = split within a window (unchanged)

Type renames: `WorkspaceMeta→Context`, `Context→Window`, `ContextMenuAction→WindowMenuAction`, `SavedWorkspaceMeta→SavedContext`, `SavedContext→SavedWindow`.

Field renames: `workspace_id→context_id` (on Window), `context_id→window_id` (Window's own ID), `self.workspaces→self.contexts`, `self.contexts→self.windows`, `active_workspace→active_context`, `active_context→active_window`, `workspace_active_window→context_active_window`, `renaming_context→renaming_window`.

Comment terminology updated in `keys.rs`. Pure mechanical rename — 536 insertions, 536 deletions, zero behaviour change.

**Breaks if:** anything that touches saved workspace files (`.plexi/workspaces/`) — serialized field names changed, so old saves won't load cleanly. Expected on alpha; acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)