### PR TITLE
fix(terminal): clear scroll-back on alt-screen exit to prevent ghost duplication

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -328,6 +328,16 @@ impl TerminalBackend {
             None => None,
         };
 
+        // When a full-screen TUI (e.g. Claude Code) exits the alternate screen,
+        // the scroll-back buffer retains stale render frames that appear as
+        // duplicated content when the user scrolls up. Clear history on the
+        // ALT_SCREEN → normal transition so scroll-back starts clean.
+        let was_alt_screen = self.last_content.terminal_mode.contains(TermMode::ALT_SCREEN);
+        let is_alt_screen = terminal.mode().contains(TermMode::ALT_SCREEN);
+        if was_alt_screen && !is_alt_screen {
+            terminal.grid_mut().clear_history();
+        }
+
         let cursor = terminal.grid_mut().cursor_cell().clone();
         self.last_content.grid = terminal.grid().clone();
         self.last_content.selectable_range = selectable_range;


### PR DESCRIPTION
## Summary
- When a full-screen TUI (e.g. Claude Code) exits the alternate screen buffer, stale render frames remain in the normal screen scroll-back
- Scrolling up surfaced these as duplicated content — e.g. the Claude Code startup banner appearing twice
- Detects the `ALT_SCREEN → normal` transition in `sync()` and calls `grid.clear_history()` so scroll-back starts clean on return to the normal screen

**Breaks if:** after exiting a TUI app in a Plexi terminal pane, scrolling up shows duplicated content from before the TUI ran