### PR TITLE
fix(pty): fix quit freeze — subscription busy-loop + reap_child off render thread

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -190,8 +190,11 @@ impl TerminalBackend {
         let shared_size_clone = shared_size.clone();
         let _pty_event_subscription = std::thread::Builder::new()
             .name(format!("pty_event_subscription_{}", id))
-            .spawn(move || loop {
-                if let Ok(event) = event_receiver.recv() {
+            .spawn(move || {
+                // `while let Ok` exits cleanly when the sender drops (channel
+                // closed on TerminalBackend drop), preventing a busy-loop on
+                // a dead channel that would spin a full CPU core at shutdown.
+                while let Ok(event) = event_receiver.recv() {
                     if let Event::ColorRequest(index, formatter) = &event {
                         if let Some(color) =
                             resolve_dynamic_color(&event_term, &dynamic_colors, *index)
@@ -211,11 +214,10 @@ impl TerminalBackend {
                         event_notifier.notify(formatter(size.into()).into_bytes());
                         continue;
                     }
-                    pty_event_proxy_sender
-                        .send((id, event.clone()))
-                        .unwrap_or_else(|_| {
-                            panic!("pty_event_subscription_{}: sending PtyEvent is failed", id)
-                        });
+                    // If the receiver is gone (app shutting down) just exit.
+                    if pty_event_proxy_sender.send((id, event.clone())).is_err() {
+                        break;
+                    }
                     app_context.clone().request_repaint();
                     if let Event::Exit = event {
                         break;
@@ -789,11 +791,16 @@ impl Default for RenderableContent {
 impl Drop for TerminalBackend {
     fn drop(&mut self) {
         let _ = self.notifier.0.send(Msg::Shutdown);
-        // Reap the PTY child so it doesn't get orphaned if the event loop
-        // doesn't propagate the shutdown to the shell in time. Poll for up to
-        // 200 ms (8 × 25 ms) for a clean exit, then SIGKILL + blocking wait.
+        // Reap the PTY child on a background thread. reap_child polls for up
+        // to 200 ms then issues SIGKILL + blocking waitpid — running that on
+        // the caller's thread (the render thread during quit) froze the UI.
         #[cfg(unix)]
-        reap_child(self.child_pid);
+        {
+            let pid = self.child_pid;
+            let _ = std::thread::Builder::new()
+                .name(format!("pty-reap-{pid}"))
+                .spawn(move || reap_child(pid));
+        }
     }
 }
 


### PR DESCRIPTION
## Root cause

Two bugs in `deps/egui_term/src/backend/mod.rs` combined to freeze the app on Cmd+Q whenever a full-screen TUI (Claude Code, `btop`, `files`, etc.) was running in any terminal pane.

**Bug 1 — `pty_event_subscription` busy-loop on channel close**

The thread was `loop { if let Ok(event) = event_receiver.recv() { ... } }`. When `TerminalBackend` drops and the sender is released, `recv()` returns `Err` immediately. The `if let Ok` silently falls through and the loop spins again — indefinitely — pegging a full CPU core. This is what produced the ~25% CPU reading on the frozen process.

**Bug 2 — `reap_child` blocking the render thread**

`TerminalBackend::drop` called `reap_child(self.child_pid)` synchronously on the caller's thread. `reap_child` polls `waitpid(WNOHANG)` 8 × 25 ms, then sends SIGKILL and blocks on `waitpid(0)`. Full-screen TUIs don't exit cleanly within 200 ms of `Msg::Shutdown` — they need to restore the terminal before exiting — so drop blocked the render thread for 200+ ms per pane, freezing the UI.

## Fix

**Bug 1:** `loop { if let Ok }` → `while let Ok` so the thread exits cleanly when the channel closes. Also changed the `panic!` on a failed proxy send to a `break` — the receiver can legitimately be gone during shutdown.

**Bug 2:** Spawn `reap_child` on a named background thread (`pty-reap-<pid>`) so `drop` returns immediately. The background thread handles the 200 ms grace window and SIGKILL. The OS reaps any remaining zombies on process exit.

## Breaks if

Cmd+Q with a full-screen TUI running (Claude Code, btop, files) freezes the app or requires force-quit.