### PR TITLE
feat(perf): log a warning when a render frame exceeds 50ms

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -965,6 +965,7 @@ impl PlexiApp {
 
 impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        let _frame_start = std::time::Instant::now();
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_notify_queue();
@@ -2035,6 +2036,11 @@ impl eframe::App for PlexiApp {
         }
 
         self.draw_feature_effects(ctx);
+
+        let frame_ms = _frame_start.elapsed().as_millis();
+        if frame_ms > 50 {
+            log::warn!("slow frame: {}ms", frame_ms);
+        }
     }
 }
 


### PR DESCRIPTION
Any blocking operation on the render thread — blocking syscall, `thread::sleep`, slow `Drop` — will now appear in `~/.plexi-alpha/plexi.log` as:

```
[WARN] slow frame: 847ms
```

This makes the class of "render thread blocked on shutdown" bugs self-diagnosing. The quit freeze that required attaching `lldb` and sampling the process would have shown up immediately in the log on the first Cmd+Q.

The threshold is 50ms — well above normal egui frame budget (~16ms at 60fps, ~50ms at 20fps for terminal repaints) but low enough to catch anything genuinely blocking.