### PR TITLE
fix(config): uncomment theme_preset by default; comment out accent override

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -338,11 +338,11 @@ interrupt_threshold = 100
 # ── Theme ──────────────────────────────────────────────────────
 # Pick a preset OR customize individual colors below.
 # Presets: catppuccin-mocha, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark
-# theme_preset = "catppuccin-mocha"
+theme_preset = "catppuccin-mocha"
 
 [theme]
-# UI chrome colors (hex format)
-accent = "#89b4fa"
+# Uncomment any color below to override the preset value.
+# accent = "#89b4fa"
 # bg_darkest = "#11111b"      # Deepest background (window edges)
 # bg_sidebar = "#181825"      # Sidebar background
 # bg_toolbar = "#181825"      # Toolbar/status bar background


### PR DESCRIPTION
## What was broken

Two bugs combined to make themes appear completely non-functional:

1. `theme_preset` was commented out in `CONFIG_TEMPLATE` — new installs had no active preset and no obvious path to enabling one.

2. `accent = "#89b4fa"` was unconditionally uncommented in `[theme]`. `apply_preset()` gives user `[theme]` values priority over the preset, so this hardcoded accent silently defeated every theme switch. The most visible color never changed, making it look like themes did nothing at all.

## Fix

- `theme_preset = "catppuccin-mocha"` is now active by default.
- `accent` is commented out with a note that individual colors can be uncommented to override the preset.

## Note for existing users

Anyone with `accent = "#89b4fa"` still set in their `config.toml` will need to comment it out manually for the preset accent to take effect. Cmd+Shift+, reloads the config after editing.