### PR TITLE
fix(sdk): bundle plexi_sdk in .app Resources; add as PYTHONPATH fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ osx_minimum_system_version = "12.0"
 # `cpal::Stream::play()` call. Without this string the prompt is suppressed
 # and capture silently records zeros (#277).
 osx_info_plist_exts = ["assets/Info.plist.fragment"]
+resources = ["sdk/python/plexi_sdk"]
 
 [dependencies]
 egui = "0.31"

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -268,8 +268,20 @@ impl ProcessApp {
             }
         }
         // Make the shared Plexi SDK importable by Python apps without per-app copies.
+        // Priority: user's local SDK (~/.plexi-alpha/sdk/) first, then the copy
+        // bundled inside the .app bundle (Contents/Resources/). The bundle path
+        // ensures apps work on a fresh install where just install-alpha was never run.
         let sdk_dir = crate::config::config_dir().join("sdk");
-        cmd.env("PYTHONPATH", sdk_dir);
+        let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
+        if let Some(bundle_sdk) = std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.join("Resources")))
+            .filter(|p| p.exists())
+        {
+            pythonpath.push(':');
+            pythonpath.push_str(&bundle_sdk.to_string_lossy());
+        }
+        cmd.env("PYTHONPATH", pythonpath);
         let mut child = cmd.spawn()?;
 
         let stdin = child.stdin.take().expect("stdin piped");


### PR DESCRIPTION
## Problem

On a machine where only the `.app` bundle is installed (not built from source), `~/.plexi-alpha/sdk/` never gets populated, so all Python example apps fail to import `plexi_sdk`.

## Fix

- Add `sdk/python/plexi_sdk` to the bundle's `resources` in `Cargo.toml` — `cargo bundle` copies it to `Contents/Resources/plexi_sdk/`
- In `process_app/mod.rs`, append `Contents/Resources/` to `PYTHONPATH` as a fallback after the user-local SDK dir

Priority order: `~/.plexi-alpha/sdk/` (developer installs from `just install-alpha`) → `Contents/Resources/` (bundle, works on fresh machines).

## Test plan

- [ ] `just install-alpha` — verify apps still load SDK from `~/.plexi-alpha/sdk/` (user path still takes precedence)
- [ ] Check `Contents/Resources/plexi_sdk/` exists inside the built `.app`
- [ ] On a fresh machine with no `~/.plexi-alpha/sdk/`, apps should import `plexi_sdk` successfully

**Breaks if:** Python apps fail to import `plexi_sdk` — either the bundle path is wrong or the Resources dir wasn't populated during bundle.
**Merged:** PR #2469 → alpha (current version v0.2.0, 2026-07-23)