### PR TITLE
feat(runtime): bundle Python 3.12 in .app via python-build-standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ Thumbs.db
 # Generated bundle assets (cargo bundle generates its own from Cargo.toml)
 assets/Info.plist
 
+# Bundled Python runtime (fetched by `just fetch-python-runtime` at build time)
+assets/python/
+
 # Misc
 *.log
 *.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ osx_minimum_system_version = "12.0"
 # `cpal::Stream::play()` call. Without this string the prompt is suppressed
 # and capture silently records zeros (#277).
 osx_info_plist_exts = ["assets/Info.plist.fragment"]
-resources = ["sdk/python/plexi_sdk"]
+resources = ["sdk/python/plexi_sdk", "assets/python"]
 
 [dependencies]
 egui = "0.31"

--- a/justfile
+++ b/justfile
@@ -1,3 +1,53 @@
+PYTHON_VERSION := "3.12.13"
+PYTHON_PBS_DATE := "20260414"
+
+# Download the python-build-standalone runtime into assets/python/ for bundling.
+# Skips if the correct version is already present. macOS only.
+fetch-python-runtime:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ "$(uname)" != "Darwin" ]]; then
+        echo "fetch-python-runtime: macOS only, skipping"
+        exit 0
+    fi
+
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "arm64" ]]; then
+        PBS_ARCH="aarch64-apple-darwin"
+    else
+        PBS_ARCH="x86_64-apple-darwin"
+    fi
+
+    VERSION="{{PYTHON_VERSION}}"
+    DATE="{{PYTHON_PBS_DATE}}"
+    EXPECTED="${VERSION}+${DATE}-${PBS_ARCH}"
+    VERSION_FILE="assets/python/.pbs-version"
+
+    if [[ -f "$VERSION_FILE" ]] && [[ "$(cat "$VERSION_FILE")" == "$EXPECTED" ]]; then
+        echo "Python runtime ${VERSION} (${PBS_ARCH}) already present, skipping download"
+        exit 0
+    fi
+
+    FILENAME="cpython-${VERSION}+${DATE}-${PBS_ARCH}-install_only.tar.gz"
+    URL="https://github.com/astral-sh/python-build-standalone/releases/download/${DATE}/${FILENAME}"
+
+    echo "Downloading Python ${VERSION} (${PBS_ARCH}) from python-build-standalone..."
+    rm -rf assets/python
+    mkdir -p assets
+
+    TMP=$(mktemp -d)
+    trap "rm -rf $TMP" EXIT
+
+    curl -fL --progress-bar "$URL" -o "$TMP/$FILENAME"
+    tar xzf "$TMP/$FILENAME" -C assets/
+
+    # Strip headers — not needed at runtime, saves ~5 MB
+    rm -rf assets/python/include
+
+    echo "$EXPECTED" > "$VERSION_FILE"
+    echo "Python ${VERSION} ready at assets/python/"
+
 dev:
     cargo run
 
@@ -242,7 +292,7 @@ install-apps:
     echo "install-apps is deprecated. Use 'just install-alpha', 'just install-beta', or 'just install-v3'."
     exit 1
 
-install-alpha:
+install-alpha: fetch-python-runtime
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -314,7 +364,7 @@ install-alpha:
     echo "Config dir: ~/.plexi-alpha/"
     echo "Apps: $(ls ~/.plexi-alpha/apps | wc -l | tr -d ' ') synced from examples/"
 
-install-v3:
+install-v3: fetch-python-runtime
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -378,7 +428,7 @@ install-v3:
     echo "Config dir: ~/.plexi-v3/"
     echo "Apps: $(ls ~/.plexi-v3/apps | wc -l | tr -d ' ') installed"
 
-install-beta:
+install-beta: fetch-python-runtime
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -267,19 +267,30 @@ impl ProcessApp {
                 cmd.env(k, v);
             }
         }
+        // Prepend the bundled Python interpreter's bin/ dir to PATH so that
+        // Python app shebangs (`#!/usr/bin/env python3`) resolve to our hermetic
+        // Python 3.12, not whatever the host machine happens to have installed.
+        // Falls back silently to host PATH if the bundle runtime isn't present
+        // (dev builds that haven't run `just fetch-python-runtime` yet).
+        let bundle_contents = std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()));
+        if let Some(ref contents) = bundle_contents {
+            let py_bin = contents.join("Resources").join("assets").join("python").join("bin");
+            if py_bin.exists() {
+                let host_path = std::env::var("PATH").unwrap_or_default();
+                cmd.env("PATH", format!("{}:{}", py_bin.display(), host_path));
+            }
+        }
+
         // Make the shared Plexi SDK importable by Python apps without per-app copies.
         // Priority: user's local SDK (~/.plexi-alpha/sdk/) first, then the copy
         // bundled inside the .app bundle (Contents/Resources/sdk/python/). The bundle path
         // ensures apps work on a fresh install where just install-alpha was never run.
         let sdk_dir = crate::config::config_dir().join("sdk");
         let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
-        if let Some(bundle_sdk) = std::env::current_exe()
-            .ok()
-            .and_then(|exe| {
-                exe.parent()
-                    .and_then(|p| p.parent())
-                    .map(|p| p.join("Resources").join("sdk").join("python"))
-            })
+        if let Some(bundle_sdk) = bundle_contents
+            .map(|p| p.join("Resources").join("sdk").join("python"))
             .filter(|p| p.exists())
         {
             pythonpath.push(':');


### PR DESCRIPTION
## What

Bundles a hermetic CPython 3.12.13 interpreter inside the `.app` so Python apps work on any machine — no Python install required.

## How

- **`just fetch-python-runtime`** — downloads the arch-appropriate [python-build-standalone](https://github.com/astral-sh/python-build-standalone) `install_only` tarball into `assets/python/`. Skips if the correct version is already present. Strips `include/` (headers not needed at runtime).
- **`install-alpha/beta/v3`** each declare `fetch-python-runtime` as a dependency — runs automatically before every bundle, no manual step.
- **`Cargo.toml resources`** — adds `assets/python` so cargo bundle copies it to `Contents/Resources/assets/python/`.
- **`process_app/mod.rs`** — prepends `Contents/Resources/assets/python/bin` to `PATH` before spawning any app. Python scripts' `#!/usr/bin/env python3` shebangs resolve to our Python 3.12 first. Falls back to host PATH silently if the bundle runtime isn't present (dev builds that skipped the fetch).
- **`.gitignore`** — `assets/python/` is gitignored; populated at build time.

## Size

~49 MB added to the `.app` bundle (uncompressed). Compressed distribution will be ~30 MB larger.

## Follow-up

`from __future__ import annotations` can now be removed from all Python example apps — Python 3.12 supports `str | None` natively. Separate cleanup PR.

## Test plan

- [ ] `just install-alpha` — verify fetch runs, bundle succeeds
- [ ] Confirm `Contents/Resources/assets/python/bin/python3 --version` → `Python 3.12.13`
- [ ] Launch any Python example app and verify it loads without import errors
- [ ] On a machine with no system Python, verify apps still launch

**Breaks if:** Python apps fail to start — check that `Contents/Resources/assets/python/bin/` exists in the installed `.app` and that `PATH` in the spawned process includes it.