### PR TITLE
chore: remove from __future__ import annotations (Python 3.12 bundled)

### DIFF
--- a/examples/agent-coordinator/agent_coordinator.py
+++ b/examples/agent-coordinator/agent_coordinator.py
@@ -19,7 +19,6 @@ loop stays free to dispatch the worker's `pipe_message` reply back into
 `on_pipe_message`. `respond` returns `None` (manual append mode) and
 the worker thread does the final `append_assistant_message` itself.
 """
-from __future__ import annotations
 
 import queue
 import threading

--- a/examples/agent-tester/agent_tester.py
+++ b/examples/agent-tester/agent_tester.py
@@ -10,7 +10,6 @@ the `iq.query` broker.
 Build: ~10 lines of substance. The `Agent` SDK base class handles
 history mirroring, append helpers, and event wiring.
 """
-from __future__ import annotations
 
 from plexi_sdk import Agent
 

--- a/examples/agent-tester/tests/test_agent.py
+++ b/examples/agent-tester/tests/test_agent.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 """Unit tests for the v3.3 SDK `Agent` base class (issue #338, part 2 of #285).
 

--- a/examples/agent-worker/agent_worker.py
+++ b/examples/agent-worker/agent_worker.py
@@ -13,7 +13,6 @@ JSON pipe opened by a coordinator agent. The worker:
 Both pipe-receive and direct-user paths run their `iq.query` calls on
 a background thread so the SDK stdin loop stays free.
 """
-from __future__ import annotations
 
 import threading
 

--- a/examples/ai-query-denied-test/ai_query_denied_test.py
+++ b/examples/ai-query-denied-test/ai_query_denied_test.py
@@ -7,7 +7,6 @@ reaching the LLM backend. The SDK turns that into a CapabilityDeniedError.
 
 Press `s` to send a test query and watch the gate fire.
 """
-from __future__ import annotations
 
 import threading
 

--- a/examples/ai-query-test/ai_query_test.py
+++ b/examples/ai-query-test/ai_query_test.py
@@ -14,7 +14,6 @@ Keys:
 The host requires `ai.query` declared in manifest.toml. This app
 declares it; see `ai-query-denied-test/` for the gate-denied path.
 """
-from __future__ import annotations
 
 import threading
 

--- a/examples/app-store/app_store.py
+++ b/examples/app-store/app_store.py
@@ -19,7 +19,6 @@ single source of truth (`crate::install`) stays canonical.
 Capability approval is mandatory before any install — the user sees
 exactly which manifest-declared capabilities they're granting.
 """
-from __future__ import annotations
 
 import json
 import os

--- a/examples/app-store/tests/test_app_store.py
+++ b/examples/app-store/tests/test_app_store.py
@@ -11,7 +11,6 @@ Tests in scope (#308 Phase 3 acceptance):
   4. _install_action shells out to `plexi-<channel> install <spec>` (after a
      forced-True capability prompt).
 """
-from __future__ import annotations
 
 import sys
 import textwrap

--- a/examples/audio-bridge-test/audio_bridge_test.py
+++ b/examples/audio-bridge-test/audio_bridge_test.py
@@ -20,7 +20,6 @@ Keys:
   s - Stop (end capture + echo "# capture stopped")
   c - Clear waveform
 """
-from __future__ import annotations
 
 import struct
 import threading

--- a/examples/audio-player/audio_player.py
+++ b/examples/audio-player/audio_player.py
@@ -24,7 +24,6 @@ Keys:
   i - ffprobe info dump
   c - Clear log
 """
-from __future__ import annotations
 
 import shlex
 import sys

--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -5,7 +5,6 @@ hjkl navigation. e/Enter opens in default app. a archives. d deletes (confirm).
 n creates a new item via host TextInput (issue #283). r refreshes. / searches.
 Items are markdown files inside <workspace>/.plexi/backlog/.
 """
-from __future__ import annotations
 
 import os
 import shutil

--- a/examples/backlog/tests/test_text_input.py
+++ b/examples/backlog/tests/test_text_input.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 """Unit tests for the v3.1 host-owned `TextInput` SDK wrapper (issue #283).
 

--- a/examples/balls/balls.py
+++ b/examples/balls/balls.py
@@ -7,7 +7,6 @@ physics, ctx.clear(), and on_click to spawn new balls.
 Physics model: constant gravity, elastic circle-circle collisions with
 impulse resolution, wall bounce with damping.
 """
-from __future__ import annotations
 
 import math
 import random

--- a/examples/canvas-terminal-bindings-test/canvas_terminal_bindings_test.py
+++ b/examples/canvas-terminal-bindings-test/canvas_terminal_bindings_test.py
@@ -14,7 +14,6 @@ Buttons (click or press the matching number):
 
 Capability: `terminal.bindings`.
 """
-from __future__ import annotations
 
 import os
 

--- a/examples/clipboard-test/clipboard_test.py
+++ b/examples/clipboard-test/clipboard_test.py
@@ -9,7 +9,6 @@ Three things on screen:
 
 Cmd+V (or right-click → Paste) anywhere in the pane fires `on_paste`.
 """
-from __future__ import annotations
 
 import time
 

--- a/examples/daw/daw.py
+++ b/examples/daw/daw.py
@@ -9,7 +9,6 @@ Grid: 8 rows × 64 steps (4 bars × 16 steps each).
 Physics balls float over the grid, bouncing off its walls, providing
 visual modulation cues (which column region is "hot").
 """
-from __future__ import annotations
 
 import time
 import threading

--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -11,7 +11,6 @@ Form view:   host-managed text_input per arg/flag; first field auto-focused;
              Tab cycles fields; Enter on last field runs the command.
              Escape returns to list.
 """
-from __future__ import annotations
 
 import json
 import sys

--- a/examples/github-tree/commit_graph.py
+++ b/examples/github-tree/commit_graph.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import annotations
 
 """Commit Graph — subway-style git history viewer for Plexi.
 

--- a/examples/github-tree/git_log.py
+++ b/examples/github-tree/git_log.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 """git_log — pure-function git data layer for commit_graph.py.
 

--- a/examples/github-tree/tests/test_layout.py
+++ b/examples/github-tree/tests/test_layout.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 """Unit tests for git_log lane layout and parse_commits.
 

--- a/examples/hot-reload-test/hot_reload_test.py
+++ b/examples/hot-reload-test/hot_reload_test.py
@@ -10,7 +10,6 @@ To exercise this: copy this directory under a workspace's `.plexi/apps/` and
 launch Plexi from that workspace. The manifest's `watch = true` only engages
 for workspace-local installs, never global.
 """
-from __future__ import annotations
 
 import os
 import sys

--- a/examples/lifecycle-tester/lifecycle_tester.py
+++ b/examples/lifecycle-tester/lifecycle_tester.py
@@ -9,7 +9,6 @@ Keys:
   j — spam malformed JSON (protocol_error pill)
   x — exit cleanly (no pill)
 """
-from __future__ import annotations
 
 import sys
 import time

--- a/examples/logs/logs.py
+++ b/examples/logs/logs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Logs — live tail of ~/.plexi-beta/plexi.log, newest-first, color-coded by level."""
-from __future__ import annotations
 
 import os
 import re

--- a/examples/midi-test/midi_test.py
+++ b/examples/midi-test/midi_test.py
@@ -22,7 +22,6 @@ Keys:
 
 The host requires `midi.in` and `midi.out` declared in manifest.toml.
 """
-from __future__ import annotations
 
 import threading
 import time

--- a/examples/mind-map/mind_map.py
+++ b/examples/mind-map/mind_map.py
@@ -4,7 +4,6 @@
 Vim-style navigation (h/j/k/l), Tab to add child, Enter to add sibling,
 r/F2 to rename, Backspace/Delete to remove. Zoom with +/-/0. Click to select.
 """
-from __future__ import annotations
 
 import sys
 import os

--- a/examples/notification-tester/notification_tester.py
+++ b/examples/notification-tester/notification_tester.py
@@ -29,7 +29,6 @@ Scope (context vs global) is NOT a runtime choice. It's declared per-app
 in manifest.toml::default_notification_scope. Flip this app's manifest to
 "global" to test cross-context visibility.
 """
-from __future__ import annotations
 
 import threading
 import time

--- a/examples/plexi-descriptor-demo/plexi_descriptor_demo.py
+++ b/examples/plexi-descriptor-demo/plexi_descriptor_demo.py
@@ -11,7 +11,6 @@ Try it:
     plexi-alpha descriptor probe python plexi_descriptor_demo.py
 """
 
-from __future__ import annotations
 
 import json
 import sys

--- a/examples/quick-note/quick_note.py
+++ b/examples/quick-note/quick_note.py
@@ -5,7 +5,6 @@ Opens to blank composer. Enter saves note (first line = title).
 Cmd+K or F1 opens note browser. Saves to <workspace_root>/.plexi/notes/<timestamp>.md.
 Posts a notification on save (surfaces in notification palette).
 """
-from __future__ import annotations
 
 import pathlib
 from datetime import datetime

--- a/examples/screen-time/screen_time.py
+++ b/examples/screen-time/screen_time.py
@@ -6,7 +6,6 @@ Layout:
   - The clock face + month grid are drawn with primitive ctx.circle/arc/text —
     they're data surfaces, not chrome.
 """
-from __future__ import annotations
 
 import datetime
 import json

--- a/examples/secrets-routing-tester/secrets_routing_tester.py
+++ b/examples/secrets-routing-tester/secrets_routing_tester.py
@@ -11,7 +11,6 @@ Keys:
   g — Fetch GITHUB_TOKEN (optional)
   r — Refresh both
 """
-from __future__ import annotations
 
 import threading
 

--- a/examples/snake/snake.py
+++ b/examples/snake/snake.py
@@ -5,7 +5,6 @@ Written in Python (not Rust) to keep the example self-contained and avoid a
 separate Rust sub-project. The spec allows either; Python is 80 lines vs a
 new cargo crate + cross-compile setup. This is the intentional choice.
 """
-from __future__ import annotations
 
 import sys
 import os

--- a/examples/stand-up-reminder/stand_up_reminder.py
+++ b/examples/stand-up-reminder/stand_up_reminder.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import annotations
 
 import random
 import time

--- a/examples/storyboard/storyboard.py
+++ b/examples/storyboard/storyboard.py
@@ -5,7 +5,6 @@ Canvas-style horizontal scene strip. Each scene card has a synthetic
 16:9 image placeholder rendered from draw primitives based on description
 keywords, plus description and dialogue sections. Fully interactive.
 """
-from __future__ import annotations
 
 import sys
 import os

--- a/examples/tetris/tetris.py
+++ b/examples/tetris/tetris.py
@@ -4,7 +4,6 @@
 Demonstrates: time-based game logic in on_render, ghost piece, wall kicks,
 hard drop, level progression, and the ScheduleRender protocol extension.
 """
-from __future__ import annotations
 
 import random
 import sys

--- a/examples/todo/todo.py
+++ b/examples/todo/todo.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Todo — fs.read + fs.write + persistence example for PGAP v3."""
-from __future__ import annotations
 
 import json
 import pathlib

--- a/examples/ui-playground/ui_playground.py
+++ b/examples/ui-playground/ui_playground.py
@@ -9,7 +9,6 @@ Keys:
   l — append a line to the scroll log (for watching it grow)
   c — clear the log
 """
-from __future__ import annotations
 
 import time
 

--- a/examples/video-editor/video_editor.py
+++ b/examples/video-editor/video_editor.py
@@ -7,7 +7,6 @@ and a multi-track timeline with clips, ruler, and animated playhead.
 
 No video decoding — all frames are synthetic. Space to play/pause.
 """
-from __future__ import annotations
 
 import math
 import threading

--- a/examples/video-player/video_player.py
+++ b/examples/video-player/video_player.py
@@ -33,7 +33,6 @@ Keys:
 Manifest declares `video.playback`. Without it, open_video() raises
 CapabilityDeniedError immediately and the app surfaces it in the log.
 """
-from __future__ import annotations
 
 import os
 import shlex

--- a/examples/wikipedia/wikipedia.py
+++ b/examples/wikipedia/wikipedia.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Wikipedia — net.http + text render example for PGAP v3."""
-from __future__ import annotations
 
 import json
 import threading

--- a/examples/workspace-config-tester/workspace_config_tester.py
+++ b/examples/workspace-config-tester/workspace_config_tester.py
@@ -13,7 +13,6 @@ Surfaces:
 Keys:
   r — Reload from disk
 """
-from __future__ import annotations
 
 from pathlib import Path
 

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -398,7 +398,6 @@ auto-emits FrameDone; all others must NOT emit FrameDone.
 
 Call MyApp().run() to start the PGAP event loop. This blocks until Shutdown.
 """
-from __future__ import annotations
 
 __version__ = "0.5.0"
 SDK_ID = f"plexi-sdk-py/{__version__}"

--- a/sdk/python/plexi_sdk/midi.py
+++ b/sdk/python/plexi_sdk/midi.py
@@ -10,7 +10,6 @@ system real-time 0xF8..=0xFF). SysEx (0xF0..0xF7) is out of scope for v3.4.
 All channel arguments are 0-indexed (channel 0 = MIDI channel 1 in DAWs).
 All note / CC / value arguments are 0..=127.
 """
-from __future__ import annotations
 
 from dataclasses import dataclass
 

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -3,7 +3,6 @@
 Spawns the plexi binary with `--render`, feeds it DrawCommand JSON,
 reads back PNG bytes. Provides pixel-level assertions and snapshot file helpers.
 """
-from __future__ import annotations
 
 import json
 import os

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -35,7 +35,6 @@ than the total fixed-height content, grow spacers collapse to 0 and
 content at the bottom may not render — keep the total intentionally
 below the minimum pane size, or use `ScrollLog` for variable content.
 """
-from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import List, Optional, Union

--- a/sdk/python/plexi_sdk/widgets/scroll.py
+++ b/sdk/python/plexi_sdk/widgets/scroll.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 
 import warnings
 

--- a/sdk/python/plexi_sdk/widgets/text_area.py
+++ b/sdk/python/plexi_sdk/widgets/text_area.py
@@ -5,7 +5,6 @@ vertical scrolling. Emits PGAP-compatible DrawCommand dicts (same shape
 as ctx.rect / ctx.text). All coordinates are absolute within the
 render viewport passed to render().
 """
-from __future__ import annotations
 
 from dataclasses import dataclass
 

--- a/sdk/python/plexi_sdk/widgets/text_buffer.py
+++ b/sdk/python/plexi_sdk/widgets/text_buffer.py
@@ -2,7 +2,6 @@
 
 Lines + cursor + selection. No rendering; that is the TextArea widget's job.
 """
-from __future__ import annotations
 
 from dataclasses import dataclass, field
 

--- a/sdk/python/plexi_sdk/widgets/text_input.py
+++ b/sdk/python/plexi_sdk/widgets/text_input.py
@@ -20,7 +20,6 @@ apps cannot inspect the typed value between keystrokes.
 Real-time validation (per-keystroke value access) is intentionally out
 of scope for v3.1 — see issue #283 option A.
 """
-from __future__ import annotations
 
 import json
 import sys

--- a/sdk/python/tests/test_appbar.py
+++ b/sdk/python/tests/test_appbar.py
@@ -1,5 +1,4 @@
 """Tests for AppBar component layout."""
-from __future__ import annotations
 
 from unittest.mock import MagicMock, call
 


### PR DESCRIPTION
## Summary

- Removes `from __future__ import annotations` from all 49 Python files under `examples/` and `sdk/python/`
- This import was required when the host launched apps with macOS's frozen `/usr/bin/python3` (3.9.6), which doesn't support `str | None` syntax natively
- Now that Python 3.12 is bundled with the app (PR #459), the shim is dead weight

## Test plan

- [ ] `cargo build` passes (confirmed clean — 6 pre-existing warnings, no errors)
- [ ] Spot-check a few example apps launch without import errors on the alpha build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)