### PR TITLE
fix(sidebar): double-click context row to rename

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -308,8 +308,10 @@ impl PlexiApp {
                         }
                     });
 
-                    // Only switch context on click, not on drag release
-                    if row_response.clicked() && self.drag_context.is_none() {
+                    // Double-click → rename; single click → switch context (not on drag release)
+                    if row_response.double_clicked() && self.drag_context.is_none() {
+                        menu_action = Some((i, WindowMenuAction::Rename));
+                    } else if row_response.clicked() && self.drag_context.is_none() {
                         clicked_workspace = Some(i);
                     }
                 }


### PR DESCRIPTION
Double-clicking a sidebar context row now opens the inline rename field. Single-click still switches context. Previously there was no double-click handler — rename was only reachable via right-click menu.