### PR TITLE
fix(sidebar): restrict rename double-click to text label hitbox

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -85,6 +85,7 @@ impl PlexiApp {
             let is_active = i == self.active_context;
             let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
+            let mut label_double_clicked = false;
 
             let row_rect = ui.cursor();
             let row_rect = Rect::from_min_size(row_rect.min, Vec2::new(sidebar_width, ROW_HEIGHT));
@@ -213,14 +214,20 @@ impl PlexiApp {
                                     .color(self.colors.text_dim),
                             );
                         }
-                        ui.add(
+                        let label_resp = ui.add(
                             egui::Label::new(
                                 RichText::new(&self.contexts[i].name)
                                     .size(12.0)
                                     .color(text_color),
                             )
-                            .sense(egui::Sense::hover()),
+                            .sense(egui::Sense::click()),
                         );
+                        if label_resp.hovered() {
+                            ui.ctx().set_cursor_icon(egui::CursorIcon::Default);
+                        }
+                        if label_resp.double_clicked() {
+                            label_double_clicked = true;
+                        }
 
                         // Per-context notification badge.
                         // Active context: count visible notifs (context-scoped for active + globals).
@@ -308,8 +315,8 @@ impl PlexiApp {
                         }
                     });
 
-                    // Double-click → rename; single click → switch context (not on drag release)
-                    if row_response.double_clicked() && self.drag_context.is_none() {
+                    // Double-click on the text label → rename; single click anywhere → switch context
+                    if label_double_clicked && self.drag_context.is_none() {
                         menu_action = Some((i, WindowMenuAction::Rename));
                     } else if row_response.clicked() && self.drag_context.is_none() {
                         clicked_workspace = Some(i);


### PR DESCRIPTION
Previously any double-click on the row triggered rename, even where the cursor shows a grab hand. The fix should restrict rename to the label hitbox only — or remove double-click rename entirely in favour of context-menu-only rename.

## Prior Attempts

**Attempt 1:** PR #825 — restrict double-click rename to text label hitbox only.
**Why it failed:** Double-clicking the label text did not reliably trigger rename. The `Sense::click()` on the label didn't compose well with the full-row `Sense::click_and_drag()` interact.
**What to try next:** Remove double-click rename entirely. Simplify `sidebar_row.rs` by reverting the `content_fn` return-type change, deleting `SidebarAction::Rename` (it becomes dead code — context menu uses `menu_action` directly), and stripping the cursor override. Rename stays available via right-click context menu only.