### PR TITLE
fix(textinput): auto-focus on all nodes + Shift+Enter multiline (#404)

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,15 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-04-30 — [FIX] TextInput: auto-focus only first node + Shift+Enter multiline (#404 → alpha)
+
+Two bugs in `render_text_inputs` in `src/process_app/mod.rs`.
+
+**Bug 1 — auto-focus last node wins instead of first:** `request_focus()` was called on every newly-visible TextInput in a frame. egui's `request_focus` is last-write-wins within a frame, so when multiple inputs appear together (e.g. a form), only the last one received focus. Fixed by tracking a `focus_granted` bool per call and only requesting focus on the first newly-visible input.
+
+**Bug 2 — Shift+Enter did nothing in multiline mode:** egui's multiline `TextEdit` only inserts `\n` for plain Enter — it does not handle Shift+Enter at all. The existing code intercepted plain Enter to submit (stripping the egui-inserted `\n`), but the Shift+Enter case fell through to egui with no result. Fixed by explicitly detecting `Shift+Enter` while focused and pushing `\n` into the buffer manually.
+
+**Breaks if:** (1) A form with multiple TextInput nodes — the second and later inputs never auto-focus on first appearance. (2) A multiline TextInput — pressing Shift+Enter does nothing instead of inserting a newline.
+
 ## 2026-04-30 — [FIX] Cmd+Q freezes when any full-screen TUI is running in a terminal pane (PR #454 → alpha)
 
 Two bugs in `deps/egui_term/src/backend/mod.rs` combined to freeze the app on Cmd+Q whenever a full-screen TUI (Claude Code, `btop`, `files`) was running. The 25% CPU ghost + indefinite freeze were separate symptoms from separate root causes.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -695,7 +695,10 @@ impl ProcessApp {
             // frame would build a fresh widget and lose the cursor.
             let widget_id = ui.id().with(("text_input", self.pane_id, id.as_str()));
 
-            let resp = {
+            // Use TextEdit::show() instead of ui.add() so we get TextEditOutput,
+            // which carries cursor_range. We need the cursor char index to insert
+            // '\n' at the right position for Shift+Enter (not just append to end).
+            let (resp, cursor_char_idx) = {
                 let buffer = self.text_input_buffers.entry(id.clone()).or_default();
                 let mut child = ui.new_child(
                     egui::UiBuilder::new()
@@ -715,17 +718,18 @@ impl ProcessApp {
                         .hint_text(placeholder.as_str())
                         .frame(true)
                 };
-                let r = child.add(edit);
+                let output = edit.show(&mut child);
                 // Auto-focus the first newly-visible input so the user can
                 // type immediately without clicking. Subsequent newly-visible
                 // inputs in the same frame are skipped — request_focus is
                 // last-write-wins in egui, so focusing all of them would
                 // leave only the last one focused.
                 if newly_visible && !focus_granted {
-                    r.request_focus();
+                    output.response.request_focus();
                     focus_granted = true;
                 }
-                r
+                let cursor_idx = output.cursor_range.map(|cr| cr.primary.ccursor.index);
+                (output.response, cursor_idx)
             };
 
             if *multiline {
@@ -753,10 +757,17 @@ impl ProcessApp {
                         }
                         submitted.push(id.clone());
                     } else if shift_enter {
-                        // egui ignores Shift+Enter in multiline mode; push
-                        // the newline ourselves so the UX is consistent.
-                        if let Some(buf) = self.text_input_buffers.get_mut(id.as_str()) {
-                            buf.push('\n');
+                        // egui ignores Shift+Enter in multiline mode; insert '\n'
+                        // at the cursor position (not just the end of the buffer).
+                        if let (Some(buf), Some(char_idx)) =
+                            (self.text_input_buffers.get_mut(id.as_str()), cursor_char_idx)
+                        {
+                            let byte_idx = buf
+                                .char_indices()
+                                .nth(char_idx)
+                                .map(|(i, _)| i)
+                                .unwrap_or(buf.len());
+                            buf.insert(byte_idx, '\n');
                         }
                     }
                 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -657,6 +657,11 @@ impl ProcessApp {
         // `text_input_visible_prev` after the loop.
         let mut visible_this_frame: std::collections::HashSet<String> =
             std::collections::HashSet::new();
+        // Auto-focus: only focus the first newly-visible input per frame.
+        // egui's request_focus is last-write-wins within a frame, so calling
+        // it on every newly-visible input would leave only the last one
+        // focused. We want the first one.
+        let mut focus_granted = false;
 
         for cmd in frame {
             let DrawCommand::TextInput {
@@ -711,31 +716,49 @@ impl ProcessApp {
                         .frame(true)
                 };
                 let r = child.add(edit);
-                // Auto-focus newly-visible inputs so the user can type
-                // immediately without clicking.
-                if newly_visible {
+                // Auto-focus the first newly-visible input so the user can
+                // type immediately without clicking. Subsequent newly-visible
+                // inputs in the same frame are skipped — request_focus is
+                // last-write-wins in egui, so focusing all of them would
+                // leave only the last one focused.
+                if newly_visible && !focus_granted {
                     r.request_focus();
+                    focus_granted = true;
                 }
                 r
             };
 
             if *multiline {
-                // Multiline: Enter submits, Shift+Enter inserts newline.
-                // We check for Enter *without* Shift while the widget is
-                // focused. egui does not consume Enter for multiline edits
-                // (it inserts a newline), so we have to intercept it here.
-                if resp.has_focus()
-                    && ui.input(|i| {
+                // Multiline submit/newline handling:
+                //   Enter (no Shift)  → submit. egui inserts a '\n' first;
+                //                       strip it before submitting.
+                //   Shift+Enter       → insert newline. egui does NOT handle
+                //                       Shift+Enter in multiline mode, so we
+                //                       insert '\n' into the buffer ourselves
+                //                       and consume the key event.
+                if resp.has_focus() {
+                    let enter_no_shift = ui.input(|i| {
                         i.key_pressed(egui::Key::Enter) && !i.modifiers.shift
-                    })
-                {
-                    // Strip the newline egui already inserted before we submit.
-                    if let Some(buf) = self.text_input_buffers.get_mut(id.as_str()) {
-                        if buf.ends_with('\n') {
-                            buf.pop();
+                    });
+                    let shift_enter = ui.input(|i| {
+                        i.key_pressed(egui::Key::Enter) && i.modifiers.shift
+                    });
+
+                    if enter_no_shift {
+                        // Strip the '\n' egui already inserted before submitting.
+                        if let Some(buf) = self.text_input_buffers.get_mut(id.as_str()) {
+                            if buf.ends_with('\n') {
+                                buf.pop();
+                            }
+                        }
+                        submitted.push(id.clone());
+                    } else if shift_enter {
+                        // egui ignores Shift+Enter in multiline mode; push
+                        // the newline ourselves so the UX is consistent.
+                        if let Some(buf) = self.text_input_buffers.get_mut(id.as_str()) {
+                            buf.push('\n');
                         }
                     }
-                    submitted.push(id.clone());
                 }
             } else {
                 // Submit on Enter while focused. The egui idiom for


### PR DESCRIPTION
## Summary

- **Auto-focus bug:** `request_focus()` was called on every newly-visible `TextInput` in a frame. egui's focus model is last-write-wins within a frame, so only the last input on screen ever received focus. Fixed by tracking a `focus_granted` flag and calling `request_focus()` only on the first newly-visible input per frame.
- **Shift+Enter bug:** egui's multiline `TextEdit` only inserts `\n` for plain Enter — Shift+Enter is silently ignored. The existing code intercepted plain Enter to submit (stripping the egui-inserted `\n`), but left Shift+Enter unhandled. Fixed by explicitly detecting `Shift+Enter` while the widget is focused and pushing `\n` into the host-owned buffer directly.

## Test plan

- [ ] Open an app that renders multiple `TextInput` nodes in the same frame — the first field should receive focus automatically without clicking
- [ ] Subsequent fields should NOT steal focus on the same frame they appear
- [ ] With `multiline: true`, pressing Shift+Enter should insert a newline into the field
- [ ] With `multiline: true`, pressing plain Enter should submit the field (existing behavior preserved)
- [ ] Singleline submit behavior is unchanged