### PR TITLE
feat(pgap): host-managed ScrollRegion primitive (#446)

### DIFF
--- a/examples/scroll-list/manifest.toml
+++ b/examples/scroll-list/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "scroll-list"
+type = "app"
+name = "Scroll List"
+version = "0.1.0"
+description = "POC for host-managed scroll regions (#446). Renders 100 items using BeginScroll/EndScroll."
+entry = "scroll_list.py"
+
+[app.capabilities]
+capabilities = []
+
+[launch]
+layout_hint = { side = "right", split = 0.5 }

--- a/examples/scroll-list/scroll_list.py
+++ b/examples/scroll-list/scroll_list.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""scroll-list — POC for host-managed scroll regions (#446).
+
+Renders 100 rows using DrawCommand::BeginScroll / EndScroll. The host owns
+the scroll offset; this app just receives ScrollOffset events via on_scroll
+and re-renders the list at the updated position.
+
+Verification checklist:
+  1. Launch the app — a list of 100 items should appear, most off-screen.
+  2. Hover over the list and scroll with the mouse wheel — items should scroll.
+  3. Items outside the declared viewport height must be clipped (not visible).
+  4. The host log should show no "clip stack not empty" warnings.
+"""
+
+import sys
+import os
+
+# Prefer the SDK from the repo tree over any installed version.
+_sdk_path = os.path.join(os.path.dirname(__file__), "..", "..", "sdk", "python")
+if os.path.isdir(_sdk_path):
+    sys.path.insert(0, _sdk_path)
+
+from plexi_sdk import App, BG, SURFACE, HIGHLIGHT, FG, MUTED, ACCENT, BODY, CAPTION, PAD
+
+ITEM_COUNT = 100
+ROW_H = 36.0
+HEADER_H = 48.0
+SCROLL_ID = "main-list"
+
+
+class ScrollListApp(App):
+    def on_init(self, ctx):
+        self.scroll_y = 0.0
+
+    def on_scroll(self, ctx, id, offset_y):
+        if id == SCROLL_ID:
+            self.scroll_y = offset_y
+
+    def on_render(self, ctx):
+        # Background
+        ctx.clear(BG)
+
+        # Header bar
+        ctx.rect(0, 0, ctx.w, HEADER_H, fill=SURFACE)
+        ctx.text(PAD, HEADER_H / 2, "Host-Managed Scroll — 100 Items",
+                 size=BODY, color=FG, align="left_center")
+        offset_label = f"offset: {self.scroll_y:.1f}px"
+        ctx.text(ctx.w - PAD, HEADER_H / 2, offset_label,
+                 size=CAPTION, color=MUTED, align="right_center")
+
+        # Total content height for all 100 rows
+        content_height = ITEM_COUNT * ROW_H
+
+        # Scroll viewport fills the pane below the header
+        viewport_y = HEADER_H
+        viewport_h = ctx.h - HEADER_H
+
+        ctx.begin_scroll(SCROLL_ID, 0, viewport_y, ctx.w, viewport_h,
+                         content_height=content_height)
+
+        # Render only the rows that are (potentially) visible to avoid
+        # painting thousands of off-screen items. This is optional —
+        # the host will clip anything outside the viewport — but it
+        # keeps the draw-command stream lean.
+        first_visible = max(0, int(self.scroll_y / ROW_H))
+        last_visible = min(ITEM_COUNT, int((self.scroll_y + viewport_h) / ROW_H) + 2)
+
+        for i in range(first_visible, last_visible):
+            row_y = viewport_y + i * ROW_H - self.scroll_y
+            is_even = i % 2 == 0
+            bg = SURFACE if is_even else BG
+            ctx.rect(0, row_y, ctx.w, ROW_H, fill=bg)
+
+            # Row number badge
+            badge_label = f"{i + 1:>3}"
+            ctx.text(PAD, row_y + ROW_H / 2, badge_label,
+                     size=CAPTION, color=ACCENT, monospace=True, align="left_center")
+
+            # Item label
+            ctx.text(PAD + 40, row_y + ROW_H / 2,
+                     f"Item {i + 1:03d} — host scroll region",
+                     size=BODY, color=FG, align="left_center")
+
+            # Right-side hint
+            ctx.text(ctx.w - PAD, row_y + ROW_H / 2,
+                     f"y={i * ROW_H:.0f}",
+                     size=CAPTION, color=MUTED, align="right_center")
+
+            # Separator line
+            ctx.line(0, row_y + ROW_H - 1, ctx.w, row_y + ROW_H - 1,
+                     color=HIGHLIGHT, width=0.5)
+
+        ctx.end_scroll()
+
+        # Footer hint
+        footer_y = ctx.h - 28
+        ctx.text(ctx.w / 2, footer_y,
+                 "Scroll with mouse wheel  •  100 items  •  host clips viewport",
+                 size=CAPTION, color=MUTED, align="center")
+
+
+if __name__ == "__main__":
+    ScrollListApp().run()

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1688,6 +1688,42 @@ class RenderContext:
                "items": items, "selected": selected,
                "item_height": item_height})
 
+    def begin_scroll(self, id: str, x: float, y: float, w: float, h: float,
+                     content_height: float) -> None:
+        """Begin a host-managed vertical scroll region (#446).
+
+        Declares a viewport at (x, y, w, h) within this pane. All draw
+        commands until the matching `end_scroll()` call are clipped to that
+        viewport. The host tracks the scroll position across frames and calls
+        `on_scroll(ctx, id, offset_y)` whenever the user scrolls so the app
+        can re-render content translated by `offset_y`.
+
+        `content_height` is the total virtual height of the scrollable content
+        in logical pixels — the host uses this to size the scrollbar thumb.
+        Pass the full height of all items even if most are off-screen.
+
+        `id` must be stable across frames — use a descriptive string rather
+        than a counter. Typical pattern::
+
+            def on_scroll(self, ctx, id, offset_y):
+                if id == "main-list":
+                    self.scroll_y = offset_y
+
+            def on_render(self, ctx):
+                ctx.begin_scroll("main-list", 0, 48, ctx.w, ctx.h - 48,
+                                 content_height=100 * ROW_H)
+                for i, item in enumerate(self.items):
+                    y = i * ROW_H - self.scroll_y
+                    ctx.text(8, y, item, size=14, color=FG)
+                ctx.end_scroll()
+        """
+        _emit({"type": "begin_scroll", "id": id, "x": x, "y": y,
+               "w": w, "h": h, "content_height": content_height})
+
+    def end_scroll(self) -> None:
+        """Close the most recently opened scroll region. Must balance begin_scroll."""
+        _emit({"type": "end_scroll"})
+
     def text_input(self, id: str, x: float, y: float, w: float,
                    placeholder: str = "",
                    multiline: bool = False) -> "str | None":
@@ -1932,6 +1968,13 @@ class App:
     def on_inject(self, _ctx: RenderContext, _payload: Any) -> Coroutine[Any, Any, None] | None: return None
     def on_app_spawned(self, _pane_id: int, _type_id: str) -> None: pass
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> Coroutine[Any, Any, None] | None: return None
+    def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> Coroutine[Any, Any, None] | None: return None
+    """Called when the host updates the scroll offset for a BeginScroll region.
+
+    `id` matches the id passed to `ctx.begin_scroll`. `offset_y` is the new
+    vertical offset in logical pixels. Override to re-render content at the
+    new position.
+    """
     def on_midi_input_opened(
         self,
         _pipe_id: str,
@@ -2318,6 +2361,18 @@ class App:
                     timer_id = ev.get("timer_id", "")
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_timer, ctx, timer_id)
+
+                elif t == "scroll_offset":
+                    # Host-managed scroll region (#446): the user scrolled inside
+                    # a BeginScroll viewport. Forward to on_scroll so the app can
+                    # store the new offset and re-render at the translated position.
+                    scroll_id = ev.get("id", "")
+                    offset_y = float(ev.get("offset_y", 0.0))
+                    ctx = self._make_ctx()
+                    try:
+                        await self._dispatch_hook(self.on_scroll, ctx, scroll_id, offset_y)
+                    except Exception as e:
+                        sys.stderr.write(f"on_scroll handler raised: {e}\n")
 
                 elif t == "app_spawned":
                     # Confirmation that a SpawnApp request succeeded. Apps that

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -322,6 +322,15 @@ pub enum PlexiEvent {
     /// depth is > 0. The app handles this by popping its own internal view
     /// and emitting `DrawCommand::PopNav` to decrement the host counter.
     NavBack {},
+
+    /// Emitted by the host when the scroll offset for a `BeginScroll` region
+    /// changes (mouse wheel, drag). The app should re-render using `offset_y`
+    /// as the vertical translation applied to all content within that region.
+    ///
+    /// `id` matches the `id` from the `DrawCommand::BeginScroll` that declared
+    /// the region. `offset_y` is always >= 0 and clamped to
+    /// `max(0, content_height - viewport_height)`.
+    ScrollOffset { id: String, offset_y: f32 },
 }
 
 /// On-the-wire shape of one MIDI port. Mirrors `midi::MidiPortInfo` but lives
@@ -1087,6 +1096,36 @@ pub enum DrawCommand {
     /// App signals it has popped a navigation level. The host decrements its
     /// per-pane nav stack depth counter (saturating — never below 0).
     PopNav {},
+
+    // ── Host-managed scroll regions (#446) ───────────────────────────────
+
+    /// Begin a host-managed vertical scroll region.
+    ///
+    /// All draw commands between this and the matching `EndScroll` are clipped
+    /// to the viewport rect `(x, y, w, h)`. The host tracks the scroll offset
+    /// for `id` across frames and emits `PlexiEvent::ScrollOffset { id, offset_y }`
+    /// whenever the user scrolls (mouse wheel / drag). The app translates its
+    /// content coordinates by `offset_y` before emitting draw commands.
+    ///
+    /// `content_height` is the total virtual height of the scrollable content
+    /// in logical pixels. The host uses this to size the scrollbar thumb.
+    ///
+    /// `id` must be stable across frames — use a meaningful string (e.g. the
+    /// region name) rather than a counter that may change.
+    BeginScroll {
+        id: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        content_height: f32,
+    },
+
+    /// Close the most recently opened scroll region.
+    ///
+    /// Must be balanced with a preceding `BeginScroll`. Imbalanced pairs are
+    /// logged at `warn` level and the stack is reset at frame end.
+    EndScroll,
 }
 
 /// Replace-vs-append behaviour for `DrawCommand::InsertPathToken`.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1153,7 +1153,10 @@ impl App for ProcessApp {
 
             if scroll_delta.y != 0.0 {
                 if let Some(pos) = pointer_pos {
-                    for (id, viewport, content_height) in &scroll_regions {
+                    // Iterate in reverse so the innermost (last-declared) region wins
+                    // when regions are nested. The outermost BeginScroll appears first
+                    // in the command stream; iterating forward would give it priority.
+                    for (id, viewport, content_height) in scroll_regions.iter().rev() {
                         if viewport.contains(pos) {
                             let viewport_h = viewport.height();
                             let max_offset = (content_height - viewport_h).max(0.0);
@@ -1167,7 +1170,7 @@ impl App for ProcessApp {
                                     offset_y: next,
                                 });
                             }
-                            break; // innermost region wins
+                            break;
                         }
                     }
                 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -196,6 +196,11 @@ pub struct ProcessApp {
     /// inputs and call `request_focus()` on them so the user can type
     /// immediately without clicking.
     text_input_visible_prev: std::collections::HashSet<String>,
+    /// Per-region scroll offsets for `DrawCommand::BeginScroll` / `EndScroll`
+    /// (#446). Key = scroll region id; value = current vertical offset in
+    /// logical pixels. Persists across frames — the offset is only reset when
+    /// content_height or viewport size shrinks past it (clamped on emit).
+    pub(crate) scroll_offsets: HashMap<String, f32>,
     /// Test-only seam used by `process_app::agent` unit tests to inject
     /// `DrawCommand`s without spinning up a real subprocess pipeline.
     /// Drained on every `agent_tick` (and thus invisible in production).
@@ -480,6 +485,7 @@ impl ProcessApp {
             show_stderr_overlay: false,
             text_input_buffers: HashMap::new(),
             text_input_visible_prev: std::collections::HashSet::new(),
+            scroll_offsets: HashMap::new(),
             #[cfg(test)]
             test_injected_commands: Arc::new(Mutex::new(VecDeque::new())),
         })
@@ -1116,6 +1122,57 @@ impl App for ProcessApp {
         // mutable per-app buffer map — they can't share the painter-only
         // render path. Render them in a second pass on top of the frame.
         self.render_text_inputs(ui, pane_rect, &frame_clone);
+
+        // ── Host-managed scroll regions (#446) ──────────────────────────────
+        // Scan the committed frame for BeginScroll regions. For each region,
+        // check if the pointer is hovering inside its viewport rect and a
+        // scroll event occurred this frame. Update the stored offset and emit
+        // PlexiEvent::ScrollOffset whenever the offset changes.
+        //
+        // Scroll events are read from egui's per-frame InputState snapshot;
+        // we do not consume them (no `consume_scroll_delta`) so other egui
+        // widgets in the host still receive them normally.
+        {
+            let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
+            let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+
+            // Collect (id, viewport_rect, content_height) for every BeginScroll
+            // in the current frame. We walk the flat command list and match
+            // BeginScroll entries; EndScroll entries are not needed here.
+            let mut scroll_regions: Vec<(String, egui::Rect, f32)> = Vec::new();
+            let origin = pane_rect.min;
+            for cmd in &frame_clone {
+                if let DrawCommand::BeginScroll { id, x, y, w, h, content_height } = cmd {
+                    let viewport = egui::Rect::from_min_size(
+                        egui::pos2(origin.x + x, origin.y + y),
+                        egui::vec2(*w, *h),
+                    );
+                    scroll_regions.push((id.clone(), viewport, *content_height));
+                }
+            }
+
+            if scroll_delta.y != 0.0 {
+                if let Some(pos) = pointer_pos {
+                    for (id, viewport, content_height) in &scroll_regions {
+                        if viewport.contains(pos) {
+                            let viewport_h = viewport.height();
+                            let max_offset = (content_height - viewport_h).max(0.0);
+                            let prev = self.scroll_offsets.get(id).copied().unwrap_or(0.0);
+                            // Positive scroll_delta.y = scroll up (reveal content above).
+                            let next = (prev - scroll_delta.y).clamp(0.0, max_offset);
+                            if (next - prev).abs() > 0.01 {
+                                self.scroll_offsets.insert(id.clone(), next);
+                                self.outbound_events.push_back(PlexiEvent::ScrollOffset {
+                                    id: id.clone(),
+                                    offset_y: next,
+                                });
+                            }
+                            break; // innermost region wins
+                        }
+                    }
+                }
+            }
+        }
 
         // ── Error fallback ──────────────────────────────────────────────────
         // Surface recent stderr in the pane when:

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -415,6 +415,33 @@ pub(super) fn render_draw_commands(
             // safety net for any stray commands that leak through.
             | DrawCommand::PushNav { .. }
             | DrawCommand::PopNav { .. } => {}
+
+            // ── Host-managed scroll regions (#446) ───────────────────────────
+            //
+            // BeginScroll declares a clipped viewport. All draw commands until
+            // the matching EndScroll are painted with that viewport as the clip
+            // rect. The app has already translated its content coordinates by
+            // the scroll offset (received via PlexiEvent::ScrollOffset); the
+            // renderer's only job here is enforcing the clip boundary.
+            //
+            // Implementation mirrors PushClip/PopClip — the scroll viewport is
+            // intersected with the current clip top so nested clips tighten
+            // correctly, and the existing balanced-stack warning fires for
+            // unmatched EndScroll calls.
+            DrawCommand::BeginScroll { x, y, w, h, .. } => {
+                let new_rect = egui::Rect::from_min_size(
+                    egui::pos2(origin.x + x, origin.y + y),
+                    egui::vec2(*w, *h),
+                );
+                let effective = clip.intersect(new_rect);
+                clip_stack.push(effective);
+            }
+
+            DrawCommand::EndScroll => {
+                if clip_stack.pop().is_none() {
+                    log::warn!("render: EndScroll on empty clip stack (app bug)");
+                }
+            }
         }
     }
 
@@ -423,7 +450,7 @@ pub(super) fn render_draw_commands(
     // subsequent frames or other panes.
     if !clip_stack.is_empty() {
         log::warn!(
-            "render: clip stack not empty at frame end (depth={}); app sent unbalanced PushClip/PopClip",
+            "render: clip stack not empty at frame end (depth={}); app sent unbalanced PushClip/PopClip or BeginScroll/EndScroll",
             clip_stack.len()
         );
     }


### PR DESCRIPTION
## Summary

- Adds `DrawCommand::BeginScroll { id, x, y, w, h, content_height }` and `DrawCommand::EndScroll` — app declares a scrollable viewport; host enforces clip
- Adds `PlexiEvent::ScrollOffset { id, offset_y }` — host emits this whenever the user scrolls inside a viewport so the app can re-render at the new offset
- Renderer: `BeginScroll` pushes the viewport rect onto the existing clip stack (intersected with the current top); `EndScroll` pops it — mirrors `PushClip`/`PopClip` exactly, so balanced-stack checks apply to both
- `ProcessApp`: new `scroll_offsets: HashMap<String, f32>` field persists offset per ID; per-frame scroll delta detection fires `ScrollOffset` only when the pointer is inside the declared viewport
- Python SDK: `ctx.begin_scroll(id, x, y, w, h, content_height)`, `ctx.end_scroll()`, `on_scroll(ctx, id, offset_y)` hook
- POC app at `examples/scroll-list/` renders 100 rows with virtual-scroll optimisation (only visible rows emitted as draw commands)

## Test plan

- [ ] Launch `scroll-list` on the alpha build
- [ ] Hover over the list and scroll with the mouse wheel — rows scroll, offset label updates
- [ ] Items outside the declared viewport height are clipped (not visible above/below the scroll region)
- [ ] No "clip stack not empty" warnings in `~/.plexi-alpha/plexi.log`
- [ ] `cargo build` passes clean

**Breaks if:** scroll wheel over the scroll-list pane produces no movement, or rows render outside the declared viewport bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)