### PR TITLE
fix(pgap): PlexiEvent::Mouse* events now fire in apps (#331)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1316,6 +1316,16 @@ class Emitter:
         """Cancel a pending timer set with set_timer()."""
         _emit({"type": "cancel_timer", "timer_id": timer_id})
 
+    def set_mouse_tracking(self, enabled: bool) -> None:
+        """Enable or disable PlexiEvent::MouseMove delivery for this pane.
+
+        MouseMove is off by default to avoid flooding apps that don't need
+        continuous pointer tracking. Call set_mouse_tracking(True) after
+        on_init to start receiving on_mouse_move callbacks. Call with False
+        to stop.
+        """
+        _emit({"type": "set_mouse_tracking", "enabled": enabled})
+
     # Binary pipe
     def pipe_open(self, pipe_id: str, mode: str = "binary",
                   direction: str = "in") -> "Pipe":
@@ -1834,6 +1844,12 @@ class RenderContext:
     def cancel_timer(self, timer_id: str) -> None:
         self.emit.cancel_timer(timer_id)
 
+    def set_mouse_tracking(self, enabled: bool) -> None:
+        """Enable or disable on_mouse_move delivery for this pane.
+        Call with True in on_init to start receiving mouse-move events.
+        Delegates to emit.set_mouse_tracking()."""
+        self.emit.set_mouse_tracking(enabled)
+
     def schedule_render(self, after_ms: int = 16) -> None:
         """Ask the host to send a new Render event after `after_ms` milliseconds.
         Delegates to emit.schedule_render(). 16 ms ≈ 60 fps. 32 ms ≈ 30 fps."""
@@ -1961,6 +1977,9 @@ class App:
     def on_render(self, _ctx: RenderContext) -> None: pass
     def on_key(self, _ctx: RenderContext, _key: str, _mods: dict) -> Coroutine[Any, Any, None] | None: return None
     def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> Coroutine[Any, Any, None] | None: return None
+    def on_mouse_down(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> Coroutine[Any, Any, None] | None: return None
+    def on_mouse_up(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> Coroutine[Any, Any, None] | None: return None
+    def on_mouse_move(self, _ctx: RenderContext, _x: float, _y: float, _buttons: list) -> Coroutine[Any, Any, None] | None: return None
     def on_command(self, _ctx: RenderContext, _text: str) -> Coroutine[Any, Any, None] | None: return None
     def on_paste(self, _ctx: RenderContext, _text: str) -> Coroutine[Any, Any, None] | None: return None
     def on_pipe_message(self, _ctx: RenderContext, _pipe_id: str, _payload: Any) -> Coroutine[Any, Any, None] | None: return None
@@ -2286,6 +2305,21 @@ class App:
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_click, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
                                              ev.get("button", "primary"))
+
+                elif t == "mouse_down":
+                    ctx = self._make_ctx()
+                    await self._dispatch_hook(self.on_mouse_down, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
+                                              ev.get("button", "primary"))
+
+                elif t == "mouse_up":
+                    ctx = self._make_ctx()
+                    await self._dispatch_hook(self.on_mouse_up, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
+                                              ev.get("button", "primary"))
+
+                elif t == "mouse_move":
+                    ctx = self._make_ctx()
+                    await self._dispatch_hook(self.on_mouse_move, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
+                                              ev.get("buttons", []))
 
                 elif t == "command":
                     ctx = self._make_ctx()

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -71,6 +71,14 @@ pub enum PlexiEvent {
     Key { key: String, modifiers: Modifiers },
     /// Mouse click at logical coordinates within the app surface.
     Click { x: f32, y: f32, button: MouseButton },
+    /// Pointer button pressed (fires on the frame the button goes down).
+    MouseDown { x: f32, y: f32, button: MouseButton },
+    /// Pointer button released (fires on the frame the button goes up).
+    MouseUp { x: f32, y: f32, button: MouseButton },
+    /// Pointer moved over the app surface. Only fires when the app has opted in
+    /// via `DrawCommand::SetMouseTracking { enabled: true }`. Pane-local
+    /// coordinates; `buttons` lists which buttons are currently held.
+    MouseMove { x: f32, y: f32, buttons: Vec<MouseButton> },
     /// User submitted a command via the command bar.
     Command { text: String },
     /// Response to a runtime CapabilityRequest.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -185,6 +185,11 @@ pub struct ProcessApp {
     /// When true, the click-to-reveal stderr overlay is displayed in the
     /// pane. Toggled by clicking a non-Running lifecycle pill.
     show_stderr_overlay: bool,
+    /// When true, `PlexiEvent::MouseMove` is delivered to the app every frame
+    /// that the pointer moves over the pane. Controlled by
+    /// `DrawCommand::SetMouseTracking { enabled }`. Off by default to avoid
+    /// flooding apps that don't need continuous pointer tracking.
+    mouse_tracking_enabled: bool,
     /// Per-pane host-owned text input buffers, keyed on the `id` field of
     /// `DrawCommand::TextInput`. Survives across frames and pane resizes
     /// — typed characters never reach the app until Enter triggers a
@@ -483,6 +488,7 @@ impl ProcessApp {
             pending_timers: HashMap::new(),
             lifecycle: lifecycle_tracker,
             show_stderr_overlay: false,
+            mouse_tracking_enabled: false,
             text_input_buffers: HashMap::new(),
             text_input_visible_prev: std::collections::HashSet::new(),
             scroll_offsets: HashMap::new(),
@@ -864,7 +870,8 @@ impl ProcessApp {
                 | DrawCommand::RequestCommandPreview { .. }
                 | DrawCommand::OpenArtifact { .. }
                 | DrawCommand::PushNav { .. }
-                | DrawCommand::PopNav { .. }) => {
+                | DrawCommand::PopNav { .. }
+                | DrawCommand::SetMouseTracking { .. }) => {
                     self.route_command(cmd);
                 }
                 // Visual commands, FrameDone, Ready, MeasureText, ScheduleRender
@@ -1071,7 +1078,8 @@ impl App for ProcessApp {
                 | DrawCommand::RequestCommandPreview { .. }
                 | DrawCommand::OpenArtifact { .. }
                 | DrawCommand::PushNav { .. }
-                | DrawCommand::PopNav { .. }) => {
+                | DrawCommand::PopNav { .. }
+                | DrawCommand::SetMouseTracking { .. }) => {
                     self.route_command(cmd);
                 }
                 other => self.pending_frame.push(other),
@@ -1250,22 +1258,94 @@ impl App for ProcessApp {
             false
         };
 
-        // Detect clicks over the pane and forward them as PlexiEvent::Click.
-        let click_response = ui.interact(pane_rect, ui.id(), egui::Sense::click());
+        // Detect pointer interactions over the pane rect and forward as
+        // PlexiEvent::{Click,MouseDown,MouseUp,MouseMove}.
+        //
+        // Sense::click_and_drag() is required here — Sense::click() alone only
+        // fires on button-release and does not track press or motion.
+        let mouse_response = ui.interact(pane_rect, ui.id(), egui::Sense::click_and_drag());
         if !pill_consumed_click {
-            if let Some(pos) = click_response.interact_pointer_pos() {
-                let origin = pane_rect.min;
-                let button = if click_response.secondary_clicked() {
-                    crate::app_protocol::MouseButton::Secondary
-                } else {
-                    crate::app_protocol::MouseButton::Primary
-                };
-                if click_response.clicked() || click_response.secondary_clicked() {
-                    self.send_event(&PlexiEvent::Click {
+            let origin = pane_rect.min;
+
+            // MouseDown — fires on the frame the primary or secondary button goes down.
+            if let Some(pos) = mouse_response.interact_pointer_pos() {
+                let is_primary_down = ui.input(|i| {
+                    i.pointer.button_pressed(egui::PointerButton::Primary)
+                        && pane_rect.contains(i.pointer.interact_pos().unwrap_or(pos))
+                });
+                let is_secondary_down = ui.input(|i| {
+                    i.pointer.button_pressed(egui::PointerButton::Secondary)
+                        && pane_rect.contains(i.pointer.interact_pos().unwrap_or(pos))
+                });
+                if is_primary_down {
+                    self.send_event(&PlexiEvent::MouseDown {
                         x: pos.x - origin.x,
                         y: pos.y - origin.y,
-                        button,
+                        button: crate::app_protocol::MouseButton::Primary,
                     });
+                }
+                if is_secondary_down {
+                    self.send_event(&PlexiEvent::MouseDown {
+                        x: pos.x - origin.x,
+                        y: pos.y - origin.y,
+                        button: crate::app_protocol::MouseButton::Secondary,
+                    });
+                }
+            }
+
+            // MouseUp — fires on the frame the button is released; also emits
+            // the legacy Click event for backwards compatibility with apps that
+            // use on_click rather than on_mouse_down/on_mouse_up.
+            if let Some(pos) = mouse_response.interact_pointer_pos() {
+                let x = pos.x - origin.x;
+                let y = pos.y - origin.y;
+                if mouse_response.clicked() {
+                    self.send_event(&PlexiEvent::MouseUp {
+                        x,
+                        y,
+                        button: crate::app_protocol::MouseButton::Primary,
+                    });
+                    self.send_event(&PlexiEvent::Click {
+                        x,
+                        y,
+                        button: crate::app_protocol::MouseButton::Primary,
+                    });
+                }
+                if mouse_response.secondary_clicked() {
+                    self.send_event(&PlexiEvent::MouseUp {
+                        x,
+                        y,
+                        button: crate::app_protocol::MouseButton::Secondary,
+                    });
+                    self.send_event(&PlexiEvent::Click {
+                        x,
+                        y,
+                        button: crate::app_protocol::MouseButton::Secondary,
+                    });
+                }
+            }
+
+            // MouseMove — only delivered when the app opts in via
+            // DrawCommand::SetMouseTracking { enabled: true }.
+            if self.mouse_tracking_enabled {
+                if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                    if pane_rect.contains(pos) && ui.input(|i| i.pointer.is_moving()) {
+                        let buttons = {
+                            let mut held = Vec::new();
+                            if ui.input(|i| i.pointer.button_down(egui::PointerButton::Primary)) {
+                                held.push(crate::app_protocol::MouseButton::Primary);
+                            }
+                            if ui.input(|i| i.pointer.button_down(egui::PointerButton::Secondary)) {
+                                held.push(crate::app_protocol::MouseButton::Secondary);
+                            }
+                            held
+                        };
+                        self.send_event(&PlexiEvent::MouseMove {
+                            x: pos.x - origin.x,
+                            y: pos.y - origin.y,
+                            buttons,
+                        });
+                    }
                 }
             }
         }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1293,13 +1293,18 @@ impl App for ProcessApp {
                 }
             }
 
-            // MouseUp — fires on the frame the button is released; also emits
-            // the legacy Click event for backwards compatibility with apps that
-            // use on_click rather than on_mouse_down/on_mouse_up.
+            // MouseUp — fires on the frame any button is released, including
+            // after a drag. clicked() only fires for clean clicks (no significant
+            // drag); drag_released() / drag_released_by() cover the drag-then-
+            // release case. Both paths also emit the legacy Click for compat.
             if let Some(pos) = mouse_response.interact_pointer_pos() {
                 let x = pos.x - origin.x;
                 let y = pos.y - origin.y;
-                if mouse_response.clicked() {
+                let primary_up = mouse_response.clicked()
+                    || mouse_response.drag_released();
+                let secondary_up = mouse_response.secondary_clicked()
+                    || mouse_response.drag_released_by(egui::PointerButton::Secondary);
+                if primary_up {
                     self.send_event(&PlexiEvent::MouseUp {
                         x,
                         y,
@@ -1311,7 +1316,7 @@ impl App for ProcessApp {
                         button: crate::app_protocol::MouseButton::Primary,
                     });
                 }
-                if mouse_response.secondary_clicked() {
+                if secondary_up {
                     self.send_event(&PlexiEvent::MouseUp {
                         x,
                         y,
@@ -1327,9 +1332,15 @@ impl App for ProcessApp {
 
             // MouseMove — only delivered when the app opts in via
             // DrawCommand::SetMouseTracking { enabled: true }.
+            // During a drag the pointer may leave the pane; we continue sending
+            // events while any button is held so the app can track drag-to-outside.
             if self.mouse_tracking_enabled {
                 if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                    if pane_rect.contains(pos) && ui.input(|i| i.pointer.is_moving()) {
+                    let is_dragging = ui.input(|i| {
+                        i.pointer.button_down(egui::PointerButton::Primary)
+                            || i.pointer.button_down(egui::PointerButton::Secondary)
+                    });
+                    if (pane_rect.contains(pos) || is_dragging) && ui.input(|i| i.pointer.is_moving()) {
                         let buttons = {
                             let mut held = Vec::new();
                             if ui.input(|i| i.pointer.button_down(egui::PointerButton::Primary)) {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -555,6 +555,16 @@ impl ProcessApp {
                 );
             }
 
+            // ── Mouse tracking toggle ──────────────────────────────────────
+            DrawCommand::SetMouseTracking { enabled } => {
+                self.mouse_tracking_enabled = enabled;
+                log::debug!(
+                    "ProcessApp[{}]: SetMouseTracking → {}",
+                    self.type_id,
+                    enabled
+                );
+            }
+
             // ── Spawn app ──────────────────────────────────────────────────
             DrawCommand::SpawnApp {
                 type_id,


### PR DESCRIPTION
## Summary

- `PlexiEvent::MouseDown`, `MouseUp`, and `MouseMove` variants never existed in the protocol enum — only `Click` was wired. The April 12 ship claim was false.
- Changed `Sense::click()` → `Sense::click_and_drag()` on the pane rect so `button_pressed()` and pointer motion are observable.
- Added `mouse_tracking_enabled` field to `ProcessApp`; `DrawCommand::SetMouseTracking { enabled }` controls it. `MouseMove` is opt-in (off by default) to avoid per-frame flooding.
- `Click` is still emitted on mouse-up for backwards compat with existing apps.
- Python SDK: `on_mouse_down`, `on_mouse_up`, `on_mouse_move` hooks; `set_mouse_tracking(True/False)` on `Emitter` and `RenderContext`.

## Files changed

- `src/app_protocol.rs` — added `MouseDown`/`MouseUp`/`MouseMove` to `PlexiEvent`; `SetMouseTracking` to `DrawCommand`
- `src/process_app/mod.rs` — `Sense::click_and_drag()`, dispatch logic, `mouse_tracking_enabled` field
- `src/process_app/routing.rs` — `SetMouseTracking` handler
- `src/process_app/render.rs` — safety-net no-op arm for `SetMouseTracking`
- `sdk/python/plexi_sdk/__init__.py` — hooks + dispatch arms + `set_mouse_tracking()`

## Test plan

- [ ] Install alpha build and open an existing app that uses `on_click` — clicks still work (backwards compat)
- [ ] Create a test app that overrides `on_mouse_down` / `on_mouse_up` and logs the coordinates — click in the pane and confirm both fire with pane-local coords
- [ ] Create a test app that calls `ctx.set_mouse_tracking(True)` in `on_init` and logs `on_mouse_move` — move mouse over the pane and confirm events arrive; move away and confirm they stop
- [ ] Confirm `on_mouse_move` is NOT called for an app that never calls `set_mouse_tracking(True)`

Closes #331