### PR TITLE
feat(pgap): navigation stack — PushNav/PopNav/NavBack (#392)

### DIFF
--- a/examples/nav-tester/manifest.toml
+++ b/examples/nav-tester/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "nav-tester"
+type = "app"
+name = "Nav Tester"
+version = "0.1.0"
+description = "POC for the PGAP navigation stack — PushNav/PopNav/NavBack (#392)."
+entry = "nav_tester.py"
+
+[app.capabilities]
+capabilities = []
+
+[launch]
+layout_hint = { side = "right", split = 0.4 }

--- a/examples/nav-tester/nav_tester.py
+++ b/examples/nav-tester/nav_tester.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Nav Tester — POC app for the PGAP navigation stack (#392).
+
+Demonstrates PushNav / PopNav / NavBack with a simple two-level UI:
+
+  List view  (root)      — shows 5 named items.  Press Enter or click to open.
+  Detail view (pushed)   — shows item detail.  Press Escape / Cmd+[ / back arrow
+                           to go back.
+
+The host shows a back arrow + view title in the pane chrome while the detail
+view is active.  When the user navigates back, the host emits NavBack and the
+app calls pop_nav() + returns to the list.
+"""
+
+from plexi_sdk import App, RenderContext, FG, MUTED, SURFACE, ACCENT, BODY, CAPTION  # type: ignore[attr-defined]
+
+# ── View identifiers ──────────────────────────────────────────────────────────
+VIEW_LIST   = ""          # root — empty string means "no back target"
+VIEW_DETAIL = "detail"
+
+# Sample items for the list
+ITEMS = [
+    ("Mountains",   "Tall rocky things with snow on top."),
+    ("Oceans",      "Very large and rather wet."),
+    ("Forests",     "Full of trees. Birds optional."),
+    ("Deserts",     "Surprisingly not empty."),
+    ("Tundra",      "Cold, flat, and windswept."),
+]
+
+
+class NavTesterApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._view = VIEW_LIST
+        self._selected = 0
+        self._detail_index = 0
+
+    # ── Navigation helpers ────────────────────────────────────────────────────
+
+    def _open_detail(self, ctx: RenderContext, index: int) -> None:
+        """Push the detail view onto the nav stack and switch views."""
+        self._detail_index = index
+        self._view = VIEW_DETAIL
+        name = ITEMS[index][0]
+        ctx.emit.push_nav(VIEW_DETAIL, name)
+
+    def _go_back(self, ctx: RenderContext) -> None:
+        """Return to the list view and pop the nav stack."""
+        self._view = VIEW_LIST
+        ctx.emit.pop_nav()
+
+    # ── NavBack handler ───────────────────────────────────────────────────────
+
+    def on_nav_back(self, ctx: RenderContext, view_id: str) -> None:
+        """Host emitted NavBack (Cmd+[ or back arrow in chrome).
+
+        ``view_id`` is the view we're going back *to*.  Since this app only
+        has one level of depth, that's always the root (empty string).
+        """
+        if view_id == VIEW_LIST:
+            self._go_back(ctx)
+
+    # ── Key handler ───────────────────────────────────────────────────────────
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if self._view == VIEW_LIST:
+            if key in ("ArrowUp", "k"):
+                self._selected = max(0, self._selected - 1)
+            elif key in ("ArrowDown", "j"):
+                self._selected = min(len(ITEMS) - 1, self._selected + 1)
+            elif key == "Enter":
+                self._open_detail(ctx, self._selected)
+        elif self._view == VIEW_DETAIL:
+            # Escape in the detail view triggers back navigation.  The host
+            # intercepts Escape when nav depth > 0 and sends NavBack instead of
+            # closing the pane — so we handle it here for apps that want to
+            # process it directly too.  NavBack is the canonical path; this is
+            # just belt-and-suspenders for apps that don't want to wait.
+            if key == "Escape":
+                self._go_back(ctx)
+
+    # ── Render ────────────────────────────────────────────────────────────────
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.background()
+
+        if self._view == VIEW_LIST:
+            self._render_list(ctx)
+        else:
+            self._render_detail(ctx)
+
+    def _render_list(self, ctx: RenderContext) -> None:
+        w, h = ctx.w, ctx.h
+        pad = 16.0
+        y = pad
+
+        ctx.text(pad, y, "Navigation Stack Tester", size=16.0, color=FG, bold=True)
+        y += 28.0
+        ctx.text(pad, y, "Select an item and press Enter to open detail view.",
+                 size=CAPTION, color=MUTED)
+        y += 24.0
+
+        row_h = 40.0
+        for i, (name, _) in enumerate(ITEMS):
+            row_y = y + i * row_h
+            is_sel = i == self._selected
+            bg = ACCENT if is_sel else SURFACE
+            fg = FG
+            ctx.rect(pad, row_y, w - pad * 2, row_h - 2, fill=bg, radius=4.0)
+            ctx.text(pad + 12, row_y + 12, name, size=BODY, color=fg)
+
+        footer_y = h - 28.0
+        ctx.text(pad, footer_y, "↑/↓ select   Enter open",
+                 size=CAPTION, color=MUTED)
+
+    def _render_detail(self, ctx: RenderContext) -> None:
+        w, h = ctx.w, ctx.h
+        pad = 16.0
+        y = pad
+
+        name, desc = ITEMS[self._detail_index]
+
+        ctx.text(pad, y, name, size=18.0, color=FG, bold=True)
+        y += 32.0
+        ctx.rect(pad, y, w - pad * 2, 1, fill=SURFACE, radius=0.0)
+        y += 12.0
+        ctx.text(pad, y, desc, size=BODY, color=FG)
+        y += 24.0
+        ctx.text(pad, y, "This is the detail view.  Use Cmd+[ or the back arrow to go back.",
+                 size=CAPTION, color=MUTED)
+
+        footer_y = h - 28.0
+        ctx.text(pad, footer_y, "Cmd+[ or back arrow to return to list",
+                 size=CAPTION, color=MUTED)
+
+
+if __name__ == "__main__":
+    NavTesterApp().run()

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -789,6 +789,32 @@ class Emitter:
     def status_summary(self, text: str) -> None:
         _emit({"type": "status_summary", "text": text})
 
+    # ── Navigation stack (#392) ─────────────────────────────────────────────
+
+    def push_nav(self, view_id: str, title: str) -> None:
+        """Push a new view onto the host navigation stack.
+
+        The host appends an entry keyed on `view_id` with display `title`
+        and shows a back arrow + `title` in the pane chrome while this view
+        is active. Cmd+[ (or clicking the back arrow) sends
+        ``PlexiEvent::NavBack { view_id }`` back to the app, where
+        ``view_id`` is the view being navigated *back to* (the entry below
+        the current top, or empty string for root).
+
+        The app is responsible for tracking its own internal view state and
+        calling ``pop_nav()`` after navigating back.
+        """
+        _emit({"type": "push_nav", "view_id": view_id, "title": title})
+
+    def pop_nav(self) -> None:
+        """Pop the current view off the host navigation stack.
+
+        Call this after the app has already rendered the previous view (e.g.
+        inside the ``on_nav_back`` handler). The host removes the top entry
+        from the stack; if the stack becomes empty the back arrow disappears.
+        """
+        _emit({"type": "pop_nav"})
+
     def cd_to(self, cwd: str) -> None:
         """Request the host to cd all terminals in the same pane group to `cwd`."""
         _emit({"type": "cd_request", "cwd": cwd})
@@ -1966,6 +1992,15 @@ class App:
     def on_pipe_message(self, _ctx: RenderContext, _pipe_id: str, _payload: Any) -> Coroutine[Any, Any, None] | None: return None
     def on_path_changed(self, _ctx: RenderContext, _cwd: str) -> Coroutine[Any, Any, None] | None: return None
     def on_inject(self, _ctx: RenderContext, _payload: Any) -> Coroutine[Any, Any, None] | None: return None
+    def on_nav_back(self, _ctx: RenderContext, _view_id: str) -> "Coroutine[Any, Any, None] | None":
+        """Called when the host emits ``NavBack`` — user pressed Cmd+[ or the
+        back arrow in the pane chrome. ``view_id`` is the view being navigated
+        *back to* (the new top of stack, or empty string for root).
+
+        The app should update its own view state to show ``view_id``, then call
+        ``ctx.emit.pop_nav()`` to remove the entry from the host stack.
+        """
+        return None
     def on_app_spawned(self, _pane_id: int, _type_id: str) -> None: pass
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> Coroutine[Any, Any, None] | None: return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> Coroutine[Any, Any, None] | None: return None
@@ -2381,6 +2416,15 @@ class App:
                         self.on_app_spawned,
                         int(ev.get("pane_id", 0)),
                         str(ev.get("type_id", "")),
+                    )
+
+                elif t == "nav_back":
+                    # Navigation stack back event (#392). The host pops the top
+                    # nav entry and sends this with the view_id the app should
+                    # navigate back to (empty string = root view).
+                    ctx = self._make_ctx()
+                    await self._dispatch_hook(
+                        self.on_nav_back, ctx, str(ev.get("view_id", ""))
                     )
 
         reader_task = asyncio.create_task(_reader())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1506,42 +1506,22 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::ClosePane => {
-                    // If the focused app pane has declared internal navigation
-                    // depth (via PushNav), Escape routes NavBack to the app
+                    // If the focused app pane has a non-empty nav stack
+                    // (via PushNav), Escape routes NavBack to the app
                     // instead of closing the pane.
-                    let nav_pane_id = {
-                        let active_ctx = &self.windows[self.active_window];
-                        active_ctx.focused_pane.and_then(|tile_id| {
-                            if let Some(egui_tiles::Tile::Pane(pane_id)) =
-                                active_ctx.tree.tiles.get(tile_id)
-                            {
-                                active_ctx.panes.get(pane_id).and_then(|pane| {
-                                    pane.as_app().and_then(|app| {
-                                        if app.runtime.nav_stack_depth() > 0 {
-                                            Some(*pane_id)
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                    };
-                    if let Some(pane_id) = nav_pane_id {
-                        let active = self.active_window;
-                        if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
-                            if let Some(app) = pane.as_app_mut() {
-                                app.runtime.queue_outbound_event(
-                                    crate::app_protocol::PlexiEvent::NavBack {},
-                                );
-                            }
+                    if !self.try_nav_back_focused() {
+                        if self.confirm_close() {
+                            self.pending_close = true;
+                        } else if self.execute_close_pane() {
+                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         }
-                    } else if self.confirm_close() {
-                        self.pending_close = true;
-                    } else if self.execute_close_pane() {
-                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                }
+                Action::NavBackApp => {
+                    // Cmd+[ when a nav-active app pane is focused: go back one
+                    // level. Falls through to cycling tabs backwards if no nav is active.
+                    if !self.try_nav_back_focused() {
+                        self.cycle_tab(false);
                     }
                 }
                 Action::NewTab => self.new_tab(),
@@ -1611,9 +1591,6 @@ impl eframe::App for PlexiApp {
                 }
                 Action::NextTab => {
                     self.cycle_tab(true);
-                }
-                Action::PrevTab => {
-                    self.cycle_tab(false);
                 }
                 Action::IncreasePaneFontSize => {
                     self.adjust_focused_pane_font_size(1.0);
@@ -2090,6 +2067,45 @@ impl PlexiApp {
     /// users get the confirmation dialog unless they explicitly opt out.
     pub(crate) fn confirm_close(&self) -> bool {
         self.config.confirm_close.unwrap_or(true)
+    }
+
+    /// If the currently focused pane is an app with a non-empty nav stack,
+    /// emit `PlexiEvent::NavBack` to it and return `true`. Returns `false`
+    /// when there is no nav-active focused pane (caller may fall back to
+    /// default behaviour such as closing the pane or cycling tabs).
+    pub(crate) fn try_nav_back_focused(&mut self) -> bool {
+        let active = self.active_window;
+        let active_ctx = &self.windows[active];
+
+        // Read nav state under shared borrow first.
+        let nav_result = active_ctx.focused_pane.and_then(|tile_id| {
+            if let Some(egui_tiles::Tile::Pane(pane_id)) = active_ctx.tree.tiles.get(tile_id) {
+                active_ctx.panes.get(pane_id).and_then(|pane| {
+                    pane.as_app().and_then(|app| {
+                        if app.runtime.nav_stack_depth() > 0 {
+                            Some((*pane_id, app.runtime.nav_back_view_id()))
+                        } else {
+                            None
+                        }
+                    })
+                })
+            } else {
+                None
+            }
+        });
+
+        if let Some((pane_id, view_id)) = nav_result {
+            if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
+                if let Some(app) = pane.as_app_mut() {
+                    app.runtime.queue_outbound_event(
+                        crate::app_protocol::PlexiEvent::NavBack { view_id },
+                    );
+                }
+            }
+            true
+        } else {
+            false
+        }
     }
 
     /// Re-read configuration from disk and apply changes that can take

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1086,15 +1086,16 @@ pub enum DrawCommand {
     OpenArtifact { path: String, mode: ArtifactOpenMode },
 
     // ── Navigation stack ─────────────────────────────────────────────────
-    /// App signals it has pushed a navigation level. The host increments its
-    /// per-pane nav stack depth counter. While depth > 0, pressing Escape
-    /// emits `PlexiEvent::NavBack` to the app instead of closing the pane.
+    /// App signals it has pushed a navigation level. The host appends the
+    /// entry to its per-pane nav stack. While the stack has entries, the pane
+    /// chrome shows a back arrow + the current view's title, and Cmd+[
+    /// emits `PlexiEvent::NavBack` to the app instead of cycling tabs.
     ///
-    /// The optional `title` is reserved for future breadcrumb rendering and
-    /// is ignored by the host in this version.
-    PushNav { title: String },
-    /// App signals it has popped a navigation level. The host decrements its
-    /// per-pane nav stack depth counter (saturating — never below 0).
+    /// `view_id` must be a stable identifier for this view (e.g. `"detail"`);
+    /// `title` is shown in the pane chrome while this view is active.
+    PushNav { view_id: String, title: String },
+    /// App signals it has popped a navigation level. The host removes the top
+    /// entry from the per-pane nav stack (saturating — no-op on empty stack).
     PopNav {},
 
     // ── Host-managed scroll regions (#446) ───────────────────────────────

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -57,7 +57,6 @@ pub enum Action {
     NewTab,
     SwitchContext(usize),
     NextTab,
-    PrevTab,
     Quit,
     ToggleSidebar,
     ToggleShortcuts,
@@ -109,6 +108,10 @@ pub enum Action {
     ToggleMinimap,
     /// Reload configuration from disk. Bound to Cmd+Shift+,.
     ReloadConfig,
+    /// Cmd+[ when a nav-active app pane is focused: pop one nav level and
+    /// emit `PlexiEvent::NavBack`. Falls through to cycling tabs backwards
+    /// if no nav is active on the focused pane.
+    NavBackApp,
 }
 
 /// Poll global keyboard actions.
@@ -201,7 +204,7 @@ pub fn poll_actions(
             actions.push(if notification_modal_open {
                 Action::NotificationCyclePrev
             } else {
-                Action::PrevTab
+                Action::NavBackApp
             });
         }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -215,6 +215,24 @@ impl AppRuntime {
             AppRuntime::Builtin(_) => 0,
         }
     }
+
+    /// Title of the current top-of-stack view for pane chrome display.
+    /// `None` when the stack is empty (root view — no back arrow shown).
+    pub fn nav_top_title(&self) -> Option<&str> {
+        match self {
+            AppRuntime::Process(app) => app.nav_top_title(),
+            AppRuntime::Builtin(_) => None,
+        }
+    }
+
+    /// The `view_id` the app should navigate back to (the entry below current
+    /// top, or empty string for root). Used to populate `NavBack { view_id }`.
+    pub fn nav_back_view_id(&self) -> String {
+        match self {
+            AppRuntime::Process(app) => app.nav_back_view_id(),
+            AppRuntime::Builtin(_) => String::new(),
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -73,6 +73,20 @@ enum StdinItem {
 }
 
 // ---------------------------------------------------------------------------
+// NavEntry
+// ---------------------------------------------------------------------------
+
+/// One entry on a pane's navigation stack, pushed by `DrawCommand::PushNav`.
+#[derive(Debug, Clone)]
+pub struct NavEntry {
+    /// Stable identifier for this view (e.g. `"detail"`). Echoed back to the
+    /// app in `PlexiEvent::NavBack { view_id }` when this becomes the active view.
+    pub view_id: String,
+    /// Human-readable title shown in the pane chrome while this view is active.
+    pub title: String,
+}
+
+// ---------------------------------------------------------------------------
 // ProcessApp
 // ---------------------------------------------------------------------------
 
@@ -116,10 +130,11 @@ pub struct ProcessApp {
     pub(crate) run_registry: RunRegistry,
     pub(crate) pending_prompts: VecDeque<PendingPrompt>,
     pub(crate) status_summary: Option<String>,
-    /// Current navigation stack depth as reported by the app via
-    /// `DrawCommand::PushNav` / `DrawCommand::PopNav`. When > 0, Escape emits
-    /// `PlexiEvent::NavBack` to the app instead of closing the pane.
-    pub(crate) nav_stack_depth: usize,
+    /// Navigation stack maintained by `DrawCommand::PushNav` / `PopNav`.
+    /// Each entry carries a stable `view_id` and a display `title`. When the
+    /// stack is non-empty the pane chrome shows a back arrow + the top title,
+    /// and Cmd+[ emits `PlexiEvent::NavBack` to the app.
+    pub(crate) nav_stack: Vec<NavEntry>,
     pub(crate) outbound_events: VecDeque<PlexiEvent>,
     pub(crate) secret_input_buf: String,
     /// Recent stderr lines from the subprocess. Capped at the last
@@ -463,7 +478,7 @@ impl ProcessApp {
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
             status_summary: None,
-            nav_stack_depth: 0,
+            nav_stack: Vec::new(),
             outbound_events: VecDeque::new(),
             secret_input_buf: String::new(),
             recent_stderr: Arc::clone(&recent_stderr_capture),
@@ -499,9 +514,26 @@ impl ProcessApp {
     }
 
     /// Current nav stack depth as tracked by `PushNav`/`PopNav` commands.
-    /// Returns 0 for Builtin apps that never emit these commands.
+    /// Returns 0 for apps that have never pushed a view.
     pub fn nav_stack_depth(&self) -> usize {
-        self.nav_stack_depth
+        self.nav_stack.len()
+    }
+
+    /// The title of the current top-of-stack view, or `None` when the stack
+    /// is empty (root view — no back navigation available).
+    pub fn nav_top_title(&self) -> Option<&str> {
+        self.nav_stack.last().map(|e| e.title.as_str())
+    }
+
+    /// The `view_id` the app should navigate *back to* — the entry below the
+    /// current top, or empty string when the stack would return to root.
+    pub fn nav_back_view_id(&self) -> String {
+        let len = self.nav_stack.len();
+        if len >= 2 {
+            self.nav_stack[len - 2].view_id.clone()
+        } else {
+            String::new()
+        }
     }
 
     pub(crate) fn send_event(&mut self, event: &PlexiEvent) {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -538,20 +538,21 @@ impl ProcessApp {
             }
 
             // ── Navigation stack ───────────────────────────────────────────
-            DrawCommand::PushNav { title: _ } => {
-                self.nav_stack_depth = self.nav_stack_depth.saturating_add(1);
+            DrawCommand::PushNav { view_id, title } => {
+                self.nav_stack.push(crate::process_app::NavEntry { view_id, title });
                 log::debug!(
-                    "ProcessApp[{}]: PushNav → depth={}",
+                    "ProcessApp[{}]: PushNav → depth={} title={:?}",
                     self.type_id,
-                    self.nav_stack_depth
+                    self.nav_stack.len(),
+                    self.nav_stack.last().map(|e| &e.title),
                 );
             }
             DrawCommand::PopNav {} => {
-                self.nav_stack_depth = self.nav_stack_depth.saturating_sub(1);
+                self.nav_stack.pop();
                 log::debug!(
                     "ProcessApp[{}]: PopNav → depth={}",
                     self.type_id,
-                    self.nav_stack_depth
+                    self.nav_stack.len(),
                 );
             }
 

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -1,14 +1,79 @@
 //! App pane render path — extracted from `tiling::PlexiBehavior::pane_ui`.
 //!
 //! Builds the `AppRenderContext` and delegates to the app runtime's `ui`
-//! method. The outer `pane_ui` path already painted the pane background and
-//! shrunk into the inner UI, so this renderer does not repaint.
+//! method. When the app has a non-empty navigation stack, a slim nav bar is
+//! rendered above the app content showing the current view title and a back
+//! arrow (‹). Clicking the back arrow emits `PlexiEvent::NavBack` to the app.
 
+use crate::app_protocol::PlexiEvent;
 use crate::app_trait::AppRenderContext;
 use crate::pane::AppPane;
+use crate::style;
 use crate::theme::Colors;
+use egui::RichText;
+
+/// Height of the nav bar shown when the app has pushed at least one view.
+const NAV_BAR_HEIGHT: f32 = 32.0;
+/// Horizontal padding inside the nav bar.
+const NAV_BAR_PAD: f32 = style::SPACE_SM;
 
 pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_focused: bool) {
-    let ctx = AppRenderContext { colors, is_focused };
-    app_pane.runtime.ui(ui, &ctx);
+    // Check if we need a nav bar (non-empty stack).
+    let nav_title: Option<String> = app_pane
+        .runtime
+        .nav_top_title()
+        .map(|t| t.to_owned());
+
+    if let Some(title) = nav_title {
+        // Render nav bar at the top, then app content below.
+        let nav_back_view_id = app_pane.runtime.nav_back_view_id();
+
+        ui.vertical(|ui| {
+            let bar_rect = egui::Rect::from_min_size(
+                ui.cursor().left_top(),
+                egui::vec2(ui.available_width(), NAV_BAR_HEIGHT),
+            );
+
+            // Dim background for the nav bar to distinguish it from app content.
+            ui.painter().rect_filled(bar_rect, 0.0, colors.bg_active);
+
+            ui.allocate_ui_at_rect(bar_rect, |ui| {
+                ui.horizontal_centered(|ui| {
+                    ui.add_space(NAV_BAR_PAD);
+
+                    // Back arrow button — ‹ (single angle quotation mark, U+2039)
+                    let back_btn = ui.add(
+                        egui::Button::new(
+                            RichText::new("‹")
+                                .size(style::TEXT_BODY + 2.0)
+                                .color(colors.accent),
+                        )
+                        .frame(false),
+                    );
+                    if back_btn.clicked() {
+                        app_pane.runtime.queue_outbound_event(
+                            PlexiEvent::NavBack { view_id: nav_back_view_id },
+                        );
+                    }
+
+                    ui.add_space(4.0);
+
+                    // Current view title — truncate with ellipsis if needed.
+                    ui.label(
+                        RichText::new(&title)
+                            .size(style::TEXT_CAPTION)
+                            .color(colors.text_dim),
+                    );
+                });
+            });
+
+            // App content fills remaining space.
+            let ctx = AppRenderContext { colors, is_focused };
+            app_pane.runtime.ui(ui, &ctx);
+        });
+    } else {
+        // No nav stack — render app content directly (hot path, no allocation).
+        let ctx = AppRenderContext { colors, is_focused };
+        app_pane.runtime.ui(ui, &ctx);
+    }
 }


### PR DESCRIPTION
## Summary

- Upgrades `DrawCommand::PushNav` to carry both `view_id` and `title` (was title-only with view_id ignored). Upgrades `PlexiEvent::NavBack` to carry `view_id` (the view being navigated *back to*).
- Replaces the bare `nav_stack_depth: usize` counter in `ProcessApp` with `nav_stack: Vec<NavEntry>` so the host tracks the full stack and can supply the correct `view_id` in `NavBack` events.
- Adds a slim nav bar to the app pane chrome: when the stack is non-empty, a back arrow (‹) + the current view title are shown above the app content. Clicking the arrow emits `NavBack`.
- Cmd+[ now triggers back navigation on nav-active app panes and falls through to tab cycling when no nav is active (`PrevTab` action removed — it was only ever reachable via Cmd+[).
- Python SDK: `emit.push_nav(view_id, title)`, `emit.pop_nav()`, and `on_nav_back(ctx, view_id)` hook.
- `examples/nav-tester/`: two-level list → detail POC demonstrating the full round-trip.

## Test plan

- [ ] `cargo build` passes clean (verified)
- [ ] Open the `nav-tester` example app; verify the list view renders with 5 items
- [ ] Press Enter on an item — detail view opens, back arrow + item name appear in pane chrome
- [ ] Click the back arrow — returns to list view, chrome disappears
- [ ] Open detail again, press Cmd+[ — returns to list view
- [ ] Verify Cmd+[ on a pane with no active nav still cycles tabs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)