### PR TITLE
fix(egui_term): replace link-open panic with warn log

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -405,9 +405,9 @@ impl TerminalBackend {
                 }
             }
 
-            open::that(url).unwrap_or_else(|_| {
-                panic!("link opening is failed");
-            })
+            if let Err(e) = open::that(&url) {
+                log::warn!("egui_term: failed to open link {:?}: {}", url, e);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `open::that(url)` in `egui_term`'s terminal backend was wrapped in a `panic!` on failure, crashing the entire host process
- Replaced with a `log::warn!` — failed link opens are surfaced in the log with the URL and OS error, but the host keeps running

**Root cause:** `deps/egui_term/src/backend/mod.rs:408` — `unwrap_or_else(|_| panic!("link opening is failed"))`. Triggered in beta on 2026-04-30 23:50:34 by clicking a link that the OS couldn't open.

**Breaks if:** clicking a URL in a terminal pane crashes the host instead of logging a warning.

## Test plan
- [ ] Open a terminal pane, click a valid URL — should open in browser as normal
- [ ] Check log — no panic entries after link clicks