### PR TITLE
feat: May 1 session — palette overhaul, pulse removal, shortcut fixes, UI polish

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,51 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-05-01 — [CHANGED] Remove PLEXI logo + toolbar label; normalize dot sizes
+
+Removed the "PLEXI" heading and divider from the sidebar top (`sidebar.rs`). Removed the context/pane title label from the toolbar (`overlays.rs` `draw_toolbar`). Toolbar dots and tab dots both set to radius 4.0, spacing 12.0 — a slight bump from the original 3.5/4.0 without oversizing.
+
+## 2026-05-01 — [CHANGED] Shortcuts overlay redesign — two-column layout, square chips, HJKL blocks
+
+Widened the shortcuts overlay from 320px to 620px and split it into two columns. Left: pane/window management. Right: navigation (HJKL blocks at top). Key chips are now square for single-char keys (`chip_w` floor raised from fixed 18px to `chip_h`). HJKL navigation rendered as `⌘ [H][J][K][L]` and `⌘⇧ [H][J][K][L]` blocks instead of paired two-combo rows. Fixed stale label: `⌘N` → "New terminal", `⌘⇧N` → "New context".
+
+## 2026-05-01 — [FIX] Reload Configuration keyboard shortcut not firing
+
+`Cmd+Shift+,` via egui's `consume_key` was unreliable — macOS can consume shift+comma before egui sees it. The "Reload Configuration" menu item also had an empty `keyEquivalent`, so macOS had no knowledge of the shortcut. Fixed by setting `keyEquivalent: ","` and `keyEquivalentModifierMask: NSEventModifierFlagCommand | NSEventModifierFlagShift` on the menu item in `macos_menu.rs`. The macOS menu now intercepts the key and fires the `RELOAD_CONFIG_FLAG` atomic → `reload_config()` path, which is the same path that clicking the menu item uses and is known to work.
+
+## 2026-05-01 — [CHANGED] Gut TextEditorApp — Cmd+, now opens system editor
+
+Deleted `src/text_editor_app.rs` entirely. `Action::OpenConfig` (Cmd+,) now calls `open_config_file()` — the same `open` invocation the macOS menu uses — instead of spawning the half-baked in-app text viewer. `Cmd+Shift+,` (`ReloadConfig`) was already correct and unchanged.
+
+## 2026-05-01 — [CHANGED] Command palette — context/pane model overhaul
+
+Rewrote the palette entry logic three times to converge on the right model. Key decisions:
+
+**Terminology settled:** Context = sidebar project item (`Context.name`). Window = spatial grid page within a context (`Window.name` — never user-set, always auto-generated). Pane = individual terminal/app split (`TerminalPane.name: Option<String>` — user-set via rename-pane overlay). The palette should surface contexts and named panes; windows are invisible to the user.
+
+**Window.name stripped from palette entirely.** Old auto-names ("Page X,Y", "Context N") were written before windows defaulted to `""`. Migration strips them on load via `is_auto_window_name()` in `app/mod.rs`. New windows get `name: String::new()` at creation.
+
+**Primary entry model:** Each context gets exactly one primary entry. If the active pane (context_active_window → focused_pane → TerminalPane.name) is named, that named pane IS the primary entry ("context › pane-name"). If unnamed, the context name is shown bare. Additional named panes (not the active one) appear as secondary entries below. This preserves the ⌘P → ↓ → Enter flow — the first entry for each context always represents wherever you last were.
+
+**Named pane jump now focuses the pane.** `jump_to_context` gained an optional `pane_id` param. When set, it finds the `TileId` for that pane in the window's tile tree and sets `window.focused_pane`.
+
+**`delete_window` cleanup:** Added `context_active_window` update when the deleted window was the stored last-visited for its context, preventing palette navigation to ghost window IDs.
+
+**Minimap page numbers:** Changed from 1-based to 0-based (`p + 1` → `p` in minimap.rs).
+
+**Breaks if:** Jumping to a named pane from the palette doesn't focus that pane (tile tree walk fails). Or: a context with a named active pane shows a bare context-name entry instead of the pane name (primary entry logic fell through to unnamed path).
+
+## 2026-05-01 — [CHANGED] Gut pulse beta feature — applied to full window border, not per-pane
+
+Removed `pulse` entirely: `BetaConfig.pulse` field, the `# pulse = false` line in the config template, the `features.rs` flag insertion, and the `draw_feature_effects` rendering block. The implementation painted a breathing glow rect over `ctx.screen_rect()` — the entire window border — with no per-pane awareness. Gutted rather than fixed; can be revisited properly when the renderer has a focused-pane rect to target. `ghost` and `crt` flags are unaffected.
+
+## 2026-05-01 — [GOTCHA] theme_preset silently ignored — TOML section ordering
+
+`theme_preset` is a top-level field in `PlexiConfig` but `CONFIG_TEMPLATE` placed it after the `[notifications]` section header. TOML parses all keys after a `[section]` header as belonging to that section, so `theme_preset` was deserialized as `notifications.theme_preset`. `NotificationsConfig` has no such field, serde silently drops it, and `PlexiConfig.theme_preset` is always `None` — no preset ever applied.
+
+Fix: moved `theme_preset` above `[notifications]` in `CONFIG_TEMPLATE`. Also updated `~/.plexi-alpha/config.toml` (the existing user config had the same ordering).
+
+**What NOT to do:** Any top-level TOML key added to `PlexiConfig` must appear in the template *before* the first `[section]` header, or it will silently be swallowed by that section. Never place bare keys between two section headers in the template.
+
 ## 2026-04-30 — [FIX] Async input handlers stall event loop; import crash from list builtin shadow (PR #466 → alpha)
 
 **Issue #393 — blocking in event handlers freezes frame loop.** `_dispatcher` used `await _dispatch_hook(hook, ...)` for all events including input hooks. A slow `on_key` suspended the dispatcher — no further events processed, app froze. Fix: `_dispatch_hook_task` schedules async hooks via `asyncio.create_task()`. `on_render`, `on_init`, `on_shutdown` still awaited for ordering. Task refs stored in `_background_tasks` set to prevent GC; `_log_task_exception` callback surfaces unhandled errors.

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -10,6 +10,8 @@ enum PaletteEntry {
         context_id: u64,
         name: String,
         workspace_name: String,
+        /// If set, focus this specific pane after navigating to the window.
+        pane_id: Option<u64>,
     },
     App {
         id: String,
@@ -43,33 +45,132 @@ impl PlexiApp {
         };
 
         let mut entries: Vec<PaletteEntry> = {
-            let mut ctx_entries: Vec<PaletteEntry> = self
-                .windows
-                .iter()
-                .enumerate()
-                .filter_map(|(ci, w)| {
-                    let ctx_name = self
-                        .contexts
-                        .iter()
-                        .find(|c| c.context_id == w.context_id)
-                        .map(|c| c.name.clone())
-                        .unwrap_or_default();
+            // For each context we emit exactly ONE primary entry — either the
+            // context name (active pane is unnamed) or "context › pane-name"
+            // (active pane is named). Additional named panes beyond the active
+            // one appear as secondary entries. This keeps the ⌘P → ↓ → Enter
+            // flow clean: the top entry for each context always represents the
+            // most-recently-active pane.
+            let mut seen_contexts: std::collections::HashSet<u64> =
+                std::collections::HashSet::new();
+            let mut ctx_entries: Vec<PaletteEntry> = Vec::new();
 
-                    if query.is_empty()
-                        || w.name.to_lowercase().contains(&query)
-                        || ctx_name.to_lowercase().contains(&query)
-                    {
-                        Some(PaletteEntry::Context {
-                            ctx_idx: ci,
-                            context_id: w.window_id,
-                            name: w.name.clone(),
-                            workspace_name: ctx_name,
+            // Resolve the active pane name for a context (following
+            // context_active_window → focused_pane → terminal name).
+            let active_pane_for_context = |ctx_id: u64| -> Option<(usize, u64, u64, String)> {
+                let active_win_id = self.context_active_window.get(&ctx_id).copied()?;
+                let (win_ci, win) = self
+                    .windows
+                    .iter()
+                    .enumerate()
+                    .find(|(_, w)| w.window_id == active_win_id)?;
+                let tile_id = win.focused_pane?;
+                let tile = win.tree.tiles.get(tile_id)?;
+                let pane_id = match tile {
+                    egui_tiles::Tile::Pane(pid) => *pid,
+                    _ => return None,
+                };
+                let pane_name = win
+                    .panes
+                    .get(&pane_id)
+                    .and_then(|p| p.as_terminal())
+                    .and_then(|t| t.name.clone())?;
+                Some((win_ci, active_win_id, pane_id, pane_name))
+            };
+
+            for (ci, w) in self.windows.iter().enumerate() {
+                let ctx_name = self
+                    .contexts
+                    .iter()
+                    .find(|c| c.context_id == w.context_id)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_default();
+
+                // Primary entry — one per context.
+                if !seen_contexts.contains(&w.context_id) {
+                    seen_contexts.insert(w.context_id);
+
+                    // Fallback window if context_active_window is absent/stale.
+                    let fallback_win_id = self
+                        .context_active_window
+                        .get(&w.context_id)
+                        .copied()
+                        .and_then(|id| {
+                            self.windows.iter().enumerate().find(|(_, w2)| w2.window_id == id)
                         })
+                        .map(|(i, w2)| (i, w2.window_id))
+                        .unwrap_or((ci, w.window_id));
+
+                    if let Some((win_ci, win_id, pane_id, pane_name)) =
+                        active_pane_for_context(w.context_id)
+                    {
+                        // Active pane is named — it IS the primary entry.
+                        if query.is_empty()
+                            || pane_name.to_lowercase().contains(&query)
+                            || ctx_name.to_lowercase().contains(&query)
+                        {
+                            ctx_entries.push(PaletteEntry::Context {
+                                ctx_idx: win_ci,
+                                context_id: win_id,
+                                name: pane_name,
+                                workspace_name: ctx_name.clone(),
+                                pane_id: Some(pane_id),
+                            });
+                        }
                     } else {
-                        None
+                        // Active pane is unnamed — show the context by name.
+                        if query.is_empty() || ctx_name.to_lowercase().contains(&query) {
+                            ctx_entries.push(PaletteEntry::Context {
+                                ctx_idx: fallback_win_id.0,
+                                context_id: fallback_win_id.1,
+                                name: ctx_name.clone(),
+                                workspace_name: String::new(),
+                                pane_id: None,
+                            });
+                        }
                     }
-                })
-                .collect();
+                }
+
+                // Secondary entries — named panes that are NOT the active pane.
+                let active_win_id = self
+                    .context_active_window
+                    .get(&w.context_id)
+                    .copied()
+                    .unwrap_or(0);
+                let active_pane_id = if w.window_id == active_win_id {
+                    w.focused_pane.and_then(|tid| {
+                        w.tree.tiles.get(tid).and_then(|tile| match tile {
+                            egui_tiles::Tile::Pane(pid) => Some(*pid),
+                            _ => None,
+                        })
+                    })
+                } else {
+                    None
+                };
+
+                for (&pane_id, pane) in &w.panes {
+                    if let Some(t) = pane.as_terminal() {
+                        if let Some(pane_name) = &t.name {
+                            // Skip if this is already the primary entry.
+                            if Some(pane_id) == active_pane_id && w.window_id == active_win_id {
+                                continue;
+                            }
+                            if query.is_empty()
+                                || pane_name.to_lowercase().contains(&query)
+                                || ctx_name.to_lowercase().contains(&query)
+                            {
+                                ctx_entries.push(PaletteEntry::Context {
+                                    ctx_idx: ci,
+                                    context_id: w.window_id,
+                                    name: pane_name.clone(),
+                                    workspace_name: ctx_name.clone(),
+                                    pane_id: Some(pane_id),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
 
             ctx_entries.sort_by_key(|e| match e {
                 PaletteEntry::Context { context_id, .. } => rank_of(*context_id),
@@ -152,7 +253,7 @@ impl PlexiApp {
         // ── Keyboard nav ───────────────────────────────────────────────────
         #[derive(Clone)]
         enum Action {
-            JumpContext(usize, u64),
+            JumpContext(usize, u64, Option<u64>),
             LaunchApp(String),
             RunAction(String),
         }
@@ -182,9 +283,10 @@ impl PlexiApp {
                     Some(PaletteEntry::Context {
                         ctx_idx,
                         context_id,
+                        pane_id,
                         ..
                     }) => {
-                        action = Some(Action::JumpContext(*ctx_idx, *context_id));
+                        action = Some(Action::JumpContext(*ctx_idx, *context_id, *pane_id));
                     }
                     Some(PaletteEntry::App { id, .. }) => {
                         action = Some(Action::LaunchApp(id.clone()));
@@ -198,8 +300,8 @@ impl PlexiApp {
         });
 
         match action {
-            Some(Action::JumpContext(ctx_idx, context_id)) => {
-                self.jump_to_context(ctx_idx, context_id);
+            Some(Action::JumpContext(ctx_idx, context_id, pane_id)) => {
+                self.jump_to_context(ctx_idx, context_id, pane_id);
                 self.show_command_palette = false;
                 self.palette_query.clear();
                 return;
@@ -299,6 +401,7 @@ impl PlexiApp {
                                             context_id,
                                             name,
                                             workspace_name,
+                                            pane_id,
                                         } => {
                                             let is_active = *context_id == active_win_id;
                                             let name_color = if is_active {
@@ -341,6 +444,7 @@ impl PlexiApp {
                                                 click_action = Some(Action::JumpContext(
                                                     *ctx_idx,
                                                     *context_id,
+                                                    *pane_id,
                                                 ));
                                             }
                                             if r.hovered() {
@@ -459,8 +563,8 @@ impl PlexiApp {
 
                         if let Some(act) = click_action {
                             match act {
-                                Action::JumpContext(ctx_idx, context_id) => {
-                                    self.jump_to_context(ctx_idx, context_id);
+                                Action::JumpContext(ctx_idx, context_id, pane_id) => {
+                                    self.jump_to_context(ctx_idx, context_id, pane_id);
                                     self.show_command_palette = false;
                                     self.palette_query.clear();
                                 }
@@ -481,7 +585,8 @@ impl PlexiApp {
     }
 
     /// Jump to a window by index, switching context if necessary.
-    fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64) {
+    /// If `pane_id` is provided, also focuses that specific pane in the window.
+    fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
         let target_ctx_id = self.windows[ctx_idx].context_id;
         if let Some(ctx_idx_sidebar) = self
             .contexts
@@ -500,6 +605,25 @@ impl PlexiApp {
         let ctx_id = self.contexts[self.active_context].context_id;
         self.context_active_window.insert(ctx_id, win_id);
         self.record_context_visit(win_id);
+
+        // Focus the specific pane if requested — find its TileId in the tree.
+        if let Some(pid) = pane_id {
+            let win = &mut self.windows[ctx_idx];
+            if let Some(tile_id) = win
+                .tree
+                .tiles
+                .iter()
+                .find_map(|(tid, tile)| {
+                    if matches!(tile, egui_tiles::Tile::Pane(p) if *p == pid) {
+                        Some(*tid)
+                    } else {
+                        None
+                    }
+                })
+            {
+                win.focused_pane = Some(tile_id);
+            }
+        }
     }
 
     /// Dispatch a static palette action. Adding a new action means

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,6 @@ impl LogConfig {
 #[derive(Deserialize, Default, Clone)]
 pub struct BetaConfig {
     pub crt: Option<bool>,
-    pub pulse: Option<bool>,
     pub ghost: Option<bool>,
 }
 
@@ -291,6 +290,11 @@ const CONFIG_TEMPLATE: &str = r##"# ╔═════════════�
 
 font_size = 14.0
 
+# ── Theme ──────────────────────────────────────────────────────
+# Pick a preset OR customize individual colors below.
+# Presets: catppuccin-mocha, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark
+theme_preset = "catppuccin-mocha"
+
 # ── Confirmation Dialogs ───────────────────────────────────────
 # confirm_quit requires triple Cmd+Q to exit (safer than a single press).
 # confirm_close shows a dialog before Cmd+W closes a pane.
@@ -334,11 +338,6 @@ interrupt_threshold = 100
 #   Esc = defer. Modal closes but the notification stays in the queue —
 #     open Cmd+Shift+A later to come back to it. No NotifyAction dispatched.
 #   Required notifications (required = true) cannot be Esc'd.
-
-# ── Theme ──────────────────────────────────────────────────────
-# Pick a preset OR customize individual colors below.
-# Presets: catppuccin-mocha, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark
-theme_preset = "catppuccin-mocha"
 
 [theme]
 # Uncomment any color below to override the preset value.
@@ -407,7 +406,6 @@ model_high   = "anthropic/claude-opus-4-7"
 # Flip any flag to true and restart to enable.
 [beta]
 # crt   = false    # Retro CRT scanlines + green phosphor tint
-# pulse = false    # Focused pane border gently breathes
 # ghost = false    # Unfocused panes render at reduced opacity
 
 # ── Logging ────────────────────────────────────────────────────
@@ -574,9 +572,6 @@ impl BetaConfig {
     fn overlay(&mut self, other: Self) {
         if other.crt.is_some() {
             self.crt = other.crt;
-        }
-        if other.pulse.is_some() {
-            self.pulse = other.pulse;
         }
         if other.ghost.is_some() {
             self.ghost = other.ghost;

--- a/src/features.rs
+++ b/src/features.rs
@@ -16,9 +16,6 @@ impl FeatureFlags {
             if beta.crt.unwrap_or(false) {
                 enabled.insert("crt".to_string());
             }
-            if beta.pulse.unwrap_or(false) {
-                enabled.insert("pulse".to_string());
-            }
             if beta.ghost.unwrap_or(false) {
                 enabled.insert("ghost".to_string());
             }

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -104,8 +104,13 @@ pub fn customize_app_menu() {
             mtm.alloc(),
             &reload_title,
             Some(sel!(reloadConfig:)),
-            &NSString::from_str(""),
+            &NSString::from_str(","),
         )
+    };
+    // NSEventModifierFlagCommand (1<<20) | NSEventModifierFlagShift (1<<17)
+    unsafe {
+        let mask: usize = (1 << 20) | (1 << 17);
+        let _: () = objc2::msg_send![&*reload_item, setKeyEquivalentModifierMask: mask];
     };
     unsafe { reload_item.setTarget(Some(&*handler)) };
     app_menu.addItem(&reload_item);

--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -158,8 +158,8 @@ pub fn render_minimap(
             egui::StrokeKind::Inside,
         );
 
-        // Small page number inside each cell (1-based, left-bottom)
-        let page_num = visible.iter().position(|(i, _)| *i == idx).map(|p| p + 1).unwrap_or(0);
+        // Small page number inside each cell (0-based, left-bottom)
+        let page_num = visible.iter().position(|(i, _)| *i == idx).unwrap_or(0);
         ui.painter().text(
             egui::pos2(cell_rect.left() + 3.0, cell_rect.bottom() - 2.0),
             egui::Align2::LEFT_BOTTOM,

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -68,7 +68,6 @@ impl PlexiApp {
             };
             row_rects.push(row_rect);
 
-            let hover = ui.rect_contains_pointer(row_rect);
             let row_alpha = if is_dragging { 0.4_f32 } else { 1.0_f32 };
 
             let row_response = ui
@@ -81,6 +80,7 @@ impl PlexiApp {
                             egui::Id::new(("ctx_row", i)),
                             Sense::click_and_drag(),
                         );
+                        let hover = row_resp.hovered();
 
                         let rect = ui.max_rect();
 
@@ -243,7 +243,7 @@ impl PlexiApp {
                 }
             }
 
-            if hover || is_dragging {
+            if row_response.hovered() || is_dragging {
                 let icon = if is_dragging || self.drag_context.is_some() {
                     egui::CursorIcon::Grabbing
                 } else {

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -80,8 +80,6 @@ pub(crate) fn selectable_row<R>(
 /// Padding around the key label text inside the chip.
 const KEYCAP_PAD_H: f32 = 6.0;
 const KEYCAP_PAD_V: f32 = 3.0;
-/// Minimum chip width — keeps single-char keys like `[` from looking cramped.
-const KEYCAP_MIN_W: f32 = 18.0;
 
 /// Render a single keycap chip. Allocates its own exact-size rect and
 /// returns the egui Response so callers can compose with other widgets.
@@ -91,8 +89,8 @@ pub(crate) fn key_chip(ui: &mut egui::Ui, label: &str, colors: &Colors) -> egui:
         .fonts(|f| f.layout_no_wrap(label.to_string(), font_id, colors.text_primary));
     let text_w = galley.size().x;
     let text_h = galley.size().y;
-    let chip_w = (text_w + KEYCAP_PAD_H * 2.0).max(KEYCAP_MIN_W);
     let chip_h = text_h + KEYCAP_PAD_V * 2.0;
+    let chip_w = (text_w + KEYCAP_PAD_H * 2.0).max(chip_h);
     let (rect, response) = ui.allocate_exact_size(
         Vec2::new(chip_w, chip_h),
         egui::Sense::hover(),


### PR DESCRIPTION
## Summary
- **Command palette overhaul**: context/pane model rewrite — contexts as primary entries, named pane jump with focus, `delete_window` cleanup, strip stale auto window names on load
- **Remove `pulse` beta feature**: config field, features flag, and rendering block all gone
- **Fix `Cmd+Shift+,` reload shortcut**: was unreliable via egui; now wired through macOS menu `NSEventModifierMask`
- **Fix `theme_preset` TOML ordering**: was silently swallowed by `[notifications]` section — moved above first section header
- **Sidebar hover fix**: moved hover detection to egui response (was computed before layout)
- **Minimap**: page numbers switched to 0-based
- **Key chips**: square chips (`chip_w >= chip_h`) replacing fixed 18px minimum width

## Breaks if
- Jumping to a named pane from the palette doesn't focus that pane
- `Cmd+Shift+,` still doesn't fire reload config
- `theme_preset = "catppuccin-mocha"` in config has no effect after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)