### PR TITLE
ci: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
           zip -r Plexi-${{ github.ref_name }}.zip Plexi.app
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: target/release/bundle/osx/Plexi-${{ github.ref_name }}.zip
           generate_release_notes: true


### PR DESCRIPTION
Bumps the three deprecated Node.js 20 actions before the June 2 forced migration:
- `actions/checkout@v4` → `v6`
- `actions/cache@v4` → `v5`
- `softprops/action-gh-release@v2` → `v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)