### PR TITLE
fix(sidebar): eliminate I-beam cursor on context names (#481)

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::context::WindowMenuAction;
 use crate::sidebar_row::{with_alpha, SidebarRow, ROW_HEIGHT};
-use egui::{Align, CornerRadius, Layout, Rect, RichText, Sense, Stroke, Vec2};
+use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 
 use crate::app::PlexiApp;
 
@@ -146,7 +146,6 @@ impl PlexiApp {
                     }
                     row_ui.add(
                         egui::Label::new(RichText::new(&ctx_name).size(12.0).color(text_color))
-                            .sense(Sense::hover())
                             .selectable(false),
                     );
                     // Badge — only when not hovering (X button takes that space on hover)


### PR DESCRIPTION
## Summary
- Removes `.sense(Sense::hover())` from the context name Label in the sidebar row content closure
- The Label's hover sense was causing egui to set an I-beam cursor, fighting with the row-level `Grab` cursor set by `SidebarRow::resolve_cursor`
- Also removes the now-unused `Sense` import

## Test plan
- [ ] Hover over context names in the sidebar — cursor should be Grab, not I-beam
- [ ] Verify drag-reorder still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)