### PR TITLE
fix(ui): hide sidebar separator line (#483)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1777,6 +1777,7 @@ impl eframe::App for PlexiApp {
             egui::SidePanel::left("sidebar")
                 .exact_width(220.0)
                 .resizable(false)
+                .show_separator_line(false)
                 .frame(
                     egui::Frame::new()
                         .fill(self.colors.bg_sidebar)


### PR DESCRIPTION
## Summary
- Adds `.show_separator_line(false)` to the sidebar `SidePanel` builder
- The panel is not resizable, so the separator line on hover was a misleading visual cue

## Test plan
- [ ] Hover near the right edge of the sidebar — no separator line should appear
- [ ] Sidebar width remains fixed at 220px

🤖 Generated with [Claude Code](https://claude.com/claude-code)