### PR TITLE
fix(ui): Escape dismisses shortcuts overlay (#484)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2004,7 +2004,11 @@ impl eframe::App for PlexiApp {
 
         // Shortcuts overlay
         if self.show_shortcuts {
-            self.draw_shortcuts_overlay(ctx);
+            if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+                self.show_shortcuts = false;
+            } else {
+                self.draw_shortcuts_overlay(ctx);
+            }
         }
 
         // Minimap overlay — auto-hidden when current workspace has <2 windows.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2004,7 +2004,7 @@ impl eframe::App for PlexiApp {
 
         // Shortcuts overlay
         if self.show_shortcuts {
-            if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
                 self.show_shortcuts = false;
             } else {
                 self.draw_shortcuts_overlay(ctx);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1509,7 +1509,7 @@ impl eframe::App for PlexiApp {
 
         // Handle keyboard shortcuts
         let modal_open = self.show_notification_modal;
-        for action in keys::poll_actions(ctx, app_active, keyboard_capture_active, modal_open) {
+        for action in keys::poll_actions(ctx, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -125,6 +125,7 @@ pub fn poll_actions(
     app_active: bool,
     keyboard_capture_active: bool,
     notification_modal_open: bool,
+    shortcuts_overlay_open: bool,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
     let cmd_shift = egui::Modifiers {
@@ -279,8 +280,11 @@ pub fn poll_actions(
 
         // App surface: Escape closes app, Tab toggles terminal split.
         // Only intercepted when an app is active so Escape/Tab work normally in plain terminals.
+        // Escape is suppressed when the shortcuts overlay is open — the overlay owns it.
         if app_active {
-            if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+            if !shortcuts_overlay_open
+                && input.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
+            {
                 actions.push(Action::CloseApp);
             }
             if input.consume_key(egui::Modifiers::NONE, egui::Key::Tab) {


### PR DESCRIPTION
## Summary
- Checks for Escape key press before drawing the shortcuts overlay
- If Escape is pressed, sets `show_shortcuts = false` and skips drawing that frame

## Test plan
- [ ] Open shortcuts overlay (Cmd+/), press Escape — overlay closes
- [ ] Verify Cmd+/ still toggles the overlay open/closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)