### PR TITLE
feat(toolbar): show app version number next to ? button

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -54,6 +54,12 @@ impl PlexiApp {
                     self.show_shortcuts = !self.show_shortcuts;
                 }
 
+                ui.label(
+                    RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+                        .size(10.0)
+                        .color(self.colors.text_dim),
+                );
+
                 let notif_count = self.visible_notification_count();
                 if notif_count > 0 {
                     let badge_text = if notif_count > 9 {


### PR DESCRIPTION
## Summary
- Adds a dim `v3.x.y` label immediately to the left of the `?` shortcuts button in the toolbar
- Version string is baked in at compile time via `env!("CARGO_PKG_VERSION")` — zero runtime cost, always matches `Cargo.toml`

## Issues
Closes #485

## Test plan
- [ ] Toolbar shows `v3.4.2` (or current build version) to the left of the `?` button
- [ ] Version string matches `Cargo.toml` version field
- [ ] Label does not overlap other toolbar elements at normal window widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)