### PR TITLE
fix(ui): align shortcuts overlay — key_combo_list for HJKL rows (#482)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -109,6 +109,7 @@ impl PlexiApp {
                             // Left column — window / pane management
                             egui::Grid::new("shortcuts_grid_left")
                                 .num_columns(2)
+                                .min_col_width(80.0)
                                 .spacing([style::SPACE_SM, 4.0])
                                 .show(&mut cols[0], |ui| {
                                     let rows: &[(&[&str], &str)] = &[
@@ -141,18 +142,15 @@ impl PlexiApp {
                             // Right column — navigation
                             egui::Grid::new("shortcuts_grid_right")
                                 .num_columns(2)
+                                .min_col_width(80.0)
                                 .spacing([style::SPACE_SM, 4.0])
                                 .show(&mut cols[1], |ui| {
-                                    // ⌘ + HJKL block
-                                    ui.horizontal(|ui| {
-                                        ui.spacing_mut().item_spacing.x = 2.0;
-                                        crate::widgets::key_chip(ui, "\u{2318}", colors);
-                                        ui.add_space(4.0);
-                                        crate::widgets::key_chip(ui, "H", colors);
-                                        crate::widgets::key_chip(ui, "J", colors);
-                                        crate::widgets::key_chip(ui, "K", colors);
-                                        crate::widgets::key_chip(ui, "L", colors);
-                                    });
+                                    crate::widgets::key_combo_list(
+                                        ui,
+                                        &[&["\u{2318}"], &["H", "J", "K", "L"]],
+                                        None,
+                                        colors,
+                                    );
                                     ui.label(
                                         RichText::new("Move between panes")
                                             .size(style::TEXT_HINT)
@@ -160,17 +158,12 @@ impl PlexiApp {
                                     );
                                     ui.end_row();
 
-                                    // ⌘⇧ + HJKL block
-                                    ui.horizontal(|ui| {
-                                        ui.spacing_mut().item_spacing.x = 2.0;
-                                        crate::widgets::key_chip(ui, "\u{2318}", colors);
-                                        crate::widgets::key_chip(ui, "\u{21E7}", colors);
-                                        ui.add_space(4.0);
-                                        crate::widgets::key_chip(ui, "H", colors);
-                                        crate::widgets::key_chip(ui, "J", colors);
-                                        crate::widgets::key_chip(ui, "K", colors);
-                                        crate::widgets::key_chip(ui, "L", colors);
-                                    });
+                                    crate::widgets::key_combo_list(
+                                        ui,
+                                        &[&["\u{2318}", "\u{21E7}"], &["H", "J", "K", "L"]],
+                                        None,
+                                        colors,
+                                    );
                                     ui.label(
                                         RichText::new("Move/create windows")
                                             .size(style::TEXT_HINT)


### PR DESCRIPTION
## Summary
- Replaced bare `ui.horizontal()` blocks in the right-column HJKL rows with `key_combo_list` calls — consistent cell height across the entire right grid
- Added `min_col_width(80.0)` to both grids so description text always starts at the same x offset
- Net -7 lines

## Test plan
- [ ] `Cmd+/` opens the shortcuts overlay
- [ ] Key chip(s) in the left column and description text in the right column are horizontally aligned on the same baseline for every row
- [ ] The `H J K L` navigation rows render key chips using `key_combo_list` (not plain label text)
- [ ] No row has its description visually higher or lower than its key chips

Closes #482