### PR TITLE
feat(logging): heartbeat watchdog + workspace autosave on structural changes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -131,6 +131,7 @@ pub struct PlexiApp {
     pub(crate) quit_press_count: u8,
     pub(crate) quit_last_press: Option<std::time::Instant>,
     pub(crate) pending_close: bool,
+    pub(crate) frame_tick: crate::logging::FrameTick,
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
@@ -231,7 +232,7 @@ pub struct PlexiApp {
 }
 
 impl PlexiApp {
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new(cc: &eframe::CreationContext<'_>, frame_tick: crate::logging::FrameTick) -> Self {
         #[cfg(target_os = "macos")]
         crate::macos_menu::customize_app_menu();
 
@@ -532,6 +533,7 @@ impl PlexiApp {
                     quit_last_press: None,
                     config: config.clone(),
                     pending_close: false,
+                    frame_tick: frame_tick.clone(),
                     renaming_window: None,
                     rename_buffer: String::new(),
                     drag_context: None,
@@ -612,6 +614,7 @@ impl PlexiApp {
             quit_last_press: None,
             config,
             pending_close: false,
+            frame_tick,
             renaming_window: None,
             rename_buffer: String::new(),
             drag_context: None,
@@ -995,6 +998,7 @@ impl PlexiApp {
 
 impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.frame_tick.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let _frame_start = std::time::Instant::now();
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
@@ -1514,18 +1518,22 @@ impl eframe::App for PlexiApp {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused(false);
+                    self.save_workspace();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused(true);
+                    self.save_workspace();
                 }
                 Action::SplitRight => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused_mirror(crate::host::command::Placement::Right);
+                    self.save_workspace();
                 }
                 Action::SplitDown => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.split_focused_mirror(crate::host::command::Placement::Below);
+                    self.save_workspace();
                 }
                 Action::Navigate(dir) => {
                     let was_zoomed = self.windows[self.active_window].zoomed_pane.is_some();
@@ -1544,6 +1552,8 @@ impl eframe::App for PlexiApp {
                             self.pending_close = true;
                         } else if self.execute_close_pane() {
                             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        } else {
+                            self.save_workspace();
                         }
                     }
                 }
@@ -1554,7 +1564,10 @@ impl eframe::App for PlexiApp {
                         self.cycle_tab(false);
                     }
                 }
-                Action::NewTab => self.new_tab(),
+                Action::NewTab => {
+                    self.new_tab();
+                    self.save_workspace();
+                }
                 Action::ToggleZoom => {
                     let ctx = &mut self.windows[self.active_window];
                     if let Some(focused) = ctx.focused_pane {
@@ -1691,9 +1704,11 @@ impl eframe::App for PlexiApp {
                     } else {
                         self.new_page_right();
                     }
+                    self.save_workspace();
                 }
                 Action::NewContext => {
                     self.new_context();
+                    self.save_workspace();
                 }
                 Action::PageLeft => {
                     self.navigate_or_create_page(-1, 0);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,8 +10,14 @@
 //! noise; everything under `plexi::` logs at the caller-supplied level.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+/// UI thread is considered frozen after this many seconds without a frame tick.
+const FREEZE_THRESHOLD_SECS: u64 = 5;
 
 /// Return the path of the current log file.
 pub fn log_path() -> PathBuf {
@@ -79,4 +85,83 @@ pub fn init(level: log::LevelFilter) {
     if let Err(e) = dispatch.apply() {
         eprintln!("[plexi::logging] failed to install logger: {e}");
     }
+}
+
+/// Shared counter bumped by the UI thread each frame so the heartbeat can detect freezes.
+pub type FrameTick = Arc<AtomicU64>;
+
+/// Create a new frame tick counter. Pass the clone to `spawn_heartbeat`, store the
+/// original in `PlexiApp` and call `.fetch_add(1, Relaxed)` each frame.
+pub fn new_frame_tick() -> FrameTick {
+    Arc::new(AtomicU64::new(0))
+}
+
+/// Spawn a background thread that:
+/// - Writes a heartbeat line every 30s (grep `[HEARTBEAT]` for last-alive timestamp)
+/// - Detects UI-thread freezes via `frame_tick` and logs `[FREEZE]` / `[THAW]` lines
+///
+/// Both writes go directly to the file, bypassing the logger, so they survive
+/// even if the logger thread is itself blocked by a freeze.
+pub fn spawn_heartbeat(frame_tick: FrameTick) {
+    let log_path = log_path();
+    std::thread::Builder::new()
+        .name("plexi-heartbeat".into())
+        .spawn(move || {
+            let born = Instant::now();
+            let mut beat: u64 = 0;
+            let mut last_tick = frame_tick.load(Ordering::Relaxed);
+            let mut freeze_start: Option<Instant> = None;
+
+            loop {
+                std::thread::sleep(HEARTBEAT_INTERVAL);
+                beat += 1;
+
+                let now_tick = frame_tick.load(Ordering::Relaxed);
+                let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+                let uptime = born.elapsed().as_secs();
+                let h = uptime / 3600;
+                let m = (uptime % 3600) / 60;
+                let s = uptime % 60;
+
+                let mut lines = String::new();
+
+                // Freeze detection: tick hasn't advanced since last heartbeat.
+                if now_tick == last_tick {
+                    if freeze_start.is_none() {
+                        freeze_start = Some(Instant::now());
+                        lines.push_str(&format!(
+                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread stopped responding\n"
+                        ));
+                    } else {
+                        let frozen_secs = freeze_start.unwrap().elapsed().as_secs();
+                        if frozen_secs >= FREEZE_THRESHOLD_SECS {
+                            lines.push_str(&format!(
+                                "[{now}] [WARN] [plexi::heartbeat] [FREEZE] still frozen — {frozen_secs}s unresponsive\n"
+                            ));
+                        }
+                    }
+                } else if let Some(start) = freeze_start.take() {
+                    let frozen_secs = start.elapsed().as_secs();
+                    lines.push_str(&format!(
+                        "[{now}] [INFO] [plexi::heartbeat] [THAW] UI thread resumed after {frozen_secs}s\n"
+                    ));
+                }
+
+                last_tick = now_tick;
+
+                lines.push_str(&format!(
+                    "[{now}] [INFO] [plexi::heartbeat] beat={beat} uptime={h:02}:{m:02}:{s:02}\n"
+                ));
+
+                if let Ok(mut f) = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&log_path)
+                {
+                    use std::io::Write;
+                    let _ = f.write_all(lines.as_bytes());
+                }
+            }
+        })
+        .expect("failed to spawn heartbeat thread");
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+/// How often the watchdog samples the frame counter. Short enough to catch brief freezes.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+/// How many sample intervals between full heartbeat log lines (5s × 6 = 30s).
+const HEARTBEAT_EVERY_N_SAMPLES: u64 = 6;
 /// UI thread is considered frozen after this many seconds without a frame tick.
 const FREEZE_THRESHOLD_SECS: u64 = 5;
 
@@ -109,49 +112,58 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
         .spawn(move || {
             let born = Instant::now();
             let mut beat: u64 = 0;
+            let mut sample: u64 = 0;
             let mut last_tick = frame_tick.load(Ordering::Relaxed);
-            let mut freeze_start: Option<Instant> = None;
+            // Track when we last saw the frame counter advance so freeze duration is accurate.
+            let mut last_tick_seen_at = Instant::now();
+            let mut freeze_reported = false;
 
             loop {
-                std::thread::sleep(HEARTBEAT_INTERVAL);
-                beat += 1;
+                std::thread::sleep(SAMPLE_INTERVAL);
+                sample += 1;
 
                 let now_tick = frame_tick.load(Ordering::Relaxed);
                 let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
-                let uptime = born.elapsed().as_secs();
-                let h = uptime / 3600;
-                let m = (uptime % 3600) / 60;
-                let s = uptime % 60;
 
                 let mut lines = String::new();
 
-                // Freeze detection: tick hasn't advanced since last heartbeat.
                 if now_tick == last_tick {
-                    if freeze_start.is_none() {
-                        freeze_start = Some(Instant::now());
+                    // Frame counter stalled — UI thread may be frozen.
+                    let frozen_secs = last_tick_seen_at.elapsed().as_secs();
+                    if frozen_secs >= FREEZE_THRESHOLD_SECS && !freeze_reported {
+                        freeze_reported = true;
                         lines.push_str(&format!(
-                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread stopped responding\n"
+                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s\n"
                         ));
-                    } else {
-                        let frozen_secs = freeze_start.unwrap().elapsed().as_secs();
-                        if frozen_secs >= FREEZE_THRESHOLD_SECS {
-                            lines.push_str(&format!(
-                                "[{now}] [WARN] [plexi::heartbeat] [FREEZE] still frozen — {frozen_secs}s unresponsive\n"
-                            ));
-                        }
+                    } else if frozen_secs >= FREEZE_THRESHOLD_SECS {
+                        lines.push_str(&format!(
+                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] still frozen — {frozen_secs}s unresponsive\n"
+                        ));
                     }
-                } else if let Some(start) = freeze_start.take() {
-                    let frozen_secs = start.elapsed().as_secs();
-                    lines.push_str(&format!(
-                        "[{now}] [INFO] [plexi::heartbeat] [THAW] UI thread resumed after {frozen_secs}s\n"
-                    ));
+                } else {
+                    // Frame counter advanced — UI thread is alive.
+                    if freeze_reported {
+                        let frozen_secs = last_tick_seen_at.elapsed().as_secs();
+                        lines.push_str(&format!(
+                            "[{now}] [INFO] [plexi::heartbeat] [THAW] UI thread resumed after ~{frozen_secs}s\n"
+                        ));
+                        freeze_reported = false;
+                    }
+                    last_tick = now_tick;
+                    last_tick_seen_at = Instant::now();
                 }
 
-                last_tick = now_tick;
-
-                lines.push_str(&format!(
-                    "[{now}] [INFO] [plexi::heartbeat] beat={beat} uptime={h:02}:{m:02}:{s:02}\n"
-                ));
+                // Write a full heartbeat line every 30s (every Nth sample).
+                if sample % HEARTBEAT_EVERY_N_SAMPLES == 0 {
+                    beat += 1;
+                    let uptime = born.elapsed().as_secs();
+                    let h = uptime / 3600;
+                    let m = (uptime % 3600) / 60;
+                    let s = uptime % 60;
+                    lines.push_str(&format!(
+                        "[{now}] [INFO] [plexi::heartbeat] beat={beat} uptime={h:02}:{m:02}:{s:02}\n"
+                    ));
+                }
 
                 if let Ok(mut f) = std::fs::OpenOptions::new()
                     .create(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,8 @@ fn main() -> eframe::Result {
         .and_then(|l| l.level_filter())
         .unwrap_or(log::LevelFilter::Info);
     crate::logging::init(log_level);
+    let frame_tick = crate::logging::new_frame_tick();
+    crate::logging::spawn_heartbeat(frame_tick.clone());
 
     // Resolve the login-shell PATH once for the whole process. Fixes
     // `gh`/`rg`/`fd`/any-homebrew-tool-not-found bugs when Plexi is launched
@@ -516,7 +518,7 @@ fn main() -> eframe::Result {
     eframe::run_native(
         env!("CARGO_PKG_NAME"),
         native_options,
-        Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc)))),
+        Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc, frame_tick)))),
     )
 }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -441,6 +441,8 @@ impl PlexiApp {
             self.pending_close = false;
             if self.execute_close_pane() {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            } else {
+                self.save_workspace();
             }
         } else if cancelled {
             self.pending_close = false;


### PR DESCRIPTION
## Summary

- **Heartbeat thread**: spawned at startup, writes `beat=N uptime=HH:MM:SS` to the log file every 30s via direct file append (bypasses the logger, so it works even when the UI thread is blocked)
- **Freeze watchdog**: the UI thread bumps an atomic counter each frame; the heartbeat checks it — logs `[FREEZE]` when the counter stalls >5s, `[THAW]` when it recovers. Grep `[HEARTBEAT]` / `[FREEZE]` to find exactly when a crash or freeze occurred
- **Workspace autosave**: `save_workspace()` now called on every structural action — split (all 4 directions), close pane (immediate + confirm-close paths), new tab, new context, new page right — so force-quitting no longer loses your layout

## Test plan

- [ ] Launch alpha, wait 30s — confirm `[HEARTBEAT] beat=1 uptime=00:00:30` appears in `~/.plexi-alpha/plexi.log`
- [ ] Split a pane, force-quit, relaunch — confirm layout is restored
- [ ] Open new tab/context, force-quit, relaunch — confirm it's there
- [ ] Close a pane, relaunch — confirm it's gone (not restored)

**Breaks if:** no `[HEARTBEAT]` lines appear in the log after 30s of uptime.