### PR TITLE
refactor(#380): WorkspaceRouter — compile-enforced context switching invariant

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -127,7 +127,7 @@ impl PlexiApp {
                         ..
                     } => {
                         let ws_idx = self.windows.get(ctx_idx)
-                            .and_then(|w| self.contexts.iter().position(|c| c.context_id == w.context_id))
+                            .and_then(|w| self.router.position(|c| c.context_id == w.context_id))
                             .unwrap_or(0);
                         deferred.push(AppCommand::ShowNotification {
                             notify_id,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -99,7 +99,7 @@ pub(crate) enum NotificationImageState {
 use crate::agent_workspace::MergeOutcome;
 use crate::app_registry::AppRegistry;
 use crate::config;
-use crate::context::{Context, Window};
+use crate::context::Window;
 use crate::keys::{self, Action};
 use crate::pane::{Pane, TerminalPane};
 use crate::shell;
@@ -121,10 +121,9 @@ pub struct PlexiApp {
     pub(crate) colors: Colors,
     pub(crate) default_font_size: f32,
     pub(crate) ctx: egui::Context,
-    pub(crate) contexts: Vec<Context>,
+    pub(crate) router: crate::workspace_router::WorkspaceRouter,
     pub(crate) windows: Vec<Window>,
     pub(crate) active_window: usize,
-    pub(crate) active_context: usize,
     pub(crate) sidebar_visible: bool,
     pub(crate) show_shortcuts: bool,
     pub(crate) quitting: bool,
@@ -522,10 +521,9 @@ impl PlexiApp {
                     colors,
                     default_font_size,
                     ctx: cc.egui_ctx.clone(),
-                    contexts,
+                    router: crate::workspace_router::WorkspaceRouter::new(contexts, active_ctx),
                     windows,
                     active_window: active,
-                    active_context: active_ctx,
                     sidebar_visible: ws.sidebar_visible,
                     show_shortcuts: false,
                     quitting: false,
@@ -588,11 +586,14 @@ impl PlexiApp {
             colors,
             default_font_size,
             ctx: cc.egui_ctx.clone(),
-            contexts: vec![crate::context::Context {
-                name: "Default".into(),
-                path: path.clone(),
-                context_id: 1,
-            }],
+            router: crate::workspace_router::WorkspaceRouter::new(
+                vec![crate::context::Context {
+                    name: "Default".into(),
+                    path: path.clone(),
+                    context_id: 1,
+                }],
+                0,
+            ),
             windows: vec![Window {
                 name: "Default".into(),
                 path,
@@ -606,7 +607,6 @@ impl PlexiApp {
                 context_id: 1,
             }],
             active_window: 0,
-            active_context: 0,
             sidebar_visible: true,
             show_shortcuts: false,
             quitting: false,
@@ -708,7 +708,7 @@ impl PlexiApp {
                 sender_pane_id: 0,
                 // Host-originated notifications are global (they originate
                 // outside any context) and always visible.
-                source_context: self.active_context,
+                source_context: self.router.active_idx(),
                 scope: crate::app_protocol::NotifyScope::Global,
                 level,
                 title,
@@ -792,14 +792,14 @@ impl PlexiApp {
     // push order (we never reorder the Vec; dismissal removes by id).
     //
     // Visibility: Context-scoped notifications are only visible when
-    // `source_context == self.active_context`. Global notifications are
+    // `source_context == self.router.active_idx()`. Global notifications are
     // always visible. The raw `pending_notifications` Vec stays flat;
     // only the *view* changes with the active workspace.
 
     /// True when this notification should appear in the current workspace view.
     pub(crate) fn notification_is_visible(&self, n: &PendingNotification) -> bool {
         matches!(n.scope, crate::app_protocol::NotifyScope::Global)
-            || n.source_context == self.active_context
+            || n.source_context == self.router.active_idx()
     }
 
     /// Return ids of all *visible* notifications (for the current context),
@@ -972,7 +972,7 @@ impl PlexiApp {
         self.pending_notifications.push(PendingNotification {
             notify_id: internal_id.clone(),
             sender_pane_id: 0,
-            source_context: self.active_context,
+            source_context: self.router.active_idx(),
             scope: crate::app_protocol::NotifyScope::Global,
             level,
             title,
@@ -1471,7 +1471,7 @@ impl eframe::App for PlexiApp {
                         pane.as_app().map(|a| a.name.clone())
                     }
                 });
-            let ws = &self.contexts[self.active_context];
+            let ws = self.router.active();
             let ws_id = ws.context_id;
             let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
             let context_label = if window_count > 1 {
@@ -1628,7 +1628,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SwitchContext(n) => {
-                    if n < self.contexts.len() {
+                    if n < self.router.len() {
                         self.switch_workspace(n);
                     }
                 }
@@ -2028,7 +2028,7 @@ impl eframe::App for PlexiApp {
         }
 
         // Minimap overlay — auto-hidden when current workspace has <2 windows.
-        let ws_id = self.contexts[self.active_context].context_id;
+        let ws_id = self.router.active().context_id;
         let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
         if window_count >= 2 {
             self.draw_minimap_overlay(ctx);

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -80,7 +80,7 @@ impl PlexiApp {
 
             for (ci, w) in self.windows.iter().enumerate() {
                 let ctx_name = self
-                    .contexts
+                    .router
                     .iter()
                     .find(|c| c.context_id == w.context_id)
                     .map(|c| c.name.clone())
@@ -589,11 +589,10 @@ impl PlexiApp {
     fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
         let target_ctx_id = self.windows[ctx_idx].context_id;
         if let Some(ctx_idx_sidebar) = self
-            .contexts
-            .iter()
+            .router
             .position(|c| c.context_id == target_ctx_id)
         {
-            if ctx_idx_sidebar != self.active_context {
+            if ctx_idx_sidebar != self.router.active_idx() {
                 // switch_workspace → pick_active_context_from_workspace sets
                 // active_window based on context_active_window. We override it
                 // immediately below.
@@ -602,7 +601,7 @@ impl PlexiApp {
         }
         self.active_window = ctx_idx;
         self.windows[ctx_idx].zoomed_pane = None;
-        let ctx_id = self.contexts[self.active_context].context_id;
+        let ctx_id = self.router.active().context_id;
         self.context_active_window.insert(ctx_id, win_id);
         self.record_context_visit(win_id);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod quick_note_app;
 mod runs;
 mod secrets;
 mod secrets_app;
+mod workspace_router;
 mod workspace_secrets;
 mod shell;
 mod minimap;

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -13,7 +13,7 @@ impl PlexiApp {
     pub(crate) fn draw_toolbar(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             // Workspace dots
-            let sidebar_contexts: Vec<usize> = (0..self.contexts.len()).collect();
+            let sidebar_contexts: Vec<usize> = (0..self.router.len()).collect();
             if sidebar_contexts.len() > 1 {
                 let dot_radius = 4.0;
                 let dot_spacing = 12.0;
@@ -26,7 +26,7 @@ impl PlexiApp {
                 let start_x = rect.left() + dot_radius;
                 for (dot_i, ctx_i) in sidebar_contexts.iter().enumerate() {
                     let cx = start_x + (dot_i as f32) * dot_spacing;
-                    let color = if *ctx_i == self.active_context {
+                    let color = if *ctx_i == self.router.active_idx() {
                         self.colors.accent
                     } else {
                         self.colors.bg_active
@@ -1292,8 +1292,8 @@ impl PlexiApp {
         let content_rect = ctx.screen_rect();
         let active_context = self.active_window;
         let colors = self.colors;
-        let ws_id = self.contexts[self.active_context].context_id;
-        let ws_name = self.contexts[self.active_context].name.clone();
+        let ws_id = self.router.active().context_id;
+        let ws_name = self.router.active().name.clone();
 
         egui::Area::new(egui::Id::new("minimap_overlay"))
             .order(egui::Order::Foreground)

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -120,7 +120,6 @@ impl PlexiApp {
         // Remove all windows belonging to this context.
         self.windows.retain(|c| c.context_id != ws_id);
         self.router.remove_at(ws_index);
-        self.router.adjust_active_after_remove(ws_index);
 
         // Pick a valid active window in the new active context.
         self.pick_active_context_from_workspace();
@@ -175,7 +174,6 @@ impl PlexiApp {
         if !ws_has_windows {
             if let Some(ws_idx) = self.router.position(|w| w.context_id == removed_ws_id) {
                 self.router.remove_at(ws_idx);
-                self.router.adjust_active_after_remove(ws_idx);
             }
         }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -21,8 +21,8 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        let ctx_name = format!("Context {}", self.contexts.len() + 1);
-        self.contexts.push(crate::context::Context {
+        let ctx_name = format!("Context {}", self.router.len() + 1);
+        self.router.push(crate::context::Context {
             name: ctx_name,
             path: home.clone(),
             context_id: ctx_id,
@@ -39,21 +39,21 @@ impl PlexiApp {
             window_id: win_id,
             context_id: ctx_id,
         });
-        self.active_context = self.contexts.len() - 1;
+        self.router.activate_last();
         self.active_window = self.windows.len() - 1;
         self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = false;
 
         // Auto-open inline rename so the user can name the context immediately.
-        let new_ctx_idx = self.contexts.len() - 1;
+        let new_ctx_idx = self.router.len() - 1;
         self.renaming_window = Some(new_ctx_idx);
-        self.rename_buffer = self.contexts[new_ctx_idx].name.clone();
+        self.rename_buffer = self.router.get(new_ctx_idx).name.clone();
     }
 
     /// Create a new page immediately to the right of the active page on the
     /// same grid row, then switch to it.
     pub(crate) fn new_page_right(&mut self) {
-        let ws_id = self.contexts[self.active_context].context_id;
+        let ws_id = self.router.active().context_id;
         let active_y = self.windows[self.active_window].grid_y;
         let max_x = self.windows.iter()
             .filter(|c| c.context_id == ws_id && c.grid_y == active_y)
@@ -76,7 +76,7 @@ impl PlexiApp {
             return;
         };
         let name = String::new();
-        let ctx_id = self.contexts[self.active_context].context_id;
+        let ctx_id = self.router.active().context_id;
         let win_id = self.next_window_id;
         self.next_window_id += 1;
         self.windows.push(Window {
@@ -112,25 +112,20 @@ impl PlexiApp {
     }
 
     pub(crate) fn delete_context(&mut self, ws_index: usize) {
-        if self.contexts.len() <= 1 {
+        if self.router.len() <= 1 {
             return;
         }
-        let ws_id = self.contexts[ws_index].context_id;
+        let ws_id = self.router.get(ws_index).context_id;
 
-        // Remove all contexts belonging to this workspace.
+        // Remove all windows belonging to this context.
         self.windows.retain(|c| c.context_id != ws_id);
-        self.contexts.remove(ws_index);
+        self.router.remove_at(ws_index);
+        self.router.adjust_active_after_remove(ws_index);
 
-        // Fix active indices.
-        if self.active_context >= self.contexts.len() {
-            self.active_context = self.contexts.len().saturating_sub(1);
-        } else if self.active_context > ws_index {
-            self.active_context -= 1;
-        }
-        // Pick a valid active_context in the new active workspace.
+        // Pick a valid active window in the new active context.
         self.pick_active_context_from_workspace();
 
-        // Notifications scoped to this workspace are dropped.
+        // Notifications scoped to this context are dropped.
         self.pending_notifications.retain(|n| {
             !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
                 && n.source_context == ws_index)
@@ -142,8 +137,8 @@ impl PlexiApp {
             }
         }
 
-        // Restore minimap state for the workspace we landed on.
-        let new_ws_id = self.contexts[self.active_context].context_id;
+        // Restore minimap state for the context we landed on.
+        let new_ws_id = self.router.active().context_id;
         let page_count = self.windows.iter().filter(|c| c.context_id == new_ws_id).count();
         self.minimap.visible = self
             .minimap_visible_per_context
@@ -175,25 +170,21 @@ impl PlexiApp {
             }
         }
 
-        // If workspace now has no windows, remove it too.
+        // If context now has no windows, remove it too.
         let ws_has_windows = self.windows.iter().any(|c| c.context_id == removed_ws_id);
         if !ws_has_windows {
-            if let Some(ws_idx) = self.contexts.iter().position(|w| w.context_id == removed_ws_id) {
-                self.contexts.remove(ws_idx);
-                if self.active_context >= self.contexts.len() {
-                    self.active_context = self.contexts.len().saturating_sub(1);
-                } else if self.active_context > ws_idx {
-                    self.active_context -= 1;
-                }
+            if let Some(ws_idx) = self.router.position(|w| w.context_id == removed_ws_id) {
+                self.router.remove_at(ws_idx);
+                self.router.adjust_active_after_remove(ws_idx);
             }
         }
 
         if was_active {
             self.active_window = self.nearest_context_after_delete(removed_x, removed_y);
-            // Sync context to the new active window.
+            // Sync router active to the new active window's context.
             let new_ctx_id = self.windows[self.active_window].context_id;
-            if let Some(ctx_idx) = self.contexts.iter().position(|w| w.context_id == new_ctx_id) {
-                self.active_context = ctx_idx;
+            if let Some(ctx_idx) = self.router.position(|w| w.context_id == new_ctx_id) {
+                self.router.set_active(ctx_idx);
                 self.context_active_window.insert(new_ctx_id, self.windows[self.active_window].window_id);
             }
         } else if self.active_window >= self.windows.len() {
@@ -213,8 +204,8 @@ impl PlexiApp {
         // ── Compact the grid: shift columns left if a column becomes empty ──
         self.compact_workspace_grid(removed_ws_id);
 
-        // Restore minimap state for the workspace we landed on.
-        let ws_id = self.contexts[self.active_context].context_id;
+        // Restore minimap state for the context we landed on.
+        let ws_id = self.router.active().context_id;
         let page_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
         self.minimap.visible = self
             .minimap_visible_per_context
@@ -267,26 +258,25 @@ impl PlexiApp {
         }
     }
 
-    /// Switch the active workspace to `new_ws_idx`, saving the current
-    /// workspace's minimap state and restoring the target workspace's saved
-    /// state. Falls back to `visible = (page count > 1)` on first visit.
+    /// Switch the active context to `new_ctx_idx`, saving the current
+    /// context's minimap state and restoring the target context's saved state.
+    /// Falls back to `visible = (page count > 1)` on first visit.
     ///
-    /// This is the **only** place workspace switching should be performed —
-    /// do not inline `active_workspace = i` + `pick_active_context_from_workspace`
-    /// elsewhere, as that bypasses the save/restore.
+    /// This is the **only** place context navigation should be performed —
+    /// calling `router.set_active` directly bypasses the minimap save/restore.
     pub(crate) fn switch_workspace(&mut self, new_ctx_idx: usize) {
         // Save current context's active window + minimap state.
-        let old_ctx_id = self.contexts[self.active_context].context_id;
+        let old_ctx_id = self.router.active().context_id;
         self.context_active_window
             .insert(old_ctx_id, self.windows[self.active_window].window_id);
         self.minimap_visible_per_context
             .insert(old_ctx_id, self.minimap.visible);
 
-        self.active_context = new_ctx_idx;
+        self.router.set_active(new_ctx_idx);
         self.pick_active_context_from_workspace();
 
         // Restore minimap state for the new context.
-        let new_ctx_id = self.contexts[self.active_context].context_id;
+        let new_ctx_id = self.router.active().context_id;
         let page_count = self
             .windows
             .iter()
@@ -300,7 +290,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn pick_active_context_from_workspace(&mut self) {
-        let ctx_id = self.contexts[self.active_context].context_id;
+        let ctx_id = self.router.active().context_id;
         let preferred = self.context_active_window.get(&ctx_id).copied();
         if let Some(win_id) = preferred {
             if let Some(idx) = self.windows.iter().position(|w| w.window_id == win_id && w.context_id == ctx_id) {
@@ -321,7 +311,7 @@ impl PlexiApp {
         let mut saved_contexts = Vec::new();
         let mut saved_windows = Vec::new();
 
-        for ctx in &self.contexts {
+        for ctx in self.router.iter() {
             saved_contexts.push(crate::workspace::SavedContext {
                 name: ctx.name.clone(),
                 path: ctx.path.clone(),
@@ -398,7 +388,7 @@ impl PlexiApp {
 
         let ws = WorkspaceFile {
             version: 2,
-            active_context: self.active_context,
+            active_context: self.router.active_idx(),
             sidebar_visible: self.sidebar_visible,
             next_pane_id: self.host.next_pane_id(),
             contexts: saved_contexts,

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -37,7 +37,7 @@ impl PlexiApp {
         });
         ui.add_space(4.0);
 
-        let num_contexts = self.contexts.len();
+        let num_contexts = self.router.len();
         let mut clicked_workspace: Option<usize> = None;
         let mut delete_context: Option<usize> = None;
         let mut menu_action: Option<(usize, WindowMenuAction)> = None;
@@ -45,7 +45,7 @@ impl PlexiApp {
         let mut drag_released = false;
 
         for i in 0..num_contexts {
-            let is_active = i == self.active_context;
+            let is_active = i == self.router.active_idx();
             let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
             let any_dragging = self.drag_context.is_some();
@@ -86,7 +86,7 @@ impl PlexiApp {
                             } else {
                                 let new_name = self.rename_buffer.trim().to_string();
                                 if !new_name.is_empty() {
-                                    self.contexts[i].name = new_name;
+                                    self.router.get_mut(i).name = new_name;
                                 }
                                 self.renaming_window = None;
                             }
@@ -124,7 +124,7 @@ impl PlexiApp {
                 if is_active { self.colors.text_primary } else { self.colors.text_dim },
                 if is_dragging { 0.4 } else { 1.0 },
             );
-            let ctx_name = self.contexts[i].name.clone();
+            let ctx_name = self.router.get(i).name.clone();
             let badge_count = if is_active {
                 self.visible_notification_count()
             } else {
@@ -208,15 +208,7 @@ impl PlexiApp {
             if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
                 if dst != src && dst != src + 1 {
                     let effective_dst = if dst > src { dst - 1 } else { dst };
-                    let ctx = self.contexts.remove(src);
-                    self.contexts.insert(effective_dst, ctx);
-                    if self.active_context == src {
-                        self.active_context = effective_dst;
-                    } else if src < self.active_context && effective_dst >= self.active_context {
-                        self.active_context -= 1;
-                    } else if src > self.active_context && effective_dst <= self.active_context {
-                        self.active_context += 1;
-                    }
+                    self.router.reorder_tracking_active(src, effective_dst);
                 }
             }
             self.drag_context = None;
@@ -243,30 +235,19 @@ impl PlexiApp {
             match action {
                 WindowMenuAction::Rename => {
                     self.renaming_window = Some(i);
-                    self.rename_buffer = self.contexts[i].name.clone();
+                    self.rename_buffer = self.router.get(i).name.clone();
                 }
                 WindowMenuAction::MoveToTop => {
-                    let ctx = self.contexts.remove(i);
-                    self.contexts.insert(0, ctx);
-                    if self.active_context == i { self.active_context = 0; }
-                    else if self.active_context < i { self.active_context += 1; }
+                    self.router.move_to_front_tracking_active(i);
                 }
                 WindowMenuAction::MoveUp => {
-                    self.contexts.swap(i, i - 1);
-                    if self.active_context == i { self.active_context = i - 1; }
-                    else if self.active_context == i - 1 { self.active_context = i; }
+                    self.router.swap_tracking_active(i, i - 1);
                 }
                 WindowMenuAction::MoveDown => {
-                    self.contexts.swap(i, i + 1);
-                    if self.active_context == i { self.active_context = i + 1; }
-                    else if self.active_context == i + 1 { self.active_context = i; }
+                    self.router.swap_tracking_active(i, i + 1);
                 }
                 WindowMenuAction::MoveToBottom => {
-                    let last = num_contexts - 1;
-                    let ctx = self.contexts.remove(i);
-                    self.contexts.push(ctx);
-                    if self.active_context == i { self.active_context = last; }
-                    else if self.active_context > i { self.active_context -= 1; }
+                    self.router.move_to_back_tracking_active(i);
                 }
                 WindowMenuAction::Delete => {
                     self.delete_context(i);

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -83,7 +83,7 @@ impl PlexiApp {
     pub(crate) fn navigate_page(&mut self, dx: i32, dy: i32) {
         let cur_x = self.windows[self.active_window].grid_x;
         let cur_y = self.windows[self.active_window].grid_y;
-        let ws_id = self.contexts[self.active_context].context_id;
+        let ws_id = self.router.active().context_id;
 
         let pages: Vec<(u32, u32, u64)> = self
             .windows
@@ -149,7 +149,7 @@ impl PlexiApp {
         removed_x: u32,
         removed_y: u32,
     ) -> usize {
-        let ws_id = self.contexts[self.active_context].context_id;
+        let ws_id = self.router.active().context_id;
         self.windows
             .iter()
             .enumerate()

--- a/src/workspace_router.rs
+++ b/src/workspace_router.rs
@@ -15,6 +15,7 @@ pub(crate) struct WorkspaceRouter {
 
 impl WorkspaceRouter {
     pub(crate) fn new(contexts: Vec<Context>, active: usize) -> Self {
+        debug_assert!(contexts.is_empty() || active < contexts.len(), "Active index out of bounds");
         Self { active, contexts }
     }
 
@@ -59,23 +60,22 @@ impl WorkspaceRouter {
         self.active = self.contexts.len().saturating_sub(1);
     }
 
+    /// Remove at `idx` and adjust the active index to stay coherent.
     pub(crate) fn remove_at(&mut self, idx: usize) -> Context {
-        self.contexts.remove(idx)
-    }
-
-    /// After removing at `removed_idx`, clamp/adjust active to stay valid.
-    pub(crate) fn adjust_active_after_remove(&mut self, removed_idx: usize) {
+        let ctx = self.contexts.remove(idx);
         if self.active >= self.contexts.len() {
             self.active = self.contexts.len().saturating_sub(1);
-        } else if self.active > removed_idx {
+        } else if self.active > idx {
             self.active -= 1;
         }
+        ctx
     }
 
     /// Raw set — used by `switch_workspace` (which handles minimap save/restore)
     /// and post-delete sync when the exact target index is known.
     /// Never call from action handlers; call `PlexiApp::switch_workspace` instead.
     pub(crate) fn set_active(&mut self, idx: usize) {
+        debug_assert!(idx < self.contexts.len(), "Target active index out of bounds");
         self.active = idx;
     }
 

--- a/src/workspace_router.rs
+++ b/src/workspace_router.rs
@@ -1,0 +1,127 @@
+//! Encapsulates the active-context index so it can only be mutated through
+//! controlled methods. Direct field assignment (`active_context = n`) is a
+//! compile error outside this module, which makes the class of "forgot to call
+//! switch_workspace" bugs structurally impossible.
+//!
+//! Navigation (with minimap save/restore) → `PlexiApp::switch_workspace`
+//! Structural ops (create/delete/reorder) → methods on this struct
+
+use crate::context::Context;
+
+pub(crate) struct WorkspaceRouter {
+    active: usize,
+    contexts: Vec<Context>,
+}
+
+impl WorkspaceRouter {
+    pub(crate) fn new(contexts: Vec<Context>, active: usize) -> Self {
+        Self { active, contexts }
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    pub(crate) fn active_idx(&self) -> usize {
+        self.active
+    }
+
+    pub(crate) fn active(&self) -> &Context {
+        &self.contexts[self.active]
+    }
+
+    pub(crate) fn get(&self, idx: usize) -> &Context {
+        &self.contexts[idx]
+    }
+
+    pub(crate) fn get_mut(&mut self, idx: usize) -> &mut Context {
+        &mut self.contexts[idx]
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.contexts.len()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Context> {
+        self.contexts.iter()
+    }
+
+    pub(crate) fn position<F: Fn(&Context) -> bool>(&self, f: F) -> Option<usize> {
+        self.contexts.iter().position(f)
+    }
+
+    // ── Structural mutation (create / delete) ────────────────────────────────
+
+    pub(crate) fn push(&mut self, ctx: Context) {
+        self.contexts.push(ctx);
+    }
+
+    /// Set active to the last context (call after push for new-context flow).
+    pub(crate) fn activate_last(&mut self) {
+        self.active = self.contexts.len().saturating_sub(1);
+    }
+
+    pub(crate) fn remove_at(&mut self, idx: usize) -> Context {
+        self.contexts.remove(idx)
+    }
+
+    /// After removing at `removed_idx`, clamp/adjust active to stay valid.
+    pub(crate) fn adjust_active_after_remove(&mut self, removed_idx: usize) {
+        if self.active >= self.contexts.len() {
+            self.active = self.contexts.len().saturating_sub(1);
+        } else if self.active > removed_idx {
+            self.active -= 1;
+        }
+    }
+
+    /// Raw set — used by `switch_workspace` (which handles minimap save/restore)
+    /// and post-delete sync when the exact target index is known.
+    /// Never call from action handlers; call `PlexiApp::switch_workspace` instead.
+    pub(crate) fn set_active(&mut self, idx: usize) {
+        self.active = idx;
+    }
+
+    // ── Reorder ops (sidebar drag / move-to-top etc.) ────────────────────────
+    // Each op maintains active coherence atomically.
+
+    pub(crate) fn swap_tracking_active(&mut self, a: usize, b: usize) {
+        self.contexts.swap(a, b);
+        if self.active == a {
+            self.active = b;
+        } else if self.active == b {
+            self.active = a;
+        }
+    }
+
+    /// Remove at `src`, insert at `dst` (after removal), tracking active.
+    pub(crate) fn reorder_tracking_active(&mut self, src: usize, dst: usize) {
+        let ctx = self.contexts.remove(src);
+        self.contexts.insert(dst, ctx);
+        if self.active == src {
+            self.active = dst;
+        } else if src < self.active && dst >= self.active {
+            self.active -= 1;
+        } else if src > self.active && dst <= self.active {
+            self.active += 1;
+        }
+    }
+
+    pub(crate) fn move_to_front_tracking_active(&mut self, idx: usize) {
+        let ctx = self.contexts.remove(idx);
+        self.contexts.insert(0, ctx);
+        if self.active == idx {
+            self.active = 0;
+        } else if self.active < idx {
+            self.active += 1;
+        }
+    }
+
+    pub(crate) fn move_to_back_tracking_active(&mut self, idx: usize) {
+        let last = self.contexts.len() - 1;
+        let ctx = self.contexts.remove(idx);
+        self.contexts.push(ctx);
+        if self.active == idx {
+            self.active = last;
+        } else if self.active > idx {
+            self.active -= 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `active_context` and `contexts` into a new `WorkspaceRouter` type with private fields
- Direct `active_context = n` is now a compile error from any module outside `workspace_router.rs`
- Navigation with minimap save/restore stays in `PlexiApp::switch_workspace`, which calls `router.set_active()` — the only sanctioned raw mutation, clearly named and auditable via grep
- Sidebar reorder ops (`swap`, `move_to_front`, `move_to_back`, drag `reorder`) are atomic methods on the router that maintain active-index coherence internally
- No logic changes; zero warnings; `cargo build` clean

## Test plan

- [ ] Switch between contexts (sidebar click, ⌘1-9) — minimap state saves/restores correctly per context
- [ ] Create a new context (+ button) — opens rename, becomes active
- [ ] Delete a context — remaining context becomes active, minimap state correct
- [ ] Drag-reorder contexts — active highlight follows the moved context
- [ ] Move Up / Move Down / Move to Top / Move to Bottom — same
- [ ] Close a page (⌘W) when it's the last in its context — context also removed, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)