### PR TITLE
feat(#508): chat-poc — conversational chat via AiQuery/AiResponse

### DIFF
--- a/examples/chat-poc/chat.py
+++ b/examples/chat-poc/chat.py
@@ -11,6 +11,7 @@ from plexi_sdk.ui import (
     Divider,
     Footer,
     Label,
+    RED,
     Scrollable,
     Section,
     Spacer,
@@ -44,9 +45,8 @@ class ChatApp(App):
         if not self._scroll_to_bottom_next:
             return
         self._scroll_to_bottom_next = False
-        self._scroll.scroll_offset = max(
-            0.0, self._scroll._child_h - self._scroll._avail_h
-        )
+        # Large value — clamped to actual max by Scrollable.render() on the next frame.
+        self._scroll.scroll_offset = 1_000_000.0
 
     def _send(self, text: str) -> None:
         if not text.strip():
@@ -107,32 +107,24 @@ class ChatApp(App):
             elif turn.role == "assistant":
                 children.append(Label(turn.text, max_lines=50))
             else:
-                children.append(Label(turn.text, color="#f38ba8", max_lines=10))
+                children.append(Label(turn.text, color=RED, max_lines=10))
             children.append(Spacer(size=8.0))
         if self._in_flight:
             children.append(Label("thinking…", tone="hint"))
         if not children:
             children.append(Label("No messages yet — type below and press Enter.", tone="hint"))
-        return Column(children)
+        return Column(children, padding=0)
 
     def on_render(self, ctx: RenderContext) -> None:
         ox, oy, ow = ctx.x, ctx.y, ctx.w
+
+        self._scroll.child = self._build_history_column()
 
         placeholder = (
             "Waiting for response…"
             if self._in_flight
             else "Type a message… (Enter to send, l/m/h to change tier)"
         )
-        submitted = ctx.text_input(
-            "chat-input",
-            x=ox + 16, y=oy + ctx.h - 48, w=ow - 32,
-            placeholder=placeholder,
-        )
-        if submitted is not None and not self._in_flight:
-            self._send(submitted)
-
-        self._scroll.child = self._build_history_column()
-
         tier_label = TIER_LABELS.get(self._tier, self._tier)
         ctx.render(Column([
             AppBar(title="Chat"),
@@ -144,6 +136,15 @@ class ChatApp(App):
                 f"Tier: {tier_label}  |  l=Low  m=Medium  h=High  |  j/k=scroll"
             ),
         ]))
+
+        submitted = ctx.text_input(
+            "chat-input",
+            x=ox + 16, y=oy + ctx.h - 48, w=ow - 32,
+            placeholder=placeholder,
+        )
+        if submitted is not None and not self._in_flight:
+            self._send(submitted)
+
         self._maybe_scroll_to_bottom()
 
 

--- a/examples/chat-poc/chat.py
+++ b/examples/chat-poc/chat.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from plexi_sdk import App, RenderContext, CapabilityDeniedError, AiResponse
+from plexi_sdk.ui import (
+    AppBar,
+    Column,
+    Divider,
+    Footer,
+    Label,
+    Scrollable,
+    Section,
+    Spacer,
+)
+
+SYSTEM_PROMPT = (
+    "You are a helpful, concise assistant. "
+    "Answer clearly without unnecessary padding."
+)
+
+TIER_LABELS = {"low": "Low (fast)", "medium": "Medium", "high": "High (best)"}
+
+
+@dataclass
+class Turn:
+    role: str   # "user" | "assistant" | "error"
+    text: str
+
+
+class ChatApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._tier: str = "medium"
+        self._turns: list[Turn] = []
+        self._in_flight: bool = False
+        self._scroll = Scrollable(child=Column([]))
+        self._scroll_to_bottom_next: bool = False
+        ctx.status_summary("Chat — type a message and press Enter")
+        self.emit.info("chat-poc started")
+
+    def _maybe_scroll_to_bottom(self) -> None:
+        if not self._scroll_to_bottom_next:
+            return
+        self._scroll_to_bottom_next = False
+        self._scroll.scroll_offset = max(
+            0.0, self._scroll._child_h - self._scroll._avail_h
+        )
+
+    def _send(self, text: str) -> None:
+        if not text.strip():
+            return
+        if self._in_flight:
+            return
+
+        self._turns.append(Turn("user", text))
+        self._in_flight = True
+        self._scroll_to_bottom_next = True
+        self.emit.schedule_render(after_ms=20)
+
+        history = [{"role": t.role, "content": t.text}
+                   for t in self._turns if t.role in ("user", "assistant")]
+        tier = self._tier
+
+        def runner() -> None:
+            try:
+                resp: AiResponse = self.emit.run_sync(self.emit.ai_query(
+                    model_tier=tier,
+                    system=SYSTEM_PROMPT,
+                    messages=history,
+                ))
+                self._turns.append(Turn("assistant", resp.content))
+                self.emit.info(f"chat: {resp.tokens_in}/{resp.tokens_out} tokens")
+            except CapabilityDeniedError as e:
+                self._turns.append(Turn("error", f"Capability denied: {e}"))
+                self.emit.warn(f"chat: capability denied: {e}")
+            except Exception as e:
+                self._turns.append(Turn("error", str(e)))
+                self.emit.warn(f"chat: query failed: {e}")
+            finally:
+                self._in_flight = False
+                self._scroll_to_bottom_next = True
+                self.emit.schedule_render(after_ms=20)
+
+        threading.Thread(target=runner, daemon=True).start()
+
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+        k = key.lower()
+        if k == "l":
+            self._tier = "low"
+            self.emit.schedule_render(after_ms=20)
+        elif k == "m":
+            self._tier = "medium"
+            self.emit.schedule_render(after_ms=20)
+        elif k == "h":
+            self._tier = "high"
+            self.emit.schedule_render(after_ms=20)
+        else:
+            self._scroll.handle_key(key)
+
+    def _build_history_column(self) -> Column:
+        children: list = []
+        for turn in self._turns:
+            if turn.role == "user":
+                children.append(Label(f"You: {turn.text}", bold=True))
+            elif turn.role == "assistant":
+                children.append(Label(turn.text, max_lines=50))
+            else:
+                children.append(Label(turn.text, color="#f38ba8", max_lines=10))
+            children.append(Spacer(size=8.0))
+        if self._in_flight:
+            children.append(Label("thinking…", tone="hint"))
+        if not children:
+            children.append(Label("No messages yet — type below and press Enter.", tone="hint"))
+        return Column(children)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ox, oy, ow = ctx.x, ctx.y, ctx.w
+
+        placeholder = (
+            "Waiting for response…"
+            if self._in_flight
+            else "Type a message… (Enter to send, l/m/h to change tier)"
+        )
+        submitted = ctx.text_input(
+            "chat-input",
+            x=ox + 16, y=oy + ctx.h - 48, w=ow - 32,
+            placeholder=placeholder,
+        )
+        if submitted is not None and not self._in_flight:
+            self._send(submitted)
+
+        self._scroll.child = self._build_history_column()
+
+        tier_label = TIER_LABELS.get(self._tier, self._tier)
+        ctx.render(Column([
+            AppBar(title="Chat"),
+            Section("Conversation"),
+            self._scroll,
+            Spacer(size=56.0),
+            Divider(),
+            Footer(
+                f"Tier: {tier_label}  |  l=Low  m=Medium  h=High  |  j/k=scroll"
+            ),
+        ]))
+        self._maybe_scroll_to_bottom()
+
+
+ChatApp().run()

--- a/examples/chat-poc/manifest.toml
+++ b/examples/chat-poc/manifest.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+
+[app]
+id = "chat-poc"
+type = "app"
+name = "Chat"
+version = "0.1.0"
+description = "Conversational chat POC — proves AiQuery/AiResponse round-trip end-to-end via OpenRouter."
+entry = "chat.py"
+default_notification_scope = "context"
+
+[app.capabilities]
+capabilities = ["ai.query"]
+
+[launch]
+background = false


### PR DESCRIPTION
## Summary

- Adds `examples/chat-poc/` — minimal conversational chat app proving the Plexi AI broker end-to-end via OpenRouter
- Tier selector: `l` = Low, `m` = Medium (default), `h` = High — next request uses the selected tier
- Full multi-turn history sent on every `AiQuery` so the model has context
- Loading state: placeholder changes to "Waiting for response…" while in-flight, submit ignored
- Errors render inline in red, app never crashes on broker failure
- Auto-scrolls to bottom on new turns; `j`/`k` to scroll back through history

`ai-query-test` is kept — it remains useful for single-shot tier testing. `chat-poc` replaces it as the primary AI demo.

## Test plan

- [ ] Install alpha: `just install` from `worktrees/alpha/` after merge
- [ ] Open chat-poc in a pane, type a message, press Enter — reply appears
- [ ] Change tier with `l`/`m`/`h`, send another message — uses the new tier
- [ ] Send several messages — history scrolls, j/k navigates
- [ ] Broker failure (bad API key) — error shown inline, app stays alive

Closes #508