### PR TITLE
feat(error-visibility): boot timeout + render exception re-raise (#424, partial)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1980,6 +1980,7 @@ class App:
         self._pending_measure_text: "dict[str, asyncio.Queue]" = {}
         self._pipes: dict[str, Pipe] = {}
         self._last_render_time: float | None = None
+        self._consecutive_render_errors: int = 0
         # Strong references to background asyncio tasks created by
         # _dispatch_hook_task. Without this, CPython may GC a task before it
         # completes. The done callback removes each task from the set.
@@ -2328,8 +2329,12 @@ class App:
                     ctx = self._make_ctx(frame_id, elapsed=elapsed)
                     try:
                         await self._dispatch_hook(self.on_render, ctx)
+                        self._consecutive_render_errors = 0
                     except Exception as e:
+                        self._consecutive_render_errors += 1
                         ctx.error(f"on_render exception: {e}")
+                        if self._consecutive_render_errors >= 3:
+                            raise
                     ctx.frame_done()
 
                 elif t == "key":

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -2334,6 +2334,8 @@ class App:
                         self._consecutive_render_errors += 1
                         ctx.error(f"on_render exception: {e}")
                         if self._consecutive_render_errors >= 3:
+                            import traceback as _tb
+                            _tb.print_exc()
                             raise
                     ctx.frame_done()
 

--- a/src/process_app/lifecycle.rs
+++ b/src/process_app/lifecycle.rs
@@ -59,8 +59,11 @@ impl LifecycleState {
 // Tunables. `HUNG_FRAME_GAP` is the spec's 5s stall threshold. The
 // protocol-error counter ticks N=3 within M=10s — three malformed lines
 // from an app is catastrophic regardless of why; show the user something
-// is wrong.
+// is wrong. `BOOT_TIMEOUT` caps how long an app may stay in Booting before
+// the pane transitions to Crashed — prevents silent "starting…" hangs when
+// an app deadlocks during init or never emits Ready.
 pub const HUNG_FRAME_GAP: Duration = Duration::from_secs(5);
+pub const BOOT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const PROTOCOL_ERROR_THRESHOLD: u32 = 3;
 pub const PROTOCOL_ERROR_WINDOW: Duration = Duration::from_secs(10);
 
@@ -218,13 +221,16 @@ impl LifecycleTracker {
         if current.is_terminal() || current == LifecycleState::Hung {
             return current;
         }
+        let now = self.elapsed_ms();
         let last_frame = self.last_frame_done_ms.load(Ordering::Acquire);
         if last_frame == 0 {
-            // Still booting — Hung doesn't apply until we've at least seen
-            // one frame land.
+            // Still booting — flip to Crashed if boot timeout exceeded.
+            if now > BOOT_TIMEOUT.as_millis() as u64 {
+                self.set_terminal(LifecycleState::Crashed);
+                return LifecycleState::Crashed;
+            }
             return current;
         }
-        let now = self.elapsed_ms();
         let gap_ms = now.saturating_sub(last_frame);
         if gap_ms < HUNG_FRAME_GAP.as_millis() as u64 {
             return current;
@@ -342,10 +348,22 @@ mod tests {
 
     #[test]
     fn hung_requires_a_frame_already_landed() {
-        let t = tracker();
-        // No FrameDone ever — Hung must not trigger.
+        // Use a fresh tracker so we're well within BOOT_TIMEOUT.
+        let t = LifecycleTracker::new();
+        // No FrameDone ever — must stay Booting, not flip to Hung.
         t.on_user_input();
         assert_eq!(t.tick_check_hung(), LifecycleState::Booting);
+    }
+
+    #[test]
+    fn boot_timeout_flips_to_crashed() {
+        // tracker() pins origin 60s in the past — well beyond BOOT_TIMEOUT.
+        let t = tracker();
+        // No FrameDone ever → boot timeout fires.
+        assert_eq!(t.tick_check_hung(), LifecycleState::Crashed);
+        // Must be sticky.
+        t.on_frame_done();
+        assert_eq!(t.state(), LifecycleState::Crashed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two independent error visibility improvements from #424. The remaining item (AI config error surfacing) depends on v3.6 landing and is deferred.

**`lifecycle.rs` — `BOOT_TIMEOUT = 10s`**
Apps that never emit `Ready` (deadlocked init, missing dependency) stayed in `Booting` forever, showing "starting…" indefinitely. `tick_check_hung` now transitions to `Crashed` after 10s without a FrameDone — the red "crashed" pill appears instead of hanging.

**SDK — consecutive render exception re-raise (threshold = 3)**
`on_render` exceptions were caught and swallowed indefinitely — a broken app produced no visible signal. After 3 consecutive failed renders with no successful one in between, the exception re-raises, causing a Python Traceback on stderr. The lifecycle detects it and flips to `Crashed`.

## Test plan

- [ ] `cargo test process_app::lifecycle` — 18 tests pass (new: `boot_timeout_flips_to_crashed`)
- [ ] Launch an app that never sends `Ready` — pane should transition from "starting" to "crashed" pill within ~10s
- [ ] Launch an app whose `on_render` always raises — pane should show "crashed" pill after 3 render frames (not hang forever)
- [ ] Normal apps unaffected — successful render resets the consecutive error counter

Partial fix for #424. AI config error surfacing left for after v3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)