### PR TITLE
feat(changelog): clickable version badge opens changelog modal + just bump-alpha

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,6 +92,40 @@ clear-apps channel="":
     echo "Cleared $count app directories from $dir"
     echo "Re-run 'just install' from the matching worktree to re-sync from examples/"
 
+bump-alpha:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+    base=$(echo "$current" | sed 's/-.*//')
+    IFS='.' read -r major minor patch <<< "$base"
+    new="$major.$minor.$((patch + 1))"
+    sed -i '' "s/^version = \"$current\"/version = \"$new\"/" Cargo.toml
+    cargo generate-lockfile
+    # Collect commits since last tag, stripping merge commits and chore: DEV_LOG entries
+    last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    if [[ -n "$last_tag" ]]; then
+        range="$last_tag..HEAD"
+    else
+        range="HEAD~20..HEAD"
+    fi
+    mapfile -t commits < <(git log "$range" --oneline --no-merges --format="%s" | grep -v '^chore: DEV_LOG' | grep -v '^chore: bump' || true)
+    today=$(date +%Y-%m-%d)
+    # Build the new unreleased section
+    section="## [alpha] — $today\n\n### Changes"
+    for c in "${commits[@]}"; do
+        section="$section\n- $c"
+    done
+    section="$section\n"
+    # Prepend the section after the header line
+    awk -v block="$section" '
+        /^# Changelog/ { print; getline; print; print ""; printf "%s\n", block; next }
+        { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp
+    mv CHANGELOG.md.tmp CHANGELOG.md
+    git add Cargo.toml Cargo.lock CHANGELOG.md
+    git commit -m "chore: bump alpha to $new, update changelog"
+    echo "Bumped to $new"
+
 bump:
     #!/usr/bin/env bash
     set -e

--- a/justfile
+++ b/justfile
@@ -108,17 +108,17 @@ bump-alpha:
     else
         range="HEAD~20..HEAD"
     fi
-    mapfile -t commits < <(git log "$range" --oneline --no-merges --format="%s" | grep -v '^chore: DEV_LOG' | grep -v '^chore: bump' || true)
+    commits=()
+    while IFS= read -r line; do [[ -n "$line" ]] && commits+=("$line"); done < <(git log "$range" --no-merges --format="%s" | grep -v '^chore: DEV_LOG' | grep -v '^chore: bump' || true)
     today=$(date +%Y-%m-%d)
-    # Build the new unreleased section
-    section="## [alpha] — $today\n\n### Changes"
+    # Build the new alpha section with real newlines
+    section="## [alpha] — $today"$'\n\n'"### Changes"
     for c in "${commits[@]}"; do
-        section="$section\n- $c"
+        section="$section"$'\n'"- $c"
     done
-    section="$section\n"
-    # Prepend the section after the header line
+    # Insert before the first ## version header
     awk -v block="$section" '
-        /^# Changelog/ { print; getline; print; print ""; printf "%s\n", block; next }
+        /^## / && !inserted { printf "%s\n\n", block; inserted=1 }
         { print }
     ' CHANGELOG.md > CHANGELOG.md.tmp
     mv CHANGELOG.md.tmp CHANGELOG.md

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -126,6 +126,7 @@ pub struct PlexiApp {
     pub(crate) active_window: usize,
     pub(crate) sidebar_visible: bool,
     pub(crate) show_shortcuts: bool,
+    pub(crate) show_changelog: bool,
     pub(crate) quitting: bool,
     pub(crate) quit_press_count: u8,
     pub(crate) quit_last_press: Option<std::time::Instant>,
@@ -526,6 +527,7 @@ impl PlexiApp {
                     active_window: active,
                     sidebar_visible: ws.sidebar_visible,
                     show_shortcuts: false,
+                    show_changelog: false,
                     quitting: false,
                     quit_press_count: 0,
                     quit_last_press: None,
@@ -609,6 +611,7 @@ impl PlexiApp {
             active_window: 0,
             sidebar_visible: true,
             show_shortcuts: false,
+            show_changelog: false,
             quitting: false,
             quit_press_count: 0,
             quit_last_press: None,
@@ -2024,6 +2027,15 @@ impl eframe::App for PlexiApp {
                 self.show_shortcuts = false;
             } else {
                 self.draw_shortcuts_overlay(ctx);
+            }
+        }
+
+        // Changelog overlay
+        if self.show_changelog {
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
+                self.show_changelog = false;
+            } else {
+                self.draw_changelog_overlay(ctx);
             }
         }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -54,11 +54,21 @@ impl PlexiApp {
                     self.show_shortcuts = !self.show_shortcuts;
                 }
 
-                ui.label(
-                    RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
-                        .size(10.0)
-                        .color(self.colors.text_dim),
-                );
+                if ui
+                    .add(
+                        egui::Button::new(
+                            RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+                                .size(10.0)
+                                .color(self.colors.text_dim),
+                        )
+                        .frame(false),
+                    )
+                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                    .on_hover_text("Changelog")
+                    .clicked()
+                {
+                    self.show_changelog = !self.show_changelog;
+                }
 
                 let notif_count = self.visible_notification_count();
                 if notif_count > 0 {
@@ -204,6 +214,92 @@ impl PlexiApp {
                                     ui.end_row();
                                 });
                         });
+                    });
+            });
+    }
+
+    pub(crate) fn draw_changelog_overlay(&mut self, ctx: &egui::Context) {
+        const CHANGELOG: &str = include_str!("../CHANGELOG.md");
+
+        egui::Area::new(egui::Id::new("changelog_overlay"))
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar.gamma_multiply(0.95))
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(24, 20))
+                    .show(ui, |ui| {
+                        ui.set_width(560.0);
+                        ui.set_max_height(480.0);
+
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                RichText::new("Changelog")
+                                    .size(13.0)
+                                    .color(self.colors.text_primary)
+                                    .strong(),
+                            );
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                if ui
+                                    .add(
+                                        egui::Button::new(
+                                            RichText::new("✕")
+                                                .size(11.0)
+                                                .color(self.colors.text_dim),
+                                        )
+                                        .frame(false),
+                                    )
+                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                    .clicked()
+                                {
+                                    self.show_changelog = false;
+                                }
+                            });
+                        });
+
+                        ui.add_space(8.0);
+
+                        egui::ScrollArea::vertical()
+                            .max_height(420.0)
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| {
+                                ui.set_width(512.0);
+                                for line in CHANGELOG.lines() {
+                                    if line.starts_with("## ") {
+                                        ui.add_space(6.0);
+                                        ui.label(
+                                            RichText::new(&line[3..])
+                                                .size(style::TEXT_BODY)
+                                                .color(self.colors.text_primary)
+                                                .strong(),
+                                        );
+                                        ui.add_space(2.0);
+                                    } else if line.starts_with("### ") {
+                                        ui.label(
+                                            RichText::new(&line[4..])
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim)
+                                                .strong(),
+                                        );
+                                    } else if line.starts_with("- ") || line.starts_with("* ") {
+                                        ui.label(
+                                            RichText::new(line)
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_primary),
+                                        );
+                                    } else if line.starts_with('#') || line.trim().is_empty() {
+                                        // skip top-level # heading and blank lines
+                                    } else {
+                                        ui.label(
+                                            RichText::new(line)
+                                                .size(style::TEXT_HINT)
+                                                .color(self.colors.text_dim),
+                                        );
+                                    }
+                                }
+                            });
                     });
             });
     }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -267,10 +267,11 @@ impl PlexiApp {
                             .show(ui, |ui| {
                                 ui.set_width(512.0);
                                 for line in CHANGELOG.lines() {
+                                    let clean = |s: &str| s.replace("**", "");
                                     if line.starts_with("## ") {
                                         ui.add_space(6.0);
                                         ui.label(
-                                            RichText::new(&line[3..])
+                                            RichText::new(clean(&line[3..]))
                                                 .size(style::TEXT_BODY)
                                                 .color(self.colors.text_primary)
                                                 .strong(),
@@ -278,14 +279,14 @@ impl PlexiApp {
                                         ui.add_space(2.0);
                                     } else if line.starts_with("### ") {
                                         ui.label(
-                                            RichText::new(&line[4..])
+                                            RichText::new(clean(&line[4..]))
                                                 .size(style::TEXT_HINT)
                                                 .color(self.colors.text_dim)
                                                 .strong(),
                                         );
                                     } else if line.starts_with("- ") || line.starts_with("* ") {
                                         ui.label(
-                                            RichText::new(line)
+                                            RichText::new(clean(line))
                                                 .size(style::TEXT_HINT)
                                                 .color(self.colors.text_primary),
                                         );
@@ -293,7 +294,7 @@ impl PlexiApp {
                                         // skip top-level # heading and blank lines
                                     } else {
                                         ui.label(
-                                            RichText::new(line)
+                                            RichText::new(clean(line))
                                                 .size(style::TEXT_HINT)
                                                 .color(self.colors.text_dim),
                                         );


### PR DESCRIPTION
## Summary
- Version badge in toolbar top-right is now a clickable button — opens a scrollable changelog modal
- Escape or ✕ button dismisses the modal
- CHANGELOG.md is embedded at compile time via `include_str!` — no runtime file access needed
- Adds `just bump-alpha`: patch-bumps Cargo.toml, auto-generates an `[alpha]` section from commits since last tag, commits in one shot (no release build, no tag)

## Test plan
- [ ] Click `v3.4.3` in the toolbar top-right — changelog modal opens
- [ ] Escape dismisses it; ✕ button dismisses it
- [ ] Changelog content renders with section headers bold, bullet entries readable
- [ ] `just bump-alpha` increments patch version, prepends `## [alpha]` section to CHANGELOG.md with recent commits, commits cleanly
- [ ] `just bump` still works unchanged

**Breaks if:** version label in toolbar is no longer visible, or clicking it has no effect.