### PR TITLE
fix: login-shell env inheritance + TextInput layout widget

### DIFF
--- a/examples/chat-poc/chat.py
+++ b/examples/chat-poc/chat.py
@@ -15,6 +15,7 @@ from plexi_sdk.ui import (
     Scrollable,
     Section,
     Spacer,
+    TextInput,
 )
 
 SYSTEM_PROMPT = (
@@ -37,6 +38,7 @@ class ChatApp(App):
         self._turns: list[Turn] = []
         self._in_flight: bool = False
         self._scroll = Scrollable(child=Column([]))
+        self._input = TextInput("chat-input")
         self._scroll_to_bottom_next: bool = False
         ctx.status_summary("Chat — type a message and press Enter")
         self.emit.info("chat-poc started")
@@ -116,11 +118,9 @@ class ChatApp(App):
         return Column(children, padding=0)
 
     def on_render(self, ctx: RenderContext) -> None:
-        ox, oy, ow = ctx.x, ctx.y, ctx.w
-
         self._scroll.child = self._build_history_column()
 
-        placeholder = (
+        self._input.placeholder = (
             "Waiting for response…"
             if self._in_flight
             else "Type a message… (Enter to send, l/m/h to change tier)"
@@ -130,20 +130,15 @@ class ChatApp(App):
             AppBar(title="Chat"),
             Section("Conversation"),
             self._scroll,
-            Spacer(size=56.0),
             Divider(),
+            self._input,
             Footer(
                 f"Tier: {tier_label}  |  l=Low  m=Medium  h=High  |  j/k=scroll"
             ),
         ]))
 
-        submitted = ctx.text_input(
-            "chat-input",
-            x=ox + 16, y=oy + ctx.h - 48, w=ow - 32,
-            placeholder=placeholder,
-        )
-        if submitted is not None and not self._in_flight:
-            self._send(submitted)
+        if self._input.submitted is not None and not self._in_flight:
+            self._send(self._input.submitted)
 
         self._maybe_scroll_to_bottom()
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -901,6 +901,49 @@ class Card(Component):
 
 
 @dataclass
+class TextInput(Component):
+    """Layout-aware text input. Place inside a Column like any other child.
+
+    After ``ctx.render(column)``, read ``.submitted`` to get the text the user
+    submitted (pressed Enter), or ``None`` if nothing was submitted this frame.
+
+    Create once (in ``on_init``) and update ``placeholder`` as needed — the
+    instance is stable across renders so the host can track focus state.
+
+    Example::
+
+        def on_init(self, ctx):
+            self._input = TextInput("chat-input", placeholder="Type a message…")
+
+        def on_render(self, ctx):
+            ctx.render(Column([
+                ...,
+                self._input,
+                Footer("Enter to send"),
+            ]))
+            if self._input.submitted:
+                self._send(self._input.submitted)
+    """
+    id: str
+    placeholder: str = ""
+    height: float = 48.0
+
+    _submitted: Optional[str] = field(default=None, init=False, repr=False)
+
+    def measure(self, avail_w: float) -> float:
+        return self.height
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        self._submitted = ctx.text_input(self.id, x=x, y=y, w=w,
+                                         placeholder=self.placeholder)
+
+    @property
+    def submitted(self) -> Optional[str]:
+        """Text submitted this frame (user pressed Enter), else None."""
+        return self._submitted
+
+
+@dataclass
 class Column(Component):
     """The root container. Stacks children vertically. Handles grow spacers:
     measures fixed-height children first, then distributes leftover space to
@@ -988,7 +1031,7 @@ __all__ = [
     "Component", "Column", "Card",
     "AppBar", "Section", "KeyRow", "Heading", "Label",
     "Spacer", "Divider", "ScrollLog", "Scrollable", "Footer", "FooterKeys",
-    "ListItem", "Row",
+    "ListItem", "Row", "TextInput",
     # badge primitive
     "badge",
     # scroll helpers

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,10 @@ fn main() -> eframe::Result {
     // `gh`/`rg`/`fd`/any-homebrew-tool-not-found bugs when Plexi is launched
     // as a GUI bundle (which inherits only `/usr/bin:/bin:/usr/sbin:/sbin`).
     crate::shell::install_login_shell_path();
+    // Adopt API keys and other user secrets set in ~/.zshrc / ~/.zsh_secrets.
+    // GUI bundles don't inherit these — OPENROUTER_API_KEY, ANTHROPIC_API_KEY,
+    // etc. are invisible without this call.
+    crate::shell::install_login_shell_env();
 
     // One-shot migration from the v3.0 global-namespace secrets index to the
     // workspace-namespaced layout (issue #322). Idempotent: a no-op once the

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -55,6 +55,74 @@ pub fn install_login_shell_path() {
     }
 }
 
+/// Adopt user-defined env vars from the login shell that are missing from the
+/// process environment.
+///
+/// macOS GUI bundles only inherit a minimal environment — API keys, tokens,
+/// and other secrets set in `~/.zshrc` or `~/.zsh_secrets` are invisible to
+/// Plexi and every app it spawns. This probes the login shell for its full
+/// `env` output and sets any var not already present in the process env.
+///
+/// Skips system vars (HOME, USER, SHELL, PWD, etc.) and vars already set —
+/// never overwrites existing values so the GUI context wins on conflicts.
+/// Called after `install_login_shell_path` since PATH is already handled.
+pub fn install_login_shell_env() {
+    // System/terminal vars that are either already correct in the GUI context
+    // or that build_env() sets explicitly later. Never adopt these from the shell.
+    const SKIP: &[&str] = &[
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR",
+        "TERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "COLORTERM", "TERMINFO",
+        "SHLVL", "OLDPWD", "PWD", "_", "PS1", "PS2",
+        "XPC_FLAGS", "XPC_SERVICE_NAME",
+        "APPLE_SECURITY_ASSESSMENT", "COMMAND_MODE",
+        "SECURITYSESSIONID", "SSH_AUTH_SOCK",
+    ];
+
+    let Some(vars) = probe_login_shell_env() else { return };
+    let mut count = 0;
+    for (k, v) in &vars {
+        if SKIP.contains(&k.as_str()) {
+            continue;
+        }
+        if std::env::var(k).is_err() {
+            // SAFETY: called once, early in main(), before any threads read env.
+            unsafe { std::env::set_var(k, v); }
+            count += 1;
+        }
+    }
+    if count > 0 {
+        log::info!("Adopted {count} env vars from login shell");
+    }
+}
+
+fn probe_login_shell_env() -> Option<HashMap<String, String>> {
+    let shell = detect_shell();
+    let output = Command::new(&shell)
+        .args(["-l", "-c", "env"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        log::warn!(
+            "Login-shell env probe failed: {} exited {}",
+            shell,
+            output.status
+        );
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let mut map = HashMap::new();
+    for line in text.lines() {
+        // Only parse lines that look like KEY=value; skip shell functions and
+        // multiline continuations from the previous key.
+        if let Some((k, v)) = line.split_once('=') {
+            if !k.is_empty() && k.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                map.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+    Some(map)
+}
+
 fn probe_login_shell_path() -> Option<String> {
     let shell = detect_shell();
     let output = Command::new(&shell)


### PR DESCRIPTION
## Summary

- **`shell.rs`**: `install_login_shell_env()` runs `zsh -l -c env` at startup and adopts any env var not already in the process env. Fixes `OPENROUTER_API_KEY` (and any `*_API_KEY` / `*_TOKEN`) being invisible to Plexi when launched as a GUI bundle — previously only `PATH` was inherited.

- **`sdk/python/plexi_sdk/ui.py`**: `TextInput` widget participates in Column layout. Reports a fixed height (`48px` default), receives layout-computed `(x, y, w)` coordinates, and exposes `.submitted` after `ctx.render()`. Eliminates the class of overlap bug where `ctx.text_input()` with manual absolute coords fights with Column's `Footer`/`Divider` children.

- **`examples/chat-poc/chat.py`**: Migrated to `TextInput` inside Column. Removes the `Spacer(56)` + out-of-band `ctx.text_input()` call that was causing the input box to visually overlap footer content.

## Test plan

- [ ] Launch chat-poc: text input box renders below the divider, not overlapping the footer
- [ ] Type a message and press Enter: submitted text appears in history, AI response returns (no timeout)
- [ ] `OPENROUTER_API_KEY` visible to apps: check log for "Adopted N env vars from login shell" on startup
- [ ] `from plexi_sdk.ui import TextInput` works in any app

🤖 Generated with [Claude Code](https://claude.com/claude-code)