### PR TITLE
fix: tighten freeze watchdog + throttle macOS drag-cursor polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 Newest releases appear first.
 
+## [3.4.10] — 2026-05-02
+
+### Changes
+- fix: adopt login-shell env vars + TextInput layout widget (#531)
+- chore: CLAUDE.md — add 'To test' line to Ship Cycle summary format
+- feat(v3.7): app tool protocol — ExposeTools/ToolCall/ToolResult + host context injection (#526)
+- chore: promote to beta — v3.4.8
+- chore: CLAUDE.md — clarify post-merge workflow, standardize just bump-and-install, use GitHub issues over backlog
+- chore: justfile bump-alpha fixes, changelog version labels, overlay opacity
+- feat(changelog): clickable version badge opens changelog modal + just bump-alpha (#524)
+- feat(error-visibility): boot timeout + render exception re-raise (#424, partial) (#522)
+- feat(sdk/ui): ListItem and Row auto-centering components (#388) (#521)
+- feat(#508): chat-poc — conversational chat via AiQuery/AiResponse (#519)
+- chore(#509): delete stale docs/specs/, purge dangling references (#518)
+- refactor(#380): WorkspaceRouter — compile-enforced context switching invariant (#510)
+- docs: clarify alpha as starting branch for all changes
+- fix(egui-term): empty clipboard guard, auto-scroll boundary, HiDPI column sync (#475, #492, #472) (#504)
+- feat(#425): config migration on install (#503)
+- fix(#429): delete orphaned src/plexi_iq/ (#502)
+- chore(promote): use --force-with-lease instead of --force for alpha→beta
+- chore(promote): force-push alpha→beta to handle diverged history
+- chore: promote to beta — v3.4.3
+- fix(install): rename binary in bundle for non-stable channels to match config detection
+- feat(commit-graph): flat N-commit load, host scroll, badge overflow fix, PR badges (#500)
+- feat(logging): heartbeat watchdog + workspace autosave on structural changes (#499)
+- fix(ui): hide sidebar separator line — panel is not resizable (#483) (#495)
+- fix(sidebar): remove hover sense from context label — eliminates I-beam cursor (#481) (#494)
+- fix(ui): Escape dismisses shortcuts overlay (#484) (#496)
+- fix(ui): align shortcuts overlay — use key_combo_list for HJKL rows, add min_col_width (#482) (#498)
+- feat(toolbar): show app version label next to ? button (closes #485) (#497)
+- chore: sync alpha version to 3.4.2
+- refactor(promote): bump+changelog on alpha before push; aggregate all entries since last tag for GitHub release
+- fix: awk newline-in-variable error in prepend_changelog — use temp file + getline
+- fix: bash 3.2 compat in promote.sh — replace ${var,,} with explicit y/Y check
+- feat: channel promotion pipeline (just promote)
+- refactor(sidebar): zone-based row abstraction with single cursor authority
+- chore: set RUSTFLAGS=-D warnings globally via justfile export
+- chore: remove version lifecycle, fail on warnings
+- chore: untrack .channel from git index
+- chore: move install logic to scripts/install.sh
+- chore: unify install-alpha/beta/stable into single just install recipe
+- chore: stable channel identity — name=plexi everywhere, build.rs reads .channel
+- chore: derive app title from CARGO_PKG_NAME via build.rs
+- chore: gitignore .channel and set per-worktree values
+- docs: update CLAUDE.md, README, DEV_LOG and add icon.svg (#479)
+- ci: bump actions to Node.js 24-compatible versions (#477)
+
 ## [3.4.9] — 2026-05-02
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.9"
+version = "3.4.10"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.9"
+version = "3.4.10"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,15 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't replace mistakes. -->
 
+## 2026-05-02 — [FIX] Login-shell env inheritance + TextInput layout widget (PR #531 → alpha)
+
+**Root cause 1 — API keys invisible to Plexi:** `install_login_shell_path()` only adopted `PATH` from the login shell. `OPENROUTER_API_KEY` and other user secrets set in `~/.zsh_secrets` (sourced from `.zshrc`) were never in the process env. Added `install_login_shell_env()`: runs `zsh -l -c env`, skips system/terminal vars (HOME, USER, TERM, etc.), sets any remaining var not already in the process env. Called in `main()` immediately after `install_login_shell_path()`. Log line "Adopted N env vars from login shell" confirms it ran.
+
+**Root cause 2 — TextInput overlap with Column children:** `ctx.text_input()` requires manual absolute coordinates. Apps that used it alongside a `Column` (which renders `Divider`/`Footer` at the bottom) had the input float at the absolute position, visually overlapping the Column's bottom children. Added `TextInput` to `sdk/python/plexi_sdk/ui.py` — a proper `Component` subclass that participates in Column layout: `measure()` returns fixed height (48px default), `render()` calls `ctx.text_input()` with the layout-computed `(x, y, w)`, and `.submitted` property exposes the result after `ctx.render()`. `chat.py` migrated to use it.
+
+**What NOT to do:** Never use `ctx.text_input()` with manual absolute coords inside an app that also uses a Column — they have no shared coordinate authority. Always use `TextInput` as a Column child instead.
+
+**Breaks if:** chat-poc text input box overlaps the footer (regression). Or: `from plexi_sdk.ui import TextInput` raises ImportError. Or: log does NOT show "Adopted N env vars from login shell" on alpha startup (env probe failed silently).
+
 ## 2026-05-02 — [CHANGED] v3.7 complete — app tool protocol + host context injection (PR #526 → alpha)
 
 Full v3.7 milestone: ExposeTools/ToolCall/ToolResult PGAP protocol, global tool registry (`src/plexi_ai/tool_dispatch.rs`), multi-round broker tool loop, OpenRouter streaming tool_call delta accumulation, host context injection, Python `@app.tool` decorator, and `examples/tool-poc/` counter POC.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1848,14 +1848,22 @@ impl eframe::App for PlexiApp {
                     || self.renaming_pane.is_some()
                     || self.renaming_window.is_some();
 
+                // When a pane is zoomed, drag targeting is moot (the whole
+                // window targets one pane), so skip the unsafe ObjC cursor
+                // probe entirely. Otherwise, throttle the repaint to 100ms
+                // — 60fps polling of NSApplication APIs from the render
+                // loop is wasteful and a candidate cause of the file-drag
+                // spinning ball seen in production.
                 #[cfg(target_os = "macos")]
-                let drag_cursor_pos: Option<egui::Pos2> = {
+                let drag_cursor_pos: Option<egui::Pos2> = if zoomed_pane.is_some() {
+                    None
+                } else {
                     let has_drag = ui.input(|i| {
                         !i.raw.hovered_files.is_empty() || !i.raw.dropped_files.is_empty()
                     });
                     if has_drag {
                         ui.ctx()
-                            .request_repaint_after(std::time::Duration::from_millis(16)); // continuous repaints while dragging
+                            .request_repaint_after(std::time::Duration::from_millis(100));
                         use objc2_app_kit::NSApplication;
                         use objc2_foundation::MainThreadMarker;
                         MainThreadMarker::new()

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -22,7 +22,7 @@ const HEARTBEAT_EVERY_N_SAMPLES: u64 = 30;
 /// UI thread is considered frozen after this many seconds without a frame tick.
 /// Lowered from 5s — real stalls of 3–4s (enough for the macOS spinning ball)
 /// were silently missed by the old threshold.
-const FREEZE_THRESHOLD_SECS: u64 = 1;
+const FREEZE_THRESHOLD_SECS: u64 = 2;
 
 /// Return the path of the current log file.
 pub fn log_path() -> PathBuf {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,11 +16,13 @@ use std::time::{Duration, Instant};
 
 const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 /// How often the watchdog samples the frame counter. Short enough to catch brief freezes.
-const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
-/// How many sample intervals between full heartbeat log lines (5s × 6 = 30s).
-const HEARTBEAT_EVERY_N_SAMPLES: u64 = 6;
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+/// How many sample intervals between full heartbeat log lines (1s × 30 = 30s).
+const HEARTBEAT_EVERY_N_SAMPLES: u64 = 30;
 /// UI thread is considered frozen after this many seconds without a frame tick.
-const FREEZE_THRESHOLD_SECS: u64 = 5;
+/// Lowered from 5s — real stalls of 3–4s (enough for the macOS spinning ball)
+/// were silently missed by the old threshold.
+const FREEZE_THRESHOLD_SECS: u64 = 1;
 
 /// Return the path of the current log file.
 pub fn log_path() -> PathBuf {


### PR DESCRIPTION
## Summary
Three defensive changes after the silent crashes documented in #530.

- **Watchdog** (`src/logging.rs`): `SAMPLE_INTERVAL` 5s → 1s, `FREEZE_THRESHOLD_SECS` 5s → 1s, `HEARTBEAT_EVERY_N_SAMPLES` 6 → 30. The old config could not detect a stall under 5 seconds. Logs in #530 show 3453ms slow frames that were enough to trigger the macOS spinning ball but never logged a `[FREEZE]` line. Heartbeat cadence stays at 30s.
- **Drag-cursor repaint** (`src/app/mod.rs`): 16ms → 100ms while a drag is active. The previous setting ran unsafe `NSApplication.mainWindow` and `NSWindow.mouseLocationOutsideOfEventStream` 60× per second from the render loop. Whether or not these calls are the root cause of the freeze, the rate is unjustified.
- **Skip cursor probe when zoomed**: when a pane is zoomed, drag targeting is moot — the whole window points at one pane. The unsafe ObjC path is now skipped entirely in this case, which is exactly the scenario in #530.

## What this does NOT do
Does not catch SIGKILL: the macOS watchdog killing a frozen process bypasses every Rust handler. The lower watchdog threshold buys diagnostic data on the next freeze (a `[FREEZE]` line written before the OS kills us) but cannot prevent the kill.

Does not address terminal-renderer cost. If the 3.4s stalls are actually from `TerminalView` rendering large pty output bursts, that is a separate issue.

## Test plan
- [ ] Build alpha: `just bump-and-install` from `worktrees/alpha/` after merge.
- [ ] Drag a file into a zoomed terminal pane — should not stall the UI.
- [ ] Confirm heartbeats still fire every 30s in `~/.plexi-alpha/plexi.log`.
- [ ] If a freeze recurs, confirm `[FREEZE]` lines appear in the log.

Closes #530.