### PR TITLE
fix(shell): use -i -l for env probe so .zshrc-defined secrets load

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -97,8 +97,11 @@ pub fn install_login_shell_env() {
 
 fn probe_login_shell_env() -> Option<HashMap<String, String>> {
     let shell = detect_shell();
+    // `-i -l`: interactive + login. Login alone loads `~/.zprofile` /
+    // `~/.zlogin` but NOT `~/.zshrc`, so secrets sourced from `.zshrc` (e.g.
+    // `~/.zsh_secrets`) are invisible. Interactive forces `.zshrc` to load.
     let output = Command::new(&shell)
-        .args(["-l", "-c", "env"])
+        .args(["-i", "-l", "-c", "env"])
         .output()
         .ok()?;
     if !output.status.success() {


### PR DESCRIPTION
## Summary
- `probe_login_shell_env()` was running `zsh -l -c env` (login-only). Login profiles don't load `~/.zshrc`, so secrets sourced from `.zshrc` (e.g. `~/.zsh_secrets` containing `OPENROUTER_API_KEY`) were invisible to the GUI bundle.
- Adding `-i` forces interactive mode, which loads `.zshrc` alongside login profiles. API keys now propagate.

## Verification
- Local repro before fix: \`env -i /bin/zsh -l -c env | grep OPENROUTER\` → empty
- Local repro after fix: \`env -i /bin/zsh -i -l -c env | grep OPENROUTER\` → key present

## Test plan
- [ ] Fresh GUI launch (Plexi Alpha.app from /Applications)
- [ ] Open chat-poc, send a message, confirm reply within ~5s (no 35s timeout)
- [ ] Log shows "Adopted N env vars from login shell" with N >> 5