### PR TITLE
fix: text input refocus + AI response flush + env probe diagnostics

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -839,6 +839,9 @@ impl ProcessApp {
                 // — `lost_focus` alone fires on tab-out / click-away too.
                 if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                     submitted.push(id.clone());
+                    // Re-focus so the user can type another message immediately
+                    // without clicking the input again (chat UX).
+                    resp.request_focus();
                 }
             }
         }
@@ -1410,6 +1413,11 @@ impl App for ProcessApp {
                 }
             }
         }
+
+        // Flush events accumulated during this frame (broker AiResponse,
+        // TextSubmitted, ScrollOffset, etc.) so apps receive them without
+        // waiting for the next frame's start-of-ui flush.
+        self.flush_outbound_events();
 
         // Idle polling for async HTTP responses. Apps that need faster repaints
         // (games, animations) emit DrawCommand::ScheduleRender { after_ms } each frame.

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -79,7 +79,7 @@ pub fn install_login_shell_env() {
     ];
 
     let Some(vars) = probe_login_shell_env() else { return };
-    let mut count = 0;
+    let mut adopted_keys: Vec<&str> = Vec::new();
     for (k, v) in &vars {
         if SKIP.contains(&k.as_str()) {
             continue;
@@ -87,11 +87,15 @@ pub fn install_login_shell_env() {
         if std::env::var(k).is_err() {
             // SAFETY: called once, early in main(), before any threads read env.
             unsafe { std::env::set_var(k, v); }
-            count += 1;
+            adopted_keys.push(k.as_str());
         }
     }
-    if count > 0 {
-        log::info!("Adopted {count} env vars from login shell");
+    if !adopted_keys.is_empty() {
+        log::info!(
+            "Adopted {} env vars from login shell: [{}]",
+            adopted_keys.len(),
+            adopted_keys.join(", ")
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- **TextInput refocus**: re-request focus after singleline Enter so users can type consecutive chat messages without clicking the input again
- **Outbound event flush**: flush `outbound_events` at end of `ui()` so broker `AiResponse` events are delivered in the same frame they arrive on `http_rx`, not delayed to the next frame's start-of-ui flush
- **Env probe diagnostics**: log adopted key names (not just count) so we can verify `OPENROUTER_API_KEY` is among the adopted vars on GUI launch

## Test plan
- [ ] Open chat-poc, send a message, verify text input stays focused after Enter — type a second message immediately without clicking
- [ ] Verify AI response arrives within ~200ms (not 35s timeout) — check `~/.plexi-alpha/plexi.log` for the AiResponse timing
- [ ] Check log for `Adopted N env vars from login shell: [OPENROUTER_API_KEY, ...]` — key names should be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)