### PR TITLE
fix(routing): AiQuery/ExposeTools/ToolResult silently dropped — never dispatched

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -924,7 +924,17 @@ impl ProcessApp {
                 | DrawCommand::OpenArtifact { .. }
                 | DrawCommand::PushNav { .. }
                 | DrawCommand::PopNav { .. }
-                | DrawCommand::SetMouseTracking { .. }) => {
+                | DrawCommand::SetMouseTracking { .. }
+                // AI
+                | DrawCommand::AiQuery { .. }
+                | DrawCommand::ExposeTools { .. }
+                | DrawCommand::ToolResult { .. }
+                // Video / image / audio meter
+                | DrawCommand::OpenVideo { .. }
+                | DrawCommand::CloseVideo { .. }
+                | DrawCommand::SetVideoState { .. }
+                | DrawCommand::Image { .. }
+                | DrawCommand::AudioMeter { .. }) => {
                     self.route_command(cmd);
                 }
                 // Visual commands, FrameDone, Ready, MeasureText, ScheduleRender
@@ -1132,7 +1142,17 @@ impl App for ProcessApp {
                 | DrawCommand::OpenArtifact { .. }
                 | DrawCommand::PushNav { .. }
                 | DrawCommand::PopNav { .. }
-                | DrawCommand::SetMouseTracking { .. }) => {
+                | DrawCommand::SetMouseTracking { .. }
+                // AI
+                | DrawCommand::AiQuery { .. }
+                | DrawCommand::ExposeTools { .. }
+                | DrawCommand::ToolResult { .. }
+                // Video / image / audio meter
+                | DrawCommand::OpenVideo { .. }
+                | DrawCommand::CloseVideo { .. }
+                | DrawCommand::SetVideoState { .. }
+                | DrawCommand::Image { .. }
+                | DrawCommand::AudioMeter { .. }) => {
                     self.route_command(cmd);
                 }
                 other => self.pending_frame.push(other),


### PR DESCRIPTION
## Summary
- `DrawCommand::AiQuery`, `ExposeTools`, `ToolResult` (and `OpenVideo`, `CloseVideo`, `SetVideoState`, `Image`, `AudioMeter`) were absent from the dispatch lists in both `ui()` and `background_tick` in `process_app/mod.rs`
- These commands fell through to `other => pending_frame.push(other)` in `ui()`, and `_ => {}` in `background_tick` — silently dropped, never reaching `route_command`
- Root cause of chat never working: `AiQuery` was added in PR #526 but the two routing match lists weren't updated
- Fix: added all 8 missing commands to both lists

## Test plan
- [ ] Open `chat-poc` — send a message — should get a response within a few seconds
- [ ] Confirm no timeout error in `~/.plexi-alpha/plexi.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)