### PR TITLE
feat: markdown chat bubbles, TextInput scroll, counter shortcuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_commonmark"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1e5d9a91b1b7a320c9b7f56d1878416d7c9bab3eaf337b036e0ddfabf58623"
+dependencies = [
+ "egui",
+ "egui_commonmark_backend",
+ "egui_extras",
+ "pulldown-cmark",
+]
+
+[[package]]
+name = "egui_commonmark_backend"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb41b6833a6aaa99ca5c4f8e75b2410d69a7b3e30148d413f541147404a0dfa"
+dependencies = [
+ "egui",
+ "egui_extras",
+ "pulldown-cmark",
+]
+
+[[package]]
+name = "egui_extras"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "image",
+ "log",
+ "mime_guess2",
+ "profiling",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1235,27 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumflags2"
@@ -2250,6 +2309,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess2"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
+dependencies = [
+ "mime",
+ "phf",
+ "phf_shared",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3066,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "unicase",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,6 +3170,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "egui_commonmark",
  "egui_term",
  "egui_tiles",
  "fern",
@@ -3177,6 +3299,17 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
 
 [[package]]
 name = "pxfm"
@@ -3659,6 +3792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,6 +4219,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ cpal = "0.17"
 # `macos_fsevent` is the recommended backend (kqueue is the alt, slower for
 # nested dirs). default-features disabled to avoid pulling crossbeam-channel.
 notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
+egui_commonmark = "0.20"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # CoreMIDI I/O (#320). macOS-only; non-mac builds skip MIDI hardware (mock impl

--- a/examples/tool-poc/counter.py
+++ b/examples/tool-poc/counter.py
@@ -68,9 +68,16 @@ class CounterApp(App):
         ctx.text(ctx.w / 2 - 60, 100, f"Count: {self._count}", size=32.0, color=accent, bold=True)
 
         # Instructions
-        ctx.text(20, ctx.h - 80, "Open chat-poc in another pane.", size=13.0, color=dim)
-        ctx.text(20, ctx.h - 58, 'Ask: "increment the counter 3 times"', size=13.0, color=dim)
-        ctx.text(20, ctx.h - 36, 'or: "reset the counter"', size=13.0, color=dim)
+        ctx.text(20, ctx.h - 100, "Open chat-poc in another pane.", size=13.0, color=dim)
+        ctx.text(20, ctx.h - 78, 'Ask: "increment the counter 3 times"', size=13.0, color=dim)
+        ctx.text(20, ctx.h - 56, 'or: "reset the counter"', size=13.0, color=dim)
+        ctx.text(20, ctx.h - 30, "Keys: [i]/[+] increment  [r] reset", size=13.0, color=dim)
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if key in ("i", "+"):
+            self._count += 1
+        elif key == "r":
+            self._count = 0
 
 
 if __name__ == "__main__":

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -1594,6 +1594,19 @@ class RenderContext:
                "align": align, "max_width": max_width, "elide": elide,
                "selectable": selectable})
 
+    def markdown(self, x: float, y: float, w: float, text: str,
+                 base_size: float = 14.0, color: str = FG) -> None:
+        """Render markdown text via the host's egui_commonmark renderer.
+
+        The host creates a child Ui at (x, y) with width w and renders the
+        markdown with proper formatting (bold, italic, code blocks, lists, etc.).
+
+        `base_size` — body font size in pt (headers scale relative to this).
+        `color`     — default text colour (hex).
+        """
+        _emit({"type": "markdown", "x": x, "y": y, "w": w, "text": text,
+               "base_size": base_size, "color": color})
+
     def copy_to_clipboard(self, text: str) -> None:
         """Convenience shortcut for `emit.copy_to_clipboard(text)` (#146)."""
         _emit({"type": "copy_to_clipboard", "text": text})

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -991,12 +991,10 @@ class ChatBubble(Component):
         bx = x + w - bubble_w if self.role == "user" else x
         ctx.rect(bx, y, bubble_w, h, fill=bg, radius=RADIUS_LG)
         fs = self._font_size()
-        line_h = self._line_h()
         text_x = bx + self.BUBBLE_PAD
         text_y = y + self.BUBBLE_PAD
-        for i, line in enumerate(self._lines(w)):
-            ctx.text(text_x, text_y + i * line_h, line,
-                     size=fs, color=fg, bold=False)
+        text_w = bubble_w - 2 * self.BUBBLE_PAD
+        ctx.markdown(text_x, text_y, text_w, self.text, base_size=fs, color=fg)
 
 
 @dataclass

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1192,6 +1192,21 @@ pub enum DrawCommand {
     /// tracking. Send `{ enabled: true }` after `Ready` to start receiving
     /// `on_mouse_move` callbacks. Send `{ enabled: false }` to stop.
     SetMouseTracking { enabled: bool },
+
+    /// Render markdown text using the host's `egui_commonmark` renderer.
+    ///
+    /// The host creates a child `Ui` at `(x, y)` with width `w` and renders
+    /// the markdown with proper formatting (bold, italic, code blocks, etc.).
+    /// `base_size` controls the body font size; `color` sets the default text
+    /// colour.
+    Markdown {
+        x: f32,
+        y: f32,
+        w: f32,
+        text: String,
+        base_size: f32,
+        color: String,
+    },
 }
 
 /// Replace-vs-append behaviour for `DrawCommand::InsertPathToken`.

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -596,6 +596,20 @@ impl PlexiApp {
         if let Some(focused) = ctx.focused_pane {
             if let Some(target) = ctx.find_pane_in_direction_from(focused, dir) {
                 self.windows[self.active_window].focused_pane = Some(target);
+                // Signal the newly-focused pane so render_text_inputs auto-focuses
+                // the first TextInput on the next frame.
+                if let Some(egui_tiles::Tile::Pane(pane_id)) =
+                    self.windows[self.active_window].tree.tiles.get(target)
+                {
+                    let pane_id = *pane_id;
+                    if let Some(pane) = self.windows[self.active_window].panes.get_mut(&pane_id) {
+                        if let Some(app) = pane.as_app_mut() {
+                            if let crate::pane::AppRuntime::Process(ref mut proc_app) = app.runtime {
+                                proc_app.pane_just_focused = true;
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -20,6 +20,20 @@ use std::thread;
 
 use super::{AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent};
 
+fn parse_usage_tokens(usage: &serde_json::Value) -> (Option<u32>, Option<u32>) {
+    let input = usage["prompt_tokens"]
+        .as_u64()
+        .or_else(|| usage["input_tokens"].as_u64())
+        .or_else(|| usage["tokens_in"].as_u64())
+        .map(|n| n as u32);
+    let output = usage["completion_tokens"]
+        .as_u64()
+        .or_else(|| usage["output_tokens"].as_u64())
+        .or_else(|| usage["tokens_out"].as_u64())
+        .map(|n| n as u32);
+    (input, output)
+}
+
 /// OpenRouter streaming backend.
 pub struct OpenRouterBackend {
     pub api_key: String,
@@ -216,8 +230,9 @@ fn stream_openrouter(
         // Usage-only chunk: choices is empty/absent, usage is present.
         if chunk["choices"].as_array().map_or(true, |c| c.is_empty()) {
             if let Some(usage) = chunk.get("usage").filter(|v| !v.is_null()) {
-                input_tokens = usage["prompt_tokens"].as_u64().map(|n| n as u32);
-                output_tokens = usage["completion_tokens"].as_u64().map(|n| n as u32);
+                let (inp, out) = parse_usage_tokens(usage);
+                input_tokens = inp;
+                output_tokens = out;
             }
             continue;
         }
@@ -268,8 +283,9 @@ fn stream_openrouter(
             let _ = tx.send(StreamEvent::ToolCalls(calls));
             // Token counts may arrive in subsequent chunks or in this one.
             if let Some(usage) = chunk.get("usage").filter(|v| !v.is_null()) {
-                input_tokens = usage["prompt_tokens"].as_u64().map(|n| n as u32);
-                output_tokens = usage["completion_tokens"].as_u64().map(|n| n as u32);
+                let (inp, out) = parse_usage_tokens(usage);
+                input_tokens = inp;
+                output_tokens = out;
             }
             let _ = tx.send(StreamEvent::Done {
                 input_tokens,
@@ -295,6 +311,11 @@ fn stream_openrouter(
         output_tokens,
         generation_id: gen_id,
     });
+    if input_tokens.is_none() && output_tokens.is_none() {
+        log::warn!(
+            "openrouter: stream completed without usage metadata (model may omit stream usage)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -67,11 +67,18 @@ impl ToolRegistry {
     }
 
     /// Snapshot of all tools visible right now, keyed by tool name.
-    /// When the same tool name appears in multiple panes, the last one wins
-    /// (non-deterministic order — callers should ensure unique names).
+    ///
+    /// Duplicate names are resolved deterministically: highest pane_id wins
+    /// (typically the most recently opened pane). This avoids hash-iteration
+    /// nondeterminism when multiple panes expose the same tool name.
     fn snapshot(&self) -> HashMap<String, (u64, AiTool)> {
         let mut map = HashMap::new();
-        for (&pane_id, entry) in &self.entries {
+        let mut pane_ids: Vec<u64> = self.entries.keys().copied().collect();
+        pane_ids.sort_unstable();
+        for pane_id in pane_ids {
+            let Some(entry) = self.entries.get(&pane_id) else {
+                continue;
+            };
             for tool in &entry.tools {
                 map.insert(tool.name.clone(), (pane_id, tool.clone()));
             }
@@ -153,7 +160,27 @@ pub struct ToolDispatcher {
 impl ToolDispatcher {
     /// Build a dispatcher from the current global registry state.
     pub fn from_registry() -> Self {
-        let tools = global_registry().lock().unwrap().snapshot();
+        let registry = global_registry().lock().unwrap();
+        let tools = registry.snapshot();
+        let mut owners_by_name: HashMap<String, Vec<u64>> = HashMap::new();
+        for (&pane_id, entry) in &registry.entries {
+            for tool in &entry.tools {
+                owners_by_name
+                    .entry(tool.name.clone())
+                    .or_default()
+                    .push(pane_id);
+            }
+        }
+        for (name, mut owners) in owners_by_name {
+            if owners.len() > 1 {
+                owners.sort_unstable();
+                log::warn!(
+                    "tool_dispatch: duplicate tool name {:?} exposed by panes {:?}; dispatch will target highest pane_id",
+                    name,
+                    owners
+                );
+            }
+        }
         Self { tools }
     }
 

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -220,6 +220,13 @@ pub struct ProcessApp {
     /// `render_text_inputs` pass. Used by `handle_key` to suppress
     /// forwarding text/key events to the app while the user is typing.
     text_input_has_focus: bool,
+    /// Set to true when this pane gains focus via keyboard navigation.
+    /// `render_text_inputs` checks this flag and focuses the first TextInput
+    /// in the frame, then clears it.
+    pub(crate) pane_just_focused: bool,
+    /// Cached state for `egui_commonmark` markdown rendering. Persists across
+    /// frames so the parser doesn't re-allocate on every repaint.
+    commonmark_cache: egui_commonmark::CommonMarkCache,
     /// Per-region scroll offsets for `DrawCommand::BeginScroll` / `EndScroll`
     /// (#446). Key = scroll region id; value = current vertical offset in
     /// logical pixels. Persists across frames — the offset is only reset when
@@ -515,6 +522,8 @@ impl ProcessApp {
             text_input_buffers: HashMap::new(),
             text_input_visible_prev: std::collections::HashSet::new(),
             text_input_has_focus: false,
+            pane_just_focused: false,
+            commonmark_cache: egui_commonmark::CommonMarkCache::default(),
             scroll_offsets: HashMap::new(),
             exposed_tools: Vec::new(),
             #[cfg(test)]
@@ -772,26 +781,30 @@ impl ProcessApp {
                         .max_rect(widget_rect)
                         .id_salt(widget_id),
                 );
-                let edit = if *multiline {
-                    egui::TextEdit::multiline(buffer)
+                let output = if *multiline {
+                    let edit = egui::TextEdit::multiline(buffer)
                         .id(widget_id)
                         .desired_width(*w)
                         .hint_text(placeholder.as_str())
-                        .frame(true)
+                        .frame(true);
+                    egui::ScrollArea::vertical()
+                        .max_height(height)
+                        .show(&mut child, |ui| edit.show(ui))
+                        .inner
                 } else {
-                    egui::TextEdit::singleline(buffer)
+                    let edit = egui::TextEdit::singleline(buffer)
                         .id(widget_id)
                         .desired_width(*w)
                         .hint_text(placeholder.as_str())
-                        .frame(true)
+                        .frame(true);
+                    edit.show(&mut child)
                 };
-                let output = edit.show(&mut child);
-                // Auto-focus the first newly-visible input so the user can
-                // type immediately without clicking. Subsequent newly-visible
-                // inputs in the same frame are skipped — request_focus is
-                // last-write-wins in egui, so focusing all of them would
-                // leave only the last one focused.
-                if newly_visible && !focus_granted {
+                // Auto-focus the first input when: (a) it just appeared in
+                // the frame, or (b) the pane just gained focus via keyboard
+                // navigation. Subsequent inputs in the same frame are skipped
+                // — request_focus is last-write-wins in egui, so focusing all
+                // of them would leave only the last one focused.
+                if (newly_visible || self.pane_just_focused) && !focus_granted {
                     output.response.request_focus();
                     focus_granted = true;
                 }
@@ -871,6 +884,7 @@ impl ProcessApp {
         }
 
         self.text_input_visible_prev = visible_this_frame;
+        self.pane_just_focused = false;
         // Track whether any TextInput has focus so handle_key can suppress
         // key forwarding while the user is typing into an input field.
         self.text_input_has_focus = any_has_focus;
@@ -1225,7 +1239,7 @@ impl App for ProcessApp {
         let pane_rect = ui.available_rect_before_wrap();
         ui.painter().rect_filled(pane_rect, 0.0, ctx.colors.terminal_bg);
         let frame_clone = self.frame.clone();
-        render::render_draw_commands(ui, pane_rect, &frame_clone, ctx.colors);
+        render::render_draw_commands(ui, pane_rect, &frame_clone, ctx.colors, &mut self.commonmark_cache);
         // Interactive widgets (TextInput) need real egui widgets and a
         // mutable per-app buffer map — they can't share the painter-only
         // render path. Render them in a second pass on top of the frame.

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -32,6 +32,7 @@ pub(super) fn render_draw_commands(
     pane_rect: egui::Rect,
     commands: &[DrawCommand],
     colors: &Colors,
+    commonmark_cache: &mut egui_commonmark::CommonMarkCache,
 ) {
     let origin = pane_rect.min;
 
@@ -349,6 +350,50 @@ pub(super) fn render_draw_commands(
 
             DrawCommand::TextRow { x, y, items, gap, align } => {
                 render_text_row(ui, origin, clip, *x, *y, items, *gap, align, colors);
+            }
+
+            DrawCommand::Markdown {
+                x,
+                y,
+                w,
+                text,
+                base_size,
+                color,
+            } => {
+                let text_color = parse_color(color).unwrap_or(colors.text_primary);
+                let md_rect = egui::Rect::from_min_size(
+                    egui::pos2(origin.x + x, origin.y + y),
+                    egui::vec2(*w, pane_rect.max.y - (origin.y + y)),
+                );
+                let mut child = ui.new_child(
+                    egui::UiBuilder::new()
+                        .max_rect(md_rect)
+                        .layout(egui::Layout::top_down(egui::Align::LEFT)),
+                );
+                child.set_clip_rect(clip);
+                // Override default text colour so markdown body text matches the
+                // app-specified colour. Header/code styling is handled internally
+                // by egui_commonmark but inherits the base visuals.
+                child.style_mut().visuals.override_text_color = Some(text_color);
+                // Scale body font size to match the app's base_size.
+                child.style_mut().text_styles.insert(
+                    egui::TextStyle::Body,
+                    egui::FontId::proportional(*base_size),
+                );
+                child.style_mut().text_styles.insert(
+                    egui::TextStyle::Small,
+                    egui::FontId::proportional(base_size * 0.85),
+                );
+                child.style_mut().text_styles.insert(
+                    egui::TextStyle::Heading,
+                    egui::FontId::proportional(base_size * 1.4),
+                );
+                child.style_mut().text_styles.insert(
+                    egui::TextStyle::Monospace,
+                    egui::FontId::monospace(base_size * 0.9),
+                );
+                egui_commonmark::CommonMarkViewer::new()
+                    .show(&mut child, commonmark_cache, text);
             }
 
             // MeasureText is handled in routing.rs (needs a response channel);


### PR DESCRIPTION
## Summary
- **Markdown rendering**: New `DrawCommand::Markdown` + `ctx.markdown()` SDK method powered by `egui_commonmark`. ChatBubble now renders AI responses with full CommonMark formatting (bold, italic, code, lists, headers).
- **TextInput scroll fix**: Multiline TextEdit wrapped in `ScrollArea::vertical()` so it scrolls after filling its allocated height instead of expanding below the screen.
- **Counter shortcuts**: `on_key` handler with `i`/`+` to increment, `r` to reset. Shortcut hints displayed in UI.
- **Pane focus → TextInput focus**: When navigating to a pane via keyboard (Ctrl+h/j/k/l), the first TextInput auto-focuses so the user can type immediately.

## Test plan
- [ ] Open `chat-poc` — send a message, verify the response renders markdown (bold, code, etc.)
- [ ] Type a long message in the chat input — after ~4 lines it should scroll, not expand
- [ ] Open `tool-poc` — press `i` or `+` to increment, `r` to reset
- [ ] Navigate to `chat-poc` via keyboard — TextInput should auto-focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)