### PR TITLE
fix(sidebar): stabilise hit rects, clear renaming_window on reorder

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -191,6 +191,7 @@ impl PlexiApp {
                 } else if result.primary_double_clicked && !any_dragging {
                     menu_action = Some((i, WindowMenuAction::Rename));
                 } else if result.primary_clicked && !any_dragging {
+                    log::debug!("sidebar: primary_clicked ctx={i} active={}", self.router.active_idx());
                     clicked_workspace = Some(i);
                 }
             }
@@ -208,6 +209,7 @@ impl PlexiApp {
             if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
                 if dst != src && dst != src + 1 {
                     let effective_dst = if dst > src { dst - 1 } else { dst };
+                    self.renaming_window = None;
                     self.router.reorder_tracking_active(src, effective_dst);
                 }
             }
@@ -238,15 +240,19 @@ impl PlexiApp {
                     self.rename_buffer = self.router.get(i).name.clone();
                 }
                 WindowMenuAction::MoveToTop => {
+                    self.renaming_window = None;
                     self.router.move_to_front_tracking_active(i);
                 }
                 WindowMenuAction::MoveUp => {
+                    self.renaming_window = None;
                     self.router.swap_tracking_active(i, i - 1);
                 }
                 WindowMenuAction::MoveDown => {
+                    self.renaming_window = None;
                     self.router.swap_tracking_active(i, i + 1);
                 }
                 WindowMenuAction::MoveToBottom => {
+                    self.renaming_window = None;
                     self.router.move_to_back_tracking_active(i);
                 }
                 WindowMenuAction::Delete => {

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -13,16 +13,17 @@ pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
 pub struct RowLayout {
     /// The full row rect: background, border, hover detection.
     pub full: Rect,
-    /// The drag/click/context-menu zone (left portion).
+    /// The drag/click/context-menu zone (left portion). Stable regardless of hover state.
     pub content: Rect,
-    /// The action zone (delete button) — right-anchored, None when hidden.
+    /// The action zone (delete button) — right-anchored, None when the action is disabled.
+    /// Geometry is always carved out when Some; glyph + interaction are gated on hover in draw().
     pub action: Option<Rect>,
 }
 
 impl RowLayout {
-    fn new(origin: Pos2, width: f32, show_action: bool) -> Self {
+    fn new(origin: Pos2, width: f32, action_enabled: bool) -> Self {
         let full = Rect::from_min_size(origin, Vec2::new(width, ROW_HEIGHT));
-        let action = show_action.then(|| {
+        let action = action_enabled.then(|| {
             Rect::from_min_size(
                 egui::pos2(full.max.x - ACTION_ZONE_WIDTH, full.min.y),
                 Vec2::new(ACTION_ZONE_WIDTH, ROW_HEIGHT),
@@ -74,14 +75,13 @@ pub struct SidebarRow {
 
 impl SidebarRow {
     /// Compute layout zones from the current cursor position.
-    /// `show_action_if_hovered`: whether to show the action zone when hovered.
-    /// Pass `false` when dragging is active, only one context exists, or row is renaming.
-    pub fn new(ui: &egui::Ui, width: f32, show_action_if_hovered: bool) -> Self {
+    /// `action_enabled`: whether to carve out the action zone.
+    /// Pass `false` when only one context exists or dragging is active.
+    /// The action glyph and interaction are gated on hover inside draw() — geometry is stable.
+    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool) -> Self {
         let origin = ui.cursor().min;
-        let probe = Rect::from_min_size(origin, Vec2::new(width, ROW_HEIGHT));
-        let show_action = show_action_if_hovered && ui.rect_contains_pointer(probe);
         Self {
-            layout: RowLayout::new(origin, width, show_action),
+            layout: RowLayout::new(origin, width, action_enabled),
             is_active: false,
             is_this_dragging: false,
             is_any_dragging: false,
@@ -109,7 +109,6 @@ impl SidebarRow {
     ) -> RowResult {
         let row_alpha = if self.is_this_dragging { 0.4_f32 } else { 1.0_f32 };
         let hovered = self.layout.hovered(ui);
-        let in_action = self.layout.in_action(ui);
 
         // Advance the layout cursor — must happen before any allocate_new_ui calls
         // that would otherwise try to use the same origin.
@@ -142,25 +141,31 @@ impl SidebarRow {
             |ui| content_fn(ui, hovered),
         );
 
-        // Action zone — glyph painted then full-zone interaction registered
+        // Action zone — glyph and interaction only active when hovered.
+        // Geometry is always carved out (content rect is stable), so no hit-rect shifts on hover.
         let action_clicked = if let Some(az) = self.layout.action {
-            let glyph_color = with_alpha(
-                if in_action { colors.text_primary } else { colors.text_dim },
-                row_alpha,
-            );
-            ui.painter().text(
-                az.center(),
-                egui::Align2::CENTER_CENTER,
-                "\u{2715}",
-                egui::FontId::proportional(13.0),
-                glyph_color,
-            );
-            let resp = ui.interact(az, id.with("action"), Sense::click());
-            let clicked = resp.clicked();
-            if in_action {
-                resp.on_hover_text("Delete context");
+            if hovered && !self.is_this_dragging {
+                let in_action = self.layout.in_action(ui);
+                let glyph_color = with_alpha(
+                    if in_action { colors.text_primary } else { colors.text_dim },
+                    row_alpha,
+                );
+                ui.painter().text(
+                    az.center(),
+                    egui::Align2::CENTER_CENTER,
+                    "\u{2715}",
+                    egui::FontId::proportional(13.0),
+                    glyph_color,
+                );
+                let resp = ui.interact(az, id.with("action"), Sense::click());
+                let clicked = resp.clicked();
+                if in_action {
+                    resp.on_hover_text("Delete context");
+                }
+                clicked
+            } else {
+                false
             }
-            clicked
         } else {
             false
         };


### PR DESCRIPTION
Closes #550 (partial — click-fallthrough to third context still under investigation).

## What changed

**`sidebar_row.rs` — stable hit rects**

`SidebarRow::new()` previously called `ui.rect_contains_pointer(probe)` and baked the result into the content rect geometry. When hovered, content shrank by 30px (ACTION_ZONE_WIDTH). This made the drag/click interaction rect change size every frame depending on hover state — the most likely cause of the unreliable second-item hit area.

Fix: remove hover from layout construction entirely. The action zone is always carved out in geometry when `action_enabled=true`. The glyph and `interact()` call are gated on `hovered` inside `draw()` (visual gate only). Content rect is now stable regardless of hover.

**`sidebar.rs` — renaming_window coherence on reorder**

`renaming_window` stored a raw usize index. All reorder paths (drag, MoveUp/Down/ToTop/ToBottom) now clear it to `None`. A mid-reorder rename was theoretical with the current UX but structurally incorrect.

**`sidebar.rs` — debug log for click-fallthrough**

`log::debug!("sidebar: primary_clicked ctx={i} active={}")` added to the `primary_clicked` branch. Set `log_level = "debug"` in `config.toml` to observe which ctx index fires when reproducing the fallthrough bug.

## Breaks if
Action zone (×) appears on non-hovered rows, or clicking a context when hovered no longer works from the right portion of the row.