### PR TITLE
feat(pty): inject PLEXI_PANE_ID + PLEXI_SOCKET into every managed PTY

### DIFF
--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -64,7 +64,7 @@ impl PlexiApp {
 
         // Allocate the terminal pane.
         let new_id = self.host.alloc_pane_id();
-        let settings = Self::make_backend_settings(resolved_cwd, &self.colors);
+        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors);
         let Some(term) = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -455,7 +455,7 @@ impl PlexiApp {
                     }
 
                     if pane_entry.is_none() {
-                        let settings = Self::make_backend_settings(cwd, &colors);
+                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors);
                         if let Some(mut pane) = TerminalPane::new(
                             saved_pane.id,
                             cc.egui_ctx.clone(),
@@ -780,13 +780,21 @@ impl PlexiApp {
     }
 
     pub(crate) fn make_backend_settings(
+        pane_id: u64,
         working_directory: Option<PathBuf>,
         colors: &Colors,
     ) -> BackendSettings {
+        let mut env = shell::build_env();
+        env.insert("PLEXI_PANE_ID".into(), pane_id.to_string());
+        let socket = crate::config::config_dir()
+            .join("notify.sock")
+            .to_string_lossy()
+            .into_owned();
+        env.insert("PLEXI_SOCKET".into(), socket);
         BackendSettings {
             shell: shell::detect_shell(),
             args: vec!["-l".to_string()],
-            env: shell::build_env(),
+            env,
             dynamic_colors: theme::terminal_dynamic_colors(colors),
             working_directory,
         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -337,7 +337,7 @@ impl PlexiApp {
     ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.host.alloc_pane_id();
 
-        let settings = Self::make_backend_settings(cwd, &self.colors);
+        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
         let pane = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -237,7 +237,7 @@ impl PlexiApp {
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(cwd, &self.colors);
+        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
         let Some(pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),
@@ -315,7 +315,7 @@ impl PlexiApp {
         // Empty context (welcome screen): create the first pane as tree root.
         if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
-            let settings = Self::make_backend_settings(None, &self.colors);
+            let settings = Self::make_backend_settings(new_id, None, &self.colors);
             let Some(pane) = TerminalPane::new(
                 new_id,
                 self.ctx.clone(),
@@ -342,7 +342,7 @@ impl PlexiApp {
         let new_id = self.host.alloc_pane_id();
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(cwd, &self.colors);
+        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
         let Some(pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),


### PR DESCRIPTION
## Summary

- Every PTY-backed terminal pane now receives `PLEXI_PANE_ID` (numeric pane id) and `PLEXI_SOCKET` (variant-correct path to `~/.plexi-{channel}/notify.sock`) in its environment
- Child processes (subshells, scripts, hooks) inherit both vars naturally
- `make_backend_settings()` accepts the pane ID as a new first parameter; all six call sites updated
- Socket path is derived from `config::config_dir()` so it's automatically correct for alpha/beta/stable/PR builds

## Test plan

- [ ] Open a terminal pane in Plexi alpha
- [ ] Run `echo $PLEXI_PANE_ID` — should print a non-zero integer
- [ ] Run `echo $PLEXI_SOCKET` — should print `~/.plexi-alpha/notify.sock`
- [ ] Open a second pane, confirm its `PLEXI_PANE_ID` differs from the first
- [ ] Open a subshell (`zsh`), confirm both vars are still set

**Breaks if:** `PLEXI_PANE_ID` is empty or `PLEXI_SOCKET` doesn't contain the expected channel-specific path in any terminal pane.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)