### PR TITLE
feat(widgets): dismissable_modal helper — escape + click-outside for overlays

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2152,22 +2152,10 @@ impl eframe::App for PlexiApp {
             });
 
         // Shortcuts overlay
-        if self.show_shortcuts {
-            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
-                self.show_shortcuts = false;
-            } else {
-                self.draw_shortcuts_overlay(ctx);
-            }
-        }
+        self.draw_shortcuts_overlay(ctx);
 
         // Changelog overlay
-        if self.show_changelog {
-            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
-                self.show_changelog = false;
-            } else {
-                self.draw_changelog_overlay(ctx);
-            }
-        }
+        self.draw_changelog_overlay(ctx);
 
         // Minimap overlay — auto-hidden when current workspace has <2 windows.
         let ws_id = self.router.active().context_id;

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -99,17 +99,17 @@ impl PlexiApp {
         });
     }
 
-    pub(crate) fn draw_shortcuts_overlay(&self, ctx: &egui::Context) {
-        egui::Area::new(egui::Id::new("shortcuts_overlay"))
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(self.colors.bg_sidebar.gamma_multiply(0.95))
-                    .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
-                    .inner_margin(egui::Margin::symmetric(24, 20))
-                    .show(ui, |ui| {
+    pub(crate) fn draw_shortcuts_overlay(&mut self, ctx: &egui::Context) {
+        if !self.show_shortcuts {
+            return;
+        }
+        let dismissed = crate::widgets::dismissable_modal(ctx, "shortcuts", |ui| {
+            egui::Frame::new()
+                .fill(self.colors.bg_sidebar.gamma_multiply(0.95))
+                .stroke(Stroke::new(1.0, self.colors.border))
+                .corner_radius(R6)
+                .inner_margin(egui::Margin::symmetric(24, 20))
+                .show(ui, |ui| {
                         ui.set_width(620.0);
                         ui.label(
                             RichText::new("Keyboard Shortcuts")
@@ -215,94 +215,81 @@ impl PlexiApp {
                                 });
                         });
                     });
-            });
+        });
+        if dismissed {
+            self.show_shortcuts = false;
+        }
     }
 
     pub(crate) fn draw_changelog_overlay(&mut self, ctx: &egui::Context) {
+        if !self.show_changelog {
+            return;
+        }
         const CHANGELOG: &str = include_str!("../CHANGELOG.md");
 
-        egui::Area::new(egui::Id::new("changelog_overlay"))
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(self.colors.bg_sidebar.gamma_multiply(0.95))
-                    .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
-                    .inner_margin(egui::Margin::symmetric(24, 20))
-                    .show(ui, |ui| {
-                        ui.set_width(560.0);
-                        ui.set_max_height(480.0);
+        let dismissed = crate::widgets::dismissable_modal(ctx, "changelog", |ui| {
+            egui::Frame::new()
+                .fill(self.colors.bg_sidebar.gamma_multiply(0.95))
+                .stroke(Stroke::new(1.0, self.colors.border))
+                .corner_radius(R6)
+                .inner_margin(egui::Margin::symmetric(24, 20))
+                .show(ui, |ui| {
+                    ui.set_width(560.0);
+                    ui.set_max_height(480.0);
 
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new("Changelog")
-                                    .size(13.0)
-                                    .color(self.colors.text_primary)
-                                    .strong(),
-                            );
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                if ui
-                                    .add(
-                                        egui::Button::new(
-                                            RichText::new("✕")
-                                                .size(11.0)
-                                                .color(self.colors.text_dim),
-                                        )
-                                        .frame(false),
-                                    )
-                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                    .clicked()
-                                {
-                                    self.show_changelog = false;
+                    ui.label(
+                        RichText::new("Changelog")
+                            .size(13.0)
+                            .color(self.colors.text_primary)
+                            .strong(),
+                    );
+                    ui.add_space(8.0);
+
+                    egui::ScrollArea::vertical()
+                        .max_height(420.0)
+                        .auto_shrink([false, true])
+                        .show(ui, |ui| {
+                            ui.set_width(512.0);
+                            for line in CHANGELOG.lines() {
+                                let clean = |s: &str| s.replace("**", "");
+                                if line.starts_with("## ") {
+                                    ui.add_space(6.0);
+                                    ui.label(
+                                        RichText::new(clean(&line[3..]))
+                                            .size(style::TEXT_BODY)
+                                            .color(self.colors.text_primary)
+                                            .strong(),
+                                    );
+                                    ui.add_space(2.0);
+                                } else if line.starts_with("### ") {
+                                    ui.label(
+                                        RichText::new(clean(&line[4..]))
+                                            .size(style::TEXT_HINT)
+                                            .color(self.colors.text_dim)
+                                            .strong(),
+                                    );
+                                } else if line.starts_with("- ") || line.starts_with("* ") {
+                                    ui.label(
+                                        RichText::new(clean(line))
+                                            .size(style::TEXT_HINT)
+                                            .color(self.colors.text_primary),
+                                    );
+                                } else if line.starts_with('#') || line.trim().is_empty() {
+                                    // skip top-level # heading and blank lines
+                                } else {
+                                    ui.label(
+                                        RichText::new(clean(line))
+                                            .size(style::TEXT_HINT)
+                                            .color(self.colors.text_dim),
+                                    );
                                 }
-                            });
+                            }
                         });
-
-                        ui.add_space(8.0);
-
-                        egui::ScrollArea::vertical()
-                            .max_height(420.0)
-                            .auto_shrink([false, true])
-                            .show(ui, |ui| {
-                                ui.set_width(512.0);
-                                for line in CHANGELOG.lines() {
-                                    let clean = |s: &str| s.replace("**", "");
-                                    if line.starts_with("## ") {
-                                        ui.add_space(6.0);
-                                        ui.label(
-                                            RichText::new(clean(&line[3..]))
-                                                .size(style::TEXT_BODY)
-                                                .color(self.colors.text_primary)
-                                                .strong(),
-                                        );
-                                        ui.add_space(2.0);
-                                    } else if line.starts_with("### ") {
-                                        ui.label(
-                                            RichText::new(clean(&line[4..]))
-                                                .size(style::TEXT_HINT)
-                                                .color(self.colors.text_dim)
-                                                .strong(),
-                                        );
-                                    } else if line.starts_with("- ") || line.starts_with("* ") {
-                                        ui.label(
-                                            RichText::new(clean(line))
-                                                .size(style::TEXT_HINT)
-                                                .color(self.colors.text_primary),
-                                        );
-                                    } else if line.starts_with('#') || line.trim().is_empty() {
-                                        // skip top-level # heading and blank lines
-                                    } else {
-                                        ui.label(
-                                            RichText::new(clean(line))
-                                                .size(style::TEXT_HINT)
-                                                .color(self.colors.text_dim),
-                                        );
-                                    }
-                                }
-                            });
-                    });
-            });
+                });
+        });
+        if dismissed {
+            self.show_changelog = false;
+        }
     }
 
     pub(crate) fn draw_rename_pane_overlay(&mut self, ctx: &egui::Context) {

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, CornerRadius, Pos2, Stroke, StrokeKind, Vec2};
+use egui::{Align2, Color32, CornerRadius, Pos2, Stroke, StrokeKind, Vec2};
 
 use crate::style;
 use crate::theme::Colors;
@@ -168,4 +168,44 @@ pub(crate) fn key_combo_list(
             );
         }
     });
+}
+
+/// Renders a dismissable centered modal overlay. Handles Escape and click-outside.
+/// Returns `true` if the user dismissed it this frame. Callers guard with
+/// `if !open { return; }` and apply `if dismissed { open = false; }` after.
+pub fn dismissable_modal(
+    ctx: &egui::Context,
+    id: &str,
+    add_contents: impl FnOnce(&mut egui::Ui),
+) -> bool {
+    if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
+        return true;
+    }
+
+    let screen_rect = ctx.screen_rect();
+    let mut dismissed = false;
+
+    let base_id = egui::Id::new(id);
+    egui::Area::new(base_id.with("scrim"))
+        .fixed_pos(screen_rect.min)
+        .order(egui::Order::Middle)
+        .show(ctx, |ui| {
+            ui.painter()
+                .rect_filled(screen_rect, 0.0, Color32::from_black_alpha(80));
+            if ui
+                .allocate_rect(screen_rect, egui::Sense::click())
+                .clicked()
+            {
+                dismissed = true;
+            }
+        });
+
+    egui::Area::new(base_id.with("overlay"))
+        .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            add_contents(ui);
+        });
+
+    dismissed
 }


### PR DESCRIPTION
## Summary
- Adds `widgets::dismissable_modal(ctx, id, |ui| { ... }) -> bool` — handles Escape consumption and a click-absorbing scrim at `Order::Middle` so callers only write content
- Shortcuts and changelog overlays refactored to use the helper; dismiss logic removed from the call site in `app/mod.rs`
- `✕` button removed from changelog header — escape/click-outside is sufficient
- `draw_shortcuts_overlay` promoted from `&self` to `&mut self` (needed to write back `show_shortcuts = false`)

## Test plan
- [ ] Open shortcuts overlay (⌘/) — press Escape to dismiss
- [ ] Open shortcuts overlay — click outside to dismiss
- [ ] Open changelog — press Escape to dismiss
- [ ] Open changelog — click outside to dismiss
- [ ] Confirm no visual regression on either overlay content

**Breaks if:** escape or clicking outside the shortcuts or changelog overlay does nothing