### PR TITLE
feat(sidebar): context naming modal when sidebar is hidden

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,6 +49,10 @@ pub(crate) enum FocusLayer {
     /// "New Agent Workspace…" modal (#349) — CLI dropdown, repo picker, task
     /// textarea.
     AgentWorkspaceModal,
+    /// Context naming modal shown when a new context is created while the
+    /// sidebar is hidden. Mirrors the inline sidebar rename but as a centred
+    /// overlay so the terminal is immediately usable after dismissal.
+    ContextRename,
 }
 
 #[derive(Clone)]
@@ -1140,6 +1144,7 @@ impl eframe::App for PlexiApp {
         self.sync_run_palette_focus();
         self.sync_rename_pane_focus();
         self.sync_agent_workspace_modal_focus();
+        self.sync_context_rename_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
         // notification modal's TextEdit for the `input` kind, the palette's
@@ -1169,6 +1174,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::AgentWorkspaceModal) => {
                     self.draw_agent_workspace_modal(ctx);
                 }
+                Some(FocusLayer::ContextRename) => {
+                    self.draw_rename_context_overlay(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -1182,6 +1190,7 @@ impl eframe::App for PlexiApp {
             self.sync_run_palette_focus();
             self.sync_rename_pane_focus();
             self.sync_agent_workspace_modal_focus();
+            self.sync_context_rename_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -2226,6 +2235,7 @@ impl PlexiApp {
                 | Some(FocusLayer::RunPalette)
                 | Some(FocusLayer::RenamePane)
                 | Some(FocusLayer::AgentWorkspaceModal)
+                | Some(FocusLayer::ContextRename)
         )
     }
 
@@ -2423,6 +2433,22 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::RenamePane);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::RenamePane);
+        }
+    }
+
+    /// Reconcile the context-rename focus layer. Active when `renaming_window`
+    /// is set AND the sidebar is hidden — in that case the inline sidebar row
+    /// never renders, so we promote the rename to a modal overlay instead.
+    pub(crate) fn sync_context_rename_focus(&mut self) {
+        let should_own = self.renaming_window.is_some() && !self.sidebar_visible;
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::ContextRename);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::ContextRename);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::ContextRename);
         }
     }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -384,6 +384,73 @@ impl PlexiApp {
     }
 
 
+    /// Modal for naming a newly-created context when the sidebar is hidden.
+    /// Mirrors the inline sidebar rename but as a centred overlay so the
+    /// terminal becomes immediately usable after the user hits Enter or Escape.
+    pub(crate) fn draw_rename_context_overlay(&mut self, ctx: &egui::Context) {
+        let ctx_idx = match self.renaming_window {
+            Some(idx) => idx,
+            None => return,
+        };
+
+        let (commit, cancel) = ctx.input_mut(|i| {
+            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            (enter, esc)
+        });
+
+        egui::Area::new(egui::Id::new("rename_context_overlay"))
+            .anchor(Align2::CENTER_TOP, Vec2::new(0.0, 80.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(16, 12))
+                    .show(ui, |ui| {
+                        ui.set_width(MODAL_WIDTH);
+                        ui.label(
+                            RichText::new("Name this context")
+                                .size(13.0)
+                                .color(self.colors.text_primary)
+                                .strong(),
+                        );
+                        ui.add_space(6.0);
+
+                        let te_id = egui::Id::new("rename_context_input");
+                        let te = ui.add(
+                            egui::TextEdit::singleline(&mut self.rename_buffer)
+                                .id(te_id)
+                                .desired_width(MODAL_WIDTH)
+                                .hint_text("Context name...")
+                                .font(egui::TextStyle::Body),
+                        );
+
+                        if !te.has_focus() {
+                            te.request_focus();
+                            if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), te_id) {
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::two(
+                                    egui::text::CCursor::new(0),
+                                    egui::text::CCursor::new(self.rename_buffer.len()),
+                                )));
+                                state.store(ui.ctx(), te_id);
+                            }
+                        }
+                    });
+            });
+
+        if cancel {
+            self.renaming_window = None;
+        } else if commit {
+            let new_name = self.rename_buffer.trim().to_string();
+            if !new_name.is_empty() {
+                self.router.get_mut(ctx_idx).name = new_name;
+            }
+            self.renaming_window = None;
+        }
+    }
+
     pub(crate) fn draw_quit_confirm_overlay(&self, ctx: &egui::Context) {
         let count = self.quit_press_count;
         egui::Area::new(egui::Id::new("quit_confirm_overlay"))


### PR DESCRIPTION
## Problem

When the sidebar is hidden and you create a new context (⌘T or clicking the + button with sidebar toggled off), the inline sidebar rename TextEdit was never rendered — but `renaming_window` stayed set, which suppresses terminal focus via the `suppress_focus` check. The result: the new terminal was permanently non-interactive until the app was restarted or the sidebar was briefly shown.

## Fix

Added a `ContextRename` focus layer that activates whenever `renaming_window.is_some() && !sidebar_visible`. A centred modal (identical UX to the existing "Rename Pane" overlay) pops up, the user names the context, and the terminal is immediately usable after Enter or Escape.

When the sidebar IS visible, nothing changes — the inline sidebar rename still renders as before.

## Behaviour

- Sidebar visible → new context → inline rename in sidebar row (existing)
- Sidebar hidden → new context → "Name this context" modal → terminal active after dismiss

Closes #583

**Breaks if:** Creating a new context with the sidebar hidden shows no naming modal, or the terminal remains unresponsive after a context is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)