### PR TITLE
fix(ui): make ghost empty state impossible — defensive tree.root guards + clear zoomed_pane on app close

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,8 +36,8 @@ if [[ -n "$suffix" ]]; then
   cp Cargo.toml "$backup_dir/Cargo.toml"
   cleanup() { cp "$backup_dir/Cargo.toml" Cargo.toml; rm -rf "$backup_dir"; }
   trap cleanup EXIT
-  sed -i '' "s/name = \"Plexi\"/name = \"${display}\"/" Cargo.toml
-  sed -i '' "s/identifier = \"com.ianjamesburke.plexi\"/identifier = \"${bundle_id}\"/" Cargo.toml
+  sed -i '' "s/name = \"Plexi[^\"]*\"/name = \"${display}\"/" Cargo.toml
+  sed -i '' "s/identifier = \"com.ianjamesburke.plexi[^\"]*\"/identifier = \"${bundle_id}\"/" Cargo.toml
 fi
 
 cargo bundle --release

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1824,7 +1824,9 @@ impl eframe::App for PlexiApp {
                     self.force_reload_focused_app();
                 }
                 Action::NewPageRight => {
-                    if self.windows[self.active_window].panes.is_empty() {
+                    if self.windows[self.active_window].panes.is_empty()
+                        || self.windows[self.active_window].tree.root.is_none()
+                    {
                         self.reset_active_context();
                     } else {
                         self.new_page_right();
@@ -1938,7 +1940,7 @@ impl eframe::App for PlexiApp {
             })
             .show(ctx, |ui| {
                 let active = self.active_window;
-                if self.windows[active].panes.is_empty() {
+                if self.windows[active].panes.is_empty() || self.windows[active].tree.root.is_none() {
                     self.draw_welcome_screen(ui);
                     return;
                 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -676,6 +676,7 @@ impl PlexiApp {
             .is_some();
         if is_app {
             self.close_tile(active, focused_tile);
+            self.windows[active].zoomed_pane = None;
         }
     }
 


### PR DESCRIPTION
Fixes #571

## What changed
Three targeted guards to make the blank void state structurally impossible:

1. **Render guard** (`app/mod.rs`): welcome screen now fires when `panes.is_empty() || tree.root.is_none()` — catches the case where panes has stale entries but the tree has no root to render
2. **Cmd+N guard** (`app/mod.rs`): `Action::NewPageRight` uses the same condition, so it calls `reset_active_context()` instead of `new_page_right()` when the window is in a broken empty state
3. **Zoomed pane cleanup** (`pane_ops/layout.rs`): `close_focused_app()` now clears `zoomed_pane` after `close_tile`, preventing a stale `TileId` from persisting after the app tile is removed from the tree

**Breaks if:** the welcome screen appears when a pane should be visible, or Cmd+N stops creating new pages in a multi-page layout.