### PR TITLE
feat(logging): drop-event breadcrumbs in zoomed overlay path

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2070,10 +2070,15 @@ impl eframe::App for PlexiApp {
                         // zoomed terminal, NOT a background tile. The
                         // per-tile drop path in `tiling.rs` is gated off
                         // while zoomed; we handle the drop here instead.
-                        let dropped_to_zoom = child_ui.input(|i| {
-                            !i.raw.dropped_files.is_empty()
-                                && child_ui.rect_contains_pointer(inner_rect)
-                        });
+                        let has_drop =
+                            child_ui.input(|i| !i.raw.dropped_files.is_empty());
+                        let dropped_to_zoom =
+                            has_drop && child_ui.rect_contains_pointer(inner_rect);
+                        if has_drop {
+                            log::info!(
+                                "drop: zoomed overlay received drop event — dropped_to_zoom={dropped_to_zoom}, pane_id={pane_id:?}"
+                            );
+                        }
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -199,6 +199,7 @@ pub(crate) fn write_dropped_paths_to_terminal(ui: &egui::Ui, t: &mut TerminalPan
     for file in dropped {
         let Some(path) = &file.path else { continue };
         let path_str = path.display().to_string();
+        log::info!("drop: writing path to terminal: {path_str}");
         let escaped = if path_str.contains(|c: char| {
             c.is_whitespace() || "\"'\\()&|;$`!#".contains(c)
         }) {
@@ -208,5 +209,6 @@ pub(crate) fn write_dropped_paths_to_terminal(ui: &egui::Ui, t: &mut TerminalPan
         };
         t.backend
             .process_command(BackendCommand::Write(escaped.as_bytes().to_vec()));
+        log::info!("drop: path written ok");
     }
 }


### PR DESCRIPTION
Adds `info`-level log lines around the drag-drop path in the zoomed overlay so the next occurrence of the zoom-drop freeze (#579) leaves a diagnostic trail in `~/.plexi-alpha/plexi.log`.

## What's logged

On any drop while a pane is zoomed:
```
[INFO] drop: zoomed overlay received drop event — dropped_to_zoom=true/false, pane_id=PaneId(N)
[INFO] drop: writing path to terminal: /var/folders/.../Screenshot....png
[INFO] drop: path written ok
```

If the app freezes, the last emitted line identifies exactly where execution stalled — whether it's before the write, during it, or not reached at all (`dropped_to_zoom=false` means the rect check failed and neither path handled the drop).

## Repro context

Freeze confirmed on alpha: 4-terminal split → drag screenshot (works) → zoom one terminal → drag same screenshot again → full freeze. See #579 for full analysis.

**Breaks if:** log file contains no `drop:` lines after dragging a file into any terminal pane (zoomed or not).