### PR TITLE
fix(drag): skip TerminalView render during file hover on zoomed pane

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2021,6 +2021,24 @@ impl eframe::App for PlexiApp {
                 #[cfg(not(target_os = "macos"))]
                 let drag_cursor_pos: Option<egui::Pos2> = None;
 
+                // Cache once per frame — used by PlexiBehavior to avoid O(n) ui.input() reads.
+                let hovered_files = ui.input(|i| !i.raw.hovered_files.is_empty());
+
+                // Edge-trigger: log the first frame a file drag enters the window (zoomed path).
+                // Subsequent frames are silent. Used to pinpoint freeze location in the log.
+                if hovered_files && zoomed_pane.is_some() {
+                    let hover_id = egui::Id::new("drag_hover_was_active");
+                    let was_hovering: bool =
+                        ui.ctx().data(|d| d.get_temp(hover_id).unwrap_or(false));
+                    if !was_hovering {
+                        log::info!("[DRAG] hover: hovered_files became non-empty on zoomed pane");
+                    }
+                    ui.ctx().data_mut(|d| d.insert_temp(hover_id, true));
+                } else {
+                    let hover_id = egui::Id::new("drag_hover_was_active");
+                    ui.ctx().data_mut(|d| d.insert_temp(hover_id, false));
+                }
+
                 let mut behavior = PlexiBehavior {
                     panes: &mut ctx.panes,
                     focused_tile: if suppress_focus {
@@ -2036,9 +2054,12 @@ impl eframe::App for PlexiApp {
                     colors: self.colors,
                     pane_names,
                     drag_cursor_pos,
+                    hovered_files,
                     workspace_root: crate::config::active_workspace_root(),
                 };
+                log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ctx.tree.ui(&mut behavior, ui);
+                log::debug!("[DRAG] tiling: done");
 
                 if let Some(new) = behavior.new_focused {
                     ctx.focused_pane = Some(new);
@@ -2116,6 +2137,28 @@ impl eframe::App for PlexiApp {
                                                     });
                                                 },
                                             );
+                                        } else if hovered_files {
+                                            // Skip TerminalView render while a file is being
+                                            // dragged over the zoomed pane. TerminalView::show()
+                                            // calls backend.sync() which clones the full grid
+                                            // under FairMutex contention — on a large terminal
+                                            // (e.g. a full-window Claude Code session) this
+                                            // blocked the main thread for several seconds.
+                                            // The drop itself is handled above (dropped_to_zoom
+                                            // guard), so we skip only the hover-frame renders.
+                                            log::debug!("[DRAG] zoom overlay: skipping TerminalView render during file hover");
+                                            let rect = ui.max_rect();
+                                            ui.allocate_new_ui(
+                                                egui::UiBuilder::new().max_rect(rect),
+                                                |ui| {
+                                                    ui.centered_and_justified(|ui| {
+                                                        ui.colored_label(
+                                                            self.colors.text_dim,
+                                                            "Drop to paste path",
+                                                        );
+                                                    });
+                                                },
+                                            );
                                         } else {
                                             // Reserve space for tab dots if in a tab group
                                             if zoomed_tab_info.is_some() {
@@ -2124,6 +2167,7 @@ impl eframe::App for PlexiApp {
                                                 );
                                             }
                                             let font_size = t.font_size;
+                                            log::debug!("[DRAG] zoom overlay: TerminalView render start");
                                             let terminal = TerminalView::new(ui, &mut t.backend)
                                                 .set_focus(true)
                                                 .set_theme(self.theme.clone())
@@ -2133,6 +2177,7 @@ impl eframe::App for PlexiApp {
                                                     ui.available_height(),
                                                 ));
                                             ui.add(terminal);
+                                            log::debug!("[DRAG] zoom overlay: TerminalView render done");
                                         }
                                     } else if let Some(a) = pane.as_app_mut() {
                                         let app_ctx = crate::app_trait::AppRenderContext {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2103,11 +2103,16 @@ impl eframe::App for PlexiApp {
                         // while zoomed; we handle the drop here instead.
                         let has_drop =
                             child_ui.input(|i| !i.raw.dropped_files.is_empty());
-                        let dropped_to_zoom =
-                            has_drop && child_ui.rect_contains_pointer(inner_rect);
+                        // When zoomed there is only one pane covering the entire overlay —
+                        // no ambiguity about the target. Skip rect_contains_pointer: egui's
+                        // pointer position is stale during macOS OS-level file drags (we skip
+                        // the NSApplication cursor query when zoomed), so rect_contains_pointer
+                        // would only return true if the last known position happened to fall
+                        // inside inner_rect (typically the original split-pane location).
+                        let dropped_to_zoom = has_drop;
                         if has_drop {
                             log::info!(
-                                "drop: zoomed overlay received drop event — dropped_to_zoom={dropped_to_zoom}, pane_id={pane_id:?}"
+                                "drop: zoomed overlay received drop event — pane_id={pane_id:?}"
                             );
                         }
                         egui::Frame::new()

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -46,6 +46,9 @@ pub struct PlexiBehavior<'a> {
     pub colors: Colors,
     pub pane_names: HashMap<PaneId, String>,
     pub drag_cursor_pos: Option<egui::Pos2>,
+    /// Cached once per frame — true if files are being dragged over the window.
+    /// Avoids O(n) `ui.input()` calls inside `pane_ui` for each background pane.
+    pub hovered_files: bool,
     /// The active workspace root (or `None` when running outside a workspace).
     /// Used by `terminal_pane::render` to flag terminal panes whose CWD has
     /// drifted outside the workspace tree. See issue #308 Phase 1.
@@ -54,46 +57,38 @@ pub struct PlexiBehavior<'a> {
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
     fn pane_ui(&mut self, ui: &mut egui::Ui, tile_id: TileId, pane_id: &mut PaneId) -> UiResponse {
-        // Detect clicks or file drags for focus (skip when a pane is zoomed — input belongs to the overlay)
+        // While any pane is zoomed, paint background panes as dark placeholders
+        // and skip all input detection — the zoom overlay owns focus and drop
+        // handling. This avoids per-pane `ui.input()` calls during hover, which
+        // were O(n) and ran even when the results could never be acted on.
+        if self.zoomed_pane.is_some() {
+            let pane_rect = ui.available_rect_before_wrap();
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
+            return UiResponse::None;
+        }
+
+        // Detect clicks or file drags for focus.
         let is_click =
             ui.input(|i| i.pointer.any_pressed()) && ui.rect_contains_pointer(ui.max_rect());
         let is_drag_hovering = match self.drag_cursor_pos {
             Some(pos) => ui.max_rect().contains(pos),
-            None => {
-                ui.input(|i| !i.raw.hovered_files.is_empty())
-                    && ui.rect_contains_pointer(ui.max_rect())
-            }
+            None => self.hovered_files && ui.rect_contains_pointer(ui.max_rect()),
         };
-        if self.zoomed_pane.is_none() && (is_click || is_drag_hovering) {
+        if is_click || is_drag_hovering {
             self.new_focused = Some(tile_id);
         }
 
         let is_focused = self.focused_tile == Some(tile_id);
 
-        // Drop target matches the visual focus rect above.
-        //
-        // Skip when a pane is zoomed: background tiles are still rendered
-        // as dark placeholders and still receive pointer input, but the
-        // user can't see them. Without this guard, dropping a file onto a
-        // zoomed pane silently writes its path into a terminal *behind*
-        // the overlay. The zoomed overlay in `app.rs` owns drop handling
-        // for the zoomed pane itself.
-        if is_drag_hovering && self.zoomed_pane.is_none() {
+        // Drop target: the zoomed overlay owns drops when a pane is zoomed,
+        // so this path only runs when zoomed_pane.is_none() (guaranteed above).
+        if is_drag_hovering {
             if let Some(t) = self.panes.get_mut(pane_id).and_then(Pane::as_terminal_mut) {
                 write_dropped_paths_to_terminal(ui, t);
             }
         }
 
-        // While any pane is zoomed, paint background panes as dark placeholders.
-        // The zoomed pane itself is rendered by the overlay in `app.rs`.
-        // Painter-only fill: wrapping in `egui::Frame` collapses to a grey
-        // square in the top-left when inner renderers don't allocate UI space.
         let pane_rect = ui.available_rect_before_wrap();
-        if self.zoomed_pane.is_some() {
-            ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
-            return UiResponse::None;
-        }
-
         let Some(pane) = self.panes.get_mut(pane_id) else {
             return UiResponse::None;
         };


### PR DESCRIPTION
## Summary
- When a file is dragged over a zoomed terminal, `TerminalView::show()` calls `backend.sync()` which clones the full terminal grid under `FairMutex` contention — blocked the main thread for 5-7s on a large Claude Code session
- Fix: replace TerminalView with a "Drop to paste path" indicator during file hover; drop handling itself is unchanged (happens before the render)
- Also caches `hovered_files` once per frame instead of O(n) per-pane reads, and moves the zoomed early-return to the top of `pane_ui` to skip all input detection for background panes when zoomed

## Breaks if
Drop onto a zoomed terminal no longer pastes the file path, or the freeze still occurs when dragging a file over a zoomed terminal.

Fixes #582