### PR TITLE
feat(cli): plexi notify --choice blocking flow

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -84,6 +84,11 @@ pub(crate) struct PendingNotification {
     /// matching binary ring on first render and caches the texture under
     /// `PlexiApp::notification_images`.
     pub image_pipe_id: Option<String>,
+    /// Path to a file the CLI polls for the chosen key. Set when the
+    /// notification was queued by `plexi notify --choice …`. The host writes
+    /// the chosen value here when the user picks an option so the blocking CLI
+    /// process can read it and exit.
+    pub response_file: Option<String>,
 }
 
 /// Render state for a notification's image attachment. Computed once and
@@ -825,6 +830,26 @@ impl PlexiApp {
             let level = val["level"].as_str().unwrap_or("info").to_string();
             let title = val["title"].as_str().unwrap_or("").to_string();
             let body = val["body"].as_str().unwrap_or("").to_string();
+            let choices_json = val["choices"].as_array();
+            let options: Vec<crate::app_protocol::NotifyOption> = choices_json
+                .map(|arr| {
+                    arr.iter()
+                        .map(|item| crate::app_protocol::NotifyOption {
+                            label: item["label"].as_str().unwrap_or("").to_string(),
+                            value: item["key"].as_str().unwrap_or("").to_string(),
+                            shortcut: Some(
+                                item["key"].as_str().unwrap_or("").to_string(),
+                            ),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let kind = if options.is_empty() {
+                crate::app_protocol::NotifyKind::Message
+            } else {
+                crate::app_protocol::NotifyKind::Choice
+            };
+            let response_file = val["response_file"].as_str().map(|s| s.to_string());
             let internal_id = format!(
                 "__host__:{}",
                 std::time::SystemTime::now()
@@ -842,13 +867,14 @@ impl PlexiApp {
                 level,
                 title,
                 body,
-                kind: crate::app_protocol::NotifyKind::Message,
-                options: vec![],
+                kind,
+                options,
                 input_prompt: None,
                 required: false,
                 priority: 0,
                 image_inline: None,
                 image_pipe_id: None,
+                response_file,
             });
             // Host-originated notifications are always LOW (priority 0) —
             // below any reasonable interrupt threshold — so they queue
@@ -1113,6 +1139,7 @@ impl PlexiApp {
             priority: 0,
             image_inline: None,
             image_pipe_id: None,
+            response_file: None,
         });
         let should_auto_open = !self.notifications_focus_mode
             && 0 >= self.notifications_interrupt_threshold;
@@ -1313,6 +1340,7 @@ impl eframe::App for PlexiApp {
                         scope,
                         image_inline,
                         image_pipe_id,
+                        response_file: None,
                     });
                     // Auto-open rules:
                     //   1. Visibility (Global or in active context) — else
@@ -1342,6 +1370,20 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } => {
+                    // Write response to the CLI response file when this was a
+                    // host-originated blocking notification (sender_pane_id == 0).
+                    if pane_id == 0 {
+                        if let Some(notif) = self
+                            .pending_notifications
+                            .iter()
+                            .find(|n| n.notify_id == notify_id)
+                        {
+                            if let Some(ref rf) = notif.response_file {
+                                let content = value.as_deref().unwrap_or("");
+                                let _ = std::fs::write(rf, content);
+                            }
+                        }
+                    }
                     let active = self.active_window;
                     if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
                         if let Some(app) = pane.as_app_mut() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1373,28 +1373,15 @@ impl eframe::App for PlexiApp {
                         self.current_notify_id = Some(new_id);
                     }
                 }
-                AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } => {
+                AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file } => {
                     log::info!(
                         "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?}"
                     );
-                    // Write response to the CLI response file when this was a
-                    // host-originated blocking notification (sender_pane_id == 0).
-                    if pane_id == 0 {
-                        let found = self.pending_notifications.iter()
-                            .find(|n| n.notify_id == notify_id);
-                        log::info!(
-                            "notify:action: host-originated, found={} response_file={:?}",
-                            found.is_some(),
-                            found.and_then(|n| n.response_file.as_deref())
-                        );
-                        if let Some(notif) = found {
-                            if let Some(ref rf) = notif.response_file {
-                                let content = value.as_deref().unwrap_or("");
-                                match std::fs::write(rf, content) {
-                                    Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
-                                    Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
-                                }
-                            }
+                    if let Some(rf) = &response_file {
+                        let content = value.as_deref().unwrap_or("");
+                        match std::fs::write(rf, content) {
+                            Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
+                            Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
                         }
                     }
                     let active = self.active_window;
@@ -2610,7 +2597,17 @@ impl PlexiApp {
     pub(crate) fn dispatch_notify_action_cmds(&mut self, cmds: Vec<crate::app_trait::AppCommand>) {
         use crate::app_trait::AppCommand;
         for cmd in cmds {
-            if let AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } = cmd {
+            if let AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file } = cmd {
+                log::info!(
+                    "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?}"
+                );
+                if let Some(rf) = &response_file {
+                    let content = value.as_deref().unwrap_or("");
+                    match std::fs::write(rf, content) {
+                        Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
+                        Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
+                    }
+                }
                 let active = self.active_window;
                 if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
                     if let Some(app) = pane.as_app_mut() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -850,6 +850,10 @@ impl PlexiApp {
                 crate::app_protocol::NotifyKind::Choice
             };
             let response_file = val["response_file"].as_str().map(|s| s.to_string());
+            log::info!(
+                "notify:drain: title={:?} choices={} response_file={:?}",
+                title, options.len(), response_file
+            );
             let internal_id = format!(
                 "__host__:{}",
                 std::time::SystemTime::now()
@@ -1370,17 +1374,26 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value } => {
+                    log::info!(
+                        "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?}"
+                    );
                     // Write response to the CLI response file when this was a
                     // host-originated blocking notification (sender_pane_id == 0).
                     if pane_id == 0 {
-                        if let Some(notif) = self
-                            .pending_notifications
-                            .iter()
-                            .find(|n| n.notify_id == notify_id)
-                        {
+                        let found = self.pending_notifications.iter()
+                            .find(|n| n.notify_id == notify_id);
+                        log::info!(
+                            "notify:action: host-originated, found={} response_file={:?}",
+                            found.is_some(),
+                            found.and_then(|n| n.response_file.as_deref())
+                        );
+                        if let Some(notif) = found {
                             if let Some(ref rf) = notif.response_file {
                                 let content = value.as_deref().unwrap_or("");
-                                let _ = std::fs::write(rf, content);
+                                match std::fs::write(rf, content) {
+                                    Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
+                                    Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
+                                }
                             }
                         }
                     }

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -90,6 +90,8 @@ pub enum AppCommand {
         notify_id: String,
         action_label: String,
         value: Option<String>,
+        /// Path to write the chosen value for host-originated blocking notifications.
+        response_file: Option<String>,
     },
     /// Canvas Terminal Binding Primitives (#78). The host opens a fresh
     /// terminal next to `sender_pane_id`, sets the new terminal as the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -869,10 +869,15 @@ pub fn notify_cli(
         "response_file": response_file.to_string_lossy(),
     });
     let queue_file = queue_dir.join(format!("{id}.json"));
+    log::info!(
+        "notify:cli: writing queue file {:?} choices={} response_file={:?}",
+        queue_file, choices.len(), response_file
+    );
     if let Err(e) = std::fs::write(&queue_file, payload.to_string()) {
         eprintln!("error: could not write notification: {e}");
         return 1;
     }
+    log::info!("notify:cli: queue file written, polling for response");
 
     let deadline = if timeout_secs > 0 {
         Some(
@@ -887,11 +892,13 @@ pub fn notify_cli(
         if response_file.exists() {
             match std::fs::read_to_string(&response_file) {
                 Ok(key) => {
+                    log::info!("notify:cli: response received {:?}", key.trim());
                     let _ = std::fs::remove_file(&response_file);
                     print!("{}", key.trim());
                     return 0;
                 }
                 Err(e) => {
+                    log::warn!("notify:cli: could not read response file: {e}");
                     eprintln!("error: could not read response file: {e}");
                     return 1;
                 }
@@ -899,6 +906,7 @@ pub fn notify_cli(
         }
         if let Some(dl) = deadline {
             if std::time::Instant::now() >= dl {
+                log::info!("notify:cli: timed out after {timeout_secs}s");
                 return 2;
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -816,9 +816,20 @@ pub fn pack_export_cli(dest_path: &str) -> i32 {
     }
 }
 
-/// Entry point for `plexi notify --title <text> --body <text> [--level info|warn|error]`.
-/// Writes a JSON file to the notify queue dir; the running host polls and ingests it.
-pub fn notify_cli(title: &str, body: &str, level: &str) -> i32 {
+/// Entry point for `plexi notify --title <text> --body <text> [--level info|warn|error]
+///   [--choice key:Label]... [--timeout N]`.
+///
+/// With no choices: fire-and-forget (writes queue file, prints "notification queued", exits 0).
+/// With choices: writes queue file with `choices` + `response_file`, polls the response file
+/// until the user selects an option, prints the chosen key to stdout, exits 0.
+/// On timeout: exits 2. On queue write error: exits 1.
+pub fn notify_cli(
+    title: &str,
+    body: &str,
+    level: &str,
+    choices: &[(String, String)],
+    timeout_secs: u64,
+) -> i32 {
     let queue_dir = crate::config::config_dir().join("notify-queue");
     if let Err(e) = std::fs::create_dir_all(&queue_dir) {
         eprintln!("error: could not create notify queue: {e}");
@@ -828,18 +839,71 @@ pub fn notify_cli(title: &str, body: &str, level: &str) -> i32 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let file = queue_dir.join(format!("{id}.json"));
+
+    if choices.is_empty() {
+        let file = queue_dir.join(format!("{id}.json"));
+        let payload = serde_json::json!({
+            "level": level,
+            "title": title,
+            "body": body,
+        });
+        if let Err(e) = std::fs::write(&file, payload.to_string()) {
+            eprintln!("error: could not write notification: {e}");
+            return 1;
+        }
+        println!("notification queued");
+        return 0;
+    }
+
+    // Blocking path: create a response file path and poll for it.
+    let response_file = crate::config::config_dir().join(format!("notify-response-{id}.txt"));
+    let choices_json: Vec<serde_json::Value> = choices
+        .iter()
+        .map(|(key, label)| serde_json::json!({"key": key, "label": label}))
+        .collect();
     let payload = serde_json::json!({
         "level": level,
         "title": title,
         "body": body,
+        "choices": choices_json,
+        "response_file": response_file.to_string_lossy(),
     });
-    if let Err(e) = std::fs::write(&file, payload.to_string()) {
+    let queue_file = queue_dir.join(format!("{id}.json"));
+    if let Err(e) = std::fs::write(&queue_file, payload.to_string()) {
         eprintln!("error: could not write notification: {e}");
         return 1;
     }
-    println!("notification queued");
-    0
+
+    let deadline = if timeout_secs > 0 {
+        Some(
+            std::time::Instant::now()
+                + std::time::Duration::from_secs(timeout_secs),
+        )
+    } else {
+        None
+    };
+
+    loop {
+        if response_file.exists() {
+            match std::fs::read_to_string(&response_file) {
+                Ok(key) => {
+                    let _ = std::fs::remove_file(&response_file);
+                    print!("{}", key.trim());
+                    return 0;
+                }
+                Err(e) => {
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if let Some(dl) = deadline {
+            if std::time::Instant::now() >= dl {
+                return 2;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 fn to_title_case(s: &str) -> String {
@@ -1535,5 +1599,20 @@ mod descriptor_tests {
             code, 1,
             "registry fallback only applies when no user args are passed"
         );
+    }
+}
+
+#[cfg(test)]
+mod notify_tests {
+    use super::notify_cli;
+
+    /// Fire-and-forget path: no choices → exit 0, queue file written.
+    #[test]
+    fn notify_cli_fire_and_forget_returns_zero() {
+        // Uses the real config_dir() path; just verifies the function exits 0
+        // without blocking. The queue file creation may fail in sandboxed
+        // environments, but the function must not panic.
+        let code = notify_cli("Test title", "Test body", "info", &[], 0);
+        assert_eq!(code, 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,14 +137,6 @@ fn main() -> eframe::Result {
     // the shell probes below don't trigger false FREEZE alerts. The heartbeat
     // should only monitor actual eframe operation, not pre-startup work.
 
-    // Resolve the login-shell PATH once for the whole process. Fixes
-    // `gh`/`rg`/`fd`/any-homebrew-tool-not-found bugs when Plexi is launched
-    // as a GUI bundle (which inherits only `/usr/bin:/bin:/usr/sbin:/sbin`).
-    crate::shell::install_login_shell_path();
-    // Adopt API keys and other user secrets set in ~/.zshrc / ~/.zsh_secrets.
-    // GUI bundles don't inherit these — OPENROUTER_API_KEY, ANTHROPIC_API_KEY,
-    // etc. are invisible without this call.
-    crate::shell::install_login_shell_env();
 
     // One-shot migration from the v3.0 global-namespace secrets index to the
     // workspace-namespaced layout (issue #322). Idempotent: a no-op once the
@@ -540,9 +532,17 @@ fn main() -> eframe::Result {
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/app-icon.png"))
         .expect("failed to load app icon");
 
+    // Resolve the login-shell PATH and adopt API keys only for the GUI.
+    // CLI subcommands already inherit the full shell environment from the
+    // calling terminal — running this there corrupts terminal signal state
+    // (zsh -i hijacks SIGINT) and spams the user's stdout with log noise.
+    crate::shell::install_login_shell_path();
+    crate::shell::install_login_shell_env();
+
     // Shell probes are done. Start the heartbeat now so it only monitors
     // eframe operation — not pre-startup shell work (#588).
     crate::logging::spawn_heartbeat(frame_tick.clone());
+
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,6 +391,8 @@ fn main() -> eframe::Result {
                 let mut title = String::new();
                 let mut body = String::new();
                 let mut level = "info";
+                let mut choices: Vec<(String, String)> = Vec::new();
+                let mut timeout_secs: u64 = 0;
                 let mut i = 2;
                 while i < args.len() {
                     match args[i].as_str() {
@@ -406,6 +408,28 @@ fn main() -> eframe::Result {
                             level = args[i + 1].as_str();
                             i += 2;
                         }
+                        "--choice" if i + 1 < args.len() => {
+                            let raw = &args[i + 1];
+                            if let Some(colon) = raw.find(':') {
+                                let key = raw[..colon].to_string();
+                                let label = raw[colon + 1..].to_string();
+                                choices.push((key, label));
+                            } else {
+                                eprintln!("error: --choice value must be key:Label");
+                                std::process::exit(1);
+                            }
+                            i += 2;
+                        }
+                        "--timeout" if i + 1 < args.len() => {
+                            match args[i + 1].parse::<u64>() {
+                                Ok(n) => timeout_secs = n,
+                                Err(_) => {
+                                    eprintln!("error: --timeout must be a non-negative integer");
+                                    std::process::exit(1);
+                                }
+                            }
+                            i += 2;
+                        }
                         _ => {
                             i += 1;
                         }
@@ -413,11 +437,11 @@ fn main() -> eframe::Result {
                 }
                 if title.is_empty() {
                     eprintln!(
-                        "Usage: plexi notify --title <text> --body <text> [--level info|warn|error]"
+                        "Usage: plexi notify --title <text> --body <text> [--level info|warn|error] [--choice key:Label]... [--timeout N]"
                     );
                     std::process::exit(1);
                 }
-                std::process::exit(cli::notify_cli(&title, &body, level));
+                std::process::exit(cli::notify_cli(&title, &body, level, &choices, timeout_secs));
             }
             "descriptor" => {
                 // `plexi descriptor probe <cmd> [args...] [--no-registry]` —

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -995,6 +995,7 @@ impl PlexiApp {
                                             notify_id: notif.notify_id.clone(),
                                             action_label: opt.label.clone(),
                                             value: Some(value),
+                                            response_file: notif.response_file.clone(),
                                         });
                                     }
                                     ui.add_space(style::SPACE_SM);
@@ -1046,6 +1047,7 @@ impl PlexiApp {
                                         notify_id: notif.notify_id.clone(),
                                         action_label: "acknowledge".to_string(),
                                         value: None,
+                                        response_file: notif.response_file.clone(),
                                     });
                                 }
                             });
@@ -1158,6 +1160,7 @@ impl PlexiApp {
                             notify_id: notif.notify_id.clone(),
                             action_label: "acknowledge".to_string(),
                             value: None,
+                            response_file: notif.response_file.clone(),
                         });
                     }
                 }
@@ -1196,6 +1199,7 @@ impl PlexiApp {
                             notify_id: notif.notify_id.clone(),
                             action_label: opt.label.clone(),
                             value: Some(value),
+                            response_file: notif.response_file.clone(),
                         });
                     }
                 }
@@ -1210,6 +1214,7 @@ impl PlexiApp {
                                 notify_id: notif.notify_id.clone(),
                                 action_label: "submit".to_string(),
                                 value: Some(buf),
+                                response_file: notif.response_file.clone(),
                             });
                         }
                     }


### PR DESCRIPTION
## Summary
- Adds `--choice key:Label` (repeatable) and `--timeout N` to `plexi notify`
- With choices: CLI writes response file path into queue JSON, polls until host writes chosen key, exits 0 + prints key
- On timeout: exits 2. Fire-and-forget (no choices) path unchanged
- Host: `PendingNotification` gains `response_file` field; `drain_notify_queue` parses choices + builds `NotifyOption` list; `DeliverNotifyAction` writes chosen value to response file for `pane_id == 0` notifications

## Breaks if
`plexi notify --title "Test" --body "body" --choice "y:Yes" --choice "n:No"` does not block and return the chosen key after selecting an option in the notification panel, or the fire-and-forget path (no `--choice`) no longer prints "notification queued".

Fixes #295