### PR TITLE
fix(startup): defer heartbeat until after shell probes (#588)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,15 @@ Use `uv` for all Python projects. `pyproject.toml` with `requires-python = ">=3.
 
 Try-catch on all I/O, network, external API calls, and anything that can reasonably fail. Every catch logs where + what failed with enough context to diagnose. Never swallow errors silently. If a failure can't be meaningfully recovered from, propagate or re-throw.
 
+## Issue Visibility Before Work Begins
+
+Before making any progress on a bug or issue, establish visibility of the problem. Never take a reporter's word alone — you need to see it yourself:
+
+- **Preferred:** reproduce it in a `HostHarness` test that fails. This becomes the done condition.
+- **Acceptable:** add a targeted `log::info!` or `log::warn!` that fires when the bad state occurs, then confirm it appears in `plexi.log` against the alpha build before writing any fix.
+
+If you can't reproduce it or instrument it, stop and flag it. A fix written against an unconfirmed symptom is a guess. This check belongs at the triage step — before the issue is labeled `in progress` and before any worktree is created.
+
 ## Implementation Discipline (no half-refactors)
 
 **Define done by the test, not the code.** Before writing any new module or refactoring an existing one, write the test that must pass when the work is complete. A PR is done when `cargo test` is green — not when the code looks right.

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,9 @@ fn main() -> eframe::Result {
         .unwrap_or(log::LevelFilter::Info);
     crate::logging::init(log_level);
     let frame_tick = crate::logging::new_frame_tick();
-    crate::logging::spawn_heartbeat(frame_tick.clone());
+    // Note: spawn_heartbeat is deferred to just before eframe::run_native so
+    // the shell probes below don't trigger false FREEZE alerts. The heartbeat
+    // should only monitor actual eframe operation, not pre-startup work.
 
     // Resolve the login-shell PATH once for the whole process. Fixes
     // `gh`/`rg`/`fd`/any-homebrew-tool-not-found bugs when Plexi is launched
@@ -513,6 +515,10 @@ fn main() -> eframe::Result {
 
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/app-icon.png"))
         .expect("failed to load app icon");
+
+    // Shell probes are done. Start the heartbeat now so it only monitors
+    // eframe operation — not pre-startup shell work (#588).
+    crate::logging::spawn_heartbeat(frame_tick.clone());
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()


### PR DESCRIPTION
## Summary
- `install_login_shell_path/env` run `zsh -i -l -c env` on the main thread before eframe starts
- The heartbeat was spawning before those probes, so `frame_tick` stayed at 0 for the full probe duration (8-12s on a heavy `.zshrc`)
- This produced false `[FREEZE]` logs that overlapped with the first eframe frames — including the notify drain — making the freeze look correlated with the notify drain

Fix: defer `spawn_heartbeat` to just before `eframe::run_native`, after shell probes complete. Heartbeat now only monitors actual eframe operation.

## Test plan
- [ ] Launch Plexi Alpha, confirm no `[FREEZE]` logs appear at startup before any UI interaction
- [ ] Run `plexi notify --title "test" --choice "y:Yes" --choice "n:No" --timeout 30` once PR #586 is available — notification panel should open without a freeze log
- [ ] Normal app operation: pane creation, keyboard shortcuts, terminal usage — no regressions

**Breaks if:** `[FREEZE]` logs appear at startup during shell probe phase (regression), or `[FREEZE]` is no longer detected during actual UI-thread stalls during eframe operation.

Fixes #588