### PR TITLE
fix(notifications): Cmd+Shift+A always opens modal, empty state when queue is empty

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2289,10 +2289,6 @@ impl eframe::App for PlexiApp {
         // path at the top of `update()` — they own a `FocusLayer` and render
         // their own keystrokes before the drain. Drawing again here would
         // double-dispatch Enter/Escape after keys have been drained.
-        if self.visible_notification_count() == 0 {
-            self.show_notification_modal = false;
-        }
-
         // Quit confirmation overlay
         if self.confirm_quit() && self.quit_press_count > 0 {
             // Reset on Escape or timeout

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1856,7 +1856,7 @@ impl eframe::App for PlexiApp {
                 Action::ToggleNotificationModal => {
                     if self.show_notification_modal {
                         self.show_notification_modal = false;
-                    } else if self.visible_notification_count() > 0 {
+                    } else {
                         self.show_notification_modal = true;
                         // Pick highest-priority when re-opening the modal and
                         // nothing is currently pinned. If something IS pinned

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2476,8 +2476,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn sync_notification_modal_focus(&mut self) {
-        let should_own = self.show_notification_modal
-            && self.visible_notification_count() > 0;
+        let should_own = self.show_notification_modal;
         let has_layer = self
             .focus_stack
             .iter()

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -698,8 +698,52 @@ impl PlexiApp {
         // never set, pick the highest-priority remaining — never arbitrarily
         // index into the Vec.
         if self.pending_notifications.is_empty() {
-            self.show_notification_modal = false;
-            self.current_notify_id = None;
+            // Show an empty-state card so Cmd+Shift+A always gives feedback.
+            let screen_rect = ctx.screen_rect();
+            egui::Area::new(egui::Id::new("notification_modal_scrim"))
+                .order(egui::Order::Foreground)
+                .fixed_pos(screen_rect.min)
+                .interactable(true)
+                .show(ctx, |ui| {
+                    let (rect, _) = ui.allocate_exact_size(
+                        screen_rect.size(),
+                        egui::Sense::click(),
+                    );
+                    ui.painter().rect_filled(
+                        rect,
+                        CornerRadius::ZERO,
+                        Color32::from_black_alpha(style::SCRIM_ALPHA),
+                    );
+                });
+            egui::Area::new(egui::Id::new("notification_modal"))
+                .order(egui::Order::Tooltip)
+                .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+                .show(ctx, |ui| {
+                    egui::Frame::new()
+                        .fill(self.colors.bg_sidebar)
+                        .stroke(Stroke::new(1.0, self.colors.border))
+                        .corner_radius(style::RADIUS_LG)
+                        .inner_margin(egui::Margin::symmetric(
+                            style::MODAL_PADDING_H,
+                            style::MODAL_PADDING_V,
+                        ))
+                        .show(ui, |ui| {
+                            ui.set_width(style::MODAL_WIDTH_MD);
+                            ui.vertical_centered(|ui| {
+                                ui.add_space(style::SPACE_MD);
+                                ui.label(
+                                    RichText::new("No notifications")
+                                        .size(style::TEXT_BODY)
+                                        .color(self.colors.text_dim),
+                                );
+                                ui.add_space(style::SPACE_MD);
+                            });
+                        });
+                });
+            let esc_pressed = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+            if esc_pressed {
+                self.show_notification_modal = false;
+            }
             return cmds;
         }
         if self


### PR DESCRIPTION
Fixes #590.

## Changes

`src/app/mod.rs`:
- Removed `visible_notification_count() > 0` guard from `ToggleNotificationModal` so Cmd+Shift+A always opens the modal
- Removed count guard from `sync_notification_modal_focus` so the focus layer is active for the empty state (Esc works)
- Removed the frame-level `count == 0 → show_notification_modal = false` guard that would immediately kill the modal before the empty-state could render

`src/overlays.rs`:
- When `pending_notifications.is_empty()`, render scrim + centered modal card with dim "No notifications" text + Esc to close, instead of silently returning

## Breaks if
Cmd+Shift+A with no pending notifications does nothing (no modal appears).