### PR TITLE
refactor(cli): reserve 'plexi update' for self-update; move app updates to 'plexi update apps'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Every issue gets one **type**, one **priority**, one **version**.
 - **status** (optional): `in progress` | `testing` | `ready` | `blocked`
 
 **Priority definitions:**
-- `P0` — Won't fix. Known platform limitation or deliberate non-solution. Explicitly closed and documented so it's never re-investigated. Keep P0s rare.
+- `P0` — Drop everything. On-fire critical; fix before anything else.
 - `P1` — Shipping blocker or severe user-facing bug. Must be resolved before the next release.
 - `P2` — Important but not blocking a release. Should happen in the near term.
 - `P3` — Nice to have. Polish, ergonomics, or low-urgency improvements.
@@ -206,6 +206,7 @@ If you can't reproduce it or instrument it, stop and flag it. A fix written agai
 - **Platform behavior validation:** Before implementing any macOS-specific behavior (menu lifecycle, bundle naming, eframe/winit callback order), add a throwaway `log::info!()` to observe the actual runtime value on the first frame. Never assume which callback fires when or what a property returns — observe first, then code.
 - **Egui pointer state during macOS file drags:** `ui.rect_contains_pointer()` and `i.pointer.hover_pos()` are stale during macOS OS-level file drags — winit only updates them from its own events, not the drag-tracking run loop. Never gate drop-target detection on egui pointer checks; test for drop event presence alone. When the drop target is unambiguous (e.g. a single zoomed pane covering the whole overlay), drop the check entirely.
 - **Command self-containment:** Any data a command handler needs must be in the command's own fields — never looked up from ambient state (like a queue or map) at dispatch time. By dispatch, that state may have been mutated or cleared by an earlier step in the same frame. If you find yourself writing `self.some_collection.iter().find(|x| x.id == cmd.id)` inside a handler, the missing data belongs in the command variant instead. This also means split dispatch paths (e.g. early modal cmds vs. deferred queue) both get complete handling automatically, since the data travels with the command.
+- **Test constructor sync:** When adding a field to any struct that has a `new_for_test()` constructor, update that constructor in the same commit. Before running `cargo test` on a fresh worktree, run it once on the base branch first to distinguish pre-existing failures from regressions.
 
 ## PlexiApp State
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -607,7 +607,7 @@ pub fn install_cli(spec: &str) -> i32 {
             } => {
                 eprintln!(
                     "'{}' already installed at {installed} (requested {requested}); \
-                     uninstall first or use `plexi update`",
+                     uninstall first or use `plexi update apps`",
                     outcome.id
                 );
                 1
@@ -716,7 +716,7 @@ pub fn uninstall_cli(id: &str, assume_yes: bool) -> i32 {
     }
 }
 
-/// `plexi update [<id>]` — git-pull one installed app, or all of them.
+/// `plexi update apps [<id>]` — git-pull one installed app, or all of them.
 /// Apps that aren't git checkouts (e.g. bundled core entries) are skipped
 /// with a debug-level log line and reported but not failed.
 pub fn update_cli(maybe_id: Option<&str>) -> i32 {
@@ -750,6 +750,13 @@ pub fn update_cli(maybe_id: Option<&str>) -> i32 {
     } else {
         0
     }
+}
+
+/// `plexi update` — update the Plexi binary itself (binary self-update; see #594 for implementation).
+pub fn self_update_cli() -> i32 {
+    eprintln!("Binary self-update is not yet implemented.");
+    eprintln!("To update installed apps, use: plexi update apps [<id>]");
+    1
 }
 
 /// `plexi list` — show installed apps grouped by scope (global vs. workspace).

--- a/src/install.rs
+++ b/src/install.rs
@@ -3,7 +3,7 @@
 //! Three top-level CLI subcommands route here:
 //!   - `plexi install <source-spec>[@ref]` — clone + place one app
 //!   - `plexi install --pack <path|core>`  — apply every [[app]] in a pack
-//!   - `plexi update [<id>]`               — git-pull installed app(s)
+//!   - `plexi update apps [<id>]`           — git-pull installed app(s)
 //!   - `plexi uninstall <id>`              — remove the install dir
 //!   - `plexi list`                        — show installed apps
 //!
@@ -64,7 +64,7 @@ pub trait Cloner: Send + Sync {
     /// Check out a specific ref (tag, branch, or sha) inside an existing
     /// clone. Optional — `None` = leave on the default branch.
     fn checkout(&self, repo_dir: &Path, git_ref: &str) -> Result<(), String>;
-    /// `git fetch && git pull` — used by `plexi update`.
+    /// `git fetch && git pull` — used by `plexi update apps`.
     fn pull(&self, repo_dir: &Path) -> Result<(), String>;
 }
 
@@ -229,7 +229,7 @@ fn install_one_git(
         cleanup(&stage_root);
         return Err(format!(
             "app '{id}' already installed at {}; \
-             run `plexi uninstall {id}` or `plexi update {id}` first",
+             run `plexi uninstall {id}` or `plexi update apps {id}` first",
             dest.display()
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,12 +347,16 @@ fn main() -> eframe::Result {
                 }
             }
             "update" => {
-                let id = args
-                    .iter()
-                    .skip(2)
-                    .find(|a| !a.starts_with("--"))
-                    .cloned();
-                std::process::exit(cli::update_cli(id.as_deref()));
+                if args.get(2).map(String::as_str) == Some("apps") {
+                    let id = args
+                        .iter()
+                        .skip(3)
+                        .find(|a| !a.starts_with("--"))
+                        .cloned();
+                    std::process::exit(cli::update_cli(id.as_deref()));
+                } else {
+                    std::process::exit(cli::self_update_cli());
+                }
             }
             "list" => {
                 std::process::exit(cli::list_cli());


### PR DESCRIPTION
## Summary
- `plexi update` now routes to `self_update_cli()` (stub returning error until #594 lands)
- `plexi update apps [<id>]` is the new surface for git-pulling installed apps (previous `plexi update [<id>]` behavior, unchanged logic)
- Updated all doc comments and error strings in `src/cli.rs`, `src/install.rs` to reflect the new shape

## Breaking change
`plexi update <id>` no longer updates that app — use `plexi update apps <id>`. Alpha is the right time to fix this before any scripts depend on it.

## Related
- Closes #595
- #594 — binary download implementation (will replace the stub in `self_update_cli`)

## Test plan
- [ ] `plexi update apps` git-pulls all installed apps (existing behavior)
- [ ] `plexi update apps <id>` git-pulls a specific app
- [ ] `plexi update` prints "Binary self-update is not yet implemented" and exits 1