### PR TITLE
feat(cli): plexi update — detached relaunch when run from inside Plexi

### DIFF
--- a/docs/superpowers/plans/2026-05-03-copy-mode.md
+++ b/docs/superpowers/plans/2026-05-03-copy-mode.md
@@ -1,0 +1,644 @@
+# Copy-Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tmux-style keyboard-driven copy-mode to terminal panes. `Cmd+Shift+[` enters copy-mode; `hjkl`/arrows navigate a block cursor through the scrollback; `v` starts visual selection; `y` yanks to clipboard and exits; `Esc`/`q` cancels.
+
+**Architecture:** Copy-mode state (`Option<CopyModeState>`) lives on `TerminalBackend` as a public field, accessible to both the host (to enter via `BackendCommand::EnterCopyMode`) and the view render pass (to draw the block cursor). The `view.rs` input processor checks `backend.copy_mode` first each key event; when `Some`, it intercepts all keyboard input and translates it to copy-mode commands instead of forwarding to the PTY. Selection uses the existing `BackendCommand::SelectStart`/`SelectUpdate` pixel-coordinate API — copy-mode translates its viewport-relative cursor position to pixel coordinates before dispatching.
+
+**Tech Stack:** Rust, egui, egui_term (vendored at `deps/egui_term/`), alacritty_terminal 0.25. Depends on plan `2026-05-03-scrollback-navigation-keys.md` being merged first (reuses `BackendCommand::ScrollTop`/`ScrollBottom`/`ScrollPage`).
+
+---
+
+## File Map
+
+- **Modify:** `deps/egui_term/src/backend/mod.rs` — add `CopyModeState` struct; add `copy_mode: Option<CopyModeState>` field to `TerminalBackend`; add `BackendCommand::EnterCopyMode`, `BackendCommand::ExitCopyMode`, `BackendCommand::CopyModeMove { drow: i32, dcol: i32 }`, `BackendCommand::CopyModeSelectToggle`, `BackendCommand::CopyModeSelectLine`, `BackendCommand::CopyModeYank`; handle them in `process_command`; add `pub fn copy_mode(&self)` accessor
+- **Modify:** `deps/egui_term/src/view.rs` — intercept key events when `backend.copy_mode.is_some()` in `process_input`; render block cursor and `[COPY]` badge in `show()`
+- **Modify:** `src/keys.rs` — add `Action::EnterCopyMode`; consume `Cmd+Shift+[`
+- **Modify:** `src/pane_ops/layout.rs` — add `enter_copy_mode_focused_pane()` method
+- **Modify:** `src/app/mod.rs` — handle `Action::EnterCopyMode`
+
+---
+
+## Task 1: CopyModeState struct and TerminalBackend field
+
+**Files:**
+- Modify: `deps/egui_term/src/backend/mod.rs`
+
+- [ ] **Step 1: Add `CopyModeState` and new `BackendCommand` variants**
+
+In `deps/egui_term/src/backend/mod.rs`, after the existing `BackendCommand` enum, add:
+
+```rust
+/// Viewport-relative cursor position for keyboard-driven copy-mode.
+/// `row` ∈ [0, num_lines), `col` ∈ [0, num_cols).
+#[derive(Debug, Clone)]
+pub struct CopyModeState {
+    pub row: usize,
+    pub col: usize,
+    pub selection_start: Option<(usize, usize)>, // (row, col) when visual mode is active
+    pub line_select: bool, // true when V (line-wise) was pressed
+}
+```
+
+Add new variants to `BackendCommand`:
+```rust
+pub enum BackendCommand {
+    // ... existing variants ...
+    EnterCopyMode,
+    ExitCopyMode,
+    CopyModeMove { drow: i32, dcol: i32 },    // relative cursor movement
+    CopyModeScrollPage(i32),                   // +1 up, -1 down
+    CopyModeGotoTop,
+    CopyModeGotoBottom,
+    CopyModeSelectToggle,                      // 'v' — start/clear visual selection
+    CopyModeSelectLine,                        // 'V' — line-wise selection
+    CopyModeYank,                              // 'y' — copy selection + exit
+}
+```
+
+- [ ] **Step 2: Add `copy_mode` field to `TerminalBackend`**
+
+In `TerminalBackend` struct (around line 138), add:
+```rust
+pub struct TerminalBackend {
+    pub id: u64,
+    pub copy_mode: Option<CopyModeState>,  // None = normal mode
+    pub url_regex: RegexSearch,
+    // ... rest unchanged
+}
+```
+
+Initialize to `None` in `TerminalBackend::new()` (where `initial_content` is built, around line 230):
+```rust
+Ok(Self {
+    id,
+    copy_mode: None,
+    url_regex,
+    // ... rest unchanged
+})
+```
+
+- [ ] **Step 3: Compile**
+
+```bash
+cd /path/to/worktrees/alpha && cargo build 2>&1 | grep "^error"
+```
+Expected: errors about unhandled `BackendCommand` variants in `process_command`. That's expected — fixed in next step.
+
+- [ ] **Step 4: Implement `process_command` handlers**
+
+In `process_command`, add handling for each new variant. Note: `process_command` already holds `let mut term = term.lock()` — all new arms reuse `term`.
+
+```rust
+BackendCommand::EnterCopyMode => {
+    let is_alt = term.mode().contains(TermMode::ALT_SCREEN);
+    if !is_alt && self.copy_mode.is_none() {
+        let lines = self.size.num_lines as usize;
+        self.copy_mode = Some(CopyModeState {
+            row: lines.saturating_sub(1),
+            col: 0,
+            selection_start: None,
+            line_select: false,
+        });
+        log::info!("egui_term: entered copy-mode");
+    }
+},
+BackendCommand::ExitCopyMode => {
+    self.copy_mode = None;
+    terminal.selection = None;
+    log::info!("egui_term: exited copy-mode");
+},
+BackendCommand::CopyModeMove { drow, dcol } => {
+    if let Some(cm) = &mut self.copy_mode {
+        let lines = self.size.num_lines as usize;
+        let cols = self.size.num_cols as usize;
+        let new_row = (cm.row as i32 + drow)
+            .clamp(0, lines as i32 - 1) as usize;
+        let new_col = (cm.col as i32 + dcol)
+            .clamp(0, cols as i32 - 1) as usize;
+        let hit_top = drow < 0 && cm.row == 0 && new_row == 0;
+        let hit_bottom = drow > 0 && cm.row == lines - 1 && new_row == lines - 1;
+        cm.row = new_row;
+        cm.col = new_col;
+        // Scroll viewport when cursor hits edges
+        if hit_top {
+            term.grid_mut().scroll_display(Scroll::Delta(1));
+        } else if hit_bottom {
+            term.grid_mut().scroll_display(Scroll::Delta(-1));
+        }
+    }
+},
+BackendCommand::CopyModeScrollPage(sign) => {
+    if self.copy_mode.is_some() {
+        if sign > 0 {
+            term.grid_mut().scroll_display(Scroll::PageUp);
+        } else {
+            term.grid_mut().scroll_display(Scroll::PageDown);
+        }
+        // Keep cursor clamped to visible area
+        if let Some(cm) = &mut self.copy_mode {
+            let lines = self.size.num_lines as usize;
+            cm.row = cm.row.min(lines.saturating_sub(1));
+        }
+    }
+},
+BackendCommand::CopyModeGotoTop => {
+    if self.copy_mode.is_some() {
+        term.grid_mut().scroll_display(Scroll::Top);
+        if let Some(cm) = &mut self.copy_mode {
+            cm.row = 0;
+            cm.col = 0;
+        }
+    }
+},
+BackendCommand::CopyModeGotoBottom => {
+    if self.copy_mode.is_some() {
+        term.grid_mut().scroll_display(Scroll::Bottom);
+        if let Some(cm) = &mut self.copy_mode {
+            let lines = self.size.num_lines as usize;
+            cm.row = lines.saturating_sub(1);
+        }
+    }
+},
+BackendCommand::CopyModeSelectToggle => {
+    if let Some(cm) = &mut self.copy_mode {
+        if cm.selection_start.is_some() {
+            cm.selection_start = None;
+            cm.line_select = false;
+            terminal.selection = None;
+        } else {
+            cm.selection_start = Some((cm.row, cm.col));
+            cm.line_select = false;
+        }
+    }
+},
+BackendCommand::CopyModeSelectLine => {
+    if let Some(cm) = &mut self.copy_mode {
+        cm.selection_start = Some((cm.row, 0));
+        cm.line_select = true;
+    }
+},
+BackendCommand::CopyModeYank => {
+    // Selection is already set via SelectStart/SelectUpdate from the view render pass.
+    // selectable_content() reads from last_content which is updated on sync().
+    // Return the text; the view dispatches WriteToClipboard.
+    // The actual yank action is: view reads copy_mode, sees Yank command, calls
+    // selectable_content() and emits WriteToClipboard, then calls ExitCopyMode.
+    // Nothing to do here in the backend — state is cleared via ExitCopyMode.
+},
+```
+
+- [ ] **Step 5: Add a `copy_mode_cursor_px` helper method**
+
+This converts the copy-mode cursor's viewport position to pixel coordinates relative to the pane rect. The view uses this to drive `SelectStart`/`SelectUpdate` and to position the block cursor highlight.
+
+```rust
+/// Returns (x, y) pixel coords of the copy-mode cursor relative to the pane top-left.
+/// Returns None when not in copy-mode.
+pub fn copy_mode_cursor_px(&self) -> Option<(f32, f32)> {
+    let cm = self.copy_mode.as_ref()?;
+    let cw = self.size.cell_width as f32;
+    let ch = self.size.cell_height as f32;
+    Some((cm.col as f32 * cw + cw / 2.0, cm.row as f32 * ch + ch / 2.0))
+}
+
+/// Returns (x, y) of the selection start in pixel coords, or None.
+pub fn copy_mode_selection_start_px(&self) -> Option<(f32, f32)> {
+    let cm = self.copy_mode.as_ref()?;
+    let (sr, sc) = cm.selection_start?;
+    let cw = self.size.cell_width as f32;
+    let ch = self.size.cell_height as f32;
+    let x = if cm.line_select { 0.0 } else { sc as f32 * cw + cw / 2.0 };
+    let y = sr as f32 * ch + ch / 2.0;
+    Some((x, y))
+}
+```
+
+- [ ] **Step 6: Compile clean**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add deps/egui_term/src/backend/mod.rs
+git commit -m "feat(egui_term): CopyModeState, BackendCommand copy-mode variants, process_command handlers"
+```
+
+---
+
+## Task 2: Key intercept in view.rs process_input
+
+**Files:**
+- Modify: `deps/egui_term/src/view.rs` — `process_input` method
+
+The copy-mode key intercept must run BEFORE the normal `process_keyboard_event` path. When `backend.copy_mode.is_some()`, all keyboard events are consumed and interpreted as copy-mode commands. Mouse events still pass through (so the user can still scroll with trackpad).
+
+- [ ] **Step 1: Write a test verifying that key events reach the PTY when NOT in copy-mode**
+
+In `deps/egui_term/src/backend/mod.rs` tests section (or a new `#[cfg(test)]` block):
+
+```rust
+#[cfg(test)]
+mod copy_mode_tests {
+    use super::*;
+
+    #[test]
+    fn enter_copy_mode_sets_state() {
+        // We can't easily unit-test TerminalBackend (requires PTY).
+        // This test verifies CopyModeState initialization logic only.
+        let state = CopyModeState {
+            row: 23,
+            col: 0,
+            selection_start: None,
+            line_select: false,
+        };
+        assert_eq!(state.row, 23);
+        assert!(state.selection_start.is_none());
+    }
+
+    #[test]
+    fn copy_mode_move_clamps_to_bounds() {
+        let mut state = CopyModeState {
+            row: 0,
+            col: 0,
+            selection_start: None,
+            line_select: false,
+        };
+        // Simulate clamping in process_command CopyModeMove
+        let lines: usize = 24;
+        let cols: usize = 80;
+        let drow: i32 = -5;
+        let dcol: i32 = -5;
+        state.row = (state.row as i32 + drow).clamp(0, lines as i32 - 1) as usize;
+        state.col = (state.col as i32 + dcol).clamp(0, cols as i32 - 1) as usize;
+        assert_eq!(state.row, 0);
+        assert_eq!(state.col, 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cargo test -p egui_term copy_mode 2>&1 | grep -E "ok|FAILED"
+```
+Expected: both pass (they're pure logic tests, no PTY needed).
+
+- [ ] **Step 3: Add copy-mode key dispatch in `process_input`**
+
+In `deps/egui_term/src/view.rs`, in `process_input`, find where keyboard events are matched:
+
+```rust
+egui::Event::Text(_)
+| egui::Event::Key { .. }
+| egui::Event::Copy
+| egui::Event::Paste(_) => {
+    if !has_focus {
+        continue;
+    }
+    // ...
+    input_actions.push(process_keyboard_event(...))
+},
+```
+
+Before the `process_keyboard_event` call, check if copy-mode is active and intercept:
+
+```rust
+egui::Event::Text(_)
+| egui::Event::Key { .. }
+| egui::Event::Copy
+| egui::Event::Paste(_) => {
+    if !has_focus {
+        continue;
+    }
+    state.cursor_visible = true;
+    state.last_cursor_toggle = Instant::now();
+
+    // Copy-mode intercepts all keyboard input.
+    if self.backend.copy_mode.is_some() {
+        if let Some(action) = process_copy_mode_key(&event, modifiers) {
+            input_actions.push(action);
+        }
+        continue; // do NOT fall through to normal PTY key handling
+    }
+
+    input_actions.push(process_keyboard_event(
+        event,
+        self.backend,
+        &self.bindings_layout,
+        modifiers,
+    ))
+},
+```
+
+- [ ] **Step 4: Implement `process_copy_mode_key`**
+
+Add this free function at the bottom of `view.rs` (before the closing brace):
+
+```rust
+fn process_copy_mode_key(
+    event: &egui::Event,
+    modifiers: Modifiers,
+) -> Option<InputAction> {
+    let egui::Event::Key { key, pressed: true, .. } = event else {
+        return None;
+    };
+
+    let cmd = match key {
+        // Movement
+        egui::Key::ArrowUp | egui::Key::K =>
+            BackendCommand::CopyModeMove { drow: -1, dcol: 0 },
+        egui::Key::ArrowDown | egui::Key::J =>
+            BackendCommand::CopyModeMove { drow: 1, dcol: 0 },
+        egui::Key::ArrowLeft | egui::Key::H =>
+            BackendCommand::CopyModeMove { drow: 0, dcol: -1 },
+        egui::Key::ArrowRight | egui::Key::L =>
+            BackendCommand::CopyModeMove { drow: 0, dcol: 1 },
+
+        // Page scroll
+        egui::Key::PageUp =>
+            BackendCommand::CopyModeScrollPage(1),
+        egui::Key::PageDown =>
+            BackendCommand::CopyModeScrollPage(-1),
+
+        // Top / bottom
+        egui::Key::G if modifiers.shift =>
+            BackendCommand::CopyModeGotoBottom,
+        egui::Key::G =>
+            BackendCommand::CopyModeGotoTop,
+
+        // Selection
+        egui::Key::V if modifiers.shift =>
+            BackendCommand::CopyModeSelectLine,
+        egui::Key::V =>
+            BackendCommand::CopyModeSelectToggle,
+
+        // Yank
+        egui::Key::Y =>
+            BackendCommand::CopyModeYank,
+
+        // Exit
+        egui::Key::Escape | egui::Key::Q =>
+            BackendCommand::ExitCopyMode,
+
+        _ => return None,
+    };
+
+    Some(InputAction::BackendCall(cmd))
+}
+```
+
+Note: `CopyModeYank` is special — it needs to both write to clipboard and exit. Handle it in the `for action in input_actions` dispatch loop specially:
+
+In `view.rs`'s `process_input`, where `InputAction::BackendCall(cmd)` is dispatched:
+```rust
+for action in input_actions {
+    match action {
+        InputAction::BackendCall(BackendCommand::CopyModeYank) => {
+            let text = self.backend.selectable_content();
+            if !text.trim().is_empty() {
+                layout.ctx.copy_text(text);
+            }
+            self.backend.process_command(BackendCommand::ExitCopyMode);
+        },
+        InputAction::BackendCall(cmd) => {
+            self.backend.process_command(cmd);
+        },
+        InputAction::WriteToClipboard(data) => {
+            layout.ctx.copy_text(data);
+        },
+        InputAction::Ignore => {},
+    }
+}
+```
+
+- [ ] **Step 5: Compile**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deps/egui_term/src/view.rs
+git commit -m "feat(egui_term): copy-mode key intercept in process_input"
+```
+
+---
+
+## Task 3: Block cursor and selection rendering in view.rs show()
+
+**Files:**
+- Modify: `deps/egui_term/src/view.rs` — `show()` method
+
+The block cursor is painted as an inverted cell overlay after all other shapes. When selection is active, we sync `SelectStart`/`SelectUpdate` each frame so the existing selection highlight renders the region.
+
+- [ ] **Step 1: Drive selection state from copy-mode cursor each frame**
+
+In `process_input`, at the very end — after the `for event in events` loop but before returning `self` — add a per-frame selection sync block. This is the same pattern as auto-scroll during drag selection (already at the bottom of `process_input`):
+
+```rust
+// Sync copy-mode selection into alacritty each frame so the highlight renders.
+// Runs after key handling so the cursor position is already updated.
+if self.backend.copy_mode.as_ref().map(|c| c.selection_start.is_some()).unwrap_or(false) {
+    let ppp = layout.ctx.pixels_per_point();
+    if let (Some((sx, sy)), Some((cx, cy))) = (
+        self.backend.copy_mode_selection_start_px(),
+        self.backend.copy_mode_cursor_px(),
+    ) {
+        self.backend.process_command(BackendCommand::SelectStart(
+            SelectionType::Simple, sx, sy, ppp,
+        ));
+        self.backend.process_command(BackendCommand::SelectUpdate(cx, cy, ppp));
+    }
+}
+
+self
+```
+
+`copy_mode_selection_start_px()` and `copy_mode_cursor_px()` were defined in Task 1. They use `self.size` (private to `TerminalBackend`) which is always current. The `SelectStart`/`SelectUpdate` calls set `terminal.selection` before `sync()` runs in `show()`, so the selection is captured into `last_content.selectable_range` and drives the per-cell `is_selected` highlight in the render loop.
+
+- [ ] **Step 2: Add block cursor overlay in show()**
+
+After `painter.extend(shapes);` in `show()`, add:
+
+```rust
+// Copy-mode block cursor overlay
+if let Some(cm) = &self.backend.copy_mode {
+    let cw = cell_width;
+    let ch = cell_height;
+    let cursor_x = layout_min.x + cm.col as f32 * cw;
+    let cursor_y = layout_min.y + cm.row as f32 * ch;
+    let cursor_rect = Rect::from_min_size(
+        Pos2::new(cursor_x, cursor_y),
+        Vec2::new(cw, ch),
+    );
+    // Bright highlight with partial opacity so underlying text is visible
+    painter.rect_filled(
+        cursor_rect,
+        CornerRadius::ZERO,
+        Color32::from_rgba_unmultiplied(255, 255, 255, 120),
+    );
+}
+```
+
+- [ ] **Step 3: Add `[COPY]` badge**
+
+After the block cursor paint, still in `show()`:
+
+```rust
+// [COPY] mode badge — top-right corner of the pane
+if self.backend.copy_mode.is_some() {
+    let label = "[COPY]";
+    let font = egui::FontId::monospace(10.0);
+    let badge_color = Color32::from_rgba_unmultiplied(255, 200, 60, 200);
+    let galley = painter.layout_no_wrap(label.to_string(), font, badge_color);
+    let pad = 4.0;
+    let pos = Pos2::new(
+        layout_max.x - galley.size().x - pad,
+        layout_min.y + pad,
+    );
+    painter.galley(pos, galley, badge_color);
+}
+```
+
+- [ ] **Step 4: Compile**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deps/egui_term/src/view.rs
+git commit -m "feat(egui_term): copy-mode block cursor and [COPY] badge rendering"
+```
+
+---
+
+## Task 4: Host entry shortcut (Cmd+Shift+[)
+
+**Files:**
+- Modify: `src/keys.rs` — add `Action::EnterCopyMode`; add keybind
+- Modify: `src/pane_ops/layout.rs` — add `enter_copy_mode_focused_pane()`
+- Modify: `src/app/mod.rs` — handle `Action::EnterCopyMode`
+
+- [ ] **Step 1: Add `Action::EnterCopyMode` to the Action enum**
+
+In `src/keys.rs`, find the `pub enum Action { ... }` definition and add:
+```rust
+EnterCopyMode,
+```
+
+- [ ] **Step 2: Add the keybind in `poll_actions`**
+
+In `src/keys.rs`'s `poll_actions`, add after the existing `Cmd+[` binding (around line 204):
+
+```rust
+// Enter copy-mode (Cmd+Shift+[). Check BEFORE Cmd+[ so the shifted variant
+// is matched first.
+if input.consume_key(cmd_shift, egui::Key::OpenBracket) {
+    actions.push(Action::EnterCopyMode);
+}
+```
+
+Make sure this is checked BEFORE the `Cmd+[` (NavBackApp) check. In the current code, `Cmd+[` is an `if` not an `else if`, so order matters — add the shifted check directly above the unshifted one.
+
+- [ ] **Step 3: Add `enter_copy_mode_focused_pane` to layout.rs**
+
+In `src/pane_ops/layout.rs`, after `scroll_focused_pane`:
+
+```rust
+pub(crate) fn enter_copy_mode_focused_pane(&mut self) {
+    let ctx = &mut self.windows[self.active_window];
+    let Some(focused_tile) = ctx.focused_pane else { return };
+    let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.get(focused_tile) else { return };
+    let pane_id = *pane_id;
+    if let Some(pane) = ctx.panes.get_mut(&pane_id) {
+        if let Some(t) = pane.as_terminal_mut() {
+            t.backend.process_command(BackendCommand::EnterCopyMode);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Handle `Action::EnterCopyMode` in app/mod.rs**
+
+In `src/app/mod.rs`, in the action dispatch block (around where `Action::ScrollUp` is handled), add:
+
+```rust
+Action::EnterCopyMode => {
+    self.enter_copy_mode_focused_pane();
+}
+```
+
+- [ ] **Step 5: Compile**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/keys.rs src/pane_ops/layout.rs src/app/mod.rs
+git commit -m "feat(terminal): Cmd+Shift+[ enters copy-mode on focused terminal pane"
+```
+
+---
+
+## Task 5: Manual smoke test
+
+- [ ] **Step 1: Build and install**
+
+From inside `worktrees/alpha/`:
+```bash
+just bump-and-install
+```
+
+- [ ] **Step 2: Verify entry and exit**
+
+1. Open Plexi Alpha with a terminal pane running bash/zsh.
+2. Generate scrollback: `seq 1 200`.
+3. Press `Cmd+Shift+[`. Expected: `[COPY]` badge appears in top-right of the pane. Terminal no longer responds to typed characters.
+4. Press `Esc`. Expected: `[COPY]` badge disappears, terminal is interactive again.
+
+- [ ] **Step 3: Verify navigation**
+
+1. Enter copy-mode (`Cmd+Shift+[`).
+2. Press `k` or `↑` repeatedly. Expected: block cursor moves up through the visible lines; when it hits the top, the viewport scrolls up.
+3. Press `g`. Expected: jumps to top of scrollback buffer.
+4. Press `G`. Expected: jumps back to live bottom.
+5. Press `PgUp`. Expected: scrolls one page up, cursor stays on screen.
+
+- [ ] **Step 4: Verify selection and yank**
+
+1. Enter copy-mode. Navigate to a line of text.
+2. Press `v`. Expected: no visible change yet (cursor is the anchor).
+3. Move with `l` or `→` a few times. Expected: selected region highlights blue.
+4. Press `y`. Expected: `[COPY]` badge disappears, clipboard contains the selected text. Verify by pasting (`Cmd+V`) into the terminal.
+
+- [ ] **Step 5: Verify alt-screen guard**
+
+1. Open `vim` in the terminal.
+2. With vim open, press `Cmd+Shift+[`. Expected: nothing happens — vim is NOT interrupted, `[COPY]` badge does NOT appear, vim remains interactive.
+
+- [ ] **Step 6: Verify line-select**
+
+1. Enter copy-mode. Navigate to a line.
+2. Press `V` (capital). Expected: entire line is selected (from column 0 to end).
+3. Press `y`. Expected: full line text in clipboard.
+
+---
+
+## Task 6: Open PR
+
+Follow the standard PLEXI branch workflow. PR targets `alpha`. Title: `feat(terminal): copy-mode — keyboard-driven scrollback selection (tmux-style) (#603)`.
+
+DEV_LOG entry required before merge. `Breaks if:` — `Cmd+Shift+[` on a focused terminal pane does nothing (no `[COPY]` badge appears), or pressing `y` in copy-mode does not copy any text to the clipboard, or entering copy-mode inside vim (alt-screen) incorrectly freezes vim input.

--- a/docs/superpowers/plans/2026-05-03-scrollback-navigation-keys.md
+++ b/docs/superpowers/plans/2026-05-03-scrollback-navigation-keys.md
@@ -1,0 +1,411 @@
+# Scrollback Navigation Keys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add keyboard shortcuts for navigating the terminal scrollback buffer: `Shift+PgUp/PgDn` (page), `Cmd+Up/Down` (1 line, fix existing 3-line increment), `Cmd+Home/End` (top/bottom), plus a scroll position indicator when not at the bottom.
+
+**Architecture:** All scroll commands route through the existing `BackendCommand::Scroll(i32)` or the new `BackendCommand::ScrollTop`/`ScrollBottom` variants. `Shift+PgUp/PgDn` and `Cmd+Home/End` are handled via new `BindingAction` variants in `egui_term`'s bindings system. `Cmd+Up/Down` are already consumed by the Plexi host and just need their line count fixed from 3 → 1.
+
+**Tech Stack:** Rust, egui, egui_term (vendored at `deps/egui_term/`), alacritty_terminal 0.25 (`Scroll::PageUp`, `Scroll::PageDown`, `Scroll::Top`, `Scroll::Bottom` all confirmed available)
+
+---
+
+## File Map
+
+- **Modify:** `deps/egui_term/src/bindings.rs` — add `BindingAction::ScrollPage(i32)`, `BindingAction::ScrollTop`, `BindingAction::ScrollBottom`; add bindings for `Shift+PgUp/PgDn` (non-alt-screen only) and `Cmd+Home/End`
+- **Modify:** `deps/egui_term/src/backend/mod.rs` — add `BackendCommand::ScrollPage(i32)`, `BackendCommand::ScrollTop`, `BackendCommand::ScrollBottom` variants; handle them in `process_command`
+- **Modify:** `deps/egui_term/src/view.rs` — handle new `BindingAction` variants in `process_keyboard_key`; add scroll position indicator in `show()`
+- **Modify:** `src/pane_ops/layout.rs:617` — change `scroll_focused_pane(3)` caller amounts from 3 to 1
+
+---
+
+## Task 1: Add new BackendCommand variants and handle them
+
+**Files:**
+- Modify: `deps/egui_term/src/backend/mod.rs:35-43` (BackendCommand enum)
+- Modify: `deps/egui_term/src/backend/mod.rs:240-267` (process_command match)
+
+- [ ] **Step 1: Add the new variants to `BackendCommand`**
+
+In `deps/egui_term/src/backend/mod.rs`, replace:
+```rust
+#[derive(Debug, Clone)]
+pub enum BackendCommand {
+    Write(Vec<u8>),
+    Scroll(i32),
+    Resize(Size, Size),
+    SelectStart(SelectionType, f32, f32, f32),
+    SelectUpdate(f32, f32, f32),
+    ProcessLink(LinkAction, Point),
+    MouseReport(MouseButton, Modifiers, Point, bool),
+}
+```
+with:
+```rust
+#[derive(Debug, Clone)]
+pub enum BackendCommand {
+    Write(Vec<u8>),
+    Scroll(i32),
+    ScrollPage(i32),   // +1 = page up, -1 = page down (uses Scroll::PageUp/PageDown)
+    ScrollTop,
+    ScrollBottom,
+    Resize(Size, Size),
+    SelectStart(SelectionType, f32, f32, f32),
+    SelectUpdate(f32, f32, f32),
+    ProcessLink(LinkAction, Point),
+    MouseReport(MouseButton, Modifiers, Point, bool),
+}
+```
+
+- [ ] **Step 2: Handle the new variants in `process_command`**
+
+`process_command` already holds `let mut term = term.lock()` at the top of the function. Add these arms inside the existing `match cmd { ... }`, reusing that `term` binding (same pattern as the existing `Scroll` arm):
+
+```rust
+BackendCommand::ScrollPage(sign) => {
+    if sign > 0 {
+        term.grid_mut().scroll_display(Scroll::PageUp);
+    } else {
+        term.grid_mut().scroll_display(Scroll::PageDown);
+    }
+},
+BackendCommand::ScrollTop => {
+    term.grid_mut().scroll_display(Scroll::Top);
+},
+BackendCommand::ScrollBottom => {
+    term.grid_mut().scroll_display(Scroll::Bottom);
+},
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cd /path/to/worktrees/alpha && cargo build 2>&1 | grep -E "^error"
+```
+Expected: no `error` lines (warnings OK).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deps/egui_term/src/backend/mod.rs
+git commit -m "feat(egui_term): add ScrollPage/ScrollTop/ScrollBottom BackendCommand variants"
+```
+
+---
+
+## Task 2: Add BindingAction variants and keyboard bindings
+
+**Files:**
+- Modify: `deps/egui_term/src/bindings.rs:5-12` (BindingAction enum)
+- Modify: `deps/egui_term/src/bindings.rs:138-349` (binding tables)
+
+- [ ] **Step 1: Add new variants to `BindingAction`**
+
+In `deps/egui_term/src/bindings.rs`, replace:
+```rust
+#[derive(Clone, Hash, Debug, PartialEq, Eq)]
+pub enum BindingAction {
+    Copy,
+    Paste,
+    Char(char),
+    Esc(String),
+    LinkOpen,
+    Ignore,
+}
+```
+with:
+```rust
+#[derive(Clone, Hash, Debug, PartialEq, Eq)]
+pub enum BindingAction {
+    Copy,
+    Paste,
+    Char(char),
+    Esc(String),
+    LinkOpen,
+    Ignore,
+    ScrollPage(i32),  // +1 = page up, -1 = page down
+    ScrollTop,
+    ScrollBottom,
+}
+```
+
+- [ ] **Step 2: Write a failing test**
+
+At the bottom of `deps/egui_term/src/bindings.rs`, add:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::TerminalMode;
+
+    fn normal_mode() -> TerminalMode {
+        TerminalMode::empty()
+    }
+
+    fn alt_screen_mode() -> TerminalMode {
+        TerminalMode::ALT_SCREEN
+    }
+
+    fn shift() -> Modifiers {
+        Modifiers::SHIFT
+    }
+
+    #[test]
+    fn shift_pageup_scrolls_in_normal_mode() {
+        let layout = BindingsLayout::new();
+        let action = layout.get_action(
+            InputKind::KeyCode(Key::PageUp),
+            shift(),
+            normal_mode(),
+        );
+        assert_eq!(action, BindingAction::ScrollPage(1));
+    }
+
+    #[test]
+    fn shift_pageup_sends_escape_in_alt_screen() {
+        let layout = BindingsLayout::new();
+        let action = layout.get_action(
+            InputKind::KeyCode(Key::PageUp),
+            shift(),
+            alt_screen_mode(),
+        );
+        assert_eq!(action, BindingAction::Esc("\x1b[5;2~".into()));
+    }
+
+    #[test]
+    fn shift_pagedown_scrolls_in_normal_mode() {
+        let layout = BindingsLayout::new();
+        let action = layout.get_action(
+            InputKind::KeyCode(Key::PageDown),
+            shift(),
+            normal_mode(),
+        );
+        assert_eq!(action, BindingAction::ScrollPage(-1));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to confirm it fails**
+
+```bash
+cd /path/to/worktrees/alpha && cargo test -p egui_term 2>&1 | grep -E "FAILED|error"
+```
+Expected: `shift_pageup_scrolls_in_normal_mode` FAILED (BindingAction::Ignore returned, not ScrollPage).
+
+- [ ] **Step 4: Add the scroll bindings**
+
+In `default_keyboard_bindings()` in `bindings.rs`, after the existing `Shift+PgUp` alt-screen entry (line ~245), add the non-alt-screen scroll variants. The binding table uses `~` for "mode must NOT be set". Add after the existing `PageDown, Modifiers::SHIFT, +TerminalMode::ALT_SCREEN` line:
+
+```rust
+// Scrollback navigation — only when NOT in alt-screen (TUI apps get the escape seq above)
+PageUp,   Modifiers::SHIFT, ~TerminalMode::ALT_SCREEN; BindingAction::ScrollPage(1);
+PageDown, Modifiers::SHIFT, ~TerminalMode::ALT_SCREEN; BindingAction::ScrollPage(-1);
+```
+
+And for Home/End with Cmd — these use `Modifiers::COMMAND` (= Cmd on macOS). Add in `platform_keyboard_bindings()` (macOS section) after the Copy/Paste entries:
+```rust
+Home, Modifiers::MAC_CMD; BindingAction::ScrollTop;
+End,  Modifiers::MAC_CMD; BindingAction::ScrollBottom;
+```
+
+Note: use `Modifiers::MAC_CMD` (not `Modifiers::COMMAND`) to avoid conflicting with the Ctrl+Home binding in the default table. On macOS, `MAC_CMD` is Cmd, `COMMAND` is also Cmd — but `MAC_CMD` is more specific and avoids the general COMMAND modifier collision with Ctrl bindings on Linux.
+
+Actually verify which modifier constant egui uses for Cmd-only on macOS by checking the existing Copy binding:
+```
+C, Modifiers::MAC_CMD; BindingAction::Copy;
+```
+Use the same constant: `Modifiers::MAC_CMD`.
+
+- [ ] **Step 5: Run test to confirm it passes**
+
+```bash
+cd /path/to/worktrees/alpha && cargo test -p egui_term 2>&1 | grep -E "test.*ok|FAILED"
+```
+Expected: all three new tests pass.
+
+- [ ] **Step 6: Compile check**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add deps/egui_term/src/bindings.rs
+git commit -m "feat(egui_term): add ScrollPage/ScrollTop/ScrollBottom BindingAction variants and bindings"
+```
+
+---
+
+## Task 3: Wire BindingAction → BackendCommand in view.rs
+
+**Files:**
+- Modify: `deps/egui_term/src/view.rs:621-633` (`process_keyboard_key` match)
+
+- [ ] **Step 1: Handle the new BindingAction variants in `process_keyboard_key`**
+
+In `deps/egui_term/src/view.rs`, find `process_keyboard_key` and its match block:
+```rust
+match binding_action {
+    BindingAction::Char(c) => { ... },
+    BindingAction::Esc(seq) => { ... },
+    _ => InputAction::Ignore,
+}
+```
+
+Replace the `_ => InputAction::Ignore` arm with explicit handling plus a final catch-all:
+```rust
+    BindingAction::ScrollPage(sign) => {
+        InputAction::BackendCall(BackendCommand::ScrollPage(sign))
+    },
+    BindingAction::ScrollTop => {
+        InputAction::BackendCall(BackendCommand::ScrollTop)
+    },
+    BindingAction::ScrollBottom => {
+        InputAction::BackendCall(BackendCommand::ScrollBottom)
+    },
+    _ => InputAction::Ignore,
+```
+
+- [ ] **Step 2: Compile and verify**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deps/egui_term/src/view.rs
+git commit -m "feat(egui_term): wire ScrollPage/ScrollTop/ScrollBottom through process_keyboard_key"
+```
+
+---
+
+## Task 4: Fix Cmd+Up/Down line increment (host side)
+
+**Files:**
+- Modify: `src/app/mod.rs` — change the `scroll_focused_pane` call amounts
+
+Currently `Action::ScrollUp` calls `self.scroll_focused_pane(3)` and `Action::ScrollDown` calls `self.scroll_focused_pane(-3)`. These scroll 3 lines per keypress, which is too coarse for line-by-line navigation.
+
+- [ ] **Step 1: Find the call sites**
+
+```bash
+grep -n "scroll_focused_pane" src/app/mod.rs
+```
+Expected output: two lines around 1934-1938 with `scroll_focused_pane(3)` and `scroll_focused_pane(-3)`.
+
+- [ ] **Step 2: Change to 1 line**
+
+In `src/app/mod.rs`, change:
+```rust
+Action::ScrollUp => {
+    self.scroll_focused_pane(3);
+}
+Action::ScrollDown => {
+    self.scroll_focused_pane(-3);
+}
+```
+to:
+```rust
+Action::ScrollUp => {
+    self.scroll_focused_pane(1);
+}
+Action::ScrollDown => {
+    self.scroll_focused_pane(-1);
+}
+```
+
+- [ ] **Step 3: Compile and verify**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/mod.rs
+git commit -m "fix(scrollback): Cmd+Up/Down scrolls 1 line instead of 3"
+```
+
+---
+
+## Task 5: Add scroll position indicator
+
+**Files:**
+- Modify: `deps/egui_term/src/view.rs` — `show()` method, after `painter.extend(shapes)`
+
+- [ ] **Step 1: Add the indicator after `painter.extend(shapes)`**
+
+In `deps/egui_term/src/view.rs`, find `painter.extend(shapes);` in `show()`. After that line, add:
+
+```rust
+// Scroll position indicator: dim "↑ N" in bottom-right when not at live bottom.
+let display_offset = content.grid.display_offset();
+if display_offset > 0 {
+    let label = format!("↑ {}", display_offset);
+    let font = egui::FontId::monospace(11.0);
+    let color = Color32::from_rgba_unmultiplied(255, 255, 255, 80);
+    let galley = painter.layout_no_wrap(label, font, color);
+    let pad = 6.0;
+    let pos = egui::Pos2::new(
+        layout_max.x - galley.size().x - pad,
+        layout_max.y - galley.size().y - pad,
+    );
+    painter.galley(pos, galley, color);
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo build 2>&1 | grep "^error"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deps/egui_term/src/view.rs
+git commit -m "feat(egui_term): scroll position indicator when viewport is in scrollback"
+```
+
+---
+
+## Task 6: Manual smoke test
+
+- [ ] **Step 1: Build and install the alpha build**
+
+From inside `worktrees/alpha/`:
+```bash
+just bump-and-install
+```
+
+- [ ] **Step 2: Verify each binding**
+
+Open Plexi Alpha with a terminal pane. Run `git log` or `seq 1 200` to populate scrollback. Then verify:
+
+| Action | Expected |
+|--------|----------|
+| `Shift+PgUp` | Viewport scrolls up one full page |
+| `Shift+PgDn` | Viewport scrolls down one full page |
+| `Cmd+Up` | Viewport scrolls up exactly one line |
+| `Cmd+Down` | Viewport scrolls down exactly one line |
+| `Cmd+Home` (Fn+←) | Jumps to top of scrollback |
+| `Cmd+End` (Fn+→) | Jumps back to live bottom |
+| Scroll indicator | "↑ N" appears dim in bottom-right when scrolled up; disappears at bottom |
+
+- [ ] **Step 3: Verify alt-screen guard**
+
+Open `vim` in the terminal. With vim open, press `Shift+PgUp`. Expected: vim processes the keypress (scrolls within vim's internal view, or does nothing) — Plexi does NOT scroll the scrollback. The `+TerminalMode::ALT_SCREEN` binding should fire instead.
+
+---
+
+## Task 7: Open PR
+
+Follow the standard PLEXI branch workflow from `docs/superpowers/specs/2026-05-03-scrollback-design.md`. PR targets `alpha`. Title: `feat(terminal): scrollback navigation keys — Shift+PgUp/Dn, Cmd+Up/Down, Cmd+Home/End (#602)`.
+
+DEV_LOG entry required before merge. `Breaks if:` — `Shift+PgUp` in a normal terminal does nothing (doesn't scroll), or pressing `Shift+PgUp` inside vim unexpectedly scrolls the Plexi scrollback buffer instead of letting vim handle it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -968,6 +968,67 @@ pub fn self_update_cli() -> i32 {
         }
     }
 
+    // When running inside Plexi the bundle can't be replaced while the app is live.
+    // Write a relaunch script, launch it detached, trigger app quit, and exit.
+    if std::env::var("PLEXI_RUNNING").as_deref() == Ok("1") {
+        let bin_name = current_exe
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("plexi");
+        let app_display_name = app_bundle
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Plexi");
+        let script = format!(
+            "#!/bin/bash\n\
+             while pgrep -x '{bin_name}' > /dev/null 2>&1; do sleep 0.3; done\n\
+             rm -rf '{bundle}'\n\
+             mv '{staging_path}' '{bundle}'\n\
+             ln -sf '{bundle}/Contents/MacOS/{bin_name}' /usr/local/bin/{bin_name} 2>/dev/null || true\n\
+             open '{bundle}'\n",
+            bin_name = bin_name,
+            staging_path = staging.display(),
+            bundle = app_bundle.display(),
+        );
+        let script_path = tmp_dir.join("plexi-relaunch.sh");
+        if let Err(e) = std::fs::write(&script_path, &script) {
+            eprintln!("error: failed to write relaunch script: {e}");
+            let _ = std::fs::remove_dir_all(&staging);
+            return 1;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(
+                &script_path,
+                std::fs::Permissions::from_mode(0o755),
+            );
+        }
+        match std::process::Command::new("nohup")
+            .arg("bash")
+            .arg(&script_path)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("error: failed to launch relaunch script: {e}");
+                let _ = std::fs::remove_dir_all(&staging);
+                return 1;
+            }
+        }
+        println!("Plexi will restart to apply the update.");
+        let _ = std::process::Command::new("osascript")
+            .args([
+                "-e",
+                &format!("tell application \"{app_display_name}\" to quit"),
+            ])
+            .status();
+        return 0;
+    }
+
     if let Err(e) = std::fs::remove_dir_all(&app_bundle) {
         eprintln!("error: failed to remove old app bundle: {e}");
         eprintln!("Run with sudo if /Applications is not user-writable.");


### PR DESCRIPTION
Closes #604.

## What

Extends `plexi update` so that when run from inside a Plexi terminal pane (`PLEXI_RUNNING=1`), it:

1. Downloads and stages the new bundle to `/Applications/Plexi.app.update-staging` (existing logic)
2. Writes a bash relaunch script to temp that polls `pgrep -x plexi`, then `mv`s the staging bundle into place and opens the new app
3. Launches the script via `nohup` (detached — survives SIGHUP when the terminal session closes)
4. Prints "Plexi will restart to apply the update."
5. Triggers `osascript -e 'tell application "Plexi" to quit'`
6. Exits 0

External terminal path (`PLEXI_RUNNING` unset) is completely unchanged.

## Why

Without this, running `plexi update` inside a Plexi pane would try to swap the bundle while the app is live. The detached-script pattern cleanly solves the "can't replace yourself" problem without Sparkle or Obj-C bindings.

## Test plan

- [ ] Run `plexi update` from an external terminal — should behave exactly as before ("Already up to date" or download + install)
- [ ] Run `PLEXI_RUNNING=1 plexi update` from an external terminal (simulating the in-Plexi case) — should print "Plexi will restart to apply the update." and exit 0 (or "Already up to date" if already latest)

Note: full end-to-end testing (actual bundle swap + relaunch) requires a stable build with an available update, which won't be testable on an alpha PR build. The PR-install smoke test can verify the non-relaunch path and the `PLEXI_RUNNING` branch exit behavior.