### PR TITLE
fix(config): confirm_close defaults to false, matching template and UX intent

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2468,10 +2468,10 @@ impl PlexiApp {
         self.config.confirm_quit.unwrap_or(true)
     }
 
-    /// Read `confirm_close` from the config tunnel. Defaults to `true` so
-    /// users get the confirmation dialog unless they explicitly opt out.
+    /// Read `confirm_close` from the config tunnel. Defaults to `false` so
+    /// pane close is instant unless the user explicitly enables the dialog.
     pub(crate) fn confirm_close(&self) -> bool {
-        self.config.confirm_close.unwrap_or(true)
+        self.config.confirm_close.unwrap_or(false)
     }
 
     /// If the currently focused pane is an app with a non-empty nav stack,


### PR DESCRIPTION
Fixes #613.

`confirm_close()` used `unwrap_or(true)`, so users without a config file (first launch) got pane-close confirmation dialogs enabled. The generated config template and intended default both say `false`.

One-line fix: `unwrap_or(true)` → `unwrap_or(false)`. Docstring updated to match.

**Breaks if:** Cmd+W on a pane shows a confirmation dialog when `confirm_close` is absent from config (i.e. default behavior changed back to broken).