### PR TITLE
feat(ui): minimap at 75% opacity

### DIFF
--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -56,6 +56,8 @@ pub fn render_minimap(
         return None;
     }
 
+    ui.set_opacity(0.75);
+
     // ── Collapse empty rows so the grid is always compact ─────────────────
     let mut raw_ys: Vec<u32> = visible.iter().map(|(_, c)| c.grid_y).collect();
     raw_ys.sort_unstable();


### PR DESCRIPTION
## Summary
- Sets the minimap overlay to 75% opacity via `ui.set_opacity(0.75)` at the top of `render_minimap`
- All painter calls (background panel, borders, cells, text) inherit the opacity automatically through egui's painter opacity propagation

## Test plan
- [ ] Open Plexi alpha build
- [ ] Toggle minimap on (⌘⇧M)
- [ ] Confirm the minimap appears visibly semi-transparent (content behind it bleeds through at ~25%)