### PR TITLE
feat(ui): increase zoomed pane inset from 5px to 10px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Newest releases appear first.
 
+## [3.4.59] — 2026-05-03 21:34 ET
+
+### Changes
+
 ## [3.4.58] — 2026-05-03 21:27 ET
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.58"
+version = "3.4.59"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.58"
+version = "3.4.59"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2038,7 +2038,6 @@ impl eframe::App for PlexiApp {
                                 "drop: zoomed overlay received drop event — pane_id={pane_id:?}"
                             );
                         }
-                        child_ui.set_opacity(0.95);
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2038,6 +2038,7 @@ impl eframe::App for PlexiApp {
                                 "drop: zoomed overlay received drop event — pane_id={pane_id:?}"
                             );
                         }
+                        child_ui.set_opacity(0.95);
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2005,7 +2005,7 @@ impl eframe::App for PlexiApp {
                             .rect_filled(panel_rect, 0.0, Color32::from_black_alpha(75));
 
                         // Inset rect for the zoomed pane
-                        let inset = 5.0;
+                        let inset = 10.0;
                         let zoom_rect = panel_rect.shrink(inset);
 
                         // Thicker accent border (2px)


### PR DESCRIPTION
Closes #617

## Summary
- Changes `inset` in the zoom overlay block (`src/app/mod.rs:2008`) from `5.0` to `10.0`
- `zoom_rect = panel_rect.shrink(inset)` so the gap increases uniformly on all four sides
- No other values change — border stroke and inner margin are layered on top

## Test plan
- [ ] Zoom any pane (⌘↩ or double-click)
- [ ] Confirm the gap between the window edge and the zoomed pane border is visibly wider (~10px) than before (~5px)
- [ ] Unzoom — layout returns to normal