### PR TITLE
feat(ui): zoomed pane overlay at 99% opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Newest releases appear first.
 
+## [3.4.59] — 2026-05-03 21:34 ET
+
+### Changes
+
 ## [3.4.58] — 2026-05-03 21:27 ET
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.58"
+version = "3.4.59"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.58"
+version = "3.4.59"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2039,7 +2039,10 @@ impl eframe::App for PlexiApp {
                             );
                         }
                         egui::Frame::new()
-                            .fill(self.colors.terminal_bg)
+                            .fill({
+                                let c = self.colors.terminal_bg;
+                                Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), 252)
+                            })
                             .inner_margin(egui::Margin::same(8))
                             .show(&mut child_ui, |ui| {
                                 if let Some(pane) = ctx.panes.get_mut(&pane_id) {


### PR DESCRIPTION
Closes #572

Changes the zoomed pane overlay `Frame` fill from fully-opaque `terminal_bg` to a 99% alpha version (alpha=252/255). The scrim behind the overlay is faintly visible through the frame, matching the issue spec.

**Breaks if:** Zooming any pane shows the overlay frame as fully transparent or fully opaque with no visible bleed-through from the scrim.