### PR TITLE
feat(palette): Cmd+J / Cmd+K navigate down/up in command palette

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -224,13 +224,15 @@ impl PlexiApp {
             if input.consume_key(egui::Modifiers::COMMAND, egui::Key::P) {
                 self.show_command_palette = false;
             }
-            if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || input.consume_key(egui::Modifiers::COMMAND, egui::Key::J))
                 && total > 0
                 && self.palette_selected < total - 1
             {
                 self.palette_selected += 1;
             }
-            if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || input.consume_key(egui::Modifiers::COMMAND, egui::Key::K))
                 && self.palette_selected > 0
             {
                 self.palette_selected -= 1;


### PR DESCRIPTION
Closes #501

Adds `Cmd+J` and `Cmd+K` as aliases for `ArrowDown` / `ArrowUp` in the command palette. The existing arrow-key handlers are wrapped in a logical-or with the new key combos — zero change to existing behaviour, bounds checks are identical.

**Breaks if:** `Cmd+J` / `Cmd+K` do nothing while the command palette is open.