### PR TITLE
refactor(routing): split DrawCommand into RenderCommand + HostCommand + ControlCommand

### DIFF
--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -432,11 +432,10 @@ pub enum MouseButton {
 
 // ── Commands sent FROM the app TO Plexi ──────────────────────────────────────
 
+/// Render primitives — go to `pending_frame` → drawn to screen.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum DrawCommand {
-    // ── Visual primitives (frame-scoped) ─────────────────────────────────
-
+pub enum RenderCommand {
     /// Push a clip rect onto the host's clip stack.
     ///
     /// The effective clip rect is the intersection of the new rect with the
@@ -510,6 +509,26 @@ pub enum DrawCommand {
         #[serde(default = "default_stroke_width")]
         width: f32,
     },
+    /// Draw a filled circle. Alpha is supported via 8-digit hex fill (#rrggbbaa).
+    Circle {
+        cx: f32,
+        cy: f32,
+        r: f32,
+        fill: String,
+    },
+
+    /// Draw a filled arc / pie slice.
+    /// `start_angle` and `end_angle` are in radians, measured clockwise from the right (east).
+    /// A full circle is 0.0 to std::f32::consts::TAU.
+    Arc {
+        cx: f32,
+        cy: f32,
+        r: f32,
+        start_angle: f32,
+        end_angle: f32,
+        fill: String,
+    },
+
     /// High-level scrollable list — host handles layout and scrolling.
     List {
         #[serde(default)]
@@ -525,19 +544,200 @@ pub enum DrawCommand {
         #[serde(default)]
         item_height: f32,
     },
-    /// End of frame. Host renders everything queued since last FrameDone.
-    FrameDone {
-        /// Must match the frame_id from the triggering Render event.
-        frame_id: u64,
+
+    // ── Host-measured layout primitives ──────────────────────────────────
+    //
+    // These commands delegate text measurement and pill geometry entirely to
+    // the host. The SDK emits intent; the host measures with real egui font
+    // metrics and renders. No Python-side width estimation.
+
+    /// Host-rendered pill badge. The host measures the label with real font
+    /// metrics, sizes the pill (text_w + padding), and centres the text
+    /// both horizontally and vertically. No width math in the SDK.
+    ///
+    /// `x`      — left edge of the badge.
+    /// `y`      — vertical centre (the badge is drawn centred on this y).
+    /// `label`  — text to display inside the pill.
+    /// `fill`   — pill background colour (hex).
+    /// `fg`     — text colour (hex).
+    /// `font_size` — label font size in pt.
+    /// `radius` — pill corner radius. Use a large value (e.g. font_size) for
+    ///            a fully-rounded pill, or RADIUS_SM (4.0) for tag chips.
+    Badge {
+        x: f32,
+        y: f32,
+        label: String,
+        fill: String,
+        fg: String,
+        font_size: f32,
+        radius: f32,
     },
 
-    // ── Out-of-frame commands ─────────────────────────────────────────────
-    /// Forward a log message into Plexi's logger (tagged with app_id).
-    Log {
-        /// One of: "error" | "warn" | "info" | "debug"
-        level: String,
-        message: String,
+    /// Host-rendered keycap chip. The host measures the label with real
+    /// monospace font metrics, sizes the chip, and centres the text inside.
+    ///
+    /// `x`         — left edge of the chip (top-left, matching ctx.text).
+    /// `y`         — top edge of the chip.
+    /// `label`     — key label (e.g. "⌘", "[", "Enter").
+    /// `font_size` — label font size in pt.
+    KeyChip {
+        x: f32,
+        y: f32,
+        label: String,
+        font_size: f32,
     },
+
+    /// A horizontal row of keycap chips. The host flows them left-to-right
+    /// with a fixed 2px gap between chips, sizes each chip from real font
+    /// metrics, and places an optional trailing description label after the
+    /// last chip.
+    ///
+    /// `x`, `y`      — top-left origin of the row.
+    /// `keys`        — ordered list of key labels to render as chips.
+    /// `description` — optional label rendered after the last chip.
+    /// `font_size`   — applies to all chips and the description.
+    KeyChipRow {
+        x: f32,
+        y: f32,
+        keys: Vec<String>,
+        description: Option<String>,
+        font_size: f32,
+    },
+
+    /// A multi-group shortcut row. The host owns all layout — chip widths
+    /// from real font metrics, flow horizontally with configurable inter-
+    /// group gap, wrap to a new line when the next group would exceed
+    /// `max_width`. Returns nothing; correct by construction.
+    ///
+    /// `x`, `y`      — top-left origin.
+    /// `max_width`   — wrap budget. Wrap to a new line when the next group
+    ///                 would exceed it. Caller passes the available pane
+    ///                 width minus its own padding.
+    /// `pairs`       — ordered list of `(chip-labels, description)` groups.
+    ///                 Each pair renders as one or more chips followed by
+    ///                 the description text.
+    /// `font_size`   — applies to all chips and descriptions.
+    Shortcuts {
+        x: f32,
+        y: f32,
+        max_width: f32,
+        pairs: Vec<ShortcutPair>,
+        font_size: f32,
+    },
+
+    /// Multiple text segments rendered horizontally with host-measured layout.
+    /// The host measures each segment with real font metrics and flows them
+    /// left-to-right with configurable gap spacing.
+    ///
+    /// `x`, `y`  — origin of the text row.
+    /// `items`   — list of text segments, each with text, color, size, monospace.
+    /// `gap`     — spacing between items in pixels.
+    /// `align`   — vertical alignment (e.g., "left_center").
+    TextRow {
+        x: f32,
+        y: f32,
+        items: Vec<TextRowItem>,
+        gap: f32,
+        align: String,
+    },
+
+    /// Render markdown text using the host's `egui_commonmark` renderer.
+    ///
+    /// The host creates a child `Ui` at `(x, y)` with width `w` and renders
+    /// the markdown with proper formatting (bold, italic, code blocks, etc.).
+    /// `base_size` controls the body font size; `color` sets the default text
+    /// colour.
+    Markdown {
+        x: f32,
+        y: f32,
+        w: f32,
+        text: String,
+        base_size: f32,
+        color: String,
+    },
+
+    /// Draw an image from a workspace-scoped path or data URL.
+    Image {
+        src: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        /// One of: "contain" | "cover" | "fill". Default: "contain".
+        #[serde(default = "default_image_fit")]
+        fit: String,
+    },
+
+    /// Render an amplitude meter reading from a binary pipe.
+    AudioMeter { rect: Rect, pipe_id: String },
+
+    /// Text input field (host-owned buffer, submit-only).
+    ///
+    /// Emitted by the app each frame at `(x, y)` with width `w`. The host
+    /// owns the underlying buffer keyed on `id` — typed characters never
+    /// reach the app between frames. On Enter the host emits
+    /// `PlexiEvent::TextSubmitted { id, value }` and clears its buffer.
+    ///
+    /// When `multiline` is `false` (the default), the host renders a
+    /// single-line `TextEdit` and Enter submits. When `multiline` is `true`,
+    /// the host renders a multi-line `TextEdit`; Enter still submits but
+    /// Shift+Enter inserts a newline.
+    ///
+    /// Real-time validation (per-keystroke value access) is intentionally
+    /// out of scope — see issue #283 option A. Apps that need it must
+    /// wait for a future protocol revision.
+    TextInput {
+        id: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        /// Height of the input widget in pixels. Defaults to 24.0 for
+        /// backwards compatibility with older SDKs that don't send `h`.
+        #[serde(default = "default_text_input_h")]
+        h: f32,
+        placeholder: String,
+        /// When `true`, render as a multi-line editor. Enter submits;
+        /// Shift+Enter inserts a newline. Defaults to `false` so existing
+        /// draw commands without this field continue to work.
+        #[serde(default)]
+        multiline: bool,
+    },
+
+    // ── Host-managed scroll regions (#446) ───────────────────────────────
+
+    /// Begin a host-managed vertical scroll region.
+    ///
+    /// All draw commands between this and the matching `EndScroll` are clipped
+    /// to the viewport rect `(x, y, w, h)`. The host tracks the scroll offset
+    /// for `id` across frames and emits `PlexiEvent::ScrollOffset { id, offset_y }`
+    /// whenever the user scrolls (mouse wheel / drag). The app translates its
+    /// content coordinates by `offset_y` before emitting draw commands.
+    ///
+    /// `content_height` is the total virtual height of the scrollable content
+    /// in logical pixels. The host uses this to size the scrollbar thumb.
+    ///
+    /// `id` must be stable across frames — use a meaningful string (e.g. the
+    /// region name) rather than a counter that may change.
+    BeginScroll {
+        id: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        content_height: f32,
+    },
+
+    /// Close the most recently opened scroll region.
+    ///
+    /// Must be balanced with a preceding `BeginScroll`. Imbalanced pairs are
+    /// logged at `warn` level and the stack is reset at frame end.
+    EndScroll,
+}
+
+/// Side-effectful commands — go to `route_command`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum HostCommand {
     /// Request a runtime capability prompt. Host shows modal; responds with CapabilityDecision.
     CapabilityRequest {
         request_id: String,
@@ -722,46 +922,6 @@ pub enum DrawCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
-    /// Draw an image from a workspace-scoped path or data URL.
-    Image {
-        src: String,
-        x: f32,
-        y: f32,
-        w: f32,
-        h: f32,
-        /// One of: "contain" | "cover" | "fill". Default: "contain".
-        #[serde(default = "default_image_fit")]
-        fit: String,
-    },
-    /// Open a video decoder (#345). The host responds with
-    /// `PlexiEvent::VideoOpenAck { request_id, handle_id, width, height,
-    /// fps, duration_ms }` on success or `PlexiEvent::VideoOpenError
-    /// { request_id, error }` on failure (capability denied, source not
-    /// found, decoder error, NotImplemented from the production stub).
-    /// Decoded RGBA8 frames flow over the binary pipe at `pipe_id`; one
-    /// pipe frame = one video frame, packed `[R,G,B,A,...]` of length
-    /// `width * height * 4`.
-    ///
-    /// Requires `video.playback` capability. All fields required —
-    /// no `serde(default)`.
-    OpenVideo {
-        request_id: String,
-        source: String,
-        pipe_id: String,
-    },
-    /// Drive playback state for a previously-opened video handle (#345).
-    /// `handle_id` is the value returned in `VideoOpenAck`. State variants:
-    /// `play`, `pause`, or `seek` to an absolute position in milliseconds.
-    SetVideoState {
-        handle_id: u64,
-        state: crate::video::VideoState,
-    },
-    /// Close a previously-opened video handle (#345). Tears down the
-    /// decoder thread and the associated binary pipe drains. No response
-    /// event — fire-and-forget.
-    CloseVideo { handle_id: u64 },
-    /// Render an amplitude meter reading from a binary pipe.
-    AudioMeter { rect: Rect, pipe_id: String },
     /// Host-owned audio playback via `rodio`.
     AudioPlay {
         #[serde(default)]
@@ -796,7 +956,6 @@ pub enum DrawCommand {
     /// capability gate — enumeration discloses only port names already
     /// visible in Audio MIDI Setup.
     ListMidiDevices { request_id: String },
-
     /// Open a MIDI input port and forward every incoming message as a binary
     /// pipe frame on `pipe_id`. Each frame is a single MIDI 1.0 byte stream
     /// (1–3 bytes for channel-voice / system real-time). Requires `midi.in`.
@@ -820,217 +979,43 @@ pub enum DrawCommand {
     /// app exits.
     SendMidi { port_id: String, bytes: Vec<u8> },
 
-    /// SDK ready handshake. Sent once by the app after receiving Init.
-    /// Host captures sdk and features_used; the message is otherwise a no-op.
-    Ready {
-        #[serde(default)]
-        sdk: String,
-        #[serde(default)]
-        features_used: Vec<String>,
+    /// Open a video decoder (#345). The host responds with
+    /// `PlexiEvent::VideoOpenAck { request_id, handle_id, width, height,
+    /// fps, duration_ms }` on success or `PlexiEvent::VideoOpenError
+    /// { request_id, error }` on failure (capability denied, source not
+    /// found, decoder error, NotImplemented from the production stub).
+    /// Decoded RGBA8 frames flow over the binary pipe at `pipe_id`; one
+    /// pipe frame = one video frame, packed `[R,G,B,A,...]` of length
+    /// `width * height * 4`.
+    ///
+    /// Requires `video.playback` capability. All fields required —
+    /// no `serde(default)`.
+    OpenVideo {
+        request_id: String,
+        source: String,
+        pipe_id: String,
     },
+    /// Drive playback state for a previously-opened video handle (#345).
+    /// `handle_id` is the value returned in `VideoOpenAck`. State variants:
+    /// `play`, `pause`, or `seek` to an absolute position in milliseconds.
+    SetVideoState {
+        handle_id: u64,
+        state: crate::video::VideoState,
+    },
+    /// Close a previously-opened video handle (#345). Tears down the
+    /// decoder thread and the associated binary pipe drains. No response
+    /// event — fire-and-forget.
+    CloseVideo { handle_id: u64 },
+
     /// Request the host to cd all terminals in the same pane group to `cwd`.
     /// Terminals receive `cd <cwd>\n` written to their PTY.
     CdRequest { cwd: String },
-
-    /// Ask the host to trigger a new Render event after `after_ms` milliseconds.
-    /// Intended for game loops and animations — emit once per frame to sustain a
-    /// tick rate without relying on egui's unconditional repaint cadence.
-    /// Apps that do not emit this will still repaint on keyboard/inject events.
-    ScheduleRender { after_ms: u32 },
 
     /// Request a one-shot timer. Requires `timer` capability.
     /// Host fires `PlexiEvent::Timer { timer_id }` after `after_ms` milliseconds.
     SetTimer { timer_id: String, after_ms: u64 },
     /// Cancel a pending timer. No-op if the timer has already fired or doesn't exist.
     CancelTimer { timer_id: String },
-
-    /// Draw a filled circle. Alpha is supported via 8-digit hex fill (#rrggbbaa).
-    Circle {
-        cx: f32,
-        cy: f32,
-        r: f32,
-        fill: String,
-    },
-
-    /// Draw a filled arc / pie slice.
-    /// `start_angle` and `end_angle` are in radians, measured clockwise from the right (east).
-    /// A full circle is 0.0 to std::f32::consts::TAU.
-    Arc {
-        cx: f32,
-        cy: f32,
-        r: f32,
-        start_angle: f32,
-        end_angle: f32,
-        fill: String,
-    },
-
-    // ── Host-measured layout primitives ──────────────────────────────────
-    //
-    // These commands delegate text measurement and pill geometry entirely to
-    // the host. The SDK emits intent; the host measures with real egui font
-    // metrics and renders. No Python-side width estimation.
-
-    /// Host-rendered pill badge. The host measures the label with real font
-    /// metrics, sizes the pill (text_w + padding), and centres the text
-    /// both horizontally and vertically. No width math in the SDK.
-    ///
-    /// `x`      — left edge of the badge.
-    /// `y`      — vertical centre (the badge is drawn centred on this y).
-    /// `label`  — text to display inside the pill.
-    /// `fill`   — pill background colour (hex).
-    /// `fg`     — text colour (hex).
-    /// `font_size` — label font size in pt.
-    /// `radius` — pill corner radius. Use a large value (e.g. font_size) for
-    ///            a fully-rounded pill, or RADIUS_SM (4.0) for tag chips.
-    Badge {
-        x: f32,
-        y: f32,
-        label: String,
-        fill: String,
-        fg: String,
-        font_size: f32,
-        radius: f32,
-    },
-
-    /// Host-rendered keycap chip. The host measures the label with real
-    /// monospace font metrics, sizes the chip, and centres the text inside.
-    ///
-    /// `x`         — left edge of the chip (top-left, matching ctx.text).
-    /// `y`         — top edge of the chip.
-    /// `label`     — key label (e.g. "⌘", "[", "Enter").
-    /// `font_size` — label font size in pt.
-    KeyChip {
-        x: f32,
-        y: f32,
-        label: String,
-        font_size: f32,
-    },
-
-    /// A horizontal row of keycap chips. The host flows them left-to-right
-    /// with a fixed 2px gap between chips, sizes each chip from real font
-    /// metrics, and places an optional trailing description label after the
-    /// last chip.
-    ///
-    /// `x`, `y`      — top-left origin of the row.
-    /// `keys`        — ordered list of key labels to render as chips.
-    /// `description` — optional label rendered after the last chip.
-    /// `font_size`   — applies to all chips and the description.
-    KeyChipRow {
-        x: f32,
-        y: f32,
-        keys: Vec<String>,
-        description: Option<String>,
-        font_size: f32,
-    },
-
-    /// A multi-group shortcut row. The host owns all layout — chip widths
-    /// from real font metrics, flow horizontally with configurable inter-
-    /// group gap, wrap to a new line when the next group would exceed
-    /// `max_width`. Returns nothing; correct by construction.
-    ///
-    /// `x`, `y`      — top-left origin.
-    /// `max_width`   — wrap budget. Wrap to a new line when the next group
-    ///                 would exceed it. Caller passes the available pane
-    ///                 width minus its own padding.
-    /// `pairs`       — ordered list of `(chip-labels, description)` groups.
-    ///                 Each pair renders as one or more chips followed by
-    ///                 the description text.
-    /// `font_size`   — applies to all chips and descriptions.
-    Shortcuts {
-        x: f32,
-        y: f32,
-        max_width: f32,
-        pairs: Vec<ShortcutPair>,
-        font_size: f32,
-    },
-
-    /// Multiple text segments rendered horizontally with host-measured layout.
-    /// The host measures each segment with real font metrics and flows them
-    /// left-to-right with configurable gap spacing.
-    ///
-    /// `x`, `y`  — origin of the text row.
-    /// `items`   — list of text segments, each with text, color, size, monospace.
-    /// `gap`     — spacing between items in pixels.
-    /// `align`   — vertical alignment (e.g., "left_center").
-    TextRow {
-        x: f32,
-        y: f32,
-        items: Vec<TextRowItem>,
-        gap: f32,
-        align: String,
-    },
-
-    /// Request a one-shot text measurement. The host measures `text` at
-    /// `font_size` with the proportional font and replies immediately with
-    /// `PlexiEvent::TextMeasured { request_id, width, height }`.
-    ///
-    /// Use this only when layout genuinely depends on measured text width
-    /// (e.g. flowing multiple badges horizontally). Avoid on hot render paths.
-    MeasureText {
-        request_id: String,
-        text: String,
-        font_size: f32,
-        #[serde(default)]
-        monospace: bool,
-    },
-
-    /// Write `text` to the OS clipboard.
-    ///
-    /// Routed through `egui::Context::copy_text`, which handles platform-
-    /// specific clipboard backends (NSPasteboard / X11 / Wayland / Win32).
-    /// Synchronous from the app's perspective — no acknowledgement event.
-    /// No capability flag required: clipboard write is low-risk and the
-    /// app already controls when it fires (key handler, button, etc.).
-    CopyToClipboard { text: String },
-
-    /// Append a row to the host-owned conversation history of an agent pane.
-    ///
-    /// Only meaningful for panes whose manifest declares `[app] type = "agent"`.
-    /// The host renders the conversation history as the pane's primary surface;
-    /// the agent emits one of these per logical turn boundary (user echo,
-    /// assistant reply, tool result, system note).
-    ///
-    /// `role` is one of `"user"` | `"assistant"` | `"tool"` | `"system"`. Other
-    /// values are accepted at the wire level (forward-compatibility) but the
-    /// host renders unknown roles as plain text. Required field — no
-    /// `serde(default)`.
-    ///
-    /// `content` is the plain-text body of the row. Required field. Empty
-    /// strings are valid (e.g. a placeholder turn while a stream is in flight)
-    /// but discouraged — emit on completion, not on dispatch.
-    AppendConversation { role: String, content: String },
-
-    /// Text input field (host-owned buffer, submit-only).
-    ///
-    /// Emitted by the app each frame at `(x, y)` with width `w`. The host
-    /// owns the underlying buffer keyed on `id` — typed characters never
-    /// reach the app between frames. On Enter the host emits
-    /// `PlexiEvent::TextSubmitted { id, value }` and clears its buffer.
-    ///
-    /// When `multiline` is `false` (the default), the host renders a
-    /// single-line `TextEdit` and Enter submits. When `multiline` is `true`,
-    /// the host renders a multi-line `TextEdit`; Enter still submits but
-    /// Shift+Enter inserts a newline.
-    ///
-    /// Real-time validation (per-keystroke value access) is intentionally
-    /// out of scope — see issue #283 option A. Apps that need it must
-    /// wait for a future protocol revision.
-    TextInput {
-        id: String,
-        x: f32,
-        y: f32,
-        w: f32,
-        /// Height of the input widget in pixels. Defaults to 24.0 for
-        /// backwards compatibility with older SDKs that don't send `h`.
-        #[serde(default = "default_text_input_h")]
-        h: f32,
-        placeholder: String,
-        /// When `true`, render as a multi-line editor. Enter submits;
-        /// Shift+Enter inserts a newline. Defaults to `false` so existing
-        /// draw commands without this field continue to work.
-        #[serde(default)]
-        multiline: bool,
-    },
 
     // ── Canvas Terminal Binding Primitives (#78) ─────────────────────────
     //
@@ -1140,57 +1125,12 @@ pub enum DrawCommand {
     /// entry from the per-pane nav stack (saturating — no-op on empty stack).
     PopNav {},
 
-    // ── Host-managed scroll regions (#446) ───────────────────────────────
-
-    /// Begin a host-managed vertical scroll region.
-    ///
-    /// All draw commands between this and the matching `EndScroll` are clipped
-    /// to the viewport rect `(x, y, w, h)`. The host tracks the scroll offset
-    /// for `id` across frames and emits `PlexiEvent::ScrollOffset { id, offset_y }`
-    /// whenever the user scrolls (mouse wheel / drag). The app translates its
-    /// content coordinates by `offset_y` before emitting draw commands.
-    ///
-    /// `content_height` is the total virtual height of the scrollable content
-    /// in logical pixels. The host uses this to size the scrollbar thumb.
-    ///
-    /// `id` must be stable across frames — use a meaningful string (e.g. the
-    /// region name) rather than a counter that may change.
-    BeginScroll {
-        id: String,
-        x: f32,
-        y: f32,
-        w: f32,
-        h: f32,
-        content_height: f32,
-    },
-
-    /// Close the most recently opened scroll region.
-    ///
-    /// Must be balanced with a preceding `BeginScroll`. Imbalanced pairs are
-    /// logged at `warn` level and the stack is reset at frame end.
-    EndScroll,
-
     /// Enable or disable `PlexiEvent::MouseMove` delivery for this pane.
     ///
     /// Off by default to avoid flooding apps that don't need continuous pointer
     /// tracking. Send `{ enabled: true }` after `Ready` to start receiving
     /// `on_mouse_move` callbacks. Send `{ enabled: false }` to stop.
     SetMouseTracking { enabled: bool },
-
-    /// Render markdown text using the host's `egui_commonmark` renderer.
-    ///
-    /// The host creates a child `Ui` at `(x, y)` with width `w` and renders
-    /// the markdown with proper formatting (bold, italic, code blocks, etc.).
-    /// `base_size` controls the body font size; `color` sets the default text
-    /// colour.
-    Markdown {
-        x: f32,
-        y: f32,
-        w: f32,
-        text: String,
-        base_size: f32,
-        color: String,
-    },
 
     // ── File picker (#514) ────────────────────────────────────────────────────
     /// Show a native macOS file picker dialog. Requires `fs.pick` capability.
@@ -1207,6 +1147,84 @@ pub enum DrawCommand {
         filter: Vec<String>,
         multiple: bool,
     },
+}
+
+/// Inline-handled commands (processed directly in `ui()` or `background_tick()`).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlCommand {
+    /// SDK ready handshake. Sent once by the app after receiving Init.
+    /// Host captures sdk and features_used; the message is otherwise a no-op.
+    Ready {
+        #[serde(default)]
+        sdk: String,
+        #[serde(default)]
+        features_used: Vec<String>,
+    },
+    /// End of frame. Host renders everything queued since last FrameDone.
+    FrameDone {
+        /// Must match the frame_id from the triggering Render event.
+        frame_id: u64,
+    },
+    /// Forward a log message into Plexi's logger (tagged with app_id).
+    Log {
+        /// One of: "error" | "warn" | "info" | "debug"
+        level: String,
+        message: String,
+    },
+    /// Ask the host to trigger a new Render event after `after_ms` milliseconds.
+    /// Intended for game loops and animations — emit once per frame to sustain a
+    /// tick rate without relying on egui's unconditional repaint cadence.
+    /// Apps that do not emit this will still repaint on keyboard/inject events.
+    ScheduleRender { after_ms: u32 },
+    /// Write `text` to the OS clipboard.
+    ///
+    /// Routed through `egui::Context::copy_text`, which handles platform-
+    /// specific clipboard backends (NSPasteboard / X11 / Wayland / Win32).
+    /// Synchronous from the app's perspective — no acknowledgement event.
+    /// No capability flag required: clipboard write is low-risk and the
+    /// app already controls when it fires (key handler, button, etc.).
+    CopyToClipboard { text: String },
+    /// Request a one-shot text measurement. The host measures `text` at
+    /// `font_size` with the proportional font and replies immediately with
+    /// `PlexiEvent::TextMeasured { request_id, width, height }`.
+    ///
+    /// Use this only when layout genuinely depends on measured text width
+    /// (e.g. flowing multiple badges horizontally). Avoid on hot render paths.
+    MeasureText {
+        request_id: String,
+        text: String,
+        font_size: f32,
+        #[serde(default)]
+        monospace: bool,
+    },
+    /// Append a row to the host-owned conversation history of an agent pane.
+    ///
+    /// Only meaningful for panes whose manifest declares `[app] type = "agent"`.
+    /// The host renders the conversation history as the pane's primary surface;
+    /// the agent emits one of these per logical turn boundary (user echo,
+    /// assistant reply, tool result, system note).
+    ///
+    /// `role` is one of `"user"` | `"assistant"` | `"tool"` | `"system"`. Other
+    /// values are accepted at the wire level (forward-compatibility) but the
+    /// host renders unknown roles as plain text. Required field — no
+    /// `serde(default)`.
+    ///
+    /// `content` is the plain-text body of the row. Required field. Empty
+    /// strings are valid (e.g. a placeholder turn while a stream is in flight)
+    /// but discouraged — emit on completion, not on dispatch.
+    AppendConversation { role: String, content: String },
+}
+
+/// Top-level wire type. The `type` field is globally unique across all three
+/// inner enums, so `#[serde(untagged)]` deserializes unambiguously.
+/// The JSON `{"type":"rect",...}` still works; `{"type":"ai_query",...}` still works.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum DrawCommand {
+    Render(RenderCommand),
+    Host(HostCommand),
+    Control(ControlCommand),
 }
 
 /// Replace-vs-append behaviour for `DrawCommand::InsertPathToken`.
@@ -1391,7 +1409,7 @@ mod tests {
         let json = r#"{"type":"copy_to_clipboard","text":"snippet"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::CopyToClipboard { text } => assert_eq!(text, "snippet"),
+            DrawCommand::Control(ControlCommand::CopyToClipboard { text }) => assert_eq!(text, "snippet"),
             other => panic!("expected CopyToClipboard, got {other:?}"),
         }
         let serialised = serde_json::to_string(&cmd).expect("serialise");
@@ -1406,9 +1424,9 @@ mod tests {
         let json = r##"{"type":"text","x":1.0,"y":2.0,"text":"hi","size":14.0,"color":"#fff","monospace":false,"bold":false,"align":"top_left","max_width":null,"elide":true,"selectable":true}"##;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Text {
+            DrawCommand::Render(RenderCommand::Text {
                 text, selectable, ..
-            } => {
+            }) => {
                 assert_eq!(text, "hi");
                 assert!(*selectable, "selectable should be true");
             }
@@ -1442,13 +1460,13 @@ mod tests {
         let json = r#"{"type":"ai_query","request_id":"req-1","model_tier":"medium","system":"You are helpful.","messages":[{"role":"user","content":"hi"}],"tools":[]}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::AiQuery {
+            DrawCommand::Host(HostCommand::AiQuery {
                 request_id,
                 model_tier,
                 system,
                 messages,
                 tools,
-            } => {
+            }) => {
                 assert_eq!(request_id, "req-1");
                 assert_eq!(*model_tier, ModelTier::Medium);
                 assert_eq!(system, "You are helpful.");
@@ -1562,7 +1580,7 @@ mod tests {
             r#"{"type":"append_conversation","role":"assistant","content":"Hello!"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::AppendConversation { role, content } => {
+            DrawCommand::Control(ControlCommand::AppendConversation { role, content }) => {
                 assert_eq!(role, "assistant");
                 assert_eq!(content, "Hello!");
             }
@@ -1611,7 +1629,7 @@ mod tests {
         let json = r#"{"type":"list_audio_devices","request_id":"req-9"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::ListAudioDevices { request_id } => {
+            DrawCommand::Host(HostCommand::ListAudioDevices { request_id }) => {
                 assert_eq!(request_id, "req-9");
             }
             other => panic!("expected ListAudioDevices, got {other:?}"),
@@ -1655,7 +1673,7 @@ mod tests {
         let json = r#"{"type":"list_midi_devices","request_id":"req-m1"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::ListMidiDevices { request_id } => {
+            DrawCommand::Host(HostCommand::ListMidiDevices { request_id }) => {
                 assert_eq!(request_id, "req-m1");
             }
             other => panic!("expected ListMidiDevices, got {other:?}"),
@@ -1703,7 +1721,7 @@ mod tests {
         let json = r#"{"type":"send_midi","port_id":"123","bytes":[144,60,100]}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::SendMidi { port_id, bytes } => {
+            DrawCommand::Host(HostCommand::SendMidi { port_id, bytes }) => {
                 assert_eq!(port_id, "123");
                 assert_eq!(bytes, &vec![0x90u8, 0x3C, 0x64]);
             }
@@ -1728,7 +1746,7 @@ mod tests {
         let json = r#"{"type":"pipe_open_directed","pipe_id":"coord-to-worker","target_pane_id":42}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::PipeOpenDirected { pipe_id, target_pane_id } => {
+            DrawCommand::Host(HostCommand::PipeOpenDirected { pipe_id, target_pane_id }) => {
                 assert_eq!(pipe_id, "coord-to-worker");
                 assert_eq!(*target_pane_id, 42);
             }
@@ -1768,7 +1786,7 @@ mod tests {
         let good = r#"{"type":"audio_capture","pipe_id":"mic","device_id":null,"sample_rate":48000,"buffer_size":512}"#;
         let cmd: DrawCommand = serde_json::from_str(good).expect("deserialise");
         match &cmd {
-            DrawCommand::AudioCapture { pipe_id, device_id, sample_rate, buffer_size } => {
+            DrawCommand::Host(HostCommand::AudioCapture { pipe_id, device_id, sample_rate, buffer_size }) => {
                 assert_eq!(pipe_id, "mic");
                 assert!(device_id.is_none());
                 assert_eq!(*sample_rate, 48_000);
@@ -1788,7 +1806,7 @@ mod tests {
         let json = r#"{"type":"open_video","request_id":"req-1","source":"mock://gradient","pipe_id":"video-stream"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::OpenVideo { request_id, source, pipe_id } => {
+            DrawCommand::Host(HostCommand::OpenVideo { request_id, source, pipe_id }) => {
                 assert_eq!(request_id, "req-1");
                 assert_eq!(source, "mock://gradient");
                 assert_eq!(pipe_id, "video-stream");
@@ -1821,7 +1839,7 @@ mod tests {
         let play_json = r#"{"type":"set_video_state","handle_id":7,"state":{"kind":"play"}}"#;
         let cmd: DrawCommand = serde_json::from_str(play_json).expect("deserialise play");
         match &cmd {
-            DrawCommand::SetVideoState { handle_id, state } => {
+            DrawCommand::Host(HostCommand::SetVideoState { handle_id, state }) => {
                 assert_eq!(*handle_id, 7);
                 assert_eq!(*state, crate::video::VideoState::Play);
             }
@@ -1835,7 +1853,7 @@ mod tests {
 
         let pause_json = r#"{"type":"set_video_state","handle_id":7,"state":{"kind":"pause"}}"#;
         let cmd: DrawCommand = serde_json::from_str(pause_json).expect("deserialise pause");
-        if let DrawCommand::SetVideoState { state, .. } = &cmd {
+        if let DrawCommand::Host(HostCommand::SetVideoState { state, .. }) = &cmd {
             assert_eq!(*state, crate::video::VideoState::Pause);
         } else {
             panic!("expected SetVideoState pause, got {cmd:?}");
@@ -1844,7 +1862,7 @@ mod tests {
         let seek_json =
             r#"{"type":"set_video_state","handle_id":7,"state":{"kind":"seek","position_ms":1500}}"#;
         let cmd: DrawCommand = serde_json::from_str(seek_json).expect("deserialise seek");
-        if let DrawCommand::SetVideoState { state, .. } = &cmd {
+        if let DrawCommand::Host(HostCommand::SetVideoState { state, .. }) = &cmd {
             assert_eq!(
                 *state,
                 crate::video::VideoState::Seek { position_ms: 1500 }
@@ -1859,7 +1877,7 @@ mod tests {
         let json = r#"{"type":"close_video","handle_id":42}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::CloseVideo { handle_id } => assert_eq!(*handle_id, 42),
+            DrawCommand::Host(HostCommand::CloseVideo { handle_id }) => assert_eq!(*handle_id, 42),
             other => panic!("expected CloseVideo, got {other:?}"),
         }
         let bad = r#"{"type":"close_video"}"#;
@@ -1914,7 +1932,7 @@ mod tests {
         let json = r#"{"type":"request_linked_terminal","request_id":"req-1","cwd":"/tmp/foo","label":"bindings demo"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::RequestLinkedTerminal { request_id, cwd, label } => {
+            DrawCommand::Host(HostCommand::RequestLinkedTerminal { request_id, cwd, label }) => {
                 assert_eq!(request_id, "req-1");
                 assert_eq!(cwd.as_deref(), Some("/tmp/foo"));
                 assert_eq!(label.as_deref(), Some("bindings demo"));
@@ -1938,7 +1956,7 @@ mod tests {
         let null_json = r#"{"type":"request_linked_terminal","request_id":"r2","cwd":null,"label":null}"#;
         let cmd: DrawCommand = serde_json::from_str(null_json).expect("deserialise null");
         match &cmd {
-            DrawCommand::RequestLinkedTerminal { cwd, label, .. } => {
+            DrawCommand::Host(HostCommand::RequestLinkedTerminal { cwd, label, .. }) => {
                 assert!(cwd.is_none());
                 assert!(label.is_none());
             }
@@ -1974,7 +1992,7 @@ mod tests {
         let json = r#"{"type":"run_in_linked_terminal","terminal_pane_id":42,"command":"ls -la","echo":true}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::RunInLinkedTerminal { terminal_pane_id, command, echo } => {
+            DrawCommand::Host(HostCommand::RunInLinkedTerminal { terminal_pane_id, command, echo }) => {
                 assert_eq!(*terminal_pane_id, 42);
                 assert_eq!(command, "ls -la");
                 assert!(*echo);
@@ -2000,7 +2018,7 @@ mod tests {
         let replace_json = r#"{"type":"insert_path_token","terminal_pane_id":7,"path":"/tmp/x","mode":"replace"}"#;
         let cmd: DrawCommand = serde_json::from_str(replace_json).expect("deserialise replace");
         match &cmd {
-            DrawCommand::InsertPathToken { mode, path, terminal_pane_id } => {
+            DrawCommand::Host(HostCommand::InsertPathToken { mode, path, terminal_pane_id }) => {
                 assert_eq!(*mode, PathTokenMode::Replace);
                 assert_eq!(path, "/tmp/x");
                 assert_eq!(*terminal_pane_id, 7);
@@ -2010,7 +2028,7 @@ mod tests {
 
         let append_json = r#"{"type":"insert_path_token","terminal_pane_id":7,"path":"/tmp/y","mode":"append"}"#;
         let cmd: DrawCommand = serde_json::from_str(append_json).expect("deserialise append");
-        if let DrawCommand::InsertPathToken { mode, .. } = &cmd {
+        if let DrawCommand::Host(HostCommand::InsertPathToken { mode, .. }) = &cmd {
             assert_eq!(*mode, PathTokenMode::Append);
         } else {
             panic!("expected InsertPathToken, got {cmd:?}");
@@ -2036,7 +2054,7 @@ mod tests {
         let json = r#"{"type":"request_command_preview","request_id":"req-9","terminal_pane_id":3,"command":"rm -rf .git"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::RequestCommandPreview { request_id, terminal_pane_id, command } => {
+            DrawCommand::Host(HostCommand::RequestCommandPreview { request_id, terminal_pane_id, command }) => {
                 assert_eq!(request_id, "req-9");
                 assert_eq!(*terminal_pane_id, 3);
                 assert_eq!(command, "rm -rf .git");
@@ -2069,7 +2087,7 @@ mod tests {
             );
             let cmd: DrawCommand = serde_json::from_str(&json).expect("deserialise");
             match &cmd {
-                DrawCommand::OpenArtifact { path, mode } => {
+                DrawCommand::Host(HostCommand::OpenArtifact { path, mode }) => {
                     assert_eq!(path, "/tmp/x");
                     assert_eq!(*mode, expected, "wire {wire} → {expected:?}");
                 }
@@ -2078,10 +2096,10 @@ mod tests {
         }
 
         // Round-trip serialise → snake_case on the wire.
-        let cmd = DrawCommand::OpenArtifact {
+        let cmd = DrawCommand::Host(HostCommand::OpenArtifact {
             path: "/tmp/x".to_string(),
             mode: ArtifactOpenMode::RevealInFinder,
-        };
+        });
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(
             serialised.contains(r#""mode":"reveal_in_finder""#),
@@ -2120,14 +2138,14 @@ mod tests {
         let json = r#"{"type":"notify","level":"info","title":"Pick","body":"choose","kind":"choice","options":[{"label":"A","value":"sidebar","shortcut":"1"},{"label":"B","value":"fullwidth","shortcut":"2"}],"priority":100}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Notify {
+            DrawCommand::Host(HostCommand::Notify {
                 kind,
                 options,
                 priority,
                 image_inline,
                 image_pipe_id,
                 ..
-            } => {
+            }) => {
                 assert_eq!(*kind, NotifyKind::Choice);
                 assert_eq!(options.len(), 2);
                 assert_eq!(options[0].value, "sidebar");
@@ -2152,11 +2170,11 @@ mod tests {
         let json = r#"{"type":"notify","level":"info","title":"Pic","body":"see image","kind":"message","priority":50,"image_inline":{"mime":"image/png","base64":"AAAA"}}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Notify {
+            DrawCommand::Host(HostCommand::Notify {
                 image_inline,
                 image_pipe_id,
                 ..
-            } => {
+            }) => {
                 let img = image_inline.as_ref().expect("inline image present");
                 assert_eq!(img.mime, "image/png");
                 assert_eq!(img.base64, "AAAA");
@@ -2182,11 +2200,11 @@ mod tests {
         let json = r#"{"type":"notify","level":"info","title":"Pic","body":"piped","kind":"message","priority":50,"image_pipe_id":"render-out"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Notify {
+            DrawCommand::Host(HostCommand::Notify {
                 image_pipe_id,
                 image_inline,
                 ..
-            } => {
+            }) => {
                 assert_eq!(image_pipe_id.as_deref(), Some("render-out"));
                 assert!(image_inline.is_none());
             }
@@ -2201,11 +2219,11 @@ mod tests {
         let json = r#"{"type":"notify","level":"info","title":"Plain","body":"no image","kind":"message","priority":50}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match cmd {
-            DrawCommand::Notify {
+            DrawCommand::Host(HostCommand::Notify {
                 image_inline,
                 image_pipe_id,
                 ..
-            } => {
+            }) => {
                 assert!(image_inline.is_none());
                 assert!(image_pipe_id.is_none());
             }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -19,7 +19,7 @@ mod routing;
 pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 
 use crate::app_permissions::{AppPermissions, Capability};
-use crate::app_protocol::{DrawCommand, Modifiers, PlexiEvent};
+use crate::app_protocol::{ControlCommand, DrawCommand, Modifiers, PlexiEvent, RenderCommand};
 use crate::app_trait::{App, AppCommand, AppRenderContext};
 use crate::audio::{AudioDevice, CaptureSession};
 use crate::midi::{MidiDevice, MidiInputSession, MidiOutputHandle};
@@ -110,9 +110,9 @@ pub struct ProcessApp {
     /// Receives draw commands from the subprocess on a background thread.
     draw_rx: Option<Receiver<DrawCommand>>,
     /// The last fully committed frame (commands between two FrameDones).
-    pub(crate) frame: Vec<DrawCommand>,
+    pub(crate) frame: Vec<RenderCommand>,
     /// Accumulates draw commands for the frame currently being received.
-    pending_frame: Vec<DrawCommand>,
+    pending_frame: Vec<RenderCommand>,
     /// Pending host app commands collected from the subprocess.
     pub(crate) pending_commands: Vec<AppCommand>,
     last_size: egui::Vec2,
@@ -829,7 +829,7 @@ impl ProcessApp {
         &mut self,
         ui: &mut egui::Ui,
         pane_rect: egui::Rect,
-        frame: &[DrawCommand],
+        frame: &[RenderCommand],
     ) {
         let origin = pane_rect.min;
         // Collect submit events out-of-band so we don't hold a mutable
@@ -848,7 +848,7 @@ impl ProcessApp {
         let mut any_has_focus = false;
 
         for cmd in frame {
-            let DrawCommand::TextInput {
+            let RenderCommand::TextInput {
                 id,
                 x,
                 y,
@@ -1044,7 +1044,8 @@ impl ProcessApp {
         self.flush_outbound_events();
         for cmd in self.drain_draw_commands() {
             match cmd {
-                DrawCommand::Log { level, message } => {
+                DrawCommand::Host(h) => self.route_command(h),
+                DrawCommand::Control(ControlCommand::Log { level, message }) => {
                     let target = format!("app::{}", self.type_id);
                     match level.as_str() {
                         "error" => log::error!(target: &target, "{message}"),
@@ -1053,55 +1054,88 @@ impl ProcessApp {
                         _       => log::info!(target: &target, "{message}"),
                     }
                 }
-                cmd @ (DrawCommand::CapabilityRequest { .. }
-                | DrawCommand::SecretGet { .. }
-                | DrawCommand::RunGet { .. }
-                | DrawCommand::RunComplete { .. }
-                | DrawCommand::Notify { .. }
-                | DrawCommand::PipeOpen { .. }
-                | DrawCommand::PipeOpenDirected { .. }
-                | DrawCommand::PipeSend { .. }
-                | DrawCommand::StatusSummary { .. }
-                | DrawCommand::SpawnApp { .. }
-                | DrawCommand::SpawnPane { .. }
-                | DrawCommand::HttpRequest { .. }
-                | DrawCommand::AudioPlay { .. }
-                | DrawCommand::AudioCapture { .. }
-                | DrawCommand::ListAudioDevices { .. }
-                | DrawCommand::ListMidiDevices { .. }
-                | DrawCommand::OpenMidiInput { .. }
-                | DrawCommand::CloseMidiInput { .. }
-                | DrawCommand::SendMidi { .. }
-                | DrawCommand::CdRequest { .. }
-                | DrawCommand::SetTimer { .. }
-                | DrawCommand::CancelTimer { .. }
-                // Canvas Terminal Binding Primitives (#78).
-                | DrawCommand::RequestLinkedTerminal { .. }
-                | DrawCommand::RunInLinkedTerminal { .. }
-                | DrawCommand::InsertPathToken { .. }
-                | DrawCommand::RequestCommandPreview { .. }
-                | DrawCommand::OpenArtifact { .. }
-                | DrawCommand::PushNav { .. }
-                | DrawCommand::PopNav { .. }
-                | DrawCommand::SetMouseTracking { .. }
-                // AI
-                | DrawCommand::AiQuery { .. }
-                | DrawCommand::ExposeTools { .. }
-                | DrawCommand::ToolResult { .. }
-                // Video / image / audio meter
-                | DrawCommand::OpenVideo { .. }
-                | DrawCommand::CloseVideo { .. }
-                | DrawCommand::SetVideoState { .. }
-                | DrawCommand::Image { .. }
-                | DrawCommand::AudioMeter { .. }
-                // File picker (#514)
-                | DrawCommand::OpenFilePicker { .. }) => {
-                    self.route_command(cmd);
-                }
-                // Visual commands, FrameDone, Ready, MeasureText, ScheduleRender
-                // are discarded — no pane to render into.
-                _ => {}
+                DrawCommand::Control(_) => {} // Ready/FrameDone/etc. irrelevant without a pane
+                DrawCommand::Render(_) => {} // No pane to render into
             }
+        }
+    }
+
+    /// Dispatch a `ControlCommand` that arrived during `ui()`. Called inline
+    /// from the `ui()` dispatch loop; has access to `egui::Ui` for operations
+    /// that require UI-thread context (font metrics, clipboard, repaint).
+    fn handle_control_command(
+        &mut self,
+        ui: &mut egui::Ui,
+        frame_id: u64,
+        cmd: ControlCommand,
+    ) {
+        match cmd {
+            ControlCommand::Ready { sdk, features_used } => {
+                self.sdk = Some(sdk);
+                self.features_used = features_used;
+            }
+            ControlCommand::FrameDone { frame_id: done_id } => {
+                if done_id != frame_id {
+                    log::debug!(
+                        "ProcessApp[{}]: FrameDone frame_id={done_id} expected={frame_id}",
+                        self.type_id
+                    );
+                }
+                std::mem::swap(&mut self.frame, &mut self.pending_frame);
+                self.pending_frame.clear();
+                // Lifecycle: a frame just landed → Running (unless terminal).
+                self.lifecycle.on_frame_done();
+            }
+            ControlCommand::Log { level, message } => {
+                let target = format!("app::{}", self.type_id);
+                match level.as_str() {
+                    "error" => log::error!(target: &target, "{message}"),
+                    "warn"  => log::warn!(target: &target, "{message}"),
+                    "debug" => log::debug!(target: &target, "{message}"),
+                    _       => log::info!(target: &target, "{message}"),
+                }
+            }
+            ControlCommand::ScheduleRender { after_ms } => {
+                ui.ctx().request_repaint_after(
+                    std::time::Duration::from_millis(after_ms as u64),
+                );
+            }
+            // CopyToClipboard is handled here (not in routing.rs) because
+            // `egui::Context::copy_text` is a UI-context method. The host
+            // owns the clipboard backend selection (pasteboard / X11 /
+            // Wayland / Win32) — we just hand egui the string.
+            ControlCommand::CopyToClipboard { text } => {
+                ui.ctx().copy_text(text);
+            }
+            // MeasureText is handled here (not in routing.rs) because it
+            // needs `ui` to access egui font metrics on the UI thread.
+            ControlCommand::MeasureText {
+                request_id,
+                text,
+                font_size,
+                monospace,
+            } => {
+                let family = if monospace {
+                    egui::FontFamily::Monospace
+                } else {
+                    egui::FontFamily::Proportional
+                };
+                let font_id = egui::FontId::new(font_size, family);
+                let galley = ui.fonts(|f| {
+                    f.layout_no_wrap(text, font_id, egui::Color32::WHITE)
+                });
+                let sz = galley.size();
+                self.outbound_events
+                    .push_back(crate::app_protocol::PlexiEvent::TextMeasured {
+                        request_id,
+                        width: sz.x,
+                        height: sz.y,
+                    });
+            }
+            // AppendConversation is a host-side no-op — it is intended as a
+            // signal to the SDK for conversation-history management. The host
+            // acknowledges receipt silently.
+            ControlCommand::AppendConversation { .. } => {}
         }
     }
 }
@@ -1215,114 +1249,9 @@ impl App for ProcessApp {
 
         for cmd in new_cmds {
             match cmd {
-                DrawCommand::Ready { sdk, features_used } => {
-                    self.sdk = Some(sdk);
-                    self.features_used = features_used;
-                }
-                DrawCommand::FrameDone { frame_id: done_id } => {
-                    if done_id != frame_id {
-                        log::debug!(
-                            "ProcessApp[{}]: FrameDone frame_id={done_id} expected={frame_id}",
-                            self.type_id
-                        );
-                    }
-                    std::mem::swap(&mut self.frame, &mut self.pending_frame);
-                    self.pending_frame.clear();
-                    // Lifecycle: a frame just landed → Running (unless terminal).
-                    self.lifecycle.on_frame_done();
-                }
-                DrawCommand::Log { level, message } => {
-                    let target = format!("app::{}", self.type_id);
-                    match level.as_str() {
-                        "error" => log::error!(target: &target, "{message}"),
-                        "warn" => log::warn!(target: &target, "{message}"),
-                        "debug" => log::debug!(target: &target, "{message}"),
-                        _ => log::info!(target: &target, "{message}"),
-                    }
-                }
-                DrawCommand::ScheduleRender { after_ms } => {
-                    ui.ctx().request_repaint_after(
-                        std::time::Duration::from_millis(after_ms as u64),
-                    );
-                }
-                // CopyToClipboard is handled here (not in routing.rs) because
-                // `egui::Context::copy_text` is a UI-context method. The host
-                // owns the clipboard backend selection (pasteboard / X11 /
-                // Wayland / Win32) — we just hand egui the string.
-                DrawCommand::CopyToClipboard { text } => {
-                    ui.ctx().copy_text(text);
-                }
-                // MeasureText is handled here (not in routing.rs) because it
-                // needs `ui` to access egui font metrics on the UI thread.
-                DrawCommand::MeasureText {
-                    request_id,
-                    text,
-                    font_size,
-                    monospace,
-                } => {
-                    let family = if monospace {
-                        egui::FontFamily::Monospace
-                    } else {
-                        egui::FontFamily::Proportional
-                    };
-                    let font_id = egui::FontId::new(font_size, family);
-                    let galley = ui.fonts(|f| {
-                        f.layout_no_wrap(text, font_id, egui::Color32::WHITE)
-                    });
-                    let sz = galley.size();
-                    self.outbound_events
-                        .push_back(crate::app_protocol::PlexiEvent::TextMeasured {
-                            request_id,
-                            width: sz.x,
-                            height: sz.y,
-                        });
-                }
-                cmd @ (DrawCommand::CapabilityRequest { .. }
-                | DrawCommand::SecretGet { .. }
-                | DrawCommand::RunGet { .. }
-                | DrawCommand::RunComplete { .. }
-                | DrawCommand::Notify { .. }
-                | DrawCommand::PipeOpen { .. }
-                | DrawCommand::PipeOpenDirected { .. }
-                | DrawCommand::PipeSend { .. }
-                | DrawCommand::StatusSummary { .. }
-                | DrawCommand::SpawnApp { .. }
-                | DrawCommand::SpawnPane { .. }
-                | DrawCommand::HttpRequest { .. }
-                | DrawCommand::AudioPlay { .. }
-                | DrawCommand::AudioCapture { .. }
-                | DrawCommand::ListAudioDevices { .. }
-                | DrawCommand::ListMidiDevices { .. }
-                | DrawCommand::OpenMidiInput { .. }
-                | DrawCommand::CloseMidiInput { .. }
-                | DrawCommand::SendMidi { .. }
-                | DrawCommand::CdRequest { .. }
-                | DrawCommand::SetTimer { .. }
-                | DrawCommand::CancelTimer { .. }
-                // Canvas Terminal Binding Primitives (#78).
-                | DrawCommand::RequestLinkedTerminal { .. }
-                | DrawCommand::RunInLinkedTerminal { .. }
-                | DrawCommand::InsertPathToken { .. }
-                | DrawCommand::RequestCommandPreview { .. }
-                | DrawCommand::OpenArtifact { .. }
-                | DrawCommand::PushNav { .. }
-                | DrawCommand::PopNav { .. }
-                | DrawCommand::SetMouseTracking { .. }
-                // AI
-                | DrawCommand::AiQuery { .. }
-                | DrawCommand::ExposeTools { .. }
-                | DrawCommand::ToolResult { .. }
-                // Video / image / audio meter
-                | DrawCommand::OpenVideo { .. }
-                | DrawCommand::CloseVideo { .. }
-                | DrawCommand::SetVideoState { .. }
-                | DrawCommand::Image { .. }
-                | DrawCommand::AudioMeter { .. }
-                // File picker (#514)
-                | DrawCommand::OpenFilePicker { .. }) => {
-                    self.route_command(cmd);
-                }
-                other => self.pending_frame.push(other),
+                DrawCommand::Control(c) => self.handle_control_command(ui, frame_id, c),
+                DrawCommand::Host(h) => self.route_command(h),
+                DrawCommand::Render(r) => self.pending_frame.push(r),
             }
         }
 
@@ -1390,7 +1319,7 @@ impl App for ProcessApp {
             let mut scroll_regions: Vec<(String, egui::Rect, f32)> = Vec::new();
             let origin = pane_rect.min;
             for cmd in &frame_clone {
-                if let DrawCommand::BeginScroll { id, x, y, w, h, content_height } = cmd {
+                if let RenderCommand::BeginScroll { id, x, y, w, h, content_height } = cmd {
                     let viewport = egui::Rect::from_min_size(
                         egui::pos2(origin.x + x, origin.y + y),
                         egui::vec2(*w, *h),
@@ -1856,22 +1785,23 @@ mod clipboard_tests {
 
     #[test]
     fn copy_to_clipboard_drawcommand_calls_egui_copy() {
-        // Verify the wired path: `DrawCommand::CopyToClipboard { text }` →
+        // Verify the wired path: `ControlCommand::CopyToClipboard { text }` →
         // `egui::Context::copy_text(text)` → `OutputCommand::CopyText` on
         // the platform output. We construct a fresh egui Context, mirror
-        // the one-line dispatch from `ProcessApp::ui()`, and inspect the
-        // platform output for the CopyText command. If the dispatch ever
-        // changes shape (e.g. a different egui method), this test forces
-        // the breakage to surface.
+        // the one-line dispatch from `ProcessApp::handle_control_command()`,
+        // and inspect the platform output for the CopyText command. If the
+        // dispatch ever changes shape (e.g. a different egui method), this
+        // test forces the breakage to surface.
+        use crate::app_protocol::ControlCommand;
         let ctx = egui::Context::default();
-        let cmd = DrawCommand::CopyToClipboard {
+        let cmd = ControlCommand::CopyToClipboard {
             text: "selected snippet".to_string(),
         };
 
-        // This mirrors the exact branch in `ProcessApp::ui()`. Keep it
-        // in sync — if you refactor the dispatch, refactor this too.
+        // This mirrors the exact branch in `ProcessApp::handle_control_command()`.
+        // Keep it in sync — if you refactor the dispatch, refactor this too.
         match cmd {
-            DrawCommand::CopyToClipboard { text } => ctx.copy_text(text),
+            ControlCommand::CopyToClipboard { text } => ctx.copy_text(text),
             _ => panic!("test setup error"),
         }
 
@@ -2148,7 +2078,7 @@ mod ai_tests {
     //! path also confirms that the routing layer forwarded the right
     //! `model_tier`, `system`, and `messages` payload to the broker.
     use super::*;
-    use crate::app_protocol::{AiMessage, DrawCommand, ModelTier, PlexiEvent};
+    use crate::app_protocol::{AiMessage, HostCommand, ModelTier, PlexiEvent};
     use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest, AiBrokerResponse};
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -2206,7 +2136,7 @@ mod ai_tests {
         }
         app.ai_broker = Arc::new(PanicBroker);
 
-        app.route_command(DrawCommand::AiQuery {
+        app.route_command(HostCommand::AiQuery {
             request_id: "req-denied".to_string(),
             model_tier: ModelTier::Low,
             system: "system".to_string(),
@@ -2269,7 +2199,7 @@ mod ai_tests {
             response: AiBrokerResponse::ok("Pong.".to_string(), 12, 4),
         });
 
-        app.route_command(DrawCommand::AiQuery {
+        app.route_command(HostCommand::AiQuery {
             request_id: "req-ok".to_string(),
             model_tier: ModelTier::High,
             system: "be terse".to_string(),
@@ -2326,7 +2256,7 @@ mod midi_tests {
     //!   2. App with the capability — `MockMidiDevice` records the open and
     //!      the routing layer queues `MidiInputOpened` on success.
     use super::*;
-    use crate::app_protocol::{DrawCommand, PlexiEvent};
+    use crate::app_protocol::{HostCommand, PlexiEvent};
     use crate::midi::MockMidiDevice;
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -2364,7 +2294,7 @@ mod midi_tests {
         let mock = Arc::new(MockMidiDevice::new());
         app.midi_device = Arc::clone(&mock) as Arc<dyn crate::midi::MidiDevice>;
 
-        app.route_command(DrawCommand::OpenMidiInput {
+        app.route_command(HostCommand::OpenMidiInput {
             port_id: "mock-input-1".to_owned(),
             pipe_id: "midi-in-pipe".to_owned(),
         });
@@ -2400,7 +2330,7 @@ mod midi_tests {
         );
 
         // SendMidi without `midi.out` is the same shape.
-        app.route_command(DrawCommand::SendMidi {
+        app.route_command(HostCommand::SendMidi {
             port_id: "mock-output-1".to_owned(),
             bytes: vec![0x90, 0x3C, 0x64],
         });
@@ -2442,7 +2372,7 @@ mod midi_tests {
         let mock = Arc::new(MockMidiDevice::new());
         app.midi_device = Arc::clone(&mock) as Arc<dyn crate::midi::MidiDevice>;
 
-        app.route_command(DrawCommand::OpenMidiInput {
+        app.route_command(HostCommand::OpenMidiInput {
             port_id: "mock-input-1".to_owned(),
             pipe_id: "midi-in-pipe".to_owned(),
         });
@@ -2474,7 +2404,7 @@ mod midi_tests {
         );
 
         // SendMidi path: dispatches one note-on to the mock output log.
-        app.route_command(DrawCommand::SendMidi {
+        app.route_command(HostCommand::SendMidi {
             port_id: "mock-output-1".to_owned(),
             bytes: vec![0x90, 0x3C, 0x64],
         });
@@ -2497,7 +2427,7 @@ mod video_tests {
     //!   2. App with the capability — `MockVideoDecoder` opens the source,
     //!      the routing layer queues `VideoOpenAck` and pumps frames.
     use super::*;
-    use crate::app_protocol::{DrawCommand, PlexiEvent};
+    use crate::app_protocol::{HostCommand, PlexiEvent};
     use crate::video::{MockVideoDecoder, MockVideoDecoderConfig};
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -2535,7 +2465,7 @@ mod video_tests {
         let mock = Arc::new(MockVideoDecoder::new(MockVideoDecoderConfig::default()));
         app.video_device = Arc::clone(&mock) as Arc<dyn crate::video::VideoDecoder>;
 
-        app.route_command(DrawCommand::OpenVideo {
+        app.route_command(HostCommand::OpenVideo {
             request_id: "req-denied".to_owned(),
             source: "mock://gradient".to_owned(),
             pipe_id: "video-stream".to_owned(),
@@ -2596,7 +2526,7 @@ mod video_tests {
         }));
         app.video_device = Arc::clone(&mock) as Arc<dyn crate::video::VideoDecoder>;
 
-        app.route_command(DrawCommand::OpenVideo {
+        app.route_command(HostCommand::OpenVideo {
             request_id: "req-1".to_owned(),
             source: "mock://gradient".to_owned(),
             pipe_id: "video-stream".to_owned(),
@@ -2645,15 +2575,15 @@ mod video_tests {
 
         // SetVideoState — pause then play, neither should panic and no error
         // event should arrive.
-        app.route_command(DrawCommand::SetVideoState {
+        app.route_command(HostCommand::SetVideoState {
             handle_id: ack_handle_id,
             state: crate::video::VideoState::Pause,
         });
-        app.route_command(DrawCommand::SetVideoState {
+        app.route_command(HostCommand::SetVideoState {
             handle_id: ack_handle_id,
             state: crate::video::VideoState::Play,
         });
-        app.route_command(DrawCommand::SetVideoState {
+        app.route_command(HostCommand::SetVideoState {
             handle_id: ack_handle_id,
             state: crate::video::VideoState::Seek { position_ms: 1_000 },
         });
@@ -2666,7 +2596,7 @@ mod video_tests {
         assert_eq!(errors, 0, "set_state must not produce VideoOpenError");
 
         // CloseVideo tears down the handle and unregisters the pipe id map.
-        app.route_command(DrawCommand::CloseVideo {
+        app.route_command(HostCommand::CloseVideo {
             handle_id: ack_handle_id,
         });
         assert!(
@@ -2700,7 +2630,7 @@ mod video_tests {
 mod canvas_bindings_tests {
     use super::*;
     use crate::app_protocol::{
-        ArtifactOpenMode, DrawCommand, PathTokenMode, PlexiEvent,
+        ArtifactOpenMode, HostCommand, PathTokenMode, PlexiEvent,
     };
     use std::collections::HashSet;
     use std::path::PathBuf;
@@ -2736,7 +2666,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::RequestLinkedTerminal {
+        app.route_command(HostCommand::RequestLinkedTerminal {
             request_id: "req-0".to_string(),
             cwd: None,
             label: None,
@@ -2776,7 +2706,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::RunInLinkedTerminal {
+        app.route_command(HostCommand::RunInLinkedTerminal {
             terminal_pane_id: 42,
             command: "ls".to_string(),
             echo: true,
@@ -2798,7 +2728,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::RequestCommandPreview {
+        app.route_command(HostCommand::RequestCommandPreview {
             request_id: "req-9".to_string(),
             terminal_pane_id: 42,
             command: "rm -rf .git".to_string(),
@@ -2835,7 +2765,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::RequestLinkedTerminal {
+        app.route_command(HostCommand::RequestLinkedTerminal {
             request_id: "req-ok".to_string(),
             cwd: Some("/tmp/foo".to_string()),
             label: Some("bindings demo".to_string()),
@@ -2879,7 +2809,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::RunInLinkedTerminal {
+        app.route_command(HostCommand::RunInLinkedTerminal {
             terminal_pane_id: 42,
             command: "ls -la".to_string(),
             echo: true,
@@ -2913,7 +2843,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::InsertPathToken {
+        app.route_command(HostCommand::InsertPathToken {
             terminal_pane_id: 42,
             path: "/tmp/x".to_string(),
             mode: PathTokenMode::Replace,
@@ -2940,7 +2870,7 @@ mod canvas_bindings_tests {
             eprintln!("skipping: no /bin/sh available");
             return;
         };
-        app.route_command(DrawCommand::OpenArtifact {
+        app.route_command(HostCommand::OpenArtifact {
             path: "/tmp/x".to_string(),
             mode: ArtifactOpenMode::RevealInFinder,
         });

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -1,6 +1,6 @@
 //! Frame rendering — translates committed DrawCommands into egui paint calls.
 
-use crate::app_protocol::DrawCommand;
+use crate::app_protocol::RenderCommand;
 use crate::style;
 use crate::theme::Colors;
 use egui::Color32;
@@ -30,7 +30,7 @@ use egui::Color32;
 pub(super) fn render_draw_commands(
     ui: &mut egui::Ui,
     pane_rect: egui::Rect,
-    commands: &[DrawCommand],
+    commands: &[RenderCommand],
     colors: &Colors,
     commonmark_cache: &mut egui_commonmark::CommonMarkCache,
 ) {
@@ -45,7 +45,7 @@ pub(super) fn render_draw_commands(
 
         match cmd {
             // ── Clip stack ────────────────────────────────────────────────────
-            DrawCommand::PushClip { x, y, w, h } => {
+            RenderCommand::PushClip { x, y, w, h } => {
                 let new_rect = egui::Rect::from_min_size(
                     egui::pos2(origin.x + x, origin.y + y),
                     egui::vec2(*w, *h),
@@ -56,14 +56,14 @@ pub(super) fn render_draw_commands(
                 continue;
             }
 
-            DrawCommand::PopClip => {
+            RenderCommand::PopClip => {
                 if clip_stack.pop().is_none() {
                     log::warn!("render: PopClip on empty clip stack (app bug)");
                 }
                 continue;
             }
 
-            DrawCommand::Rect {
+            RenderCommand::Rect {
                 x,
                 y,
                 w,
@@ -79,7 +79,7 @@ pub(super) fn render_draw_commands(
                 ui.painter().with_clip_rect(clip).rect_filled(rect, *radius, color);
             }
 
-            DrawCommand::Text {
+            RenderCommand::Text {
                 x,
                 y,
                 text,
@@ -217,7 +217,7 @@ pub(super) fn render_draw_commands(
                 }
             }
 
-            DrawCommand::Line {
+            RenderCommand::Line {
                 x1,
                 y1,
                 x2,
@@ -235,13 +235,13 @@ pub(super) fn render_draw_commands(
                 );
             }
 
-            DrawCommand::Circle { cx, cy, r, fill } => {
+            RenderCommand::Circle { cx, cy, r, fill } => {
                 let center = egui::pos2(origin.x + cx, origin.y + cy);
                 let color = parse_color(fill).unwrap_or(colors.accent);
                 ui.painter().with_clip_rect(clip).circle_filled(center, *r, color);
             }
 
-            DrawCommand::Arc {
+            RenderCommand::Arc {
                 cx,
                 cy,
                 r,
@@ -268,7 +268,7 @@ pub(super) fn render_draw_commands(
                 ui.painter().with_clip_rect(clip).add(shape);
             }
 
-            DrawCommand::List {
+            RenderCommand::List {
                 x,
                 y,
                 w,
@@ -332,27 +332,27 @@ pub(super) fn render_draw_commands(
 
             // ── Host-measured layout primitives ──────────────────────────
 
-            DrawCommand::Badge { x, y, label, fill, fg, font_size, radius } => {
+            RenderCommand::Badge { x, y, label, fill, fg, font_size, radius } => {
                 render_badge(ui, origin, clip, *x, *y, label, fill, fg, *font_size, *radius);
             }
 
-            DrawCommand::KeyChip { x, y, label, font_size } => {
+            RenderCommand::KeyChip { x, y, label, font_size } => {
                 render_key_chip_at(ui, origin, clip, *x, *y, label, *font_size, colors);
             }
 
-            DrawCommand::KeyChipRow { x, y, keys, description, font_size } => {
+            RenderCommand::KeyChipRow { x, y, keys, description, font_size } => {
                 render_key_chip_row(ui, origin, clip, *x, *y, keys, description.as_deref(), *font_size, colors);
             }
 
-            DrawCommand::Shortcuts { x, y, max_width, pairs, font_size } => {
+            RenderCommand::Shortcuts { x, y, max_width, pairs, font_size } => {
                 render_shortcuts(ui, origin, clip, *x, *y, *max_width, pairs, *font_size, colors);
             }
 
-            DrawCommand::TextRow { x, y, items, gap, align } => {
+            RenderCommand::TextRow { x, y, items, gap, align } => {
                 render_text_row(ui, origin, clip, *x, *y, items, *gap, align, colors);
             }
 
-            DrawCommand::Markdown {
+            RenderCommand::Markdown {
                 x,
                 y,
                 w,
@@ -400,78 +400,19 @@ pub(super) fn render_draw_commands(
                     .show(&mut child, commonmark_cache, text);
             }
 
-            // MeasureText is handled in routing.rs (needs a response channel);
-            // it is never a frame-scoped visual command.
-            DrawCommand::MeasureText { .. } => {}
-
             // TextInput is rendered as an interactive egui widget by
             // `process_app::mod` after this painter pass finishes — it
             // can't share the painter-only path because it needs a
             // mutable buffer + focus tracking. See `render_text_inputs`.
-            DrawCommand::TextInput { .. } => {}
+            RenderCommand::TextInput { .. } => {}
 
-            // These are handled at the App trait level or routed upstream — never rendered.
-            DrawCommand::Log { .. }
-            | DrawCommand::FrameDone { .. }
-            | DrawCommand::CapabilityRequest { .. }
-            | DrawCommand::SecretGet { .. }
-            | DrawCommand::RunGet { .. }
-            | DrawCommand::RunComplete { .. }
-            | DrawCommand::Notify { .. }
-            | DrawCommand::PipeOpen { .. }
-            | DrawCommand::PipeSend { .. }
-            | DrawCommand::StatusSummary { .. }
-            | DrawCommand::SpawnApp { .. }
-            | DrawCommand::SpawnPane { .. }
-            | DrawCommand::HttpRequest { .. }
-            | DrawCommand::AiQuery { .. }
-            | DrawCommand::CdRequest { .. }
-            | DrawCommand::Image { .. }
-            | DrawCommand::OpenVideo { .. }
-            | DrawCommand::SetVideoState { .. }
-            | DrawCommand::CloseVideo { .. }
-            | DrawCommand::AudioMeter { .. }
-            | DrawCommand::AudioPlay { .. }
-            | DrawCommand::AudioCapture { .. }
-            | DrawCommand::ListAudioDevices { .. }
-            | DrawCommand::ListMidiDevices { .. }
-            | DrawCommand::OpenMidiInput { .. }
-            | DrawCommand::CloseMidiInput { .. }
-            | DrawCommand::SendMidi { .. }
-            | DrawCommand::Ready { .. }
-            | DrawCommand::ScheduleRender { .. }
-            | DrawCommand::SetTimer { .. }
-            | DrawCommand::CancelTimer { .. }
-            | DrawCommand::CopyToClipboard { .. }
-            // AppendConversation is consumed by the host's agent-pane conversation
-            // history surface (issue #285); it never paints into the draw canvas.
-            // The host integration (forthcoming follow-up PR) drains it from the
-            // command stream before this painter sees it; this arm is the safety
-            // net for the wire-only landing.
-            | DrawCommand::AppendConversation { .. }
-            // PipeOpenDirected is a control command routed by `route_command`;
-            // it never paints and the painter sees it only as a safety net.
-            | DrawCommand::PipeOpenDirected { .. }
-            // Canvas Terminal Binding Primitives (#78). All five are control
-            // commands routed by `route_command`; the painter never sees them
-            // unless the dispatcher missed a peel-off — silent no-op is the
-            // safe default to keep frames clean.
-            | DrawCommand::RequestLinkedTerminal { .. }
-            | DrawCommand::RunInLinkedTerminal { .. }
-            | DrawCommand::InsertPathToken { .. }
-            | DrawCommand::RequestCommandPreview { .. }
-            | DrawCommand::OpenArtifact { .. }
-            // Navigation stack commands are handled by route_command; the
-            // painter never sees them in the normal path — this arm is the
-            // safety net for any stray commands that leak through.
-            | DrawCommand::PushNav { .. }
-            | DrawCommand::PopNav { .. }
-            | DrawCommand::SetMouseTracking { .. }
-            // Tool protocol commands are control-only; the painter never paints them.
-            | DrawCommand::ExposeTools { .. }
-            | DrawCommand::ToolResult { .. }
-            // File picker is a control command; result arrives via PlexiEvent.
-            | DrawCommand::OpenFilePicker { .. } => {}
+            // Image rendering is not yet implemented; no-op until the
+            // image-loading pipeline lands.
+            RenderCommand::Image { .. } => {}
+
+            // AudioMeter rendering is not yet implemented; no-op until
+            // the audio-meter primitive lands.
+            RenderCommand::AudioMeter { .. } => {}
 
             // ── Host-managed scroll regions (#446) ───────────────────────────
             //
@@ -485,7 +426,7 @@ pub(super) fn render_draw_commands(
             // intersected with the current clip top so nested clips tighten
             // correctly, and the existing balanced-stack warning fires for
             // unmatched EndScroll calls.
-            DrawCommand::BeginScroll { x, y, w, h, .. } => {
+            RenderCommand::BeginScroll { x, y, w, h, .. } => {
                 let new_rect = egui::Rect::from_min_size(
                     egui::pos2(origin.x + x, origin.y + y),
                     egui::vec2(*w, *h),
@@ -494,7 +435,7 @@ pub(super) fn render_draw_commands(
                 clip_stack.push(effective);
             }
 
-            DrawCommand::EndScroll => {
+            RenderCommand::EndScroll => {
                 if clip_stack.pop().is_none() {
                     log::warn!("render: EndScroll on empty clip stack (app bug)");
                 }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -4,7 +4,7 @@
 //! (media, pipes, capabilities, secrets, runs, notifications) are routed here.
 
 use crate::app_permissions::{check, Capability, PermissionCheck};
-use crate::app_protocol::{AudioDeviceWire, DrawCommand, MidiPortWire, PlexiEvent};
+use crate::app_protocol::{AudioDeviceWire, HostCommand, MidiPortWire, PlexiEvent};
 use crate::app_trait::AppCommand;
 use crate::audio::AudioCaptureRequest;
 use crate::event_log::{self, HostEvent};
@@ -14,12 +14,12 @@ use crate::typed_pipes::PipeDirection;
 use super::ProcessApp;
 
 impl ProcessApp {
-    /// Route a v3 out-of-frame draw command to the appropriate subsystem.
-    /// Visual primitives must not reach this method — callers filter them upstream.
-    pub(super) fn route_command(&mut self, cmd: DrawCommand) {
+    /// Route a v3 host command to the appropriate subsystem.
+    /// Exhaustive match — no wildcard arm. The compiler enforces coverage.
+    pub(super) fn route_command(&mut self, cmd: HostCommand) {
         match cmd {
             // ── Capability request ─────────────────────────────────────────
-            DrawCommand::CapabilityRequest {
+            HostCommand::CapabilityRequest {
                 request_id,
                 capability,
             } => {
@@ -54,7 +54,7 @@ impl ProcessApp {
             }
 
             // ── Secret get ─────────────────────────────────────────────────
-            DrawCommand::SecretGet { key } => {
+            HostCommand::SecretGet { key } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::SecretsGet)
                 {
@@ -188,7 +188,7 @@ impl ProcessApp {
             }
 
             // ── Run get ────────────────────────────────────────────────────
-            DrawCommand::RunGet { intent, .. } => {
+            HostCommand::RunGet { intent, .. } => {
                 let run_id = self.run_registry.allocate(&self.type_id);
                 log::info!(
                     "ProcessApp[{}]: RunGet intent='{}' → run_id='{}'",
@@ -209,7 +209,7 @@ impl ProcessApp {
             }
 
             // ── Run complete ───────────────────────────────────────────────
-            DrawCommand::RunComplete { run_id, result } => {
+            HostCommand::RunComplete { run_id, result } => {
                 log::info!(
                     "ProcessApp[{}]: RunComplete run_id='{run_id}' result={result}",
                     self.type_id
@@ -239,7 +239,7 @@ impl ProcessApp {
             }
 
             // ── Notify ─────────────────────────────────────────────────────
-            DrawCommand::Notify {
+            HostCommand::Notify {
                 level,
                 title,
                 body,
@@ -372,7 +372,7 @@ impl ProcessApp {
             }
 
             // ── Pipe open ──────────────────────────────────────────────────
-            DrawCommand::PipeOpen {
+            HostCommand::PipeOpen {
                 pipe_id,
                 mode,
                 direction,
@@ -442,7 +442,7 @@ impl ProcessApp {
             // host. We register the JSON pipe locally so subsequent
             // `PipeSend` calls succeed; `has_reader` returns true for the
             // sender side because the direction is duplex.
-            DrawCommand::PipeOpenDirected {
+            HostCommand::PipeOpenDirected {
                 pipe_id,
                 target_pane_id,
             } => {
@@ -481,7 +481,7 @@ impl ProcessApp {
             }
 
             // ── Pipe send ──────────────────────────────────────────────────
-            DrawCommand::PipeSend { pipe_id, payload } => {
+            HostCommand::PipeSend { pipe_id, payload } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PipeOpen)
                 {
@@ -506,12 +506,12 @@ impl ProcessApp {
             }
 
             // ── Status summary ─────────────────────────────────────────────
-            DrawCommand::StatusSummary { text } => {
+            HostCommand::StatusSummary { text } => {
                 self.status_summary = Some(text);
             }
 
             // ── Navigation stack ───────────────────────────────────────────
-            DrawCommand::PushNav { view_id, title } => {
+            HostCommand::PushNav { view_id, title } => {
                 self.nav_stack.push(crate::process_app::NavEntry { view_id, title });
                 log::debug!(
                     "ProcessApp[{}]: PushNav → depth={} title={:?}",
@@ -520,7 +520,7 @@ impl ProcessApp {
                     self.nav_stack.last().map(|e| &e.title),
                 );
             }
-            DrawCommand::PopNav {} => {
+            HostCommand::PopNav {} => {
                 self.nav_stack.pop();
                 log::debug!(
                     "ProcessApp[{}]: PopNav → depth={}",
@@ -530,7 +530,7 @@ impl ProcessApp {
             }
 
             // ── File picker (#514) ─────────────────────────────────────────
-            DrawCommand::OpenFilePicker { request_id, filter, multiple } => {
+            HostCommand::OpenFilePicker { request_id, filter, multiple } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::FsPick)
                 {
@@ -561,7 +561,7 @@ impl ProcessApp {
             }
 
             // ── Mouse tracking toggle ──────────────────────────────────────
-            DrawCommand::SetMouseTracking { enabled } => {
+            HostCommand::SetMouseTracking { enabled } => {
                 self.mouse_tracking_enabled = enabled;
                 log::debug!(
                     "ProcessApp[{}]: SetMouseTracking → {}",
@@ -571,7 +571,7 @@ impl ProcessApp {
             }
 
             // ── Spawn app ──────────────────────────────────────────────────
-            DrawCommand::SpawnApp {
+            HostCommand::SpawnApp {
                 type_id,
                 layout,
                 args,
@@ -594,7 +594,7 @@ impl ProcessApp {
             }
 
             // ── Spawn pane (#592) ──────────────────────────────────────────────────────
-            DrawCommand::SpawnPane {
+            HostCommand::SpawnPane {
                 type_id,
                 layout,
                 args,
@@ -621,7 +621,7 @@ impl ProcessApp {
             }
 
             // ── HTTP request (broker via HostServices::net) ───────────────
-            DrawCommand::HttpRequest {
+            HostCommand::HttpRequest {
                 request_id,
                 url,
                 method,
@@ -682,7 +682,7 @@ impl ProcessApp {
                 });
             }
             // ── ai.query broker (#284) ─────────────────────────────────────
-            DrawCommand::AiQuery {
+            HostCommand::AiQuery {
                 request_id,
                 model_tier,
                 system,
@@ -748,7 +748,7 @@ impl ProcessApp {
                 });
             }
 
-            DrawCommand::AudioPlay { .. } => {
+            HostCommand::AudioPlay { .. } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::AudioPlayback)
                 {
@@ -763,7 +763,7 @@ impl ProcessApp {
                     self.type_id
                 );
             }
-            DrawCommand::AudioCapture {
+            HostCommand::AudioCapture {
                 pipe_id,
                 device_id,
                 sample_rate,
@@ -784,7 +784,7 @@ impl ProcessApp {
                 }
                 self.start_audio_capture(pipe_id, device_id, sample_rate, buffer_size);
             }
-            DrawCommand::ListAudioDevices { request_id } => {
+            HostCommand::ListAudioDevices { request_id } => {
                 // Enumeration is not gated — device names are already visible
                 // to any macOS app via System Information. The per-device
                 // capture call goes through the `AudioRecord` gate.
@@ -808,7 +808,7 @@ impl ProcessApp {
                         error: None,
                     });
             }
-            DrawCommand::ListMidiDevices { request_id } => {
+            HostCommand::ListMidiDevices { request_id } => {
                 // MIDI enumeration mirrors audio: not gated. Port names are
                 // already visible in Audio MIDI Setup.app, no privacy gate.
                 let inputs = self
@@ -831,7 +831,7 @@ impl ProcessApp {
                         error: None,
                     });
             }
-            DrawCommand::OpenMidiInput { port_id, pipe_id } => {
+            HostCommand::OpenMidiInput { port_id, pipe_id } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::MidiIn)
                 {
@@ -847,7 +847,7 @@ impl ProcessApp {
                 }
                 self.start_midi_input(port_id, pipe_id);
             }
-            DrawCommand::CloseMidiInput { port_id } => {
+            HostCommand::CloseMidiInput { port_id } => {
                 // Drop the session — its Drop impl disconnects from CoreMIDI.
                 // No response event; closing is fire-and-forget.
                 if self.midi_input_sessions.remove(&port_id).is_some() {
@@ -862,7 +862,7 @@ impl ProcessApp {
                     );
                 }
             }
-            DrawCommand::SendMidi { port_id, bytes } => {
+            HostCommand::SendMidi { port_id, bytes } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::MidiOut)
                 {
@@ -878,13 +878,8 @@ impl ProcessApp {
                 }
                 self.send_midi(port_id, bytes);
             }
-            DrawCommand::Image { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: Image not yet implemented (v3.1)",
-                    self.type_id
-                );
-            }
-            DrawCommand::OpenVideo {
+
+            HostCommand::OpenVideo {
                 request_id,
                 source,
                 pipe_id,
@@ -904,7 +899,7 @@ impl ProcessApp {
                 }
                 self.start_video(request_id, source, pipe_id);
             }
-            DrawCommand::SetVideoState { handle_id, state } => {
+            HostCommand::SetVideoState { handle_id, state } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::VideoPlayback)
                 {
@@ -931,7 +926,7 @@ impl ProcessApp {
                     }
                 }
             }
-            DrawCommand::CloseVideo { handle_id } => {
+            HostCommand::CloseVideo { handle_id } => {
                 // Drop the handle (its Drop impl tears down the worker /
                 // decoder) and close the associated binary pipe so the
                 // drain thread exits. Fire-and-forget — no response event.
@@ -954,21 +949,16 @@ impl ProcessApp {
                     );
                 }
             }
-            DrawCommand::AudioMeter { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: AudioMeter not yet implemented (v3.1)",
-                    self.type_id
-                );
-            }
+
 
             // ── Cd request ─────────────────────────────────────────────────
-            DrawCommand::CdRequest { cwd } => {
+            HostCommand::CdRequest { cwd } => {
                 log::info!("ProcessApp[{}]: CdRequest cwd='{cwd}'", self.type_id);
                 self.pending_commands.push(AppCommand::CdRequest { cwd, sender_pane_id: self.pane_id });
             }
 
             // ── Set timer ──────────────────────────────────────────────────
-            DrawCommand::SetTimer { timer_id, after_ms } => {
+            HostCommand::SetTimer { timer_id, after_ms } => {
                 if let PermissionCheck::Denied(reason) = check(&self.permissions, Capability::Timer) {
                     log::warn!("ProcessApp[{}]: SetTimer {timer_id} denied — {reason}", self.type_id);
                     return;
@@ -987,7 +977,7 @@ impl ProcessApp {
             }
 
             // ── Cancel timer ───────────────────────────────────────────────
-            DrawCommand::CancelTimer { timer_id } => {
+            HostCommand::CancelTimer { timer_id } => {
                 if let Some(flag) = self.pending_timers.remove(&timer_id) {
                     flag.store(true, std::sync::atomic::Ordering::Relaxed);
                     log::debug!("ProcessApp[{}]: timer {timer_id} cancelled", self.type_id);
@@ -1000,7 +990,7 @@ impl ProcessApp {
             // injecting bytes into its PTY) lives at the `PlexiApp`
             // dispatch site — the routing layer just enforces the
             // capability gate, logs, and forwards an `AppCommand`.
-            DrawCommand::RequestLinkedTerminal { request_id, cwd, label } => {
+            HostCommand::RequestLinkedTerminal { request_id, cwd, label } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::TerminalBindings)
                 {
@@ -1029,7 +1019,7 @@ impl ProcessApp {
                     label,
                 });
             }
-            DrawCommand::RunInLinkedTerminal { terminal_pane_id, command, echo } => {
+            HostCommand::RunInLinkedTerminal { terminal_pane_id, command, echo } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::TerminalBindings)
                 {
@@ -1045,7 +1035,7 @@ impl ProcessApp {
                     echo,
                 });
             }
-            DrawCommand::InsertPathToken { terminal_pane_id, path, mode } => {
+            HostCommand::InsertPathToken { terminal_pane_id, path, mode } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::TerminalBindings)
                 {
@@ -1061,7 +1051,7 @@ impl ProcessApp {
                     mode,
                 });
             }
-            DrawCommand::RequestCommandPreview { request_id, terminal_pane_id, command } => {
+            HostCommand::RequestCommandPreview { request_id, terminal_pane_id, command } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::TerminalBindings)
                 {
@@ -1083,7 +1073,7 @@ impl ProcessApp {
                     command,
                 });
             }
-            DrawCommand::OpenArtifact { path, mode } => {
+            HostCommand::OpenArtifact { path, mode } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::TerminalBindings)
                 {
@@ -1099,7 +1089,7 @@ impl ProcessApp {
             // ── Tool protocol (#398, #399) ─────────────────────────────────
 
             // App declares its callable tools to the host.
-            DrawCommand::ExposeTools { tools } => {
+            HostCommand::ExposeTools { tools } => {
                 log::debug!(
                     "ProcessApp[{}]: ExposeTools {} tool(s)",
                     self.type_id,
@@ -1122,7 +1112,7 @@ impl ProcessApp {
             }
 
             // App returns the result of a ToolCall from the broker.
-            DrawCommand::ToolResult {
+            HostCommand::ToolResult {
                 call_id,
                 output_json,
                 error,
@@ -1141,7 +1131,6 @@ impl ProcessApp {
                 );
             }
 
-            _ => unreachable!("route_command called with non-control command"),
         }
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -10,7 +10,7 @@
 
 use crate::app::PlexiApp;
 use crate::app_permissions::AppPermissions;
-use crate::app_protocol::{AiMessage, DrawCommand, ModelTier};
+use crate::app_protocol::{AiMessage, DrawCommand, HostCommand, ModelTier};
 use crate::pane::{AppPane, AppRuntime, Pane};
 use crate::process_app::ProcessApp;
 use crate::tiling::PaneId;
@@ -236,9 +236,9 @@ impl HostHarness {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Build a minimal `DrawCommand::AiQuery` for use in routing tests.
+/// Build a minimal `DrawCommand::Host(HostCommand::AiQuery)` for use in routing tests.
 pub fn ai_query(request_id: &str) -> DrawCommand {
-    DrawCommand::AiQuery {
+    DrawCommand::Host(HostCommand::AiQuery {
         request_id: request_id.to_string(),
         model_tier: ModelTier::Low,
         system: String::new(),
@@ -247,7 +247,7 @@ pub fn ai_query(request_id: &str) -> DrawCommand {
             content: "hello".to_string(),
         }],
         tools: vec![],
-    }
+    })
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -333,10 +333,10 @@ mod tests {
 
         h.inject(
             pane,
-            DrawCommand::PushNav {
+            DrawCommand::Host(HostCommand::PushNav {
                 view_id: "detail".to_string(),
                 title: "Detail".to_string(),
-            },
+            }),
         );
         h.run_frames(2);
 
@@ -357,14 +357,14 @@ mod tests {
 
         h.inject(
             pane,
-            DrawCommand::PushNav {
+            DrawCommand::Host(HostCommand::PushNav {
                 view_id: "detail".to_string(),
                 title: "Detail".to_string(),
-            },
+            }),
         );
         h.run_frames(1);
 
-        h.inject(pane, DrawCommand::PopNav {});
+        h.inject(pane, DrawCommand::Host(HostCommand::PopNav {}));
         h.run_frames(1);
 
         let win = &h.app.windows[0];
@@ -388,9 +388,9 @@ mod tests {
 
         h.inject(
             pane,
-            DrawCommand::StatusSummary {
+            DrawCommand::Host(HostCommand::StatusSummary {
                 text: "Working…".to_string(),
-            },
+            }),
         );
         h.run_frames(1);
 


### PR DESCRIPTION
## Summary

- Splits the monolithic `DrawCommand` enum into three typed sub-enums: `RenderCommand` (paint primitives), `HostCommand` (side-effectful commands), `ControlCommand` (frame lifecycle + clipboard + logging)
- `DrawCommand` becomes an `#[serde(untagged)]` union — wire format unchanged, existing apps require no updates
- `route_command` now takes `HostCommand` with an exhaustive match — adding a new host command variant without a `route_command` arm is a **compile error**
- Dispatch in `ui()` and `background_tick()` collapses from two 30+ arm lists to a clean 3-arm match

## Bug fix included

`AgentRosterGet` was missing from `background_tick()`'s dispatch list and was being silently dropped for any background app calling it. The exhaustive type split fixes this automatically.

## Test plan

- [ ] `cargo test` — 258 passed, 0 failed
- [ ] Confirm alpha build launches normally and app panes render
- [ ] Confirm `just pr-install` installs and a canvas app (e.g. chat-poc or todo) renders and routes commands correctly

## Breaks if

Adding a new `HostCommand` variant without a `route_command` arm now produces a **compile error** (this is the intended behavior). Any code that calls `route_command(DrawCommand::X)` is also a compile error — callers must use `route_command(HostCommand::X)`.