### PR TITLE
feat: zoom overlay at 88% opacity — scrim bleed-through

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2038,6 +2038,7 @@ impl eframe::App for PlexiApp {
                                 "drop: zoomed overlay received drop event — pane_id={pane_id:?}"
                             );
                         }
+                        child_ui.set_opacity(0.88);
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))


### PR DESCRIPTION
Closes #572

## Summary
- Adds `child_ui.set_opacity(0.88)` before the `egui::Frame` in the zoom overlay path
- Prior attempts at 0.99 and 0.95 were visually imperceptible on dark themes; 0.88 lands in the 0.85–0.92 range suggested in the issue comments
- One-line change; no logic affected

## Test plan
- [ ] Zoom any terminal pane (⌘⇧Z or palette)
- [ ] Scrim bleed-through is faintly visible through the overlay frame
- [ ] Unzoom — overlay disappears, normal split layout unchanged
- [ ] File drag onto zoomed pane still works (no regression)