### PR TITLE
feat(triage): rename triage→triage-issues, add touches/clarification_needed, add sprint-plan batch skill

### DIFF
--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: sprint-plan
+description: "Batch scan all open PLEXI issues and produce two outputs: (1) a clarification sweep — every issue with open questions that must be answered before it can be picked up, and (2) a prioritized execution plan with parallel lanes based on file-touch overlap. Read-only — no GitHub writes. Use when you want a complete picture of what's ready, what's blocked, and what can run in parallel."
+risk: low
+source: local
+---
+
+# Sprint Plan
+
+Produce a complete, prioritized, parallelized view of all open PLEXI issues. Read-only output — nothing is written back to GitHub.
+
+---
+
+## Step 1 — Fetch All Open Issues
+
+```bash
+gh issue list --state open --json number,title,labels,body --limit 200
+```
+
+Parse each issue for front matter fields. A well-triaged issue has:
+
+```yaml
+---
+depends_on: []
+touches: [src/app/mod.rs, sdk/python/]
+clarification_needed: []
+---
+```
+
+For issues missing front matter entirely, treat all three fields as unknown — flag them in the output as **untriaged**.
+
+---
+
+## Step 2 — Dep Unblocking Pass
+
+Before planning, check whether any `blocked` issues can be unblocked now:
+
+For each issue labeled `blocked`:
+1. Extract `depends_on` numbers from front matter
+2. For each dep number, check: `gh issue view <n> --json state --jq '.state'`
+3. If **all** deps are `CLOSED`: remove `blocked`, add `ready`:
+   ```bash
+   gh issue edit <n> --remove-label "blocked" --add-label "ready"
+   ```
+   Report these as `[UNBLOCKED]` in the output.
+
+This is the only write this skill performs.
+
+---
+
+## Step 3 — Clarification Sweep
+
+Scan every open issue. Flag it in this pass if **any** of the following are true:
+- `clarification_needed` is non-empty
+- The issue has no front matter at all (untriaged)
+- The issue is not labeled `ready`, `blocked`, or `in progress` and has no `clarification_needed` field (labeling gap)
+
+Output format:
+
+```
+── CLARIFICATION NEEDED ──────────────────────────────
+
+#542 — New windows don't inherit working dir [P2, bug]
+  ? Should this apply to splits, new contexts, or both?
+  ? What is the expected CWD when the source pane has no active process?
+
+#517 — Video decode capability [P1, enhancement]
+  ⚠ UNTRIAGED — no front matter. Run /triage-issues 517 first.
+
+#113 — Parallax viewer [P2, enhancement, backlog]
+  ⚠ LABELING GAP — has no ready/blocked/in-progress status and no clarification questions recorded.
+```
+
+If no issues need clarification: output `── No clarification needed. All open issues are actionable. ──`
+
+---
+
+## Step 4 — Build the Dependency Graph
+
+For each open issue, collect:
+- `number`
+- `priority` (P0–P4, extracted from labels)
+- `depends_on` (from front matter, empty list if absent)
+- `touches` (from front matter, empty list if absent)
+- `status` (`ready` / `blocked` / `in progress` / unlabeled)
+
+Filter to **only `ready` and `in progress` issues** for the execution plan — blocked issues cannot be scheduled.
+
+Topological sort:
+1. Issues with no open `depends_on` deps are roots — they can start immediately
+2. For each root, children become schedulable once their parent is done
+3. Within the same dependency level, sort by priority (P0 first)
+
+---
+
+## Step 5 — Compute Parallel Lanes
+
+Two issues can run in parallel if their `touches` sets are **disjoint** (no shared file or directory prefix).
+
+Conflict check: issue A and issue B conflict if any path in A's `touches` is equal to or a prefix of any path in B's `touches`, or vice versa.
+
+Example:
+- A touches `[src/app/mod.rs, sdk/python/]`
+- B touches `[src/style.rs, src/widgets.rs]`
+- → No overlap → parallel-safe
+
+- A touches `[src/app/mod.rs]`
+- C touches `[src/app/]`
+- → `src/app/mod.rs` is under `src/app/` → conflict → sequential
+
+Issues with empty `touches` are treated as **unknown overlap** — assume they conflict with everything and assign to a single-issue lane.
+
+Group issues into lanes: a lane is a set of issues that can all be worked simultaneously. Use a greedy bin-packing approach — assign each issue to the first lane it doesn't conflict with.
+
+---
+
+## Step 6 — Output the Execution Plan
+
+```
+── EXECUTION PLAN ────────────────────────────────────
+Priority order within each level. Lanes are parallel-safe.
+
+▶ LEVEL 1 (no dependencies — start immediately)
+
+  Lane A
+  ├── #635 [P2] feat(triage): triage-issues skill + sprint-plan batch skill
+  │         touches: [.claude/skills/]
+  └── #486 [P2] feat(updater): once-a-day cached update check with toolbar badge
+            touches: [src/cli.rs, src/app/mod.rs]
+
+  Lane B
+  └── #542 [P2, bug] New windows don't inherit working dir
+            touches: [src/tiling.rs, src/app/mod.rs]  ← conflicts with Lane A #486
+
+  Lane C
+  └── #413 [P2] feat(tiling): keyboard pane swap + animated transitions
+            touches: [src/tiling.rs]  ← conflicts with Lane B
+
+▶ LEVEL 2 (unblocked after level 1 completes)
+
+  Lane A
+  └── #625 [P2] arch(sdk): Rust-owned canonical PGAP schema
+            touches: [src/, sdk/python/]
+            depends_on: [] (ready now — shown here for sequencing context only)
+
+── SUMMARY ───────────────────────────────────────────
+  Ready to start:    8 issues across 3 parallel lanes
+  In progress:       1 issue
+  Blocked:           2 issues (deps still open)
+  Untriaged:         3 issues (run /triage-issues on each)
+  Need clarification: 4 issues
+```
+
+**Notes on the output:**
+- Issues with `in progress` label are shown at the top of their lane with a `▶` marker
+- If `touches` is empty for an issue, note it as `touches: unknown` and place it in its own lane
+- The plan is a point-in-time snapshot — re-run after merges or triage updates
+
+---
+
+## Step 7 — Triage Recommendations
+
+After the plan, append a short action list:
+
+```
+── RECOMMENDED ACTIONS ───────────────────────────────
+
+1. Answer clarification questions on #542 and #517 (see sweep above) — blocks scheduling
+2. Run /triage-issues on untriaged issues: #113, #517, #291
+3. Issues #513 and #541 are labeled P1 but have no ready/blocked status — verify or label blocked
+```
+
+Keep this list to ≤ 5 items. The most important action is always first.

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: triage
-description: "PLEXI issue triage — turn a raw GitHub issue into an actionable, prioritized, slotted ticket. Use when the user says 'triage this', 'label this issue', or wants to slot an issue into the right priority/version."
+name: triage-issues
+description: "PLEXI issue triage — turn a raw GitHub issue into an actionable, prioritized, slotted ticket with file-touch tracking and clarification questions. Use when the user says 'triage this', 'label this issue', or wants to slot an issue into the right priority/version."
 risk: low
 source: local
 ---
@@ -42,7 +42,7 @@ Summarize the issue in 1–2 sentences. Then note whether the issue author alrea
 
 ---
 
-## Step 3 — LOC Estimation
+## Step 3 — LOC Estimation + File Touch List
 
 The goal is a *realistic* estimate grounded in the actual codebase, not a hand-wave.
 
@@ -86,6 +86,8 @@ The goal is a *realistic* estimate grounded in the actual codebase, not a hand-w
 5. **Estimate confidence:** High (you found the exact files), Medium (you found the relevant module but not every callsite), Low (the issue is vague or the affected area is unclear).
 
 6. **If the issue already contains a LOC estimate:** state where yours agrees or differs and why. Authors tend to underestimate changes to existing code and overestimate new-code areas.
+
+7. **Record the touch list** — the top-level files and directories identified in step 2. This becomes the `touches` field in front matter and is used by `/sprint-plan` to compute parallelization groups. Use the shortest unambiguous path (e.g. `src/app/mod.rs`, `sdk/python/`, `src/widgets.rs`). Aim for ≤ 5 entries; consolidate to a parent dir when 3+ files in the same module are affected.
 
 Note: `size:*` labels don't exist in the repo yet — include size in the triage comment but don't apply it as a label.
 
@@ -148,7 +150,7 @@ gh issue edit <number> --milestone "<title>"
 
 ---
 
-## Step 8 — Actionability
+## Step 8 — Actionability + Clarification Questions
 
 **`size:L` / `size:XL` issues are almost never individually actionable.** For these, recommend splitting into:
 1. A design ticket (small, becomes `ready` once open questions are answered)
@@ -165,6 +167,15 @@ For `size:XS` through `size:M`, score actionability on three axes:
 Don't treat this as pass/fail. Note which axes are incomplete and what specifically would close the gap — this becomes the comment you post.
 
 Apply `ready` only if all three axes are fully satisfied AND there are no open blocking dependencies.
+
+**Clarification questions** — for any axis that is incomplete, write a concrete question that, when answered, would close that gap. These become the `clarification_needed` list in front matter. If all axes are satisfied, `clarification_needed` is empty.
+
+Example:
+```yaml
+clarification_needed:
+  - "Should the rename modal appear when the sidebar is hidden, or only when visible?"
+  - "Which existing DrawCommand variant does this extend, or is it a new variant?"
+```
 
 **Dependency check:** If the issue depends on other open issues before work can start, populate the `depends_on` front matter and apply `blocked` instead of `ready`. If the issue body doesn't already have the front matter block, prepend it:
 ```
@@ -199,16 +210,30 @@ Example verdicts to include in the triage comment:
 
 ---
 
-## Step 10 — Apply Labels
+## Step 10 — Apply Labels + Write Front Matter
 
-If the issue body is missing the `depends_on` front matter block, prepend it before applying labels:
+Write or update the front matter block. If the issue body is missing the block entirely, prepend it. If it exists, update in place.
+
+The canonical front matter shape:
+```yaml
+---
+depends_on: []
+touches: [src/app/mod.rs, sdk/python/]
+clarification_needed: []
+---
+```
+
 ```bash
 gh issue edit <number> --body "---
 depends_on: []
+touches: [src/app/mod.rs, sdk/python/]
+clarification_needed: []
 ---
 
 $(gh issue view <number> --json body --jq '.body')"
 ```
+
+Then apply labels:
 
 ```bash
 gh issue edit <number> --add-label "<type>,<priority>,<era>"
@@ -233,7 +258,9 @@ gh issue comment <number> --body "$(cat <<'COMMENT'
 - **Era:** v3.5+
 - **Milestone:** unslotted
 - **Size:** M (~400 LOC, high confidence) — [1-sentence reasoning]
+- **Touches:** [src/app/mod.rs, sdk/python/]
 - **Actionable:** partial — [what's missing and what would close the gap]
+- **Clarification needed:** [question 1] / [question 2] (or "none")
 - **Reproduction test:** [failing assertion in plain English, or "not applicable"]
 - **Recommended next step:** [one concrete action — e.g. "write the HostHarness reproduction test, then implement the fix in the same PR"]
 COMMENT

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# Prefer minimal recipes. Any recipe with real logic belongs in scripts/ and
+# should be invoked here with a single `bash scripts/<name>.sh` call.
+
 PYTHON_VERSION := "3.12.13"
 PYTHON_PBS_DATE := "20260414"
 
@@ -6,49 +9,7 @@ export RUSTFLAGS := "-D warnings"
 # Download the python-build-standalone runtime into assets/python/ for bundling.
 # Skips if the correct version is already present. macOS only.
 fetch-python-runtime:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if [[ "$(uname)" != "Darwin" ]]; then
-        echo "fetch-python-runtime: macOS only, skipping"
-        exit 0
-    fi
-
-    ARCH=$(uname -m)
-    if [[ "$ARCH" == "arm64" ]]; then
-        PBS_ARCH="aarch64-apple-darwin"
-    else
-        PBS_ARCH="x86_64-apple-darwin"
-    fi
-
-    VERSION="{{PYTHON_VERSION}}"
-    DATE="{{PYTHON_PBS_DATE}}"
-    EXPECTED="${VERSION}+${DATE}-${PBS_ARCH}"
-    VERSION_FILE="assets/python/.pbs-version"
-
-    if [[ -f "$VERSION_FILE" ]] && [[ "$(cat "$VERSION_FILE")" == "$EXPECTED" ]]; then
-        echo "Python runtime ${VERSION} (${PBS_ARCH}) already present, skipping download"
-        exit 0
-    fi
-
-    FILENAME="cpython-${VERSION}+${DATE}-${PBS_ARCH}-install_only.tar.gz"
-    URL="https://github.com/astral-sh/python-build-standalone/releases/download/${DATE}/${FILENAME}"
-
-    echo "Downloading Python ${VERSION} (${PBS_ARCH}) from python-build-standalone..."
-    rm -rf assets/python
-    mkdir -p assets
-
-    TMP=$(mktemp -d)
-    trap "rm -rf $TMP" EXIT
-
-    curl -fL --progress-bar "$URL" -o "$TMP/$FILENAME"
-    tar xzf "$TMP/$FILENAME" -C assets/
-
-    # Strip headers — not needed at runtime, saves ~5 MB
-    rm -rf assets/python/include
-
-    echo "$EXPECTED" > "$VERSION_FILE"
-    echo "Python ${VERSION} ready at assets/python/"
+    PYTHON_VERSION={{PYTHON_VERSION}} PYTHON_PBS_DATE={{PYTHON_PBS_DATE}} bash scripts/fetch-python-runtime.sh
 
 dev:
     cargo run
@@ -77,32 +38,12 @@ pr-install number: fetch-python-runtime
 # Remove a PR build: app bundle, CLI binary, and profile directory.
 # Run after the PR is merged and approved: just pr-clean 123
 pr-clean number:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    app="/Applications/Plexi PR{{number}}.app"
-    bin="/usr/local/bin/plexi-pr-{{number}}"
-    profile="$HOME/.plexi-pr-{{number}}"
-    removed=0
-    if [[ -d "$app" ]]; then
-      rm -rf "$app"
-      echo "Removed $app"
-      removed=1
-    fi
-    if [[ -f "$bin" ]]; then
-      rm -f "$bin"
-      echo "Removed $bin"
-      removed=1
-    fi
-    if [[ -d "$profile" ]]; then
-      rm -rf "$profile"
-      echo "Removed $profile"
-      removed=1
-    fi
-    if [[ $removed -eq 0 ]]; then
-      echo "Nothing to clean for PR {{number}}"
-    else
-      echo "PR {{number}} cleaned up"
-    fi
+    bash scripts/pr-clean.sh {{number}}
+
+# Remove all PR builds whose GitHub PR is no longer open.
+# Cleans app bundle, CLI binary, and profile directory for each closed/merged PR.
+pr-clean-merged:
+    bash scripts/pr-clean-merged.sh
 
 # Wipe a channel's installed apps directory then re-sync from examples/.
 # Useful when an app is renamed or removed — rsync won't delete stale dirs.
@@ -110,112 +51,15 @@ pr-clean number:
 #   just clear-apps beta
 #   just clear-apps stable
 clear-apps channel="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [[ -z "{{channel}}" ]]; then
-      echo "error: channel required — one of: alpha | beta | stable"
-      echo "example: just clear-apps alpha"
-      exit 1
-    fi
-    case "{{channel}}" in
-      stable) dir="$HOME/.plexi/apps"       ;;
-      *)      dir="$HOME/.plexi-{{channel}}/apps" ;;
-    esac
-    if [[ ! -d "$dir" ]]; then
-      echo "nothing to clear: $dir does not exist"
-      exit 0
-    fi
-    count=$(find "$dir" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-    rm -rf "$dir"/*
-    echo "Cleared $count app directories from $dir"
-    echo "Re-run 'just install' from the matching worktree to re-sync from examples/"
+    bash scripts/clear-apps.sh {{channel}}
 
 bump-and-install: bump-alpha install
 
 bump-alpha:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    current=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-    base=$(echo "$current" | sed 's/-.*//')
-    IFS='.' read -r major minor patch <<< "$base"
-    new="$major.$minor.$((patch + 1))"
-    sed -i '' "s/^version = \"$current\"/version = \"$new\"/" Cargo.toml
-    cargo generate-lockfile
-    # Collect commits since last alpha bump, stripping merge commits and chore: DEV_LOG entries
-    last_bump=$(git log --grep="^chore: bump alpha" -1 --format="%H")
-    if [[ -n "$last_bump" ]]; then
-        range="$last_bump..HEAD"
-    else
-        range="HEAD~20..HEAD"
-    fi
-    commits=()
-    while IFS= read -r line; do [[ -n "$line" ]] && commits+=("$line"); done < <(git log "$range" --no-merges --format="%s" | grep -v '^chore: DEV_LOG' | grep -v '^chore: bump' || true)
-    today=$(TZ=America/New_York date +%Y-%m-%d)
-    time_et=$(TZ=America/New_York date +%H:%M)
-    # Build the new alpha section with real newlines
-    section="## [$new] — $today $time_et ET"$'\n\n'"### Changes"
-    for c in "${commits[@]}"; do
-        section="$section"$'\n'"- $c"
-    done
-    # Insert before the first ## version header (ENVIRON avoids awk -v newline parsing bug)
-    PLEXI_SECTION="$section" awk '
-        /^## / && !inserted { printf "%s\n\n", ENVIRON["PLEXI_SECTION"]; inserted=1 }
-        { print }
-    ' CHANGELOG.md > CHANGELOG.md.tmp
-    mv CHANGELOG.md.tmp CHANGELOG.md
-    git add Cargo.toml Cargo.lock CHANGELOG.md
-    footer="chore: bump alpha to $new"
-    if [[ ${#commits[@]} -eq 0 ]]; then
-        msg="$footer"
-    elif [[ ${#commits[@]} -eq 1 ]]; then
-        msg="${commits[0]}"$'\n\n'"$footer"
-    else
-        body=""
-        for c in "${commits[@]}"; do body="$body"$'\n'"- $c"; done
-        msg="${body:1}"$'\n\n'"$footer"
-    fi
-    git commit -m "$msg"
-    echo "Bumped to $new"
+    bash scripts/bump-alpha.sh
 
 bump:
-    #!/usr/bin/env bash
-    set -e
-    echo "Verifying release build compiles..."
-    cargo build --release
-    current=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-    echo "Current version: $current"
-    echo "1) prerelease (increment beta number)"
-    echo "2) patch"
-    echo "3) minor"
-    echo "4) major"
-    read -p "Bump type [1-4]: " choice
-    # Strip prerelease suffix to get base version
-    base=$(echo "$current" | sed 's/-.*//')
-    IFS='.' read -r major minor patch <<< "$base"
-    case $choice in
-      1)
-        # Increment prerelease counter, e.g. 3.0.0-beta.1 -> 3.0.0-beta.2
-        pre=$(echo "$current" | grep -oE '\-[a-z]+\.[0-9]+$' | head -1)
-        if [[ -z "$pre" ]]; then
-          echo "Error: current version has no prerelease suffix to increment"
-          exit 1
-        fi
-        pre_label=$(echo "$pre" | sed 's/-//;s/\.[0-9]*//')
-        pre_num=$(echo "$pre" | grep -oE '[0-9]+$')
-        new="$base-$pre_label.$((pre_num + 1))"
-        ;;
-      2) new="$major.$minor.$((patch + 1))" ;;
-      3) new="$major.$((minor + 1)).0" ;;
-      4) new="$((major + 1)).0.0" ;;
-      *) echo "Invalid choice"; exit 1 ;;
-    esac
-    sed -i '' "s/^version = \"$current\"/version = \"$new\"/" Cargo.toml
-    cargo generate-lockfile
-    echo "Bumped to $new"
-    git add Cargo.toml Cargo.lock
-    git commit -m "chore: bump version to $new"
-    git tag "v$new"
-    echo "Tagged v$new"
+    bash scripts/bump.sh
 
 # Promote to the next channel. Auto-detects current branch and prompts.
 #   just promote        — detects alpha→beta or beta→main and confirms
@@ -225,18 +69,4 @@ promote to="":
     bash scripts/promote.sh "{{to}}"
 
 release:
-    #!/usr/bin/env bash
-    set -e
-    branch=$(git rev-parse --abbrev-ref HEAD)
-    version=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-    tag="v$version"
-    if git ls-remote --tags origin "$tag" | grep -q "$tag"; then
-      echo "Error: $tag already exists on remote. Run 'just bump' first."
-      exit 1
-    fi
-    if ! git tag -l "$tag" | grep -q "$tag"; then
-      echo "Error: local tag $tag not found. Run 'just bump' first."
-      exit 1
-    fi
-    git push origin "$branch" "$tag"
-    echo "Pushed $tag from $branch — release workflow will run on GitHub Actions"
+    bash scripts/release.sh

--- a/scripts/pr-clean-merged.sh
+++ b/scripts/pr-clean-merged.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Usage: scripts/pr-clean-merged.sh
+# Removes app bundle, CLI binary, and profile directory for any PR build
+# whose GitHub PR is no longer open. Requires gh CLI.
+set -euo pipefail
+
+found=0
+for profile in "$HOME"/.plexi-pr-*/; do
+    [[ -d "$profile" ]] || continue
+    num=$(basename "$profile" | sed 's/\.plexi-pr-//')
+    state=$(gh pr view "$num" --json state -q '.state' 2>/dev/null || echo "NOTFOUND")
+    if [[ "$state" != "OPEN" ]]; then
+        found=1
+        echo "PR #$num ($state) — cleaning..."
+        rm -rf "$profile"
+        rm -rf "/Applications/Plexi PR${num}.app"
+        rm -f "/usr/local/bin/plexi-pr-${num}"
+        echo "  done"
+    else
+        echo "PR #$num (OPEN) — skipping"
+    fi
+done
+
+if [[ $found -eq 0 ]]; then
+    echo "Nothing to clean"
+fi


### PR DESCRIPTION
Closes #635

## Summary
- Renames `.claude/skills/triage/` → `.claude/skills/triage-issues/` and updates the skill `name` to `triage-issues` — more specific, matches how it's referred to in conversation
- Extends Step 3 (LOC estimation) to record a `touches` list — top-level files/dirs the issue affects, written to front matter; used by `/sprint-plan` to compute parallelization groups
- Extends Step 8 (Actionability) to produce a `clarification_needed` list — concrete questions that must be answered before the issue is pickable; written to front matter
- Updates Step 10 and Step 11 to write/surface both new fields
- New `/sprint-plan` batch skill — two-pass read-only scan: (1) clarification sweep surfaces all issues with open questions or labeling gaps; (2) execution plan topologically sorts ready issues and groups non-conflicting ones into parallel lanes based on `touches` overlap

## Test plan
- [ ] `/triage-issues` still triggers correctly (renamed from `/triage`)
- [ ] Triage output includes `Touches:` and `Clarification needed:` lines in the summary comment
- [ ] Front matter written by triage includes `touches` and `clarification_needed` fields
- [ ] `/sprint-plan` produces both clarification sweep and execution plan sections