### PR TITLE
feat(release): git-cliff changelog + release-version command

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = "# Changelog\n\nNewest releases appear first.\n"
+body = """
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+
+### Changes
+{% for commit in commits -%}
+- {{ commit.message | split(pat="\n") | first | trim }}
+{% endfor %}
+"""
+trim = true
+footer = ""
+postprocessors = []
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+filter_commits = true
+tag_pattern = "v[0-9].*"
+topo_order = false
+sort_commits = "newest"
+
+[[git.commit_parsers]]
+message = "^chore: bump"
+skip = true
+
+[[git.commit_parsers]]
+message = "^chore: promote"
+skip = true
+
+[[git.commit_parsers]]
+message = "^chore: DEV_LOG"
+skip = true
+
+[[git.commit_parsers]]
+message = "^- "
+skip = true
+
+[[git.commit_parsers]]
+message = "^Merge"
+skip = true
+
+[[git.commit_parsers]]
+message = ".*"
+group = "Changes"

--- a/justfile
+++ b/justfile
@@ -90,3 +90,11 @@ promote to="":
 
 release:
     bash scripts/release.sh
+
+# Bump version, generate CHANGELOG via git-cliff, and commit.
+# Defaults to patch. Run before: just promote beta
+#   just release-version          — patch bump
+#   just release-version minor    — minor bump
+#   just release-version major    — major bump
+release-version bump="patch":
+    bash scripts/release-version.sh "{{bump}}"

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -43,31 +43,41 @@ bump_patch() {
 
 prepend_changelog() {
     local tree="$1" ver="$2"
-    local today commits_file tmp
-    today=$(date '+%Y-%m-%d')
-    commits_file=$(mktemp)
-    git -C "$tree" log origin/beta..alpha --oneline --no-merges \
-        | sed 's/^[a-f0-9]* /- /' \
-        | grep -v '^- chore: DEV_LOG' \
-        | grep -v '^- chore: bump' \
-        | grep -v '^- chore: promote' \
-        | grep -v '^- - ' \
-        > "$commits_file"
-    [[ -s "$commits_file" ]] || echo "- (no new commits since last beta)" > "$commits_file"
-    tmp=$(mktemp)
-    awk -v ver="$ver" -v dt="$today" -v cf="$commits_file" '
-        /^## \[/ && !inserted {
-            print "## [" ver "] — " dt
-            print ""
-            print "### Changes"
-            while ((getline line < cf) > 0) print line
-            print ""
-            inserted=1
-        }
-        { print }
-    ' "$tree/CHANGELOG.md" > "$tmp"
-    rm -f "$commits_file"
-    mv "$tmp" "$tree/CHANGELOG.md"
+    if command -v git-cliff >/dev/null 2>&1; then
+        git-cliff \
+            --config "$tree/cliff.toml" \
+            --workdir "$tree" \
+            --unreleased \
+            --tag "v$ver" \
+            --prepend "$tree/CHANGELOG.md"
+    else
+        # fallback: manual log when git-cliff is unavailable
+        local today commits_file tmp
+        today=$(date '+%Y-%m-%d')
+        commits_file=$(mktemp)
+        git -C "$tree" log origin/beta..alpha --oneline --no-merges \
+            | sed 's/^[a-f0-9]* /- /' \
+            | grep -v '^- chore: DEV_LOG' \
+            | grep -v '^- chore: bump' \
+            | grep -v '^- chore: promote' \
+            | grep -v '^- - ' \
+            > "$commits_file"
+        [[ -s "$commits_file" ]] || echo "- (no new commits since last beta)" > "$commits_file"
+        tmp=$(mktemp)
+        awk -v ver="$ver" -v dt="$today" -v cf="$commits_file" '
+            /^## \[/ && !inserted {
+                print "## [" ver "] — " dt
+                print ""
+                print "### Changes"
+                while ((getline line < cf) > 0) print line
+                print ""
+                inserted=1
+            }
+            { print }
+        ' "$tree/CHANGELOG.md" > "$tmp"
+        rm -f "$commits_file"
+        mv "$tmp" "$tree/CHANGELOG.md"
+    fi
 }
 
 # ── resolve target ────────────────────────────────────────────────────────────

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Bump version, regenerate CHANGELOG via git-cliff, and commit.
+# Usage: scripts/release-version.sh [patch|minor|major]
+# Default: patch
+# After this, run: just promote [beta|main]
+set -euo pipefail
+
+REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
+TREE="${REPO_ROOT}/worktrees/alpha"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# ── validate args ─────────────────────────────────────────────────────────────
+
+bump="${1:-patch}"
+case "$bump" in
+    patch|minor|major) ;;
+    *) die "unknown bump type '$bump' — must be: patch | minor | major" ;;
+esac
+
+# ── require clean state ───────────────────────────────────────────────────────
+
+git -C "$TREE" diff --quiet && git -C "$TREE" diff --cached --quiet \
+    || die "alpha has uncommitted changes — commit first"
+
+# ── require git-cliff ─────────────────────────────────────────────────────────
+
+command -v git-cliff >/dev/null 2>&1 || die "git-cliff not found — brew install git-cliff"
+
+# ── calculate new version ─────────────────────────────────────────────────────
+
+current=$(grep '^version' "$TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+base=$(echo "$current" | sed 's/-.*//')
+IFS='.' read -r major minor patch <<< "$base"
+
+case "$bump" in
+    patch) new="$major.$minor.$((patch + 1))" ;;
+    minor) new="$major.$((minor + 1)).0" ;;
+    major) new="$((major + 1)).0.0" ;;
+esac
+
+echo "Bumping $current → $new ($bump)..."
+
+# ── bump Cargo.toml ───────────────────────────────────────────────────────────
+
+sed -i '' "s/^version = \"$current\"/version = \"$new\"/" "$TREE/Cargo.toml"
+(cd "$TREE" && cargo generate-lockfile --quiet 2>/dev/null || cargo generate-lockfile)
+
+# ── update CHANGELOG via git-cliff ───────────────────────────────────────────
+
+echo "Generating changelog..."
+git-cliff \
+    --config "$TREE/cliff.toml" \
+    --workdir "$TREE" \
+    --unreleased \
+    --tag "v$new" \
+    --prepend "$TREE/CHANGELOG.md"
+
+# ── commit ────────────────────────────────────────────────────────────────────
+
+git -C "$TREE" add Cargo.toml Cargo.lock CHANGELOG.md
+git -C "$TREE" commit -m "chore: release v$new"
+
+echo ""
+echo "v$new committed on alpha."
+echo "Next: just promote beta"


### PR DESCRIPTION
## Summary

- **cliff.toml** — git-cliff config that matches current CHANGELOG format (flat list, first line only, skips chore/bump/promote/DEV_LOG/merge noise)
- **scripts/release-version.sh** — explicit `patch|minor|major` bump with git-cliff changelog; use before `just promote` when you want control over bump type
- **scripts/promote.sh** — `promote alpha→beta` now calls git-cliff when available, falls back to manual log otherwise
- **justfile** — adds `just release-version [bump]` recipe

## New commands

```bash
# Patch bump + git-cliff changelog + commit (then just promote)
just release-version

# Minor or major
just release-version minor
just release-version major
```

`just promote` still auto-bumps patch and generates changelog (now via git-cliff).

## Shell changes (dotfiles, not in this PR)

- `alias jc='just --choose'` renamed to `jp`
- `jc()` function: runs `just <recipe>`; on failure opens Claude Code with full error context

## Test plan

- [ ] `just release-version patch` on a clean alpha → bumps version, updates CHANGELOG, commits
- [ ] `just promote beta` → uses git-cliff for changelog, not manual awk
- [ ] `just promote beta` on machine without git-cliff → falls back gracefully
- [ ] `jc promote` with uncommitted changes → Claude Code session with error context

**Breaks if:** `just promote beta` changelog section is empty or missing after merge