### PR TITLE
fix(promote): idempotent tag on beta→main

### DIFF
--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -90,8 +90,17 @@ git push origin beta:main
 echo "Syncing main worktree..."
 git -C "$REPO_ROOT" pull origin main
 
-git -C "$REPO_ROOT" tag "v$version"
-git -C "$REPO_ROOT" push origin "v$version"
+if git -C "$REPO_ROOT" tag -l "v$version" | grep -q "v$version"; then
+    echo "Tag v$version already exists — skipping tag creation."
+else
+    git -C "$REPO_ROOT" tag "v$version"
+fi
+
+if git ls-remote --tags origin "v$version" | grep -q "v$version"; then
+    echo "Tag v$version already on remote — skipping push."
+else
+    git -C "$REPO_ROOT" push origin "v$version"
+fi
 
 echo ""
-echo "Released v$version — tag pushed, GitHub Actions release workflow will run."
+echo "Released v$version — GitHub Actions release workflow will run."


### PR DESCRIPTION
Re-running `just promote main` no longer crashes with `fatal: tag already exists`.

Checks local tag and remote tag separately before creating/pushing. Safe to run twice.

**Breaks if:** `just promote main` on a fresh release fails to create the tag (regression in the guard logic)