### PR TITLE
fix(ci): use lowercase plexi.app path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
         run: cargo bundle --release
 
       - name: Ad-hoc sign (required for ARM64)
-        run: codesign --force --deep --sign - target/release/bundle/osx/Plexi.app
+        run: codesign --force --deep --sign - target/release/bundle/osx/plexi.app
 
       - name: Create zip
         run: |
           cd target/release/bundle/osx
-          zip -r Plexi-${{ github.ref_name }}.zip Plexi.app
+          zip -r Plexi-${{ github.ref_name }}.zip plexi.app
 
       - name: Extract release notes since last tag
         id: notes


### PR DESCRIPTION
## Summary
- `cargo bundle` with multiple `[[bin]]` entries names the bundle after the binary (`plexi`), not the display name (`Plexi`)
- Release workflow was looking for `Plexi.app` → `No such file or directory`
- Fixed codesign and zip steps to use `plexi.app`

## Root cause
From CLAUDE.md: *"When any `[[bin]]` entry exists in Cargo.toml, cargo bundle assigns the metadata bundle name to the first binary it encounters; subsequent binaries fall back to their own name."*

## Test plan
- [ ] Next release tag push should complete the build/sign/zip steps without error
- [ ] Zip artifact `Plexi-vX.Y.Z.zip` still uses the display name (unchanged — that's the output filename, not the `.app` path)

**Breaks if:** release workflow fails at codesign or zip step with `No such file or directory`