### PR TITLE
fix: pass --bin plexi to cargo bundle in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo install cargo-bundle
 
       - name: Build app bundle
-        run: cargo bundle --release
+        run: cargo bundle --release --bin plexi
 
       - name: Ad-hoc sign (required for ARM64)
         run: codesign --force --deep --sign - target/release/bundle/osx/plexi.app


### PR DESCRIPTION
## Summary
- `cargo bundle --release` without `--bin` uses the display name from `[package]` metadata, producing `Plexi Alpha.app` (with space) instead of `plexi.app`
- Adding `--bin plexi` forces cargo-bundle to name the bundle after the binary, matching the paths expected by the codesign and zip steps

## Test plan
- [ ] Release workflow codesign step no longer fails with `No such file or directory`
- [ ] Zip is created as `Plexi-vX.Y.Z.zip` containing `plexi.app`

**Breaks if:** codesign or zip step fails with `No such file or directory`