### PR TITLE
fix: BSD awk compat in release notes extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,7 @@ jobs:
           # If there is no previous tag, include everything.
           notes=$(awk -v stop="$prev_ver" '
             /^## \[/ {
-              if (stop != "") {
-                match($0, /\[([^]]+)\]/, arr)
-                if (arr[1] == stop) exit
-              }
+              if (stop != "" && index($0, "[" stop "]") > 0) exit
               found=1
             }
             found { print }


### PR DESCRIPTION
## Summary
- macOS CI runners use BSD awk, which does not support the three-argument `match($0, regex, arr)` form (GNU awk extension)
- Replaced with `index($0, "[" stop "]") > 0`, which is POSIX/BSD awk compatible

## Test plan
- [ ] Release workflow "Extract release notes" step completes without `awk: syntax error`
- [ ] Release body is populated with CHANGELOG entries since the previous tag

**Breaks if:** "Extract release notes" step exits with `awk: syntax error at source line 4`