### PR TITLE
feat(tiling): keyboard pane swap Cmd+Ctrl+HJKL + edge pulse (#413)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -119,7 +119,6 @@ use std::path::PathBuf;
 use std::sync::mpsc;
 
 struct PaneSwapAnim {
-    tile: egui_tiles::TileId,
     from: egui::Rect,
     to: egui::Rect,
     started_at: std::time::Instant,
@@ -1633,12 +1632,13 @@ impl eframe::App for PlexiApp {
                 Action::SwapPane(dir) => {
                     match self.swap_pane(dir) {
                         crate::pane_ops::SwapResult::Swapped {
-                            tile_a, rect_a, tile_b, rect_b,
+                            rect_a, rect_b, ..
+
                         } => {
                             let now = std::time::Instant::now();
                             self.pane_anims = vec![
-                                PaneSwapAnim { tile: tile_a, from: rect_a, to: rect_b, started_at: now },
-                                PaneSwapAnim { tile: tile_b, from: rect_b, to: rect_a, started_at: now },
+                                PaneSwapAnim { from: rect_a, to: rect_b, started_at: now },
+                                PaneSwapAnim { from: rect_b, to: rect_a, started_at: now },
                             ];
                             self.ctx.request_repaint();
                         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -118,6 +118,19 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc;
 
+struct PaneSwapAnim {
+    tile: egui_tiles::TileId,
+    from: egui::Rect,
+    to: egui::Rect,
+    started_at: std::time::Instant,
+}
+
+struct EdgePulse {
+    tile: egui_tiles::TileId,
+    dir: crate::keys::Direction,
+    started_at: std::time::Instant,
+}
+
 pub struct PlexiApp {
     pub(crate) pty_event_rx: mpsc::Receiver<(u64, PtyEvent)>,
     pub(crate) pty_event_tx: mpsc::Sender<(u64, PtyEvent)>,
@@ -233,6 +246,10 @@ pub struct PlexiApp {
     /// Pane count from the last snapshot push. Avoids rebuilding the global
     /// pane context every frame when no panes were opened or closed.
     pane_snapshot_len: usize,
+    /// In-flight pane swap animations. Each entry fades out over 160 ms.
+    pane_anims: Vec<PaneSwapAnim>,
+    /// Boundary edge pulse — shown when a swap is attempted at the wall.
+    edge_pulse: Option<EdgePulse>,
 }
 
 #[cfg(test)]
@@ -525,6 +542,8 @@ impl PlexiApp {
                     minimap_visible_per_context: HashMap::new(),
                     next_window_id: next_id,
                     pane_snapshot_len: 0,
+                    pane_anims: Vec::new(),
+                    edge_pulse: None,
                 };
             }
         }
@@ -610,6 +629,8 @@ impl PlexiApp {
             minimap_visible_per_context: HashMap::new(),
             next_window_id: 2,
             pane_snapshot_len: 0,
+            pane_anims: Vec::new(),
+            edge_pulse: None,
         }
     }
 
@@ -705,6 +726,8 @@ impl PlexiApp {
             minimap_visible_per_context: HashMap::new(),
             next_window_id: 2,
             pane_snapshot_len: 0,
+            pane_anims: Vec::new(),
+            edge_pulse: None,
             show_cli_setup_prompt: false,
         }
     }
@@ -1607,6 +1630,31 @@ impl eframe::App for PlexiApp {
                             self.windows[self.active_window].focused_pane;
                     }
                 }
+                Action::SwapPane(dir) => {
+                    match self.swap_pane(dir) {
+                        crate::pane_ops::SwapResult::Swapped {
+                            tile_a, rect_a, tile_b, rect_b,
+                        } => {
+                            let now = std::time::Instant::now();
+                            self.pane_anims = vec![
+                                PaneSwapAnim { tile: tile_a, from: rect_a, to: rect_b, started_at: now },
+                                PaneSwapAnim { tile: tile_b, from: rect_b, to: rect_a, started_at: now },
+                            ];
+                            self.ctx.request_repaint();
+                        }
+                        crate::pane_ops::SwapResult::AtBoundary => {
+                            if let Some(focused) = self.windows[self.active_window].focused_pane {
+                                self.edge_pulse = Some(EdgePulse {
+                                    tile: focused,
+                                    dir,
+                                    started_at: std::time::Instant::now(),
+                                });
+                                self.ctx.request_repaint();
+                            }
+                        }
+                        crate::pane_ops::SwapResult::NoFocus => {}
+                    }
+                }
                 Action::ClosePane => {
                     // If the focused app pane has a non-empty nav stack
                     // (via PushNav), Escape routes NavBack to the app
@@ -2135,6 +2183,64 @@ impl eframe::App for PlexiApp {
                     }
                 } else {
                     drop(behavior);
+                }
+
+                // ── Pane swap animation overlays ────────────────────────────────────────
+                {
+                    let anim_dur = std::time::Duration::from_millis(160);
+                    let edge_dur = std::time::Duration::from_millis(120);
+                    let now_anim = std::time::Instant::now();
+
+                    self.pane_anims.retain(|a| now_anim.duration_since(a.started_at) < anim_dur);
+                    if let Some(ref pulse) = self.edge_pulse {
+                        if now_anim.duration_since(pulse.started_at) >= edge_dur {
+                            self.edge_pulse = None;
+                        }
+                    }
+
+                    for anim in &self.pane_anims {
+                        let elapsed = now_anim.duration_since(anim.started_at).as_secs_f32();
+                        let t = (elapsed / anim_dur.as_secs_f32()).clamp(0.0, 1.0);
+                        let t_eased = 1.0 - (1.0 - t).powi(3);
+                        let animated_rect = egui::Rect {
+                            min: anim.from.min.lerp(anim.to.min, t_eased),
+                            max: anim.from.max.lerp(anim.to.max, t_eased),
+                        };
+                        ui.painter().rect_filled(
+                            animated_rect,
+                            egui::CornerRadius::same(4),
+                            self.colors.accent.gamma_multiply(0.25),
+                        );
+                        self.ctx.request_repaint();
+                    }
+
+                    if let Some(ref pulse) = self.edge_pulse {
+                        if let Some(pane_rect) = self.windows[self.active_window].tree.tiles.rect(pulse.tile) {
+                            let elapsed = now_anim.duration_since(pulse.started_at).as_secs_f32();
+                            let alpha = (1.0 - elapsed / edge_dur.as_secs_f32()).max(0.0);
+                            let edge_color = self.colors.accent.gamma_multiply(alpha);
+                            let (p1, p2) = match pulse.dir {
+                                crate::keys::Direction::Left => (
+                                    egui::pos2(pane_rect.left(), pane_rect.top()),
+                                    egui::pos2(pane_rect.left(), pane_rect.bottom()),
+                                ),
+                                crate::keys::Direction::Right => (
+                                    egui::pos2(pane_rect.right(), pane_rect.top()),
+                                    egui::pos2(pane_rect.right(), pane_rect.bottom()),
+                                ),
+                                crate::keys::Direction::Up => (
+                                    egui::pos2(pane_rect.left(), pane_rect.top()),
+                                    egui::pos2(pane_rect.right(), pane_rect.top()),
+                                ),
+                                crate::keys::Direction::Down => (
+                                    egui::pos2(pane_rect.left(), pane_rect.bottom()),
+                                    egui::pos2(pane_rect.right(), pane_rect.bottom()),
+                                ),
+                            };
+                            ui.painter().line_segment([p1, p2], egui::Stroke::new(3.0, edge_color));
+                            self.ctx.request_repaint();
+                        }
+                    }
                 }
 
                 if should_close_exited {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,6 +8,7 @@
 // Cmd+W                       — close pane
 // Cmd+H/J/K/L                 — navigate panes
 // Cmd+Shift+H/J/K/L           — navigate to adjacent window (spatial grid)
+// Cmd+Ctrl+H/J/K/L            — swap focused pane with neighbor in direction
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
 // Cmd+] / Cmd+[               — cycle tabs
@@ -110,6 +111,9 @@ pub enum Action {
     /// emit `PlexiEvent::NavBack`. Falls through to cycling tabs backwards
     /// if no nav is active on the focused pane.
     NavBackApp,
+    /// Swap the focused pane with its neighbor in the given direction.
+    /// Bound to Cmd+Ctrl+H/J/K/L.
+    SwapPane(Direction),
 }
 
 /// Poll global keyboard actions.
@@ -168,6 +172,24 @@ pub fn poll_actions(
         }
         if input.consume_key(cmd_shift, egui::Key::L) {
             actions.push(Action::PageRight);
+        }
+
+        // Pane swap (Cmd+Ctrl+HJKL) — check before plain Cmd+HJKL
+        let cmd_ctrl = egui::Modifiers {
+            ctrl: true,
+            ..egui::Modifiers::COMMAND
+        };
+        if input.consume_key(cmd_ctrl, egui::Key::H) {
+            actions.push(Action::SwapPane(Direction::Left));
+        }
+        if input.consume_key(cmd_ctrl, egui::Key::J) {
+            actions.push(Action::SwapPane(Direction::Down));
+        }
+        if input.consume_key(cmd_ctrl, egui::Key::K) {
+            actions.push(Action::SwapPane(Direction::Up));
+        }
+        if input.consume_key(cmd_ctrl, egui::Key::L) {
+            actions.push(Action::SwapPane(Direction::Right));
         }
 
         // Focus navigation (Cmd+HJKL)

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -13,12 +13,7 @@ use egui_tiles::{Container, SimplificationOptions, Tile, TileId};
 use std::collections::HashMap;
 
 pub(crate) enum SwapResult {
-    Swapped {
-        tile_a: egui_tiles::TileId,
-        rect_a: egui::Rect,
-        tile_b: egui_tiles::TileId,
-        rect_b: egui::Rect,
-    },
+    Swapped { rect_a: egui::Rect, rect_b: egui::Rect },
     AtBoundary,
     NoFocus,
 }
@@ -627,7 +622,7 @@ impl PlexiApp {
             dir, pane_a, pane_b, focused, neighbor
         );
 
-        SwapResult::Swapped { tile_a: focused, rect_a, tile_b: neighbor, rect_b }
+        SwapResult::Swapped { rect_a, rect_b }
     }
 
     pub(crate) fn scroll_focused_pane(&mut self, lines: i32) {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -12,6 +12,17 @@ use egui_term::BackendCommand;
 use egui_tiles::{Container, SimplificationOptions, Tile, TileId};
 use std::collections::HashMap;
 
+pub(crate) enum SwapResult {
+    Swapped {
+        tile_a: egui_tiles::TileId,
+        rect_a: egui::Rect,
+        tile_b: egui_tiles::TileId,
+        rect_b: egui::Rect,
+    },
+    AtBoundary,
+    NoFocus,
+}
+
 /// If `pane_id` is an app pane that was opened as an overlay over another
 /// pane (`hint = Some("overlay")`), restore the original pane and return
 /// `true`. Otherwise return `false` and leave the map unchanged.
@@ -575,6 +586,50 @@ impl PlexiApp {
         }
     }
 
+    pub(crate) fn swap_pane(&mut self, dir: Direction) -> SwapResult {
+        use egui_tiles::Tile;
+        let active = self.active_window;
+        let ctx = &mut self.windows[active];
+
+        let Some(focused) = ctx.focused_pane else {
+            return SwapResult::NoFocus;
+        };
+
+        let Some(neighbor) = ctx.find_pane_in_direction_from(focused, dir) else {
+            log::info!("swap_pane({:?}): at boundary, no neighbor", dir);
+            return SwapResult::AtBoundary;
+        };
+
+        let rect_a = ctx.tree.tiles.rect(focused).unwrap_or(egui::Rect::ZERO);
+        let rect_b = ctx.tree.tiles.rect(neighbor).unwrap_or(egui::Rect::ZERO);
+
+        let pane_a = match ctx.tree.tiles.get(focused) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+        let pane_b = match ctx.tree.tiles.get(neighbor) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(focused) {
+            *id = pane_b;
+        }
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(neighbor) {
+            *id = pane_a;
+        }
+
+        // Focus follows content: move focus to the tile now containing this pane.
+        ctx.focused_pane = Some(neighbor);
+
+        log::info!(
+            "swap_pane({:?}): pane {} ↔ pane {} (tiles {:?} ↔ {:?})",
+            dir, pane_a, pane_b, focused, neighbor
+        );
+
+        SwapResult::Swapped { tile_a: focused, rect_a, tile_b: neighbor, rect_b }
+    }
+
     pub(crate) fn scroll_focused_pane(&mut self, lines: i32) {
         let ctx = &mut self.windows[self.active_window];
         let Some(focused_tile) = ctx.focused_pane else {
@@ -652,5 +707,31 @@ impl PlexiApp {
             self.delete_window(self.active_window);
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod swap_tests {
+    use super::*;
+
+    fn test_app() -> PlexiApp {
+        let ctx = egui::Context::default();
+        let ft = crate::logging::new_frame_tick();
+        PlexiApp::new_for_test(ctx, ft)
+    }
+
+    #[test]
+    fn swap_pane_no_focus_returns_no_focus() {
+        let mut app = test_app();
+        assert!(matches!(app.swap_pane(Direction::Right), SwapResult::NoFocus));
+    }
+
+    #[test]
+    fn swap_pane_at_boundary_with_single_pane() {
+        let mut app = test_app();
+        let tile = app.windows[0].tree.tiles.insert_pane(1u64);
+        app.windows[0].focused_pane = Some(tile);
+        // No neighbors (rects unset = Rect::ZERO, geometric search returns None)
+        assert!(matches!(app.swap_pane(Direction::Right), SwapResult::AtBoundary));
     }
 }

--- a/src/pane_ops/mod.rs
+++ b/src/pane_ops/mod.rs
@@ -14,3 +14,5 @@
 mod create;
 mod layout;
 mod workspace;
+
+pub(crate) use layout::SwapResult;


### PR DESCRIPTION
## Summary

- Adds `SwapPane(Direction)` action bound to `Cmd+Ctrl+H/J/K/L`
- Swaps `PaneId` values at two `Tile::Pane` leaf nodes — tree structure and rects unchanged, pane content moves to the other position
- Focus follows the swapped pane to its new tile
- Boundary press: no-op + 120ms accent edge pulse on the blocked side
- Swap animation: translucent accent rect lerps from old position to new over 160ms ease-out cubic

## Test plan

- [ ] Open a 2-pane split (Cmd+D). Press Cmd+Ctrl+L — left pane moves right, right pane moves left. Focus follows the swapped pane.
- [ ] Press Cmd+Ctrl+H on the left-most pane — brief accent glow on the left edge, no layout change.
- [ ] Open a 3-pane layout. Swap works with directional neighbor (same as Cmd+HJKL focus navigation).
- [ ] `cargo test` green (minus pre-existing `core_pack_applies_only_when_apps_dir_empty`)

Closes #413