### PR TITLE
docs(readme): overhaul for accuracy — features + roadmap, drop stale sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
   <img src="media/screenshot-3.png" width="96%" alt="Screenshot" />
 </p>
 
-**Mac only** — Linux untested.
-
-One window. Terminals, apps, and agents all install into it — each isolated behind a single protocol (PGAP). Split any pane, run any app, talk to any agent. Nothing leaks between workspaces.
+One window. Tiling panes of terminals and Python apps, each isolated behind a single protocol (PGAP). Split any pane, run any app, chain apps together with typed pipes.
 
 ---
 
 ## Install
+
+> **macOS only.** Linux is untested.
 
 ### Download
 
@@ -36,38 +36,40 @@ curl -fsSL https://raw.githubusercontent.com/ianjamesburke/PLEXI/main/install.sh
 
 ---
 
-## Keyboard Shortcuts
+## Features
 
-| Action | Shortcut |
-|---|---|
-| Command palette | `Cmd+P` |
-| New terminal | `Cmd+N` |
-| Split right | `Cmd+D` |
-| Split below | `Cmd+Shift+D` |
-| Navigate panes | `Cmd+H/J/K/L` |
-| Move pane | `Cmd+Shift+H/J/K/L` |
-| Close pane | `Cmd+W` |
-| New context | `Cmd+T` |
-| Cycle contexts | `Cmd+]` / `Cmd+[` |
-| Zoom pane | `Cmd+Enter` |
-| Open config | `Cmd+,` |
-| Reload config | `Cmd+Shift+,` |
-| Show shortcuts | `Cmd+/` |
-| Quit | `Cmd+Q` |
+**PGAP** — every app communicates over newline-delimited JSON on stdin/stdout. No shared memory, no inherited file descriptors. Binary payloads (audio PCM, video frames) travel on typed pipes alongside the command channel.
+
+**Python app runtime** — bundled Python 3.12, self-contained. Write a Plexi app in Python with zero environment setup. Apps declare capabilities in a manifest; the host enforces them at runtime.
+
+**Tiling layout** — split panes horizontally or vertically, navigate with `Cmd+H/J/K/L`, zoom any pane to full-screen with `Cmd+Enter`. Press `Cmd+/` to see the full shortcut list.
+
+**Workspace-scoped secrets** — credentials stored in macOS Keychain, keyed to a workspace root. An app at `/foo` cannot read a secret granted at `/bar` without a new prompt.
+
+**App package manager** — install, update, uninstall, and list apps from the command palette or CLI. Ships with a bundled core pack.
+
+**AI backend** — OpenRouter with configurable model tiers and real cost tracking. `ai.query()` is available in any app via the `llm` capability.
+
+**Command palette** (`Cmd+P`) — jump to any context or named pane instantly, launch apps, run commands.
+
+**Navigation stack** — `PushNav` / `PopNav` / `NavBack` for multi-screen flows inside a single app pane.
+
+**CoreAudio + CoreMIDI** — typed pipes for audio capture and MIDI I/O. Apps request the `audio_capture` capability; the host routes PCM to the pipe.
+
+**Agent panes** — IQ turn loop backed by Claude CLI or the Anthropic API. Runs in a pane alongside your terminals and apps.
 
 ---
 
-## What's in v3
+## Roadmap
 
-- **PGAP** — clean protocol over stdin/stdout. Every pane is a `Terminal`, `App`, or `Agent`. Binary side channel via typed pipes for audio, MIDI, and video.
-- **Bundled Python 3.12** — self-contained runtime; no system Python dependency. Write apps in Python with zero setup.
-- **Workspace-scoped secrets** — a secret granted in one workspace never leaks to a sibling without a brokered prompt.
-- **App package manager** — install, uninstall, update, list with a bundled core pack.
-- **OpenRouter AI backend** — configurable model tiers, real cost tracking. `ai.query()` available in any app.
-- **Command palette** (`Cmd+P`) — jump to any context or named pane instantly.
-- **Navigation stack** — `PushNav` / `PopNav` / `NavBack` for multi-screen app flows.
-- **CoreAudio + CoreMIDI** — typed pipes for audio capture and MIDI I/O on macOS.
-- **Agent Workspace** — spawn Claude Code agents with repo context from inside Plexi.
+Near-term work tracked in GitHub Issues:
+
+- **SpawnPane** — apps open terminal and app panes programmatically ([#527](https://github.com/ianjamesburke/PLEXI/issues/527))
+- **Background apps** — apps that survive pane close and restart on demand ([#292](https://github.com/ianjamesburke/PLEXI/issues/292))
+- **Notifications** — `DrawCommand::Notify` + interactive notification panel ([#291](https://github.com/ianjamesburke/PLEXI/issues/291))
+- **Secret injection** — `emit.get_secret()` SDK method + shell env injection ([#296](https://github.com/ianjamesburke/PLEXI/issues/296))
+- **Net capability** — brokered HTTP for apps via the `net` capability ([#412](https://github.com/ianjamesburke/PLEXI/issues/412))
+- **Auto-updater** — once-a-day update check with toolbar badge ([#486](https://github.com/ianjamesburke/PLEXI/issues/486))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="media/screenshot-3.png" width="96%" alt="Screenshot" />
 </p>
 
-One window. Tiling panes of terminals and Python apps, each isolated behind a single protocol (PGAP). Split any pane, run any app, chain apps together with typed pipes.
+One binary. A tiling shell that brings Unix composability to the desktop — terminals, apps, and AI agents all speak the same protocol. Pipe output between processes, route notifications across panes, query any model from any context.
 
 ---
 
@@ -38,38 +38,31 @@ curl -fsSL https://raw.githubusercontent.com/ianjamesburke/PLEXI/main/install.sh
 
 ## Features
 
-**PGAP** — every app communicates over newline-delimited JSON on stdin/stdout. No shared memory, no inherited file descriptors. Binary payloads (audio PCM, video frames) travel on typed pipes alongside the command channel.
+**PGAP** — every pane communicates over a single protocol (newline-delimited JSON on stdin/stdout). No shared memory, no inherited file descriptors. Binary payloads travel on typed pipes alongside the command channel. The protocol is the isolation boundary.
 
-**Python app runtime** — bundled Python 3.12, self-contained. Write a Plexi app in Python with zero environment setup. Apps declare capabilities in a manifest; the host enforces them at runtime.
+**Notification bus** — any terminal process can emit a notification; any app or pane can receive it. Route events across the workspace to tie independent processes together.
 
-**Tiling layout** — split panes horizontally or vertically, navigate with `Cmd+H/J/K/L`, zoom any pane to full-screen with `Cmd+Enter`. Press `Cmd+/` to see the full shortcut list.
+**AI backend** — OpenRouter with configurable model tiers and real cost tracking. `ai.query()` is available in any app; agent panes run a full LLM turn loop backed by Claude or the Anthropic API.
+
+**App runtime** — write apps in Python (bundled 3.12, zero setup) that render native UI, play audio, capture MIDI, and communicate over typed pipes. Apps declare capabilities in a manifest; the host enforces them.
 
 **Workspace-scoped secrets** — credentials stored in macOS Keychain, keyed to a workspace root. An app at `/foo` cannot read a secret granted at `/bar` without a new prompt.
 
-**App package manager** — install, update, uninstall, and list apps from the command palette or CLI. Ships with a bundled core pack.
+**App package manager** — install, update, uninstall, and list apps from the command palette or CLI.
 
-**AI backend** — OpenRouter with configurable model tiers and real cost tracking. `ai.query()` is available in any app via the `llm` capability.
+**Tiling layout** — split panes horizontally or vertically, navigate with `Cmd+H/J/K/L`, zoom any pane full-screen with `Cmd+Enter`. Press `Cmd+/` for the full shortcut list.
 
-**Command palette** (`Cmd+P`) — jump to any context or named pane instantly, launch apps, run commands.
-
-**Navigation stack** — `PushNav` / `PopNav` / `NavBack` for multi-screen flows inside a single app pane.
-
-**CoreAudio + CoreMIDI** — typed pipes for audio capture and MIDI I/O. Apps request the `audio_capture` capability; the host routes PCM to the pipe.
-
-**Agent panes** — IQ turn loop backed by Claude CLI or the Anthropic API. Runs in a pane alongside your terminals and apps.
+**Command palette** (`Cmd+P`) — jump to any context or named pane, launch apps, run commands.
 
 ---
 
 ## Roadmap
 
-Near-term work tracked in GitHub Issues:
-
-- **SpawnPane** — apps open terminal and app panes programmatically ([#527](https://github.com/ianjamesburke/PLEXI/issues/527))
-- **Background apps** — apps that survive pane close and restart on demand ([#292](https://github.com/ianjamesburke/PLEXI/issues/292))
-- **Notifications** — `DrawCommand::Notify` + interactive notification panel ([#291](https://github.com/ianjamesburke/PLEXI/issues/291))
-- **Secret injection** — `emit.get_secret()` SDK method + shell env injection ([#296](https://github.com/ianjamesburke/PLEXI/issues/296))
-- **Net capability** — brokered HTTP for apps via the `net` capability ([#412](https://github.com/ianjamesburke/PLEXI/issues/412))
-- **Auto-updater** — once-a-day update check with toolbar badge ([#486](https://github.com/ianjamesburke/PLEXI/issues/486))
+- Background apps — persist across pane close, restart on demand
+- Apps can open terminal and app panes programmatically
+- Brokered HTTP for apps via the `net` capability
+- Secret injection into shell environment
+- Auto-updater with toolbar badge
 
 ---
 


### PR DESCRIPTION
Closes #644

## Changes

- Rewrites the lede: removes "agents all install into it" and "Nothing leaks between workspaces"
- Moves Mac-only note into the Install section as a callout
- Deletes the Keyboard Shortcuts table (in-app `Cmd+/` is the source of truth)
- Replaces "What's in v3" with a **Features** section (accurate, present-tense) and a **Roadmap** section (6 near-term issues linked by number)

## Breaks if

README on GitHub still shows "What's in v3" heading or the keyboard shortcuts table.