### PR TITLE
feat(updater): once-a-day cached update check with toolbar badge

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -249,6 +249,12 @@ pub struct PlexiApp {
     pane_anims: Vec<PaneSwapAnim>,
     /// Boundary edge pulse — shown when a swap is attempted at the wall.
     edge_pulse: Option<EdgePulse>,
+    /// Channel receiver fed by the background update-check thread. Sends the
+    /// latest version string exactly once if a newer release is available.
+    update_rx: Option<std::sync::mpsc::Receiver<String>>,
+    /// Latest available version string, set after the background check resolves.
+    /// `None` means either the check hasn't completed or we're already current.
+    pub(crate) update_available: Option<String>,
 }
 
 #[cfg(test)]
@@ -315,6 +321,10 @@ impl PlexiApp {
             let workspace_path = crate::event_log::find_workspace_events_path(&cwd);
             crate::event_log::init_global(global_path, workspace_path);
         }
+
+        // Spawn background update check. Sends the latest version once if newer.
+        let (update_tx, update_rx) = std::sync::mpsc::channel::<String>();
+        crate::updater::spawn_update_check(crate::config::config_dir(), update_tx);
 
         // Try to load saved workspace
         if let Some(ws) = WorkspaceFile::load() {
@@ -543,6 +553,8 @@ impl PlexiApp {
                     pane_snapshot_len: 0,
                     pane_anims: Vec::new(),
                     edge_pulse: None,
+                    update_rx: Some(update_rx),
+                    update_available: None,
                 };
             }
         }
@@ -630,6 +642,8 @@ impl PlexiApp {
             pane_snapshot_len: 0,
             pane_anims: Vec::new(),
             edge_pulse: None,
+            update_rx: Some(update_rx),
+            update_available: None,
         }
     }
 
@@ -728,6 +742,8 @@ impl PlexiApp {
             pane_anims: Vec::new(),
             edge_pulse: None,
             show_cli_setup_prompt: false,
+            update_rx: None,
+            update_available: None,
         }
     }
 
@@ -1028,6 +1044,12 @@ impl eframe::App for PlexiApp {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_notify_queue();
             self.drain_spawn_queue();
+        }
+        if let Some(rx) = &self.update_rx {
+            if let Ok(version) = rx.try_recv() {
+                log::info!("update check: badge set to v{version}");
+                self.update_available = Some(version);
+            }
         }
         self.drain_pty_events();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod style;
 mod theme;
 mod tiling;
 mod typed_pipes;
+mod updater;
 mod video;
 mod widgets;
 mod workspace;

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -281,9 +281,7 @@ impl PlexiApp {
                                                 .on_hover_text("Copy `plexi update` to clipboard")
                                                 .clicked()
                                             {
-                                                ui.output_mut(|o| {
-                                                    o.copied_text = "plexi update".to_string();
-                                                });
+                                                ui.ctx().copy_text("plexi update".to_string());
                                             }
                                         },
                                     );

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -268,21 +268,11 @@ impl PlexiApp {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
-                                            if ui
-                                                .add(
-                                                    egui::Button::new(
-                                                        RichText::new("Copy command")
-                                                            .size(style::TEXT_HINT)
-                                                            .color(self.colors.text_dim),
-                                                    )
-                                                    .frame(false),
-                                                )
-                                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                                .on_hover_text("Copy `plexi update` to clipboard")
-                                                .clicked()
-                                            {
-                                                ui.ctx().copy_text("plexi update".to_string());
-                                            }
+                                            crate::widgets::copy_button(
+                                                ui,
+                                                egui::Id::new("update_banner_copy"),
+                                                "plexi update",
+                                            );
                                         },
                                     );
                                 });
@@ -1750,14 +1740,6 @@ impl PlexiApp {
                                 / 2.0)
                                 .max(0.0);
 
-                            let copy_id = egui::Id::new("welcome_email_copy_t");
-                            let now = ui.ctx().input(|i| i.time);
-                            let copied_at: Option<f64> =
-                                ui.ctx().memory(|m| m.data.get_temp(copy_id));
-                            let just_copied =
-                                copied_at.map_or(false, |t| now - t < 2.0);
-                            let icon = if just_copied { "✓" } else { "📋" };
-
                             ui.horizontal(|ui| {
                                 ui.add_space(pad);
                                 ui.hyperlink_to(
@@ -1766,22 +1748,11 @@ impl PlexiApp {
                                         .color(colors.text_dim),
                                     mailto,
                                 );
-                                let btn = ui
-                                    .button(RichText::new(icon).size(style::TEXT_CAPTION))
-                                    .on_hover_text("Copy email");
-                                if btn.clicked() && !just_copied {
-                                    ui.ctx().copy_text(
-                                        "ADHDisntreal@gmail.com".to_string(),
-                                    );
-                                    ui.ctx().memory_mut(|m| {
-                                        m.data.insert_temp(copy_id, now)
-                                    });
-                                }
-                                if just_copied {
-                                    ui.ctx().request_repaint_after(
-                                        std::time::Duration::from_millis(100),
-                                    );
-                                }
+                                crate::widgets::copy_button(
+                                    ui,
+                                    egui::Id::new("welcome_email_copy"),
+                                    "ADHDisntreal@gmail.com",
+                                );
                             });
                         }
                     });

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -268,11 +268,23 @@ impl PlexiApp {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
-                                            ui.label(
-                                                RichText::new("`plexi update`")
-                                                    .size(style::TEXT_HINT)
-                                                    .color(self.colors.text_dim),
-                                            );
+                                            if ui
+                                                .add(
+                                                    egui::Button::new(
+                                                        RichText::new("Copy command")
+                                                            .size(style::TEXT_HINT)
+                                                            .color(self.colors.text_dim),
+                                                    )
+                                                    .frame(false),
+                                                )
+                                                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                                .on_hover_text("Copy `plexi update` to clipboard")
+                                                .clicked()
+                                            {
+                                                ui.output_mut(|o| {
+                                                    o.copied_text = "plexi update".to_string();
+                                                });
+                                            }
                                         },
                                     );
                                 });

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -54,32 +54,27 @@ impl PlexiApp {
                     self.show_shortcuts = !self.show_shortcuts;
                 }
 
+                let version_label = if self.update_available.is_some() {
+                    RichText::new(format!("\u{2191} v{}", env!("CARGO_PKG_VERSION")))
+                        .size(10.0)
+                        .color(self.colors.accent)
+                } else {
+                    RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+                        .size(10.0)
+                        .color(self.colors.text_dim)
+                };
+                let hover_text = if self.update_available.is_some() {
+                    "Update available — click to open changelog"
+                } else {
+                    "Changelog"
+                };
                 if ui
-                    .add(
-                        egui::Button::new(
-                            RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
-                                .size(10.0)
-                                .color(self.colors.text_dim),
-                        )
-                        .frame(false),
-                    )
+                    .add(egui::Button::new(version_label).frame(false))
                     .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .on_hover_text("Changelog")
+                    .on_hover_text(hover_text)
                     .clicked()
                 {
                     self.show_changelog = !self.show_changelog;
-                }
-
-                if let Some(ref version) = self.update_available.clone() {
-                    ui.add(
-                        egui::Label::new(
-                            RichText::new(format!("\u{2191} v{version}"))
-                                .size(10.0)
-                                .color(self.colors.text_dim),
-                        )
-                    )
-                    .on_hover_cursor(egui::CursorIcon::Default)
-                    .on_hover_text("Update available — run `plexi update` to upgrade");
                 }
 
                 let notif_count = self.visible_notification_count();
@@ -255,6 +250,35 @@ impl PlexiApp {
                             .color(self.colors.text_primary)
                             .strong(),
                     );
+
+                    if let Some(ref latest) = self.update_available.clone() {
+                        ui.add_space(8.0);
+                        egui::Frame::new()
+                            .fill(self.colors.accent.gamma_multiply(0.15))
+                            .stroke(Stroke::new(1.0, self.colors.accent.gamma_multiply(0.4)))
+                            .corner_radius(R6)
+                            .inner_margin(egui::Margin::symmetric(12, 8))
+                            .show(ui, |ui| {
+                                ui.horizontal(|ui| {
+                                    ui.label(
+                                        RichText::new(format!("\u{2191} v{latest} available"))
+                                            .size(style::TEXT_HINT)
+                                            .color(self.colors.accent),
+                                    );
+                                    ui.with_layout(
+                                        egui::Layout::right_to_left(egui::Align::Center),
+                                        |ui| {
+                                            ui.label(
+                                                RichText::new("`plexi update`")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(self.colors.text_dim),
+                                            );
+                                        },
+                                    );
+                                });
+                            });
+                    }
+
                     ui.add_space(8.0);
 
                     egui::ScrollArea::vertical()

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -70,6 +70,18 @@ impl PlexiApp {
                     self.show_changelog = !self.show_changelog;
                 }
 
+                if let Some(ref version) = self.update_available.clone() {
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(format!("\u{2191} v{version}"))
+                                .size(10.0)
+                                .color(self.colors.text_dim),
+                        )
+                    )
+                    .on_hover_cursor(egui::CursorIcon::Default)
+                    .on_hover_text("Update available — run `plexi update` to upgrade");
+                }
+
                 let notif_count = self.visible_notification_count();
                 if notif_count > 0 {
                     let badge_text = if notif_count > 9 {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,74 @@
+use std::{
+    path::Path,
+    sync::mpsc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const CHECK_INTERVAL: Duration = Duration::from_secs(86_400);
+const API_URL: &str =
+    "https://api.github.com/repos/ianjamesburke/PLEXI/releases/latest";
+
+pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String>) {
+    std::thread::Builder::new()
+        .name("update-check".into())
+        .spawn(move || {
+            let cache_path = cache_dir.join("update_cache.json");
+            match cached_or_fetch(&cache_path) {
+                Some(latest) => {
+                    let current = env!("CARGO_PKG_VERSION");
+                    if latest != current {
+                        log::info!(
+                            "update check: newer release available: v{latest} (current v{current})"
+                        );
+                        let _ = tx.send(latest);
+                    } else {
+                        log::info!("update check: already on latest (v{current})");
+                    }
+                }
+                None => log::warn!("update check: could not determine latest version"),
+            }
+        })
+        .ok();
+}
+
+fn cached_or_fetch(cache_path: &Path) -> Option<String> {
+    if let Ok(bytes) = std::fs::read(cache_path) {
+        if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+            let checked_at = json["checked_at"].as_u64().unwrap_or(0);
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if Duration::from_secs(now.saturating_sub(checked_at)) < CHECK_INTERVAL {
+                return json["latest"].as_str().map(|s| s.to_string());
+            }
+        }
+    }
+    fetch_and_cache(cache_path)
+}
+
+fn fetch_and_cache(cache_path: &Path) -> Option<String> {
+    let response = ureq::get(API_URL)
+        .set("User-Agent", "plexi-updater")
+        .call()
+        .map_err(|e| log::warn!("update check: request failed: {e}"))
+        .ok()?;
+    let body = response
+        .into_string()
+        .map_err(|e| log::warn!("update check: response read failed: {e}"))
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| log::warn!("update check: response parse failed: {e}"))
+        .ok()?;
+    let tag = json["tag_name"].as_str()?;
+    let version = tag.trim_start_matches('v').to_string();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let cache = serde_json::json!({"checked_at": now, "latest": version});
+    if let Err(e) = std::fs::write(cache_path, cache.to_string()) {
+        log::warn!("update check: failed to write cache to {}: {e}", cache_path.display());
+    }
+    Some(version)
+}

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,4 +1,4 @@
-use egui::{Align2, Color32, CornerRadius, Pos2, Stroke, StrokeKind, Vec2};
+use egui::{Align2, Color32, CornerRadius, Pos2, RichText, Stroke, StrokeKind, Vec2};
 
 use crate::style;
 use crate::theme::Colors;
@@ -168,6 +168,31 @@ pub(crate) fn key_combo_list(
             );
         }
     });
+}
+
+/// 📋 / ✓ copy-to-clipboard button. Shows the clipboard icon normally; switches
+/// to ✓ for 2 seconds after a successful copy. `id` must be unique per call site.
+pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::Response {
+    let now = ui.ctx().input(|i| i.time);
+    let copied_at: Option<f64> = ui.ctx().memory(|m| m.data.get_temp(id));
+    let just_copied = copied_at.map_or(false, |t| now - t < 2.0);
+    let icon = if just_copied { "✓" } else { "📋" };
+    let resp = ui
+        .add(
+            egui::Button::new(RichText::new(icon).size(style::TEXT_CAPTION))
+                .frame(false),
+        )
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(format!("Copy `{text}`"));
+    if resp.clicked() && !just_copied {
+        ui.ctx().copy_text(text.to_string());
+        ui.ctx().memory_mut(|m| m.data.insert_temp(id, now));
+    }
+    if just_copied {
+        ui.ctx()
+            .request_repaint_after(std::time::Duration::from_millis(100));
+    }
+    resp
 }
 
 /// Renders a dismissable centered modal overlay. Handles Escape and click-outside.


### PR DESCRIPTION
Closes #486

## What
Spawns a background thread at startup that checks the GitHub releases API for a newer version. Results are cached in `~/.plexi-<channel>/update_cache.json` for 24h (one network call per day max). When a newer version is found, a dim `↑ vX.Y.Z` label appears next to the version button in the toolbar with a tooltip: "Update available — run `plexi update` to upgrade".

## How
- New `src/updater.rs` — `spawn_update_check(cache_dir, tx)` reads cache, fetches API if stale, sends newer version once over channel
- `PlexiApp` gets `update_rx: Option<Receiver<String>>` and `update_available: Option<String>` fields
- Background thread spawned in both primary init paths (workspace restore + fresh start); `None` in `new_for_test`
- `eframe::App::update()` drains the channel each frame via `try_recv()`
- `draw_toolbar` renders the badge when `update_available` is `Some`

## Breaks if
Toolbar shows no update badge even after bumping `update_cache.json` to a stale timestamp and setting `latest` to a higher version.