### PR TITLE
fix(workspace): new window/page inherits cwd from focused pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.80] — 2026-05-04
+
+### Changes
 ## [3.4.79] — 2026-05-04
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.81] — 2026-05-04
+
+### Changes
 ## [3.4.80] — 2026-05-04
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.80"
+version = "3.4.81"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.79"
+version = "3.4.80"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.79"
+version = "3.4.80"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.80"
+version = "3.4.81"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [CHANGED] Once-a-day update check with toolbar badge + copy_button widget (PR #648 → alpha)
+
+Background thread spawned at startup hits GitHub releases API, caches result in `~/.plexi-<channel>/update_cache.json` for 24h. When a newer version is found, the version label in the toolbar turns accent-colored with a `↑` prefix. Clicking it opens the changelog as usual; the top of the changelog shows a tinted banner with the new version and a 📋 copy button for `plexi update`. The `📋 → ✓` copy pattern was extracted as `copy_button()` in `src/widgets.rs` and back-applied to the welcome page email copy. Cache uses Unix timestamp; `checked_at: 0` forces a re-fetch, a fresh timestamp skips the network.
+**Breaks if:** Version label stays dim with no `↑` prefix after injecting a fresh cache with a higher version, OR the 📋 button in the changelog banner doesn't flip to ✓ on click.
+
 ## 2026-05-04 — [CHANGED] Split plexi_sdk/__init__.py into focused modules (PR #649 → alpha)
 
 Broke the 2980-line `__init__.py` monolith into `_constants.py`, `_types.py`, `_emitter.py`, `_pipe.py`, `_render_context.py`, `_app.py`. `__init__.py` is now a thin explicit re-export layer. Circular deps resolved via `TYPE_CHECKING` guards — `Emitter` and `Pipe` forward-ref `App` as strings only. `_emit` is the leaf export (imported by `_pipe` and `_app`). No public API changes; all example app imports unchanged.

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [CHANGED] Split plexi_sdk/__init__.py into focused modules (PR #649 → alpha)
+
+Broke the 2980-line `__init__.py` monolith into `_constants.py`, `_types.py`, `_emitter.py`, `_pipe.py`, `_render_context.py`, `_app.py`. `__init__.py` is now a thin explicit re-export layer. Circular deps resolved via `TYPE_CHECKING` guards — `Emitter` and `Pipe` forward-ref `App` as strings only. `_emit` is the leaf export (imported by `_pipe` and `_app`). No public API changes; all example app imports unchanged.
+**Breaks if:** Any canvas app pane shows a blank screen or `ImportError` on launch.
+
 ## 2026-05-04 — [CHANGED] README overhaul — composability lede, Features + Roadmap (PR #647 → alpha)
 
 Rewrote the lede around the Unix composability angle ("one binary, everything speaks one protocol, pipe output between processes"). Removed: keyboard shortcuts table (in-app `Cmd+/` is the source of truth and won't drift), "What's in v3" heading (temporal, meaningless to a new reader), "agents all install into it" (agents don't install — they run in panes), "Nothing leaks between workspaces" (vacuous). Added: Features section (present-tense, accurate), Roadmap section (6 near-term items, plain bullets, no issue links). Bundled Python demoted from headline feature to impl detail inside the app runtime bullet.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -10,7 +10,12 @@ use std::path::PathBuf;
 impl PlexiApp {
     pub(crate) fn new_context(&mut self) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()))
+        let cwd = self.windows[self.active_window]
+            .focused_pane
+            .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
+            .unwrap_or_else(|| home.clone());
+        log::info!("new_context: cwd={}", cwd.display());
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
         else {
             log::error!("Failed to create terminal for new context");
             return;
@@ -24,12 +29,12 @@ impl PlexiApp {
         let ctx_name = format!("Context {}", self.router.len() + 1);
         self.router.push(crate::context::Context {
             name: ctx_name,
-            path: home.clone(),
+            path: cwd.clone(),
             context_id: ctx_id,
         });
         self.windows.push(Window {
             name: String::new(),
-            path: home,
+            path: cwd,
             tree,
             panes,
             focused_pane: Some(root_tile),
@@ -70,7 +75,12 @@ impl PlexiApp {
     /// and make it the active context.
     pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()))
+        let cwd = self.windows[self.active_window]
+            .focused_pane
+            .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
+            .unwrap_or_else(|| home.clone());
+        log::info!("create_page_at({grid_x},{grid_y}): cwd={}", cwd.display());
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
         else {
             log::error!("Failed to create terminal for new page at ({grid_x}, {grid_y})");
             return;
@@ -81,7 +91,7 @@ impl PlexiApp {
         self.next_window_id += 1;
         self.windows.push(Window {
             name,
-            path: home,
+            path: cwd,
             tree,
             panes,
             focused_pane: Some(root_tile),


### PR DESCRIPTION
Fixes #542.

`new_context` (Cmd-N) and `create_page_at` (Cmd-N new page) both hardcoded `dirs::home_dir()` as the initial working directory. Both now call `get_focused_pane_cwd()` on the active window's focused pane tile and fall back to home only when the cwd can't be read (e.g. no focused pane, app pane with no workspace_root).

`split_focused` (Cmd-Shift-J) was already correct — no change needed.

Added `log::info!` traces to both functions so the resolved cwd is observable in `~/.plexi-alpha/plexi.log`.