### PR TITLE
fix(install): add bundle.bin.plexi metadata so PR builds show correct display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.80] — 2026-05-04
+
+### Changes
 ## [3.4.79] — 2026-05-04
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.81] — 2026-05-04
+
+### Changes
 ## [3.4.80] — 2026-05-04
 
 ### Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ If you can't reproduce it or instrument it, stop and flag it. A fix written agai
 - **Test constructor sync:** When adding a field to any struct that has a `new_for_test()` constructor, update that constructor in the same commit. Before running `cargo test` on a fresh worktree, run it once on the base branch first to distinguish pre-existing failures from regressions.
 - **cargo-bundle multi-bin:** When any `[[bin]]` entry exists in `Cargo.toml`, cargo bundle assigns the metadata bundle name to the first binary it encounters; subsequent binaries fall back to their own name. Always pass `--bin plexi` to `cargo bundle` in `install.sh` and use `app_src="target/release/bundle/osx/plexi.app"` — the binary-named bundle, not the display-named one.
 - **SDK import proxy:** `plexi_sdk` is only on PYTHONPATH for Plexi-spawned app processes — a terminal pane's `python3` never sees it. Test SDK import changes by observing whether canvas apps open and render, not by running `python3` directly in a terminal.
+- **Egui clipboard API:** Before writing any egui clipboard/output call, grep the codebase for existing usage — `output_mut` is deprecated; the established pattern is `ui.ctx().copy_text(text)`.
 
 ## PlexiApp State
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.80"
+version = "3.4.81"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.79"
+version = "3.4.80"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.79"
+version = "3.4.80"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,16 @@ osx_minimum_system_version = "12.0"
 osx_info_plist_exts = ["assets/Info.plist.fragment"]
 resources = ["sdk/python/plexi_sdk", "assets/python"]
 
-# Prevent cargo-bundle from co-bundling gen_schema under the main app name.
-# Without a per-binary override, cargo-bundle assigns the package metadata
-# (name = "Plexi Alpha") to the first binary alphabetically, leaving the
-# plexi binary to fall back to "plexi.app". Setting a distinct name here
-# keeps the two bundles separate.
+# cargo-bundle assigns package metadata to the first binary alphabetically.
+# gen_schema < plexi, so without overrides gen_schema would steal "Plexi Alpha"
+# and plexi would fall back to its binary name. Both bins need explicit overrides.
 [package.metadata.bundle.bin.gen_schema]
 name = "gen_schema_tool"
+
+# install.sh sed-patches both name and identifier lines for non-stable channels.
+[package.metadata.bundle.bin.plexi]
+name = "Plexi Alpha"
+identifier = "com.ianjamesburke.plexi-alpha"
 
 [[bin]]
 name = "gen_schema"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,17 @@ resources = ["sdk/python/plexi_sdk", "assets/python"]
 [package.metadata.bundle.bin.gen_schema]
 name = "gen_schema_tool"
 
-# install.sh sed-patches both name and identifier lines for non-stable channels.
+# cargo-bundle does not merge per-binary sections with the top-level — when a
+# bin override exists it is used exclusively. All bundle fields must be present.
+# install.sh sed-patches name and identifier for non-stable channels.
 [package.metadata.bundle.bin.plexi]
 name = "Plexi Alpha"
 identifier = "com.ianjamesburke.plexi-alpha"
+icon = ["assets/app-icon.icns"]
+short_description = "Spatial terminal window manager"
+osx_minimum_system_version = "12.0"
+osx_info_plist_exts = ["assets/Info.plist.fragment"]
+resources = ["sdk/python/plexi_sdk", "assets/python"]
 
 [[bin]]
 name = "gen_schema"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plexi"
-version = "3.4.80"
+version = "3.4.81"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [CHANGED] Once-a-day update check with toolbar badge + copy_button widget (PR #648 → alpha)
+
+Background thread spawned at startup hits GitHub releases API, caches result in `~/.plexi-<channel>/update_cache.json` for 24h. When a newer version is found, the version label in the toolbar turns accent-colored with a `↑` prefix. Clicking it opens the changelog as usual; the top of the changelog shows a tinted banner with the new version and a 📋 copy button for `plexi update`. The `📋 → ✓` copy pattern was extracted as `copy_button()` in `src/widgets.rs` and back-applied to the welcome page email copy. Cache uses Unix timestamp; `checked_at: 0` forces a re-fetch, a fresh timestamp skips the network.
+**Breaks if:** Version label stays dim with no `↑` prefix after injecting a fresh cache with a higher version, OR the 📋 button in the changelog banner doesn't flip to ✓ on click.
+
 ## 2026-05-04 — [CHANGED] Split plexi_sdk/__init__.py into focused modules (PR #649 → alpha)
 
 Broke the 2980-line `__init__.py` monolith into `_constants.py`, `_types.py`, `_emitter.py`, `_pipe.py`, `_render_context.py`, `_app.py`. `__init__.py` is now a thin explicit re-export layer. Circular deps resolved via `TYPE_CHECKING` guards — `Emitter` and `Pipe` forward-ref `App` as strings only. `_emit` is the leaf export (imported by `_pipe` and `_app`). No public API changes; all example app imports unchanged.

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [CHANGED] Split plexi_sdk/__init__.py into focused modules (PR #649 → alpha)
+
+Broke the 2980-line `__init__.py` monolith into `_constants.py`, `_types.py`, `_emitter.py`, `_pipe.py`, `_render_context.py`, `_app.py`. `__init__.py` is now a thin explicit re-export layer. Circular deps resolved via `TYPE_CHECKING` guards — `Emitter` and `Pipe` forward-ref `App` as strings only. `_emit` is the leaf export (imported by `_pipe` and `_app`). No public API changes; all example app imports unchanged.
+**Breaks if:** Any canvas app pane shows a blank screen or `ImportError` on launch.
+
 ## 2026-05-04 — [CHANGED] README overhaul — composability lede, Features + Roadmap (PR #647 → alpha)
 
 Rewrote the lede around the Unix composability angle ("one binary, everything speaks one protocol, pipe output between processes"). Removed: keyboard shortcuts table (in-app `Cmd+/` is the source of truth and won't drift), "What's in v3" heading (temporal, meaningless to a new reader), "agents all install into it" (agents don't install — they run in panes), "Nothing leaks between workspaces" (vacuous). Added: Features section (present-tense, accurate), Roadmap section (6 near-term items, plain bullets, no issue links). Bundled Python demoted from headline feature to impl detail inside the app runtime bullet.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-app_src="target/release/bundle/osx/plexi.app"
+app_src="target/release/bundle/osx/${display}.app"
 app_dest="/Applications/${display}.app"
 bin_dest="/usr/local/bin/plexi${suffix}"
 profile_dir="$HOME/.plexi${suffix}"


### PR DESCRIPTION
Fixes #650.

## Root cause

`cargo-bundle` assigns `[package.metadata.bundle]` to the first binary alphabetically. `gen_schema` < `plexi`, so after PR #634 introduced the `gen_schema` bin, `gen_schema` was capturing the package metadata ("Plexi Alpha"). The `plexi` binary fell back to its binary name — lowercase "plexi", no icon.

PR #634 added `[package.metadata.bundle.bin.gen_schema]` to redirect `gen_schema` away, but didn't add a corresponding `[package.metadata.bundle.bin.plexi]` override, so `plexi` still fell back.

## Fix

Added `[package.metadata.bundle.bin.plexi]` with `name = "Plexi Alpha"` and `identifier = "com.ianjamesburke.plexi-alpha"`. The existing `sed` in `install.sh` already patches all `name = "Plexi..."` and `identifier = "com.ianjamesburke.plexi..."` occurrences — no changes to the install script needed.

## Breaks if

PR builds still show `plexi` (lowercase, no icon) in Spotlight/Alfred after install.