### PR TITLE
fix(install): move gen_schema to workspace, restore PR build display name + icon

### DIFF
--- a/.github/workflows/check-protocol.yml
+++ b/.github/workflows/check-protocol.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check schema is up to date
         run: |
-          cargo run --bin gen_schema > /tmp/fresh.schema.json
+          cargo run -p gen_schema > /tmp/fresh.schema.json
           if ! diff -q sdk/protocol/pgap.schema.json /tmp/fresh.schema.json; then
             echo "sdk/protocol/pgap.schema.json is stale. Run 'just gen-schema' and commit the result."
             diff sdk/protocol/pgap.schema.json /tmp/fresh.schema.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen_schema"
+version = "0.1.0"
+dependencies = [
+ "plexi",
+ "schemars",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["tools/gen_schema"]
+resolver = "2"
+
 [package]
 name = "plexi"
 version = "3.4.83"
@@ -14,18 +18,6 @@ osx_minimum_system_version = "12.0"
 # and capture silently records zeros (#277).
 osx_info_plist_exts = ["assets/Info.plist.fragment"]
 resources = ["sdk/python/plexi_sdk", "assets/python"]
-
-# Prevent cargo-bundle from co-bundling gen_schema under the main app name.
-# Without a per-binary override, cargo-bundle assigns the package metadata
-# (name = "Plexi Alpha") to the first binary alphabetically, leaving the
-# plexi binary to fall back to "plexi.app". Setting a distinct name here
-# keeps the two bundles separate.
-[package.metadata.bundle.bin.gen_schema]
-name = "gen_schema_tool"
-
-[[bin]]
-name = "gen_schema"
-path = "src/bin/gen_schema.rs"
 
 [[bin]]
 name = "plexi"

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ build:
 # Regenerate the canonical PGAP JSON Schema and Python protocol models.
 # Run after any change to src/app_protocol.rs.
 gen-schema:
-    cargo run --bin gen_schema > sdk/protocol/pgap.schema.json
+    cargo run -p gen_schema > sdk/protocol/pgap.schema.json
     python3 tools/gen_protocol_py.py
     @echo "Schema and Python protocol models regenerated."
 
@@ -33,7 +33,7 @@ gen-schema:
 check-schema:
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo run --bin gen_schema > /tmp/pgap_check.schema.json
+    cargo run -p gen_schema > /tmp/pgap_check.schema.json
     if ! diff -q sdk/protocol/pgap.schema.json /tmp/pgap_check.schema.json > /dev/null; then
         echo "ERROR: sdk/protocol/pgap.schema.json is stale. Run 'just gen-schema'."
         diff sdk/protocol/pgap.schema.json /tmp/pgap_check.schema.json || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-app_src="target/release/bundle/osx/plexi.app"
+app_src="target/release/bundle/osx/${display}.app"
 app_dest="/Applications/${display}.app"
 bin_dest="/usr/local/bin/plexi${suffix}"
 profile_dir="$HOME/.plexi${suffix}"
@@ -40,7 +40,7 @@ if [[ -n "$suffix" ]]; then
   sed -i '' "s/identifier = \"com.ianjamesburke.plexi[^\"]*\"/identifier = \"${bundle_id}\"/" Cargo.toml
 fi
 
-cargo bundle --release --bin plexi
+cargo bundle --release
 
 if [[ ! -d "$app_src" ]]; then
   echo "Error: bundle not found at $app_src"

--- a/tools/gen_schema/Cargo.toml
+++ b/tools/gen_schema/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gen_schema"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+plexi = { path = "../.." }
+schemars = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/tools/gen_schema/src/main.rs
+++ b/tools/gen_schema/src/main.rs
@@ -1,5 +1,5 @@
 //! Generates the canonical PGAP JSON Schema artifact.
-//! Usage: cargo run --bin gen_schema > sdk/protocol/pgap.schema.json
+//! Usage: cargo run -p gen_schema > sdk/protocol/pgap.schema.json
 
 use plexi::app_protocol::{ControlCommand, HostCommand, PlexiEvent, RenderCommand};
 


### PR DESCRIPTION
Fixes #650.

## What broke

PR #634 added `gen_schema` as a second `[[bin]]` in `Cargo.toml`. This forced `install.sh` to use `cargo bundle --release --bin plexi`, which tells cargo-bundle to use the binary name ("plexi") as the bundle name — ignoring the package metadata name ("Plexi Alpha"). PR builds and the standard alpha install both produced `plexi.app` (lowercase, no icon) instead of `Plexi Alpha.app` / `Plexi PR<N>.app`.

## Fix

Move `gen_schema` to `tools/gen_schema/` as a Cargo workspace member. The main `plexi` package now has a single binary again, so `cargo bundle --release` (no `--bin`) works correctly — the bundle name comes from `[package.metadata.bundle] name`, and `app_src` resolves to `${display}.app` as it did before PR #634.

## Changes

- `Cargo.toml` — add `[workspace]` with `members = ["tools/gen_schema"]`, remove `[[bin]] gen_schema` and `[package.metadata.bundle.bin.gen_schema]`
- `tools/gen_schema/` — new workspace member (moved from `src/bin/gen_schema.rs`)
- `scripts/install.sh` — remove `--bin plexi`, restore `app_src=".../${display}.app"`
- `justfile` + `.github/workflows/check-protocol.yml` — update `--bin gen_schema` → `-p gen_schema`

## Test plan

- [ ] `just pr-install <N>` creates `Plexi PR<N>.app` (correct name, Plexi icon) in Spotlight/Alfred
- [ ] `just gen-schema` still regenerates `sdk/protocol/pgap.schema.json`
- [ ] `cargo build` passes