### PR TITLE
fix(install): remove deleted agent apps from core pack list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.84] — 2026-05-04
+
+### Changes
 ## [3.4.83] — 2026-05-04
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3213,7 +3213,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 dependencies = [
  "base64",
  "chrono",
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4683,7 +4683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.3",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [FIX] Move gen_schema to workspace, restore PR build display name + icon (PR #655 → alpha)
+
+PR #634 added `gen_schema` as a second `[[bin]]`, forcing `install.sh` to use `cargo bundle --release --bin plexi`. The `--bin` flag tells cargo-bundle to use the binary name ("plexi") as the bundle name, ignoring `[package.metadata.bundle] name = "Plexi Alpha"`. Result: all builds (alpha, PR) produced `plexi.app` (lowercase, no icon). Fix: move `gen_schema` to `tools/gen_schema/` as a Cargo workspace member. Main package is single-binary again; `cargo bundle --release` (no `--bin`) picks up the metadata name and `app_src="${display}.app"` resolves correctly.
+**Breaks if:** `just pr-install <N>` creates `plexi.app` instead of `Plexi PR<N>.app`, or Spotlight shows the default macOS icon.
+
 ## 2026-05-04 — [CHANGED] Typed SDK command models, py.typed, and plexi validate (PR #651 → alpha)
 
 Added 6 typed dataclasses to `sdk/python/plexi_sdk/_types.py` (`TextCommand`, `RectCommand`, `BadgeCommand`, `TextInputSpec`, `ShortcutPair`, `NotifyOption`) — each validates at `__post_init__` (bad align values, negative geometry, empty required string fields). Added `py.typed` PEP 561 marker and mypy config in `pyproject.toml`. New `sdk-typecheck.yml` CI workflow runs mypy on SDK changes. Added `plexi validate <path>` CLI: reads `manifest.toml`, checks required fields (`id`, `name`, `version`, `entry`), verifies entry file exists, runs Python AST syntax check on `.py` entries. Capability validation warns on unknown capability strings. The `_render_context.py` method API is unchanged — existing app code requires no updates.

--- a/packs/core.toml
+++ b/packs/core.toml
@@ -49,15 +49,6 @@ id      = "app-store"
 source  = "local:app-store"
 version = "1.0.0"
 
-# Agent-as-app POC (#338, part 2 of #285). Demonstrates the
-# `type = "agent"` manifest path: subprocess-backed conversation
-# pane driven by `iq.query`. Requires ANTHROPIC_API_KEY in the
-# Plexi secrets store at first launch.
-[[app]]
-id      = "agent-tester"
-source  = "local:agent-tester"
-version = "0.1.0"
-
 # Video substrate POC (#345). Drives the mock decoder via
 # `video.playback`. Production AvfVideoDecoder still returns
 # NotImplemented until #346 lands real backing — launch with
@@ -65,20 +56,6 @@ version = "0.1.0"
 [[app]]
 id      = "video-player"
 source  = "local:video-player"
-version = "0.1.0"
-
-# Agent roster + inter-agent pipes POCs (#286 / v3.3 P2). Open both
-# panes, ask the coordinator to delegate to the worker, and watch the
-# round-trip surface in both conversation histories. Requires
-# ANTHROPIC_API_KEY in the Plexi secrets store.
-[[app]]
-id      = "agent-coordinator"
-source  = "local:agent-coordinator"
-version = "0.1.0"
-
-[[app]]
-id      = "agent-worker"
-source  = "local:agent-worker"
 version = "0.1.0"
 
 # Canvas Terminal Binding Primitives demo (#78 / v3.5 P1). Click any


### PR DESCRIPTION
Closes #645

## Summary
- Removed `agent-tester`, `agent-coordinator`, and `agent-worker` from `packs/core.toml` — these three apps were deleted in PR #628 but the core pack list was not updated
- Fixes `core_pack_applies_only_when_apps_dir_empty` test failure

## Test plan
- [ ] `cargo test core_pack` — all 3 tests pass