### PR TITLE
fix(sidebar): widen double-click rename hit box to full context row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.84] — 2026-05-04
+
+### Changes
 ## [3.4.83] — 2026-05-04
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3213,7 +3213,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 dependencies = [
  "base64",
  "chrono",
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4683,7 +4683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.3",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [FIX] Move gen_schema to workspace, restore PR build display name + icon (PR #655 → alpha)
+
+PR #634 added `gen_schema` as a second `[[bin]]`, forcing `install.sh` to use `cargo bundle --release --bin plexi`. The `--bin` flag tells cargo-bundle to use the binary name ("plexi") as the bundle name, ignoring `[package.metadata.bundle] name = "Plexi Alpha"`. Result: all builds (alpha, PR) produced `plexi.app` (lowercase, no icon). Fix: move `gen_schema` to `tools/gen_schema/` as a Cargo workspace member. Main package is single-binary again; `cargo bundle --release` (no `--bin`) picks up the metadata name and `app_src="${display}.app"` resolves correctly.
+**Breaks if:** `just pr-install <N>` creates `plexi.app` instead of `Plexi PR<N>.app`, or Spotlight shows the default macOS icon.
+
 ## 2026-05-04 — [CHANGED] Typed SDK command models, py.typed, and plexi validate (PR #651 → alpha)
 
 Added 6 typed dataclasses to `sdk/python/plexi_sdk/_types.py` (`TextCommand`, `RectCommand`, `BadgeCommand`, `TextInputSpec`, `ShortcutPair`, `NotifyOption`) — each validates at `__post_init__` (bad align values, negative geometry, empty required string fields). Added `py.typed` PEP 561 marker and mypy config in `pyproject.toml`. New `sdk-typecheck.yml` CI workflow runs mypy on SDK changes. Added `plexi validate <path>` CLI: reads `manifest.toml`, checks required fields (`id`, `name`, `version`, `entry`), verifies entry file exists, runs Python AST syntax check on `.py` entries. Capability validation warns on unknown capability strings. The `_render_context.py` method API is unchanged — existing app code requires no updates.

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -177,6 +177,12 @@ impl SidebarRow {
             Sense::click_and_drag(),
         );
 
+        // Full-row double-click — widens the rename hit target to the entire row
+        // (content zone excludes the action zone, leaving a 30px gap on the right)
+        let full_dblclick = ui
+            .interact(self.layout.full, id.with("full_dblclick"), Sense::click())
+            .double_clicked();
+
         // Cursor — single authority, derived from zones only
         if let Some(icon) = self.layout.resolve_cursor(ui, self.is_this_dragging, self.is_any_dragging) {
             ui.ctx().set_cursor_icon(icon);
@@ -184,7 +190,7 @@ impl SidebarRow {
 
         RowResult {
             primary_clicked: drag_response.clicked(),
-            primary_double_clicked: drag_response.double_clicked(),
+            primary_double_clicked: drag_response.double_clicked() || full_dblclick,
             drag_started: drag_response.drag_started(),
             drag_stopped: drag_response.drag_stopped(),
             action_clicked,


### PR DESCRIPTION
Fixes #367.

## What

`RowResult.primary_double_clicked` was derived from `drag_response.double_clicked()`, which is registered on `self.layout.content` — the full row minus the 30px action zone on the right. Double-clicking in that rightmost 30px did not trigger rename.

Added a separate `Sense::click()` interaction on `self.layout.full` and OR'd its `double_clicked()` into `primary_double_clicked`. Single-click and drag behavior are unchanged.

## How to verify

Open Plexi Alpha. In the sidebar with 2+ contexts, double-click:
- On the context name text → rename activates ✓
- On the left padding area of the row → rename activates ✓  
- On the right edge of the row (near the × button area) → rename activates ✓