### PR TITLE
feat(terminal): scrollback keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [3.4.84] — 2026-05-04
+
+### Changes
 ## [3.4.83] — 2026-05-04
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3213,7 +3213,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 dependencies = [
  "base64",
  "chrono",
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -3502,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4683,7 +4683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.3",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.4.83"
+version = "3.4.84"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't represent mistakes. -->
 
+## 2026-05-04 — [FIX] Move gen_schema to workspace, restore PR build display name + icon (PR #655 → alpha)
+
+PR #634 added `gen_schema` as a second `[[bin]]`, forcing `install.sh` to use `cargo bundle --release --bin plexi`. The `--bin` flag tells cargo-bundle to use the binary name ("plexi") as the bundle name, ignoring `[package.metadata.bundle] name = "Plexi Alpha"`. Result: all builds (alpha, PR) produced `plexi.app` (lowercase, no icon). Fix: move `gen_schema` to `tools/gen_schema/` as a Cargo workspace member. Main package is single-binary again; `cargo bundle --release` (no `--bin`) picks up the metadata name and `app_src="${display}.app"` resolves correctly.
+**Breaks if:** `just pr-install <N>` creates `plexi.app` instead of `Plexi PR<N>.app`, or Spotlight shows the default macOS icon.
+
 ## 2026-05-04 — [CHANGED] Typed SDK command models, py.typed, and plexi validate (PR #651 → alpha)
 
 Added 6 typed dataclasses to `sdk/python/plexi_sdk/_types.py` (`TextCommand`, `RectCommand`, `BadgeCommand`, `TextInputSpec`, `ShortcutPair`, `NotifyOption`) — each validates at `__post_init__` (bad align values, negative geometry, empty required string fields). Added `py.typed` PEP 561 marker and mypy config in `pyproject.toml`. New `sdk-typecheck.yml` CI workflow runs mypy on SDK changes. Added `plexi validate <path>` CLI: reads `manifest.toml`, checks required fields (`id`, `name`, `version`, `entry`), verifies entry file exists, runs Python AST syntax check on `.py` entries. Capability validation warns on unknown capability strings. The `_render_context.py` method API is unchanged — existing app code requires no updates.

--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -35,6 +35,8 @@ pub type SelectionType = AlacrittySelectionType;
 pub enum BackendCommand {
     Write(Vec<u8>),
     Scroll(i32),
+    ScrollToTop,
+    ScrollToBottom,
     Resize(Size, Size),
     SelectStart(SelectionType, f32, f32, f32),
     SelectUpdate(f32, f32, f32),
@@ -247,6 +249,14 @@ impl TerminalBackend {
             },
             BackendCommand::Scroll(delta) => {
                 self.scroll(&mut term, delta);
+            },
+            BackendCommand::ScrollToTop => {
+                log::info!("terminal scroll: jump to top");
+                term.grid_mut().scroll_display(Scroll::Top);
+            },
+            BackendCommand::ScrollToBottom => {
+                log::info!("terminal scroll: jump to bottom");
+                term.grid_mut().scroll_display(Scroll::Bottom);
             },
             BackendCommand::Resize(layout_size, font_size) => {
                 self.resize(&mut term, layout_size, font_size);

--- a/deps/egui_term/src/bindings.rs
+++ b/deps/egui_term/src/bindings.rs
@@ -8,6 +8,10 @@ pub enum BindingAction {
     Char(char),
     Esc(String),
     LinkOpen,
+    ScrollLines(i32),
+    ScrollPage(i32),
+    ScrollToTop,
+    ScrollToBottom,
     Ignore,
 }
 
@@ -244,6 +248,8 @@ fn default_keyboard_bindings() -> Vec<(Binding<InputKind>, BindingAction)> {
         Home,       Modifiers::SHIFT, +TerminalMode::ALT_SCREEN; BindingAction::Esc("\x1b[1;2H".into());
         PageUp,     Modifiers::SHIFT, +TerminalMode::ALT_SCREEN; BindingAction::Esc("\x1b[5;2~".into());
         PageDown,   Modifiers::SHIFT, +TerminalMode::ALT_SCREEN; BindingAction::Esc("\x1b[6;2~".into());
+        PageUp,     Modifiers::SHIFT, ~TerminalMode::ALT_SCREEN; BindingAction::ScrollPage(1);
+        PageDown,   Modifiers::SHIFT, ~TerminalMode::ALT_SCREEN; BindingAction::ScrollPage(-1);
         ArrowUp,    Modifiers::SHIFT; BindingAction::Esc("\x1b[1;2A".into());
         ArrowDown,  Modifiers::SHIFT; BindingAction::Esc("\x1b[1;2B".into());
         ArrowLeft,  Modifiers::SHIFT; BindingAction::Esc("\x1b[1;2D".into());
@@ -354,6 +360,10 @@ fn platform_keyboard_bindings() -> Vec<(Binding<InputKind>, BindingAction)> {
         KeyboardBinding;
         C, Modifiers::MAC_CMD; BindingAction::Copy;
         V, Modifiers::MAC_CMD; BindingAction::Paste;
+        ArrowUp,   Modifiers::COMMAND; BindingAction::ScrollLines(1);
+        ArrowDown, Modifiers::COMMAND; BindingAction::ScrollLines(-1);
+        Home,      Modifiers::COMMAND; BindingAction::ScrollToTop;
+        End,       Modifiers::COMMAND; BindingAction::ScrollToBottom;
     )
 }
 

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -518,7 +518,7 @@ impl<'a> TerminalView<'a> {
             painter.text(
                 Pos2::new(layout_max.x - 6.0, layout_max.y - 4.0),
                 Align2::RIGHT_BOTTOM,
-                format!("↑ {} lines", offset),
+                format!("↑ {}", offset),
                 egui::FontId::monospace(11.0),
                 Color32::from_rgba_unmultiplied(200, 200, 200, 110),
             );

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -13,6 +13,7 @@ use egui::{Align2, Color32, Painter, Pos2, Rect, Response, Stroke, Vec2};
 use egui::{Id, PointerButton};
 use std::time::{Duration, Instant};
 
+use alacritty_terminal::grid::Dimensions;
 use crate::backend::BackendCommand;
 use crate::backend::TerminalBackend;
 use crate::backend::{LinkAction, MouseButton, SelectionType};
@@ -511,6 +512,17 @@ impl<'a> TerminalView<'a> {
         }
 
         painter.extend(shapes);
+
+        let offset = content.grid.display_offset();
+        if offset > 0 {
+            painter.text(
+                Pos2::new(layout_max.x - 6.0, layout_max.y - 4.0),
+                Align2::RIGHT_BOTTOM,
+                format!("↑ {} lines", offset),
+                egui::FontId::monospace(11.0),
+                Color32::from_rgba_unmultiplied(200, 200, 200, 110),
+            );
+        }
     }
 }
 
@@ -629,6 +641,19 @@ fn process_keyboard_key(
         BindingAction::Esc(seq) => InputAction::BackendCall(
             BackendCommand::Write(seq.as_bytes().to_vec()),
         ),
+        BindingAction::ScrollLines(delta) => {
+            InputAction::BackendCall(BackendCommand::Scroll(delta))
+        },
+        BindingAction::ScrollPage(dir) => {
+            let page = backend.last_content().terminal_size.screen_lines() as i32 - 1;
+            InputAction::BackendCall(BackendCommand::Scroll(page * dir))
+        },
+        BindingAction::ScrollToTop => {
+            InputAction::BackendCall(BackendCommand::ScrollToTop)
+        },
+        BindingAction::ScrollToBottom => {
+            InputAction::BackendCall(BackendCommand::ScrollToBottom)
+        },
         _ => InputAction::Ignore,
     }
 }


### PR DESCRIPTION
Closes #602. Closes #192 (partial — copy-mode and search remain separate issues).

## What

Keyboard shortcuts for navigating terminal scrollback without entering any special mode:

| Key | Action |
|-----|--------|
| `Shift+PgUp` | Scroll up one full page (viewport height − 1 line) |
| `Shift+PgDn` | Scroll down one full page |
| `Cmd+Up` | Scroll up one line |
| `Cmd+Down` | Scroll down one line |
| `Cmd+Home` | Jump to top of scrollback |
| `Cmd+End` | Jump to bottom (resume auto-scroll) |

Bare `PgUp`/`PgDn` still send `\x1b[5~`/`\x1b[6~` to the process — unchanged.

`Shift+PgUp/Dn` in ALT_SCREEN (vim, less) still send the correct escape sequences — unchanged.

When scrolled up, a dim `↑ N lines` indicator appears in the bottom-right corner of the pane. It disappears when scrolled to the bottom.

## Changes

- `deps/egui_term/src/bindings.rs` — added `ScrollLines(i32)`, `ScrollPage(i32)`, `ScrollToTop`, `ScrollToBottom` to `BindingAction`; wired `Shift+PgUp/Dn` (non-ALT_SCREEN) and macOS `Cmd+Up/Dn/Home/End`
- `deps/egui_term/src/view.rs` — handle new binding actions in `process_keyboard_key`; scroll indicator in `show()`
- `deps/egui_term/src/backend/mod.rs` — added `ScrollToTop`/`ScrollToBottom` commands; dispatched to `Scroll::Top`/`Scroll::Bottom`