### PR TITLE
revert(sidebar): restore single-click, remove broken full-row interact

### DIFF
--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -177,12 +177,6 @@ impl SidebarRow {
             Sense::click_and_drag(),
         );
 
-        // Full-row double-click — widens the rename hit target to the entire row
-        // (content zone excludes the action zone, leaving a 30px gap on the right)
-        let full_dblclick = ui
-            .interact(self.layout.full, id.with("full_dblclick"), Sense::click())
-            .double_clicked();
-
         // Cursor — single authority, derived from zones only
         if let Some(icon) = self.layout.resolve_cursor(ui, self.is_this_dragging, self.is_any_dragging) {
             ui.ctx().set_cursor_icon(icon);
@@ -190,7 +184,7 @@ impl SidebarRow {
 
         RowResult {
             primary_clicked: drag_response.clicked(),
-            primary_double_clicked: drag_response.double_clicked() || full_dblclick,
+            primary_double_clicked: drag_response.double_clicked(),
             drag_started: drag_response.drag_started(),
             drag_stopped: drag_response.drag_stopped(),
             action_clicked,


### PR DESCRIPTION
Reverts the double-click hit-box change from PR #657.

## What broke

`ui.interact(full_row, Sense::click())` was registered after `ui.interact(content_zone, Sense::click_and_drag())`. In egui, overlapping widgets with click sense compete — the last-registered one wins. The full-row widget stole all click events, so `drag_response.clicked()` returned false and single-click context switching stopped working.

## What this does

Removes the `full_dblclick` interact and reverts `primary_double_clicked` to `drag_response.double_clicked()` only. Restores pre-#657 behavior.

## What comes next

Issue #367 (rename hit box) and this entire category of bug will be fixed properly by refactoring `SidebarRow::draw()` to return a single `SidebarAction` enum instead of `RowResult`. One `interact()` call on the full row, zone math in pure geometry — no competing egui widgets possible. Tracked in a new issue.