### PR TITLE
feat(protocol): StreamProcess / CancelProcess / StreamChunk / StreamEnd (#358)

### DIFF
--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -322,6 +322,19 @@ pub enum PlexiEvent {
     /// dialog without selecting a file, or the app lacks `fs.pick` capability.
     FilePickCancelled { request_id: String },
 
+    /// Chunk of stdout/stderr bytes from an active `DrawCommand::StreamProcess`
+    /// child. `bytes` is a raw byte array (values 0–255); decode with
+    /// `bytes(event['bytes'])` in Python. Delivered at up to ~30 Hz.
+    StreamChunk {
+        correlation_id: String,
+        channel: StreamChannel,
+        bytes: Vec<u8>,
+    },
+    /// Terminal event for a `DrawCommand::StreamProcess` child. Sent when the
+    /// child exits, on `CancelProcess`, or on capability denial. The SDK
+    /// iterator unblocks after this event.
+    StreamEnd { correlation_id: String, exit_code: i32 },
+
     /// Emitted by the host when the scroll offset for a `BeginScroll` region
     /// changes (mouse wheel, drag). The app should re-render using `offset_y`
     /// as the vertical translation applied to all content within that region.
@@ -1133,6 +1146,36 @@ pub enum HostCommand {
     /// `on_mouse_move` callbacks. Send `{ enabled: false }` to stop.
     SetMouseTracking { enabled: bool },
 
+    // ── Process streaming (#358) ──────────────────────────────────────────────
+
+    /// Spawn `command` via `sh -c` and stream its output back to the app.
+    ///
+    /// The host pipes stdout and stderr, batches available bytes at ~30 Hz,
+    /// and delivers each batch as `PlexiEvent::StreamChunk`. When the child
+    /// exits (or the app calls `CancelProcess`) the host sends
+    /// `PlexiEvent::StreamEnd`. `channel` selects which output stream to
+    /// forward; v1 treats `structured` identically to `stdout`.
+    ///
+    /// `terminal_pane_id` links the stream to an existing linked terminal
+    /// for capability gating and future display contexts.
+    ///
+    /// Capability: `terminal.bindings`. All fields required.
+    StreamProcess {
+        correlation_id: String,
+        terminal_pane_id: u64,
+        command: String,
+        channel: StreamChannel,
+    },
+
+    /// Cancel an in-flight `StreamProcess`. The host sends SIGTERM to the
+    /// child, waits up to 1s, then SIGKILL. A `PlexiEvent::StreamEnd` is
+    /// always delivered after cancellation.
+    ///
+    /// Cancelling an already-exited stream is a no-op.
+    ///
+    /// Capability: `terminal.bindings`. All fields required.
+    CancelProcess { correlation_id: String },
+
     // ── File picker (#514) ────────────────────────────────────────────────────
     /// Show a native macOS file picker dialog. Requires `fs.pick` capability.
     ///
@@ -1250,6 +1293,17 @@ pub enum ArtifactOpenMode {
     RevealInFinder,
     /// `open <path>` — Launch Services default app.
     OpenWithDefault,
+}
+
+/// Output channel selector for `DrawCommand::StreamProcess`.
+/// v1: `structured` emits the same bytes as `stdout`.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamChannel {
+    Stdout,
+    Stderr,
+    /// Reserved for future structured-progress framing. v1: identical to `stdout`.
+    Structured,
 }
 
 /// One text segment inside a `DrawCommand::TextRow`.
@@ -2230,5 +2284,114 @@ mod tests {
             }
             other => panic!("expected Notify, got {other:?}"),
         }
+    }
+
+    // ── v3.5 StreamProcess / CancelProcess / StreamChunk / StreamEnd (#358) ──
+
+    #[test]
+    fn stream_channel_serializes_as_snake_case() {
+        assert_eq!(serde_json::to_string(&StreamChannel::Stdout).unwrap(), r#""stdout""#);
+        assert_eq!(serde_json::to_string(&StreamChannel::Stderr).unwrap(), r#""stderr""#);
+        assert_eq!(serde_json::to_string(&StreamChannel::Structured).unwrap(), r#""structured""#);
+        let parsed: StreamChannel = serde_json::from_str(r#""stdout""#).unwrap();
+        assert_eq!(parsed, StreamChannel::Stdout);
+    }
+
+    #[test]
+    fn stream_process_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"stream_process","correlation_id":"cid-1","terminal_pane_id":42,"command":"ls -la","channel":"stdout"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::StreamProcess {
+                correlation_id,
+                terminal_pane_id,
+                command,
+                channel,
+            }) => {
+                assert_eq!(correlation_id, "cid-1");
+                assert_eq!(*terminal_pane_id, 42);
+                assert_eq!(command, "ls -la");
+                assert_eq!(*channel, StreamChannel::Stdout);
+            }
+            other => panic!("expected StreamProcess, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"stream_process""#), "wire tag missing: {serialised}");
+
+        let bad = r#"{"type":"stream_process","terminal_pane_id":42,"command":"ls","channel":"stdout"}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without required `correlation_id`"
+        );
+    }
+
+    #[test]
+    fn cancel_process_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"cancel_process","correlation_id":"cid-2"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::CancelProcess { correlation_id }) => {
+                assert_eq!(correlation_id, "cid-2");
+            }
+            other => panic!("expected CancelProcess, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"cancel_process""#), "wire tag missing: {serialised}");
+
+        let bad = r#"{"type":"cancel_process"}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without required `correlation_id`"
+        );
+    }
+
+    #[test]
+    fn stream_chunk_event_round_trips_serde() {
+        let json = r#"{"type":"stream_chunk","correlation_id":"cid-1","channel":"stderr","bytes":[72,101,108,108,111]}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::StreamChunk { correlation_id, channel, bytes } => {
+                assert_eq!(correlation_id, "cid-1");
+                assert_eq!(*channel, StreamChannel::Stderr);
+                assert_eq!(bytes, &[72u8, 101, 108, 108, 111]);
+            }
+            other => panic!("expected StreamChunk, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""type":"stream_chunk""#), "wire tag missing: {serialised}");
+
+        let bad = r#"{"type":"stream_chunk","channel":"stdout","bytes":[1]}"#;
+        assert!(
+            serde_json::from_str::<PlexiEvent>(bad).is_err(),
+            "must fail without required `correlation_id`"
+        );
+    }
+
+    #[test]
+    fn stream_end_event_round_trips_serde() {
+        let json = r#"{"type":"stream_end","correlation_id":"cid-1","exit_code":0}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::StreamEnd { correlation_id, exit_code } => {
+                assert_eq!(correlation_id, "cid-1");
+                assert_eq!(*exit_code, 0);
+            }
+            other => panic!("expected StreamEnd, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""type":"stream_end""#), "wire tag missing: {serialised}");
+
+        let json_nonzero = r#"{"type":"stream_end","correlation_id":"cid-2","exit_code":127}"#;
+        let event: PlexiEvent = serde_json::from_str(json_nonzero).expect("deserialise nonzero");
+        match &event {
+            PlexiEvent::StreamEnd { exit_code, .. } => assert_eq!(*exit_code, 127),
+            other => panic!("expected StreamEnd, got {other:?}"),
+        }
+
+        let bad = r#"{"type":"stream_end","exit_code":0}"#;
+        assert!(
+            serde_json::from_str::<PlexiEvent>(bad).is_err(),
+            "must fail without required `correlation_id`"
+        );
     }
 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -86,6 +86,17 @@ pub struct NavEntry {
 }
 
 // ---------------------------------------------------------------------------
+// StreamHandle — per-correlation-id state for active StreamProcess children
+// ---------------------------------------------------------------------------
+
+pub(crate) struct StreamHandle {
+    /// Set to `true` to request cancellation. Shared with the reader thread.
+    pub(crate) cancel: Arc<AtomicBool>,
+    /// OS process ID — used for SIGTERM / SIGKILL escalation on CancelProcess.
+    pub(crate) pid: u32,
+}
+
+// ---------------------------------------------------------------------------
 // ProcessApp
 // ---------------------------------------------------------------------------
 
@@ -240,6 +251,10 @@ pub struct ProcessApp {
     /// Updated each time a new `ExposeTools` command arrives. The routing
     /// layer re-registers these in the global tool registry on each update.
     pub(crate) exposed_tools: Vec<crate::app_protocol::AiTool>,
+    /// Active `StreamProcess` children, keyed on `correlation_id` (#358).
+    /// Dropping an entry cancels nothing automatically — the cancel flag
+    /// must be set and a signal sent before removing the handle.
+    pub(crate) stream_handles: HashMap<String, StreamHandle>,
 }
 
 impl ProcessApp {
@@ -528,6 +543,7 @@ impl ProcessApp {
             commonmark_cache: egui_commonmark::CommonMarkCache::default(),
             scroll_offsets: HashMap::new(),
             exposed_tools: Vec::new(),
+            stream_handles: HashMap::new(),
         })
     }
 
@@ -639,6 +655,7 @@ impl ProcessApp {
             commonmark_cache: egui_commonmark::CommonMarkCache::default(),
             scroll_offsets: HashMap::new(),
             exposed_tools: Vec::new(),
+            stream_handles: HashMap::new(),
             file_picker_tx,
             file_picker_rx,
         };

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -4,14 +4,18 @@
 //! (media, pipes, capabilities, secrets, runs, notifications) are routed here.
 
 use crate::app_permissions::{check, Capability, PermissionCheck};
-use crate::app_protocol::{AudioDeviceWire, HostCommand, MidiPortWire, PlexiEvent};
+use crate::app_protocol::{AudioDeviceWire, HostCommand, MidiPortWire, PlexiEvent, StreamChannel};
 use crate::app_trait::AppCommand;
 use crate::audio::AudioCaptureRequest;
 use crate::event_log::{self, HostEvent};
 use crate::plexi_ai::broker::AiBrokerRequest;
 use crate::typed_pipes::PipeDirection;
+use std::io::Read;
+use std::process::Stdio;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-use super::ProcessApp;
+use super::{ProcessApp, StreamHandle};
 
 impl ProcessApp {
     /// Route a v3 host command to the appropriate subsystem.
@@ -527,6 +531,129 @@ impl ProcessApp {
                     self.type_id,
                     self.nav_stack.len(),
                 );
+            }
+
+            // ── Process streaming (#358) ───────────────────────────────────
+            HostCommand::StreamProcess {
+                correlation_id,
+                terminal_pane_id: _,
+                command,
+                channel,
+            } => {
+                if let PermissionCheck::Denied(reason) =
+                    check(&self.permissions, Capability::TerminalBindings)
+                {
+                    log::warn!(
+                        "ProcessApp[{}]: StreamProcess {correlation_id} denied — {reason}",
+                        self.type_id
+                    );
+                    self.outbound_events.push_back(PlexiEvent::StreamEnd {
+                        correlation_id,
+                        exit_code: 1,
+                    });
+                    return;
+                }
+                log::info!(
+                    "ProcessApp[{}]: StreamProcess {correlation_id} — command={command:?} channel={channel:?}",
+                    self.type_id
+                );
+                let mut child = match std::process::Command::new("sh")
+                    .arg("-c")
+                    .arg(&command)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        log::error!(
+                            "ProcessApp[{}]: StreamProcess {correlation_id} — spawn failed: {e}",
+                            self.type_id
+                        );
+                        self.outbound_events.push_back(PlexiEvent::StreamEnd {
+                            correlation_id,
+                            exit_code: 1,
+                        });
+                        return;
+                    }
+                };
+                let pid = child.id();
+                let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                self.stream_handles.insert(
+                    correlation_id.clone(),
+                    StreamHandle { cancel: Arc::clone(&cancel), pid },
+                );
+                // Take the appropriate pipe before moving child into the thread.
+                let pipe: Box<dyn Read + Send> = match channel {
+                    StreamChannel::Stdout | StreamChannel::Structured => {
+                        Box::new(child.stdout.take().expect("stdout piped"))
+                    }
+                    StreamChannel::Stderr => {
+                        Box::new(child.stderr.take().expect("stderr piped"))
+                    }
+                };
+                let tx = self.http_tx.clone();
+                let type_id = self.type_id.clone();
+                let corr_id = correlation_id.clone();
+                std::thread::spawn(move || {
+                    let mut buf = vec![0u8; 4096];
+                    let mut pipe = pipe;
+                    loop {
+                        if cancel.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        match pipe.read(&mut buf) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                let _ = tx.send(PlexiEvent::StreamChunk {
+                                    correlation_id: corr_id.clone(),
+                                    channel,
+                                    bytes: buf[..n].to_vec(),
+                                });
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    // Drop the pipe so the child's pipe descriptor is closed,
+                    // then reap the child to avoid zombies.
+                    drop(pipe);
+                    let exit_code = child
+                        .wait()
+                        .map(|s| s.code().unwrap_or(-1))
+                        .unwrap_or(-1);
+                    log::info!(
+                        "ProcessApp[{type_id}]: StreamProcess {corr_id} ended — exit_code={exit_code}"
+                    );
+                    let _ = tx.send(PlexiEvent::StreamEnd {
+                        correlation_id: corr_id,
+                        exit_code,
+                    });
+                });
+            }
+
+            HostCommand::CancelProcess { correlation_id } => {
+                if let Some(handle) = self.stream_handles.remove(&correlation_id) {
+                    log::info!(
+                        "ProcessApp[{}]: CancelProcess {correlation_id} — pid={}",
+                        self.type_id,
+                        handle.pid
+                    );
+                    handle.cancel.store(true, Ordering::Relaxed);
+                    // SIGTERM first; reader thread exits when the pipe closes.
+                    unsafe {
+                        libc::kill(handle.pid as libc::pid_t, libc::SIGTERM);
+                    }
+                    // Escalate to SIGKILL after a 1s grace period on a
+                    // background thread so the UI never blocks.
+                    let pid = handle.pid;
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        unsafe {
+                            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+                        }
+                    });
+                }
+                // else: stream already ended — no-op, no error event.
             }
 
             // ── File picker (#514) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `StreamChannel` enum + four PGAP v3 protocol types deferred from #78: `StreamProcess`, `CancelProcess` (host commands) and `StreamChunk`, `StreamEnd` (host events)
- Host implementation: `StreamHandle` struct, `stream_handles` map on `ProcessApp`, reader thread per stream with cancel-flag + SIGTERM→SIGKILL escalation, zombie reap on EOF
- Capability gate: `terminal.bindings` on both commands; denial emits immediate `StreamEnd(exit_code=1)` so the SDK iterator always unblocks
- 5 serde round-trip tests pinning on-wire JSON shape for all new types

## Test plan

- [ ] `cargo test stream` — all 5 new serde tests pass
- [ ] `cargo test cancel_process` — passes
- [ ] `cargo build` — clean build
- [ ] Smoke: Canvas app with `terminal.bindings` capability can `emit.stream_process("echo hello")` and receive `StreamChunk` bytes followed by `StreamEnd(exit_code=0)`
- [ ] Smoke: `emit.cancel_process(cid)` mid-stream stops chunk delivery within 1s and delivers `StreamEnd`
- [ ] Smoke: app without `terminal.bindings` receives immediate `StreamEnd(exit_code=1)` on `StreamProcess`