### PR TITLE
feat(notifications): timeout/on_dismiss + tombstone when source pane closes

### DIFF
--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -7,7 +7,7 @@ import threading
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, PROTOCOL_VERSION
+from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList
 from ._types import CapabilityDeniedError, VideoHandle, AgentInfo
 
 if TYPE_CHECKING:
@@ -63,7 +63,9 @@ class Emitter:
                priority: "int | None" = None,
                actions: "list | None" = None,
                image_inline: "dict | None" = None,
-               image_pipe_id: "str | None" = None) -> None:
+               image_pipe_id: "str | None" = None,
+               timeout_secs: "int | None" = None,
+               on_dismiss: "str | None" = None) -> None:
         """Post a message notification. The modal shows title + body and a
         single Acknowledge button; Enter / Space acknowledge, Esc dismisses
         (unless required=True — use `notify_and_wait` for that flow).
@@ -87,6 +89,10 @@ class Emitter:
             payload["image_inline"] = image_inline
         if image_pipe_id is not None:
             payload["image_pipe_id"] = image_pipe_id
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
         _emit(payload)
 
     def run_sync(self, coro: "Any") -> Any:
@@ -117,7 +123,9 @@ class Emitter:
                             level: str = "info", required: bool = False,
                             priority: "int | None" = None,
                             image_inline: "dict | None" = None,
-                            image_pipe_id: "str | None" = None) -> str:
+                            image_pipe_id: "str | None" = None,
+                            timeout_secs: "int | None" = None,
+                            on_dismiss: "str | None" = None) -> str:
         """Post a choice notification and await until the user picks one.
 
         `options` is a list of dicts: {"label": str, "value": str (optional),
@@ -148,6 +156,10 @@ class Emitter:
             payload["image_inline"] = image_inline
         if image_pipe_id is not None:
             payload["image_pipe_id"] = image_pipe_id
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
         _emit(payload)
         return await q.get()
 
@@ -202,7 +214,9 @@ class Emitter:
     # kind = "input"
     async def notify_input(self, title: str, prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
-                           priority: "int | None" = None) -> str:
+                           priority: "int | None" = None,
+                           timeout_secs: "int | None" = None,
+                           on_dismiss: "str | None" = None) -> str:
         """Post an input notification and await until the user submits or
         cancels. Returns the typed text (possibly empty), or "__cancel__" if
         the user dismissed with Esc (only possible when required=False).
@@ -217,15 +231,22 @@ class Emitter:
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
-        _emit({"type": "notify", "level": level, "title": title, "body": body,
-               "kind": "input", "input_prompt": prompt, "required": required,
-               "priority": int(priority),
-               "notify_id": notify_id})
+        payload = {"type": "notify", "level": level, "title": title, "body": body,
+                   "kind": "input", "input_prompt": prompt, "required": required,
+                   "priority": int(priority),
+                   "notify_id": notify_id}
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
+        _emit(payload)
         return await q.get()
 
     async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
                               actions: "list | None" = None,
-                              priority: "int | None" = None) -> str:
+                              priority: "int | None" = None,
+                              timeout_secs: "int | None" = None,
+                              on_dismiss: "str | None" = None) -> str:
         """Post a message notification and await until the user acknowledges
         or cancels. Returns "acknowledge" on Enter/Space/button, "cancel" on Esc.
 
@@ -241,10 +262,15 @@ class Emitter:
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
-        _emit({"type": "notify", "level": level, "title": title, "body": body,
-               "kind": "message", "actions": actions or [],
-               "priority": int(priority),
-               "notify_id": notify_id})
+        payload = {"type": "notify", "level": level, "title": title, "body": body,
+                   "kind": "message", "actions": actions or [],
+                   "priority": int(priority),
+                   "notify_id": notify_id}
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
+        _emit(payload)
         return await q.get()
 
     # Terminal commands (legacy back-compat)

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -111,6 +111,9 @@ impl PlexiApp {
                         priority,
                         image_inline,
                         image_pipe_id,
+                        timeout_secs,
+                        on_dismiss,
+                        tombstoned,
                         ..
                     } => {
                         let ws_idx = self.windows.get(ctx_idx)
@@ -131,6 +134,9 @@ impl PlexiApp {
                             scope: resolved_scope,
                             image_inline,
                             image_pipe_id,
+                            timeout_secs,
+                            on_dismiss,
+                            tombstoned,
                         });
                     }
                     AppCommand::DeliverNotifyAction { .. } => deferred.push(cmd),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -86,6 +86,13 @@ pub(crate) struct PendingNotification {
     /// the chosen value here when the user picks an option so the blocking CLI
     /// process can read it and exit.
     pub response_file: Option<String>,
+    /// Auto-dismiss deadline. Set at enqueue time when `timeout_secs` is Some.
+    pub expires_at: Option<std::time::Instant>,
+    /// Payload delivered as response when the notification times out.
+    pub on_dismiss: Option<String>,
+    /// True when the originating app pane has closed. The modal still shows
+    /// the card (user can still dismiss) but renders a "source ended" label.
+    pub tombstoned: bool,
 }
 
 /// Render state for a notification's image attachment. Computed once and
@@ -846,6 +853,9 @@ impl PlexiApp {
                 image_inline: None,
                 image_pipe_id: None,
                 response_file,
+                expires_at: None,
+                on_dismiss: None,
+                tombstoned: false,
             });
             // Host-originated notifications are always LOW (priority 0) —
             // below any reasonable interrupt threshold — so they queue
@@ -860,6 +870,41 @@ impl PlexiApp {
                 }
             }
         }
+    }
+
+    fn tick_notification_timeouts(&mut self) -> Vec<crate::app_trait::AppCommand> {
+        let now = std::time::Instant::now();
+        let mut cmds = Vec::new();
+        let mut expired_ids: Vec<String> = Vec::new();
+        for notif in &self.pending_notifications {
+            if notif.expires_at.map(|t| now >= t).unwrap_or(false) {
+                log::info!(
+                    "notify: timeout '{}' expired — delivering on_dismiss={:?}",
+                    notif.title, notif.on_dismiss
+                );
+                if !notif.notify_id.is_empty() && notif.sender_pane_id > 0 {
+                    cmds.push(crate::app_trait::AppCommand::DeliverNotifyAction {
+                        pane_id: notif.sender_pane_id,
+                        notify_id: notif.notify_id.clone(),
+                        action_label: "__timeout__".to_string(),
+                        value: notif.on_dismiss.clone(),
+                        response_file: notif.response_file.clone(),
+                    });
+                }
+                expired_ids.push(notif.notify_id.clone());
+            }
+        }
+        if !expired_ids.is_empty() {
+            self.pending_notifications
+                .retain(|n| !expired_ids.contains(&n.notify_id));
+            // If the current notification timed out, clear the pin.
+            if let Some(cur) = &self.current_notify_id {
+                if expired_ids.contains(cur) {
+                    self.current_notify_id = None;
+                }
+            }
+        }
+        cmds
     }
 
     fn drain_spawn_queue(&mut self) {
@@ -926,6 +971,16 @@ impl PlexiApp {
         }
 
         for pane_id in panes_to_close {
+            // Tombstone any pending notifications from this closed pane.
+            let tombstone_count = self.pending_notifications.iter()
+                .filter(|n| n.sender_pane_id == pane_id)
+                .count();
+            if tombstone_count > 0 {
+                log::info!("notify: tombstoning {tombstone_count} notifications from pane {pane_id}");
+                self.pending_notifications.iter_mut()
+                    .filter(|n| n.sender_pane_id == pane_id)
+                    .for_each(|n| n.tombstoned = true);
+            }
             self.close_pane_by_id(pane_id);
         }
     }
@@ -1044,6 +1099,10 @@ impl eframe::App for PlexiApp {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_notify_queue();
             self.drain_spawn_queue();
+        }
+        let timeout_cmds = self.tick_notification_timeouts();
+        for cmd in timeout_cmds {
+            self.dispatch_notify_action_cmds(vec![cmd]);
         }
         if let Some(rx) = &self.update_rx {
             if let Ok(version) = rx.try_recv() {
@@ -1273,6 +1332,9 @@ impl eframe::App for PlexiApp {
                     scope,
                     image_inline,
                     image_pipe_id,
+                    timeout_secs,
+                    on_dismiss,
+                    tombstoned,
                 } => {
                     if !self.notifications_enabled {
                         // Silently drop — master switch off.
@@ -1282,6 +1344,10 @@ impl eframe::App for PlexiApp {
                     // Capture scope/source_context before they move into the struct.
                     let is_global = matches!(scope, crate::app_protocol::NotifyScope::Global);
                     let notif_source_ctx = source_context;
+                    let expires_at = timeout_secs.map(|s| {
+                        std::time::Instant::now()
+                            + std::time::Duration::from_secs(s as u64)
+                    });
                     self.pending_notifications.push(PendingNotification {
                         notify_id,
                         sender_pane_id,
@@ -1298,6 +1364,9 @@ impl eframe::App for PlexiApp {
                         image_inline,
                         image_pipe_id,
                         response_file: None,
+                        expires_at,
+                        on_dismiss,
+                        tombstoned,
                     });
                     // Auto-open rules:
                     //   1. Visibility (Global or in active context) — else

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -824,9 +824,13 @@ impl PlexiApp {
                 crate::app_protocol::NotifyKind::Choice
             };
             let response_file = val["response_file"].as_str().map(|s| s.to_string());
+            let timeout_secs = val["timeout_secs"].as_u64().map(|s| s as u32);
+            let on_dismiss = val["on_dismiss"].as_str().map(|s| s.to_string());
+            let expires_at = timeout_secs
+                .map(|s| std::time::Instant::now() + std::time::Duration::from_secs(s as u64));
             log::info!(
-                "notify:drain: title={:?} choices={} response_file={:?}",
-                title, options.len(), response_file
+                "notify:drain: title={:?} choices={} response_file={:?} timeout={:?}",
+                title, options.len(), response_file, timeout_secs
             );
             let internal_id = format!(
                 "__host__:{}",
@@ -853,8 +857,8 @@ impl PlexiApp {
                 image_inline: None,
                 image_pipe_id: None,
                 response_file,
-                expires_at: None,
-                on_dismiss: None,
+                expires_at,
+                on_dismiss,
                 tombstoned: false,
             });
             // Host-originated notifications are always LOW (priority 0) —
@@ -902,6 +906,10 @@ impl PlexiApp {
                 if expired_ids.contains(cur) {
                     self.current_notify_id = None;
                 }
+            }
+            // Close the modal if the queue is now empty.
+            if self.pending_notifications.is_empty() {
+                self.show_notification_modal = false;
             }
         }
         cmds

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -801,6 +801,15 @@ pub enum HostCommand {
         /// `height: u32 LE`, then `width * height * 4` bytes of RGBA.
         #[serde(skip_serializing_if = "Option::is_none")]
         image_pipe_id: Option<String>,
+        /// Optional auto-dismiss after this many seconds. When elapsed, the host
+        /// removes the notification and delivers `on_dismiss` as the response
+        /// if a `notify_id` was set.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_secs: Option<u32>,
+        /// Payload delivered as the response value when the notification is
+        /// dismissed by timeout. Ignored if `timeout_secs` is None.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        on_dismiss: Option<String>,
     },
     /// Open a typed pipe.
     /// mode: "json" | "binary"

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -82,6 +82,9 @@ pub enum AppCommand {
         /// `height: u32 LE`, then RGBA bytes. Mutually exclusive with
         /// `image_inline` — if both set, inline wins.
         image_pipe_id: Option<String>,
+        timeout_secs: Option<u32>,
+        on_dismiss: Option<String>,
+        tombstoned: bool,
     },
     /// Route a NotifyAction event back to the app pane that sent the Notify.
     DeliverNotifyAction {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1009,6 +1009,18 @@ impl PlexiApp {
 
                         ui.add_space(style::SPACE_XL);
 
+                        // Tombstone banner — shown when the originating app pane has closed.
+                        if notif.tombstoned {
+                            ui.vertical_centered(|ui| {
+                                ui.label(
+                                    RichText::new("source ended")
+                                        .size(style::TEXT_HINT)
+                                        .color(self.colors.text_dim),
+                                );
+                            });
+                            ui.add_space(style::SPACE_SM);
+                        }
+
                         // Title — centered, large.
                         ui.vertical_centered(|ui| {
                             ui.label(

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -252,6 +252,8 @@ impl ProcessApp {
                 priority,
                 image_inline,
                 image_pipe_id,
+                timeout_secs,
+                on_dismiss,
             } => {
                 let notif_id = format!("{}-{}", self.type_id, event_log::now_timestamp());
                 log::info!(
@@ -364,6 +366,9 @@ impl ProcessApp {
                     scope: crate::app_protocol::NotifyScope::Context,
                     image_inline,
                     image_pipe_id,
+                    timeout_secs,
+                    on_dismiss,
+                    tombstoned: false,
                 });
                 // `actions` intentionally dropped: they were already processed
                 // as server-side side effects above (resume_run / open_intent /


### PR DESCRIPTION
Closes #291

## What changed

Three missing pieces from the notification acceptance criteria:

**timeout_secs + on_dismiss** — Apps can now pass `timeout_secs` and `on_dismiss` to any notify variant. The host sweeps expired notifications every frame, removes them from the queue, and delivers `on_dismiss` as a `NotifyAction` response if `notify_id` was set.

**Tombstone on pane close** — When a canvas app pane closes, its pending notifications are marked `tombstoned` rather than removed. The modal renders a dim "source ended" label above the title so the user knows the originating app is gone but can still dismiss the card.

**Python SDK** — `timeout_secs: int | None` and `on_dismiss: str | None` added to all four `emit.notify*()` variants. Backward-compatible (both optional).

## Wire format

New fields on `HostCommand::Notify` use `#[serde(skip_serializing_if = "Option::is_none")]` — existing apps without these fields parse correctly.

**Breaks if:** A canvas app notification times out but the "source ended" label never appears on tombstoned cards, or `on_dismiss` is not delivered on timeout expiry.