### PR TITLE
feat(ux): show welcome screen when last pane in a context is closed

### DIFF
--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -696,10 +696,15 @@ impl PlexiApp {
         if !self.windows[self.active_window].panes.is_empty() {
             self.close_focused();
         }
-        // If the window is now empty and there are others in the same context,
-        // delete it and switch — don't strand the user on a blank welcome screen.
+        // If the window is now empty, only delete it when there are other pages
+        // in the same context (i.e. it's one of several pages). When it's the
+        // sole page, keep it alive so the welcome screen renders.
         if self.windows[self.active_window].panes.is_empty() {
-            self.delete_window(self.active_window);
+            let ctx_id = self.windows[self.active_window].context_id;
+            let pages_in_context = self.windows.iter().filter(|w| w.context_id == ctx_id).count();
+            if pages_in_context > 1 {
+                self.delete_window(self.active_window);
+            }
         }
         false
     }


### PR DESCRIPTION
## Summary

- Closing the last pane in a context no longer deletes the context
- The context stays in the sidebar; the main area shows the existing welcome screen
- If a context has multiple pages (windows), closing the last pane on one page still removes that page — only the single-page case is changed

## How it works

`execute_close_pane` previously called `delete_window` whenever a window became empty. Now it only deletes the window if there are other pages in the same context. When it's the sole page, the empty window is kept and the existing `panes.is_empty()` check in the render loop shows the welcome screen.

## Test plan

- [ ] Open Plexi, create a second context (Cmd-N). Close its pane (Cmd-W). Context stays in sidebar and shows welcome screen.
- [ ] From the welcome screen, open a new terminal (Cmd-T). Pane appears normally.
- [ ] With a multi-page context: close the last pane on one page. That page is deleted; remaining pages stay.
- [ ] Clicking × on a context in the sidebar still deletes the context immediately (unchanged path).
- [ ] With only one context total: Cmd-W on the last pane shows welcome screen (was already working).