### PR TITLE
feat(notifications): timeout_secs/on_dismiss, tombstone, required-pinned

### DIFF
--- a/examples/notification-tester/notification_tester.py
+++ b/examples/notification-tester/notification_tester.py
@@ -18,6 +18,10 @@ Priority tiers (how urgently it sorts in the queue):
   3 — HIGH       (100)  needs attention soon
   4 — CRITICAL   (200)  interrupt-level
 
+Timeout / auto-dismiss:
+  x — Auto-dismiss: fires a notification that disappears after 10 s with
+      on_dismiss="auto_dismissed". Verify via the event log.
+
 Queue demos:
   b — Burst: three messages at mixed priorities (CRITICAL / LOW / NORMAL).
       Good for verifying the live queue grows without displacing the pinned
@@ -220,6 +224,18 @@ class NotificationTesterApp(App):
         )
         self._append(f"sent: oversized image ({len(big)} bytes)")
 
+    # ── Timeout / auto-dismiss ────────────────────────────────────────────
+    def _fire_timeout(self) -> None:
+        """Auto-dismiss notification — disappears after 10 seconds."""
+        self.emit.notify(
+            title="Auto-dismiss test",
+            body="This notification disappears in 10 seconds.",
+            priority=PRIORITY_NORMAL,
+            timeout_secs=10,
+            on_dismiss="auto_dismissed",
+        )
+        self._append("sent: auto-dismiss @ 10s")
+
     # ── Queue demos ───────────────────────────────────────────────────────
     def _fire_burst(self) -> None:
         """3 notifications at mixed priorities in one sync pass.
@@ -273,6 +289,8 @@ class NotificationTesterApp(App):
         elif k == "p": self._fire_inline_image()
         elif k == "q": self._fire_inline_image_choice()
         elif k == "t": self._fire_oversized_image()
+        # Timeout
+        elif k == "x": self._fire_timeout()
         # Queue demos
         elif k == "b": self._fire_burst()
         elif k == "s": self._fire_stack()
@@ -299,6 +317,10 @@ class NotificationTesterApp(App):
                 KeyRow("p", "Inline PNG message — 64x64 gradient"),
                 KeyRow("q", "Inline PNG choice — 3 structured choices"),
                 KeyRow("t", "Oversized inline image — placeholder fires at 50 KB"),
+            ]),
+            Section("Timeout / auto-dismiss"),
+            Card([
+                KeyRow("x", "Auto-dismiss — disappears after 10 s"),
             ]),
             Section("Queue demos"),
             Card([

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -7,7 +7,7 @@ import threading
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList, PROTOCOL_VERSION
+from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList
 from ._types import CapabilityDeniedError, VideoHandle, AgentInfo
 
 if TYPE_CHECKING:
@@ -63,7 +63,9 @@ class Emitter:
                priority: "int | None" = None,
                actions: "list | None" = None,
                image_inline: "dict | None" = None,
-               image_pipe_id: "str | None" = None) -> None:
+               image_pipe_id: "str | None" = None,
+               timeout_secs: "int | None" = None,
+               on_dismiss: "str | None" = None) -> None:
         """Post a message notification. The modal shows title + body and a
         single Acknowledge button; Enter / Space acknowledge, Esc dismisses
         (unless required=True — use `notify_and_wait` for that flow).
@@ -87,6 +89,10 @@ class Emitter:
             payload["image_inline"] = image_inline
         if image_pipe_id is not None:
             payload["image_pipe_id"] = image_pipe_id
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
         _emit(payload)
 
     def run_sync(self, coro: "Any") -> Any:
@@ -117,7 +123,9 @@ class Emitter:
                             level: str = "info", required: bool = False,
                             priority: "int | None" = None,
                             image_inline: "dict | None" = None,
-                            image_pipe_id: "str | None" = None) -> str:
+                            image_pipe_id: "str | None" = None,
+                            timeout_secs: "int | None" = None,
+                            on_dismiss: "str | None" = None) -> str:
         """Post a choice notification and await until the user picks one.
 
         `options` is a list of dicts: {"label": str, "value": str (optional),
@@ -148,6 +156,10 @@ class Emitter:
             payload["image_inline"] = image_inline
         if image_pipe_id is not None:
             payload["image_pipe_id"] = image_pipe_id
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
         _emit(payload)
         return await q.get()
 
@@ -202,7 +214,9 @@ class Emitter:
     # kind = "input"
     async def notify_input(self, title: str, prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
-                           priority: "int | None" = None) -> str:
+                           priority: "int | None" = None,
+                           timeout_secs: "int | None" = None,
+                           on_dismiss: "str | None" = None) -> str:
         """Post an input notification and await until the user submits or
         cancels. Returns the typed text (possibly empty), or "__cancel__" if
         the user dismissed with Esc (only possible when required=False).
@@ -217,15 +231,22 @@ class Emitter:
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
-        _emit({"type": "notify", "level": level, "title": title, "body": body,
-               "kind": "input", "input_prompt": prompt, "required": required,
-               "priority": int(priority),
-               "notify_id": notify_id})
+        payload = {"type": "notify", "level": level, "title": title, "body": body,
+                   "kind": "input", "input_prompt": prompt, "required": required,
+                   "priority": int(priority),
+                   "notify_id": notify_id}
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
+        _emit(payload)
         return await q.get()
 
     async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
                               actions: "list | None" = None,
-                              priority: "int | None" = None) -> str:
+                              priority: "int | None" = None,
+                              timeout_secs: "int | None" = None,
+                              on_dismiss: "str | None" = None) -> str:
         """Post a message notification and await until the user acknowledges
         or cancels. Returns "acknowledge" on Enter/Space/button, "cancel" on Esc.
 
@@ -241,10 +262,15 @@ class Emitter:
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
-        _emit({"type": "notify", "level": level, "title": title, "body": body,
-               "kind": "message", "actions": actions or [],
-               "priority": int(priority),
-               "notify_id": notify_id})
+        payload = {"type": "notify", "level": level, "title": title, "body": body,
+                   "kind": "message", "actions": actions or [],
+                   "priority": int(priority),
+                   "notify_id": notify_id}
+        if timeout_secs is not None:
+            payload["timeout_secs"] = int(timeout_secs)
+        if on_dismiss is not None:
+            payload["on_dismiss"] = on_dismiss
+        _emit(payload)
         return await q.get()
 
     # Terminal commands (legacy back-compat)

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -410,20 +410,25 @@ class RenderContext:
                priority: "int | None" = None,
                actions: "list | None" = None,
                image_inline: "dict | None" = None,
-               image_pipe_id: "str | None" = None) -> None:
+               image_pipe_id: "str | None" = None,
+               timeout_secs: "int | None" = None,
+               on_dismiss: "str | None" = None) -> None:
         """Post a message notification. See Emitter.notify.
         `priority` is required (int, higher = more urgent).
         `image_inline` / `image_pipe_id` (#74) optionally attach an image.
         Scope is resolved from the app's manifest — not an argument."""
         self.emit.notify(title=title, body=body, level=level,
                          priority=priority, actions=actions,
-                         image_inline=image_inline, image_pipe_id=image_pipe_id)
+                         image_inline=image_inline, image_pipe_id=image_pipe_id,
+                         timeout_secs=timeout_secs, on_dismiss=on_dismiss)
 
     async def notify_choice(self, title: str, options: list, body: str = "",
                             level: str = "info", required: bool = False,
                             priority: "int | None" = None,
                             image_inline: "dict | None" = None,
-                            image_pipe_id: "str | None" = None) -> str:
+                            image_pipe_id: "str | None" = None,
+                            timeout_secs: "int | None" = None,
+                            on_dismiss: "str | None" = None) -> str:
         """Post a choice notification and await until the user picks.
         `priority` is required (int, higher = more urgent).
         `image_inline` / `image_pipe_id` (#74) optionally attach an image.
@@ -433,7 +438,9 @@ class RenderContext:
                                              level=level, required=required,
                                              priority=priority,
                                              image_inline=image_inline,
-                                             image_pipe_id=image_pipe_id)
+                                             image_pipe_id=image_pipe_id,
+                                             timeout_secs=timeout_secs,
+                                             on_dismiss=on_dismiss)
 
     async def notify_with_image(self, title: str, body: str, image_bytes: bytes,
                                 mime: str, level: str = "info",
@@ -448,22 +455,30 @@ class RenderContext:
 
     async def notify_input(self, title: str, prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
-                           priority: "int | None" = None) -> str:
+                           priority: "int | None" = None,
+                           timeout_secs: "int | None" = None,
+                           on_dismiss: "str | None" = None) -> str:
         """Post an input notification and await until the user submits.
         `priority` is required (int, higher = more urgent).
         Returns the typed text, or "__cancel__" if dismissed. Use with ``await``."""
         return await self.emit.notify_input(title=title, prompt=prompt, body=body,
                                             level=level, required=required,
-                                            priority=priority)
+                                            priority=priority,
+                                            timeout_secs=timeout_secs,
+                                            on_dismiss=on_dismiss)
 
     async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
                               actions: "list | None" = None,
-                              priority: "int | None" = None) -> str:
+                              priority: "int | None" = None,
+                              timeout_secs: "int | None" = None,
+                              on_dismiss: "str | None" = None) -> str:
         """Post a message notification and await for acknowledge/cancel.
         `priority` is required (int, higher = more urgent).
         See Emitter.notify_and_wait. Use with ``await``."""
         return await self.emit.notify_and_wait(title=title, body=body, level=level,
-                                               actions=actions, priority=priority)
+                                               actions=actions, priority=priority,
+                                               timeout_secs=timeout_secs,
+                                               on_dismiss=on_dismiss)
 
     def status_summary(self, text: str) -> None:
         _emit({"type": "status_summary", "text": text})

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -111,6 +111,8 @@ impl PlexiApp {
                         priority,
                         image_inline,
                         image_pipe_id,
+                        timeout_secs,
+                        on_dismiss,
                         ..
                     } => {
                         let ws_idx = self.windows.get(ctx_idx)
@@ -131,6 +133,8 @@ impl PlexiApp {
                             scope: resolved_scope,
                             image_inline,
                             image_pipe_id,
+                            timeout_secs,
+                            on_dismiss,
                         });
                     }
                     AppCommand::DeliverNotifyAction { .. } => deferred.push(cmd),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -86,6 +86,13 @@ pub(crate) struct PendingNotification {
     /// the chosen value here when the user picks an option so the blocking CLI
     /// process can read it and exit.
     pub response_file: Option<String>,
+    pub timeout_secs: Option<u64>,
+    pub on_dismiss: Option<String>,
+    /// When the notification was pushed to the queue. Used for timeout tracking.
+    pub enqueued_at: std::time::Instant,
+    /// True when the originating app pane has exited. The notification stays
+    /// in the queue so the user can read it, but action buttons are hidden.
+    pub tombstoned: bool,
 }
 
 /// Render state for a notification's image attachment. Computed once and
@@ -846,6 +853,10 @@ impl PlexiApp {
                 image_inline: None,
                 image_pipe_id: None,
                 response_file,
+                timeout_secs: None,
+                on_dismiss: None,
+                enqueued_at: std::time::Instant::now(),
+                tombstoned: false,
             });
             // Host-originated notifications are always LOW (priority 0) —
             // below any reasonable interrupt threshold — so they queue
@@ -953,18 +964,22 @@ impl PlexiApp {
     }
 
     /// Return ids of all *visible* notifications (for the current context),
-    /// ordered by (priority desc, arrival asc). Empty Vec when none visible.
+    /// ordered by (required desc, priority desc, arrival asc). Empty Vec when none visible.
     pub(crate) fn sorted_notification_ids(&self) -> Vec<String> {
-        let mut indexed: Vec<(usize, u32, &str)> = self
+        let mut indexed: Vec<(usize, u32, bool, &str)> = self
             .pending_notifications
             .iter()
             .enumerate()
             .filter(|(_, n)| self.notification_is_visible(n))
-            .map(|(i, n)| (i, n.priority, n.notify_id.as_str()))
+            .map(|(i, n)| (i, n.priority, n.required, n.notify_id.as_str()))
             .collect();
-        // Reverse-sort by priority; stable sort preserves arrival order for ties.
-        indexed.sort_by(|a, b| b.1.cmp(&a.1));
-        indexed.into_iter().map(|(_, _, id)| id.to_string()).collect()
+        // required pins to top, then priority DESC, ties broken by arrival ASC.
+        indexed.sort_by(|a, b| {
+            b.2.cmp(&a.2)
+                .then(b.1.cmp(&a.1))
+                .then(a.0.cmp(&b.0))
+        });
+        indexed.into_iter().map(|(_, _, _, id)| id.to_string()).collect()
     }
 
     /// Return the id of the highest-priority *visible* notification,
@@ -1013,6 +1028,60 @@ impl PlexiApp {
         self.current_notify_id = Some(sorted[next_pos].clone());
     }
 
+    /// Check every pending notification for expiry. For each that has exceeded
+    /// its `timeout_secs`, deliver a `NotifyAction` dismiss event and remove it.
+    /// Called once per second from `update()`.
+    pub(crate) fn tick_notification_timeouts(&mut self) {
+        let mut expired_ids: Vec<String> = Vec::new();
+        for n in &self.pending_notifications {
+            if let Some(timeout) = n.timeout_secs {
+                if n.enqueued_at.elapsed() >= std::time::Duration::from_secs(timeout) {
+                    expired_ids.push(n.notify_id.clone());
+                }
+            }
+        }
+        for id in expired_ids {
+            let Some(pos) = self.pending_notifications.iter().position(|n| n.notify_id == id) else {
+                continue;
+            };
+            let n = self.pending_notifications.remove(pos);
+            let dismiss_value = n.on_dismiss.clone().unwrap_or_else(|| "timeout".to_string());
+            log::info!(
+                "notification '{}' timed out after {}s — delivering on_dismiss='{}'",
+                n.title,
+                n.timeout_secs.unwrap_or(0),
+                dismiss_value
+            );
+            if !n.notify_id.is_empty() && !n.notify_id.starts_with("__host__:") {
+                let cmds = vec![crate::app_trait::AppCommand::DeliverNotifyAction {
+                    pane_id: n.sender_pane_id,
+                    notify_id: n.notify_id.clone(),
+                    action_label: "timeout".to_string(),
+                    value: Some(dismiss_value),
+                    response_file: n.response_file.clone(),
+                }];
+                self.dispatch_notify_action_cmds(cmds);
+            }
+            // If this was the pinned notification, clear it so the next highest
+            // becomes current on the next frame.
+            if self.current_notify_id.as_deref() == Some(&n.notify_id) {
+                self.current_notify_id = None;
+            }
+        }
+    }
+
+    /// Mark all pending notifications from `pane_id` as tombstoned. Called
+    /// when an app pane is closed. Tombstoned notifications remain in the queue
+    /// so the user can read them, but their action buttons are hidden.
+    pub(crate) fn tombstone_pane_notifications(&mut self, pane_id: crate::tiling::PaneId) {
+        for n in &mut self.pending_notifications {
+            if n.sender_pane_id == pane_id {
+                n.tombstoned = true;
+                log::info!("notification '{}' tombstoned (pane {pane_id} closed)", n.title);
+            }
+        }
+    }
+
     /// Count of context-scoped notifications whose source_context == ctx_idx.
     /// Used for per-context sidebar badges on inactive contexts.
     pub(crate) fn context_notification_count(&self, ctx_idx: usize) -> usize {
@@ -1044,6 +1113,7 @@ impl eframe::App for PlexiApp {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_notify_queue();
             self.drain_spawn_queue();
+            self.tick_notification_timeouts();
         }
         if let Some(rx) = &self.update_rx {
             if let Ok(version) = rx.try_recv() {
@@ -1273,6 +1343,8 @@ impl eframe::App for PlexiApp {
                     scope,
                     image_inline,
                     image_pipe_id,
+                    timeout_secs,
+                    on_dismiss,
                 } => {
                     if !self.notifications_enabled {
                         // Silently drop — master switch off.
@@ -1298,6 +1370,10 @@ impl eframe::App for PlexiApp {
                         image_inline,
                         image_pipe_id,
                         response_file: None,
+                        timeout_secs,
+                        on_dismiss,
+                        enqueued_at: std::time::Instant::now(),
+                        tombstoned: false,
                     });
                     // Auto-open rules:
                     //   1. Visibility (Global or in active context) — else

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -814,6 +814,16 @@ pub enum HostCommand {
         /// `height: u32 LE`, then `width * height * 4` bytes of RGBA.
         #[serde(skip_serializing_if = "Option::is_none")]
         image_pipe_id: Option<String>,
+        /// Auto-dismiss after this many seconds. On expiry, host delivers
+        /// `PlexiEvent::NotifyAction` with `value = on_dismiss` (or "timeout" if
+        /// `on_dismiss` is None). Omit for notifications that should persist.
+        #[serde(default)]
+        timeout_secs: Option<u64>,
+        /// Payload delivered to the app when the notification is dismissed without
+        /// an explicit choice (timeout, Esc, or tombstone dismiss). Defaults to
+        /// "timeout" when omitted.
+        #[serde(default)]
+        on_dismiss: Option<String>,
     },
     /// Open a typed pipe.
     /// mode: "json" | "binary"
@@ -2393,5 +2403,31 @@ mod tests {
             serde_json::from_str::<PlexiEvent>(bad).is_err(),
             "must fail without required `correlation_id`"
         );
+    }
+
+    #[test]
+    fn test_notify_timeout_fields() {
+        let json = r#"{"type":"notify","level":"info","title":"T","body":"B","priority":50,"timeout_secs":30,"on_dismiss":"user_ignored"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match cmd {
+            DrawCommand::Host(HostCommand::Notify { timeout_secs, on_dismiss, .. }) => {
+                assert_eq!(timeout_secs, Some(30));
+                assert_eq!(on_dismiss.as_deref(), Some("user_ignored"));
+            }
+            other => panic!("expected HostCommand::Notify, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_notify_timeout_fields_default() {
+        let json = r#"{"type":"notify","level":"info","title":"T","body":"B","priority":50}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match cmd {
+            DrawCommand::Host(HostCommand::Notify { timeout_secs, on_dismiss, .. }) => {
+                assert!(timeout_secs.is_none());
+                assert!(on_dismiss.is_none());
+            }
+            other => panic!("expected HostCommand::Notify, got {other:?}"),
+        }
     }
 }

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -82,6 +82,8 @@ pub enum AppCommand {
         /// `height: u32 LE`, then RGBA bytes. Mutually exclusive with
         /// `image_inline` — if both set, inline wins.
         image_pipe_id: Option<String>,
+        timeout_secs: Option<u64>,
+        on_dismiss: Option<String>,
     },
     /// Route a NotifyAction event back to the app pane that sent the Notify.
     DeliverNotifyAction {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1046,6 +1046,51 @@ impl PlexiApp {
 
                         ui.add_space(style::SPACE_XL);
 
+                        if notif.tombstoned {
+                            // Source ended — show a dim label and a plain Dismiss button.
+                            // Action buttons are hidden since the app can no longer respond.
+                            ui.add_space(style::SPACE_SM);
+                            ui.vertical_centered(|ui| {
+                                ui.label(
+                                    RichText::new("Source ended")
+                                        .size(style::TEXT_BODY)
+                                        .color(self.colors.text_dim)
+                                        .italics(),
+                                );
+                            });
+                            ui.add_space(style::SPACE_SM);
+                            ui.add_space(style::SPACE_MD);
+                            ui.vertical_centered(|ui| {
+                                let resp = primary_button(ui, "Dismiss", &self.colors, 180.0);
+                                if resp.clicked() {
+                                    if let Some(n) = self.pending_notifications
+                                        .iter()
+                                        .find(|n| n.notify_id == current_id)
+                                        .cloned()
+                                    {
+                                        self.pending_notifications
+                                            .retain(|x| x.notify_id != current_id);
+                                        self.current_notify_id = None;
+                                        if !n.notify_id.is_empty()
+                                            && !n.notify_id.starts_with("__host__:")
+                                        {
+                                            action_cmd =
+                                                Some(AppCommand::DeliverNotifyAction {
+                                                    pane_id: n.sender_pane_id,
+                                                    notify_id: n.notify_id.clone(),
+                                                    action_label: "tombstone_dismiss"
+                                                        .to_string(),
+                                                    value: Some(
+                                                        "tombstone_dismiss".to_string(),
+                                                    ),
+                                                    response_file: n.response_file.clone(),
+                                                });
+                                        }
+                                    }
+                                }
+                            });
+                            ui.add_space(style::SPACE_MD);
+                        } else {
                         // Kind-specific body.
                         match notif.kind {
                             NotifyKind::Message => {}
@@ -1133,9 +1178,11 @@ impl PlexiApp {
                             });
                             ui.add_space(style::SPACE_MD);
                         }
+                        } // end !tombstoned
 
                         // Footer keyboard hint — chips + inline labels per action.
-                        ui.vertical_centered(|ui| {
+                        // Not shown for tombstoned notifications (only a Dismiss button).
+                        if !notif.tombstoned { ui.vertical_centered(|ui| {
                             ui.horizontal(|ui| {
                                 ui.spacing_mut().item_spacing.x = 4.0;
                                 match notif.kind {
@@ -1225,13 +1272,14 @@ impl PlexiApp {
                                     }
                                 }
                             });
-                        });
+                        }); } // end !tombstoned keyboard hint
                     });
             });
 
         // ── Resolve keyboard input into an action_cmd (only if not already
         //    produced by a mouse click). Mouse wins; keyboard is a fallback.
-        if action_cmd.is_none() {
+        // Tombstoned notifications have no keyboard actions — only the mouse Dismiss.
+        if action_cmd.is_none() && !notif.tombstoned {
             match notif.kind {
                 NotifyKind::Message => {
                     if enter_pressed || space_pressed {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -549,6 +549,9 @@ impl PlexiApp {
                     }
                     // else: process_app drops here — Drop impl sends Shutdown + kills process
                 }
+                // Tombstone any notifications this pane posted — they stay visible but
+                // their action buttons are hidden since the app can no longer respond.
+                self.tombstone_pane_notifications(pane_id);
                 // else: builtin app pane drops here
             }
             _ => {}

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -256,6 +256,8 @@ impl ProcessApp {
                 priority,
                 image_inline,
                 image_pipe_id,
+                timeout_secs,
+                on_dismiss,
             } => {
                 let notif_id = format!("{}-{}", self.type_id, event_log::now_timestamp());
                 log::info!(
@@ -368,6 +370,8 @@ impl ProcessApp {
                     scope: crate::app_protocol::NotifyScope::Context,
                     image_inline,
                     image_pipe_id,
+                    timeout_secs,
+                    on_dismiss,
                 });
                 // `actions` intentionally dropped: they were already processed
                 // as server-side side effects above (resume_run / open_intent /


### PR DESCRIPTION
Closes #291 (final acceptance criteria)

## What's new

- **`timeout_secs` + `on_dismiss`** — `HostCommand::Notify` accepts two new optional fields. After `timeout_secs` seconds the host delivers a `PlexiEvent::NotifyAction` with `value = on_dismiss` (defaults to `"timeout"`) and removes the card from the queue. A 1Hz tick in `update()` drives expiry without busy-looping.

- **Tombstone behavior** — when an app pane is closed (`close_tile`), all pending notifications it posted are tombstoned instead of silently removed. Tombstoned cards stay in the panel so the user can read them; the action buttons are replaced by a dim italic _"Source ended"_ label and a single Dismiss button.

- **`required: true` pinned to top** — `sorted_notification_ids()` sorts `(required DESC, priority DESC, arrival ASC)`. Required notifications (BlockedOnUser) always float above non-required regardless of priority.

- **Python SDK** — `timeout_secs` / `on_dismiss` added to `Emitter.notify`, `notify_choice`, `notify_input`, `notify_and_wait`, and all matching `RenderContext` proxy methods.

- **Example** — `notification-tester` gains an `x` binding that fires a 10-second auto-dismiss card for manual verification.

## Test plan

- [ ] Open `notification-tester`, press `x` — card appears; after ~10s it vanishes automatically (no dismiss needed)
- [ ] Open a canvas app that posts a notification, then close the app pane — card should stay visible in the panel, show "Source ended" in italic, only Dismiss button present
- [ ] Post a `required: true` notification (press `r` in tester) alongside normal ones — required card always appears first in Cmd+] / Cmd+[ traversal
- [ ] `cargo test notify` passes