### PR TITLE
feat(ipc): PLEXI_SOCKET listener + plexi pane set-title

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -262,6 +262,9 @@ pub struct PlexiApp {
     /// Latest available version string, set after the background check resolves.
     /// `None` means either the check hasn't completed or we're already current.
     pub(crate) update_available: Option<String>,
+    /// Receiver for HostCommands sent over the PLEXI_SOCKET Unix socket listener.
+    /// Drained each frame in `drain_pane_cmd_channel`.
+    pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::HostCommand>,
 }
 
 #[cfg(test)]
@@ -270,6 +273,48 @@ fn configure_egui_ctx(ctx: &egui::Context, colors: &Colors) {
     ctx.set_visuals(egui::Visuals::dark());
     ctx.options_mut(|o| o.zoom_with_keyboard = false);
     theme::setup_style(ctx, colors);
+}
+
+fn spawn_socket_listener(
+    tx: std::sync::mpsc::Sender<crate::app_protocol::HostCommand>,
+) {
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::net::UnixListener;
+
+    let path = crate::config::config_dir().join("notify.sock");
+    let _ = std::fs::remove_file(&path);
+    let listener = match UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("pane_ipc: failed to bind {:?}: {e}", path);
+            return;
+        }
+    };
+    log::info!("pane_ipc: listening on {:?}", path);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                let reader = BufReader::new(stream);
+                for line in reader.lines() {
+                    let Ok(line) = line else { break };
+                    let line = line.trim().to_owned();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<crate::app_protocol::HostCommand>(&line) {
+                        Ok(cmd) => {
+                            let _ = tx.send(cmd);
+                        }
+                        Err(e) => {
+                            log::warn!("pane_ipc: parse error: {e}  line={line:?}");
+                        }
+                    }
+                }
+            });
+        }
+    });
 }
 
 impl PlexiApp {
@@ -332,6 +377,9 @@ impl PlexiApp {
         // Spawn background update check. Sends the latest version once if newer.
         let (update_tx, update_rx) = std::sync::mpsc::channel::<String>();
         crate::updater::spawn_update_check(crate::config::config_dir(), update_tx);
+
+        let (pane_ipc_tx, pane_ipc_rx) = std::sync::mpsc::channel::<crate::app_protocol::HostCommand>();
+        spawn_socket_listener(pane_ipc_tx);
 
         // Try to load saved workspace
         if let Some(ws) = WorkspaceFile::load() {
@@ -562,6 +610,7 @@ impl PlexiApp {
                     edge_pulse: None,
                     update_rx: Some(update_rx),
                     update_available: None,
+                    pane_ipc_rx,
                 };
             }
         }
@@ -651,6 +700,7 @@ impl PlexiApp {
             edge_pulse: None,
             update_rx: Some(update_rx),
             update_available: None,
+            pane_ipc_rx,
         }
     }
 
@@ -662,7 +712,7 @@ impl PlexiApp {
     pub fn new_for_test(
         ctx: egui::Context,
         frame_tick: crate::logging::FrameTick,
-    ) -> Self {
+    ) -> (Self, std::sync::mpsc::Sender<crate::app_protocol::HostCommand>) {
         let config = config::PlexiConfig::default();
         let theme_cfg = Self::resolve_theme_config(&config);
         let colors = Colors::from_config(&theme_cfg);
@@ -671,7 +721,8 @@ impl PlexiApp {
         let (hr_watcher, hr_rx) = crate::hot_reload::HotReloadWatcher::new();
         let path = std::env::temp_dir();
         let features = crate::features::FeatureFlags::from_config(&config);
-        Self {
+        let (pane_ipc_tx, pane_ipc_rx) = std::sync::mpsc::channel::<crate::app_protocol::HostCommand>();
+        (Self {
             pty_event_rx: rx,
             pty_event_tx: tx,
             last_notify_poll: std::time::Instant::now(),
@@ -751,7 +802,8 @@ impl PlexiApp {
             show_cli_setup_prompt: false,
             update_rx: None,
             update_available: None,
-        }
+            pane_ipc_rx,
+        }, pane_ipc_tx)
     }
 
     fn resolve_theme_config(config: &config::PlexiConfig) -> config::ThemeConfig {
@@ -868,6 +920,36 @@ impl PlexiApp {
                 self.show_notification_modal = true;
                 if self.current_notify_id.is_none() {
                     self.current_notify_id = Some(internal_id);
+                }
+            }
+        }
+    }
+
+    fn drain_pane_cmd_channel(&mut self) {
+        while let Ok(cmd) = self.pane_ipc_rx.try_recv() {
+            match &cmd {
+                crate::app_protocol::HostCommand::SetPaneTitle { pane_id, name } => {
+                    log::info!("pane_ipc: kind=set_pane_title pane_id={pane_id}");
+                    let mut found = false;
+                    for win in &mut self.windows {
+                        if let Some(pane) = win.panes.get_mut(pane_id) {
+                            if let Some(t) = pane.as_terminal_mut() {
+                                t.name = Some(name.clone());
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !found {
+                        log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
+                    }
+                }
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id}");
+                    self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                }
+                _ => {
+                    log::warn!("pane_ipc: unsupported command kind, dropping");
                 }
             }
         }
@@ -1115,6 +1197,7 @@ impl eframe::App for PlexiApp {
             self.drain_spawn_queue();
             self.tick_notification_timeouts();
         }
+        self.drain_pane_cmd_channel();
         if let Some(rx) = &self.update_rx {
             if let Ok(version) = rx.try_recv() {
                 log::info!("update check: badge set to v{version}");

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -897,6 +897,13 @@ pub enum HostCommand {
         pipe_id: Option<String>,
     },
 
+    /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
+    /// over PLEXI_SOCKET.
+    SetPaneTitle {
+        pane_id: u64,
+        name: String,
+    },
+
     // ── Media + HTTP primitives ──────────────────────────────────────────
     /// Host-brokered HTTP request. Requires `net.http` capability.
     /// Host replies with `PlexiEvent::HttpResponse { request_id, ... }`.
@@ -2429,5 +2436,12 @@ mod tests {
             }
             other => panic!("expected HostCommand::Notify, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn set_pane_title_deserializes() {
+        let json = r#"{"type":"set_pane_title","pane_id":42,"name":"my label"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).unwrap();
+        assert!(matches!(cmd, DrawCommand::Host(HostCommand::SetPaneTitle { pane_id: 42, .. })));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1325,6 +1325,54 @@ fn to_struct_name(s: &str) -> String {
         .collect::<String>()
 }
 
+/// `plexi pane set-title <name>`
+///
+/// Connects to PLEXI_SOCKET and sends a `set_pane_title` command for the
+/// current pane (identified by PLEXI_PANE_ID). Returns 0 on success, 1 on error.
+pub fn pane_set_title_cli(name: &str) -> i32 {
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let socket_path = match std::env::var("PLEXI_SOCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let pane_id: u64 = match pane_id_str.parse() {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+            return 1;
+        }
+    };
+    let payload = serde_json::json!({
+        "type": "set_pane_title",
+        "pane_id": pane_id,
+        "name": name,
+    });
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
+            return 1;
+        }
+    };
+    let line = format!("{}\n", payload);
+    if let Err(e) = stream.write_all(line.as_bytes()) {
+        eprintln!("error: could not write to socket: {e}");
+        return 1;
+    }
+    0
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// Writes a spawn request to the spawn-queue directory. The running Plexi host

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,6 +441,26 @@ fn main() -> eframe::Result {
                 }
                 std::process::exit(cli::notify_cli(&title, &body, level, &choices, timeout_secs));
             }
+            "pane" => {
+                if args.len() < 3 {
+                    eprintln!("Usage: plexi pane <set-title> [args]");
+                    std::process::exit(1);
+                }
+                match args[2].as_str() {
+                    "set-title" => {
+                        if args.len() < 4 {
+                            eprintln!("Usage: plexi pane set-title <name>");
+                            std::process::exit(1);
+                        }
+                        std::process::exit(cli::pane_set_title_cli(&args[3]));
+                    }
+                    other => {
+                        eprintln!("Unknown pane subcommand: {other}");
+                        eprintln!("Usage: plexi pane <set-title>");
+                        std::process::exit(1);
+                    }
+                }
+            }
             "open" => {
                 // plexi open <type_id> [args...] [--layout=split_v|split_h|split_above|split_left|overlay]
                 if args.len() < 3 {
@@ -606,6 +626,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "app",
         "workspace",
         "notify",
+        "pane",
         "open",
         "--render",
         // #308 Phase 2 — top-level package manager subcommands

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -720,7 +720,7 @@ mod swap_tests {
     fn test_app() -> PlexiApp {
         let ctx = egui::Context::default();
         let ft = crate::logging::new_frame_tick();
-        PlexiApp::new_for_test(ctx, ft)
+        PlexiApp::new_for_test(ctx, ft).0
     }
 
     #[test]

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1350,6 +1350,14 @@ impl ProcessApp {
                 );
             }
 
+            // SetPaneTitle is only valid over PLEXI_SOCKET; an app sending it
+            // via PGAP is a protocol error — log and drop.
+            HostCommand::SetPaneTitle { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received SetPaneTitle for pane_id={pane_id} over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
         }
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -75,6 +75,8 @@ pub struct HostHarness {
     inject_channels: HashMap<PaneId, Sender<DrawCommand>>,
     /// Next pane id to assign.
     next_pane_id: u64,
+    /// IPC sender for injecting HostCommands into the pane_ipc channel.
+    pub ipc_tx: std::sync::mpsc::Sender<HostCommand>,
 }
 
 impl HostHarness {
@@ -82,12 +84,13 @@ impl HostHarness {
     pub fn new() -> Self {
         let ctx = egui::Context::default();
         let frame_tick = Arc::new(AtomicU64::new(0));
-        let app = PlexiApp::new_for_test(ctx.clone(), frame_tick);
+        let (app, ipc_tx) = PlexiApp::new_for_test(ctx.clone(), frame_tick);
         Self {
             app,
             ctx,
             inject_channels: HashMap::new(),
             next_pane_id: 100,
+            ipc_tx,
         }
     }
 
@@ -215,6 +218,12 @@ impl HostHarness {
         if let Some(tx) = self.inject_channels.get(&pane_id) {
             let _ = tx.send(cmd);
         }
+        self
+    }
+
+    /// Inject a `HostCommand` directly into the pane_ipc channel.
+    pub fn inject_ipc(&self, cmd: HostCommand) -> &Self {
+        let _ = self.ipc_tx.send(cmd);
         self
     }
 
@@ -406,5 +415,14 @@ mod tests {
             Some("Working…"),
             "StatusSummary command must be routed to process_app.status_summary"
         );
+    }
+
+    #[test]
+    fn set_pane_title_unknown_pane_id_does_not_panic() {
+        // Injects SetPaneTitle for a pane_id that doesn't exist.
+        // Must run without panicking and log a warn — verifies the drain path is wired.
+        let mut h = HostHarness::new();
+        h.ipc_tx.send(HostCommand::SetPaneTitle { pane_id: 9999, name: "ghost".into() }).unwrap();
+        h.run_frames(1); // must not panic; logs warn "not found"
     }
 }


### PR DESCRIPTION
## Summary

- Binds a `UnixListener` on `config_dir/notify.sock` at startup; accept thread feeds `mpsc::Sender<HostCommand>`, drained every frame via `drain_pane_cmd_channel()`
- Adds `SetPaneTitle { pane_id, name }` variant to `HostCommand` — wire format `{"type":"set_pane_title","pane_id":N,"name":"..."}`  
- `SetPaneTitle` dispatch mutates `TerminalPane.name` (the source the per-frame `pane_names` snapshot is built from)
- `plexi pane set-title <name>` CLI: reads `PLEXI_PANE_ID` + `PLEXI_SOCKET` from env, connects, writes one JSON line, closes
- `SpawnPane` over socket routes to existing `launch_app_by_id_with_layout`; unsupported variants warn-and-drop
- `SetPaneTitle` over PGAP logs warn and drops (protocol error — socket is the correct channel)

## Test plan

- [ ] Open Plexi alpha, open a terminal pane, run `plexi pane set-title "my label"` — tab title should update immediately
- [ ] Verify `pane_ipc: kind=set_pane_title pane_id=N` appears in `~/.plexi-alpha/plexi.log`
- [ ] Run `plexi pane set-title "foo"` outside Plexi — should print `error: PLEXI_PANE_ID is not set` and exit 1
- [ ] `cargo test` green