### PR TITLE
fix: offload audio/MIDI device enumeration to background thread

### DIFF
--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1007,48 +1007,57 @@ impl ProcessApp {
                 // Enumeration is not gated — device names are already visible
                 // to any macOS app via System Information. The per-device
                 // capture call goes through the `AudioRecord` gate.
-                let inputs = self
-                    .audio_device
-                    .list_input_devices()
-                    .into_iter()
-                    .map(AudioDeviceWire::from)
-                    .collect();
-                let outputs = self
-                    .audio_device
-                    .list_output_devices()
-                    .into_iter()
-                    .map(AudioDeviceWire::from)
-                    .collect();
-                self.outbound_events
-                    .push_back(PlexiEvent::AudioDevicesListed {
+                // Offload to a background thread: cpal device enumeration can
+                // block for hundreds of milliseconds on macOS (Bluetooth scan).
+                let audio = std::sync::Arc::clone(&self.audio_device);
+                let tx = self.http_tx.clone();
+                let type_id = self.type_id.clone();
+                std::thread::spawn(move || {
+                    let inputs = audio
+                        .list_input_devices()
+                        .into_iter()
+                        .map(AudioDeviceWire::from)
+                        .collect();
+                    let outputs = audio
+                        .list_output_devices()
+                        .into_iter()
+                        .map(AudioDeviceWire::from)
+                        .collect();
+                    log::info!("ProcessApp[{type_id}]: ListAudioDevices complete");
+                    let _ = tx.send(PlexiEvent::AudioDevicesListed {
                         request_id,
                         inputs,
                         outputs,
                         error: None,
                     });
+                });
             }
             HostCommand::ListMidiDevices { request_id } => {
                 // MIDI enumeration mirrors audio: not gated. Port names are
                 // already visible in Audio MIDI Setup.app, no privacy gate.
-                let inputs = self
-                    .midi_device
-                    .list_input_ports()
-                    .into_iter()
-                    .map(MidiPortWire::from)
-                    .collect();
-                let outputs = self
-                    .midi_device
-                    .list_output_ports()
-                    .into_iter()
-                    .map(MidiPortWire::from)
-                    .collect();
-                self.outbound_events
-                    .push_back(PlexiEvent::MidiDevicesListed {
+                // Offload to a background thread for the same reason as audio.
+                let midi = std::sync::Arc::clone(&self.midi_device);
+                let tx = self.http_tx.clone();
+                let type_id = self.type_id.clone();
+                std::thread::spawn(move || {
+                    let inputs = midi
+                        .list_input_ports()
+                        .into_iter()
+                        .map(MidiPortWire::from)
+                        .collect();
+                    let outputs = midi
+                        .list_output_ports()
+                        .into_iter()
+                        .map(MidiPortWire::from)
+                        .collect();
+                    log::info!("ProcessApp[{type_id}]: ListMidiDevices complete");
+                    let _ = tx.send(PlexiEvent::MidiDevicesListed {
                         request_id,
                         inputs,
                         outputs,
                         error: None,
                     });
+                });
             }
             HostCommand::OpenMidiInput { port_id, pipe_id } => {
                 if let PermissionCheck::Denied(reason) =


### PR DESCRIPTION
Fixes #687.

`ListAudioDevices` and `ListMidiDevices` were handled synchronously on the UI thread. cpal device enumeration on macOS blocks while scanning for Bluetooth devices — logs showed 10+ second freezes after `audio-recorder` launches.

Fix: clone the `Arc<dyn AudioDevice/MidiDevice>`, spawn a background thread, send the result back via `http_tx` (same channel used by `HttpRequest`).

## Test plan
- [ ] Launch audio-recorder — should reach "Ready — N input device(s) found" with no freeze in plexi.log
- [ ] `grep "FREEZE" ~/.plexi-alpha/plexi.log` — should be empty after app launch
- [ ] `grep "ListAudioDevices complete" ~/.plexi-alpha/plexi.log` — should appear confirming bg thread ran
- [ ] Record + stop + save WAV still works