### PR TITLE
feat(palette): rank active-context panes above other contexts (#408)

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -24,18 +24,31 @@ impl PlexiApp {
     pub(crate) fn draw_command_palette(&mut self, ctx: &egui::Context) {
         let query = self.palette_query.to_lowercase();
 
-        // ── Window entries (active window first, then by visit recency) ──
+        // ── Window entries (active context first, then by visit recency) ──
+        // Two-tier sort: panes whose window belongs to the active context float
+        // above panes in other contexts. Within each tier, recency wins.
+        // Mirrors macOS Cmd+Tab — current app's windows first.
         let active_win_id = self.windows[self.active_window].window_id;
+        let active_ctx_id = self.windows[self.active_window].context_id;
 
-        let rank_of = |win_id: u64| -> usize {
-            if win_id == active_win_id {
-                return 0;
-            }
-            self.context_visit_history
+        let rank_of = |win_id: u64| -> (usize, usize) {
+            let in_active_ctx = self
+                .windows
                 .iter()
-                .position(|&id| id == win_id)
-                .map(|p| p + 1)
-                .unwrap_or(usize::MAX)
+                .find(|w| w.window_id == win_id)
+                .map(|w| w.context_id == active_ctx_id)
+                .unwrap_or(false);
+            let tier = if in_active_ctx { 0 } else { 1 };
+            let recency = if win_id == active_win_id {
+                0
+            } else {
+                self.context_visit_history
+                    .iter()
+                    .position(|&id| id == win_id)
+                    .map(|p| p + 1)
+                    .unwrap_or(usize::MAX)
+            };
+            (tier, recency)
         };
 
         let mut entries: Vec<PaletteEntry> = {
@@ -168,7 +181,7 @@ impl PlexiApp {
 
             ctx_entries.sort_by_key(|e| match e {
                 PaletteEntry::Context { context_id, .. } => rank_of(*context_id),
-                _ => usize::MAX,
+                _ => (usize::MAX, usize::MAX),
             });
 
             ctx_entries


### PR DESCRIPTION
## Summary
- Cmd+P palette panes now sort in two tiers: active context first, other contexts second; recency tiebreaks within each tier.
- Mirrors macOS Cmd+Tab — current app's windows first.

## Why
Today, a pane visited 10 minutes ago in another context can outrank a pane opened 10 seconds ago in the current context. Cmd+P becomes a global shuffler when 90% of the time it's used as a within-context switcher.

## Change
Single function: `draw_command_palette` in `src/command_palette.rs`.
- `rank_of` return type goes from `usize` → `(usize, usize)`
- Tier 0 = pane's window belongs to active context; tier 1 = otherwise
- Recency calculation unchanged

## Test plan
- [ ] `cargo build --release` passes (verified)
- [ ] Open contexts A and B, focus a pane in A, switch to B and touch a pane there, switch back to A → Cmd+P shows A's panes above B's panes
- [ ] Within a single context, recency ordering still works as before

**Breaks if:** Cmd+P palette ordering puts panes from other contexts above panes in the currently active context (sidebar item).

Closes #408