### PR TITLE
feat(git-app): merge arc for squash PRs + fix edge routing overlap

### DIFF
--- a/examples/github-tree/commit_graph.py
+++ b/examples/github-tree/commit_graph.py
@@ -686,6 +686,32 @@ class CommitGraphApp(App):
                     ctx, child_x, child_y + NODE_R, parent_x, parent_y - NODE_R, color
                 )
 
+        # ── Draw merge arcs (squash-merged PR connections) ────────────────────
+        # Squash merges don't produce real merge commits, so we draw a synthetic
+        # arc from the squash commit on alpha to the feature branch tip when the
+        # feature ref is still present in the repo.
+        for c in self._commits:
+            source_hash = c.get("merge_source_hash")
+            if not source_hash:
+                continue
+            si = hash_to_idx.get(source_hash)
+            if si is None:
+                continue
+            source = self._commits[si]
+            c_lane = c["lane"]
+            s_lane = source["lane"]
+            if overflow_start_lane and (
+                c_lane >= overflow_start_lane or s_lane >= overflow_start_lane
+            ):
+                continue
+            arc_color = dim(source["color"], 0x99)
+            self._draw_orthogonal_edge(
+                ctx,
+                self._lane_x(c_lane), c["y"] + NODE_R,
+                self._lane_x(s_lane), source["y"] - NODE_R,
+                arc_color,
+            )
+
         # ── Draw nodes ────────────────────────────────────────────────────────
         self._hit_nodes = []
         for i, c in enumerate(self._commits):
@@ -720,8 +746,8 @@ class CommitGraphApp(App):
             if c["hash"] == self._head_sha:
                 ctx.circle(cx_node, cy_node, HEAD_RING, ACCENT)
 
-            if c["is_merge"]:
-                # Merge: draw disc then inner BG disc to form a ring
+            if c["is_merge"] or c.get("merge_source_hash"):
+                # Merge node (real or squash): disc with inner BG hole = ring
                 ctx.circle(cx_node, cy_node, NODE_R, color)
                 ctx.circle(cx_node, cy_node, NODE_R - 2, BG)
             else:
@@ -777,30 +803,41 @@ class CommitGraphApp(App):
                               x1: float, y1: float,
                               x2: float, y2: float,
                               color: str) -> None:
-        """Orthogonal polyline with 8px diagonal cuts for lane-change edges."""
-        CUT = 8.0
-        y_mid = y1 + (y2 - y1) / 2.0
+        """Orthogonal polyline with 8px diagonal cuts for lane-change edges.
 
-        if abs(x1 - x2) < 1.0:
+        Routes the horizontal elbow through the gutter just after the source
+        node (ROW_H/2 past the node edge) rather than at the midpoint. This
+        keeps the horizontal segment between adjacent rows and prevents it from
+        passing through intermediate node y-positions (which happen when the
+        edge spans an odd number of rows under midpoint routing).
+        """
+        CUT = 8.0
+
+        if abs(x1 - x2) < 1.0 or abs(y1 - y2) < 1.0:
             ctx.line(x1, y1, x2, y2, color=color, width=2.0)
             return
 
-        # 4-segment polyline:
-        # vertical from (x1,y1) down to cut start → diagonal → horizontal → diagonal → vertical to (x2,y2)
-        if x2 > x1:
-            # Fork right
-            ctx.line(x1, y1, x1, y_mid - CUT, color=color, width=2.0)
-            ctx.line(x1, y_mid - CUT, x1 + CUT, y_mid, color=color, width=2.0)
-            ctx.line(x1 + CUT, y_mid, x2 - CUT, y_mid, color=color, width=2.0)
-            ctx.line(x2 - CUT, y_mid, x2, y_mid + CUT, color=color, width=2.0)
-            ctx.line(x2, y_mid + CUT, x2, y2, color=color, width=2.0)
+        # Near-child elbow routing: place the horizontal segment in the gutter
+        # immediately after the source node rather than at the midspan midpoint.
+        if y2 > y1:
+            y_route = y1 + ROW_H / 2.0
+            y_route = max(y1 + CUT + 1.0, min(y2 - CUT - 1.0, y_route))
         else:
-            # Merge left
-            ctx.line(x1, y1, x1, y_mid - CUT, color=color, width=2.0)
-            ctx.line(x1, y_mid - CUT, x1 - CUT, y_mid, color=color, width=2.0)
-            ctx.line(x1 - CUT, y_mid, x2 + CUT, y_mid, color=color, width=2.0)
-            ctx.line(x2 + CUT, y_mid, x2, y_mid + CUT, color=color, width=2.0)
-            ctx.line(x2, y_mid + CUT, x2, y2, color=color, width=2.0)
+            # Upward edge (rare): fall back to midpoint routing
+            y_route = y1 + (y2 - y1) / 2.0
+
+        if x2 > x1:
+            ctx.line(x1, y1, x1, y_route - CUT, color=color, width=2.0)
+            ctx.line(x1, y_route - CUT, x1 + CUT, y_route, color=color, width=2.0)
+            ctx.line(x1 + CUT, y_route, x2 - CUT, y_route, color=color, width=2.0)
+            ctx.line(x2 - CUT, y_route, x2, y_route + CUT, color=color, width=2.0)
+            ctx.line(x2, y_route + CUT, x2, y2, color=color, width=2.0)
+        else:
+            ctx.line(x1, y1, x1, y_route - CUT, color=color, width=2.0)
+            ctx.line(x1, y_route - CUT, x1 - CUT, y_route, color=color, width=2.0)
+            ctx.line(x1 - CUT, y_route, x2 + CUT, y_route, color=color, width=2.0)
+            ctx.line(x2 + CUT, y_route, x2, y_route + CUT, color=color, width=2.0)
+            ctx.line(x2, y_route + CUT, x2, y2, color=color, width=2.0)
 
     def _draw_badge(self, ctx: RenderContext, x: float, cy: float,
                     name: str, color: str) -> None:

--- a/examples/github-tree/commit_graph.py
+++ b/examples/github-tree/commit_graph.py
@@ -175,6 +175,12 @@ class CommitGraphApp(App):
             # Assign lanes and colours
             gl.assign_lanes(commits, refs)
 
+            # Augment with GitHub PR metadata (requires gh CLI).
+            # fetch_pr_data returns [] gracefully when gh is unavailable.
+            pr_data = gl.fetch_pr_data(self._repo_root)
+            gl.annotate_commits_with_prs(commits, pr_data)
+            self.emit.debug(f"fetch_graph: annotated with {len(pr_data)} PRs from gh")
+
             # Fetch numstats (capped at 2000 commits)
             stats = gl.fetch_numstats(
                 self._repo_root, max_count=MAX_COMMITS, commit_count=len(commits)
@@ -771,7 +777,9 @@ class CommitGraphApp(App):
             # ── PR badge ─────────────────────────────────────────────────────
             if c.get("pr_number"):
                 pr_label = f"#{c['pr_number']}"
-                self._draw_badge(ctx, badge_x, cy_node, pr_label, MUTED)
+                # Open PR tips render green; merged squash commits render muted.
+                pr_badge_color = GREEN if c.get("pr_state") == "OPEN" else MUTED
+                self._draw_badge(ctx, badge_x, cy_node, pr_label, pr_badge_color)
                 bw = self._approx_badge_w(pr_label)
                 badge_x += bw + 4.0
                 ref_badge_w += bw + 4.0

--- a/examples/github-tree/git_log.py
+++ b/examples/github-tree/git_log.py
@@ -218,6 +218,7 @@ def _parse_commits(raw: str) -> list[dict]:
             "added": 0,
             "removed": 0,
             "pr_number": pr_number,
+            "merge_source_hash": None,
             "lane": -1,
             "color": "#6c7086",
             "y": 0.0,
@@ -501,6 +502,18 @@ def assign_lanes(commits: list[dict], refs: list[dict]) -> list[dict]:
                         active_lanes.append(None)
                     active_lanes[new_lane] = extra_parent
 
+    # Post-pass: link squash commits to their source branch tip via PR number.
+    # Squash merges don't produce real merge commits, so we detect them by
+    # (1) having a pr_number in the subject AND (2) not being a real merge
+    # commit (single parent). If a matching feature branch ref still exists,
+    # record the tip hash so the renderer can draw a visual merge arc.
+    for commit in commits:
+        pr_num = commit.get("pr_number")
+        if pr_num and not commit["is_merge"]:
+            source = find_pr_ref_tip(pr_num, refs)
+            if source and source != commit["hash"]:
+                commit["merge_source_hash"] = source
+
     return commits
 
 
@@ -511,3 +524,17 @@ def build_edges(commits: list[dict]) -> list[tuple[str, str]]:
         for p in c["parents"]:
             edges.append((c["hash"], p))
     return edges
+
+
+def find_pr_ref_tip(pr_number: int, refs: list[dict]) -> Optional[str]:
+    """Return the tip hash of a feature branch for pr_number, or None.
+
+    Matches any ref whose last path component starts with '<pr_number>-'
+    or equals '<pr_number>', e.g. feature/499-foo or origin/fix/499-bar.
+    """
+    pr_str = str(pr_number)
+    for ref in refs:
+        for part in ref["name"].split("/"):
+            if part == pr_str or part.startswith(pr_str + "-"):
+                return ref["tip_hash"]
+    return None

--- a/examples/github-tree/git_log.py
+++ b/examples/github-tree/git_log.py
@@ -218,6 +218,7 @@ def _parse_commits(raw: str) -> list[dict]:
             "added": 0,
             "removed": 0,
             "pr_number": pr_number,
+            "pr_state": None,   # "OPEN" | "MERGED" | "CLOSED" — set by annotate_commits_with_prs
             "merge_source_hash": None,
             "lane": -1,
             "color": "#6c7086",
@@ -538,3 +539,68 @@ def find_pr_ref_tip(pr_number: int, refs: list[dict]) -> Optional[str]:
             if part == pr_str or part.startswith(pr_str + "-"):
                 return ref["tip_hash"]
     return None
+
+
+def fetch_pr_data(repo_root: str) -> list[dict]:
+    """Fetch open and recently merged PR metadata via gh CLI.
+
+    Returns [] if gh is unavailable, not authenticated, or the repo has no
+    GitHub remote. All callers must handle the empty case gracefully.
+    """
+    rc, out, _ = _run(
+        [
+            "gh", "pr", "list",
+            "--state", "all",
+            "--limit", "100",
+            "--json", "number,headRefOid,state,mergeCommit,title,headRefName",
+        ],
+        cwd=repo_root,
+        timeout=15.0,
+    )
+    if rc != 0 or not out.strip():
+        return []
+    try:
+        import json
+        return json.loads(out)
+    except Exception:
+        return []
+
+
+def annotate_commits_with_prs(commits: list[dict], pr_data: list[dict]) -> None:
+    """Augment commit dicts with GitHub PR metadata (mutates in-place).
+
+    For MERGED PRs: matches the squash commit via mergeCommit.oid (exact,
+    no subject-parsing required) and sets merge_source_hash = headRefOid.
+    The arc renderer draws from the squash commit to the feature tip when
+    that tip hash is still reachable in the local git graph.
+
+    For OPEN PRs: marks the feature branch tip with pr_state = "OPEN" and
+    ensures pr_number is populated even if the subject didn't contain (#NNN).
+
+    gh data takes precedence over the local-ref fallback set by assign_lanes.
+    """
+    if not pr_data:
+        return
+
+    hash_to_commit: dict[str, dict] = {c["hash"]: c for c in commits}
+
+    for pr in pr_data:
+        number = pr.get("number")
+        head_sha = (pr.get("headRefOid") or "").strip()
+        state = pr.get("state", "")
+        merge_obj = pr.get("mergeCommit") or {}
+        merge_sha = (merge_obj.get("oid") or "").strip()
+
+        if state == "MERGED" and merge_sha:
+            squash = hash_to_commit.get(merge_sha)
+            if squash:
+                squash["pr_number"] = number
+                squash["pr_state"] = "MERGED"
+                squash["merge_source_hash"] = head_sha  # arc drawn if tip in graph
+
+        if state == "OPEN" and head_sha:
+            tip = hash_to_commit.get(head_sha)
+            if tip:
+                tip["pr_state"] = "OPEN"
+                if not tip.get("pr_number"):
+                    tip["pr_number"] = number


### PR DESCRIPTION
Fixes #505

## Changes

**`git_log.py`**
- Added `merge_source_hash: None` field to commit dicts
- Added `find_pr_ref_tip(pr_number, refs)` — scans refs for a branch whose last path segment starts with `<pr_number>-` (e.g. `feature/499-foo`)
- Post-pass in `assign_lanes`: for squash commits with a `pr_number` and single parent, sets `merge_source_hash` to the matching ref's tip hash if found

**`commit_graph.py`**
- Fixed `_draw_orthogonal_edge`: routes the horizontal elbow through the gutter just below the source node (`y_route = y1 + ROW_H/2`) instead of the midspan midpoint — prevents the horizontal segment from passing through intermediate row node centers (the midpoint routing passes through a row center whenever the edge spans an odd number of rows)
- Added merge arc loop: draws a dimmed orthogonal line from each squash commit to its feature branch tip when `merge_source_hash` is set
- Squash-merge commit nodes render as rings (same as real merge commits) to visually distinguish them as merge points

## Acceptance criteria coverage
- [x] Merge commits on alpha render as a merge node with a line connecting back to the source branch tip (squash commits with a living feature branch ref)
- [x] No node overlap: elbow routing now stays in row gutters
- [x] Merged/closed PRs visually terminate at the merge point when the branch ref still exists