### PR TITLE
refactor(notify): migrate plexi notify CLI off file queue onto PLEXI_SOCKET

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-05-05 — [CHANGED] refactor(notify): migrate plexi notify CLI off file queue onto PLEXI_SOCKET (PR #701 → alpha)
+
+`notify_cli` now connects to `PLEXI_SOCKET` and writes a `HostCommand::Notify` JSON line instead of writing to `notify-queue/`. `drain_notify_queue` deleted; notify dispatch moved into `drain_pane_cmd_channel` alongside `set_pane_title` and `spawn_pane`. `HostCommand::Notify` gains a `response_file: Option<String>` field (CLI-only, `skip_serializing_if = "Option::is_none"`) to carry the response path for the blocking `--choice` path. One-time cleanup of `config_dir/notify-queue/` at startup. Trade-off: `plexi notify` now fails immediately if Plexi is not running — the old file queue silently buffered offline sends for pickup on next launch; the socket does not.
+**Breaks if:** `plexi notify --title Foo --body Bar` inside a terminal pane fails with "PLEXI_SOCKET is not set", OR `plexi notify --title Q --choice yes:Yes --choice no:No` does not block and return the chosen key.
+
 ## 2026-05-05 — [CHANGED] Background apps: tick parked processes + command palette indicator (PR #700 → alpha)
 
 Manifest `background = true`, `is_background()`, `background_tick()`, park-on-close (sends `Suspend`), and unpark-on-open (sends `Resume`) were all already wired. The missing piece: `drain_all_app_commands` only iterated `context.panes` — parked apps in `self.background_apps` were never ticked, so timers stalled and notifications never fired after the pane was closed. Fix: after the context-pane loop, iterate `self.background_apps`, call `background_tick()` + `take_pending_commands()`, and route `ShowNotification` to `deferred` with `sender_pane_id = 0` (no live pane sentinel). Added `running_in_background: bool` to `PaletteEntry::App` in `command_palette.rs` — populated from `self.background_apps.contains_key(&id)`, renders a dim `bg` badge. `stand-up-reminder` in `examples/` is the POC (already had `[launch] background = true`).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -381,6 +381,11 @@ impl PlexiApp {
         let (pane_ipc_tx, pane_ipc_rx) = std::sync::mpsc::channel::<crate::app_protocol::HostCommand>();
         spawn_socket_listener(pane_ipc_tx);
 
+        // One-time migration: remove the legacy file-queue directory if it
+        // still exists from a previous install. Notify commands now travel
+        // over the PLEXI_SOCKET, so the directory is dead weight.
+        let _ = std::fs::remove_dir_all(crate::config::config_dir().join("notify-queue"));
+
         // Try to load saved workspace
         if let Some(ws) = WorkspaceFile::load() {
             let mut windows = Vec::new();
@@ -839,91 +844,6 @@ impl PlexiApp {
         }
     }
 
-    fn drain_notify_queue(&mut self) {
-        let queue_dir = crate::config::config_dir().join("notify-queue");
-        let Ok(entries) = std::fs::read_dir(&queue_dir) else { return };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            let Ok(content) = std::fs::read_to_string(&path) else { continue };
-            let _ = std::fs::remove_file(&path);
-            let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) else { continue };
-            if !self.notifications_enabled {
-                continue;
-            }
-            let level = val["level"].as_str().unwrap_or("info").to_string();
-            let title = val["title"].as_str().unwrap_or("").to_string();
-            let body = val["body"].as_str().unwrap_or("").to_string();
-            let choices_json = val["choices"].as_array();
-            let options: Vec<crate::app_protocol::NotifyOption> = choices_json
-                .map(|arr| {
-                    arr.iter()
-                        .map(|item| crate::app_protocol::NotifyOption {
-                            label: item["label"].as_str().unwrap_or("").to_string(),
-                            value: item["key"].as_str().unwrap_or("").to_string(),
-                            shortcut: Some(
-                                item["key"].as_str().unwrap_or("").to_string(),
-                            ),
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            let kind = if options.is_empty() {
-                crate::app_protocol::NotifyKind::Message
-            } else {
-                crate::app_protocol::NotifyKind::Choice
-            };
-            let response_file = val["response_file"].as_str().map(|s| s.to_string());
-            log::info!(
-                "notify:drain: title={:?} choices={} response_file={:?}",
-                title, options.len(), response_file
-            );
-            let internal_id = format!(
-                "__host__:{}",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_nanos())
-                    .unwrap_or(0)
-            );
-            self.pending_notifications.push(PendingNotification {
-                notify_id: internal_id.clone(),
-                sender_pane_id: 0,
-                // Host-originated notifications are global (they originate
-                // outside any context) and always visible.
-                source_context: self.router.active_idx(),
-                scope: crate::app_protocol::NotifyScope::Global,
-                level,
-                title,
-                body,
-                kind,
-                options,
-                input_prompt: None,
-                required: false,
-                priority: 0,
-                image_inline: None,
-                image_pipe_id: None,
-                response_file,
-                timeout_secs: None,
-                on_dismiss: None,
-                enqueued_at: std::time::Instant::now(),
-                tombstoned: false,
-            });
-            // Host-originated notifications are always LOW (priority 0) —
-            // below any reasonable interrupt threshold — so they queue
-            // silently by default. They still ride focus_mode as a hard
-            // gate for consistency.
-            let should_auto_open = !self.notifications_focus_mode
-                && 0 >= self.notifications_interrupt_threshold;
-            if should_auto_open {
-                self.show_notification_modal = true;
-                if self.current_notify_id.is_none() {
-                    self.current_notify_id = Some(internal_id);
-                }
-            }
-        }
-    }
 
     fn drain_pane_cmd_channel(&mut self) {
         while let Ok(cmd) = self.pane_ipc_rx.try_recv() {
@@ -947,6 +867,56 @@ impl PlexiApp {
                 crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, .. } => {
                     log::info!("pane_ipc: kind=spawn_pane type_id={type_id}");
                     self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                }
+                crate::app_protocol::HostCommand::Notify {
+                    level, title, body, kind, options, input_prompt,
+                    required, priority, image_inline, image_pipe_id,
+                    timeout_secs, on_dismiss, response_file, ..
+                } => {
+                    if !self.notifications_enabled {
+                        log::info!("pane_ipc: notify dropped — notifications disabled");
+                        continue;
+                    }
+                    let internal_id = format!(
+                        "__host__:{}",
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_nanos())
+                            .unwrap_or(0)
+                    );
+                    log::info!(
+                        "pane_ipc: kind=notify title={:?} choices={} response_file={:?}",
+                        title, options.len(), response_file
+                    );
+                    self.pending_notifications.push(PendingNotification {
+                        notify_id: internal_id.clone(),
+                        sender_pane_id: 0,
+                        source_context: self.router.active_idx(),
+                        scope: crate::app_protocol::NotifyScope::Global,
+                        level: level.clone(),
+                        title: title.clone(),
+                        body: body.clone(),
+                        kind: kind.clone(),
+                        options: options.clone(),
+                        input_prompt: input_prompt.clone(),
+                        required: *required,
+                        priority: *priority,
+                        image_inline: image_inline.clone(),
+                        image_pipe_id: image_pipe_id.clone(),
+                        response_file: response_file.clone(),
+                        timeout_secs: *timeout_secs,
+                        on_dismiss: on_dismiss.clone(),
+                        enqueued_at: std::time::Instant::now(),
+                        tombstoned: false,
+                    });
+                    let should_auto_open = !self.notifications_focus_mode
+                        && *priority >= self.notifications_interrupt_threshold;
+                    if should_auto_open {
+                        self.show_notification_modal = true;
+                        if self.current_notify_id.is_none() {
+                            self.current_notify_id = Some(internal_id);
+                        }
+                    }
                 }
                 _ => {
                     log::warn!("pane_ipc: unsupported command kind, dropping");
@@ -1193,7 +1163,6 @@ impl eframe::App for PlexiApp {
         let _frame_start = std::time::Instant::now();
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
-            self.drain_notify_queue();
             self.drain_spawn_queue();
             self.tick_notification_timeouts();
         }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -824,6 +824,11 @@ pub enum HostCommand {
         /// "timeout" when omitted.
         #[serde(default)]
         on_dismiss: Option<String>,
+        /// CLI-only: path to a file the host writes the chosen key into when
+        /// the user responds. Used by `plexi notify --choice` to return the
+        /// result to the blocking CLI process. Never set by app SDK.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
     },
     /// Open a typed pipe.
     /// mode: "json" | "binary"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1205,10 +1205,11 @@ pub fn pack_export_cli(dest_path: &str) -> i32 {
 /// Entry point for `plexi notify --title <text> --body <text> [--level info|warn|error]
 ///   [--choice key:Label]... [--timeout N]`.
 ///
-/// With no choices: fire-and-forget (writes queue file, prints "notification queued", exits 0).
-/// With choices: writes queue file with `choices` + `response_file`, polls the response file
-/// until the user selects an option, prints the chosen key to stdout, exits 0.
-/// On timeout: exits 2. On queue write error: exits 1.
+/// Connects to PLEXI_SOCKET and sends a `notify` HostCommand JSON line.
+/// With no choices: fire-and-forget (exits 0 on send).
+/// With choices: sends the command with a `response_file` path and polls that
+/// file until the user selects an option, then prints the chosen key to stdout.
+/// On timeout: exits 2. On socket error: exits 1.
 pub fn notify_cli(
     title: &str,
     body: &str,
@@ -1216,60 +1217,79 @@ pub fn notify_cli(
     choices: &[(String, String)],
     timeout_secs: u64,
 ) -> i32 {
-    let queue_dir = crate::config::config_dir().join("notify-queue");
-    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
-        eprintln!("error: could not create notify queue: {e}");
-        return 1;
-    }
+    let socket_path = match std::env::var("PLEXI_SOCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+
     let id = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
 
-    if choices.is_empty() {
-        let file = queue_dir.join(format!("{id}.json"));
-        let payload = serde_json::json!({
-            "level": level,
-            "title": title,
-            "body": body,
-        });
-        if let Err(e) = std::fs::write(&file, payload.to_string()) {
-            eprintln!("error: could not write notification: {e}");
-            return 1;
-        }
-        println!("notification queued");
-        return 0;
-    }
-
-    // Blocking path: create a response file path and poll for it.
-    let response_file = crate::config::config_dir().join(format!("notify-response-{id}.txt"));
-    let choices_json: Vec<serde_json::Value> = choices
+    let options_json: Vec<serde_json::Value> = choices
         .iter()
-        .map(|(key, label)| serde_json::json!({"key": key, "label": label}))
+        .map(|(key, label)| {
+            serde_json::json!({"label": label, "value": key, "shortcut": key})
+        })
         .collect();
-    let payload = serde_json::json!({
+
+    let (kind, response_file_str) = if choices.is_empty() {
+        ("message".to_string(), None)
+    } else {
+        let rf = crate::config::config_dir()
+            .join(format!("notify-response-{id}.txt"))
+            .to_string_lossy()
+            .into_owned();
+        ("choice".to_string(), Some(rf))
+    };
+
+    let mut payload = serde_json::json!({
+        "type": "notify",
         "level": level,
         "title": title,
         "body": body,
-        "choices": choices_json,
-        "response_file": response_file.to_string_lossy(),
+        "kind": kind,
+        "options": options_json,
+        "priority": 50,
     });
-    let queue_file = queue_dir.join(format!("{id}.json"));
+    if let Some(ref rf) = response_file_str {
+        payload["response_file"] = serde_json::Value::String(rf.clone());
+    }
+
     log::info!(
-        "notify:cli: writing queue file {:?} choices={} response_file={:?}",
-        queue_file, choices.len(), response_file
+        "notify:cli: sending via socket choices={} response_file={:?}",
+        choices.len(), response_file_str
     );
-    if let Err(e) = std::fs::write(&queue_file, payload.to_string()) {
-        eprintln!("error: could not write notification: {e}");
+
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
+            return 1;
+        }
+    };
+    let line = format!("{payload}\n");
+    if let Err(e) = stream.write_all(line.as_bytes()) {
+        eprintln!("error: could not write to socket: {e}");
         return 1;
     }
-    log::info!("notify:cli: queue file written, polling for response");
+
+    // Fire-and-forget path — command is delivered, nothing to wait for.
+    let Some(response_file) = response_file_str else {
+        println!("notification queued");
+        return 0;
+    };
+    let response_file = std::path::PathBuf::from(response_file);
+    log::info!("notify:cli: polling for response at {:?}", response_file);
 
     let deadline = if timeout_secs > 0 {
-        Some(
-            std::time::Instant::now()
-                + std::time::Duration::from_secs(timeout_secs),
-        )
+        Some(std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs))
     } else {
         None
     };
@@ -2240,13 +2260,12 @@ pub fn validate_cli(path: &str) -> i32 {
 mod notify_tests {
     use super::notify_cli;
 
-    /// Fire-and-forget path: no choices → exit 0, queue file written.
+    /// Without PLEXI_SOCKET set, notify_cli must fail fast (exit 1) rather than panic.
     #[test]
-    fn notify_cli_fire_and_forget_returns_zero() {
-        // Uses the real config_dir() path; just verifies the function exits 0
-        // without blocking. The queue file creation may fail in sandboxed
-        // environments, but the function must not panic.
+    fn notify_cli_no_socket_returns_one() {
+        // Ensure env var is unset for this test.
+        std::env::remove_var("PLEXI_SOCKET");
         let code = notify_cli("Test title", "Test body", "info", &[], 0);
-        assert_eq!(code, 0);
+        assert_eq!(code, 1);
     }
 }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -258,6 +258,7 @@ impl ProcessApp {
                 image_pipe_id,
                 timeout_secs,
                 on_dismiss,
+                response_file: _,
             } => {
                 let notif_id = format!("{}-{}", self.type_id, event_log::now_timestamp());
                 log::info!(


### PR DESCRIPTION
Closes #666

## Summary

- `notify_cli` now connects to `PLEXI_SOCKET` and sends a `HostCommand::Notify` JSON line over the Unix socket instead of writing a file to `notify-queue/`
- `drain_notify_queue` deleted; notify dispatch moved into `drain_pane_cmd_channel` alongside `set_pane_title` and `spawn_pane`
- `HostCommand::Notify` gains a `response_file: Option<String>` field (CLI-only, `skip_serializing_if = "Option::is_none"`, ignored by app SDK) to carry the response path for the blocking choices path
- One-time cleanup of `config_dir/notify-queue/` at startup removes the stale directory from prior installs
- `process_app/routing.rs` Notify arm updated to ignore the new field

The interactive-choices response mechanism is unchanged — the blocking poll on `notify-response-{id}.txt` stays as-is; only the fire side moved to the socket.

## Test plan

- [ ] `plexi notify --title Foo --body Bar` inside a terminal pane shows a notification
- [ ] `plexi notify --title Q --choice yes:Yes --choice no:No` blocks and returns the chosen key
- [ ] No `notify-queue/` directory is created in `config_dir()`
- [ ] `cargo test` green