### PR TITLE
feat(notifications): strip reserved nav shortcuts from NotifyOption at host ingestion

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-05-05 — [FIX] NotifyOption.shortcut: strip reserved nav keys at host ingestion (PR #702 → alpha)
+
+`NotifyOption.shortcut` accepted any string, but the notification overlay reserves `j`/`k` (up/down nav), `h`/`l` (future nav), and `1`–`9` (digit-select). An app sending `shortcut: "j"` produced a silent conflict — the overlay nav fired instead of the option select. Fix: `pub fn is_reserved_shortcut(key: &str) -> bool` in `app_protocol.rs`; the `ShowNotification` dispatch site in `app/mod.rs` now strips reserved shortcuts with a `log::warn!` naming the pane, key, and option label. Python SDK warns at `notify_choice()` call time via `warnings.warn`. Note: `drain_notify_queue` was removed in PR #701 (CLI moved to PLEXI_SOCKET); the only ingestion point remaining is `AppCommand::ShowNotification`.
+**Breaks if:** An app calling `emit.notify_choice` with `shortcut: "j"` shows no `[WARN] notify:shortcut` in the log, OR pressing `j` in the notification panel selects the option instead of navigating down.
+
 ## 2026-05-05 — [CHANGED] refactor(notify): migrate plexi notify CLI off file queue onto PLEXI_SOCKET (PR #701 → alpha)
 
 `notify_cli` now connects to `PLEXI_SOCKET` and writes a `HostCommand::Notify` JSON line instead of writing to `notify-queue/`. `drain_notify_queue` deleted; notify dispatch moved into `drain_pane_cmd_channel` alongside `set_pane_title` and `spawn_pane`. `HostCommand::Notify` gains a `response_file: Option<String>` field (CLI-only, `skip_serializing_if = "Option::is_none"`) to carry the response path for the blocking `--choice` path. One-time cleanup of `config_dir/notify-queue/` at startup. Trade-off: `plexi notify` now fails immediately if Plexi is not running — the old file queue silently buffered offline sends for pickup on next launch; the socket does not.

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
     from ._app import App
     from ._pipe import Pipe
 
+# ── Reserved notification shortcuts ──────────────────────────────────────────
+# Keys reserved by the notification overlay for navigation. The host strips
+# these if an app sends them, and the SDK warns at call time.
+_RESERVED_SHORTCUTS = frozenset("jkhl") | frozenset("123456789")
+
 # ── Internal helpers ──────────────────────────────────────────────────────────
 _LOCK = threading.Lock()
 
@@ -145,6 +150,17 @@ class Emitter:
         """
         if priority is None:
             raise TypeError("notify_choice() requires 'priority' (int, higher = more urgent)")
+        # Warn if any option uses a reserved shortcut key.
+        import warnings
+        for opt in options:
+            sc = opt.get("shortcut", "")
+            if sc and sc.lower() in _RESERVED_SHORTCUTS:
+                warnings.warn(
+                    f"notify_choice: shortcut {sc!r} on option {opt.get('label', '')!r} "
+                    f"conflicts with notification navigation keys (j/k/h/l, 1-9). "
+                    f"Use y/n or another letter. The host will strip it.",
+                    stacklevel=2,
+                )
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1419,6 +1419,19 @@ impl eframe::App for PlexiApp {
                     // Capture scope/source_context before they move into the struct.
                     let is_global = matches!(scope, crate::app_protocol::NotifyScope::Global);
                     let notif_source_ctx = source_context;
+                    // Strip any per-option shortcut that conflicts with navigation keys.
+                    let options: Vec<crate::app_protocol::NotifyOption> = options.into_iter().map(|mut opt| {
+                        if let Some(ref sc) = opt.shortcut.clone() {
+                            if crate::app_protocol::is_reserved_shortcut(sc) {
+                                log::warn!(
+                                    "notify:shortcut: app pane {} sent reserved shortcut {:?} on option {:?} — stripped",
+                                    sender_pane_id, sc, opt.label
+                                );
+                                opt.shortcut = None;
+                            }
+                        }
+                        opt
+                    }).collect();
                     self.pending_notifications.push(PendingNotification {
                         notify_id,
                         sender_pane_id,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1410,8 +1410,20 @@ pub struct NotifyOption {
     #[serde(default)]
     pub value: String,
     /// Optional single-char hotkey (e.g. "y", "n"). Case-insensitive.
+    /// Reserved keys that conflict with navigation are stripped at ingestion:
+    /// `j`, `k`, `h`, `l` (navigation), `1`–`9` (digit-select).
+    /// Recommended safe set: letters excluding navigation keys; `y`/`n` for yes/no.
     #[serde(default)]
     pub shortcut: Option<String>,
+}
+
+/// Returns `true` if `key` is reserved by the notification overlay for navigation.
+/// Reserved: `j`, `k`, `h`, `l` (navigation) and `1`–`9` (digit-select).
+pub fn is_reserved_shortcut(key: &str) -> bool {
+    let Some(c) = key.chars().next() else { return false };
+    if key.chars().count() != 1 { return false }
+    matches!(c.to_ascii_lowercase(), 'j' | 'k' | 'h' | 'l')
+        || c.is_ascii_digit() && c != '0'
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
@@ -2504,5 +2516,28 @@ mod tests {
         }
         let serialised = serde_json::to_string(&event).expect("serialise");
         assert!(serialised.contains(r#""type":"pane_spawn_error""#), "wire tag missing: {serialised}");
+    }
+
+    #[test]
+    fn is_reserved_shortcut_covers_expected_set() {
+        // Navigation keys — reserved
+        assert!(is_reserved_shortcut("j"));
+        assert!(is_reserved_shortcut("k"));
+        assert!(is_reserved_shortcut("h"));
+        assert!(is_reserved_shortcut("l"));
+        assert!(is_reserved_shortcut("J")); // case-insensitive
+        // Digit-select keys — reserved
+        assert!(is_reserved_shortcut("1"));
+        assert!(is_reserved_shortcut("9"));
+        // 0 is NOT reserved (1-9 only)
+        assert!(!is_reserved_shortcut("0"));
+        // Safe keys — not reserved
+        assert!(!is_reserved_shortcut("y"));
+        assert!(!is_reserved_shortcut("n"));
+        assert!(!is_reserved_shortcut("a"));
+        // Multi-char is not a valid shortcut — treated as not reserved
+        assert!(!is_reserved_shortcut("jk"));
+        // Empty is not reserved
+        assert!(!is_reserved_shortcut(""));
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #681 — `NotifyOption.shortcut` allowed reserved nav keys (`j`, `k`, `h`, `l`, `1`–`9`) that silently conflict with the notification overlay's built-in navigation
- Host strips any reserved shortcut at both `pending_notifications.push` sites with a `log::warn!` naming the app pane, rejected key, and option label
- Python SDK warns via `warnings.warn` in `notify_choice()` at call time so authors catch the conflict before it reaches the host
- Added `pub fn is_reserved_shortcut(key: &str) -> bool` in `app_protocol.rs` + unit test covering all reserved and safe cases

## Test plan

- [ ] Send a `notify_choice` with `shortcut: "j"` on an option — confirm `grep "notify:shortcut" ~/.plexi-alpha/plexi.log` shows the warn line and the option renders without a shortcut hint
- [ ] Send `shortcut: "y"` — confirm it works correctly and selects the option
- [ ] Python SDK: call `notify_choice` with `shortcut: "j"` in a canvas app — confirm `warnings.warn` fires in the app log
- [ ] `cargo test` green (281 tests pass)