### PR TITLE
feat(context): configurable context root — project container foundation

### DIFF
--- a/examples/workspace/.plexi/config.toml
+++ b/examples/workspace/.plexi/config.toml
@@ -1,0 +1,3 @@
+# Example workspace config for a Plexi project root.
+# Place a .plexi/ directory at the root of your project; Plexi detects it
+# automatically and uses that directory as the context root when navigating here.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -545,6 +545,7 @@ impl PlexiApp {
                     contexts.push(crate::context::Context {
                         name: saved_ctx.name,
                         path: saved_ctx.path,
+                        root: saved_ctx.root,
                         context_id: saved_ctx.context_id,
                     });
                 }
@@ -638,6 +639,7 @@ impl PlexiApp {
                 vec![crate::context::Context {
                     name: "Default".into(),
                     path: path.clone(),
+                    root: None,
                     context_id: 1,
                 }],
                 0,
@@ -739,6 +741,7 @@ impl PlexiApp {
                 vec![crate::context::Context {
                     name: "Test".into(),
                     path: path.clone(),
+                    root: None,
                     context_id: 1,
                 }],
                 0,
@@ -917,6 +920,29 @@ impl PlexiApp {
                             self.current_notify_id = Some(internal_id);
                         }
                     }
+                }
+                crate::app_protocol::HostCommand::CreateContext { root, name } => {
+                    log::info!("pane_ipc: kind=create_context root={:?} name={:?}", root, name);
+                    self.new_context();
+                    if let Some(r) = root {
+                        let idx = self.router.len() - 1;
+                        self.router.get_mut(idx).root = Some(r.clone());
+                    }
+                    if let Some(n) = name {
+                        let idx = self.router.len() - 1;
+                        self.router.get_mut(idx).name = n.clone();
+                    }
+                    self.save_workspace();
+                }
+                crate::app_protocol::HostCommand::FocusContext { root } => {
+                    log::info!("pane_ipc: kind=focus_context root={}", root.display());
+                    self.focus_or_create_context_by_root(root.clone());
+                    self.save_workspace();
+                }
+                crate::app_protocol::HostCommand::SetContextRoot { root } => {
+                    log::info!("pane_ipc: kind=set_context_root root={}", root.display());
+                    self.set_active_context_root(root.clone());
+                    self.save_workspace();
                 }
                 _ => {
                     log::warn!("pane_ipc: unsupported command kind, dropping");
@@ -2202,7 +2228,7 @@ impl eframe::App for PlexiApp {
                     pane_names,
                     drag_cursor_pos,
                     hovered_files,
-                    workspace_root: crate::config::active_workspace_root(),
+                    workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ctx.tree.ui(&mut behavior, ui);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -909,6 +909,22 @@ pub enum HostCommand {
         name: String,
     },
 
+    /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
+    CreateContext {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        root: Option<std::path::PathBuf>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    /// Focus existing context by root, or create one. Sent by `plexi context open`.
+    FocusContext {
+        root: std::path::PathBuf,
+    },
+    /// Set/update the root of the active context. Sent by `plexi context set-root`.
+    SetContextRoot {
+        root: std::path::PathBuf,
+    },
+
     // ── Media + HTTP primitives ──────────────────────────────────────────
     /// Host-brokered HTTP request. Requires `net.http` capability.
     /// Host replies with `PlexiEvent::HttpResponse { request_id, ... }`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2339,58 +2339,58 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
 /// Prints a shell hook snippet that calls `plexi context open` whenever the
 /// working directory changes and a `.plexi/` directory is found above it.
 pub fn shell_init_cli(shell: Option<&str>) -> i32 {
-    match shell {
-        Some("zsh") => {
+    match shell.unwrap_or("zsh") {
+        "zsh" => {
             println!(
                 r#"
-# Plexi shell integration — added by `plexi shell-init zsh`
+# Plexi shell integration — add to ~/.zshrc: eval "$(plexi shell-init)"
 _plexi_chpwd() {{
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
         if [[ -d "$dir/.plexi" ]]; then
-            export PLEXI_ACTIVE_WORKSPACE="$dir"
-            plexi context open "$dir" &>/dev/null &
+            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
+                export PLEXI_ACTIVE_WORKSPACE="$dir"
+                plexi context open "$dir" &>/dev/null &
+            fi
             return
         fi
         dir="$(dirname "$dir")"
     done
+    unset PLEXI_ACTIVE_WORKSPACE
 }}
 autoload -Uz add-zsh-hook
 add-zsh-hook chpwd _plexi_chpwd
-# Run once on shell startup
 _plexi_chpwd
 "#
             );
             0
         }
-        Some("bash") => {
+        "bash" => {
             println!(
                 r#"
-# Plexi shell integration — added by `plexi shell-init bash`
+# Plexi shell integration — add to ~/.bashrc: eval "$(plexi shell-init --shell bash)"
 _plexi_chpwd() {{
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
         if [[ -d "$dir/.plexi" ]]; then
-            export PLEXI_ACTIVE_WORKSPACE="$dir"
-            plexi context open "$dir" &>/dev/null &
+            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
+                export PLEXI_ACTIVE_WORKSPACE="$dir"
+                plexi context open "$dir" &>/dev/null &
+            fi
             return
         fi
-        dir="$(dirname "$dir")"
+        dir="${{dir%/*}}"
     done
+    unset PLEXI_ACTIVE_WORKSPACE
 }}
 PROMPT_COMMAND="_plexi_chpwd${{PROMPT_COMMAND:+;$PROMPT_COMMAND}}"
-# Run once on shell startup
 _plexi_chpwd
 "#
             );
             0
         }
-        Some(other) => {
+        other => {
             eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash");
-            1
-        }
-        None => {
-            eprintln!("error: shell name required — usage: plexi shell-init <zsh|bash>");
             1
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2256,6 +2256,146 @@ pub fn validate_cli(path: &str) -> i32 {
     if errors.is_empty() { 0 } else { 1 }
 }
 
+/// Resolve `path` argument (canonicalize if given, else use CWD).
+fn resolve_path(path: Option<&str>) -> Result<std::path::PathBuf, String> {
+    match path {
+        Some(p) => std::fs::canonicalize(p)
+            .map_err(|e| format!("error: could not resolve path {p:?}: {e}")),
+        None => std::env::current_dir()
+            .map_err(|e| format!("error: could not get current directory: {e}")),
+    }
+}
+
+/// Send a JSON payload to PLEXI_SOCKET. Returns 0 on success, 1 on error.
+fn send_to_socket(payload: serde_json::Value) -> i32 {
+    let socket_path = match std::env::var("PLEXI_SOCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
+            return 1;
+        }
+    };
+    let line = format!("{}\n", payload);
+    if let Err(e) = stream.write_all(line.as_bytes()) {
+        eprintln!("error: could not write to socket: {e}");
+        return 1;
+    }
+    0
+}
+
+/// `plexi context new [path]`
+///
+/// Creates a new context. Uses `path` as the root (or CWD if omitted).
+pub fn context_new_cli(path: Option<&str>) -> i32 {
+    let root = match resolve_path(path) {
+        Ok(p) => p,
+        Err(e) => { eprintln!("{e}"); return 1; }
+    };
+    send_to_socket(serde_json::json!({
+        "type": "create_context",
+        "root": root,
+    }))
+}
+
+/// `plexi context open [path]`
+///
+/// Focuses the context with matching root, or creates one. Uses CWD if path omitted.
+pub fn context_open_cli(path: Option<&str>) -> i32 {
+    let root = match resolve_path(path) {
+        Ok(p) => p,
+        Err(e) => { eprintln!("{e}"); return 1; }
+    };
+    send_to_socket(serde_json::json!({
+        "type": "focus_context",
+        "root": root,
+    }))
+}
+
+/// `plexi context set-root [path]`
+///
+/// Sets the root of the active context. Uses CWD if path omitted.
+pub fn context_set_root_cli(path: Option<&str>) -> i32 {
+    let root = match resolve_path(path) {
+        Ok(p) => p,
+        Err(e) => { eprintln!("{e}"); return 1; }
+    };
+    send_to_socket(serde_json::json!({
+        "type": "set_context_root",
+        "root": root,
+    }))
+}
+
+/// `plexi shell-init <shell>`
+///
+/// Prints a shell hook snippet that calls `plexi context open` whenever the
+/// working directory changes and a `.plexi/` directory is found above it.
+pub fn shell_init_cli(shell: Option<&str>) -> i32 {
+    match shell {
+        Some("zsh") => {
+            println!(
+                r#"
+# Plexi shell integration — added by `plexi shell-init zsh`
+_plexi_chpwd() {{
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.plexi" ]]; then
+            export PLEXI_ACTIVE_WORKSPACE="$dir"
+            plexi context open "$dir" &>/dev/null &
+            return
+        fi
+        dir="$(dirname "$dir")"
+    done
+}}
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd _plexi_chpwd
+# Run once on shell startup
+_plexi_chpwd
+"#
+            );
+            0
+        }
+        Some("bash") => {
+            println!(
+                r#"
+# Plexi shell integration — added by `plexi shell-init bash`
+_plexi_chpwd() {{
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.plexi" ]]; then
+            export PLEXI_ACTIVE_WORKSPACE="$dir"
+            plexi context open "$dir" &>/dev/null &
+            return
+        fi
+        dir="$(dirname "$dir")"
+    done
+}}
+PROMPT_COMMAND="_plexi_chpwd${{PROMPT_COMMAND:+;$PROMPT_COMMAND}}"
+# Run once on shell startup
+_plexi_chpwd
+"#
+            );
+            0
+        }
+        Some(other) => {
+            eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash");
+            1
+        }
+        None => {
+            eprintln!("error: shell name required — usage: plexi shell-init <zsh|bash>");
+            1
+        }
+    }
+}
+
 #[cfg(test)]
 mod notify_tests {
     use super::notify_cli;

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,6 +21,9 @@ pub(crate) enum WindowMenuAction {
 pub struct Context {
     pub name: String,
     pub path: PathBuf,
+    /// Optional project root. When set, new panes in this context open at
+    /// this directory rather than inheriting the focused pane's CWD.
+    pub root: Option<PathBuf>,
     /// Stable unique ID, assigned at creation and never reused.
     pub context_id: u64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,6 +676,9 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "registry",
         // #627 — `plexi validate <path>` preflight app checker.
         "validate",
+        // #680 — context root and shell integration.
+        "context",
+        "shell-init",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,6 +462,35 @@ fn main() -> eframe::Result {
                     }
                 }
             }
+            "context" => {
+                if args.len() < 3 {
+                    eprintln!("Usage: plexi context <new|open|set-root> [path]");
+                    std::process::exit(1);
+                }
+                match args[2].as_str() {
+                    "new" => {
+                        let path = args.get(3).map(|s| s.as_str());
+                        std::process::exit(cli::context_new_cli(path));
+                    }
+                    "open" => {
+                        let path = args.get(3).map(|s| s.as_str());
+                        std::process::exit(cli::context_open_cli(path));
+                    }
+                    "set-root" => {
+                        let path = args.get(3).map(|s| s.as_str());
+                        std::process::exit(cli::context_set_root_cli(path));
+                    }
+                    other => {
+                        eprintln!("Unknown context subcommand: {other}");
+                        eprintln!("Usage: plexi context <new|open|set-root> [path]");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            "shell-init" => {
+                let shell = args.get(2).map(|s| s.as_str());
+                std::process::exit(cli::shell_init_cli(shell));
+            }
             "open" => {
                 // plexi open <type_id> [args...] [--layout=split_v|split_h|split_above|split_left|overlay]
                 if args.len() < 3 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,7 +488,19 @@ fn main() -> eframe::Result {
                 }
             }
             "shell-init" => {
-                let shell = args.get(2).map(|s| s.as_str());
+                let mut shell: Option<&str> = None;
+                let mut i = 2;
+                while i < args.len() {
+                    if args[i] == "--shell" && i + 1 < args.len() {
+                        shell = Some(args[i + 1].as_str());
+                        i += 2;
+                    } else if !args[i].starts_with("--") {
+                        shell = Some(args[i].as_str());
+                        i += 1;
+                    } else {
+                        i += 1;
+                    }
+                }
                 std::process::exit(cli::shell_init_cli(shell));
             }
             "open" => {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -30,6 +30,7 @@ impl PlexiApp {
         self.router.push(crate::context::Context {
             name: ctx_name,
             path: cwd.clone(),
+            root: Some(cwd.clone()),
             context_id: ctx_id,
         });
         self.windows.push(Window {
@@ -75,10 +76,11 @@ impl PlexiApp {
     /// and make it the active context.
     pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let cwd = self.windows[self.active_window]
+        let pane_cwd = self.windows[self.active_window]
             .focused_pane
             .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
             .unwrap_or_else(|| home.clone());
+        let cwd = self.router.active().root.clone().unwrap_or(pane_cwd);
         log::info!("create_page_at({grid_x},{grid_y}): cwd={}", cwd.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
         else {
@@ -315,6 +317,65 @@ impl PlexiApp {
         }
     }
 
+    /// Focus an existing context whose `root == Some(&root)`, or create a new one.
+    /// Uses the directory name as the context name.
+    pub(crate) fn focus_or_create_context_by_root(&mut self, root: PathBuf) {
+        if let Some(idx) = self.router.position(|ctx| ctx.root.as_deref() == Some(&root)) {
+            log::info!("focus_or_create_context_by_root: found existing ctx at idx={idx} root={}", root.display());
+            self.switch_workspace(idx);
+            return;
+        }
+        log::info!("focus_or_create_context_by_root: creating new ctx root={}", root.display());
+        let cwd = root.clone();
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
+        else {
+            log::error!("focus_or_create_context_by_root: failed to create terminal");
+            return;
+        };
+        let ctx_name = root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Context")
+            .to_string();
+        let ctx_id = self.next_window_id;
+        self.next_window_id += 1;
+        let win_id = self.next_window_id;
+        self.next_window_id += 1;
+        self.router.push(crate::context::Context {
+            name: ctx_name,
+            path: cwd.clone(),
+            root: Some(root),
+            context_id: ctx_id,
+        });
+        self.windows.push(crate::context::Window {
+            name: String::new(),
+            path: cwd,
+            tree,
+            panes,
+            focused_pane: Some(root_tile),
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+        self.router.activate_last();
+        self.active_window = self.windows.len() - 1;
+        self.context_active_window.insert(ctx_id, win_id);
+        self.minimap.visible = false;
+    }
+
+    /// Set the `root` of the active context.
+    pub(crate) fn set_active_context_root(&mut self, root: PathBuf) {
+        let idx = self.router.active_idx();
+        log::info!(
+            "set_active_context_root: ctx_id={} root={}",
+            self.router.active().context_id,
+            root.display()
+        );
+        self.router.get_mut(idx).root = Some(root);
+    }
+
     pub(crate) fn save_workspace(&self) {
         let mut saved_contexts = Vec::new();
         let mut saved_windows = Vec::new();
@@ -323,6 +384,7 @@ impl PlexiApp {
             saved_contexts.push(crate::workspace::SavedContext {
                 name: ctx.name.clone(),
                 path: ctx.path.clone(),
+                root: ctx.root.clone(),
                 context_id: ctx.context_id,
             });
         }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1368,6 +1368,27 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+
+            // Context commands are only valid over PLEXI_SOCKET; log and drop
+            // when sent via PGAP.
+            HostCommand::CreateContext { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received CreateContext over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            HostCommand::FocusContext { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received FocusContext over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            HostCommand::SetContextRoot { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received SetContextRoot over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
         }
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -23,6 +23,9 @@ pub struct WorkspaceFile {
 pub struct SavedContext {
     pub name: String,
     pub path: PathBuf,
+    /// Optional project root — persisted so contexts restore their root on relaunch.
+    #[serde(default)]
+    pub root: Option<PathBuf>,
     pub context_id: u64,
 }
 


### PR DESCRIPTION
Closes #680

## Summary

- Adds `root: Option<PathBuf>` to `Context` and persists it in workspace JSON (`SavedContext`)
- `new_context()` sets root from the CWD of the first terminal pane; `create_page_at()` uses context root for new pane CWD when set
- New host methods: `focus_or_create_context_by_root`, `set_active_context_root`
- Three new `HostCommand` variants: `CreateContext`, `FocusContext`, `SetContextRoot` (socket-dispatched in `drain_pane_cmd_channel`)
- CLI: `plexi context new [path]`, `plexi context open [path]`, `plexi context set-root [path]`
- CLI: `plexi shell-init [--shell zsh|bash]` prints a `chpwd`/`PROMPT_COMMAND` hook that auto-activates contexts on `cd`
- Tiling `workspace_root` now prefers the active context's root (falls back to `active_workspace_root()`)
- `examples/workspace/.plexi/config.toml` example added

## Test plan

- [ ] Open Plexi alpha, `Cmd+N` creates a new context — confirm context name auto-set from directory name
- [ ] Run `plexi context new /tmp` inside a terminal pane — confirm new context appears rooted at `/tmp`
- [ ] Run `plexi context open /tmp` — confirm existing `/tmp` context is focused (not duplicated)
- [ ] Run `plexi context set-root /some/path` — confirm tiling "outside workspace" indicator updates
- [ ] Run `plexi shell-init` — confirm zsh hook snippet printed; `plexi shell-init --shell bash` prints bash version
- [ ] `cargo test` passes (no new harness tests required — socket dispatch covered by existing IPC pattern)