### PR TITLE
feat(keys): delete RunPalette, bind Cmd+R → rename pane, Cmd+Shift+R → rename context

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-05-05 — [CHANGED] Delete RunPalette, bind Cmd+R → rename pane, Cmd+Shift+R → rename context (PR #720 → alpha)
+
+`Cmd+R` was bound to a "Run palette" modal that always showed "No active runs." — dead code since the run concept was never wired. Deleted `FocusLayer::RunPalette`, `Action::ToggleRunPalette`, `PlexiApp::show_run_palette`, `sync_run_palette_focus()`, and `draw_run_palette()` (58 lines). Rebinds: `RenamePane` moved from Cmd+Shift+R → Cmd+R; new `Action::RenameContext` added on Cmd+Shift+R (sets `renaming_window = Some(active_window)`, which hands off to the existing `ContextRename` focus layer and `draw_rename_context_overlay`).
+**Breaks if:** Cmd+R opens any "Active Runs" modal instead of the pane-rename overlay, OR Cmd+Shift+R does not open the context-rename overlay on the active context.
+
 ## 2026-05-05 — [FIX] Bundle Python runtime in release zip (PR #718 → alpha)
 
 `release.yml` never ran `fetch-python-runtime.sh` — `assets/python/` was never populated on the CI runner, so the zip shipped without a Python interpreter. Python apps (e.g. Balls) failed to launch on any clean install that lacked a system Python. Fix: add a `Fetch Python runtime` step before `cargo bundle`, using the same versions pinned in the Justfile (3.12.13 / 20260414). The script already skips the download if the correct version is cached locally, so local builds are unaffected.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -44,7 +44,6 @@ pub(crate) enum FocusLayer {
     NotificationModal,
     ConfirmClose,
     CommandPalette,
-    RunPalette,
     RenamePane,
     /// Context naming modal shown when a new context is created while the
     /// sidebar is hidden. Mirrors the inline sidebar rename but as a centred
@@ -170,8 +169,6 @@ pub struct PlexiApp {
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
     pub(crate) features: crate::features::FeatureFlags,
-    /// Whether the Run palette overlay is visible (Cmd+R).
-    pub(crate) show_run_palette: bool,
     /// Notifications queued from apps via ShowNotification.
     pub(crate) pending_notifications: Vec<PendingNotification>,
     /// Whether the centered notification modal is visible. Primary (and only)
@@ -587,7 +584,6 @@ impl PlexiApp {
                     renaming_pane: None,
                     registry,
                     features: features.clone(),
-                    show_run_palette: false,
                     pending_notifications: Vec::new(),
                     show_notification_modal: false,
                     current_notify_id: None,
@@ -678,7 +674,6 @@ impl PlexiApp {
             renaming_pane: None,
             registry: AppRegistry::load(&std::env::current_dir().unwrap_or_default()),
             features,
-            show_run_palette: false,
             pending_notifications: Vec::new(),
             show_notification_modal: false,
             current_notify_id: None,
@@ -781,7 +776,6 @@ impl PlexiApp {
                 &path.join("nonexistent-apps-dir"),
             ),
             features,
-            show_run_palette: false,
             pending_notifications: Vec::new(),
             show_notification_modal: false,
             current_notify_id: None,
@@ -1210,7 +1204,6 @@ impl eframe::App for PlexiApp {
         self.sync_notification_modal_focus();
         self.sync_confirm_close_focus();
         self.sync_command_palette_focus();
-        self.sync_run_palette_focus();
         self.sync_rename_pane_focus();
         self.sync_context_rename_focus();
 
@@ -1233,9 +1226,6 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::CommandPalette) => {
                     self.draw_command_palette(ctx);
                 }
-                Some(FocusLayer::RunPalette) => {
-                    self.draw_run_palette(ctx);
-                }
                 Some(FocusLayer::RenamePane) => {
                     self.draw_rename_pane_overlay(ctx);
                 }
@@ -1252,7 +1242,6 @@ impl eframe::App for PlexiApp {
             self.sync_notification_modal_focus();
             self.sync_confirm_close_focus();
             self.sync_command_palette_focus();
-            self.sync_run_palette_focus();
             self.sync_rename_pane_focus();
             self.sync_context_rename_focus();
         }
@@ -1984,8 +1973,8 @@ impl eframe::App for PlexiApp {
                 Action::OpenSecretsManager => {
                     self.open_secrets_manager();
                 }
-                Action::ToggleRunPalette => {
-                    self.show_run_palette = !self.show_run_palette;
+                Action::RenameContext => {
+                    self.renaming_window = Some(self.active_window);
                 }
                 Action::ToggleNotificationModal => {
                     if self.show_notification_modal {
@@ -2511,7 +2500,6 @@ impl PlexiApp {
             Some(FocusLayer::NotificationModal)
                 | Some(FocusLayer::ConfirmClose)
                 | Some(FocusLayer::CommandPalette)
-                | Some(FocusLayer::RunPalette)
                 | Some(FocusLayer::RenamePane)
                 | Some(FocusLayer::ContextRename)
         )
@@ -2682,20 +2670,6 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::CommandPalette);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::CommandPalette);
-        }
-    }
-
-    /// Reconcile the run-palette focus layer with `show_run_palette`.
-    pub(crate) fn sync_run_palette_focus(&mut self) {
-        let should_own = self.show_run_palette;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::RunPalette);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::RunPalette);
-        } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::RunPalette);
         }
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -17,7 +17,8 @@
 // Cmd+Enter                   — toggle zoom
 // Cmd+/                       — toggle shortcuts overlay
 // Cmd+P                       — command palette
-// Cmd+Shift+R                 — rename pane
+// Cmd+R                       — rename pane
+// Cmd+Shift+R                 — rename context
 // Cmd+Up / Cmd+Down           — scroll
 // Cmd+= / Cmd+-               — font size
 // Cmd+E                       — file browser
@@ -80,14 +81,14 @@ pub enum Action {
     OpenConfig,
     /// Open the secrets manager (read-only vault viewer).
     OpenSecretsManager,
-    /// Toggle the Run palette (shows active runs, BlockedOnUser prompts).
-    ToggleRunPalette,
+    /// Rename the active context. Bound to Cmd+Shift+R.
+    RenameContext,
     /// Toggle the notification panel overlay (Cmd+Shift+A).
     ToggleNotificationModal,
     NotificationCycleNext,
     NotificationCyclePrev,
     /// Force-reload the focused app pane (#83). Bound to Cmd+Option+R.
-    /// Cmd+R is the Run palette and Cmd+Shift+R is RenamePane, so the
+    /// Cmd+R is RenamePane and Cmd+Shift+R is RenameContext, so the
     /// Option (Alt) modifier is the next free chord. No-op when the
     /// focused pane isn't a process-backed app.
     ForceReloadApp,
@@ -249,8 +250,13 @@ pub fn poll_actions(
             actions.push(Action::ToggleCommandPalette);
         }
 
-        // Rename pane (Cmd+Shift+R)
+        // Rename context (Cmd+Shift+R) vs rename pane (Cmd+R). Check shifted
+        // first so Cmd+Shift+R doesn't fall through to the Cmd+R branch.
         if input.consume_key(cmd_shift, egui::Key::R) {
+            actions.push(Action::RenameContext);
+        } else if !input.modifiers.alt
+            && input.consume_key(egui::Modifiers::COMMAND, egui::Key::R)
+        {
             actions.push(Action::RenamePane);
         }
 
@@ -332,23 +338,14 @@ pub fn poll_actions(
             actions.push(Action::OpenSecretsManager);
         }
 
-        // Force-reload focused app (Cmd+Option+R, #83). Check before plain
-        // Cmd+R so the modifier-rich variant matches first. Plain Cmd+R is
-        // the Run palette; Cmd+Shift+R is RenamePane. Option (alt) is the
-        // next free chord.
+        // Force-reload focused app (Cmd+Option+R, #83). The Cmd+R branch above
+        // guards with `!input.modifiers.alt` so this variant is still reached.
         let cmd_alt = egui::Modifiers {
             alt: true,
             ..egui::Modifiers::COMMAND
         };
         if input.consume_key(cmd_alt, egui::Key::R) {
             actions.push(Action::ForceReloadApp);
-        }
-
-        // Run palette (Cmd+R — plain, not Cmd+Shift+R which is RenamePane)
-        if !input.modifiers.shift && !input.modifiers.alt
-            && input.consume_key(egui::Modifiers::COMMAND, egui::Key::R)
-        {
-            actions.push(Action::ToggleRunPalette);
         }
 
         // Notification modal (Cmd+Shift+A) — opens the queue on the front item,

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -807,68 +807,6 @@ impl PlexiApp {
         }
     }
 
-    /// Run palette overlay (Cmd+R). Shows active runs across all panes; BlockedOnUser
-    /// runs get a [!] badge and an inline text input for unblocking.
-    pub(crate) fn draw_run_palette(&mut self, ctx: &egui::Context) {
-        // Consume Escape / Cmd+R at the context level so the key can't bleed
-        // through to the focused pane or trigger `poll_actions` a second
-        // time. Pairs with `FocusLayer::RunPalette` — the overlay owns its
-        // own dismissal keys.
-        let mut close = ctx.input_mut(|i| {
-            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-            let toggle = i.consume_key(egui::Modifiers::COMMAND, egui::Key::R);
-            esc || toggle
-        });
-
-        // Collect all active runs from every app pane in every context.
-        // Clone needed because we hold &self across the window render.
-        let all_runs: Vec<(String, String, String, Option<String>)> = Vec::new(); // (run_id, app_id, status, blocked_prompt)
-        for _win in &self.windows {}
-
-        egui::Window::new("Active Runs")
-            .collapsible(false)
-            .resizable(true)
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
-            .default_size(egui::Vec2::new(500.0, 300.0))
-            .show(ctx, |ui| {
-                if all_runs.is_empty() {
-                    ui.label(egui::RichText::new("No active runs.").italics());
-                    ui.add_space(8.0);
-                    ui.label("Apps create runs via DrawCommand::RunGet.");
-                } else {
-                    for (run_id, app_id, status, blocked_prompt) in &all_runs {
-                        let badge = if status == "blocked_on_user" {
-                            "[!] "
-                        } else {
-                            "    "
-                        };
-                        ui.label(egui::RichText::new(format!("{badge}{run_id}")).monospace());
-                        ui.label(
-                            egui::RichText::new(format!("    app={app_id} status={status}"))
-                                .small(),
-                        );
-                        if let Some(prompt) = blocked_prompt {
-                            ui.label(prompt);
-                        }
-                        ui.separator();
-                    }
-                }
-                ui.add_space(8.0);
-                ui.horizontal(|ui| {
-                    if ui.button("Close").clicked() {
-                        close = true;
-                    }
-                    crate::widgets::key_combo_list(
-                        ui, &[&["\u{2318}", "R"]], None, &self.colors,
-                    );
-                });
-            });
-
-        if close {
-            self.show_run_palette = false;
-        }
-    }
-
     /// Primary notification surface: a keyboard-first centered modal over the
     /// work area. Renders the front of the queue.
     ///


### PR DESCRIPTION
Closes #719

## What

- Removes the dead RunPalette modal (Cmd+R showed "No active runs." — always empty)
- Rebinds `RenamePane` from Cmd+Shift+R → **Cmd+R**
- Adds `RenameContext` action on **Cmd+Shift+R** — sets `renaming_window = Some(active_window)`, which hands off to the existing `FocusLayer::ContextRename` → `draw_rename_context_overlay` path

## Deleted

- `FocusLayer::RunPalette` variant
- `Action::ToggleRunPalette` variant
- `PlexiApp::show_run_palette` field and all 3 initializations
- `sync_run_palette_focus()` method and 2 call sites
- `draw_run_palette()` overlay method (58 lines)

## Breaks if

Cmd+R opens any "Active Runs" modal instead of the pane-rename overlay, OR Cmd+Shift+R does not open the context-rename overlay on the active context.