### PR TITLE
fix(updater): only notify when latest > current semver

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -1,5 +1,10 @@
 <!-- DEV_LOG.md — decision journal for the Plexi project. Newest entries at the top. Records non-obvious choices, abandoned approaches, and root causes so future sessions don't repeat mistakes. -->
 
+## 2026-05-05 — [FIX] Update check: only notify when latest > current semver (PR #733 → alpha)
+
+`updater.rs` used `latest != current` — firing the update banner whenever the running version differed from the latest GitHub release, including when running a *newer* build (e.g. alpha at 3.4.113 flagged stable 3.4.111 as an update). Fixed with a local `semver_gt(a, b)` that parses M.m.p into integer tuples and returns `a > b`. No crate needed. The `config_dir()` cache path was already channel-aware; only the comparison logic was wrong.
+**Breaks if:** Running alpha at a version ahead of the latest stable release still shows the update banner in the status bar.
+
 ## 2026-05-05 — [FIX] Embed plexi_sdk in binary, seed to profile dir on first launch (PR #734 → alpha)
 
 `ensure_profile_initialized()` seeded `apps/` from embedded examples but never seeded `sdk/`. The bundle resource path (`Contents/Resources/sdk/python/`) was the only PYTHONPATH entry on fresh installs, but CI cache hits (Cargo.lock-only key) meant `cargo bundle` could skip re-embedding resources — shipping a zip with no SDK. Dev builds worked because `install.sh` explicitly ran `cp -R sdk/python/plexi_sdk ~/.plexi-<channel>/sdk/plexi_sdk`. Fix: inline `include_dir!("sdk/python/plexi_sdk")` in `ensure_profile_initialized()`, extracted to `config_dir()/sdk/plexi_sdk/` on first launch. Also updated CI cache key to hash `Cargo.toml` (belt-and-suspenders alongside the `rm -rf target/release/bundle` from PR #732).

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -16,19 +16,47 @@ pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String
             match cached_or_fetch(&cache_path) {
                 Some(latest) => {
                     let current = env!("CARGO_PKG_VERSION");
-                    if latest != current {
+                    if semver_gt(&latest, current) {
                         log::info!(
                             "update check: newer release available: v{latest} (current v{current})"
                         );
                         let _ = tx.send(latest);
                     } else {
-                        log::info!("update check: already on latest (v{current})");
+                        log::info!("update check: already on latest or ahead (v{current})");
                     }
                 }
                 None => log::warn!("update check: could not determine latest version"),
             }
         })
         .ok();
+}
+
+/// Returns true only when `a` is strictly newer than `b` by semver (M.m.p).
+/// Unparseable components are treated as 0.
+fn semver_gt(a: &str, b: &str) -> bool {
+    let parse = |s: &str| -> (u64, u64, u64) {
+        let mut parts = s.splitn(4, '.');
+        let major = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let patch = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        (major, minor, patch)
+    };
+    parse(a) > parse(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::semver_gt;
+
+    #[test]
+    fn test_semver_gt() {
+        assert!(semver_gt("3.4.114", "3.4.113"));
+        assert!(semver_gt("3.5.0", "3.4.113"));
+        assert!(semver_gt("4.0.0", "3.9.9"));
+        assert!(!semver_gt("3.4.113", "3.4.113")); // equal
+        assert!(!semver_gt("3.4.111", "3.4.113")); // behind
+        assert!(!semver_gt("3.4.112", "3.4.113")); // one behind
+    }
 }
 
 fn cached_or_fetch(cache_path: &Path) -> Option<String> {


### PR DESCRIPTION
Closes #731

## Problem
`updater.rs` used `latest != current` to decide whether to surface the update notification. Running a build *ahead* of the latest GitHub release (e.g. alpha at `3.4.113`, latest stable at `3.4.111`) incorrectly fired the notification.

## Fix
Added `semver_gt(a, b) -> bool` that parses `M.m.p` into integer tuples and returns `a > b`. No external crate needed. Notification now only fires when the release is strictly newer than the running build.

The `config_dir()` cache path is already channel-aware (`.plexi-alpha/`, `.plexi-beta/`, `.plexi/`) — no change needed there.

## Test
`updater::tests::test_semver_gt` covers equal, ahead, behind, major/minor/patch boundary cases.