### PR TITLE
docs(cli_setup): note that just pr-install pre-creates the symlink

### DIFF
--- a/src/cli_setup.rs
+++ b/src/cli_setup.rs
@@ -39,6 +39,9 @@ pub fn should_prompt() -> bool {
     true
 }
 
+/// Note: `just pr-install` always creates `/usr/local/bin/plexi-pr-<N>` as part of its
+/// setup, so this returns `true` in every PR build. To test the CLI setup modal in a PR
+/// build, first remove that symlink manually before opening the app.
 pub fn is_installed() -> bool {
     install_path().exists()
 }


### PR DESCRIPTION
Adds a doc comment on `is_installed()` explaining that `just pr-install` always creates the CLI symlink, which means the CLI setup modal is silently suppressed in PR builds unless the symlink is removed first.