### PR TITLE
fix(cli): channel-agnostic open_cli + keep bare plexi symlink in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,17 @@ Before writing any keyboard shortcut display, badge, chip, or inline label widge
 
 **Use `key_combo_list` for any shortcut hint row.** Do not render key shortcuts as plain `Label` text — it produces a visually inconsistent result that requires a separate pass to fix.
 
+## Channel-Agnostic CLI Rule
+
+Every CLI command and feature must work identically on alpha, beta, stable, and PR builds. This is non-negotiable — the release channel is an implementation detail, not something callers should need to know.
+
+**How it works:**
+- When called from inside a Plexi pane, `PLEXI_SOCKET` is set and routes directly to the correct running instance. All CLI commands that communicate with the host must check `PLEXI_SOCKET` first and use it when available.
+- When called from outside a pane, commands fall back to channel-specific mechanisms (spawn-queue, config_dir) derived from the running binary name.
+- `/usr/local/bin/plexi` (the bare `plexi` command) is kept as a symlink to the most recently installed non-PR channel binary by `scripts/install.sh`. PR builds never capture the bare name.
+
+**Enforcement:** Never hardcode a profile directory path (e.g. `~/.plexi-alpha/`) in CLI code — always use `config_dir()`. Never route around `PLEXI_SOCKET` when it is set. Any new CLI command that communicates with a running instance must follow the socket-first pattern in `open_cli()`.
+
 ## General Rules
 
 - Before SSH/networking setup, ask if machines are on the same LAN or remote. Before any multi-step infra task, clarify topology first.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,6 +62,14 @@ fi
 
 ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" "$bin_dest"
 
+# For non-PR channels (alpha, beta, stable), also update the bare `plexi`
+# symlink so that `plexi open`, `plexi notify`, etc. always reach the correct
+# running instance regardless of which channel was most recently installed.
+# PR builds are excluded — they are ephemeral and should not capture the bare name.
+if [[ ! "$channel" =~ ^pr- ]]; then
+  ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" /usr/local/bin/plexi
+fi
+
 mkdir -p "$profile_dir/sdk" "$profile_dir/apps"
 rm -rf "$profile_dir/sdk/plexi_sdk.py" "$profile_dir/sdk/plexi_sdk"
 cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1395,10 +1395,34 @@ pub fn pane_set_title_cli(name: &str) -> i32 {
 
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
-/// Writes a spawn request to the spawn-queue directory. The running Plexi host
-/// drains this queue each second and launches the app.
+/// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a
+/// spawn_pane command directly via the socket — channel-agnostic, works on
+/// alpha, beta, stable, and PR builds without caring which binary is on PATH.
+///
+/// When called from outside Plexi, falls back to the spawn-queue directory
+/// which the running host drains each second.
+///
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
+    let layout_str = layout.unwrap_or("split_v");
+    let payload = serde_json::json!({
+        "type": "spawn_pane",
+        "type_id": type_id,
+        "args": args,
+        "layout": layout_str,
+    });
+
+    // Socket path is set when running inside a Plexi pane — use it directly so
+    // the command reaches the correct running instance regardless of channel.
+    if std::env::var("PLEXI_SOCKET").is_ok() {
+        let code = send_to_socket(payload);
+        if code == 0 {
+            println!("opened: {type_id}");
+        }
+        return code;
+    }
+
+    // Fallback: write to the spawn-queue for the channel this binary belongs to.
     let queue_dir = crate::config::config_dir().join("spawn-queue");
     if let Err(e) = std::fs::create_dir_all(&queue_dir) {
         eprintln!("error: could not create spawn queue: {e}");
@@ -1408,13 +1432,13 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let payload = serde_json::json!({
+    let queue_payload = serde_json::json!({
         "type_id": type_id,
         "args": args,
-        "layout": layout.unwrap_or("split_v"),
+        "layout": layout_str,
     });
     let file = queue_dir.join(format!("{id}.json"));
-    if let Err(e) = std::fs::write(&file, payload.to_string()) {
+    if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }


### PR DESCRIPTION
## Summary

- `open_cli()` now checks `PLEXI_SOCKET` first — when called from inside a Plexi pane, sends `spawn_pane` directly via the socket instead of writing to the spawn-queue. This makes `plexi open terminal` work correctly on alpha, beta, stable, and PR builds without caring which binary is on PATH.
- `scripts/install.sh` now updates `/usr/local/bin/plexi` on every non-PR install (alpha, beta, stable), so the bare `plexi` command always reaches the most recently installed channel. PR builds are excluded.
- `CLAUDE.md` documents the channel-agnostic CLI rule so future agents enforce it.

## Root cause

`/usr/local/bin/plexi` was a stale static binary from May 2 routing to `~/.plexi/` (stable profile). The running alpha app reads `~/.plexi-alpha/spawn-queue/` — they never communicated.

## Test plan

- [ ] Run `plexi open terminal` from inside an alpha terminal pane — new terminal opens to the right
- [ ] Run `just install` from `worktrees/alpha/` — verify `/usr/local/bin/plexi` symlink updates to alpha binary
- [ ] Run `plexi open terminal` from outside Plexi (no PLEXI_SOCKET) — falls back to spawn-queue, queued message printed