### PR TITLE
fix(cli): stop PLEXI_RUNNING walk before home dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -292,15 +292,15 @@ fn main() -> eframe::Result {
         let home = dirs::home_dir().unwrap_or_default();
         let mut dir = cwd.as_path();
         loop {
+            if dir == home || dir.parent().is_none() {
+                break;
+            }
             if dir.join(".plexi").is_dir() {
                 eprintln!(
                     "plexi: already running inside Plexi. Nearest workspace: {}",
                     dir.join(".plexi").display()
                 );
                 std::process::exit(0);
-            }
-            if dir == home || dir.parent().is_none() {
-                break;
             }
             dir = dir.parent().unwrap();
         }


### PR DESCRIPTION
## What

When `PLEXI_RUNNING=1` is set (i.e. binary invoked from inside a Plexi pane with no subcommand), the walk searching for a `.plexi/` project workspace was reaching `~/` and finding `~/.plexi` (the **stable profile dir**), reporting it as "Nearest workspace: /Users/.../.plexi". This made `plexi-beta` appear to be using the wrong namespace.

## Root cause

The home-boundary break was checked *after* the `.plexi` dir check. So on the iteration where `dir == home`, it would find `~/.plexi` before ever breaking.

## Fix

Swap the two checks in the loop — break on home/root first, then test for `.plexi/`. The walk now stops before reaching `~`, so the stable profile dir is never mistaken for a project workspace. Falls through to "Use Cmd+T to open a new pane" instead.

**Breaks if:** Running any `plexi-*` binary bare (no subcommand) inside a pane, from a directory with no `.plexi/` workspace ancestor, still prints "Nearest workspace: ~/.plexi".