### PR TITLE
fix(cli): atomic response file write + UUID filename in notify_cli

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1505,7 +1505,8 @@ impl eframe::App for PlexiApp {
                     );
                     if let Some(rf) = &response_file {
                         let content = value.as_deref().unwrap_or("");
-                        match std::fs::write(rf, content) {
+                        let tmp = format!("{rf}.tmp");
+                        match std::fs::write(&tmp, content).and_then(|_| std::fs::rename(&tmp, rf)) {
                             Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
                             Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
                         }
@@ -2779,7 +2780,8 @@ impl PlexiApp {
                 );
                 if let Some(rf) = &response_file {
                     let content = value.as_deref().unwrap_or("");
-                    match std::fs::write(rf, content) {
+                    let tmp = format!("{rf}.tmp");
+                    match std::fs::write(&tmp, content).and_then(|_| std::fs::rename(&tmp, rf)) {
                         Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
                         Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1225,10 +1225,7 @@ pub fn notify_cli(
         }
     };
 
-    let id = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
+    let id = uuid::Uuid::new_v4();
 
     let options_json: Vec<serde_json::Value> = choices
         .iter()


### PR DESCRIPTION
Fixes #726.

## What

Two changes to eliminate the TOCTOU race in `notify_cli`:

1. **Atomic write (host side):** Both `DeliverNotifyAction` handlers in `src/app/mod.rs` now write to `<response_file>.tmp` and then `rename()` to the final path. POSIX `rename()` is atomic — the CLI can never read a partial file.

2. **UUID filename (CLI side):** `notify_cli` now generates the response file name using `uuid::Uuid::new_v4()` instead of `SystemTime::now().as_nanos()`. Eliminates the collision window between concurrent `plexi notify` processes.

## Test plan
- [ ] `plexi notify --title "Test" --body "Pick one" --choice ok:OK --choice cancel:Cancel` inside a pane — verify correct key is printed to stdout
- [ ] Rapid concurrent calls: `for i in 1 2 3; do plexi notify --title "T$i" --body "B" --choice a:A &; done` — all three should receive their response without timeout