### PR TITLE
fix(process_app): name all spawned threads + background reaper + stream thread cap

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -34,7 +34,7 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdout, Stdio};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, Receiver, Sender, TryRecvError},
     Arc, Mutex,
 };
@@ -264,6 +264,10 @@ pub struct ProcessApp {
     /// Dropping an entry cancels nothing automatically — the cancel flag
     /// must be set and a signal sent before removing the handle.
     pub(crate) stream_handles: HashMap<String, StreamHandle>,
+    /// Count of currently active `StreamProcess` reader threads. Incremented
+    /// before spawn, decremented when the thread exits. Capped at
+    /// `MAX_STREAM_THREADS` to bound peak stack memory.
+    pub(crate) active_stream_threads: Arc<AtomicUsize>,
 }
 
 impl ProcessApp {
@@ -380,7 +384,9 @@ impl ProcessApp {
             use std::io::Write as _;
             let render_slot_writer = Arc::clone(&render_slot);
             let render_in_queue_writer = Arc::clone(&render_in_queue);
-            thread::spawn(move || {
+            thread::Builder::new()
+                .name(format!("app-stdin-{stdin_type_id}"))
+                .spawn(move || {
                 let mut stdin = stdin;
                 for item in event_rx {
                     match item {
@@ -405,7 +411,7 @@ impl ProcessApp {
                         }
                     }
                 }
-            });
+            }).expect("failed to spawn app-stdin thread");
         }
 
         // Background thread: forward subprocess stderr to Plexi's logger,
@@ -418,7 +424,9 @@ impl ProcessApp {
         let recent_stderr_thread = Arc::clone(&recent_stderr_capture);
         let lifecycle_tracker = Arc::new(LifecycleTracker::new());
         let lifecycle_stderr = Arc::clone(&lifecycle_tracker);
-        thread::spawn(move || {
+        thread::Builder::new()
+            .name(format!("app-stderr-{stderr_type_id}"))
+            .spawn(move || {
             const STDERR_RING_CAP: usize = 32;
             let reader = std::io::BufReader::new(stderr);
             for line in std::io::BufRead::lines(reader) {
@@ -438,7 +446,7 @@ impl ProcessApp {
                     _ => {}
                 }
             }
-        });
+        }).expect("failed to spawn app-stderr thread");
 
         // Background thread: read draw commands line-by-line and forward via channel.
         // Also feeds the lifecycle tracker:
@@ -447,7 +455,9 @@ impl ProcessApp {
         let (draw_tx, draw_rx) = mpsc::channel::<DrawCommand>();
         let lifecycle_stdout = Arc::clone(&lifecycle_tracker);
         let stdout_type_id = type_id.clone();
-        thread::spawn(move || {
+        thread::Builder::new()
+            .name(format!("app-stdout-{stdout_type_id}"))
+            .spawn(move || {
             let reader = BufReader::new(stdout);
             for line in reader.lines() {
                 match line {
@@ -482,7 +492,31 @@ impl ProcessApp {
             // subprocess closed its stdout — flip Crashed unless already
             // terminal.
             lifecycle_stdout.on_stdout_closed();
-        });
+        }).expect("failed to spawn app-stdout thread");
+
+        // Background reaper: blocks on waitpid so the UI thread never polls try_wait.
+        // Fires on_process_exited() exactly once when the child exits — replaces the
+        // per-frame try_wait() poll that was causing 600 syscalls/sec with 10 panes open.
+        let reaper_pid = child.id();
+        let lifecycle_reaper = Arc::clone(&lifecycle_tracker);
+        let reaper_type_id = type_id.clone();
+        thread::Builder::new()
+            .name(format!("app-reaper-{reaper_type_id}"))
+            .spawn(move || {
+                let mut status = 0i32;
+                // SAFETY: reaper_pid is a valid child PID obtained from Command::spawn().
+                // We block until the child exits. The shutdown path's child.wait() may
+                // race and get ECHILD if we win — that's harmless since shutdown discards
+                // the result with `let _ = child.wait()`.
+                unsafe {
+                    libc::waitpid(reaper_pid as libc::pid_t, &mut status, 0);
+                }
+                log::info!(
+                    "ProcessApp[{reaper_type_id}]: child exited — reaper signaling lifecycle"
+                );
+                lifecycle_reaper.on_process_exited();
+            })
+            .expect("failed to spawn app-reaper thread");
 
         let permissions = AppPermissions {
             capabilities,
@@ -555,6 +589,7 @@ impl ProcessApp {
             scroll_offsets: HashMap::new(),
             exposed_tools: Vec::new(),
             stream_handles: HashMap::new(),
+            active_stream_threads: Arc::new(AtomicUsize::new(0)),
         })
     }
 
@@ -669,6 +704,7 @@ impl ProcessApp {
             scroll_offsets: HashMap::new(),
             exposed_tools: Vec::new(),
             stream_handles: HashMap::new(),
+            active_stream_threads: Arc::new(AtomicUsize::new(0)),
             file_picker_tx,
             file_picker_rx,
         };
@@ -1190,25 +1226,6 @@ impl App for ProcessApp {
         let size = ui.available_size();
 
         self.flush_outbound_events();
-
-        // Lifecycle: per-frame try_wait poll. `try_wait` is non-blocking on
-        // macOS — `Ok(Some(_))` means the child has exited; `Ok(None)` means
-        // still running; `Err(_)` is fatal-for-this-process and treated as
-        // "we can't observe it any more, assume crashed". Exited child is
-        // sticky Crashed.
-        if let Some(child) = self.process.as_mut() {
-            match child.try_wait() {
-                Ok(Some(_status)) => self.lifecycle.on_process_exited(),
-                Ok(None) => {}
-                Err(e) => {
-                    log::warn!(
-                        "ProcessApp[{}]: try_wait failed: {e} — marking Crashed",
-                        self.type_id
-                    );
-                    self.lifecycle.on_process_exited();
-                }
-            }
-        }
 
         // Lifecycle: track user-input recency on this pane. Only required
         // for the Hung detector — we just need a "did the user touch this

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2078,6 +2078,12 @@ impl Drop for ProcessApp {
                     Ok(None) => {
                         std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
                     }
+                    Err(e) if e.raw_os_error() == Some(libc::ECHILD) => {
+                        // Background reaper already called waitpid and won the
+                        // race — ECHILD means the child is gone. Treat as clean exit.
+                        exited = true;
+                        break;
+                    }
                     Err(e) => {
                         log::warn!(
                             "ProcessApp[{}]: try_wait error during shutdown: {e}",

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -600,7 +600,25 @@ impl ProcessApp {
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
                 let corr_id = correlation_id.clone();
-                std::thread::spawn(move || {
+                const MAX_STREAM_THREADS: usize = 32;
+                let active = Arc::clone(&self.active_stream_threads);
+                let prior = active.fetch_add(1, Ordering::Relaxed);
+                if prior >= MAX_STREAM_THREADS {
+                    active.fetch_sub(1, Ordering::Relaxed);
+                    log::warn!(
+                        "ProcessApp[{}]: StreamProcess {correlation_id} rejected — stream thread limit ({MAX_STREAM_THREADS}) reached",
+                        self.type_id
+                    );
+                    let _ = self.http_tx.send(PlexiEvent::StreamEnd {
+                        correlation_id,
+                        exit_code: -1,
+                    });
+                    return;
+                }
+                let thread_name = format!("stream-reader-{}-{}", type_id, corr_id);
+                std::thread::Builder::new()
+                    .name(thread_name)
+                    .spawn(move || {
                     let mut buf = vec![0u8; 4096];
                     let mut pipe = pipe;
                     loop {
@@ -633,7 +651,8 @@ impl ProcessApp {
                         correlation_id: corr_id,
                         exit_code,
                     });
-                });
+                    active.fetch_sub(1, Ordering::Relaxed);
+                }).expect("failed to spawn stream-reader thread");
             }
 
             HostCommand::CancelProcess { correlation_id } => {
@@ -651,12 +670,14 @@ impl ProcessApp {
                     // Escalate to SIGKILL after a 1s grace period on a
                     // background thread so the UI never blocks.
                     let pid = handle.pid;
-                    std::thread::spawn(move || {
+                    std::thread::Builder::new()
+                        .name(format!("sigkill-{pid}"))
+                        .spawn(move || {
                         std::thread::sleep(std::time::Duration::from_secs(1));
                         unsafe {
                             libc::kill(pid as libc::pid_t, libc::SIGKILL);
                         }
-                    });
+                    }).expect("failed to spawn sigkill thread");
                 }
                 // else: stream already ended — no-op, no error event.
             }
@@ -679,7 +700,9 @@ impl ProcessApp {
                 );
                 let tx = self.file_picker_tx.clone();
                 let type_id = self.type_id.clone();
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("file-picker-{type_id}"))
+                    .spawn(move || {
                     let result = pick_files(&filter, multiple);
                     log::debug!("ProcessApp[{type_id}]: OpenFilePicker {request_id} → {result:?}");
                     let event = match result {
@@ -689,7 +712,7 @@ impl ProcessApp {
                         _ => PlexiEvent::FilePickCancelled { request_id },
                     };
                     let _ = tx.send(event);
-                });
+                }).expect("failed to spawn file-picker thread");
             }
 
             // ── Mouse tracking toggle ──────────────────────────────────────
@@ -802,7 +825,9 @@ impl ProcessApp {
                 let net = std::sync::Arc::clone(&self.net);
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("http-{type_id}-{request_id}"))
+                    .spawn(move || {
                     let resp = net.http(&method, &url, &headers, body.as_deref());
                     log::debug!("ProcessApp[{type_id}]: HttpRequest {request_id} → {}", resp.status);
                     let _ = tx.send(PlexiEvent::HttpResponse {
@@ -811,7 +836,7 @@ impl ProcessApp {
                         body: resp.body,
                         error: resp.error,
                     });
-                });
+                }).expect("failed to spawn http thread");
             }
             // ── ai.query broker (#284) ─────────────────────────────────────
             HostCommand::AiQuery {
@@ -856,7 +881,9 @@ impl ProcessApp {
                 let tool_dispatcher = std::sync::Arc::new(
                     crate::plexi_ai::tool_dispatch::ToolDispatcher::from_registry(),
                 );
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("ai-query-{app_id}-{request_id}"))
+                    .spawn(move || {
                     let resp = broker.dispatch(AiBrokerRequest {
                         app_id,
                         model_tier,
@@ -877,7 +904,7 @@ impl ProcessApp {
                     if let Err(e) = tx.send(event) {
                         log::warn!("ai broker: response receiver dropped: {e}");
                     }
-                });
+                }).expect("failed to spawn ai-query thread");
             }
 
             HostCommand::AudioPlay {
@@ -1013,7 +1040,9 @@ impl ProcessApp {
                 let audio = std::sync::Arc::clone(&self.audio_device);
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("audio-devices-{type_id}"))
+                    .spawn(move || {
                     let inputs = audio
                         .list_input_devices()
                         .into_iter()
@@ -1031,7 +1060,7 @@ impl ProcessApp {
                         outputs,
                         error: None,
                     });
-                });
+                }).expect("failed to spawn audio-devices thread");
             }
             HostCommand::ListMidiDevices { request_id } => {
                 // MIDI enumeration mirrors audio: not gated. Port names are
@@ -1040,7 +1069,9 @@ impl ProcessApp {
                 let midi = std::sync::Arc::clone(&self.midi_device);
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("midi-devices-{type_id}"))
+                    .spawn(move || {
                     let inputs = midi
                         .list_input_ports()
                         .into_iter()
@@ -1058,7 +1089,7 @@ impl ProcessApp {
                         outputs,
                         error: None,
                     });
-                });
+                }).expect("failed to spawn midi-devices thread");
             }
             HostCommand::OpenMidiInput { port_id, pipe_id } => {
                 if let PermissionCheck::Denied(reason) =
@@ -1196,13 +1227,15 @@ impl ProcessApp {
                 self.pending_timers.insert(timer_id.clone(), std::sync::Arc::clone(&cancelled));
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
-                std::thread::spawn(move || {
+                std::thread::Builder::new()
+                    .name(format!("timer-{type_id}-{timer_id}"))
+                    .spawn(move || {
                     std::thread::sleep(std::time::Duration::from_millis(after_ms));
                     if !cancelled.load(std::sync::atomic::Ordering::Relaxed) {
                         log::debug!("ProcessApp[{type_id}]: timer {timer_id} fired");
                         let _ = tx.send(PlexiEvent::Timer { timer_id });
                     }
-                });
+                }).expect("failed to spawn timer thread");
             }
 
             // ── Cancel timer ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #727

## What

**Thread naming:** All 11 anonymous `thread::spawn` calls now use `thread::Builder::new().name(...)`. Named by role and app ID: `app-stdin-<id>`, `app-stderr-<id>`, `app-stdout-<id>`, `app-reaper-<id>`, `stream-reader-<id>-<corr>`, `sigkill-<pid>`, `file-picker-<id>`, `http-<id>-<req>`, `ai-query-<id>-<req>`, `audio-devices-<id>`, `midi-devices-<id>`, `timer-<id>-<timer>`.

**Background reaper:** Replaces the per-frame `try_wait()` syscall poll (600 syscalls/sec with 10 panes @ 60fps) with one background thread per process that blocks on `libc::waitpid` and fires `on_process_exited()` exactly once. The shutdown path's `child.wait()` harmlessly gets `ECHILD` if the reaper wins the race.

**Stream thread cap:** `StreamProcess` reader threads are now bounded at 32 concurrent threads via an `AtomicUsize` counter. Excess requests get an immediate `StreamEnd{exit_code:-1}` instead of spawning unbounded OS threads (512KB–8MB stack each).

## Test plan
- [ ] Open a process-app pane — app renders normally, lifecycle pill shows Running
- [ ] Close the pane — lifecycle transitions to Crashed, no zombie processes
- [ ] If possible: open 10+ panes and verify no 600 syscall/sec noise in logs
- [ ] `cargo build` passes ✅