### PR TITLE
fix(typed_pipes): detect drain thread broken pipe within one render frame

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1291,6 +1291,41 @@ impl App for ProcessApp {
             self.outbound_events.push_back(event);
         }
 
+        // Per-frame: detect audio capture pipes whose drain thread exited due
+        // to a write error (e.g. Broken pipe when the app-side socket closed
+        // unexpectedly). Emit AudioCaptureError immediately so the app is
+        // notified within one render frame rather than waiting for the next
+        // start_audio_capture retry to discover the stale session.
+        let failed_audio_pipes: Vec<String> = self
+            .audio_capture_sessions
+            .keys()
+            .filter(|pipe_id| {
+                self.pipe_registry
+                    .lock()
+                    .map(|r| r.drain_failed(pipe_id))
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+        for pipe_id in failed_audio_pipes {
+            log::warn!(
+                "ProcessApp[{}]: AudioCapture pipe_id={pipe_id} drain failed — cleaning up",
+                self.type_id
+            );
+            self.audio_capture_sessions.remove(&pipe_id);
+            self.pipe_registry
+                .lock()
+                .expect("pipe_registry poisoned")
+                .close(&pipe_id);
+            if let Ok(mut m) = self.audio_peak_meters.lock() {
+                m.remove(&pipe_id);
+            }
+            self.outbound_events.push_back(PlexiEvent::AudioCaptureError {
+                pipe_id,
+                error: "pipe drain failed (broken pipe)".to_owned(),
+            });
+        }
+
         let new_cmds = self.drain_draw_commands();
 
         for cmd in new_cmds {

--- a/src/typed_pipes.rs
+++ b/src/typed_pipes.rs
@@ -71,6 +71,11 @@ struct BinaryPipeEntry {
     /// capture callback) clone this `Arc` and push frames; the drain thread
     /// pops and writes them to the socket.
     ring: Arc<ArrayQueue<Vec<u8>>>,
+    /// Set by the drain thread before it exits due to a write error (e.g.
+    /// Broken pipe). The host polls this flag per-frame via `drain_failed()`
+    /// and emits an error event so the app is notified promptly rather than
+    /// waiting for the next retry attempt.
+    error_flag: Arc<AtomicBool>,
 }
 
 struct JsonPipeEntry {
@@ -142,9 +147,11 @@ impl TypedPipeRegistry {
 
         let ring: Arc<ArrayQueue<Vec<u8>>> = Arc::new(ArrayQueue::new(DEFAULT_RING_CAPACITY));
         let shutdown = Arc::new(AtomicBool::new(false));
+        let error_flag = Arc::new(AtomicBool::new(false));
 
         let ring_drain = Arc::clone(&ring);
         let shutdown_drain = Arc::clone(&shutdown);
+        let error_flag_drain = Arc::clone(&error_flag);
         let socket_path_drain = socket_path.clone();
         let pipe_id_log = pipe_id.clone();
 
@@ -181,6 +188,7 @@ impl TypedPipeRegistry {
                     if let Some(frame) = ring_drain.pop() {
                         if let Err(e) = write_frame(&mut writer, &frame) {
                             log::warn!("typed_pipes: drain write error: {e}");
+                            error_flag_drain.store(true, Ordering::Release);
                             break;
                         }
                     } else if shutdown_drain.load(Ordering::Acquire) {
@@ -201,6 +209,7 @@ impl TypedPipeRegistry {
             shutdown,
             drain_handle: Some(drain_handle),
             ring: Arc::clone(&ring),
+            error_flag,
         };
 
         self.pipes.insert(pipe_id.clone(), PipeEntry::Binary(entry));
@@ -261,6 +270,16 @@ impl TypedPipeRegistry {
         match self.pipes.get(pipe_id) {
             Some(PipeEntry::Binary(b)) => Some(Arc::clone(&b.ring)),
             _ => None,
+        }
+    }
+
+    /// Returns true if the drain thread for `pipe_id` exited due to a write
+    /// error (e.g. Broken pipe). The host polls this per-frame to detect pipe
+    /// failures promptly rather than waiting for the app to retry.
+    pub fn drain_failed(&self, pipe_id: &str) -> bool {
+        match self.pipes.get(pipe_id) {
+            Some(PipeEntry::Binary(b)) => b.error_flag.load(Ordering::Acquire),
+            _ => false,
         }
     }
 
@@ -354,6 +373,56 @@ mod tests {
         assert!(
             !bystander_reg.has_reader("coord-to-worker"),
             "bystander pane never opted in — has_reader must be false"
+        );
+    }
+
+    #[test]
+    fn drain_failed_set_after_broken_pipe() {
+        // Open a binary pipe, connect a client, then immediately drop it to
+        // simulate the app-side socket closing unexpectedly (Broken pipe).
+        // After the drain thread attempts a write and fails, drain_failed()
+        // must return true.
+        let mut reg = TypedPipeRegistry::new();
+        let alloc = reg
+            .open_binary("test-broken-pipe".to_string(), PipeDirection::In)
+            .expect("open_binary");
+
+        // Connect and immediately close to give the drain thread a peer that
+        // will produce Broken pipe / Connection reset on the first write.
+        {
+            let _client =
+                std::os::unix::net::UnixStream::connect(&alloc.socket_path).expect("connect");
+            // `_client` drops here, closing the far end.
+        }
+
+        // Give the drain thread time to accept the connection.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Push a frame — drain thread will attempt to write to the closed socket.
+        let ring = reg.binary_ring("test-broken-pipe").expect("ring");
+        let _ = ring.push(vec![1, 2, 3]);
+
+        // Give the drain thread time to attempt the write and set error_flag.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        assert!(
+            reg.drain_failed("test-broken-pipe"),
+            "drain_failed should be true after Broken pipe"
+        );
+    }
+
+    #[test]
+    fn drain_failed_false_for_healthy_pipe() {
+        let mut reg = TypedPipeRegistry::new();
+        reg.open_binary("test-healthy".to_string(), PipeDirection::In)
+            .expect("open_binary");
+        assert!(
+            !reg.drain_failed("test-healthy"),
+            "drain_failed should be false before any write error"
+        );
+        assert!(
+            !reg.drain_failed("nonexistent"),
+            "drain_failed should be false for unknown pipe"
         );
     }
 


### PR DESCRIPTION
Closes #759

## What

When the drain thread exits due to a write error (e.g. `Broken pipe os error 32`), the host had no signal — it only discovered the stale session on the next `start_audio_capture` retry, 3–21 seconds later.

## How

**`src/typed_pipes.rs`**
- Add `error_flag: Arc<AtomicBool>` to `BinaryPipeEntry`
- Drain thread sets it before breaking on a write error (alongside the existing `log::warn!`)
- New `TypedPipeRegistry::drain_failed(pipe_id) -> bool` polls the flag

**`src/process_app/mod.rs`**
- Per-frame check: after draining HTTP/file-picker async results, iterate all active `audio_capture_sessions` and call `drain_failed()` on each pipe
- On failure: remove session, close pipe, clear peak meter, push `PlexiEvent::AudioCaptureError` immediately
- Eliminates the `stale session` warn — pipe is cleaned up before any retry

## Tests

- `drain_failed_set_after_broken_pipe` — connects/drops a client socket, pushes a frame, asserts `drain_failed()` returns true within 300ms
- `drain_failed_false_for_healthy_pipe` — asserts flag is false before any error and for unknown pipe ids

## Breaks if

`AudioCaptureError` is not emitted within ~one render frame (~16ms) after a `Broken pipe` on the drain thread, or the `stale session — cleaning up and restarting` warn still appears in the log after a device switch.