### PR TITLE
feat(cli): plexi open terminal <cmd> passthrough + just next-issue recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -88,3 +88,23 @@ bump bump="patch":
 #   just promote main   — skip prompt, promote beta→main
 promote to="":
     bash scripts/promote.sh "{{to}}"
+
+# Print the numbers of the top N unblocked open issues (default 1), labelling each "in progress".
+# Enables: just next-issue 4 | while read -r num; do plexi open terminal --layout split_v "c /ship $num"; done
+next-issue n="1":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    gh issue list --state open --limit 100 \
+      --json number,labels \
+      --jq '[.[] | select(.labels | map(.name) | (contains(["in progress"]) | not))] |
+            sort_by(.labels | map(.name) |
+              if contains(["P0"]) then 0
+              elif contains(["P1"]) then 1
+              elif contains(["P2"]) then 2
+              elif contains(["P3"]) then 3
+              else 4 end) |
+            .[: {{n}}][].number' | \
+    while read -r num; do
+        gh issue edit "$num" --add-label "in progress" > /dev/null
+        echo "$num"
+    done

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1367,10 +1367,15 @@ impl eframe::App for PlexiApp {
                         //   split_focused(true)  → insert_vertical_tile   → stacked (BELOW)
                         // So: split_v (right) → false, split_h/split_above (below) → true.
                         let vertical = matches!(layout.as_str(), "split_h" | "split_above");
+                        let initial_cmd = if effective_args.is_empty() {
+                            None
+                        } else {
+                            Some(effective_args.join(" "))
+                        };
                         log::info!(
-                            "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id}"
+                            "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
                         );
-                        self.split_focused(vertical);
+                        self.split_focused(vertical, initial_cmd.as_deref());
                     } else {
                         self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
@@ -1799,12 +1804,12 @@ impl eframe::App for PlexiApp {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
-                    self.split_focused(false);
+                    self.split_focused(false, None);
                     self.save_workspace();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].zoomed_pane = None;
-                    self.split_focused(true);
+                    self.split_focused(true, None);
                     self.save_workspace();
                 }
                 Action::SplitRight => {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -468,8 +468,11 @@ impl PlexiApp {
         if id == "terminal" {
             let layout_str = layout.as_deref().unwrap_or("split_v");
             let vertical = matches!(layout_str, "split_h" | "split_above");
-            log::info!("SpawnPane: terminal layout='{layout_str}' vertical={vertical}");
-            self.split_focused(vertical);
+            let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+            log::info!(
+                "SpawnPane: terminal layout='{layout_str}' vertical={vertical} initial_cmd={initial_cmd:?}"
+            );
+            self.split_focused(vertical, initial_cmd.as_deref());
             return;
         }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -182,7 +182,7 @@ impl PlexiApp {
         match kind {
             Kind::Terminal => {
                 // Reuse the existing terminal split path.
-                self.split_focused(vertical);
+                self.split_focused(vertical, None);
             }
             Kind::App(manifest_id) => {
                 // Fresh instance of the same app at the requested placement.
@@ -199,7 +199,7 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn split_focused(&mut self, vertical: bool) {
+    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>) {
         let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
@@ -222,7 +222,11 @@ impl PlexiApp {
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors);
+        if let Some(cmd) = initial_cmd {
+            log::info!("split_focused: initial_cmd={cmd:?}");
+            settings.args = vec!["-l".to_string(), "-c".to_string(), cmd.to_string()];
+        }
         let Some(pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),


### PR DESCRIPTION
Closes #760

## Changes

**1. `plexi open terminal <cmd>` passthrough**

Extra args passed to `plexi open terminal` are now forwarded to the shell as an initial command: `zsh -l -c "<args joined>"`. Previously silently discarded.

- `split_focused` gains `initial_cmd: Option<&str>` parameter
- When `Some(cmd)`, overrides `BackendSettings.args` to `["-l", "-c", cmd]`
- All 5 call sites updated: keyboard shortcuts and `split_focused_mirror` pass `None`; the two terminal dispatch paths (`launch_app_by_id_with_layout` and the in-process `SpawnPane` handler) derive `initial_cmd` from args

**2. `just next-issue [N]` recipe**

Queries GitHub for the top N unblocked (not `in progress`), open issues sorted by priority label (P0→P4), labels each `in progress`, and prints issue numbers one per line.

Enables:
```bash
just next-issue 4 | while read -r num; do
  plexi open terminal --layout split_v "c /ship $num"
done
```

## Test plan
- [ ] `plexi-pr-<N> open terminal "echo hello"` opens a pane that runs `echo hello` and exits
- [ ] `plexi-pr-<N> open terminal "c /ship 725"` opens a pane running claude /ship 725
- [ ] `just next-issue 4` (run from worktrees/feature/760-../) prints 4 issue numbers, each labelled `in progress`
- [ ] Keyboard `Cmd+D` / `Cmd+Shift+D` still open plain terminals (no regression)
- [ ] `cargo test --lib` passes