### PR TITLE
fix(tetris): remove keyboard_capture = true from manifest

### DIFF
--- a/examples/tetris/manifest.toml
+++ b/examples/tetris/manifest.toml
@@ -13,4 +13,3 @@ capabilities = []
 
 [launch]
 layout_hint = { side = "right", split = 0.5 }
-keyboard_capture = true


### PR DESCRIPTION
Removes the `keyboard_capture = true` flag from `examples/tetris/manifest.toml`. This flag was suppressing all host shortcuts (Cmd+HJKL pane navigation, splits, etc.) whenever the Tetris pane was focused. Tetris only needs plain h/j/k/l and arrow key handling, which `on_key` already handles without capture mode.

Fixes #762