### PR TITLE
fix(zoom): block background resize handles when pane is zoomed

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2230,7 +2230,16 @@ impl eframe::App for PlexiApp {
                     workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
-                ctx.tree.ui(&mut behavior, ui);
+                ui.scope(|ui| {
+                    // When a pane is zoomed, the resize handles inside egui_tiles' linear
+                    // container are still rendered unconditionally. Disabling the UI prevents
+                    // their interact() calls from returning hovered/dragged, blocking background
+                    // pane resizing while the zoom overlay is active.
+                    if zoomed_pane.is_some() {
+                        ui.disable();
+                    }
+                    ctx.tree.ui(&mut behavior, ui);
+                });
                 log::debug!("[DRAG] tiling: done");
 
                 // Paint the active pane focus outline using the parent painter which

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -161,6 +161,9 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
     }
 
     fn resize_stroke(&self, _style: &egui::Style, resize_state: ResizeState) -> egui::Stroke {
+        if self.zoomed_pane.is_some() {
+            return egui::Stroke::NONE;
+        }
         match resize_state {
             ResizeState::Idle => egui::Stroke::NONE,
             ResizeState::Hovering | ResizeState::Dragging => {


### PR DESCRIPTION
Closes #761

## What

When a pane is zoomed, `egui_tiles`' linear container still rendered resize handles and processed their `interact()` calls unconditionally during `tree.ui()`, letting background pane layout be resized through the zoom overlay.

## Fix

**`src/app/mod.rs`** — wrap `ctx.tree.ui()` in a `ui.scope()` that calls `ui.disable()` when `zoomed_pane.is_some()`. A disabled UI returns `hovered: false, dragged: false` for all `interact()` calls inside, so the resize handles never see drag events while zoomed. The scope ends before the zoom overlay renders, leaving the zoomed pane content fully interactive.

**`src/tiling.rs`** — `resize_stroke` now returns `Stroke::NONE` for all `ResizeState` values (not just `Idle`) when zoomed. Previously `Hovering`/`Dragging` still painted a visible stroke through the scrim.

## Breaks if

Zooming a pane and dragging the area where a background resize gap sits alters the layout behind the overlay.