### PR TITLE
feat(terminal): auto-close pane when initial_cmd process exits

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -995,6 +995,10 @@ impl PlexiApp {
                         if let Some(pane) = win.panes.get_mut(&id) {
                             if let Some(t) = pane.as_terminal_mut() {
                                 t.exited = true;
+                                if t.close_on_exit {
+                                    log::info!("pty: pane {id} process exited — auto-closing (close_on_exit=true)");
+                                    panes_to_close.push(id);
+                                }
                             }
                             break;
                         }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -62,6 +62,9 @@ pub struct TerminalPane {
     pub exited: bool,
     pub name: Option<String>,
     pub font_size: f32,
+    /// When true, the pane closes automatically when its process exits.
+    /// Set for panes spawned with an initial_cmd (e.g. `plexi open terminal <cmd>`).
+    pub close_on_exit: bool,
 }
 
 impl TerminalPane {
@@ -85,6 +88,7 @@ impl TerminalPane {
             exited: false,
             name: None,
             font_size: default_font_size,
+            close_on_exit: false,
         })
     }
 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -227,7 +227,7 @@ impl PlexiApp {
             log::info!("split_focused: initial_cmd={cmd:?}");
             settings.args = vec!["-l".to_string(), "-c".to_string(), cmd.to_string()];
         }
-        let Some(pane) = TerminalPane::new(
+        let Some(mut pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),
             self.pty_event_tx.clone(),
@@ -237,6 +237,7 @@ impl PlexiApp {
             log::error!("Failed to create new terminal pane");
             return;
         };
+        pane.close_on_exit = initial_cmd.is_some();
         self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));


### PR DESCRIPTION
## Summary
- Adds `close_on_exit: bool` to `TerminalPane` (default `false`)
- `split_focused` sets it `true` when spawned with an `initial_cmd`
- `drain_pty_events` auto-closes the pane on `PtyEvent::Exit` when flag is set

Panes opened via `Cmd+D` / `Cmd+Shift+D` are unaffected.

Closes #768

## Test plan
- [ ] `plexi open terminal "echo hello"` — pane closes automatically after the command exits
- [ ] `plexi open terminal "sleep 3 && echo done"` — pane stays open for 3s then auto-closes
- [ ] `Cmd+D` split — pane stays open after exit (no auto-close)