### PR TITLE
fix(minimap): preserve visibility when closing a window in same context

### DIFF
--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -168,6 +168,10 @@ impl PlexiApp {
         let removed_x = self.windows[index].grid_x;
         let removed_y = self.windows[index].grid_y;
 
+        // Save current minimap state before deletion so it's always fresh.
+        self.minimap_visible_per_context
+            .insert(removed_ws_id, self.minimap.visible);
+
         self.windows.remove(index);
 
         // If the deleted window was the stored last-visited for its context,
@@ -214,14 +218,19 @@ impl PlexiApp {
         // ── Compact the grid: shift columns left if a column becomes empty ──
         self.compact_workspace_grid(removed_ws_id);
 
-        // Restore minimap state for the context we landed on.
+        // Minimap: if we stayed in the same context, preserve the current
+        // visibility state (the render loop hides it when page_count < 2). If
+        // the deletion caused a context switch (context was fully deleted), restore
+        // the saved state for the new context.
         let ws_id = self.router.active().context_id;
-        let page_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
-        self.minimap.visible = self
-            .minimap_visible_per_context
-            .get(&ws_id)
-            .copied()
-            .unwrap_or(page_count > 1);
+        if ws_id != removed_ws_id {
+            let page_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
+            self.minimap.visible = self
+                .minimap_visible_per_context
+                .get(&ws_id)
+                .copied()
+                .unwrap_or(page_count > 1);
+        }
     }
 
     /// After a deletion, compact each row independently: within each row,


### PR DESCRIPTION
Fixes #543

## Root cause

`delete_window()` was unconditionally restoring `minimap.visible` from `minimap_visible_per_context` after removing a page. That map is only written during context switches (`switch_workspace`), so the stored value was stale — e.g. saved as `false` when the context had only 1 page, then never updated when more pages were added. Closing any page then overwrote the live `visible = true` with the stale `false`.

## Fix

Two changes in `delete_window()`:

1. **Save before delete** — write current `minimap.visible` into `minimap_visible_per_context` before removing the window, so the map is always fresh.
2. **Preserve on same-context stay** — only run the restore logic when the deletion caused an actual context switch (`removed_ws_id != new ws_id`). When staying in the same context, leave `minimap.visible` alone. The render loop already force-hides the minimap when page count drops below 2.

## Test plan
- [ ] Open multiple pages in one context (Cmd+Shift+L)
- [ ] Confirm minimap is visible (Cmd+Shift+M to toggle if needed)
- [ ] Close one page with Cmd+W — minimap should remain visible
- [ ] Repeat until 2 pages remain, then close one → minimap should hide (down to 1 page)
- [ ] Create new page, switch to another context and back, close a page → minimap still stays visible

**Breaks if:** minimap disappears after Cmd+W when ≥2 pages remain in the context