### PR TITLE
feat(pty): inject PLEXI_CHANNEL into PTY environment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,25 @@ pub fn ensure_profile_initialized() {
 }
 
 /// Returns the config directory name.
+/// Returns the build channel for this binary: `alpha`, `beta`, `pr-<N>`, `v3`, or `None` (stable).
+pub fn build_channel() -> Option<String> {
+    let binary = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))?;
+    let name = binary.as_str();
+    if name.contains("alpha") {
+        Some("alpha".into())
+    } else if name.contains("beta") {
+        Some("beta".into())
+    } else if name.contains("pr-") {
+        Some(name.trim_start_matches("plexi-").to_string())
+    } else if name.contains("v3") {
+        Some("v3".into())
+    } else {
+        None
+    }
+}
+
 /// Priority: `--profile <name>` CLI flag → binary-name detection → `.plexi`.
 fn config_dir_name() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -183,6 +183,10 @@ pub fn build_env() -> HashMap<String, String> {
     }
     env.insert("COLORTERM".into(), "truecolor".into());
     env.insert("PLEXI_RUNNING".into(), "1".into());
+    if let Some(channel) = crate::config::build_channel() {
+        log::info!("shell::build_env: PLEXI_CHANNEL={channel}");
+        env.insert("PLEXI_CHANNEL".into(), channel);
+    }
 
     env.insert(
         "LANG".into(),


### PR DESCRIPTION
## Summary

- Adds `config::build_channel()` — derives channel name from the running binary (`plexi-alpha` → `alpha`, `plexi-pr-355` → `pr-355`, bare `plexi` → `None`)
- `shell::build_env()` injects `PLEXI_CHANNEL` into every PTY child environment when on a non-stable build
- `~/dotfiles/zshrc` gets a `plexi()` wrapper: routes to `plexi-$PLEXI_CHANNEL` when set, falls back to the stable symlink

Stable builds (`plexi`) don't set the var — the wrapper falls through to `command plexi` naturally.

## Test plan

- [ ] Open a terminal pane in the alpha PR build; run `echo $PLEXI_CHANNEL` → prints `alpha`
- [ ] Run `plexi --version` from that pane → resolves to `plexi-alpha --version` (not the stable symlink)
- [ ] Open a pane in the stable build → `PLEXI_CHANNEL` is unset, `plexi` routes to stable binary

Closes #774