### PR TITLE
feat(tts): audio.speak primitive — emit.speak(text) via Gemini TTS

### DIFF
--- a/examples/speak-tester/manifest.toml
+++ b/examples/speak-tester/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "speak-tester"
+type = "app"
+name = "Speak Tester"
+version = "0.1.0"
+description = "POC app — tests the audio.speak TTS primitive. Press Enter to say 'Hello from Plexi'."
+entry = "speak_tester.py"
+
+[app.capabilities]
+capabilities = ["audio.speak"]
+
+[launch]
+layout_hint = { side = "right", split = 0.3 }

--- a/examples/speak-tester/speak_tester.py
+++ b/examples/speak-tester/speak_tester.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Speak Tester — POC for emit.speak() TTS primitive.
+
+Press Enter to fire a speak command. Watch plexi.log for TTS latency.
+"""
+from plexi_sdk import App, RenderContext
+
+
+class SpeakTester(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self._count = 0
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.text(10, 20, "Speak Tester", size=16, color="#cdd6f4", bold=True)
+        ctx.text(10, 50, f"Press Enter to speak. Count: {self._count}", size=13, color="#a6adc8")
+        ctx.text(10, 75, "Requires GOOGLE_API_KEY to be set.", size=12, color="#6c7086")
+
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+        if key == "Return":
+            self._count += 1
+            self.emit.speak(f"Hello from Plexi. This is message {self._count}.")
+            self.emit.info(f"speak fired: count={self._count}")
+
+
+SpeakTester().run()

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -969,6 +969,16 @@ class Emitter:
         })
         return pipe
 
+    def speak(self, text: str, voice: "str | None" = None) -> None:
+        """Synthesize ``text`` as speech via the host TTS broker (Gemini).
+        Requires ``audio.speak`` capability. Fire-and-forget — no response event.
+        ``voice``: optional Gemini voice name (e.g. "Kore"). None = host default.
+        """
+        payload: dict = {"type": "speak", "text": text}
+        if voice is not None:
+            payload["voice"] = voice
+        _emit(payload)
+
     def set_timer(self, timer_id: str, after_ms: int) -> None:
         """Fire PlexiEvent::Timer after after_ms milliseconds. Requires timer capability."""
         _emit({"type": "set_timer", "timer_id": timer_id, "after_ms": after_ms})

--- a/src/app_permissions.rs
+++ b/src/app_permissions.rs
@@ -68,6 +68,9 @@ pub enum Capability {
     FsPick,
     /// Spawn a new pane via DrawCommand::SpawnPane (#592).
     PanesSpawn,
+    /// Synthesize speech via host TTS broker (Gemini TTS, #747).
+    /// Required to use `emit.speak()` / the `speak` PGAP command.
+    AudioSpeak,
 }
 
 impl fmt::Display for Capability {
@@ -97,6 +100,7 @@ impl Capability {
             Self::TerminalBindings => "terminal.bindings",
             Self::FsPick => "fs.pick",
             Self::PanesSpawn => "panes.spawn",
+            Self::AudioSpeak => "audio.speak",
         }
     }
 
@@ -120,6 +124,7 @@ impl Capability {
             "terminal.bindings",
             "fs.pick",
             "panes.spawn",
+            "audio.speak",
         ]
     }
 }
@@ -161,6 +166,7 @@ impl<'a> TryFrom<&'a str> for Capability {
             "terminal.bindings" => Ok(Self::TerminalBindings),
             "fs.pick" => Ok(Self::FsPick),
             "panes.spawn" => Ok(Self::PanesSpawn),
+            "audio.speak" => Ok(Self::AudioSpeak),
             other => Err(UnknownCapability(other.to_string())),
         }
     }
@@ -348,6 +354,28 @@ mod tests {
         match check(&AppPermissions::from_capability_strings(&[]), Capability::PanesSpawn) {
             PermissionCheck::Denied(reason) => {
                 assert!(reason.contains("panes.spawn"), "denial must name capability: {reason}");
+            }
+            PermissionCheck::Allowed => panic!("must be denied without declaration"),
+        }
+    }
+
+    #[test]
+    fn audio_speak_capability_recognized() {
+        let parsed = Capability::try_from("audio.speak").expect("audio.speak must parse");
+        assert_eq!(parsed, Capability::AudioSpeak);
+        assert_eq!(parsed.as_str(), "audio.speak");
+        let perms = AppPermissions::from_capability_strings(&["audio.speak".to_string()]);
+        assert!(
+            perms.capabilities.contains(&Capability::AudioSpeak),
+            "audio.speak must end up in granted capabilities"
+        );
+        assert!(matches!(
+            check(&perms, Capability::AudioSpeak),
+            PermissionCheck::Allowed
+        ));
+        match check(&AppPermissions::from_capability_strings(&[]), Capability::AudioSpeak) {
+            PermissionCheck::Denied(reason) => {
+                assert!(reason.contains("audio.speak"), "denial must name capability: {reason}");
             }
             PermissionCheck::Allowed => panic!("must be denied without declaration"),
         }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1003,6 +1003,15 @@ pub enum HostCommand {
     /// visible to any macOS app.
     ListAudioDevices { request_id: String },
 
+    /// Host TTS: synthesize `text` and play audio via Gemini TTS + rodio (#747).
+    /// Requires `audio.speak` capability. Fire-and-forget — no response event.
+    /// `voice`: optional Gemini voice name (e.g. "Kore"). Null = host default.
+    Speak {
+        text: String,
+        #[serde(default)]
+        voice: Option<String>,
+    },
+
     /// Request enumeration of MIDI ports (#320). Host responds with
     /// `PlexiEvent::MidiDevicesListed { request_id, inputs, outputs }`. No
     /// capability gate — enumeration discloses only port names already
@@ -2532,6 +2541,19 @@ mod tests {
         }
         let serialised = serde_json::to_string(&event).expect("serialise");
         assert!(serialised.contains(r#""type":"pane_spawn_error""#), "wire tag missing: {serialised}");
+    }
+
+    #[test]
+    fn speak_command_roundtrips() {
+        let json = r#"{"type":"speak","text":"Hello world","voice":null}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match cmd {
+            DrawCommand::Host(HostCommand::Speak { text, voice }) => {
+                assert_eq!(text, "Hello world");
+                assert_eq!(voice, None);
+            }
+            other => panic!("expected Speak, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -164,6 +164,10 @@ impl PlaybackSession {
     pub fn set_volume(&self, v: f32) {
         self.sink.set_volume(v);
     }
+    /// Block the calling thread until playback has drained completely.
+    pub fn sleep_until_end(&self) {
+        self.sink.sleep_until_end();
+    }
 }
 
 #[cfg(not(test))]
@@ -212,6 +216,7 @@ impl PlaybackSession {
     pub fn pause(&self) {}
     pub fn resume(&self) {}
     pub fn set_volume(&self, _v: f32) {}
+    pub fn sleep_until_end(&self) {}
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct PlexiConfig {
     pub log: Option<LogConfig>,
     pub notifications: Option<NotificationsConfig>,
     pub ai: Option<AiConfig>,
+    pub voice: Option<VoiceConfig>,
     /// Set to false to quit immediately on Cmd+Q without triple-press confirmation (default: true).
     pub confirm_quit: Option<bool>,
     /// Set to false to close panes immediately on Cmd+W without a confirmation dialog (default: true).
@@ -54,6 +55,21 @@ pub struct OllamaBackendConfig {
     pub model_medium: Option<String>,
     /// High-tier model. e.g. "qwq:32b"
     pub model_high: Option<String>,
+}
+
+/// Voice / TTS configuration (`[voice]` section in config.toml).
+#[derive(Deserialize, Default, Clone)]
+pub struct VoiceConfig {
+    pub tts: Option<TtsConfig>,
+}
+
+/// TTS backend configuration.
+#[derive(Deserialize, Default, Clone)]
+pub struct TtsConfig {
+    /// Gemini model ID. Default: "gemini-2.5-flash-preview-tts".
+    pub model: Option<String>,
+    /// Environment variable name for the API key. Default: "GOOGLE_API_KEY".
+    pub api_key_env: Option<String>,
 }
 
 impl AiConfig {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1031,6 +1031,188 @@ impl ProcessApp {
                 }
                 self.start_audio_capture(pipe_id, device_id, sample_rate, buffer_size);
             }
+            HostCommand::Speak { text, voice } => {
+                if let PermissionCheck::Denied(reason) =
+                    check(&self.permissions, Capability::AudioSpeak)
+                {
+                    log::warn!(
+                        "ProcessApp[{}]: Speak denied — {reason}",
+                        self.type_id
+                    );
+                    return;
+                }
+
+                log::info!(
+                    "ProcessApp[{}]: Speak text={:?} voice={:?}",
+                    self.type_id,
+                    &text[..text.len().min(40)],
+                    voice
+                );
+
+                let app_id = self.type_id.clone();
+                std::thread::Builder::new()
+                    .name(format!("tts-{app_id}"))
+                    .spawn(move || {
+                        let config = crate::config::PlexiConfig::load();
+                        let tts = config.voice.as_ref()
+                            .and_then(|v| v.tts.as_ref());
+                        let model = tts.and_then(|t| t.model.as_deref())
+                            .unwrap_or("gemini-2.5-flash-preview-tts")
+                            .to_owned();
+                        let api_key_env = tts.and_then(|t| t.api_key_env.as_deref())
+                            .unwrap_or("GOOGLE_API_KEY")
+                            .to_owned();
+
+                        let api_key = match std::env::var(&api_key_env) {
+                            Ok(k) if !k.is_empty() => k,
+                            _ => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: {api_key_env} not set — cannot call TTS");
+                                return;
+                            }
+                        };
+
+                        let url = format!(
+                            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+                        );
+                        let body = serde_json::json!({
+                            "contents": [{"parts": [{"text": text}]}],
+                            "generationConfig": {
+                                "response_modalities": ["AUDIO"],
+                                "speech_config": {
+                                    "voice_config": {
+                                        "prebuilt_voice_config": {
+                                            "voice_name": voice.as_deref().unwrap_or("Kore")
+                                        }
+                                    }
+                                }
+                            }
+                        });
+
+                        let t0 = std::time::Instant::now();
+                        let resp = match ureq::post(&url)
+                            .set("Content-Type", "application/json")
+                            .send_string(&body.to_string())
+                        {
+                            Ok(r) => r,
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: Gemini API request failed: {e}");
+                                return;
+                            }
+                        };
+
+                        let resp_body = match resp.into_string() {
+                            Ok(s) => s,
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: failed to read API response: {e}");
+                                return;
+                            }
+                        };
+
+                        let api_latency_ms = t0.elapsed().as_millis();
+
+                        let parsed: serde_json::Value = match serde_json::from_str(&resp_body) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: failed to parse API response: {e}");
+                                return;
+                            }
+                        };
+
+                        let inline_data = parsed
+                            .pointer("/candidates/0/content/parts/0/inlineData")
+                            .and_then(|v| v.as_object());
+
+                        let Some(inline) = inline_data else {
+                            log::warn!(
+                                "ProcessApp[{app_id}]: Speak: no inlineData in API response; response keys: {:?}",
+                                parsed.as_object().map(|o| o.keys().collect::<Vec<_>>())
+                            );
+                            return;
+                        };
+
+                        let mime = inline.get("mimeType").and_then(|v| v.as_str()).unwrap_or("unknown");
+                        let b64 = match inline.get("data").and_then(|v| v.as_str()) {
+                            Some(d) => d,
+                            None => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: no data field in inlineData");
+                                return;
+                            }
+                        };
+
+                        let pcm_bytes = match base64::Engine::decode(
+                            &base64::engine::general_purpose::STANDARD, b64
+                        ) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: base64 decode failed: {e}");
+                                return;
+                            }
+                        };
+
+                        log::info!(
+                            "ProcessApp[{app_id}]: Speak: TTS latency={api_latency_ms}ms mime={mime} pcm_bytes={}",
+                            pcm_bytes.len()
+                        );
+
+                        // Parse sample rate from mimeType e.g. "audio/pcm;rate=24000"
+                        let sample_rate: u32 = mime
+                            .split(';')
+                            .find(|s| s.trim().starts_with("rate="))
+                            .and_then(|s| s.trim().strip_prefix("rate="))
+                            .and_then(|r| r.parse().ok())
+                            .unwrap_or(24000);
+
+                        // Write temp WAV file wrapping the raw PCM
+                        let wav_path = std::env::temp_dir()
+                            .join(format!("plexi-tts-{}.wav", uuid::Uuid::new_v4()));
+                        let spec = hound::WavSpec {
+                            channels: 1,
+                            sample_rate,
+                            bits_per_sample: 16,
+                            sample_format: hound::SampleFormat::Int,
+                        };
+                        let mut writer = match hound::WavWriter::create(&wav_path, spec) {
+                            Ok(w) => w,
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: failed to create WAV file: {e}");
+                                return;
+                            }
+                        };
+                        for chunk in pcm_bytes.chunks(2) {
+                            if chunk.len() < 2 { break; }
+                            let sample = i16::from_le_bytes([chunk[0], chunk[1]]);
+                            if let Err(e) = writer.write_sample(sample) {
+                                log::warn!("ProcessApp[{app_id}]: Speak: WAV write error: {e}");
+                                let _ = std::fs::remove_file(&wav_path);
+                                return;
+                            }
+                        }
+                        if let Err(e) = writer.finalize() {
+                            log::warn!("ProcessApp[{app_id}]: Speak: WAV finalize error: {e}");
+                            let _ = std::fs::remove_file(&wav_path);
+                            return;
+                        }
+
+                        let duration_secs = pcm_bytes.len() as f64 / (sample_rate as f64 * 2.0);
+                        log::info!("ProcessApp[{app_id}]: Speak: playing audio duration={duration_secs:.2}s");
+
+                        match crate::audio::start_playback(crate::audio::PlaybackRequest {
+                            source: wav_path.to_string_lossy().into_owned(),
+                            volume: 1.0,
+                        }) {
+                            Ok(session) => {
+                                session.sleep_until_end();
+                                log::info!("ProcessApp[{app_id}]: Speak: playback complete");
+                            }
+                            Err(e) => {
+                                log::warn!("ProcessApp[{app_id}]: Speak: playback failed: {e}");
+                            }
+                        }
+
+                        let _ = std::fs::remove_file(&wav_path);
+                    })
+                    .expect("failed to spawn tts thread");
+            }
             HostCommand::ListAudioDevices { request_id } => {
                 // Enumeration is not gated — device names are already visible
                 // to any macOS app via System Information. The per-device


### PR DESCRIPTION
## Summary

- Adds `HostCommand::Speak` to the PGAP protocol — apps emit `{"type":"speak","text":"..."}` and the host handles TTS + playback
- New `audio.speak` capability gates the command; apps must declare it in `manifest.toml`
- Host calls Gemini TTS API in a background thread (non-blocking), decodes PCM → WAV via hound, plays via rodio
- Python SDK: `emit.speak(text, voice=None)` on the `Emitter` class
- Config via `~/.plexi-alpha/config.toml` `[voice.tts]` section (optional — falls back to sensible defaults)
- POC app at `examples/speak-tester/` for manual verification

Closes #747

## Test plan

- [ ] Install PR build: `just pr-install <N>` from feature worktree
- [ ] Install speak-tester app and open it
- [ ] With `GOOGLE_API_KEY` set, press Enter — audio should play through speakers
- [ ] Check `~/.plexi-alpha/plexi.log` for TTS latency and playback log lines
- [ ] Open a second app without `audio.speak` in manifest, call speak — log should show capability denied