### PR TITLE
feat(cli): pane list, focus, close subcommands

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -865,6 +865,62 @@ impl PlexiApp {
                         log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
                     }
                 }
+                crate::app_protocol::HostCommand::ListPanes { response_file } => {
+                    log::info!("pane_ipc: kind=list_panes response_file={:?}", response_file);
+                    let active_win = self.active_window;
+                    let mut entries: Vec<serde_json::Value> = Vec::new();
+                    for (win_idx, win) in self.windows.iter().enumerate() {
+                        let focused_pane_id = win.focused_pane
+                            .and_then(|t| win.tree.tiles.get(t))
+                            .and_then(|tile| {
+                                if let egui_tiles::Tile::Pane(id) = tile { Some(*id) } else { None }
+                            });
+                        for (pane_id, pane) in &win.panes {
+                            let (pane_type, title) = match pane {
+                                crate::pane::Pane::Terminal(t) => {
+                                    ("terminal", t.name.clone().unwrap_or_else(|| "terminal".to_string()))
+                                }
+                                crate::pane::Pane::App(a) => {
+                                    ("app", a.name.clone())
+                                }
+                            };
+                            let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
+                            entries.push(serde_json::json!({
+                                "id": pane_id,
+                                "type": pane_type,
+                                "title": title,
+                                "focused": focused,
+                            }));
+                        }
+                    }
+                    let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                    if let Err(e) = std::fs::write(response_file, &json_str) {
+                        log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
+                    }
+                }
+                crate::app_protocol::HostCommand::FocusPane { pane_id } => {
+                    log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
+                    let mut found = false;
+                    for win in &mut self.windows {
+                        if let Some(tile_id) = win.tree.tiles.find_pane(pane_id) {
+                            win.focused_pane = Some(tile_id);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if !found {
+                        log::warn!("pane_ipc: focus_pane: pane_id={pane_id} not found");
+                    }
+                }
+                crate::app_protocol::HostCommand::ClosePane { pane_id } => {
+                    log::info!("pane_ipc: kind=close_pane pane_id={pane_id}");
+                    let before: usize = self.windows.iter().map(|w| w.panes.len()).sum();
+                    self.close_pane_by_id(*pane_id);
+                    let after: usize = self.windows.iter().map(|w| w.panes.len()).sum();
+                    if before == after {
+                        log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
+                    }
+                }
                 crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, .. } => {
                     log::info!("pane_ipc: kind=spawn_pane type_id={type_id}");
                     self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -909,6 +909,21 @@ pub enum HostCommand {
         name: String,
     },
 
+    /// List all open panes. Host writes a JSON array to `response_file`. Sent by `plexi pane list`.
+    ListPanes {
+        response_file: String,
+    },
+
+    /// Move UI focus to a pane by PaneId. Sent by `plexi pane focus`. Fire-and-forget.
+    FocusPane {
+        pane_id: u64,
+    },
+
+    /// Close a pane by PaneId. Sent by `plexi pane close`. Fire-and-forget.
+    ClosePane {
+        pane_id: u64,
+    },
+
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
     CreateContext {
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1390,6 +1390,77 @@ pub fn pane_set_title_cli(name: &str) -> i32 {
     0
 }
 
+/// `plexi pane list`
+///
+/// Sends a `list_panes` command to PLEXI_SOCKET. The host writes a JSON array
+/// to a response file; this function polls for it and prints it to stdout.
+/// Returns 0 on success, 1 on error.
+pub fn pane_list_cli() -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-list-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    let payload = serde_json::json!({
+        "type": "list_panes",
+        "response_file": response_file,
+    });
+
+    log::info!("pane_list:cli: sending via socket response_file={:?}", response_file);
+
+    let code = send_to_socket(payload);
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    print!("{content}");
+                    return 0;
+                }
+                Err(e) => {
+                    log::warn!("pane_list:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane list response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// `plexi pane focus <pane_id>`
+///
+/// Sends a `focus_pane` command to PLEXI_SOCKET. Fire-and-forget.
+/// Returns 0 on success, 1 on error.
+pub fn pane_focus_cli(pane_id: u64) -> i32 {
+    send_to_socket(serde_json::json!({
+        "type": "focus_pane",
+        "pane_id": pane_id,
+    }))
+}
+
+/// `plexi pane close <pane_id>`
+///
+/// Sends a `close_pane` command to PLEXI_SOCKET. Fire-and-forget.
+/// Returns 0 on success, 1 on error.
+pub fn pane_close_cli(pane_id: u64) -> i32 {
+    send_to_socket(serde_json::json!({
+        "type": "close_pane",
+        "pane_id": pane_id,
+    }))
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -191,6 +191,22 @@ pub enum PaneCmd {
     SetTitle {
         name: String,
     },
+    /// List all open panes as a JSON array
+    List,
+    /// Move UI focus to a pane by ID
+    ///
+    /// NOTE: This moves the *user's visual focus* to the target pane — it does NOT
+    /// relocate the agent's execution context. An agent calling this from pane A
+    /// remains in pane A after the call; only the user sees focus shift to pane B.
+    Focus {
+        /// Pane ID (from `plexi pane list`)
+        pane_id: u64,
+    },
+    /// Close a pane by ID
+    Close {
+        /// Pane ID (from `plexi pane list`)
+        pane_id: u64,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,9 @@ fn main() -> eframe::Result {
                     }
                     Commands::Pane { cmd } => match cmd {
                         PaneCmd::SetTitle { name } => std::process::exit(cli::pane_set_title_cli(&name)),
+                        PaneCmd::List => std::process::exit(cli::pane_list_cli()),
+                        PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
+                        PaneCmd::Close { pane_id } => std::process::exit(cli::pane_close_cli(pane_id)),
                     },
                     Commands::Open { type_id, layout, extra_args } => {
                         std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref()));

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1422,6 +1422,24 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            HostCommand::ListPanes { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received ListPanes over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            HostCommand::FocusPane { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received FocusPane over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            HostCommand::ClosePane { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received ClosePane over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #744

## What

Adds three subcommands to `plexi pane`:

```
plexi pane list              # JSON array of all open panes
plexi pane focus <pane-id>   # move UI focus to a pane
plexi pane close <pane-id>   # close a pane by ID
```

## How

- `list` uses the response-file pattern (same as `plexi notify --choice`): CLI sends a temp file path, polls until the host writes the JSON array, prints and exits (5s timeout)
- `focus` and `close` are fire-and-forget via the existing `send_to_socket`
- `FocusPane` walks `self.windows` to find the tile containing the PaneId, sets `focused_pane`
- `ClosePane` delegates to the existing `close_pane_by_id`
- All three are wired in `process_app/routing.rs` (socket-only, PGAP delivery logs a warn)

## JSON shape from `list`

```json
[{"id":3,"type":"terminal","title":"bash","focused":true},{"id":7,"type":"app","title":"My App","focused":false}]
```

## `--help` note on `focus`

The clap doc on `Focus` explicitly documents the pane-local agent distinction: moving UI focus does not relocate the agent's execution context.