### PR TITLE
feat(voice): voice.toml config with per-workspace overlay

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -160,6 +160,7 @@ pub struct PlexiApp {
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
+    pub(crate) voice_config: crate::config::VoiceConfig,
     pub(crate) renaming_window: Option<usize>,
     pub(crate) rename_buffer: String,
     pub(crate) drag_context: Option<usize>,
@@ -344,6 +345,11 @@ impl PlexiApp {
         // project fields preserve the global value.
         let active_workspace = config::active_workspace_root();
         let config = config::PlexiConfig::load_with_workspace(active_workspace.as_deref());
+        let voice_config = config::VoiceConfig::load_with_workspace(active_workspace.as_deref());
+        log::info!(
+            "voice: config loaded at startup — enabled={}",
+            voice_config.is_enabled()
+        );
         let features = crate::features::FeatureFlags::from_config(&config);
         let notifications_enabled = config
             .notifications
@@ -580,6 +586,7 @@ impl PlexiApp {
                     quit_press_count: 0,
                     quit_last_press: None,
                     config: config.clone(),
+                    voice_config: voice_config.clone(),
                     pending_close: false,
                     frame_tick: frame_tick.clone(),
                     renaming_window: None,
@@ -673,6 +680,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             config,
+            voice_config,
             pending_close: false,
             frame_tick,
             renaming_window: None,
@@ -774,6 +782,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             config,
+            voice_config: config::VoiceConfig::default(),
             pending_close: false,
             frame_tick,
             renaming_window: None,
@@ -2734,6 +2743,15 @@ impl PlexiApp {
 
         // Replace the cached config
         self.config = fresh;
+
+        // Voice config
+        let fresh_voice =
+            crate::config::VoiceConfig::load_with_workspace(active_workspace.as_deref());
+        log::info!(
+            "voice: config reloaded — enabled={}",
+            fresh_voice.is_enabled()
+        );
+        self.voice_config = fresh_voice;
 
         log::info!("Configuration reloaded from disk.");
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -641,6 +641,141 @@ impl NotificationsConfig {
     }
 }
 
+// ── Voice config ─────────────────────────────────────────────────────────────
+
+/// Outer TOML wrapper for `voice.toml` — the file has a top-level `[voice]` table.
+#[derive(serde::Deserialize, Default)]
+struct VoiceTomlFile {
+    voice: Option<VoiceConfig>,
+}
+
+/// Resolved voice configuration after profile + workspace merge.
+/// All fields default to `None`; `is_enabled()` returns `false` when absent.
+#[derive(serde::Deserialize, Default, Clone)]
+pub struct VoiceConfig {
+    pub enabled: Option<bool>,
+    pub tts: Option<VoiceTtsConfig>,
+    pub agent: Option<VoiceAgentConfig>,
+}
+
+#[derive(serde::Deserialize, Default, Clone)]
+pub struct VoiceTtsConfig {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub api_key_env: Option<String>,
+}
+
+#[derive(serde::Deserialize, Default, Clone)]
+pub struct VoiceAgentConfig {
+    pub tier: Option<String>,
+    pub system_prompt: Option<String>,
+}
+
+pub fn voice_config_path() -> PathBuf {
+    config_dir().join("voice.toml")
+}
+
+impl VoiceConfig {
+    /// Load from the profile-level `voice.toml`. Missing file → disabled (logged at info).
+    pub fn load() -> Self {
+        let path = voice_config_path();
+        Self::load_from_path(&path).unwrap_or_default()
+    }
+
+    /// Load and merge profile config with an optional workspace override.
+    pub fn load_with_workspace(workspace_root: Option<&Path>) -> Self {
+        let mut base = Self::load();
+        let Some(root) = workspace_root else {
+            return base;
+        };
+        let project_path = root.join(".plexi").join("voice.toml");
+        if let Some(overlay) = Self::load_from_path(&project_path) {
+            base.overlay(overlay);
+        }
+        base
+    }
+
+    fn load_from_path(path: &Path) -> Option<Self> {
+        let data = match std::fs::read_to_string(path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                log::info!(
+                    "voice: config not found at {} — voice features disabled",
+                    path.display()
+                );
+                return None;
+            }
+            Err(e) => {
+                log::warn!("voice: failed to read {}: {e}", path.display());
+                return None;
+            }
+        };
+        match toml::from_str::<VoiceTomlFile>(&data) {
+            Ok(f) => {
+                if f.voice.is_none() {
+                    log::info!(
+                        "voice: no [voice] section in {} — voice features disabled",
+                        path.display()
+                    );
+                }
+                f.voice
+            }
+            Err(e) => {
+                log::error!(
+                    "voice: failed to parse {}: {e} — voice features disabled",
+                    path.display()
+                );
+                None
+            }
+        }
+    }
+
+    fn overlay(&mut self, other: Self) {
+        if other.enabled.is_some() {
+            self.enabled = other.enabled;
+        }
+        match (self.tts.as_mut(), other.tts) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.tts = Some(incoming),
+            _ => {}
+        }
+        match (self.agent.as_mut(), other.agent) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.agent = Some(incoming),
+            _ => {}
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+}
+
+impl VoiceTtsConfig {
+    fn overlay(&mut self, other: Self) {
+        if other.provider.is_some() {
+            self.provider = other.provider;
+        }
+        if other.model.is_some() {
+            self.model = other.model;
+        }
+        if other.api_key_env.is_some() {
+            self.api_key_env = other.api_key_env;
+        }
+    }
+}
+
+impl VoiceAgentConfig {
+    fn overlay(&mut self, other: Self) {
+        if other.tier.is_some() {
+            self.tier = other.tier;
+        }
+        if other.system_prompt.is_some() {
+            self.system_prompt = other.system_prompt;
+        }
+    }
+}
+
 // ── Adopted workspace root (set once by main when an explicit path arg is
 // given) ─────────────────────────────────────────────────────────────────────
 
@@ -780,6 +915,77 @@ mod tests {
             merged.theme.as_ref().and_then(|t| t.bg_darkest.clone()),
             Some("#000000".to_string())
         );
+    }
+
+    #[test]
+    fn voice_config_missing_file_is_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("voice.toml");
+        // File does not exist.
+        let cfg = VoiceConfig::load_from_path(&path).unwrap_or_default();
+        assert!(!cfg.is_enabled());
+    }
+
+    #[test]
+    fn voice_config_enabled_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("voice.toml");
+        write(
+            &path,
+            "[voice]\nenabled = true\n\n[voice.tts]\nprovider = \"google\"\nmodel = \"gemini-2.5-flash\"\napi_key_env = \"GOOGLE_API_KEY\"\n\n[voice.agent]\ntier = \"low\"\nsystem_prompt = \"Be concise.\"\n",
+        );
+        let cfg = VoiceConfig::load_from_path(&path).unwrap();
+        assert!(cfg.is_enabled());
+        let tts = cfg.tts.as_ref().unwrap();
+        assert_eq!(tts.provider.as_deref(), Some("google"));
+        assert_eq!(tts.model.as_deref(), Some("gemini-2.5-flash"));
+        assert_eq!(tts.api_key_env.as_deref(), Some("GOOGLE_API_KEY"));
+        let agent = cfg.agent.as_ref().unwrap();
+        assert_eq!(agent.tier.as_deref(), Some("low"));
+        assert_eq!(agent.system_prompt.as_deref(), Some("Be concise."));
+    }
+
+    #[test]
+    fn voice_config_workspace_overlay() {
+        let profile_dir = tempfile::tempdir().unwrap();
+        let profile_path = profile_dir.path().join("voice.toml");
+        write(
+            &profile_path,
+            "[voice]\nenabled = true\n\n[voice.tts]\nprovider = \"google\"\nmodel = \"gemini-2.5-flash\"\n",
+        );
+
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_path = workspace.path().join(".plexi").join("voice.toml");
+        write(
+            &workspace_path,
+            "[voice]\n\n[voice.tts]\nmodel = \"gemini-2.0-flash\"\n",
+        );
+
+        let mut base = VoiceConfig::load_from_path(&profile_path).unwrap_or_default();
+        if let Some(overlay) = VoiceConfig::load_from_path(&workspace_path) {
+            base.overlay(overlay);
+        }
+        // Profile enabled survives.
+        assert!(base.is_enabled());
+        // Workspace model overrides profile model.
+        assert_eq!(
+            base.tts.as_ref().and_then(|t| t.model.clone()),
+            Some("gemini-2.0-flash".to_string())
+        );
+        // Profile provider survives (not overridden by workspace).
+        assert_eq!(
+            base.tts.as_ref().and_then(|t| t.provider.clone()),
+            Some("google".to_string())
+        );
+    }
+
+    #[test]
+    fn voice_config_invalid_toml_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("voice.toml");
+        write(&path, "not valid toml ][[\n");
+        let result = VoiceConfig::load_from_path(&path);
+        assert!(result.is_none());
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `VoiceConfig` structs (`VoiceTtsConfig`, `VoiceAgentConfig`) to `src/config.rs`
- Reads from `~/.plexi-alpha/voice.toml` at startup and on `reload_config()` (workspace change)
- Missing file → voice disabled, info-logged. Invalid TOML → error-logged at startup, voice disabled. No crash, no silent fallback.
- Workspace `.plexi/voice.toml` overlays profile config per-field (same pattern as `PlexiConfig`)
- Stores resolved `VoiceConfig` on `PlexiApp.voice_config`; all 3 init blocks updated
- 4 unit tests covering: missing file, full parse, workspace overlay, invalid TOML

Closes #750