### PR TITLE
feat(context): auto-switch context on pane focus via host-side CWD watch

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -263,6 +263,12 @@ pub struct PlexiApp {
     /// Receiver for HostCommands sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::HostCommand>,
+    /// Last tile that triggered an auto-context-switch check. Avoids re-running
+    /// the CWD lookup every frame when focus hasn't changed.
+    pub(crate) last_focused_tile_for_auto_switch: Option<egui_tiles::TileId>,
+    /// Frames remaining before auto-context-switch is allowed after a manual
+    /// context switch. Prevents immediately overriding the user's intent.
+    pub(crate) skip_auto_switch_frames: u8,
 }
 
 #[cfg(test)]
@@ -615,6 +621,8 @@ impl PlexiApp {
                     update_rx: Some(update_rx),
                     update_available: None,
                     pane_ipc_rx,
+                    last_focused_tile_for_auto_switch: None,
+                    skip_auto_switch_frames: 0,
                 };
             }
         }
@@ -706,6 +714,8 @@ impl PlexiApp {
             update_rx: Some(update_rx),
             update_available: None,
             pane_ipc_rx,
+            last_focused_tile_for_auto_switch: None,
+            skip_auto_switch_frames: 0,
         }
     }
 
@@ -809,6 +819,8 @@ impl PlexiApp {
             update_rx: None,
             update_available: None,
             pane_ipc_rx,
+            last_focused_tile_for_auto_switch: None,
+            skip_auto_switch_frames: 0,
         }, pane_ipc_tx)
     }
 
@@ -1321,6 +1333,7 @@ impl eframe::App for PlexiApp {
         // closes (which caused the "ghost queue appears on reopen" bug).
         let deferred_app_cmds = self.drain_all_app_commands();
         self.sync_app_cwd();
+        self.check_context_auto_switch();
 
         // Dispatch any DeliverNotifyAction commands the early modal render
         // produced. Routes back to the originating pane as NotifyAction events.
@@ -2003,6 +2016,7 @@ impl eframe::App for PlexiApp {
                 Action::SwitchContext(n) => {
                     if n < self.router.len() {
                         self.switch_workspace(n);
+                        self.skip_auto_switch_frames = 2;
                     }
                 }
                 Action::NextTab => {

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -3,6 +3,7 @@
 use super::PlexiApp;
 use crate::plexi_ai::broker::PaneContext;
 use crate::shell;
+use egui_tiles::Tile;
 
 impl PlexiApp {
     /// Synchronize app panes that join the `cwd` pane group with any terminal's
@@ -91,5 +92,66 @@ impl PlexiApp {
             }
         }
         crate::plexi_ai::broker::update_pane_snapshot(panes);
+    }
+
+    /// On every frame, if the focused pane changed and is a terminal, walk its CWD
+    /// up the directory tree looking for a matching context root. If found and not
+    /// already active, switch to it automatically.
+    ///
+    /// Skips when `skip_auto_switch_frames > 0` — set by manual context switches
+    /// to prevent immediately overriding the user's intent.
+    pub(super) fn check_context_auto_switch(&mut self) {
+        if self.skip_auto_switch_frames > 0 {
+            self.skip_auto_switch_frames -= 1;
+            return;
+        }
+
+        let active = self.active_window;
+        let Some(focused_tile) = self.windows[active].focused_pane else {
+            self.last_focused_tile_for_auto_switch = None;
+            return;
+        };
+
+        if self.last_focused_tile_for_auto_switch == Some(focused_tile) {
+            return;
+        }
+        self.last_focused_tile_for_auto_switch = Some(focused_tile);
+
+        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return,
+        };
+
+        let cwd = {
+            let Some(terminal) = self.windows[active]
+                .panes
+                .get(&pane_id)
+                .and_then(|p| p.as_terminal())
+            else {
+                return;
+            };
+            shell::get_pid_cwd(terminal.backend.child_pid())
+        };
+        let Some(cwd) = cwd else { return; };
+
+        let current_ctx_idx = self.router.active_idx();
+        let mut path = cwd.as_path();
+        loop {
+            if let Some(idx) = self.router.position(|ctx| ctx.root.as_deref() == Some(path)) {
+                if idx != current_ctx_idx {
+                    log::info!(
+                        "context:auto-switch: cwd={} → context_id={}",
+                        cwd.display(),
+                        self.router.get(idx).context_id
+                    );
+                    self.switch_workspace(idx);
+                }
+                break;
+            }
+            match path.parent() {
+                Some(parent) if parent != path => path = parent,
+                _ => break,
+            }
+        }
     }
 }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -524,6 +524,7 @@ impl PlexiApp {
                 // active_window based on context_active_window. We override it
                 // immediately below.
                 self.switch_workspace(ctx_idx_sidebar);
+                self.skip_auto_switch_frames = 2;
             }
         }
         self.active_window = ctx_idx;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -267,6 +267,7 @@ impl PlexiApp {
             self.delete_context(i);
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);
+            self.skip_auto_switch_frames = 2;
         }
 
         if add_clicked {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -425,4 +425,36 @@ mod tests {
         h.ipc_tx.send(HostCommand::SetPaneTitle { pane_id: 9999, name: "ghost".into() }).unwrap();
         h.run_frames(1); // must not panic; logs warn "not found"
     }
+
+    // -- Auto-switch context on pane focus ------------------------------------
+
+    /// `skip_auto_switch_frames` decrements to zero over successive frames.
+    /// This guards against regressions where the inhibit counter never clears
+    /// and auto-switch stops working after the first manual context switch.
+    #[test]
+    fn skip_auto_switch_frames_decrements_each_frame() {
+        let mut h = HostHarness::new();
+        h.app.skip_auto_switch_frames = 3;
+        h.run_frames(3);
+        assert_eq!(
+            h.app.skip_auto_switch_frames, 0,
+            "skip_auto_switch_frames should reach zero after 3 frames"
+        );
+    }
+
+    /// Auto-switch must not fire when context roots are None (no root configured).
+    /// With no terminal panes and no context roots, router stays on context 0.
+    #[test]
+    fn auto_switch_no_op_without_context_roots() {
+        let mut h = HostHarness::new();
+        h.add_test_pane();
+
+        // All contexts have root = None by default in new_for_test.
+        let before_idx = h.app.router.active_idx();
+        h.run_frames(2);
+        assert_eq!(
+            h.app.router.active_idx(), before_idx,
+            "auto-switch must not fire when no context has a root configured"
+        );
+    }
 }


### PR DESCRIPTION
Closes #717

## What

On every pane focus change, if the newly focused pane is a terminal, the host walks its CWD up the directory tree comparing against known context roots. If a match is found and it's not the currently active context, it switches automatically.

No shell config required — Plexi already calls `get_pid_cwd` every frame. This is purely host-side.

## How debounce works

Manual context switches (keyboard shortcut `Cmd+1..9`, sidebar click, command palette) set `skip_auto_switch_frames = 2`. The auto-switch check decrements this counter each frame and skips while it's non-zero. This prevents the auto-switch from immediately overriding the user's intent in the two frames following a manual switch.

## Key invariants

- Terminal panes only — app panes return early
- Only switches to *existing* contexts — never creates new ones
- Switches to the lowest-index match if multiple contexts share the same root
- Focus-change detection: `last_focused_tile_for_auto_switch` tracks the last tile checked, so the CWD lookup runs once per focus change, not every frame

## Log line

```
context:auto-switch: cwd=/Users/ian/project → context_id=42
```

## Tests

- `skip_auto_switch_frames_decrements_each_frame` — inhibit counter reaches zero after N frames
- `auto_switch_no_op_without_context_roots` — no switch when no context has a root configured