### PR TITLE
refactor(secrets): replace security CLI subprocess with security-framework crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ egui_commonmark = "0.20"
 rfd = "0.15"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# Keychain access via Security.framework C API — no subprocess, distinct error
+# types for ItemNotFound vs AuthFailed (locked keychain). Replaces security CLI.
+security-framework = "3"
 # CoreMIDI I/O (#320). macOS-only; non-mac builds skip MIDI hardware (mock impl
 # stays available under `cfg(test)`).
 coremidi = "0.9"

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -45,31 +45,21 @@ pub fn get_secret_scoped(
     app_id: &str,
     workspace_root: &Path,
 ) -> Option<Zeroizing<String>> {
-    use std::process::Command;
+    use security_framework::passwords::get_generic_password;
 
     if !validate_workspace_root(workspace_root, "get_secret_scoped", app_id, key) {
         return None;
     }
 
     let account = account_key_scoped(key, workspace_root);
-    match Command::new("security")
-        .args([
-            "find-generic-password",
-            "-s",
-            SERVICE_NAME,
-            "-a",
-            &account,
-            "-w",
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => Some(Zeroizing::new(
-            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    match get_generic_password(SERVICE_NAME, &account) {
+        Ok(data) => Some(Zeroizing::new(
+            String::from_utf8_lossy(&data).trim().to_string(),
         )),
-        Ok(_) => None,
+        Err(e) if e.code() == -25300 => None,
         Err(e) => {
-            error!(
-                "secrets::get_secret_scoped failed for app={app_id} workspace={} key={key}: {e}",
+            warn!(
+                "secrets::get_secret_scoped: keychain error for app={app_id} workspace={} key={key}: {e}",
                 workspace_root.display()
             );
             None
@@ -181,46 +171,16 @@ fn index_remove(key: &str, app_id: &str, directory: &str) {
 
 #[cfg(target_os = "macos")]
 pub fn store_secret(key: &str, value: &str, app_id: &str, directory: &str) -> bool {
-    use std::process::Command;
+    use security_framework::passwords::set_generic_password;
 
     let account = account_key(key, app_id, directory);
-
-    // Delete existing entry first (ignore errors if it doesn't exist)
-    let _ = Command::new("security")
-        .args([
-            "delete-generic-password",
-            "-s",
-            SERVICE_NAME,
-            "-a",
-            &account,
-        ])
-        .output();
-
-    match Command::new("security")
-        .args([
-            "add-generic-password",
-            "-s",
-            SERVICE_NAME,
-            "-a",
-            &account,
-            "-w",
-            value,
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
+    match set_generic_password(SERVICE_NAME, &account, value.as_bytes()) {
+        Ok(()) => {
             index_add(key, app_id, directory);
             true
         }
-        Ok(output) => {
-            error!(
-                "secrets::store_secret failed for account={account}: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-            false
-        }
         Err(e) => {
-            error!("secrets::store_secret failed to run security CLI: {e}");
+            error!("secrets::store_secret failed for account={account}: {e}");
             false
         }
     }
@@ -228,27 +188,16 @@ pub fn store_secret(key: &str, value: &str, app_id: &str, directory: &str) -> bo
 
 #[cfg(target_os = "macos")]
 pub fn retrieve_secret(key: &str, app_id: &str, directory: &str) -> Option<Zeroizing<String>> {
-    use std::process::Command;
+    use security_framework::passwords::get_generic_password;
 
     let account = account_key(key, app_id, directory);
-
-    match Command::new("security")
-        .args([
-            "find-generic-password",
-            "-s",
-            SERVICE_NAME,
-            "-a",
-            &account,
-            "-w",
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => Some(Zeroizing::new(
-            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    match get_generic_password(SERVICE_NAME, &account) {
+        Ok(data) => Some(Zeroizing::new(
+            String::from_utf8_lossy(&data).trim().to_string(),
         )),
-        Ok(_) => None, // not found is normal, not an error
+        Err(e) if e.code() == -25300 => None,
         Err(e) => {
-            error!("secrets::retrieve_secret failed to run security CLI: {e}");
+            warn!("secrets::retrieve_secret: keychain error for account={account}: {e}");
             None
         }
     }
@@ -256,33 +205,21 @@ pub fn retrieve_secret(key: &str, app_id: &str, directory: &str) -> Option<Zeroi
 
 #[cfg(target_os = "macos")]
 pub fn delete_secret(key: &str, app_id: &str, directory: &str) -> bool {
-    use std::process::Command;
+    use security_framework::passwords::delete_generic_password;
 
     let account = account_key(key, app_id, directory);
-
-    match Command::new("security")
-        .args([
-            "delete-generic-password",
-            "-s",
-            SERVICE_NAME,
-            "-a",
-            &account,
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
+    match delete_generic_password(SERVICE_NAME, &account) {
+        Ok(()) => {
             index_remove(key, app_id, directory);
             true
         }
-        Ok(output) => {
-            error!(
-                "secrets::delete_secret failed for account={account}: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-            false
+        Err(e) if e.code() == -25300 => {
+            // Already gone — treat as success.
+            index_remove(key, app_id, directory);
+            true
         }
         Err(e) => {
-            error!("secrets::delete_secret failed to run security CLI: {e}");
+            error!("secrets::delete_secret failed for account={account}: {e}");
             false
         }
     }

--- a/src/workspace_secrets.rs
+++ b/src/workspace_secrets.rs
@@ -77,25 +77,15 @@ impl MacKeychain {
 #[cfg(target_os = "macos")]
 impl SecretStore for MacKeychain {
     fn get(&self, account: &str) -> Option<Zeroizing<String>> {
-        use std::process::Command;
-        match Command::new("security")
-            .args([
-                "find-generic-password",
-                "-s",
-                "plexi",
-                "-a",
-                account,
-                "-w",
-            ])
-            .output()
-        {
-            Ok(out) if out.status.success() => Some(Zeroizing::new(
-                String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        use security_framework::passwords::get_generic_password;
+        match get_generic_password("plexi", account) {
+            Ok(data) => Some(Zeroizing::new(
+                String::from_utf8_lossy(&data).trim().to_string(),
             )),
-            Ok(_) => None,
+            Err(e) if e.code() == -25300 => None,
             Err(e) => {
-                log::error!(
-                    "workspace_secrets::MacKeychain::get failed for account={account}: {e}"
+                log::warn!(
+                    "workspace_secrets::MacKeychain::get: keychain error for account={account}: {e}"
                 );
                 None
             }
@@ -103,42 +93,20 @@ impl SecretStore for MacKeychain {
     }
 
     fn set(&self, account: &str, value: &str) -> Result<(), SecretError> {
-        use std::process::Command;
-        // Delete first so re-adds overwrite cleanly.
-        let _ = Command::new("security")
-            .args(["delete-generic-password", "-s", "plexi", "-a", account])
-            .output();
-        let out = Command::new("security")
-            .args([
-                "add-generic-password",
-                "-s",
-                "plexi",
-                "-a",
-                account,
-                "-w",
-                value,
-            ])
-            .output()
-            .map_err(|e| SecretError::Backend(format!("security CLI: {e}")))?;
-        if !out.status.success() {
-            return Err(SecretError::Backend(
-                String::from_utf8_lossy(&out.stderr).trim().to_string(),
-            ));
-        }
+        use security_framework::passwords::set_generic_password;
+        set_generic_password("plexi", account, value.as_bytes())
+            .map_err(|e| SecretError::Backend(format!("{e}")))?;
         index_add(account);
         Ok(())
     }
 
     fn delete(&self, account: &str) -> Result<(), SecretError> {
-        use std::process::Command;
-        let out = Command::new("security")
-            .args(["delete-generic-password", "-s", "plexi", "-a", account])
-            .output()
-            .map_err(|e| SecretError::Backend(format!("security CLI: {e}")))?;
-        if !out.status.success() {
-            return Err(SecretError::Backend(
-                String::from_utf8_lossy(&out.stderr).trim().to_string(),
-            ));
+        use security_framework::passwords::delete_generic_password;
+        match delete_generic_password("plexi", account) {
+            Ok(()) => {}
+            // Already gone — treat as success.
+            Err(e) if e.code() == -25300 => {}
+            Err(e) => return Err(SecretError::Backend(format!("{e}"))),
         }
         index_remove(account);
         Ok(())
@@ -246,7 +214,7 @@ fn index_remove(account: &str) {
 /// in the new flat-string form.
 #[cfg(target_os = "macos")]
 pub fn migrate_legacy_global_secrets(store: &dyn SecretStore) -> usize {
-    use std::process::Command;
+    use security_framework::passwords::get_generic_password;
     let path = index_path();
     let raw = match std::fs::read_to_string(&path) {
         Ok(s) => s,
@@ -264,21 +232,15 @@ pub fn migrate_legacy_global_secrets(store: &dyn SecretStore) -> usize {
     for entry in &legacy {
         // Read the legacy Keychain account: `{app_id}/{directory}/{key}`.
         let legacy_account = format!("{}/{}/{}", entry.app_id, entry.directory, entry.key);
-        let value_out = Command::new("security")
-            .args([
-                "find-generic-password",
-                "-s",
-                "plexi",
-                "-a",
-                &legacy_account,
-                "-w",
-            ])
-            .output();
-        let value = match value_out {
-            Ok(out) if out.status.success() => {
-                String::from_utf8_lossy(&out.stdout).trim().to_string()
+        let value = match get_generic_password("plexi", &legacy_account) {
+            Ok(data) => String::from_utf8_lossy(&data).trim().to_string(),
+            Err(e) if e.code() == -25300 => {
+                continue; // legacy entry already gone; index is stale
             }
-            _ => continue, // legacy entry already gone; index is stale
+            Err(e) => {
+                log::warn!("workspace_secrets::migrate: keychain error for {legacy_account}: {e}");
+                continue;
+            }
         };
         let new_account = keychain_user_name(&entry.key);
         if let Err(e) = store.set(&new_account, &value) {


### PR DESCRIPTION
Closes #723

## What

Replaces all `security(1)` CLI subprocess calls with direct Security.framework bindings via the `security-framework` crate. This affects:

- `src/secrets.rs` — `get_secret_scoped`, `store_secret`, `retrieve_secret`, `delete_secret`
- `src/workspace_secrets.rs` — `MacKeychain::get/set/delete`, `migrate_legacy_global_secrets`
- `Cargo.toml` — adds `security-framework = "3"` under macOS target deps

## Why

Every `ctx.secret()` call was forking a subprocess. An app resolving 5 secrets at startup forks 5 blocking subprocesses. The `security(1)` tool also has no stable output format and silently conflates "item not found" with "keychain locked".

## Changes

- **No subprocess overhead** — direct C API calls via Security.framework
- **Distinct error logging** — `errSecItemNotFound` (-25300) → silent `None` (normal); any other error → `warn!` with the OSStatus (distinguishable in `plexi.log` as a locked/denied keychain)
- **`delete` is now idempotent** — not-found on delete is treated as success in both impls
- **`secrets-index.json` retained** for `list_with_prefix` (no-subprocess listing remains; SecKeychainItemSearch replacement deferred)

## Test

`cargo test --lib` — 47 tests pass. The doc-test failure in `app_protocol.rs` is pre-existing on alpha.