### PR TITLE
feat(cli): add --version flag support

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "plexi", about = "Plexi — the last app you'll ever need")]
+#[command(name = "plexi", about = "Plexi — the last app you'll ever need", version = env!("CARGO_PKG_VERSION"))]
 pub struct Cli {
     /// Profile name (e.g. alpha, beta)
     #[arg(long, global = true, hide = true)]


### PR DESCRIPTION
## Summary
Adds `--version` flag support to the Plexi CLI using clap's built-in version feature.

## Changes
- Added `version = env!("CARGO_PKG_VERSION")` to the `#[command(...)]` macro in `src/cli_args.rs`

## Testing
- Binary builds successfully
- `plexi --version` outputs the current version (e.g., `plexi 3.5.17`)