### PR TITLE
fix(first-run): re-prompt CLI setup on migrated profiles, always seed SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,31 @@ One binary. A tiling shell that brings Unix composability to the desktop — ter
 
 > **macOS only.** Linux is untested.
 
-### Download
+### One-liner
 
-1. Grab the latest `Plexi-vX.Y.Z.zip` from [Releases](https://github.com/ianjamesburke/PLEXI/releases).
+```bash
+curl -fsSL https://plexiapp.com/install | sh
+```
+
+Downloads the latest release, installs to `/Applications`, sets up the `plexi` CLI, and wires ZSH integration. Restart your terminal when done.
+
+**First launch (unsigned app):** macOS may block it on first open.
+- **macOS 15+:** System Settings → Privacy & Security → "Open Anyway".
+- **Or:** `xattr -cr /Applications/Plexi.app && open /Applications/Plexi.app`
+
+### Manual
+
+1. Download the latest `Plexi-vX.Y.Z.zip` from [Releases](https://github.com/ianjamesburke/PLEXI/releases).
 2. Unzip and move `Plexi.app` to `/Applications`.
-3. First launch (unsigned app):
-   - **macOS 15+:** System Settings → Privacy & Security → "Open Anyway".
-   - **Or:** `xattr -cr /Applications/Plexi.app`.
+3. Run `xattr -cr /Applications/Plexi.app` if macOS blocks it.
+4. On first launch, click **Install CLI** in the setup prompt to add `plexi` to your PATH.
 
 ### Build from source
 
 Needs Rust ([rustup.rs](https://rustup.rs)).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ianjamesburke/PLEXI/main/install.sh | bash
+just install
 ```
 
 ---

--- a/scripts/user-install.sh
+++ b/scripts/user-install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Install Plexi from GitHub releases.
+# Usage: curl -fsSL https://plexiapp.com/install | sh
+set -euo pipefail
+
+REPO="ianjamesburke/PLEXI"
+APP_NAME="Plexi.app"
+APP_DEST="/Applications/Plexi.app"
+CLI_DIR="/usr/local/bin"
+CLI_DEST="$CLI_DIR/plexi"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()    { printf '\033[1;32m ✓\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33mwarn:\033[0m %s\n' "$*" >&2; }
+die()   { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() {
+    command -v "$1" &>/dev/null || die "required tool not found: $1"
+}
+
+# ── preflight ─────────────────────────────────────────────────────────────────
+
+[[ "$(uname)" == "Darwin" ]] || die "Plexi is macOS only."
+require curl
+require unzip
+
+# ── fetch latest release ──────────────────────────────────────────────────────
+
+info "Fetching latest release..."
+API="https://api.github.com/repos/$REPO/releases/latest"
+TAG=$(curl -fsSL "$API" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+[[ -n "$TAG" ]] || die "Could not determine latest release tag."
+
+ZIP_NAME="Plexi-${TAG}.zip"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$ZIP_NAME"
+
+info "Downloading $ZIP_NAME..."
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+curl -fsSL --progress-bar "$DOWNLOAD_URL" -o "$TMP/$ZIP_NAME"
+
+# ── install app bundle ─────────────────────────────────────────────────────────
+
+info "Installing $APP_NAME to /Applications..."
+unzip -q "$TMP/$ZIP_NAME" -d "$TMP/extracted"
+
+# cargo-bundle produces a lowercase bundle name on disk; find it regardless.
+APP_SRC=$(find "$TMP/extracted" -maxdepth 1 -name "*.app" | head -1)
+[[ -n "$APP_SRC" ]] || die "No .app found inside $ZIP_NAME."
+
+rm -rf "$APP_DEST"
+cp -R "$APP_SRC" "$APP_DEST"
+ok "Installed $APP_DEST"
+
+# ── CLI symlink ────────────────────────────────────────────────────────────────
+
+info "Setting up CLI..."
+BINARY="$APP_DEST/Contents/MacOS/plexi"
+[[ -f "$BINARY" ]] || die "Binary not found at $BINARY."
+
+if [[ ! -d "$CLI_DIR" ]]; then
+    sudo mkdir -p "$CLI_DIR"
+fi
+sudo ln -sf "$BINARY" "$CLI_DEST"
+ok "CLI: $CLI_DEST"
+
+# ── shell integration ─────────────────────────────────────────────────────────
+
+info "Setting up shell integration..."
+SNIPPET='eval "$(plexi shell-init)"'
+
+for RC in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [[ -f "$RC" ]] || continue
+    if ! grep -qF 'plexi shell-init' "$RC"; then
+        printf '\n# Plexi shell integration\n%s\n' "$SNIPPET" >> "$RC"
+        ok "Added shell integration to $RC"
+    else
+        ok "Shell integration already present in $RC"
+    fi
+done
+
+# ── register with macOS (dock icon, Spotlight, Open With) ─────────────────────
+
+info "Registering app with macOS..."
+LSREG="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+if [[ -x "$LSREG" ]]; then
+    "$LSREG" -f "$APP_DEST" 2>/dev/null && ok "Registered with LaunchServices"
+fi
+/System/Library/CoreServices/pbs -update 2>/dev/null || true
+
+# ── done ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "  Plexi $TAG installed."
+echo ""
+echo "  Open it:  open /Applications/Plexi.app"
+echo "  CLI:      plexi --version  (after restarting your terminal)"
+echo ""
+echo "  Or reload now:  source ~/.zshrc"

--- a/scripts/user-install.sh
+++ b/scripts/user-install.sh
@@ -30,7 +30,7 @@ require unzip
 
 info "Fetching latest release..."
 API="https://api.github.com/repos/$REPO/releases/latest"
-TAG=$(curl -fsSL "$API" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+TAG=$(curl -fsSL "$API" | grep -m 1 '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
 [[ -n "$TAG" ]] || die "Could not determine latest release tag."
 
 ZIP_NAME="Plexi-${TAG}.zip"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -673,8 +673,7 @@ impl PlexiApp {
             sidebar_visible: true,
             show_shortcuts: false,
             show_changelog: false,
-            show_cli_setup_prompt: !crate::cli_setup::was_prompted()
-                && !crate::cli_setup::is_installed(),
+            show_cli_setup_prompt: crate::cli_setup::should_prompt(),
             cli_setup_error: None,
             quitting: false,
             quit_press_count: 0,

--- a/src/cli_setup.rs
+++ b/src/cli_setup.rs
@@ -27,13 +27,23 @@ pub fn mark_prompted() {
 
 /// Shows every launch until the user clicks Install (writes sentinel).
 /// "Not now" and Escape dismiss for the session only.
+///
+/// If the sentinel exists but the binary isn't installed (e.g. profile was
+/// migrated from another machine), the stale sentinel is cleared and the
+/// prompt is shown again.
 pub fn should_prompt() -> bool {
-    if was_prompted() {
-        return false;
-    }
     if is_installed() {
         log::info!("cli_setup: {} already installed — skipping prompt", cli_name());
         return false;
+    }
+    if was_prompted() {
+        // Sentinel was set on a different machine or the symlink was deleted.
+        // Clear it so the prompt shows.
+        log::info!(
+            "cli_setup: stale sentinel found but {} not installed — clearing and re-prompting",
+            cli_name()
+        );
+        let _ = std::fs::remove_file(sentinel_path());
     }
     log::info!("cli_setup: {} not installed — showing prompt", cli_name());
     true

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,56 +204,57 @@ pub fn set_profile(name: Option<String>) {
     let _ = PROFILE_OVERRIDE.set(normalized);
 }
 
-/// If a profile is set and its directory doesn't exist yet, create it and
-/// seed `apps/` from the example apps embedded at compile time.
+/// Seed apps from embedded examples into a fresh profile dir, and ensure the
+/// Python SDK is present in the profile sdk dir. The SDK seeding runs on every
+/// launch so migrated profiles (which skip the apps-seeding block) still get
+/// the SDK written on first run with a new binary.
 pub fn ensure_profile_initialized() {
     let dir = config_dir();
-    if dir.exists() {
-        return;
-    }
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("profile init: failed to create {}: {e}", dir.display());
-        return;
-    }
-    let apps_dir = dir.join("apps");
-    if let Err(e) = std::fs::create_dir_all(&apps_dir) {
-        eprintln!("profile init: failed to create apps dir: {e}");
-        return;
-    }
-    let embedded = include_dir::include_dir!("$CARGO_MANIFEST_DIR/examples");
-    if let Err(e) = embedded.extract(&apps_dir) {
-        eprintln!("profile init: failed to seed apps from bundle: {e}");
-        return;
-    }
-    // chmod +x on all .py entries.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(entries) = std::fs::read_dir(&apps_dir) {
-            for app_dir in entries.flatten().filter(|e| e.path().is_dir()) {
-                if let Ok(files) = std::fs::read_dir(app_dir.path()) {
-                    for f in files.flatten() {
-                        let p = f.path();
-                        if p.extension().and_then(|x| x.to_str()) == Some("py") {
-                            if let Ok(meta) = std::fs::metadata(&p) {
-                                let mut perms = meta.permissions();
-                                perms.set_mode(perms.mode() | 0o111);
-                                let _ = std::fs::set_permissions(&p, perms);
+    if !dir.exists() {
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            eprintln!("profile init: failed to create {}: {e}", dir.display());
+            return;
+        }
+        let apps_dir = dir.join("apps");
+        if let Err(e) = std::fs::create_dir_all(&apps_dir) {
+            eprintln!("profile init: failed to create apps dir: {e}");
+            return;
+        }
+        let embedded = include_dir::include_dir!("$CARGO_MANIFEST_DIR/examples");
+        if let Err(e) = embedded.extract(&apps_dir) {
+            eprintln!("profile init: failed to seed apps from bundle: {e}");
+            return;
+        }
+        // chmod +x on all .py entries.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(entries) = std::fs::read_dir(&apps_dir) {
+                for app_dir in entries.flatten().filter(|e| e.path().is_dir()) {
+                    if let Ok(files) = std::fs::read_dir(app_dir.path()) {
+                        for f in files.flatten() {
+                            let p = f.path();
+                            if p.extension().and_then(|x| x.to_str()) == Some("py") {
+                                if let Ok(meta) = std::fs::metadata(&p) {
+                                    let mut perms = meta.permissions();
+                                    perms.set_mode(perms.mode() | 0o111);
+                                    let _ = std::fs::set_permissions(&p, perms);
+                                }
                             }
                         }
                     }
                 }
             }
         }
+        eprintln!(
+            "profile init: seeded {} with {} apps",
+            dir.display(),
+            std::fs::read_dir(&apps_dir).map(|r| r.count()).unwrap_or(0)
+        );
     }
-    eprintln!(
-        "profile init: seeded {} with {} apps",
-        dir.display(),
-        std::fs::read_dir(&apps_dir).map(|r| r.count()).unwrap_or(0)
-    );
 
-    // Embed the SDK so Python apps work on first launch without relying on the
-    // bundle resource path, which can be absent on a cache-hit CI build.
+    // Always ensure the SDK is present — runs on every launch so that
+    // migrated profiles (pre-existing dir) get the SDK on first run.
     let sdk_dest = dir.join("sdk").join("plexi_sdk");
     if !sdk_dest.exists() {
         if let Err(e) = std::fs::create_dir_all(&sdk_dest) {


### PR DESCRIPTION
## What broke (Ashley's machine, ash.txt log)

Three failures all shared the same root: users who drag-install or migrate a profile from another Mac get a broken first-run experience.

**1. CLI modal never showed** (`cli_setup_done` sentinel existed from old machine)
- `should_prompt()` bailed immediately on the sentinel without checking `is_installed()`
- Fix: check `is_installed()` first; if binary absent despite sentinel, clear the stale file and re-prompt

**2. Python SDK missing** (`ModuleNotFoundError: No module named 'plexi_sdk'`)
- `ensure_profile_initialized` returned early when the profile dir already existed
- SDK seeding block (added after many users had existing profiles) never ran
- Fix: moved SDK seeding outside the early-return — runs every launch, self-heals

**3. Duplicate logic in `app/mod.rs`**
- Second struct-literal init block had an inline `!was_prompted() && !is_installed()` check instead of calling `should_prompt()`
- Fixed by replacing with `should_prompt()`

## Also included

- `scripts/user-install.sh` — the backend for `curl -fsSL https://plexiapp.com/install | sh`
  - Downloads latest release from GitHub, installs to `/Applications`, creates CLI symlink, wires ZSH integration, runs `lsregister` for dock icon
- README Install section rewritten with the one-liner front-and-center

## Breaks if

Apps fail to launch with `ModuleNotFoundError: No module named 'plexi_sdk'` on a fresh install.
CLI setup modal doesn't appear on a machine where `~/.plexi/cli_setup_done` exists but `/usr/local/bin/plexi` doesn't.