### PR TITLE
revert(context): remove CWD-based auto-switch (sidebar flashing bug)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -264,12 +264,6 @@ pub struct PlexiApp {
     /// Receiver for HostCommands sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::HostCommand>,
-    /// Last tile that triggered an auto-context-switch check. Avoids re-running
-    /// the CWD lookup every frame when focus hasn't changed.
-    pub(crate) last_focused_tile_for_auto_switch: Option<egui_tiles::TileId>,
-    /// Frames remaining before auto-context-switch is allowed after a manual
-    /// context switch. Prevents immediately overriding the user's intent.
-    pub(crate) skip_auto_switch_frames: u8,
 }
 
 #[cfg(test)]
@@ -628,8 +622,6 @@ impl PlexiApp {
                     update_rx: Some(update_rx),
                     update_available: None,
                     pane_ipc_rx,
-                    last_focused_tile_for_auto_switch: None,
-                    skip_auto_switch_frames: 0,
                 };
             }
         }
@@ -721,8 +713,6 @@ impl PlexiApp {
             update_rx: Some(update_rx),
             update_available: None,
             pane_ipc_rx,
-            last_focused_tile_for_auto_switch: None,
-            skip_auto_switch_frames: 0,
         }
     }
 
@@ -827,8 +817,6 @@ impl PlexiApp {
             update_rx: None,
             update_available: None,
             pane_ipc_rx,
-            last_focused_tile_for_auto_switch: None,
-            skip_auto_switch_frames: 0,
         }, pane_ipc_tx)
     }
 
@@ -1341,7 +1329,6 @@ impl eframe::App for PlexiApp {
         // closes (which caused the "ghost queue appears on reopen" bug).
         let deferred_app_cmds = self.drain_all_app_commands();
         self.sync_app_cwd();
-        self.check_context_auto_switch();
 
         // Dispatch any DeliverNotifyAction commands the early modal render
         // produced. Routes back to the originating pane as NotifyAction events.
@@ -2024,7 +2011,6 @@ impl eframe::App for PlexiApp {
                 Action::SwitchContext(n) => {
                     if n < self.router.len() {
                         self.switch_workspace(n);
-                        self.skip_auto_switch_frames = 2;
                     }
                 }
                 Action::NextTab => {

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -3,7 +3,6 @@
 use super::PlexiApp;
 use crate::plexi_ai::broker::PaneContext;
 use crate::shell;
-use egui_tiles::Tile;
 
 impl PlexiApp {
     /// Synchronize app panes that join the `cwd` pane group with any terminal's
@@ -94,64 +93,4 @@ impl PlexiApp {
         crate::plexi_ai::broker::update_pane_snapshot(panes);
     }
 
-    /// On every frame, if the focused pane changed and is a terminal, walk its CWD
-    /// up the directory tree looking for a matching context root. If found and not
-    /// already active, switch to it automatically.
-    ///
-    /// Skips when `skip_auto_switch_frames > 0` — set by manual context switches
-    /// to prevent immediately overriding the user's intent.
-    pub(super) fn check_context_auto_switch(&mut self) {
-        if self.skip_auto_switch_frames > 0 {
-            self.skip_auto_switch_frames -= 1;
-            return;
-        }
-
-        let active = self.active_window;
-        let Some(focused_tile) = self.windows[active].focused_pane else {
-            self.last_focused_tile_for_auto_switch = None;
-            return;
-        };
-
-        if self.last_focused_tile_for_auto_switch == Some(focused_tile) {
-            return;
-        }
-        self.last_focused_tile_for_auto_switch = Some(focused_tile);
-
-        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
-            Some(Tile::Pane(id)) => *id,
-            _ => return,
-        };
-
-        let cwd = {
-            let Some(terminal) = self.windows[active]
-                .panes
-                .get(&pane_id)
-                .and_then(|p| p.as_terminal())
-            else {
-                return;
-            };
-            shell::get_pid_cwd(terminal.backend.child_pid())
-        };
-        let Some(cwd) = cwd else { return; };
-
-        let current_ctx_idx = self.router.active_idx();
-        let mut path = cwd.as_path();
-        loop {
-            if let Some(idx) = self.router.position(|ctx| ctx.root.as_deref() == Some(path)) {
-                if idx != current_ctx_idx {
-                    log::info!(
-                        "context:auto-switch: cwd={} → context_id={}",
-                        cwd.display(),
-                        self.router.get(idx).context_id
-                    );
-                    self.switch_workspace(idx);
-                }
-                break;
-            }
-            match path.parent() {
-                Some(parent) if parent != path => path = parent,
-                _ => break,
-            }
-        }
-    }
 }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -524,7 +524,6 @@ impl PlexiApp {
                 // active_window based on context_active_window. We override it
                 // immediately below.
                 self.switch_workspace(ctx_idx_sidebar);
-                self.skip_auto_switch_frames = 2;
             }
         }
         self.active_window = ctx_idx;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -267,7 +267,6 @@ impl PlexiApp {
             self.delete_context(i);
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);
-            self.skip_auto_switch_frames = 2;
         }
 
         if add_clicked {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -426,35 +426,4 @@ mod tests {
         h.run_frames(1); // must not panic; logs warn "not found"
     }
 
-    // -- Auto-switch context on pane focus ------------------------------------
-
-    /// `skip_auto_switch_frames` decrements to zero over successive frames.
-    /// This guards against regressions where the inhibit counter never clears
-    /// and auto-switch stops working after the first manual context switch.
-    #[test]
-    fn skip_auto_switch_frames_decrements_each_frame() {
-        let mut h = HostHarness::new();
-        h.app.skip_auto_switch_frames = 3;
-        h.run_frames(3);
-        assert_eq!(
-            h.app.skip_auto_switch_frames, 0,
-            "skip_auto_switch_frames should reach zero after 3 frames"
-        );
-    }
-
-    /// Auto-switch must not fire when context roots are None (no root configured).
-    /// With no terminal panes and no context roots, router stays on context 0.
-    #[test]
-    fn auto_switch_no_op_without_context_roots() {
-        let mut h = HostHarness::new();
-        h.add_test_pane();
-
-        // All contexts have root = None by default in new_for_test.
-        let before_idx = h.app.router.active_idx();
-        h.run_frames(2);
-        assert_eq!(
-            h.app.router.active_idx(), before_idx,
-            "auto-switch must not fire when no context has a root configured"
-        );
-    }
 }


### PR DESCRIPTION
## What

Removes the CWD-based context auto-switch feature that landed in #782.

## Why

The auto-switch fires every frame a new pane is focused. Manual context switches set `skip_auto_switch_frames = 2` as a guard, but 2 frames (~33ms) was never enough — the focused terminal's CWD still pointed to the previous context, so auto-switch fired immediately and bounced the user back. With two workspaced contexts, this made manual sidebar switching completely unreliable: clicking a context would flash and revert.

## What's removed

- `check_context_auto_switch()` in `src/app/sync.rs` (entire method)
- `last_focused_tile_for_auto_switch` and `skip_auto_switch_frames` fields + all 3 init sites in `src/app/mod.rs`
- `self.check_context_auto_switch()` call site in `app/mod.rs`
- `skip_auto_switch_frames = 2` in `sidebar.rs`, `command_palette.rs`, and `app/mod.rs`
- Two auto-switch tests in `src/testing.rs`

## What's kept

- `context.root` field (used by `focus_or_create_context_by_root` / CLI)
- `get_pid_cwd` (used for `sync_app_cwd`, pane workspace save, canvas bindings)
- `sync_app_cwd` (syncs app panes in the `cwd` pane group — unrelated)
- `focus_or_create_context_by_root` (CLI-driven, not per-frame)

## Test plan
- [ ] Build passes: `cargo build`
- [ ] Lib tests pass: `cargo test --lib`
- [ ] Open two contexts with workspace roots configured
- [ ] Click between contexts in the sidebar — verify selection sticks with no bounce/flash
- [ ] Keyboard shortcuts `⌘1`/`⌘2` switch contexts and stay