### PR TITLE
fix(context): remove CWD-based auto-switch (#796)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -264,12 +264,6 @@ pub struct PlexiApp {
     /// Receiver for HostCommands sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::HostCommand>,
-    /// Last tile that triggered an auto-context-switch check. Avoids re-running
-    /// the CWD lookup every frame when focus hasn't changed.
-    pub(crate) last_focused_tile_for_auto_switch: Option<egui_tiles::TileId>,
-    /// Frames remaining before auto-context-switch is allowed after a manual
-    /// context switch. Prevents immediately overriding the user's intent.
-    pub(crate) skip_auto_switch_frames: u8,
 }
 
 #[cfg(test)]
@@ -628,8 +622,6 @@ impl PlexiApp {
                     update_rx: Some(update_rx),
                     update_available: None,
                     pane_ipc_rx,
-                    last_focused_tile_for_auto_switch: None,
-                    skip_auto_switch_frames: 0,
                 };
             }
         }
@@ -721,8 +713,6 @@ impl PlexiApp {
             update_rx: Some(update_rx),
             update_available: None,
             pane_ipc_rx,
-            last_focused_tile_for_auto_switch: None,
-            skip_auto_switch_frames: 0,
         }
     }
 
@@ -827,8 +817,6 @@ impl PlexiApp {
             update_rx: None,
             update_available: None,
             pane_ipc_rx,
-            last_focused_tile_for_auto_switch: None,
-            skip_auto_switch_frames: 0,
         }, pane_ipc_tx)
     }
 
@@ -1341,7 +1329,6 @@ impl eframe::App for PlexiApp {
         // closes (which caused the "ghost queue appears on reopen" bug).
         let deferred_app_cmds = self.drain_all_app_commands();
         self.sync_app_cwd();
-        self.check_context_auto_switch();
 
         // Dispatch any DeliverNotifyAction commands the early modal render
         // produced. Routes back to the originating pane as NotifyAction events.
@@ -2024,7 +2011,6 @@ impl eframe::App for PlexiApp {
                 Action::SwitchContext(n) => {
                     if n < self.router.len() {
                         self.switch_workspace(n);
-                        self.skip_auto_switch_frames = 2;
                     }
                 }
                 Action::NextTab => {

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -3,7 +3,6 @@
 use super::PlexiApp;
 use crate::plexi_ai::broker::PaneContext;
 use crate::shell;
-use egui_tiles::Tile;
 
 impl PlexiApp {
     /// Synchronize app panes that join the `cwd` pane group with any terminal's
@@ -94,64 +93,4 @@ impl PlexiApp {
         crate::plexi_ai::broker::update_pane_snapshot(panes);
     }
 
-    /// On every frame, if the focused pane changed and is a terminal, walk its CWD
-    /// up the directory tree looking for a matching context root. If found and not
-    /// already active, switch to it automatically.
-    ///
-    /// Skips when `skip_auto_switch_frames > 0` — set by manual context switches
-    /// to prevent immediately overriding the user's intent.
-    pub(super) fn check_context_auto_switch(&mut self) {
-        if self.skip_auto_switch_frames > 0 {
-            self.skip_auto_switch_frames -= 1;
-            return;
-        }
-
-        let active = self.active_window;
-        let Some(focused_tile) = self.windows[active].focused_pane else {
-            self.last_focused_tile_for_auto_switch = None;
-            return;
-        };
-
-        if self.last_focused_tile_for_auto_switch == Some(focused_tile) {
-            return;
-        }
-        self.last_focused_tile_for_auto_switch = Some(focused_tile);
-
-        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
-            Some(Tile::Pane(id)) => *id,
-            _ => return,
-        };
-
-        let cwd = {
-            let Some(terminal) = self.windows[active]
-                .panes
-                .get(&pane_id)
-                .and_then(|p| p.as_terminal())
-            else {
-                return;
-            };
-            shell::get_pid_cwd(terminal.backend.child_pid())
-        };
-        let Some(cwd) = cwd else { return; };
-
-        let current_ctx_idx = self.router.active_idx();
-        let mut path = cwd.as_path();
-        loop {
-            if let Some(idx) = self.router.position(|ctx| ctx.root.as_deref() == Some(path)) {
-                if idx != current_ctx_idx {
-                    log::info!(
-                        "context:auto-switch: cwd={} → context_id={}",
-                        cwd.display(),
-                        self.router.get(idx).context_id
-                    );
-                    self.switch_workspace(idx);
-                }
-                break;
-            }
-            match path.parent() {
-                Some(parent) if parent != path => path = parent,
-                _ => break,
-            }
-        }
-    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2428,11 +2428,30 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
 
 /// `plexi shell-init <shell>`
 ///
-/// Reserved for future shell integration. Auto-switching context on cd was
-/// removed in #796 — context switching is now always an explicit user action.
+/// Auto-switching context on cd was removed in #796. This now emits an
+/// uninstall snippet to clean up the old `_plexi_chpwd` hook from prior versions.
 pub fn shell_init_cli(shell: Option<&str>) -> i32 {
     match shell.unwrap_or("zsh") {
-        "zsh" | "bash" => 0,
+        "zsh" => {
+            println!(
+                r#"# Plexi shell integration — auto-context-switch removed
+# Uninstall the chpwd hook installed by older Plexi versions
+chpwd_functions=(${{chpwd_functions:#_plexi_chpwd}})
+unfunction _plexi_chpwd 2>/dev/null
+unset PLEXI_ACTIVE_WORKSPACE"#
+            );
+            0
+        }
+        "bash" => {
+            println!(
+                r#"# Plexi shell integration — auto-context-switch removed
+# Uninstall the chpwd hook installed by older Plexi versions
+unset -f _plexi_chpwd 2>/dev/null
+PROMPT_COMMAND="${{PROMPT_COMMAND//_plexi_chpwd;/}}"
+unset PLEXI_ACTIVE_WORKSPACE"#
+            );
+            0
+        }
         other => {
             eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash");
             1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2428,59 +2428,11 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
 
 /// `plexi shell-init <shell>`
 ///
-/// Prints a shell hook snippet that calls `plexi context open` whenever the
-/// working directory changes and a `.plexi/` directory is found above it.
+/// Reserved for future shell integration. Auto-switching context on cd was
+/// removed in #796 — context switching is now always an explicit user action.
 pub fn shell_init_cli(shell: Option<&str>) -> i32 {
     match shell.unwrap_or("zsh") {
-        "zsh" => {
-            println!(
-                r#"
-# Plexi shell integration — add to ~/.zshrc: eval "$(plexi shell-init)"
-_plexi_chpwd() {{
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.plexi" ]]; then
-            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
-                export PLEXI_ACTIVE_WORKSPACE="$dir"
-                plexi context open "$dir" &>/dev/null &
-            fi
-            return
-        fi
-        dir="$(dirname "$dir")"
-    done
-    unset PLEXI_ACTIVE_WORKSPACE
-}}
-autoload -Uz add-zsh-hook
-add-zsh-hook chpwd _plexi_chpwd
-_plexi_chpwd
-"#
-            );
-            0
-        }
-        "bash" => {
-            println!(
-                r#"
-# Plexi shell integration — add to ~/.bashrc: eval "$(plexi shell-init --shell bash)"
-_plexi_chpwd() {{
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.plexi" ]]; then
-            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
-                export PLEXI_ACTIVE_WORKSPACE="$dir"
-                plexi context open "$dir" &>/dev/null &
-            fi
-            return
-        fi
-        dir="${{dir%/*}}"
-    done
-    unset PLEXI_ACTIVE_WORKSPACE
-}}
-PROMPT_COMMAND="_plexi_chpwd${{PROMPT_COMMAND:+;$PROMPT_COMMAND}}"
-_plexi_chpwd
-"#
-            );
-            0
-        }
+        "zsh" | "bash" => 0,
         other => {
             eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash");
             1

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -524,7 +524,6 @@ impl PlexiApp {
                 // active_window based on context_active_window. We override it
                 // immediately below.
                 self.switch_workspace(ctx_idx_sidebar);
-                self.skip_auto_switch_frames = 2;
             }
         }
         self.active_window = ctx_idx;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -267,7 +267,6 @@ impl PlexiApp {
             self.delete_context(i);
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);
-            self.skip_auto_switch_frames = 2;
         }
 
         if add_clicked {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -426,35 +426,4 @@ mod tests {
         h.run_frames(1); // must not panic; logs warn "not found"
     }
 
-    // -- Auto-switch context on pane focus ------------------------------------
-
-    /// `skip_auto_switch_frames` decrements to zero over successive frames.
-    /// This guards against regressions where the inhibit counter never clears
-    /// and auto-switch stops working after the first manual context switch.
-    #[test]
-    fn skip_auto_switch_frames_decrements_each_frame() {
-        let mut h = HostHarness::new();
-        h.app.skip_auto_switch_frames = 3;
-        h.run_frames(3);
-        assert_eq!(
-            h.app.skip_auto_switch_frames, 0,
-            "skip_auto_switch_frames should reach zero after 3 frames"
-        );
-    }
-
-    /// Auto-switch must not fire when context roots are None (no root configured).
-    /// With no terminal panes and no context roots, router stays on context 0.
-    #[test]
-    fn auto_switch_no_op_without_context_roots() {
-        let mut h = HostHarness::new();
-        h.add_test_pane();
-
-        // All contexts have root = None by default in new_for_test.
-        let before_idx = h.app.router.active_idx();
-        h.run_frames(2);
-        assert_eq!(
-            h.app.router.active_idx(), before_idx,
-            "auto-switch must not fire when no context has a root configured"
-        );
-    }
 }


### PR DESCRIPTION
Closes #796

## What

Removes `check_context_auto_switch()` and all supporting state (`last_focused_tile_for_auto_switch`, `skip_auto_switch_frames`) that silently switched the active context when a terminal's CWD matched another context's root path.

## Why

The auto-switch was actively disruptive — users got teleported to a different context by simply navigating directories or focusing a different terminal pane. The suppression mechanism (`skip_auto_switch_frames=2`) was a race: 2 frames (~33ms) wasn't enough, causing manual context switches to immediately bounce back.

## Changes

- `src/app/sync.rs` — deleted `check_context_auto_switch()` and its call site
- `src/app/mod.rs` — removed `last_focused_tile_for_auto_switch` and `skip_auto_switch_frames` fields
- `src/sidebar.rs` — removed `skip_auto_switch_frames = 2` assignment
- `src/command_palette.rs` — removed `skip_auto_switch_frames = 2` assignment
- `src/testing.rs` — deleted the two tests for this behaviour

The OSC 7 `precmd` hook in `src/shell.rs` is untouched — it's used for split-pane CWD inheritance.

**Breaks if:** Context switches when a terminal `cd`s into another context's root directory.