### PR TITLE
fix(context): strip CWD auto-switch shell hook + neutralise FocusContext

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -997,9 +997,10 @@ impl PlexiApp {
                     self.save_workspace();
                 }
                 crate::app_protocol::HostCommand::FocusContext { root } => {
-                    log::info!("pane_ipc: kind=focus_context root={}", root.display());
-                    self.focus_or_create_context_by_root(root.clone());
-                    self.save_workspace();
+                    log::warn!(
+                        "pane_ipc: FocusContext ignored — CWD-based auto-switch removed (root={})",
+                        root.display()
+                    );
                 }
                 crate::app_protocol::HostCommand::SetContextRoot { root } => {
                     log::info!("pane_ipc: kind=set_context_root root={}", root.display());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2428,64 +2428,13 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
 
 /// `plexi shell-init <shell>`
 ///
-/// Prints a shell hook snippet that calls `plexi context open` whenever the
-/// working directory changes and a `.plexi/` directory is found above it.
-pub fn shell_init_cli(shell: Option<&str>) -> i32 {
-    match shell.unwrap_or("zsh") {
-        "zsh" => {
-            println!(
-                r#"
-# Plexi shell integration — add to ~/.zshrc: eval "$(plexi shell-init)"
-_plexi_chpwd() {{
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.plexi" ]]; then
-            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
-                export PLEXI_ACTIVE_WORKSPACE="$dir"
-                plexi context open "$dir" &>/dev/null &!
-            fi
-            return
-        fi
-        dir="$(dirname "$dir")"
-    done
-    unset PLEXI_ACTIVE_WORKSPACE
-}}
-autoload -Uz add-zsh-hook
-add-zsh-hook chpwd _plexi_chpwd
-_plexi_chpwd
-"#
-            );
-            0
-        }
-        "bash" => {
-            println!(
-                r#"
-# Plexi shell integration — add to ~/.bashrc: eval "$(plexi shell-init --shell bash)"
-_plexi_chpwd() {{
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.plexi" ]]; then
-            if [[ "$dir" != "$PLEXI_ACTIVE_WORKSPACE" ]]; then
-                export PLEXI_ACTIVE_WORKSPACE="$dir"
-                plexi context open "$dir" &>/dev/null &!
-            fi
-            return
-        fi
-        dir="${{dir%/*}}"
-    done
-    unset PLEXI_ACTIVE_WORKSPACE
-}}
-PROMPT_COMMAND="_plexi_chpwd${{PROMPT_COMMAND:+;$PROMPT_COMMAND}}"
-_plexi_chpwd
-"#
-            );
-            0
-        }
-        other => {
-            eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash");
-            1
-        }
-    }
+/// Previously emitted a `_plexi_chpwd` hook that called `plexi context open`
+/// on directory change. That hook drove the CWD-based auto-switch which was
+/// removed as actively disruptive. The command is kept for backwards
+/// compatibility with dotfiles that still `eval "$(plexi shell-init)"` — it
+/// now emits nothing so those evals are safe no-ops.
+pub fn shell_init_cli(_shell: Option<&str>) -> i32 {
+    0
 }
 
 /// `plexi completions <shell>`

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -326,54 +326,6 @@ impl PlexiApp {
         }
     }
 
-    /// Focus an existing context whose `root == Some(&root)`, or create a new one.
-    /// Uses the directory name as the context name.
-    pub(crate) fn focus_or_create_context_by_root(&mut self, root: PathBuf) {
-        if let Some(idx) = self.router.position(|ctx| ctx.root.as_deref() == Some(&root)) {
-            log::info!("focus_or_create_context_by_root: found existing ctx at idx={idx} root={}", root.display());
-            self.switch_workspace(idx);
-            return;
-        }
-        log::info!("focus_or_create_context_by_root: creating new ctx root={}", root.display());
-        let cwd = root.clone();
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
-        else {
-            log::error!("focus_or_create_context_by_root: failed to create terminal");
-            return;
-        };
-        let ctx_name = root
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("Context")
-            .to_string();
-        let ctx_id = self.next_window_id;
-        self.next_window_id += 1;
-        let win_id = self.next_window_id;
-        self.next_window_id += 1;
-        self.router.push(crate::context::Context {
-            name: ctx_name,
-            path: cwd.clone(),
-            root: Some(root),
-            context_id: ctx_id,
-        });
-        self.windows.push(crate::context::Window {
-            name: String::new(),
-            path: cwd,
-            tree,
-            panes,
-            focused_pane: Some(root_tile),
-            zoomed_pane: None,
-            grid_x: 0,
-            grid_y: 0,
-            window_id: win_id,
-            context_id: ctx_id,
-        });
-        self.router.activate_last();
-        self.active_window = self.windows.len() - 1;
-        self.context_active_window.insert(ctx_id, win_id);
-        self.minimap.visible = false;
-    }
-
     /// Set the `root` of the active context.
     pub(crate) fn set_active_context_root(&mut self, root: PathBuf) {
         let idx = self.router.active_idx();


### PR DESCRIPTION
Closes #796.

## What

Two remaining trigger paths for automatic context switching, after the host-side `check_context_auto_switch` loop was already deleted in `a440eb2`:

1. **`shell_init_cli`** — previously emitted `_plexi_chpwd` which ran `plexi context open <dir> &!` on every `chpwd` event, spawning a background `plexi` process. Now emits nothing — `eval "$(plexi shell-init)"` in existing dotfiles becomes a safe no-op. Subcommand kept so dotfiles don't break.

2. **`FocusContext` IPC handler** — previously called `focus_or_create_context_by_root`, switching or creating a context silently. Now logs a `warn` and does nothing.

3. **`focus_or_create_context_by_root`** — deleted (was only reachable from the `FocusContext` handler).

## Test plan

- Open a terminal in Plexi, `cd` into a directory that matches another context's root
- Focus away and back
- Confirm: no automatic context switch occurs
- Run `eval "$(plexi-pr-<N> shell-init)"` in a terminal — confirm it produces no output and installs no hook
- Confirm `plexi-pr-<N> shell-init` exits 0

**Breaks if:** changing directories inside a terminal, or focusing a pane, silently switches the active context.