### PR TITLE
chore: update workflow for alpha-as-root layout

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -109,7 +109,7 @@ plexi pane set-title "#<number> — <short-title>"
 
 ## Phase 2 — Worktree Setup
 
-Run from inside `worktrees/alpha/`:
+Run from the repo root:
 ```bash
 wtp add -b feature/<issue-number>-short-description
 ```
@@ -119,10 +119,10 @@ wtp add -b feature/<issue-number>-short-description
 **Immediately verify the base:**
 ```bash
 git -C worktrees/<branch> log --oneline -1
-git -C worktrees/alpha log --oneline -1
+git log --oneline -1
 ```
 
-If they don't match: delete the worktree and branch, redo from inside `worktrees/alpha/`. Never proceed on the wrong base.
+If they don't match: delete the worktree and branch, redo from the repo root. Never proceed on the wrong base.
 
 ---
 
@@ -223,11 +223,11 @@ Run from inside the **feature worktree**:
 just pr-install <pr-number>
 ```
 
-> **CWD check:** If your shell is at `worktrees/alpha/`, `cd` to the feature worktree first — `just pr-install` runs `cargo bundle` from CWD, so running it from alpha silently builds the old code. A compile time under ~10s is proof the change wasn't picked up.
+> **CWD check:** If your shell is at the repo root, `cd` to the feature worktree first — `just pr-install` runs `cargo bundle` from CWD, so running it from alpha silently builds the old code. A compile time under ~10s is proof the change wasn't picked up.
 
 Installs as `/Applications/Plexi PR<number>.app` with isolated profile `~/.plexi-pr-<number>/`. Wait for it to complete.
 
-**Note for justfile/config-only changes:** `just pr-install` installs the Python binary only — justfile or config changes are not visible in `worktrees/alpha/` until after merge. For these changes, direct test steps to run from `worktrees/feature/<branch>/` instead.
+**Note for justfile/config-only changes:** `just pr-install` installs the Python binary only — justfile or config changes are not visible in the repo root until after merge. For these changes, direct test steps to run from `worktrees/feature/<branch>/` instead.
 
 **Before writing the testing block:** verify whether the PR build can actually exercise the feature's golden path. If the feature requires a configuration, environment, or runtime condition that the PR build cannot satisfy (e.g. a stable-only feature gated on a non-PR app directory, a capability requiring a device not present, a server-side dependency unavailable on the PR profile) — state that limitation explicitly at the top of the testing block as a `Note:` line rather than discovering it mid-instruction.
 
@@ -324,7 +324,7 @@ After user confirms pass. Run without stopping:
 
 1. Sync alpha — rebase handles divergence from parallel agent merges:
    ```bash
-   git pull --rebase origin alpha   # from inside worktrees/alpha/
+   git pull --rebase origin alpha   # from the repo root
    ```
    This handles all cases: behind (fast-forward replay), ahead (push after), diverged (rebase). If a rebase conflict occurs in GOTCHAS.md, keep all entries, newest-first.
 
@@ -349,10 +349,10 @@ After user confirms pass. Run without stopping:
 
    If anything non-obvious happened during this PR — a failed approach, an environment constraint, a tool behavior that cost time — add one entry to GOTCHAS.md on alpha now. Write a detailed commit message explaining the why. Skip GOTCHAS if nothing surprised you.
 
-4. `just pr-clean <pr-number>` — run from `worktrees/alpha/`
-5. `git pull --rebase origin alpha` — from inside `worktrees/alpha/`
+4. `just pr-clean <pr-number>` — run from the repo root
+5. `git pull --rebase origin alpha` — from the repo root
 6. `wtp remove <branch> --force` then `git push origin --delete <branch>`
-7. `just bump && just install` — from `worktrees/alpha/`
+7. `just bump && just install` — from the repo root
 8. `git push` — push bump commit to origin so alpha is not diverged at next session start
 
 ---
@@ -398,13 +398,13 @@ Output:
 
 ## Rules
 
-- Never branch from main — always from `worktrees/alpha/`
+- Never branch from main — always from the repo root
 - Never skip base verification after `wtp add`
 - Never merge before user confirms testing passed
 - Never claim [COMPLETE] without user verification
 - On branch protection: use `--admin` rather than rebasing just to satisfy "branch is behind" — only rebase for actual merge conflicts
 - `just pr-install` runs from the **feature worktree**
-- `just pr-clean`, `just bump`, and `just install` run from **`worktrees/alpha/`**
+- `just pr-clean`, `just bump`, and `just install` run from the **repo root**
 - Cosmetic issues spotted during testing go in separate issues — not blockers
 - "modify" is only valid if pass criteria were not yet met — not for post-pass polish or bonus improvements
 - "fail" without a description is not accepted — ask for it before taking any action

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,27 +75,27 @@ Never commit directly to `beta` or `main`. All work flows through alpha.
 All changes, no matter how small, follow this cycle:
 
 0. **Label the issue** `in progress`: `gh issue edit <number> --add-label "in progress"`
-1. **Create a worktree** from inside `worktrees/alpha/`: `wtp add -b <branch-name>`
+1. **Create a worktree** from the repo root: `wtp add -b <branch-name>`
 2. **Implement** and commit inside that worktree
 3. **Open a PR** targeting `alpha`: `gh pr create --base alpha`
 4. **Wait for user approval** — do not merge unilaterally
 5. **Squash-merge**: `gh pr merge <number> --squash` — lands one clean commit on `origin/alpha`. **Never pass `--delete-branch`** — git refuses to delete a branch checked out by a worktree.
-6. **Sync alpha**: `git pull --rebase origin alpha` from inside `worktrees/alpha/`
+6. **Sync alpha**: `git pull --rebase origin alpha` from the repo root
 7. **Close related issue(s)**: `gh issue close <number> --comment "Closed by PR #<pr>"`
-8. **Bump and install**: `just bump && just install` from inside `worktrees/alpha/`
+8. **Bump and install**: `just bump && just install` from the repo root
 9. **Remove the feature worktree**: `wtp remove <branch-name>`
 10. **Delete the remote branch**: `git push origin --delete <branch-name>`
 
-**Always run `wtp add` from inside `worktrees/alpha/`**, not the repo root. This ensures the branch forks from alpha's current HEAD so PRs merge cleanly. Cutting from main silently orphans in-flight work.
+**Always run `wtp add` from the repo root.** This ensures the branch forks from alpha's current HEAD so PRs merge cleanly. Cutting from main silently orphans in-flight work.
 
 **Verify the base immediately after `wtp add`** — before delegating any work to a subagent or writing any code, confirm the new worktree is on the right commit:
 ```bash
 git -C worktrees/<new-branch> log --oneline -1   # must match ↓
-git -C worktrees/alpha log --oneline -1
+git log --oneline -1
 ```
-If they don't match, delete the worktree and branch immediately and redo from inside `worktrees/alpha/`. Discovering the wrong base after a subagent has run wastes the entire run.
+If they don't match, delete the worktree and branch immediately and redo from the repo root. Discovering the wrong base after a subagent has run wastes the entire run.
 
-**Before creating a worktree:** run `git status` AND `git diff --stat` in `worktrees/alpha`. Alpha must be clean (no uncommitted changes, no unstaged diffs) before branching. If it's dirty, stop and ask: commit first, or is this work meant to be carried into the new branch? Never silently proceed on a dirty base.
+**Before creating a worktree:** run `git status` AND `git diff --stat` in the repo root. Alpha must be clean (no uncommitted changes, no unstaged diffs) before branching. If it's dirty, stop and ask: commit first, or is this work meant to be carried into the new branch? Never silently proceed on a dirty base.
 
 **Small-changes batch PR:** Multiple small related fixes may land in one PR if they share a single commit message and a single `Breaks if:` line. Unrelated changes go in separate PRs.
 
@@ -105,7 +105,7 @@ When alpha has stabilised enough for broader testing:
 ```
 git push origin alpha:beta
 ```
-Run from `worktrees/alpha/` (or anywhere with origin access). This fast-forwards beta to alpha's current HEAD. Then `just install` from `worktrees/beta/` to verify the beta build.
+Run from the repo root (or anywhere with origin access). This fast-forwards beta to alpha's current HEAD. Then `just install` from `worktrees/beta/` to verify the beta build.
 
 When beta is ready to ship as a release:
 ```
@@ -114,8 +114,9 @@ just promote main
 This pushes beta→main, creates and pushes the version tag, and triggers the GitHub Actions release workflow.
 
 Worktrees:
-- `worktrees/alpha` — alpha branch
+- `.` (repo root) — alpha branch
 - `worktrees/beta` — beta branch
+- `worktrees/main` — main branch
 - `worktrees/feature/<branch>` — feature branches (created by `wtp add`)
 - `worktrees/fix/<branch>` — fix branches (created by `wtp add`)
 
@@ -129,13 +130,13 @@ Release flow:
 
 ## Build & Install
 
-`just bump && just install` is the standard post-merge command — bumps the version and regenerates CHANGELOG via git-cliff, then builds and installs. Always run from inside `worktrees/alpha/`.
+`just bump && just install` is the standard post-merge command — bumps the version and regenerates CHANGELOG via git-cliff, then builds and installs. Always run from the repo root.
 
-`just install` alone is for re-installing without a version bump (e.g. after editing config or docs without a code change). Run from inside `worktrees/alpha/`.
+`just install` alone is for re-installing without a version bump (e.g. after editing config or docs without a code change). Run from the repo root.
 
 `just bump [minor|major]` without install is for explicit pre-promote version bumps when you need a minor or major release.
 
-**Never claim a task complete based on an install from a feature worktree.** Uncommitted changes compile and install successfully, making the task appear done when nothing has been committed. The full done cycle is: commit → PR → squash-merge to alpha → `git pull` in `worktrees/alpha/` → `just bump && just install` from `worktrees/alpha/`.
+**Never claim a task complete based on an install from a feature worktree.** Uncommitted changes compile and install successfully, making the task appear done when nothing has been committed. The full done cycle is: commit → PR → squash-merge to alpha → `git pull` in the repo root → `just bump && just install` from the repo root.
 
 ## Logging
 

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -96,6 +96,7 @@ fi
 check_clean "$BETA_TREE" "beta"
 check_pushed "$BETA_TREE" "beta" "beta"
 check_clean "$MAIN_TREE" "main worktree"
+[[ $(git -C "$MAIN_TREE" rev-parse --abbrev-ref HEAD) == "main" ]] || die "main worktree is not on 'main' branch"
 
 version=$(grep '^version' "$BETA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -8,8 +8,9 @@
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
-ALPHA_TREE="$REPO_ROOT/worktrees/alpha"
+ALPHA_TREE="$REPO_ROOT"
 BETA_TREE="$REPO_ROOT/worktrees/beta"
+MAIN_TREE="$REPO_ROOT/worktrees/main"
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -94,7 +95,7 @@ fi
 
 check_clean "$BETA_TREE" "beta"
 check_pushed "$BETA_TREE" "beta" "beta"
-check_clean "$REPO_ROOT" "main worktree"
+check_clean "$MAIN_TREE" "main worktree"
 
 version=$(grep '^version' "$BETA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 
@@ -102,18 +103,18 @@ echo "Promoting beta → main (v$version)..."
 git push origin beta:main
 
 echo "Syncing main worktree..."
-git -C "$REPO_ROOT" pull origin main
+git -C "$MAIN_TREE" pull origin main
 
-if git -C "$REPO_ROOT" tag -l "v$version" | grep -q "v$version"; then
+if git -C "$MAIN_TREE" tag -l "v$version" | grep -q "v$version"; then
     echo "Tag v$version already exists — skipping tag creation."
 else
-    git -C "$REPO_ROOT" tag "v$version"
+    git -C "$MAIN_TREE" tag "v$version"
 fi
 
 if git ls-remote --tags origin "v$version" | grep -q "v$version"; then
     echo "Tag v$version already on remote — skipping push."
 else
-    git -C "$REPO_ROOT" push origin "v$version"
+    git -C "$MAIN_TREE" push origin "v$version"
 fi
 
 echo ""

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
-TREE="${REPO_ROOT}/worktrees/alpha"
+TREE="$REPO_ROOT"
 
 die() { echo "error: $*" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary
- `scripts/release-version.sh`: `TREE` now points to `$REPO_ROOT` (was `$REPO_ROOT/worktrees/alpha`)
- `scripts/promote.sh`: `ALPHA_TREE` → `$REPO_ROOT`; new `MAIN_TREE="$REPO_ROOT/worktrees/main"` variable used in beta→main promotion section
- `CLAUDE.md`: all `worktrees/alpha/` references updated to "repo root"; worktrees list updated to show `.` (repo root) for alpha and `worktrees/main` for main
- `ship/SKILL.md`: same path reference updates throughout

## Context
Switching the repo root checkout from `main` to `alpha` so `cd ~/Documents/GitHub/PLEXI` lands directly in alpha. After merge, the git restructure follows:
```
git worktree remove worktrees/alpha
git checkout alpha
git worktree add worktrees/main main
```

## Test plan
- [ ] `just promote beta` still works from repo root after restructure
- [ ] `just bump` runs correctly from repo root