### PR TITLE
feat(secrets): safe CLI for plexi secret set — hidden prompt, walk-up scoping, root guard

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -603,10 +603,17 @@ pub fn apps_dir() -> PathBuf {
 /// contains a `.plexi/` itself — `~/.plexi-<channel>/` is the global config
 /// dir, which lives next to `~`, not inside it.
 pub fn resolve_workspace_root(start: &Path) -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok().map(PathBuf::from);
     let mut current = start.to_path_buf();
     loop {
         if current.join(".plexi").is_dir() {
             return Some(current);
+        }
+        // Stop at home dir — never walk above it
+        if let Some(ref h) = home {
+            if current == *h {
+                return None;
+            }
         }
         if !current.pop() {
             return None;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,6 +138,23 @@ pub fn workspace_init() -> i32 {
             return 1;
         }
     };
+    // Guard: refuse home dir, root dir, and inside any ~/.plexi* profile dir
+    {
+        let home = std::env::var("HOME").ok().map(std::path::PathBuf::from);
+        let cwd_str = cwd.to_string_lossy();
+        let is_home_or_root = cwd == std::path::Path::new("/")
+            || home.as_ref().map(|h| cwd == *h).unwrap_or(false);
+        let is_inside_profile = home.as_ref().map(|h| {
+            let prefix = format!("{}/.plexi", h.to_string_lossy());
+            cwd_str.starts_with(&prefix)
+        }).unwrap_or(false);
+        if is_home_or_root || is_inside_profile {
+            eprintln!("error: cannot initialize a workspace in your home or root directory.");
+            eprintln!("  This would conflict with your Plexi profile (~/.plexi/).");
+            eprintln!("  cd into a project directory first.");
+            return 1;
+        }
+    }
     match crate::workspace_secrets::init_workspace(&cwd) {
         Ok(cfg) => {
             println!("Initialized workspace at {}", cwd.display());
@@ -184,35 +201,73 @@ fn require_workspace(
     Ok((root, cfg))
 }
 
-/// `plexi secret set <friendly-name>` — prompt for a value (no echo) and
-/// store it under `plexi:<workspace-id>:<friendly-name>`.
-pub fn workspace_secret_set(friendly: &str) -> i32 {
-    let (root, cfg) = match require_workspace() {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return 1;
+/// `plexi secret set <friendly-name>` — store a secret in Keychain.
+///
+/// Value source (in priority order):
+///   --from-env   reads from env var named FRIENDLY_NAME
+///   default      hidden stdin prompt
+///
+/// Scope:
+///   --global     store under `plexi:user:<name>` (cross-workspace)
+///   default      walk up to nearest .plexi/ workspace, store workspace-scoped
+pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32 {
+    // Resolve value
+    let value: String = if from_env {
+        match std::env::var(friendly) {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("error: env var {friendly} is not set");
+                return 1;
+            }
+        }
+    } else {
+        eprint!("Enter value for {friendly}: ");
+        let _ = io::stderr().flush();
+        match read_secret_from_stdin() {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("\nerror: failed to read secret: {e}");
+                return 1;
+            }
         }
     };
-    eprint!("Enter value for {friendly}: ");
-    let _ = io::stderr().flush();
-    let value = match read_secret_from_stdin() {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("\nerror: failed to read secret: {e}");
-            return 1;
-        }
-    };
-    eprintln!();
     if value.is_empty() {
         eprintln!("error: empty value, nothing stored");
         return 1;
     }
+
     #[cfg(target_os = "macos")]
     {
-        use crate::workspace_secrets::{keychain_workspace_name, MacKeychain, SecretStore};
-        let account = keychain_workspace_name(&cfg.id, friendly);
+        use crate::workspace_secrets::{
+            keychain_user_name, keychain_workspace_name, MacKeychain, SecretStore,
+        };
         let store = MacKeychain::new();
+
+        if global {
+            let account = keychain_user_name(friendly);
+            return match store.set(&account, &value) {
+                Ok(()) => {
+                    eprintln!("Stored '{friendly}' globally (plexi:user:{friendly})");
+                    0
+                }
+                Err(e) => {
+                    eprintln!("error: keychain write failed: {e}");
+                    1
+                }
+            };
+        }
+
+        // Workspace-scoped: walk up to nearest .plexi/
+        let (root, cfg) = match require_workspace() {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("error: no .plexi/ workspace found in this directory tree.");
+                eprintln!("  → plexi workspace init        (initialize one here, then retry)");
+                eprintln!("  → plexi secret set --global {friendly}   (set globally — requires explicit flag)");
+                return 1;
+            }
+        };
+        let account = keychain_workspace_name(&cfg.id, friendly);
         match store.set(&account, &value) {
             Ok(()) => {
                 eprintln!(
@@ -230,7 +285,7 @@ pub fn workspace_secret_set(friendly: &str) -> i32 {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (root, cfg, friendly, value);
+        let _ = (friendly, value, global);
         eprintln!("error: keychain not available on this platform");
         1
     }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -143,9 +143,17 @@ pub enum WorkspaceCmd {
 
 #[derive(Subcommand)]
 pub enum SecretCmd {
-    /// Store a secret
+    /// Store a secret (prompts for value with hidden input; walks up to nearest .plexi/ workspace).
+    /// Use --from-env to read from an env var, or --global to store cross-workspace.
     Set {
+        /// Name of the secret (also the env var name when using --from-env)
         friendly_name: String,
+        /// Read value from the environment variable named FRIENDLY_NAME instead of prompting
+        #[arg(long = "from-env")]
+        from_env: bool,
+        /// Store globally (cross-workspace) rather than scoped to the nearest .plexi/ workspace
+        #[arg(long)]
+        global: bool,
     },
     /// List stored secrets
     List,

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn main() -> eframe::Result {
                         WorkspaceCmd::Init => std::process::exit(cli::workspace_init()),
                     },
                     Commands::Secret { cmd } => match cmd {
-                        SecretCmd::Set { friendly_name } => std::process::exit(cli::workspace_secret_set(&friendly_name)),
+                        SecretCmd::Set { friendly_name, from_env, global } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global)),
                         SecretCmd::List => std::process::exit(cli::workspace_secret_list()),
                         SecretCmd::Delete { friendly_name } => std::process::exit(cli::workspace_secret_delete(&friendly_name)),
                     },


### PR DESCRIPTION
Closes #810

## Changes

- `plexi secret set FOO` — hidden stdin prompt (no positional value arg, so `FOO bar` is rejected by clap)
- `--from-env` — reads from env var named FOO; value never appears in CLI invocation
- `--global` — stores under `plexi:user:FOO` (cross-workspace); skips workspace lookup entirely
- Walk-up scoping stops at `~` — `resolve_workspace_root` no longer walks above home dir
- No workspace found → actionable error with both recovery paths shown
- `plexi workspace init` rejects `~`, `/`, and any path inside `~/.plexi*` profile dirs

## Help strings

All new behaviors are documented in `--help` output (clap derives from doc comments), satisfying the `cli_crawl` discoverability requirement from the issue.

## Test plan

- [ ] `plexi-pr-N secret set FOO` — prompts for value with hidden input
- [ ] `echo myval | plexi-pr-N secret set FOO` — pipe works
- [ ] `FOO=myval plexi-pr-N secret set --from-env FOO` — reads from env
- [ ] `plexi-pr-N secret set --global FOO` — stores as `plexi:user:FOO`
- [ ] `plexi-pr-N secret set FOO` in dir with no `.plexi/` → actionable error with `--global` hint
- [ ] `plexi-pr-N workspace init` from `~` → hard error
- [ ] `plexi-pr-N workspace init` from `/` → hard error
- [ ] `plexi-pr-N workspace init` from inside `~/.plexi-alpha/` → hard error