### PR TITLE
fix(notify): host-side pane_navigate + cross-context action dispatch

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -908,15 +908,7 @@ impl PlexiApp {
                 }
                 crate::app_protocol::HostCommand::FocusPane { pane_id } => {
                     log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
-                    let mut found = false;
-                    for win in &mut self.windows {
-                        if let Some(tile_id) = win.tree.tiles.find_pane(pane_id) {
-                            win.focused_pane = Some(tile_id);
-                            found = true;
-                            break;
-                        }
-                    }
-                    if !found {
+                    if !self.pane_navigate(*pane_id) {
                         log::warn!("pane_ipc: focus_pane: pane_id={pane_id} not found");
                     }
                 }
@@ -1204,6 +1196,7 @@ impl PlexiApp {
                     action_label: "timeout".to_string(),
                     value: Some(dismiss_value),
                     response_file: n.response_file.clone(),
+                    host_action: None,
                 }];
                 self.dispatch_notify_action_cmds(cmds);
             }
@@ -1573,10 +1566,23 @@ impl eframe::App for PlexiApp {
                         self.current_notify_id = Some(new_id);
                     }
                 }
-                AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file } => {
+                AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file, host_action } => {
                     log::info!(
-                        "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?}"
+                        "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                     );
+                    // Execute host-side action synchronously before writing the response
+                    // file so the navigation is complete before the shell unblocks.
+                    if let Some(ref action) = host_action {
+                        if let Some(id_str) = action.strip_prefix("pane_focus:") {
+                            if let Ok(pane_id_target) = id_str.parse::<u64>() {
+                                self.pane_navigate(pane_id_target);
+                            } else {
+                                log::warn!("notify:action: pane_focus: invalid pane_id {:?}", id_str);
+                            }
+                        } else {
+                            log::warn!("notify:action: unknown host_action {:?}", action);
+                        }
+                    }
                     if let Some(rf) = &response_file {
                         let content = value.as_deref().unwrap_or("");
                         let tmp = format!("{rf}.tmp");
@@ -1585,16 +1591,20 @@ impl eframe::App for PlexiApp {
                             Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
                         }
                     }
-                    let active = self.active_window;
-                    if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
-                        if let Some(app) = pane.as_app_mut() {
-                            app.runtime.queue_outbound_event(
-                                crate::app_protocol::PlexiEvent::NotifyAction {
-                                    notify_id,
-                                    action_label,
-                                    value,
-                                },
-                            );
+                    // Search all windows for the sender pane — it may not be in the
+                    // active context (cross-context notification path).
+                    let window_idx = self.windows.iter().position(|w| w.panes.contains_key(&pane_id));
+                    if let Some(win_idx) = window_idx {
+                        if let Some(pane) = self.windows[win_idx].panes.get_mut(&pane_id) {
+                            if let Some(app) = pane.as_app_mut() {
+                                app.runtime.queue_outbound_event(
+                                    crate::app_protocol::PlexiEvent::NotifyAction {
+                                        notify_id,
+                                        action_label,
+                                        value,
+                                    },
+                                );
+                            }
                         }
                     }
                 }
@@ -2788,6 +2798,24 @@ impl PlexiApp {
         }
     }
 
+    /// Navigate to a pane by id, updating both `focused_pane` on its window and
+    /// `active_window`. Returns `true` if the pane was found.
+    pub(crate) fn pane_navigate(&mut self, pane_id: u64) -> bool {
+        for (idx, win) in self.windows.iter_mut().enumerate() {
+            if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
+                let prev = self.active_window;
+                win.focused_pane = Some(tile_id);
+                self.active_window = idx;
+                log::info!(
+                    "notify:action: pane_navigate active_window {prev}→{idx} pane_id={pane_id}"
+                );
+                return true;
+            }
+        }
+        log::warn!("notify:action: pane_navigate pane_id={pane_id} not found");
+        false
+    }
+
     /// Reconcile the rename-pane focus layer with `renaming_pane`.
     pub(crate) fn sync_rename_pane_focus(&mut self) {
         let should_own = self.renaming_pane.is_some();
@@ -2866,10 +2894,23 @@ impl PlexiApp {
     pub(crate) fn dispatch_notify_action_cmds(&mut self, cmds: Vec<crate::app_trait::AppCommand>) {
         use crate::app_trait::AppCommand;
         for cmd in cmds {
-            if let AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file } = cmd {
+            if let AppCommand::DeliverNotifyAction { pane_id, notify_id, action_label, value, response_file, host_action } = cmd {
                 log::info!(
-                    "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?}"
+                    "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                 );
+                // Execute host-side action synchronously before writing the response
+                // file so the navigation is complete before the shell unblocks.
+                if let Some(ref action) = host_action {
+                    if let Some(id_str) = action.strip_prefix("pane_focus:") {
+                        if let Ok(pane_id_target) = id_str.parse::<u64>() {
+                            self.pane_navigate(pane_id_target);
+                        } else {
+                            log::warn!("notify:action: pane_focus: invalid pane_id {:?}", id_str);
+                        }
+                    } else {
+                        log::warn!("notify:action: unknown host_action {:?}", action);
+                    }
+                }
                 if let Some(rf) = &response_file {
                     let content = value.as_deref().unwrap_or("");
                     let tmp = format!("{rf}.tmp");
@@ -2878,16 +2919,20 @@ impl PlexiApp {
                         Err(e) => log::warn!("notify:action: failed to write response file {:?}: {e}", rf),
                     }
                 }
-                let active = self.active_window;
-                if let Some(pane) = self.windows[active].panes.get_mut(&pane_id) {
-                    if let Some(app) = pane.as_app_mut() {
-                        app.runtime.queue_outbound_event(
-                            crate::app_protocol::PlexiEvent::NotifyAction {
-                                notify_id,
-                                action_label,
-                                value,
-                            },
-                        );
+                // Search all windows for the sender pane — it may not be in the
+                // active context (cross-context notification path).
+                let window_idx = self.windows.iter().position(|w| w.panes.contains_key(&pane_id));
+                if let Some(win_idx) = window_idx {
+                    if let Some(pane) = self.windows[win_idx].panes.get_mut(&pane_id) {
+                        if let Some(app) = pane.as_app_mut() {
+                            app.runtime.queue_outbound_event(
+                                crate::app_protocol::PlexiEvent::NotifyAction {
+                                    notify_id,
+                                    action_label,
+                                    value,
+                                },
+                            );
+                        }
                     }
                 }
             }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1446,6 +1446,12 @@ pub struct NotifyOption {
     /// Recommended safe set: letters excluding navigation keys; `y`/`n` for yes/no.
     #[serde(default)]
     pub shortcut: Option<String>,
+    /// Optional host-side action to execute synchronously at click time.
+    /// Format: `"action_type:action_arg"` (e.g. `"pane_focus:123"`).
+    /// If set, the host executes the action before writing the response file.
+    /// If not set, behavior is unchanged from before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_action: Option<String>,
 }
 
 /// Returns `true` if `key` is reserved by the notification overlay for navigation.

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -93,6 +93,8 @@ pub enum AppCommand {
         value: Option<String>,
         /// Path to write the chosen value for host-originated blocking notifications.
         response_file: Option<String>,
+        /// Host-side action to execute synchronously. Format: `"action_type:action_arg"`.
+        host_action: Option<String>,
     },
     /// Canvas Terminal Binding Primitives (#78). The host opens a fresh
     /// terminal next to `sender_pane_id`, sets the new terminal as the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1214,7 +1214,7 @@ pub fn notify_cli(
     title: &str,
     body: &str,
     level: &str,
-    choices: &[(String, String)],
+    choices: &[(String, String, Option<String>)],
     timeout_secs: u64,
 ) -> i32 {
     let socket_path = match std::env::var("PLEXI_SOCKET") {
@@ -1229,8 +1229,12 @@ pub fn notify_cli(
 
     let options_json: Vec<serde_json::Value> = choices
         .iter()
-        .map(|(key, label)| {
-            serde_json::json!({"label": label, "value": key, "shortcut": key})
+        .map(|(key, label, host_action)| {
+            let mut opt = serde_json::json!({"label": label, "value": key, "shortcut": key});
+            if let Some(ha) = host_action {
+                opt["host_action"] = serde_json::Value::String(ha.clone());
+            }
+            opt
         })
         .collect();
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -80,7 +80,9 @@ pub enum Commands {
         /// Level: info, warn, or error
         #[arg(long, default_value = "info")]
         level: String,
-        /// Choice option in key:Label format (repeatable)
+        /// Choice option. Format: `key:Label` (returns key when selected) or
+        /// `Label:pane_focus:<pane_id>` (navigates to pane and returns label).
+        /// Repeatable.
         #[arg(long = "choice")]
         choices: Vec<String>,
         /// Timeout in seconds (0 = no timeout)

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,13 +236,24 @@ fn main() -> eframe::Result {
                         PackCmd::Export { path } => std::process::exit(cli::pack_export_cli(&path)),
                     },
                     Commands::Notify { title, body, level, choices, timeout } => {
-                        let mut parsed_choices: Vec<(String, String)> = Vec::new();
+                        let mut parsed_choices: Vec<(String, String, Option<String>)> = Vec::new();
                         for raw in &choices {
-                            if let Some(colon) = raw.find(':') {
-                                parsed_choices.push((raw[..colon].to_string(), raw[colon+1..].to_string()));
-                            } else {
-                                eprintln!("error: --choice value must be key:Label");
-                                std::process::exit(1);
+                            let segments: Vec<&str> = raw.splitn(3, ':').collect();
+                            match segments.len() {
+                                3 => {
+                                    // Label:action_type:action_arg — host-side action
+                                    let label = segments[0].to_string();
+                                    let host_action = format!("{}:{}", segments[1], segments[2]);
+                                    parsed_choices.push((label.clone(), label, Some(host_action)));
+                                }
+                                2 => {
+                                    // key:Label — existing format
+                                    parsed_choices.push((segments[0].to_string(), segments[1].to_string(), None));
+                                }
+                                _ => {
+                                    eprintln!("error: --choice must be key:Label or Label:action_type:action_arg");
+                                    std::process::exit(1);
+                                }
                             }
                         }
                         std::process::exit(cli::notify_cli(&title, &body, &level, &parsed_choices, timeout));

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1193,6 +1193,7 @@ impl PlexiApp {
                                                         "tombstone_dismiss".to_string(),
                                                     ),
                                                     response_file: n.response_file.clone(),
+                                                    host_action: None,
                                                 });
                                         }
                                     }
@@ -1230,6 +1231,7 @@ impl PlexiApp {
                                             action_label: opt.label.clone(),
                                             value: Some(value),
                                             response_file: notif.response_file.clone(),
+                                            host_action: opt.host_action.clone(),
                                         });
                                     }
                                     ui.add_space(style::SPACE_SM);
@@ -1282,6 +1284,7 @@ impl PlexiApp {
                                         action_label: "acknowledge".to_string(),
                                         value: None,
                                         response_file: notif.response_file.clone(),
+                                        host_action: None,
                                     });
                                 }
                             });
@@ -1478,6 +1481,7 @@ impl PlexiApp {
                             action_label: "acknowledge".to_string(),
                             value: None,
                             response_file: notif.response_file.clone(),
+                            host_action: None,
                         });
                     }
                 }
@@ -1517,6 +1521,7 @@ impl PlexiApp {
                             action_label: opt.label.clone(),
                             value: Some(value),
                             response_file: notif.response_file.clone(),
+                            host_action: opt.host_action.clone(),
                         });
                     }
                 }
@@ -1532,6 +1537,7 @@ impl PlexiApp {
                                 action_label: "submit".to_string(),
                                 value: Some(buf),
                                 response_file: notif.response_file.clone(),
+                                host_action: None,
                             });
                         }
                     }


### PR DESCRIPTION
Fixes #791. Supersedes #789 (close after merge).

## What changed

**1. `pane_navigate()` — authoritative cross-context focus**
New method that sets both `focused_pane` on the owning window and `self.active_window`. `FocusPane` now delegates to it instead of only setting `focused_pane` (the missing piece that caused silent cross-context navigation failures).

**2. Cross-context `DeliverNotifyAction` delivery**
Previously searched only `self.windows[active_window]` for the sender pane — any notification from a non-active context was silently dropped. Now searches all windows.

**3. Host-side `pane_focus` action on `NotifyOption`**
Added `host_action: Option<String>` to `NotifyOption`. When set to `pane_focus:<pane_id>`, the host executes `pane_navigate` synchronously at click time, before writing the response file. Eliminates the shell-roundtrip race condition.

**CLI usage:**
\`\`\`
plexi notify --title "Agent done" --body "See results" \
  --choice "Go to pane:pane_focus:42" --choice "Dismiss:dismiss"
\`\`\`

**Log evidence when navigation fires:**
```
notify:action: pane_navigate active_window 0→1 pane_id=42
```

## Done criteria (from issue)
1. Cross-context "Send to pane" navigation works — ✅ via `pane_navigate`
2. Keyboard input functional after notification dismissal — ✅ cross-context delivery no longer drops events
3. Log shows `notify:action: pane_navigate active_window A→B pane_id=N` — ✅ instrumented
4. `pane_focus:<id>` documented in CLI help — ✅ `--choice` doc updated

## Breaks if
Clicking a choice button in a global notification silently does nothing (no `notify:action:` log line) — would indicate the `DeliverNotifyAction` dispatch path regressed.