### PR TITLE
fix(sidebar): restrict rename double-click to text label hitbox

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::context::WindowMenuAction;
 use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, ROW_HEIGHT};
-use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
+use egui::{Align, CornerRadius, Layout, Rect, RichText, Sense, Stroke, Vec2};
 
 use crate::app::PlexiApp;
 
@@ -144,9 +144,10 @@ impl PlexiApp {
                             RichText::new(format!("{}", i + 1)).size(11.0).color(dim_color),
                         );
                     }
-                    row_ui.add(
+                    let label_resp = row_ui.add(
                         egui::Label::new(RichText::new(&ctx_name).size(12.0).color(text_color))
-                            .selectable(false),
+                            .selectable(false)
+                            .sense(Sense::click()),
                     );
                     // Badge — only when not hovering (X button takes that space on hover)
                     if badge_count > 0 && !hovered {
@@ -156,6 +157,7 @@ impl PlexiApp {
                             ui.label(RichText::new(badge_text).size(10.0).color(accent_color));
                         });
                     }
+                    Some(label_resp)
                 },
             );
 

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -98,7 +98,8 @@ impl SidebarRow {
 
     /// Render the row and return a typed action plus the full-row response.
     ///
-    /// `content_fn` receives a `&mut Ui` scoped to the content zone only.
+    /// `content_fn` receives a `&mut Ui` scoped to the content zone only and should return
+    /// the `Response` of the primary label widget (used for double-click rename detection).
     /// It must not call `interact()` or set cursor icons — the row builder owns those.
     ///
     /// The returned `Response` covers the full row and is intended for context_menu attachment.
@@ -107,7 +108,7 @@ impl SidebarRow {
         ui: &mut egui::Ui,
         id: Id,
         colors: &Colors,
-        content_fn: impl FnOnce(&mut egui::Ui, bool),
+        content_fn: impl FnOnce(&mut egui::Ui, bool) -> Option<egui::Response>,
     ) -> (SidebarAction, egui::Response) {
         let row_alpha = if self.is_this_dragging { 0.4_f32 } else { 1.0_f32 };
         let hovered = self.layout.hovered(ui);
@@ -135,13 +136,13 @@ impl SidebarRow {
             );
         }
 
-        // Content zone — sub-Ui is restricted to the content rect
-        ui.allocate_new_ui(
+        // Content zone — sub-Ui is restricted to the content rect; returns the label response.
+        let label_response = ui.allocate_new_ui(
             UiBuilder::new()
                 .max_rect(self.layout.content)
                 .layout(Layout::left_to_right(Align::Center)),
             |ui| content_fn(ui, hovered),
-        );
+        ).inner;
 
         // Action zone — glyph only (no interact call). Click detection is via pointer-position
         // geometry against the single full-row interact registered below.
@@ -163,11 +164,11 @@ impl SidebarRow {
         }
 
         // Single interact on the full row. Priority chain encodes mutual exclusion:
-        // 1. double_clicked → Rename (full row is the target)
-        // 2. drag_started   → DragStart
-        // 3. drag_stopped   → DragEnd
+        // 1. label double_clicked → Rename (label hitbox only)
+        // 2. drag_started        → DragStart
+        // 3. drag_stopped        → DragEnd
         // 4. clicked + in_action + hovered → Delete
-        // 5. clicked        → Activate
+        // 5. clicked             → Activate
         let response = ui.interact(self.layout.full, id, Sense::click_and_drag());
 
         // Tooltip for the action zone — shown via the full-row response when pointer is in zone.
@@ -175,12 +176,20 @@ impl SidebarRow {
             response.clone().on_hover_text("Delete context");
         }
 
-        // Cursor — single authority, derived from zones only
+        // Cursor — single authority, derived from zones only.
+        // If the pointer is over the label text, show Default (not Grab) so it feels clickable.
         if let Some(icon) = self.layout.resolve_cursor(ui, self.is_this_dragging, self.is_any_dragging) {
             ui.ctx().set_cursor_icon(icon);
         }
+        if let Some(ref lr) = label_response {
+            if ui.rect_contains_pointer(lr.rect) {
+                ui.ctx().set_cursor_icon(CursorIcon::Default);
+            }
+        }
 
-        let action = if response.double_clicked() {
+        let label_double_clicked = label_response.as_ref().map_or(false, |r| r.double_clicked());
+        let action = if label_double_clicked {
+            log::info!("sidebar: rename triggered by label double-click");
             SidebarAction::Rename
         } else if response.drag_started() {
             SidebarAction::DragStart


### PR DESCRIPTION
Fixes #462.

Previously, double-clicking anywhere on a sidebar row triggered rename — including the left drag/grab zone. Now rename only fires when the double-click lands directly on the context name label text.

## Changes

- `sidebar_row.rs`: `draw()` signature updated — `content_fn` now returns `Option<egui::Response>` (the label widget's response). Rename action checks `label_response.double_clicked()` instead of the full-row response. Cursor overrides to `Default` when pointer is over the label rect (was showing `Grab`).
- `sidebar.rs`: Label widget gains `.sense(Sense::click())` and its response is returned from the content closure.

## Breaks if
Rename stops working when double-clicking the context name text in the sidebar.