### PR TITLE
fix(input-inspector): validate MIDI pipe delivery + re-add MIDI controls

### DIFF
--- a/examples/input-inspector/input_inspector.py
+++ b/examples/input-inspector/input_inspector.py
@@ -82,13 +82,13 @@ class InputInspectorApp(App):
 
     # ── event handlers ──────────────────────────────────────────────────────
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    async def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
         key_lower = key.lower()
         if key_lower == "i":
             self._show_inputs_page = not self._show_inputs_page
             return
         if key_lower == "m":
-            self._refresh_midi_ports()
+            await self._refresh_midi_ports()
             return
         if key_lower == "x" and self._midi_open_port_id:
             self._close_midi_input()
@@ -169,9 +169,9 @@ class InputInspectorApp(App):
 
     # ── MIDI helpers ─────────────────────────────────────────────────────────
 
-    def _refresh_midi_ports(self) -> None:
+    async def _refresh_midi_ports(self) -> None:
         try:
-            result = self.emit.run_sync(self.emit.list_midi_devices())
+            result = await self.emit.list_midi_devices()
             self._midi_inputs = result.inputs
             self._midi_error = ""
         except CapabilityDeniedError as e:

--- a/examples/input-inspector/input_inspector.py
+++ b/examples/input-inspector/input_inspector.py
@@ -4,6 +4,10 @@
 Two-panel layout:
   Left  — interactive zone; click, drag, and type here to generate events.
   Right — scrollable event log showing every key, mouse, and scroll event.
+
+MIDI support requires the `midi.in` capability (declared in manifest.toml).
+Network MIDI / RTP-MIDI is out of scope — only IAC Driver and USB/hardware
+endpoints are supported by the CoreMIDI layer.
 """
 from __future__ import annotations
 
@@ -17,7 +21,8 @@ if os.path.isdir(_sdk_path):
     sys.path.insert(0, _sdk_path)
 
 from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, FG, MUTED, ACCENT
-from plexi_sdk import BODY, CAPTION, PAD
+from plexi_sdk import BODY, CAPTION, PAD, CapabilityDeniedError
+from plexi_sdk import midi as midi_sdk
 
 MAX_EVENTS = 200
 MOVE_LOG_MIN_INTERVAL = 1.0 / 30.0
@@ -27,6 +32,7 @@ HEADER_H = 44.0
 FOOTER_H = 32.0
 DIVIDER_X_FRAC = 0.4   # left panel takes 40% of width
 INPUT_SCROLL_ID = "interactive-zone-scroll"
+MIDI_PIPE_ID = "inspector-midi-in"
 
 # Colour-code by event category
 CAT_COLOR = {
@@ -36,6 +42,7 @@ CAT_COLOR = {
     "mouse_up":   "#a6e3a1",   # green
     "mouse_move": "#fab387",   # peach
     "scroll":     "#f9e2af",   # yellow
+    "midi":       "#94e2d5",   # teal
 }
 DEFAULT_COLOR = MUTED
 
@@ -62,9 +69,16 @@ class InputInspectorApp(App):
             "mouse_up": True,
             "mouse_move": True,
             "scroll": True,
+            "midi": True,
         }
+        # MIDI state
+        self._midi_inputs: list = []     # list of MidiPortInfo
+        self._midi_pipe = None           # Pipe | None
+        self._midi_open_port_id: str = ""
+        self._midi_error: str = ""
         # Enable continuous mouse-move delivery
         ctx.set_mouse_tracking(True)
+        ctx.info("input-inspector: on_init")
 
     # ── event handlers ──────────────────────────────────────────────────────
 
@@ -73,7 +87,23 @@ class InputInspectorApp(App):
         if key_lower == "i":
             self._show_inputs_page = not self._show_inputs_page
             return
-        if key_lower in ("1", "2", "3", "4", "5", "6"):
+        if key_lower == "m":
+            self._refresh_midi_ports()
+            return
+        if key_lower == "x" and self._midi_open_port_id:
+            self._close_midi_input()
+            return
+        # Digit keys on inputs page open a MIDI port by index.
+        if self._show_inputs_page and key_lower in "0123456789":
+            idx = int(key_lower)
+            if idx < len(self._midi_inputs):
+                port = self._midi_inputs[idx]
+                if self._midi_open_port_id == port.id:
+                    self._close_midi_input()
+                else:
+                    self._open_midi_input(port.id)
+            return
+        if key_lower in ("1", "2", "3", "4", "5", "6", "7"):
             mapping = {
                 "1": "key",
                 "2": "click",
@@ -81,6 +111,7 @@ class InputInspectorApp(App):
                 "4": "mouse_up",
                 "5": "mouse_move",
                 "6": "scroll",
+                "7": "midi",
             }
             cat = mapping[key_lower]
             self._enabled_categories[cat] = not self._enabled_categories[cat]
@@ -90,6 +121,13 @@ class InputInspectorApp(App):
         label = "+".join(mod_parts + [key]) if mod_parts else key
         self._last_key = label
         self._push("key", f"key  {label!r}")
+
+    def on_midi_input_opened(
+        self, pipe_id: str, port_id: str, port_name: str
+    ) -> None:
+        self.emit.info(f"midi.input opened: port_id={port_id} port_name={port_name!r}")
+        self._midi_open_port_id = port_id
+        self._midi_error = ""
 
     def on_click(self, ctx: RenderContext, x: float, y: float, button: str) -> None:
         self._push("click", f"click  {button}  ({x:.0f}, {y:.0f})")
@@ -129,6 +167,43 @@ class InputInspectorApp(App):
             self._push("scroll", f"scroll  zone=interactive  dir={direction}  delta={delta:.1f}")
             self._last_scroll_log_at = now
 
+    # ── MIDI helpers ─────────────────────────────────────────────────────────
+
+    def _refresh_midi_ports(self) -> None:
+        try:
+            result = self.emit.run_sync(self.emit.list_midi_devices())
+            self._midi_inputs = result.inputs
+            self._midi_error = ""
+        except CapabilityDeniedError as e:
+            self._midi_error = f"capability denied: {e}"
+        except Exception as e:
+            self._midi_error = f"list_midi_devices error: {e}"
+
+    def _open_midi_input(self, port_id: str) -> None:
+        if self._midi_open_port_id:
+            self._close_midi_input()
+        try:
+            self._midi_pipe = self.emit.open_midi_input(port_id, MIDI_PIPE_ID)
+            # _midi_open_port_id is set in on_midi_input_opened
+        except CapabilityDeniedError as e:
+            self._midi_error = f"capability denied: {e}"
+
+    def _close_midi_input(self) -> None:
+        if not self._midi_open_port_id:
+            return
+        self.emit.close_midi_input(self._midi_open_port_id)
+        self._midi_open_port_id = ""
+        self._midi_pipe = None
+
+    def _drain_midi_pipe(self) -> None:
+        if self._midi_pipe is None:
+            return
+        while True:
+            frame = self._midi_pipe.read_frame()
+            if frame is None:
+                break
+            self._push("midi", f"midi  {midi_sdk.describe(frame)}")
+
     # ── helpers ─────────────────────────────────────────────────────────────
 
     def _push(self, cat: str, msg: str) -> None:
@@ -142,6 +217,7 @@ class InputInspectorApp(App):
     # ── render ───────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
+        self._drain_midi_pipe()
         ctx.clear(BG)
         if self._show_inputs_page:
             self._draw_inputs_page(ctx)
@@ -191,6 +267,11 @@ class InputInspectorApp(App):
         ctx.text(cx, base_y + 48, f"last key  {self._last_key or '—'}",
                  size=CAPTION, color=CAT_COLOR["key"], align="center", monospace=True)
 
+        # MIDI status badge
+        if self._midi_open_port_id:
+            ctx.text(cx, base_y + 74, f"midi  {self._midi_open_port_id}",
+                     size=CAPTION, color=CAT_COLOR["midi"], align="center", monospace=True)
+
         # Big crosshair dot at mouse pos (clamped to left panel)
         dot_x = min(mx, div_x - 8)
         dot_y = my
@@ -200,7 +281,7 @@ class InputInspectorApp(App):
         # Instruction hint at bottom
         hint_y = ctx.h - FOOTER_H / 2
         ctx.text(cx, hint_y,
-                 "click · drag · type · scroll · i:inputs",
+                 "click · drag · type · scroll · i:inputs · m:midi",
                  size=CAPTION, color=MUTED, align="center")
         ctx.end_scroll()
 
@@ -248,7 +329,7 @@ class InputInspectorApp(App):
         ctx.text(
             ctx.w - PAD,
             22,
-            "i:back  1-6:toggle",
+            "i:back  1-7:toggle",
             size=CAPTION,
             color=MUTED,
             align="right_center",
@@ -263,6 +344,7 @@ class InputInspectorApp(App):
             ("4", "mouse up", "mouse_up"),
             ("5", "mouse move", "mouse_move"),
             ("6", "scroll events", "scroll"),
+            ("7", "midi events", "midi"),
         ]
         y = HEADER_H + 16.0
         for key, label, cat in rows:
@@ -282,11 +364,48 @@ class InputInspectorApp(App):
             )
             y += 24.0
 
-        y += 18.0
+        # MIDI port section
+        y += 12.0
+        ctx.line(PAD, y, ctx.w - PAD, y, color=HIGHLIGHT, width=0.5)
+        y += 12.0
+        ctx.text(PAD, y, "MIDI Inputs", size=CAPTION, color=FG, align="left_top")
+        hint = "m:refresh"
+        if self._midi_open_port_id:
+            hint += "  x:close"
+        ctx.text(ctx.w - PAD, y, hint, size=CAPTION, color=MUTED, align="right_top", monospace=True)
+        y += 20.0
+
+        if self._midi_error:
+            ctx.text(PAD, y, self._midi_error, size=CAPTION, color="#f38ba8", align="left_top",
+                     max_width=ctx.w - PAD * 2)
+            y += 20.0
+        elif not self._midi_inputs:
+            ctx.text(PAD, y, "press m to enumerate ports",
+                     size=CAPTION, color=MUTED, align="left_top")
+            y += 20.0
+        else:
+            for idx, port in enumerate(self._midi_inputs):
+                is_open = port.id == self._midi_open_port_id
+                badge = "● OPEN" if is_open else f"[{idx}] open"
+                badge_color = CAT_COLOR["midi"] if is_open else MUTED
+                ctx.text_row(
+                    PAD,
+                    y,
+                    items=[
+                        {"text": f"{idx}:", "color": MUTED, "size": CAPTION, "monospace": True},
+                        {"text": port.name, "color": FG, "size": CAPTION, "monospace": True},
+                        {"text": badge, "color": badge_color, "size": CAPTION, "monospace": True},
+                    ],
+                    gap=10.0,
+                    align="left_top",
+                )
+                y += 22.0
+
+        y += 8.0
         ctx.text(
             PAD,
             y,
-            "MIDI support is temporarily removed from this inspector.",
+            "Note: Network MIDI (RTP-MIDI) is not supported.",
             size=CAPTION,
             color=MUTED,
             align="left_top",

--- a/examples/input-inspector/manifest.toml
+++ b/examples/input-inspector/manifest.toml
@@ -9,7 +9,7 @@ description = "POC for #331 — live event log showing all keyboard, mouse, and 
 entry = "input_inspector.py"
 
 [app.capabilities]
-capabilities = []
+capabilities = ["midi.in"]
 
 [launch]
 layout_hint = { side = "right", split = 0.6 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2506,6 +2506,60 @@ mod midi_tests {
         assert_eq!(entries.len(), 1, "exactly one send dispatched");
         assert_eq!(entries[0], vec![0x90u8, 0x3C, 0x64]);
     }
+
+    #[test]
+    fn midi_e2e_bytes_reach_ring() {
+        // Proves the complete host-side delivery path: bytes injected via
+        // MockMidiDevice.inject() travel through the packet sink wired by
+        // start_midi_input() and land in the binary pipe ring (#545).
+        //
+        // This is the fixture-backed validation that the plumbing works before
+        // MIDI controls are re-added to the input-inspector app.
+        let mut caps = HashSet::new();
+        caps.insert(Capability::MidiIn);
+        let Some(mut app) = make_app(caps) else {
+            eprintln!("skipping: no /bin/sh available");
+            return;
+        };
+
+        let mock = Arc::new(MockMidiDevice::new());
+        app.midi_device = Arc::clone(&mock) as Arc<dyn crate::midi::MidiDevice>;
+
+        // Use a distinct pipe_id to avoid socket-path collision with the
+        // parallel `granted_app_dispatches_open_input_to_device` test (both
+        // resolve to /tmp/plexi-pipe-{subsec_nanos}-{pipe_id}.sock and a
+        // nanosecond-level tie produces EADDRINUSE on the second bind).
+        app.route_command(HostCommand::OpenMidiInput {
+            port_id: "mock-input-1".to_owned(),
+            pipe_id: "midi-e2e-ring-pipe".to_owned(),
+        });
+
+        assert!(
+            app.outbound_events
+                .iter()
+                .any(|e| matches!(e, PlexiEvent::MidiInputOpened { .. })),
+            "expected MidiInputOpened before injecting bytes"
+        );
+
+        let ring = app
+            .pipe_registry
+            .lock()
+            .expect("pipe_registry poisoned")
+            .binary_ring("midi-e2e-ring-pipe")
+            .expect("ring must exist after OpenMidiInput");
+
+        assert_eq!(ring.len(), 0, "ring must be empty before inject");
+
+        // NoteOn ch=0 note=60 vel=100, then a clock pulse.
+        assert!(mock.inject("mock-input-1", &[0x90, 0x3C, 0x64]));
+        assert!(mock.inject("mock-input-1", &[0xF8]));
+
+        let frame1 = ring.pop().expect("NoteOn frame must be in ring");
+        let frame2 = ring.pop().expect("Clock frame must be in ring");
+        assert_eq!(frame1, vec![0x90u8, 0x3C, 0x64], "NoteOn bytes must match");
+        assert_eq!(frame2, vec![0xF8u8], "Clock bytes must match");
+        assert!(ring.pop().is_none(), "no extra frames must remain in ring");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `midi_e2e_bytes_reach_ring` test: fixture-backed proof that bytes injected via `MockMidiDevice.inject()` land in the binary pipe ring — the full host-side delivery path
- Re-adds MIDI controls to `examples/input-inspector` with port enumeration (`m`), open/close by index, and decoded MIDI events in the event log
- Declares `midi.in` capability in the inspector manifest
- Documents Network MIDI / RTP-MIDI as out of scope

Closes #545.

## Test plan

- [ ] `cargo test midi` — 16 tests pass (was 15)
- [ ] Open `input-inspector` on alpha build; press `i` → `m` to enumerate ports — port list appears
- [ ] With IAC Driver enabled in Audio MIDI Setup: press the port index key → port opens; send MIDI → teal entries appear in event log
- [ ] `x` closes the port; event log stops receiving MIDI bytes

**Breaks if:** pressing `m` in the inspector's inputs page does not populate the MIDI port list, or incoming MIDI bytes are not shown as teal entries in the event log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)