### PR TITLE
feat(manifest): notification_scope — window, context, global per app

### DIFF
--- a/examples/audio-bridge-test/manifest.toml
+++ b/examples/audio-bridge-test/manifest.toml
@@ -7,11 +7,11 @@ name = "Audio Bridge Test"
 version = "0.1.0"
 description = "POC for #79 — exercises the GUI↔Terminal media bridge end-to-end. Captures mic PCM via #277, paints a live waveform of the last 5s, and echoes the equivalent ffmpeg command into a linked terminal whenever the user starts/stops capture."
 entry = "audio_bridge_test.py"
-default_notification_scope = "context"
 layout_hint = "split_h"
 
 [app.capabilities]
 capabilities = ["audio.record", "terminal.bindings"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/audio-player/manifest.toml
+++ b/examples/audio-player/manifest.toml
@@ -7,11 +7,11 @@ name = "Audio Player"
 version = "0.1.0"
 description = "GUI↔Terminal media bridge POC (#79). Spawned by the file browser when the user opens an audio file (mp3/wav/flac/m4a/aac/ogg/opus). v3.4 path: requests a linked terminal and emits the equivalent ffplay/ffmpeg command for every transport action — actual decode is shelled. CoreAudio playback is on the v3.5+ roadmap."
 entry = "audio_player.py"
-default_notification_scope = "context"
 layout_hint = "split_h"
 
 [app.capabilities]
 capabilities = ["terminal.bindings"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/audio-recorder/manifest.toml
+++ b/examples/audio-recorder/manifest.toml
@@ -7,7 +7,9 @@ name = "Audio Recorder"
 version = "0.1.0"
 description = "POC for #341 — mic capture with device dropdown, live peak meter, and save-to-WAV. Uses emit.list_audio_devices() to populate the device list. Recorded WAV plays cleanly in QuickTime / afplay."
 entry = "audio_recorder.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = ["audio.record"]
+
+[launch]
+notification_scope = "context"

--- a/examples/calendar/manifest.toml
+++ b/examples/calendar/manifest.toml
@@ -7,10 +7,10 @@ name = "Calendar"
 version = "0.1.0"
 description = "Month-view calendar. Accepts pipe commands from the PAM voice agent for event CRUD."
 entry = "calendar_app.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = []
 
 [launch]
+notification_scope = "context"
 layout_hint = { side = "right", split = 0.4 }

--- a/examples/canvas-terminal-bindings-test/manifest.toml
+++ b/examples/canvas-terminal-bindings-test/manifest.toml
@@ -7,11 +7,11 @@ name = "Canvas Terminal Bindings Demo"
 version = "0.1.0"
 description = "POC for #78 — exercises all five Canvas Terminal Binding Primitives over a freshly-opened linked terminal."
 entry = "canvas_terminal_bindings_test.py"
-default_notification_scope = "context"
 layout_hint = "split_h"
 
 [app.capabilities]
 capabilities = ["terminal.bindings"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/clipboard-test/manifest.toml
+++ b/examples/clipboard-test/manifest.toml
@@ -7,10 +7,10 @@ name = "Clipboard Demo"
 version = "0.1.0"
 description = "Exercises clipboard write, paste, and selectable text (#200, #146)."
 entry = "clipboard_test.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = []
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/descriptor-renderer/manifest.toml
+++ b/examples/descriptor-renderer/manifest.toml
@@ -7,11 +7,11 @@ name = "Descriptor Renderer"
 version = "0.1.0"
 description = "Auto-UI renderer for --plexi CLI descriptors (#361)"
 entry = "descriptor_renderer.py"
-default_notification_scope = "context"
 layout_hint = "split_h"
 
 [app.capabilities]
 capabilities = ["terminal.bindings"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/notification-tester/manifest.toml
+++ b/examples/notification-tester/manifest.toml
@@ -7,10 +7,10 @@ name = "Notification Tester"
 version = "0.1.0"
 description = "Fires each Notify kind (message / choice / input) on demand. Proof-of-concept playground for the notification modal."
 entry = "notification_tester.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = []
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/notification-tester/notification_tester.py
+++ b/examples/notification-tester/notification_tester.py
@@ -29,9 +29,9 @@ Queue demos:
   s — Stack: fire ten LOW notifications in quick succession. Watch the
       count go live while the pinned top stays stable.
 
-Scope (context vs global) is NOT a runtime choice. It's declared per-app
-in manifest.toml::default_notification_scope. Flip this app's manifest to
-"global" to test cross-context visibility.
+Scope is NOT a runtime choice. It's declared per-app in manifest.toml under
+[launch] notification_scope. This app is set to "context". Flip to "global"
+to test cross-context visibility.
 """
 
 import threading

--- a/examples/quick-note/manifest.toml
+++ b/examples/quick-note/manifest.toml
@@ -7,10 +7,10 @@ name = "Quick Note"
 version = "0.1.0"
 description = "Markdown note composer and browser. Notes saved to <workspace_root>/.plexi/notes/."
 entry = "quick_note.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = ["fs.read", "fs.write"]
 
 [launch]
+notification_scope = "context"
 layout_hint = { side = "right", split = 0.3 }

--- a/examples/secrets-routing-tester/manifest.toml
+++ b/examples/secrets-routing-tester/manifest.toml
@@ -7,7 +7,6 @@ name = "Secrets Routing Tester"
 version = "0.1.0"
 description = "POC for #322 — resolves declared canonical secrets via .plexi/secrets.toml routing and shows masked previews."
 entry = "secrets_routing_tester.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = ["secrets.get"]
@@ -17,4 +16,5 @@ OPENAI_API_KEY = { required = true, description = "Demo: workspace-routed key" }
 GITHUB_TOKEN = { required = false, description = "Demo: optional fallback-routed key" }
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/stand-up-reminder/manifest.toml
+++ b/examples/stand-up-reminder/manifest.toml
@@ -7,11 +7,11 @@ name = "Stand Up Reminder"
 version = "0.1.0"
 description = "Background app: notifies every 15 min with a random movement prompt."
 entry = "stand_up_reminder.py"
-default_notification_scope = "global"
 
 [app.capabilities]
 capabilities = ["timer"]
 
 [launch]
+notification_scope = "global"
 background = true
 layout_hint = { side = "right", split = 0.4 }

--- a/examples/tool-poc/manifest.toml
+++ b/examples/tool-poc/manifest.toml
@@ -7,10 +7,10 @@ name = "Counter (Tool POC)"
 version = "0.1.0"
 description = "Counter app that exposes increment/reset as AI-callable tools. Demo: open alongside chat-poc and ask the AI to increment the counter."
 entry = "counter.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = []
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/video-player/manifest.toml
+++ b/examples/video-player/manifest.toml
@@ -7,11 +7,11 @@ name = "Video Player"
 version = "0.1.0"
 description = "POC for #345 + #79 — exercises the video substrate via mock or AVFoundation AND echoes the equivalent ffplay/ffmpeg CLI through a linked terminal (GUI↔Terminal media bridge). Set PLEXI_VIDEO=mock://gradient, set PLEXI_VIDEO_PATH for a real H.264 file, or pass a path as argv[1] (the file browser does this for mp4/mov/mkv files)."
 entry = "video_player.py"
-default_notification_scope = "context"
 layout_hint = "split_h"
 
 [app.capabilities]
 capabilities = ["video.playback", "terminal.bindings"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/examples/workspace-config-tester/manifest.toml
+++ b/examples/workspace-config-tester/manifest.toml
@@ -7,10 +7,10 @@ name = "Workspace Config Tester"
 version = "0.1.0"
 description = "POC for #308 Phase 1 — shows the resolved workspace root, workspace UUID, and demonstrates global → project config.toml merge."
 entry = "workspace_config_tester.py"
-default_notification_scope = "context"
 
 [app.capabilities]
 capabilities = ["fs.read"]
 
 [launch]
+notification_scope = "context"
 background = false

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -203,13 +203,18 @@ Queue model:
 - Cmd+] / Cmd+[ preview other queued notifications without acknowledging.
   Cmd+Shift+A toggles the modal on/off.
 
-Scope — context vs global — is NOT a runtime choice. It's declared per-app
-in the app's manifest.toml::default_notification_scope:
+Scope — window / context / global — is NOT a runtime choice. It's declared
+per-app in the app's manifest.toml under [launch]:
 
-  "context"  — notification is visible only when its source context is active
-               (default; safe — local confirmations stay local).
-  "global"   — notification is visible in all contexts (use for genuinely
-               cross-context things like stand-up reminders).
+  [launch]
+  notification_scope = "global"   # "window" | "context" | "global"
+
+  "window"   — default. Visible only when the app's window is active.
+               No behaviour change for apps that omit the field.
+  "context"  — visible whenever the user is in the same sidebar project,
+               regardless of which window page is showing.
+  "global"   — always visible across all contexts (use for stand-up
+               reminders, timers, monitoring dashboards).
 
 The user controls which scope a given app uses by editing its manifest.
 Apps do not see or set scope at the SDK level.
@@ -234,7 +239,8 @@ Required:
   entry = "my_app.py"       # executable entry point, relative to manifest
 
 Optional:
-  default_notification_scope = "context"  # "context" | "global" (default "context")
+  [launch]
+  notification_scope = "context"   # "window" (default) | "context" | "global"
 
   [app.capabilities]
   capabilities = []         # e.g. ["net.http", "audio.record"]

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -60,10 +60,10 @@ class Emitter:
     # values: 0 (background info), 50 (normal), 100 (important), 200
     # (critical). No default — apps must pick deliberately.
     #
-    # Scope (context vs. global) is NOT set by the app. It's a per-app
-    # user-facing policy declared in manifest.toml:default_notification_scope
-    # and resolved by the host at dispatch time. Apps just call notify();
-    # the user chooses whether to be interrupted across contexts.
+    # Scope (window / context / global) is NOT set by the app. It's declared
+    # in manifest.toml under [launch] notification_scope and resolved by the
+    # host at dispatch time. Apps just call notify(); the manifest controls
+    # whether the notification crosses window or context boundaries.
     def notify(self, title: str, body: str = "", level: str = "info",
                priority: "int | None" = None,
                actions: "list | None" = None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1089,15 +1089,24 @@ impl PlexiApp {
     // entry's current position in `pending_notifications`, which reflects
     // push order (we never reorder the Vec; dismissal removes by id).
     //
-    // Visibility: Context-scoped notifications are only visible when
-    // `source_context == self.router.active_idx()`. Global notifications are
-    // always visible. The raw `pending_notifications` Vec stays flat;
-    // only the *view* changes with the active workspace.
+    // Visibility by scope:
+    //   Window  — only when source_context == active context (default; most restrictive).
+    //             Equivalent to Context in today's single-window-per-context model;
+    //             the distinction will matter when multi-window contexts land.
+    //   Context — same as Window today; reserved for the multi-window distinction.
+    //   Global  — always visible.
+    // The raw `pending_notifications` Vec stays flat; only the *view* changes
+    // with the active workspace.
 
     /// True when this notification should appear in the current workspace view.
     pub(crate) fn notification_is_visible(&self, n: &PendingNotification) -> bool {
-        matches!(n.scope, crate::app_protocol::NotifyScope::Global)
-            || n.source_context == self.router.active_idx()
+        match n.scope {
+            crate::app_protocol::NotifyScope::Global => true,
+            crate::app_protocol::NotifyScope::Window
+            | crate::app_protocol::NotifyScope::Context => {
+                n.source_context == self.router.active_idx()
+            }
+        }
     }
 
     /// Return ids of all *visible* notifications (for the current context),
@@ -1220,14 +1229,19 @@ impl PlexiApp {
         }
     }
 
-    /// Count of context-scoped notifications whose source_context == ctx_idx.
-    /// Used for per-context sidebar badges on inactive contexts.
+    /// Count of window- or context-scoped notifications whose source_context == ctx_idx.
+    /// Used for per-context sidebar badges on inactive contexts. Global notifications
+    /// are excluded — they already appear everywhere via notification_is_visible.
     pub(crate) fn context_notification_count(&self, ctx_idx: usize) -> usize {
         self.pending_notifications
             .iter()
             .filter(|n| {
-                matches!(n.scope, crate::app_protocol::NotifyScope::Context)
-                    && n.source_context == ctx_idx
+                matches!(
+                    n.scope,
+                    crate::app_protocol::NotifyScope::Window
+                        | crate::app_protocol::NotifyScope::Context
+                )
+                && n.source_context == ctx_idx
             })
             .count()
     }
@@ -1503,7 +1517,7 @@ impl eframe::App for PlexiApp {
                     }
                     let new_id = notify_id.clone();
                     // Capture scope/source_context before they move into the struct.
-                    let is_global = matches!(scope, crate::app_protocol::NotifyScope::Global);
+                    let notif_scope = scope;
                     let notif_source_ctx = source_context;
                     // Strip any per-option shortcut that conflicts with navigation keys.
                     let options: Vec<crate::app_protocol::NotifyOption> = options.into_iter().map(|mut opt| {
@@ -1540,16 +1554,21 @@ impl eframe::App for PlexiApp {
                         tombstoned: false,
                     });
                     // Auto-open rules:
-                    //   1. Visibility (Global or in active context) — else
-                    //      it stays invisible in the queue until the user
-                    //      switches to its context.
+                    //   1. Visibility — Global always; Window/Context only when
+                    //      source_context == active context.
                     //   2. focus_mode off — the global mute gate.
                     //   3. priority >= interrupt_threshold — don't
                     //      auto-open low-urgency notifications like
                     //      "note saved".
                     // If any gate fails, the notification still queues
                     // (badge ticks) but the modal doesn't pop.
-                    let is_visible = is_global || notif_source_ctx == self.active_window;
+                    let is_visible = match notif_scope {
+                        crate::app_protocol::NotifyScope::Global => true,
+                        crate::app_protocol::NotifyScope::Window
+                        | crate::app_protocol::NotifyScope::Context => {
+                            notif_source_ctx == self.router.active_idx()
+                        }
+                    };
                     let should_auto_open = is_visible
                         && !self.notifications_focus_mode
                         && priority >= self.notifications_interrupt_threshold;

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1382,12 +1382,17 @@ pub struct ShortcutPair {
 /// - `Global`  — always visible, regardless of which context is active.
 ///
 /// Host-side enum. Apps do NOT emit this on the wire — scope is a per-app
-/// user-facing policy declared in `manifest.toml::default_notification_scope`,
+/// user-facing policy declared in `manifest.toml::[launch] notification_scope`,
 /// resolved by the host at dispatch time. Apps never think about it.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyScope {
-    /// Only visible when the source context is the active context.
+    /// Only visible when the source window is the active window. Default.
+    /// In the current single-window-per-context model this is equivalent to
+    /// `Context`; the distinction matters when multi-window contexts land.
+    Window,
+    /// Visible whenever the source context is the active context (sidebar
+    /// item), regardless of which window page is showing.
     Context,
     /// Always visible regardless of which context is active.
     Global,

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -100,12 +100,6 @@ pub struct AppManifestApp {
     pub description: String,
     #[serde(default)]
     pub capabilities: AppCapabilities,
-    /// Default notification scope for this app. Optional — defaults to
-    /// `NotifyScope::Context` when unset (safe default: local confirmations
-    /// are local). Set to "global" in manifest for apps that must interrupt
-    /// the user regardless of which context is active (e.g. stand-up-reminder).
-    #[serde(default)]
-    pub default_notification_scope: DefaultNotifyScope,
     /// Hot-reload opt-in (#83). When true AND the app was discovered from a
     /// workspace-local `.plexi/apps/`, the host watches the app dir and
     /// reloads the subprocess on save. Off by default — global installs
@@ -131,14 +125,14 @@ pub enum ManifestType {
     Agent,
 }
 
-/// Newtype for the manifest `default_notification_scope` field so it
-/// deserialises from a snake_case string ("context" | "global") and has a
-/// sensible `Default` impl without pulling `NotifyScope` into the serde
-/// derive chain.
+/// Newtype for `[launch] notification_scope` in manifest.toml. Deserialises
+/// from `"window"` | `"context"` | `"global"`. Default is `window` — the most
+/// restrictive scope and the pre-525 behaviour for apps that don't declare it.
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum DefaultNotifyScope {
     #[default]
+    Window,
     Context,
     Global,
 }
@@ -146,6 +140,7 @@ pub enum DefaultNotifyScope {
 impl From<DefaultNotifyScope> for crate::app_protocol::NotifyScope {
     fn from(d: DefaultNotifyScope) -> Self {
         match d {
+            DefaultNotifyScope::Window => crate::app_protocol::NotifyScope::Window,
             DefaultNotifyScope::Context => crate::app_protocol::NotifyScope::Context,
             DefaultNotifyScope::Global => crate::app_protocol::NotifyScope::Global,
         }
@@ -199,6 +194,13 @@ pub struct LaunchSection {
     /// field on `iq.query`). Optional — `None` when the manifest omits it.
     #[serde(default)]
     pub system_prompt: Option<String>,
+    /// Where this app's notifications surface. `"window"` (default) shows
+    /// notifications only when the app's window is active. `"context"` shows
+    /// them whenever the user is in the same sidebar context. `"global"` always
+    /// surfaces them regardless of active context — use for stand-up reminders,
+    /// timers, and monitoring dashboards.
+    #[serde(default)]
+    pub notification_scope: DefaultNotifyScope,
 }
 
 /// Structured layout hint. `side` ∈ {`"right"`, `"below"`, `"overlay"`}.
@@ -505,17 +507,16 @@ impl AppRegistry {
             .map(|h| h.split)
     }
 
-    /// Return the manifest-declared default notification scope for an app.
-    /// Used by operators and the host to understand the app's intent;
-    /// the actual scope is set per-notification by the app via the SDK.
+    /// Return the manifest-declared notification scope for an app.
+    /// Defaults to `Window` when the manifest omits `[launch] notification_scope`.
     pub fn default_notification_scope_for(
         &self,
         app_id: &str,
     ) -> crate::app_protocol::NotifyScope {
         self.apps
             .get(app_id)
-            .map(|a| a.manifest.default_notification_scope.clone().into())
-            .unwrap_or(crate::app_protocol::NotifyScope::Context)
+            .map(|a| a.launch.notification_scope.clone().into())
+            .unwrap_or(crate::app_protocol::NotifyScope::Window)
     }
 
     /// Launch an app process for the given id.
@@ -569,7 +570,7 @@ impl AppRegistry {
         ) {
             Ok(app) => {
                 log::info!(
-                    "AppRegistry: launched '{}' from {:?} (default_notification_scope={:?})",
+                    "AppRegistry: launched '{}' from {:?} (notification_scope={:?})",
                     id,
                     installed.bin_path,
                     default_scope,
@@ -1037,5 +1038,88 @@ watch = true
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         assert!(registry.get("g").is_some());
         assert_eq!(registry.list().len(), 1);
+    }
+
+    // ── #525 notification scope — `[launch] notification_scope` ─────────────
+
+    #[test]
+    fn manifest_without_notification_scope_defaults_to_window() {
+        // Apps that omit `notification_scope` must default to `Window` —
+        // the pre-525 behaviour (no change for existing apps).
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app(global.path(), "no-scope", "No Scope");
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let scope = registry.default_notification_scope_for("no-scope");
+        assert_eq!(scope, crate::app_protocol::NotifyScope::Window);
+    }
+
+    #[test]
+    fn manifest_with_notification_scope_global_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("stand-up");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"stand-up\"
+type = \"app\"
+name = \"Stand Up\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+notification_scope = \"global\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        let entry = app_dir.join("run.sh");
+        fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&entry).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&entry, perms).unwrap();
+        }
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let scope = registry.default_notification_scope_for("stand-up");
+        assert_eq!(scope, crate::app_protocol::NotifyScope::Global);
+    }
+
+    #[test]
+    fn manifest_with_notification_scope_context_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("ctx-scoped");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"ctx-scoped\"
+type = \"app\"
+name = \"Context Scoped\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+notification_scope = \"context\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        let entry = app_dir.join("run.sh");
+        fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&entry).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&entry, perms).unwrap();
+        }
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let scope = registry.default_notification_scope_for("ctx-scoped");
+        assert_eq!(scope, crate::app_protocol::NotifyScope::Context);
     }
 }


### PR DESCRIPTION
Closes #525.

## Summary
- Adds `[launch] notification_scope` to app manifests with three values: `window` (default), `context`, `global`
- `window` is the most restrictive and preserves pre-525 behaviour — apps that omit the field get no change
- `global` is the intended scope for stand-up reminders, timers, monitoring dashboards
- `context` shows notifications whenever the user is in the same sidebar project, regardless of window page

## Changes
- `NotifyScope` gains `Window` variant (`app_protocol.rs`)
- `DefaultNotifyScope` gains `Window` as default; field moved from `[app]` to `[launch]` and renamed to `notification_scope` (`app_registry.rs`)
- `notification_is_visible()` handles all three scopes
- `context_notification_count()` counts both `Window` and `Context` for sidebar badges
- Auto-open visibility check uses `router.active_idx()` consistently

## Test plan
- [ ] 3 new registry tests pass: default (window), global, and context scope
- [ ] `cargo test` (binary): 292 passed, 0 failed

## Example manifest
```toml
[launch]
notification_scope = "global"   # stand-up-reminder must always surface
```