### PR TITLE
feat(spawn_pane): add from_pane_id + request_id correlation

### DIFF
--- a/examples/spawn-pane-poc/spawn_pane_poc.py
+++ b/examples/spawn-pane-poc/spawn_pane_poc.py
@@ -1,41 +1,49 @@
 #!/usr/bin/env python3
-"""Spawn Pane POC — demonstrates DrawCommand::SpawnPane (#527).
+"""Spawn Pane POC — demonstrates from_pane_id + request_id correlation (#752).
 
-Two buttons: one spawns a terminal pane to the right, one spawns the snake
-app. The pane_id returned by PaneSpawned is displayed for verification.
+Step 1: Click "Spawn snake (split_h)" — spawns a snake pane to the right with
+        request_id="req-1". Log shows the echoed request_id.
+Step 2: Click "Spawn from first pane (split_v)" — splits relative to the
+        first snake pane (not this coordinator) using from_pane_id + request_id="req-2".
 """
 from __future__ import annotations
 
 from plexi_sdk import App, RenderContext, FG, MUTED, SURFACE, ACCENT, BG, BODY, CAPTION  # type: ignore[attr-defined]
 
 PAD = 20.0
-BTN_W = 220.0
+BTN_W = 260.0
 BTN_H = 36.0
 
 
 class SpawnPanePoc(App):
     def on_init(self, ctx: RenderContext) -> None:
         self._log: list[str] = []
+        self._first_pane_id: int | None = None
+        self._btn1_y = 0.0
+        self._btn2_y = 0.0
 
     def on_render(self, ctx: RenderContext) -> None:
         ctx.clear(BG)
         pad = PAD
         y = pad
 
-        ctx.text(pad, y, "Spawn Pane POC", size=16.0, color=FG, bold=True)
+        ctx.text(pad, y, "Spawn Pane POC (#752)", size=16.0, color=FG, bold=True)
         y += 32.0
-        ctx.text(pad, y, "Click a button to spawn a pane via panes.spawn.", size=BODY, color=MUTED)
+        ctx.text(pad, y, "Tests from_pane_id + request_id correlation.", size=BODY, color=MUTED)
         y += 28.0
 
-        # Button 1 — terminal
+        # Button 1 — spawn snake to the right, capture pane_id
         ctx.rect(pad, y, BTN_W, BTN_H, fill=ACCENT, radius=6.0)
-        ctx.text(pad + 12, y + 10, "Spawn terminal (split_h)", size=BODY, color=BG)
+        ctx.text(pad + 12, y + 10, "1. Spawn snake (split_h, req-1)", size=BODY, color=BG)
         self._btn1_y = y
         y += BTN_H + 12.0
 
-        # Button 2 — snake app
-        ctx.rect(pad, y, BTN_W, BTN_H, fill=SURFACE, radius=6.0)
-        ctx.text(pad + 12, y + 10, "Spawn snake (split_v)", size=BODY, color=FG)
+        # Button 2 — spawn below first pane using from_pane_id
+        has_first = self._first_pane_id is not None
+        btn2_fill = SURFACE if has_first else MUTED
+        label2 = f"2. Spawn below pane {self._first_pane_id} (req-2)" if has_first else "2. (spawn step 1 first)"
+        ctx.rect(pad, y, BTN_W, BTN_H, fill=btn2_fill, radius=6.0)
+        ctx.text(pad + 12, y + 10, label2, size=BODY, color=FG)
         self._btn2_y = y
         y += BTN_H + 20.0
 
@@ -43,7 +51,7 @@ class SpawnPanePoc(App):
         y += 12.0
         ctx.text(pad, y, "Log:", size=CAPTION, color=MUTED)
         y += 20.0
-        for line in self._log[-6:]:
+        for line in self._log[-8:]:
             ctx.text(pad + 8, y, line, size=CAPTION, color=FG, monospace=True)
             y += 18.0
 
@@ -52,17 +60,24 @@ class SpawnPanePoc(App):
             return
         if PAD <= x <= PAD + BTN_W:
             if self._btn1_y <= y <= self._btn1_y + BTN_H:
-                ctx.emit.spawn_pane("terminal", layout="split_h")
-                self._log.append("→ spawn_pane terminal split_h")
-            elif self._btn2_y <= y <= self._btn2_y + BTN_H:
-                ctx.emit.spawn_pane("snake", layout="split_v")
-                self._log.append("→ spawn_pane snake split_v")
+                ctx.emit.spawn_pane("snake", layout="split_h", request_id="req-1")
+                self._log.append("→ spawn snake split_h request_id=req-1")
+            elif self._btn2_y <= y <= self._btn2_y + BTN_H and self._first_pane_id is not None:
+                ctx.emit.spawn_pane(
+                    "snake",
+                    layout="split_v",
+                    from_pane_id=self._first_pane_id,
+                    request_id="req-2",
+                )
+                self._log.append(f"→ spawn snake split_v from_pane_id={self._first_pane_id} request_id=req-2")
 
-    def on_pane_spawned(self, pane_id: int) -> None:
-        self._log.append(f"✓ pane_spawned pane_id={pane_id}")
+    def on_pane_spawned(self, pane_id: int, request_id: str | None = None) -> None:
+        self._log.append(f"✓ pane_id={pane_id} request_id={request_id}")
+        if self._first_pane_id is None:
+            self._first_pane_id = pane_id
 
-    def on_pane_spawn_error(self, reason: str) -> None:
-        self._log.append(f"✗ pane_spawn_error: {reason}")
+    def on_pane_spawn_error(self, reason: str, request_id: str | None = None) -> None:
+        self._log.append(f"✗ error={reason!r} request_id={request_id}")
 
 
 if __name__ == "__main__":

--- a/examples/test-spawn/manifest.toml
+++ b/examples/test-spawn/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "test-spawn"
+type = "app"
+name = "Test Spawn"
+version = "0.1.0"
+description = "Test app for from_pane_id + request_id on spawn_pane (#752)."
+entry = "test_spawn.py"
+
+[app.capabilities]
+capabilities = ["panes.spawn"]
+
+[launch]
+layout_hint = { side = "right", split = 0.4 }

--- a/examples/test-spawn/test_spawn.py
+++ b/examples/test-spawn/test_spawn.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from plexi_sdk import App, RenderContext
+
+class TestApp(App):
+    async def on_start(self, ctx: RenderContext):
+        ctx.emit.spawn_pane("terminal", request_id="req-1")
+        ctx.emit.spawn_pane("terminal", layout="split_h", request_id="req-2")
+
+    def on_pane_spawned(self, pane_id, request_id=None):
+        import sys
+        print(f"[PASS] pane_spawned pane_id={pane_id} request_id={request_id}", file=sys.stderr, flush=True)
+
+    def on_pane_spawn_error(self, reason, request_id=None):
+        import sys
+        print(f"[FAIL] pane_spawn_error reason={reason} request_id={request_id}", file=sys.stderr, flush=True)
+
+TestApp().run()

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -161,10 +161,10 @@ class App:
         """
         return None
     def on_app_spawned(self, _pane_id: int, _type_id: str) -> None: pass
-    def on_pane_spawned(self, pane_id: int) -> None:
+    def on_pane_spawned(self, pane_id: int, request_id: "str | None" = None) -> None:
         """Called when a SpawnPane request succeeded (#592). Override to track the spawned pane."""
 
-    def on_pane_spawn_error(self, reason: str) -> None:
+    def on_pane_spawn_error(self, reason: str, request_id: "str | None" = None) -> None:
         """Called when a SpawnPane request failed (#592). Override to handle the error."""
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
@@ -718,15 +718,19 @@ class App:
                     )
 
                 elif t == "pane_spawned":
+                    req_id = ev.get("request_id")
                     self._dispatch_hook_task(
                         self.on_pane_spawned,
                         int(ev.get("pane_id", 0)),
+                        str(req_id) if req_id is not None else None,
                     )
 
                 elif t == "pane_spawn_error":
+                    req_id = ev.get("request_id")
                     self._dispatch_hook_task(
                         self.on_pane_spawn_error,
                         str(ev.get("reason", "")),
+                        str(req_id) if req_id is not None else None,
                     )
 
                 elif t == "nav_back":

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -358,12 +358,14 @@ class Emitter:
         layout: str = "split_v",
         args: "list[str] | None" = None,
         pipe_id: "str | None" = None,
+        from_pane_id: "int | None" = None,
+        request_id: "str | None" = None,
     ) -> None:
         """Request the host to open a new pane with the given app (#592).
 
         Requires the ``panes.spawn`` capability. The host responds with
-        ``on_pane_spawned(pane_id)`` on success or ``on_pane_spawn_error(reason)``
-        on failure.
+        ``on_pane_spawned(pane_id, request_id)`` on success or
+        ``on_pane_spawn_error(reason, request_id)`` on failure.
 
         Args:
             type_id: App manifest id or ``"terminal"``.
@@ -372,6 +374,10 @@ class Emitter:
             args: Extra argv passed to the spawned app.
             pipe_id: Optional. If set, the host appends ``--pipe=<id>`` to the
                      spawned app's args so it can reply via ``emit.pipe_send()``.
+            from_pane_id: Optional pane_id to split relative to instead of the
+                          currently focused pane.
+            request_id: Optional correlation id echoed back in on_pane_spawned /
+                        on_pane_spawn_error.
         """
         cmd: "dict[str, object]" = {
             "type": "spawn_pane",
@@ -381,6 +387,10 @@ class Emitter:
         }
         if pipe_id is not None:
             cmd["pipe_id"] = pipe_id
+        if from_pane_id is not None:
+            cmd["from_pane_id"] = from_pane_id
+        if request_id is not None:
+            cmd["request_id"] = request_id
         _emit(cmd)
 
     def cd_to(self, cwd: str) -> None:

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1386,6 +1386,8 @@ impl eframe::App for PlexiApp {
                     layout,
                     args,
                     pipe_id,
+                    from_pane_id,
+                    request_id,
                 } => {
                     // "background" layout is not yet implemented (blocked on #291).
                     if layout == "background" {
@@ -1407,6 +1409,7 @@ impl eframe::App for PlexiApp {
                                     a.runtime.queue_outbound_event(
                                         crate::app_protocol::PlexiEvent::PaneSpawnError {
                                             reason: "layout 'background' not yet implemented".to_string(),
+                                            request_id: request_id.clone(),
                                         },
                                     );
                                 }
@@ -1423,7 +1426,7 @@ impl eframe::App for PlexiApp {
                         effective_args.push(format!("--pipe={pid}"));
                     }
 
-                    // Predict the pane id that will be allocated (next_pane_id peeks without allocating).
+                    // Capture requesting_pane_id from the CURRENT focused pane (the calling app pane).
                     let active = self.active_window;
                     let requesting_pane_id = self.windows[active]
                         .focused_pane
@@ -1435,6 +1438,19 @@ impl eframe::App for PlexiApp {
                                 None
                             }
                         });
+
+                    // Override focused_pane for the split if from_pane_id is specified.
+                    let original_focused = self.windows[active].focused_pane;
+                    if let Some(from_id) = from_pane_id {
+                        if let Some(tile) = self.windows[active].tree.tiles.find_pane(&from_id) {
+                            log::info!("SpawnPane: splitting relative to pane_id={from_id}");
+                            self.windows[active].focused_pane = Some(tile);
+                        } else {
+                            log::warn!("SpawnPane: from_pane_id={from_id} not found, using focused pane");
+                        }
+                    }
+
+                    // Predict the pane id that will be allocated (next_pane_id peeks without allocating).
                     let new_pane_id = self.host.next_pane_id();
                     if type_id == "terminal" {
                         // "terminal" is a builtin pane type, not in the app registry.
@@ -1457,6 +1473,9 @@ impl eframe::App for PlexiApp {
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
                     }
 
+                    // Restore focused_pane after the split so the coordinator app keeps focus.
+                    self.windows[active].focused_pane = original_focused;
+
                     // Send PaneSpawned back to the requesting pane.
                     if let Some(req_pane_id) = requesting_pane_id {
                         let active = self.active_window;
@@ -1465,6 +1484,7 @@ impl eframe::App for PlexiApp {
                                 a.runtime.queue_outbound_event(
                                     crate::app_protocol::PlexiEvent::PaneSpawned {
                                         pane_id: new_pane_id,
+                                        request_id,
                                     },
                                 );
                             }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -114,9 +114,17 @@ pub enum PlexiEvent {
         type_id: String,
     },
     /// Confirmation that a SpawnPane request succeeded (#592).
-    PaneSpawned { pane_id: u64 },
+    PaneSpawned {
+        pane_id: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
     /// SpawnPane could not be fulfilled (#592). `reason` is a human-readable error.
-    PaneSpawnError { reason: String },
+    PaneSpawnError {
+        reason: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
     /// Binary pipe opened — app connects to `socket_path` as a unix socket client.
     PipeOpened {
         pipe_id: String,
@@ -900,6 +908,10 @@ pub enum HostCommand {
         args: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pipe_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from_pane_id: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
@@ -2509,11 +2521,13 @@ mod tests {
         let json = r#"{"type":"spawn_pane","type_id":"snake","layout":"split_v","args":["--foo"],"pipe_id":"p1"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Host(HostCommand::SpawnPane { type_id, layout, args, pipe_id }) => {
+            DrawCommand::Host(HostCommand::SpawnPane { type_id, layout, args, pipe_id, from_pane_id, request_id }) => {
                 assert_eq!(type_id, "snake");
                 assert_eq!(layout, "split_v");
                 assert_eq!(args, &["--foo"]);
                 assert_eq!(pipe_id.as_deref(), Some("p1"));
+                assert!(from_pane_id.is_none());
+                assert!(request_id.is_none());
             }
             other => panic!("expected SpawnPane, got {other:?}"),
         }
@@ -2524,10 +2538,12 @@ mod tests {
         let minimal = r#"{"type":"spawn_pane","type_id":"snake"}"#;
         let cmd2: DrawCommand = serde_json::from_str(minimal).expect("deserialise minimal");
         match &cmd2 {
-            DrawCommand::Host(HostCommand::SpawnPane { layout, args, pipe_id, .. }) => {
+            DrawCommand::Host(HostCommand::SpawnPane { layout, args, pipe_id, from_pane_id, request_id, .. }) => {
                 assert_eq!(layout, "split_v");
                 assert!(args.is_empty());
                 assert!(pipe_id.is_none());
+                assert!(from_pane_id.is_none());
+                assert!(request_id.is_none());
             }
             other => panic!("expected SpawnPane, got {other:?}"),
         }
@@ -2538,9 +2554,13 @@ mod tests {
         let json = r#"{"type":"pane_spawned","pane_id":99}"#;
         let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
         match &event {
-            PlexiEvent::PaneSpawned { pane_id } => assert_eq!(*pane_id, 99),
+            PlexiEvent::PaneSpawned { pane_id, .. } => {
+                assert_eq!(*pane_id, 99);
+            }
             other => panic!("expected PaneSpawned, got {other:?}"),
         }
+        // request_id is None when not present
+        assert!(matches!(event, PlexiEvent::PaneSpawned { request_id: None, .. }));
         let serialised = serde_json::to_string(&event).expect("serialise");
         assert!(serialised.contains(r#""type":"pane_spawned""#), "wire tag missing: {serialised}");
 
@@ -2553,11 +2573,63 @@ mod tests {
         let json = r#"{"type":"pane_spawn_error","reason":"capability denied"}"#;
         let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
         match &event {
-            PlexiEvent::PaneSpawnError { reason } => assert_eq!(reason, "capability denied"),
+            PlexiEvent::PaneSpawnError { reason, .. } => assert_eq!(reason, "capability denied"),
             other => panic!("expected PaneSpawnError, got {other:?}"),
         }
         let serialised = serde_json::to_string(&event).expect("serialise");
         assert!(serialised.contains(r#""type":"pane_spawn_error""#), "wire tag missing: {serialised}");
+    }
+
+    #[test]
+    fn spawn_pane_with_new_fields_round_trips_serde() {
+        let json = r#"{"type":"spawn_pane","type_id":"snake","layout":"split_v","from_pane_id":42,"request_id":"req-1"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::SpawnPane { from_pane_id, request_id, .. }) => {
+                assert_eq!(*from_pane_id, Some(42u64));
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""from_pane_id":42"#), "from_pane_id missing: {serialised}");
+        assert!(serialised.contains(r#""request_id":"req-1""#), "request_id missing: {serialised}");
+    }
+
+    #[test]
+    fn pane_spawned_with_request_id_round_trips_serde() {
+        let json = r#"{"type":"pane_spawned","pane_id":99,"request_id":"req-abc"}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::PaneSpawned { pane_id, request_id } => {
+                assert_eq!(*pane_id, 99);
+                assert_eq!(request_id.as_deref(), Some("req-abc"));
+            }
+            other => panic!("expected PaneSpawned, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""request_id":"req-abc""#), "request_id missing: {serialised}");
+        // Omitting request_id → None
+        let no_req: PlexiEvent = serde_json::from_str(r#"{"type":"pane_spawned","pane_id":1}"#).unwrap();
+        assert!(matches!(no_req, PlexiEvent::PaneSpawned { request_id: None, .. }));
+    }
+
+    #[test]
+    fn pane_spawn_error_with_request_id_round_trips_serde() {
+        let json = r#"{"type":"pane_spawn_error","reason":"denied","request_id":"req-xyz"}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::PaneSpawnError { reason, request_id } => {
+                assert_eq!(reason, "denied");
+                assert_eq!(request_id.as_deref(), Some("req-xyz"));
+            }
+            other => panic!("expected PaneSpawnError, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""request_id":"req-xyz""#), "request_id missing: {serialised}");
+        // Omitting request_id → None
+        let no_req: PlexiEvent = serde_json::from_str(r#"{"type":"pane_spawn_error","reason":"x"}"#).unwrap();
+        assert!(matches!(no_req, PlexiEvent::PaneSpawnError { request_id: None, .. }));
     }
 
     #[test]

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -23,6 +23,8 @@ pub enum AppCommand {
         layout: String,
         args: Vec<String>,
         pipe_id: Option<String>,
+        from_pane_id: Option<u64>,
+        request_id: Option<String>,
     },
     /// Request the host to cd sibling terminals (same split container) to `cwd`.
     CdRequest { cwd: String, sender_pane_id: u64 },

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -661,6 +661,8 @@ mod tests {
             layout: "split_v".to_string(),
             args: vec![],
             pipe_id: None,
+            from_pane_id: None,
+            request_id: None,
         });
         h.run_frames(2);
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -754,17 +754,19 @@ impl ProcessApp {
                 layout,
                 args,
                 pipe_id,
+                from_pane_id,
+                request_id,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)
                 {
                     log::warn!("ProcessApp[{}]: SpawnPane denied — {reason}", self.type_id);
                     self.outbound_events
-                        .push_back(PlexiEvent::PaneSpawnError { reason });
+                        .push_back(PlexiEvent::PaneSpawnError { reason, request_id });
                     return;
                 }
                 log::info!(
-                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout}' args={args:?} pipe_id={pipe_id:?}",
+                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout}' args={args:?} pipe_id={pipe_id:?} from_pane_id={from_pane_id:?} request_id={request_id:?}",
                     self.type_id
                 );
                 self.pending_commands.push(AppCommand::SpawnPane {
@@ -772,6 +774,8 @@ impl ProcessApp {
                     layout,
                     args,
                     pipe_id,
+                    from_pane_id,
+                    request_id,
                 });
             }
 


### PR DESCRIPTION
Closes #752

## What

Adds two missing fields to `SpawnPane` / `PaneSpawned` / `PaneSpawnError`:

- **`from_pane_id: Option<u64>`** — split relative to a specific pane instead of the calling pane. Enables coordinator apps to build multi-pane layouts (e.g. 2×2 grid).
- **`request_id: Option<String>`** — echoed back in both success and error events, matching the correlation pattern used by every other async SDK call.

Both fields are optional with `serde(default)` so existing apps require no changes.

## Changes

- `src/app_protocol.rs` — new fields on `SpawnPane`, `PaneSpawned`, `PaneSpawnError`; 3 new serde round-trip tests
- `src/app_trait.rs` — `AppCommand::SpawnPane` updated
- `src/process_app/routing.rs` — threads both fields; echoes `request_id` on capability-denied path
- `src/app/mod.rs` — overrides `focused_pane` for duration of split when `from_pane_id` set, restores after so coordinator keeps focus; echoes `request_id` in `PaneSpawned`
- `src/pane_ops/create.rs` — test constructor updated
- `sdk/python/plexi_sdk/_emitter.py` — `spawn_pane()` gains `from_pane_id` and `request_id` params
- `sdk/python/plexi_sdk/_app.py` — `on_pane_spawned(pane_id, request_id=None)` and `on_pane_spawn_error(reason, request_id=None)`

## Test plan

- [ ] 342 existing tests pass (`cargo test`)
- [ ] `spawn_pane(type_id, request_id="req-1")` → `on_pane_spawned` fires with matching `request_id`
- [ ] `spawn_pane(type_id, layout="split_v", from_pane_id=<other_pane>)` → new pane appears adjacent to `other_pane`, not the coordinator
- [ ] Old SDK apps that override `on_pane_spawned(self, pane_id)` without `request_id` still work (default=None)