### PR TITLE
feat(descriptor): plexi_app field — CLI custom PGAP app entry point

### DIFF
--- a/schemas/plexi-descriptor-schema.json
+++ b/schemas/plexi-descriptor-schema.json
@@ -39,7 +39,16 @@
       "description": "Top-level commands. Each command may itself contain nested `commands[]` to model subcommand groups (e.g. `git remote add`).",
       "items": { "$ref": "#/definitions/command" }
     },
-    "live_state": { "$ref": "#/definitions/liveState" }
+    "live_state": { "$ref": "#/definitions/liveState" },
+    "plexi_app": {
+      "type": "string",
+      "description": "Shell command to spawn as a PGAP process instead of rendering the auto-generated form UI. Split on whitespace: first token is the binary, rest are initial args."
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "Capability strings granted to the spawned PGAP process. Same vocabulary as manifest.toml capabilities.",
+      "items": { "type": "string" }
+    }
   },
   "definitions": {
     "uiHint": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2152,6 +2152,12 @@ pub mod descriptor {
                 ls.source, ls.path, ls.poll_ms, ls.format
             );
         }
+        if let Some(app_cmd) = &d.plexi_app {
+            println!("plexi_app: {app_cmd}");
+            if !d.capabilities.is_empty() {
+                println!("  capabilities: {}", d.capabilities.join(", "));
+            }
+        }
     }
 
     #[cfg(test)]

--- a/src/cli_crawl.rs
+++ b/src/cli_crawl.rs
@@ -83,13 +83,30 @@ pub(crate) fn crawl_with_runner(
     let cache_file = cache_dir.join(format!("{cli_name}.json"));
 
     // Cache hit — try to deserialize; on failure, fall through and re-crawl.
+    // Also check version: if the CLI version changed since we cached, invalidate.
     if cache_file.exists() {
         if let Ok(bytes) = std::fs::read_to_string(&cache_file) {
             if let Ok(descriptor) = serde_json::from_str::<PlexiDescriptor>(&bytes) {
-                return Ok(CrawlResult {
-                    descriptor,
-                    from_cache: true,
-                });
+                let current_version = runner
+                    .run_version(cli_name)
+                    .as_deref()
+                    .map(|s| extract_version(cli_name, s));
+                let stale = current_version
+                    .as_deref()
+                    .map(|v| v != descriptor.version)
+                    .unwrap_or(false);
+                if stale {
+                    log::info!(
+                        "cli_crawl: cache stale for `{cli_name}` — version changed from {} to {}; re-crawling",
+                        descriptor.version,
+                        current_version.as_deref().unwrap_or("unknown"),
+                    );
+                } else {
+                    return Ok(CrawlResult {
+                        descriptor,
+                        from_cache: true,
+                    });
+                }
             }
         }
     }
@@ -159,6 +176,8 @@ fn parse_help(cli_name: &str, text: &str, version: Option<String>) -> PlexiDescr
         },
         commands,
         live_state: None,
+        plexi_app: None,
+        capabilities: vec![],
     }
 }
 
@@ -492,6 +511,8 @@ SUBCOMMANDS:
                 commands: vec![],
             }],
             live_state: None,
+            plexi_app: None,
+            capabilities: vec![],
         };
         let json = serde_json::to_string_pretty(&descriptor).unwrap();
         std::fs::write(&cache_file, &json).unwrap();
@@ -573,5 +594,50 @@ COMMANDS
         let _ = crawl_with_runner("cached-cli", &runner, &cache_dir).unwrap();
         let result2 = crawl_with_runner("cached-cli", &runner, &cache_dir).unwrap();
         assert!(result2.from_cache);
+    }
+
+    #[test]
+    fn cache_invalidated_on_version_change() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Pre-populate cache with version "0.9.0".
+        let stale_descriptor = PlexiDescriptor {
+            plexi_version: "0.1".to_string(),
+            name: "version-cli".to_string(),
+            version: "0.9.0".to_string(),
+            description: None,
+            icon: None,
+            default_view: Some(UiHint::List),
+            commands: vec![Command {
+                name: "run".to_string(),
+                description: None,
+                icon: None,
+                ui_hint: None,
+                args: vec![],
+                flags: vec![],
+                writes: vec![],
+                reads: vec![],
+                streaming: None,
+                output_format: None,
+                commands: vec![],
+            }],
+            live_state: None,
+            plexi_app: None,
+            capabilities: vec![],
+        };
+        let cache_file = cache_dir.join("version-cli.json");
+        std::fs::write(&cache_file, serde_json::to_string(&stale_descriptor).unwrap()).unwrap();
+
+        // Runner reports version "1.0.0" and help with commands so crawl succeeds.
+        let runner = MockRunner {
+            help: "COMMANDS\n  run   Do the thing\n".to_string(),
+            version: Some("version-cli 1.0.0".to_string()),
+        };
+
+        let result = crawl_with_runner("version-cli", &runner, &cache_dir).unwrap();
+        assert!(!result.from_cache, "stale cache should have been invalidated");
+        assert_eq!(result.descriptor.version, "1.0.0");
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -492,10 +492,80 @@ impl PlexiApp {
             return;
         }
 
-        if let Some(process) = self.registry.launch_process(id, &cwd, args) {
+        // Try registry first; if it returns None, fall through to Tier 4.
+        let registry_process = self.registry.launch_process(id, &cwd, args);
+        if let Some(process) = registry_process {
             self.open_process_app_pane(id, process, cwd, group, hint.as_deref());
+            return;
+        }
+
+        // Tier 4 — CLI native descriptor (plexi_app field).
+        if let Some(process) = self.try_launch_cli_pgap_app(id, &cwd) {
+            self.open_process_app_pane(&format!("cli:{id}"), process, cwd, group, hint.as_deref());
         } else {
             log::warn!("launch_app_by_id: app '{id}' not found or failed to launch");
+        }
+    }
+
+    /// Attempt to spawn a PGAP process from the CLI's native `--plexi` descriptor
+    /// `plexi_app` field. Returns `None` if the CLI is not found, does not support
+    /// `--plexi`, or has no `plexi_app` field.
+    fn try_launch_cli_pgap_app(
+        &self,
+        cli_name: &str,
+        cwd: &PathBuf,
+    ) -> Option<crate::process_app::ProcessApp> {
+        // Step 1: Run `<cli_name> --plexi` to get the native descriptor.
+        let output = std::process::Command::new(cli_name)
+            .arg("--plexi")
+            .output()
+            .ok()?;
+        if !output.status.success() && output.stdout.is_empty() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let descriptor = crate::plexi_descriptor::parse(&stdout).ok()?;
+
+        // None = no plexi_app field declared, skip Tier 4.
+        let plexi_app_cmd = descriptor.plexi_app.as_deref()?;
+
+        // Step 2: Split the command string into binary + args.
+        let mut tokens = plexi_app_cmd.split_whitespace();
+        let bin = tokens.next()?;
+        let extra_args: Vec<String> = tokens.map(|s| s.to_string()).collect();
+
+        // Step 3: Build permissions from descriptor.capabilities.
+        let perms = crate::app_permissions::AppPermissions::from_capability_strings(
+            &descriptor.capabilities,
+        );
+        let caps = perms.capabilities.clone();
+
+        // Step 4: Spawn the ProcessApp.
+        let app_id = format!("cli:{cli_name}");
+        let bin_path = std::path::PathBuf::from(bin);
+        match crate::process_app::ProcessApp::launch(
+            app_id.clone(),
+            descriptor.name.clone(),
+            &bin_path,
+            cwd,
+            &extra_args,
+            cwd.clone(),
+            caps,
+            false, // keyboard_capture
+        ) {
+            Ok(app) => {
+                log::info!(
+                    "cli_pgap: spawned `{}` for CLI `{cli_name}` (plexi_app=`{plexi_app_cmd}`)",
+                    app_id
+                );
+                Some(app)
+            }
+            Err(e) => {
+                log::warn!(
+                    "cli_pgap: failed to launch `{cli_name}` via plexi_app=`{plexi_app_cmd}`: {e}"
+                );
+                None
+            }
         }
     }
 

--- a/src/plexi_descriptor.rs
+++ b/src/plexi_descriptor.rs
@@ -41,6 +41,15 @@ pub struct PlexiDescriptor {
     pub commands: Vec<Command>,
     #[serde(default)]
     pub live_state: Option<LiveState>,
+    /// Shell command to spawn as a PGAP process instead of rendering the
+    /// auto-generated form UI. Split on whitespace: first token is the binary,
+    /// rest are initial args.
+    #[serde(default)]
+    pub plexi_app: Option<String>,
+    /// Capability strings granted to the spawned PGAP process. Same vocabulary
+    /// as manifest.toml capabilities.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -518,6 +527,34 @@ mod tests {
             }
             other => panic!("expected EnumMissingValues, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_descriptor_with_plexi_app() {
+        let json = r#"{
+            "plexi_version": "0.1",
+            "name": "parallax",
+            "version": "1.0.0",
+            "commands": [],
+            "plexi_app": "parallax-ui --pane",
+            "capabilities": ["ai.query", "panes.spawn"]
+        }"#;
+        let d = parse(json).expect("descriptor with plexi_app parses");
+        assert_eq!(d.plexi_app.as_deref(), Some("parallax-ui --pane"));
+        assert_eq!(d.capabilities, vec!["ai.query", "panes.spawn"]);
+    }
+
+    #[test]
+    fn parse_descriptor_without_plexi_app_still_works() {
+        let json = r#"{
+            "plexi_version": "0.1",
+            "name": "old-cli",
+            "version": "0.1.0",
+            "commands": []
+        }"#;
+        let d = parse(json).expect("old-style descriptor without plexi_app parses");
+        assert!(d.plexi_app.is_none());
+        assert!(d.capabilities.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `plexi_app: Option<String>` and `capabilities: Vec<String>` to `PlexiDescriptor` so CLIs can declare a custom PGAP process to spawn instead of the auto-generated form UI
- Adds **Tier 4** resolution in `launch_app_by_id_with_layout`: when `plexi open <cli>` finds no installed app, probes `<cli> --plexi`, checks for `plexi_app`, and spawns it as a full PGAP process with identity `cli:<name>`
- Adds **version-staleness cache invalidation** to `cli_crawl`: compares cached `version` field to live `<cli> --version` on each cache hit; evicts and re-crawls on mismatch so stale `plexi_app` strings are never served
- Surfaces `plexi_app` and `capabilities` in `plexi descriptor probe` output

## Test plan

- [ ] `cargo test --lib` — 292 tests, 0 failures (1 pre-existing doctest failure in app_protocol.rs unrelated to this PR)
- [ ] `plexi descriptor probe parallax` (or any CLI with `--plexi` support + `plexi_app` field) shows the `plexi_app:` line
- [ ] `plexi open <cli>` where `<cli>` has `plexi_app` declared spawns the PGAP process in a new pane
- [ ] `plexi open parallax` where `parallax` is also installed as a registry app — registry wins (installed app opens, not the CLI PGAP process)