### PR TITLE
feat(descriptor): warn when installed app shadows same-named CLI plexi_app

### DIFF
--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -495,6 +495,12 @@ impl PlexiApp {
         // Try registry first; if it returns None, fall through to Tier 4.
         let registry_process = self.registry.launch_process(id, &cwd, args);
         if let Some(process) = registry_process {
+            if cli_binary_in_path(id) {
+                log::warn!(
+                    "launch_app_by_id: installed app '{id}' is shadowing a CLI of the same name \
+                     — installed app takes precedence; uninstall the app to use the CLI's plexi_app"
+                );
+            }
             self.open_process_app_pane(id, process, cwd, group, hint.as_deref());
             return;
         }
@@ -599,6 +605,14 @@ impl PlexiApp {
     }
 }
 
+/// Returns `true` if a binary named `name` exists in any directory on `PATH`.
+/// Used to detect when an installed Plexi app shadows a same-named CLI binary.
+fn cli_binary_in_path(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).any(|dir| dir.join(name).is_file()))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -676,6 +690,23 @@ mod tests {
             snap.pane_titles.values().any(|t| t == "Terminal"),
             "expected a Terminal pane in snapshot after SpawnPane, got: {:?}",
             snap.pane_titles,
+        );
+    }
+
+    #[test]
+    fn cli_binary_in_path_finds_real_binary() {
+        // `/bin/sh` is guaranteed to exist on macOS/Linux.
+        assert!(
+            cli_binary_in_path("sh"),
+            "expected to find `sh` on PATH"
+        );
+    }
+
+    #[test]
+    fn cli_binary_in_path_misses_nonexistent() {
+        assert!(
+            !cli_binary_in_path("plexi-815-nonexistent-binary-zzz"),
+            "expected not to find a nonexistent binary on PATH"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `cli_binary_in_path()` helper that checks PATH for a binary matching the app id
- Fires a `log::warn!` when the installed app registry returns a process for an id that also exists as a binary on PATH — surfacing the shadowing before it causes confusion
- Adds two unit tests: one verifying `sh` is found, one verifying a nonexistent binary is not

The core feature work (`plexi_app`/`capabilities` fields in `PlexiDescriptor`, version-based cache invalidation in `cli_crawl`, Tier 4 resolution in `pane_ops/create`, `cli:<name>` app identity) landed on alpha in prior commits. This PR ships the remaining "done when" criterion from #815: the shadowing warn log.

## Test plan
- [ ] `cargo test` passes (297 tests)
- [ ] `plexi open <installed-app-id>` where a same-named CLI exists → check `~/.plexi-alpha/plexi.log` for the shadowing warn

Closes #815