### PR TITLE
feat(sdk): workspace-scoped app state with walk-up resolution

### DIFF
--- a/examples/stand-up-reminder/stand_up_reminder.py
+++ b/examples/stand-up-reminder/stand_up_reminder.py
@@ -73,6 +73,12 @@ def _format_duration(secs: float) -> str:
 
 
 class StandUpReminderApp(App):
+    def on_inject(self, ctx: RenderContext, payload: dict) -> None:
+        if "interval_idx" in payload:
+            self._interval_idx = int(payload["interval_idx"])
+            _, label = INTERVALS[self._interval_idx]
+            ctx.info(f"Restored interval to {label} from persisted state")
+
     def on_init(self, ctx: RenderContext) -> None:
         self._interval_idx = 4  # default: 15 min
         self._reminders_today = 0
@@ -177,6 +183,7 @@ class StandUpReminderApp(App):
             self._schedule_timer(ctx)
             _, label = INTERVALS[self._interval_idx]
             self.emit.info(f"Interval changed to {label}")
+            ctx.save_state({"interval_idx": self._interval_idx})
             self.emit.schedule_render(after_ms=50)
 
     def on_suspend(self) -> None:

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -85,6 +85,7 @@ class App:
         # coroutine can await them without blocking the stdin reader.
         self._pending_capability: "dict[str, asyncio.Queue]" = {}
         self._pending_secret: "dict[str, asyncio.Queue]" = {}
+        self._app_state: dict = {}
         self._pending_http: "dict[str, asyncio.Queue]" = {}
         # v3.3 ai.query broker (#284): awaits PlexiEvent::AiResponse keyed
         # on request_id. Each entry is consumed by a single ai_query() call.
@@ -662,6 +663,7 @@ class App:
                     return
 
                 elif t == "inject_state":
+                    self._app_state = ev.get("payload") or {}
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_inject, ctx, ev.get("payload", {}))
 

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -504,6 +504,15 @@ class RenderContext:
         """Request a secret by key. Alias for emit.get_secret(). Use with ``await``."""
         return await self.emit.get_secret(key)
 
+    def load_state(self) -> dict:
+        """Return persisted app state loaded at startup. {} if nothing saved."""
+        return dict(self._app._app_state)
+
+    def save_state(self, state: dict) -> None:
+        """Persist state to workspace (if workspace active) or global storage.
+        Fire-and-forget — no acknowledgement from host."""
+        _emit({"type": "save_app_state", "payload": state})
+
     async def http_request(self, url: str, method: str = "GET",
                            headers: "dict[str, str] | None" = None,
                            body: "str | None" = None) -> str:

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -135,9 +135,9 @@ pub enum PlexiEvent {
         pipe_id: String,
         dropped_frames: u64,
     },
-    /// Harness-only: drop a JSON payload into the app's `on_inject` hook.
-    /// Used by `pgap_test_harness` to seed deterministic state without
-    /// round-tripping through real inputs.
+    /// Drop a JSON payload into the app's `on_inject` hook.
+    /// Sent at startup with persisted app state (workspace if available, else global).
+    /// Also usable from `pgap_test_harness` to seed deterministic state.
     InjectState { payload: serde_json::Value },
     /// Host broker response to a `DrawCommand::HttpRequest`. `error` is present
     /// when the request failed; `body` may still carry a partial response.
@@ -768,6 +768,8 @@ pub enum HostCommand {
     },
     /// Request a workspace-scoped secret. Scoped to Init.workspace_root automatically.
     SecretGet { key: String },
+    /// Save app state. Host writes to workspace or global JSON file.
+    SaveAppState { payload: serde_json::Value },
     /// Request to start a run. Host surfaces in Run palette (Cmd+R).
     RunGet {
         intent: String,

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1260,6 +1260,10 @@ impl App for ProcessApp {
                 capabilities: cap_strings,
                 feature_flags: vec!["pane_groups_v1".into()],
             });
+            // Inject persisted state before first render so on_inject runs with data.
+            let state = load_app_state(&self.type_id, &self.workspace_root);
+            self.outbound_events.push_back(PlexiEvent::InjectState { payload: state });
+            log::info!("ProcessApp[{}]: injected persisted state at startup", self.type_id);
         }
 
         if (size - self.last_size).length() > 1.0 {
@@ -1789,6 +1793,29 @@ fn default_midi_device() -> Arc<dyn MidiDevice> {
 #[cfg(test)]
 fn default_midi_device() -> Arc<dyn MidiDevice> {
     Arc::new(crate::midi::MockMidiDevice::new())
+}
+
+fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json::Value {
+    let filename = format!("{type_id}.json");
+    let workspace_path = workspace_root.join(".plexi").join("app_state").join(&filename);
+    if workspace_path.exists() {
+        if let Ok(bytes) = std::fs::read(&workspace_path) {
+            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                log::info!("load_app_state[{type_id}]: loaded workspace state from {}", workspace_path.display());
+                return val;
+            }
+        }
+    }
+    let global_path = crate::config::config_dir().join("app_state").join(&filename);
+    if global_path.exists() {
+        if let Ok(bytes) = std::fs::read(&global_path) {
+            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                log::info!("load_app_state[{type_id}]: loaded global state from {}", global_path.display());
+                return val;
+            }
+        }
+    }
+    serde_json::Value::Object(serde_json::Map::new())
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -3182,5 +3209,29 @@ mod reload_tests {
             id_a, id_b,
             "two launches of the same app must produce distinct PIDs"
         );
+    }
+}
+
+#[cfg(test)]
+mod app_state_tests {
+    use super::*;
+
+    #[test]
+    fn load_app_state_returns_empty_when_no_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = load_app_state("test-app", dir.path());
+        assert_eq!(result, serde_json::Value::Object(serde_json::Map::new()));
+    }
+
+    #[test]
+    fn load_app_state_reads_workspace_file_over_global() {
+        let ws_dir = tempfile::tempdir().expect("workspace tempdir");
+        let state_dir = ws_dir.path().join(".plexi").join("app_state");
+        std::fs::create_dir_all(&state_dir).expect("mkdir");
+        let state_path = state_dir.join("my-app.json");
+        std::fs::write(&state_path, r#"{"interval_idx":3}"#).expect("write");
+
+        let result = load_app_state("my-app", ws_dir.path());
+        assert_eq!(result["interval_idx"], serde_json::json!(3));
     }
 }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1451,6 +1451,39 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+
+            // ── App state save ─────────────────────────────────────────────
+            HostCommand::SaveAppState { payload } => {
+                let filename = format!("{}.json", self.type_id);
+                let workspace_toml = self.workspace_root.join(".plexi").join("workspace.toml");
+                let state_path = if workspace_toml.exists() {
+                    self.workspace_root.join(".plexi").join("app_state").join(&filename)
+                } else {
+                    crate::config::config_dir().join("app_state").join(&filename)
+                };
+                if let Some(dir) = state_path.parent() {
+                    if let Err(e) = std::fs::create_dir_all(dir) {
+                        log::warn!("ProcessApp[{}]: SaveAppState: mkdir failed: {e}", self.type_id);
+                        return;
+                    }
+                }
+                match serde_json::to_vec_pretty(&payload) {
+                    Ok(bytes) => {
+                        if let Err(e) = std::fs::write(&state_path, &bytes) {
+                            log::warn!("ProcessApp[{}]: SaveAppState: write failed: {e}", self.type_id);
+                        } else {
+                            log::info!(
+                                "ProcessApp[{}]: saved app state to {}",
+                                self.type_id,
+                                state_path.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("ProcessApp[{}]: SaveAppState: serialize failed: {e}", self.type_id);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #834

## Summary
- `ctx.save_state(d)` / `ctx.load_state()` added to Python SDK `RenderContext`
- Host loads persisted state at app startup and injects via `PlexiEvent::InjectState` before first render — `on_inject` receives it automatically
- Resolution: `<workspace_root>/.plexi/app_state/<app_id>.json` → `~/.plexi-<channel>/app_state/<app_id>.json` fallback
- Save writes to workspace path if `workspace.toml` detected, else global
- `stand-up-reminder` updated to persist/restore `interval_idx`
- 2 new unit tests for `load_app_state` (empty case + workspace-over-global priority)

## Test plan
- [ ] Open stand-up-reminder in a workspace directory (one with `.plexi/workspace.toml`)
- [ ] Change interval with `j`/`k` — verify `.plexi/app_state/stand-up-reminder.json` written
- [ ] Close and reopen stand-up-reminder — verify interval restored
- [ ] Open outside any workspace — verify global `~/.plexi-alpha/app_state/stand-up-reminder.json` used

## Breaks if
Stand-up-reminder opens with default interval (15 min) every time despite a saved workspace state file existing at `<workspace_root>/.plexi/app_state/stand-up-reminder.json`.