### PR TITLE
feat(pane): plexi open returns new pane ID + plexi pane send injects text

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -932,11 +932,11 @@ impl PlexiApp {
                         }
                     }
                 }
-                crate::app_protocol::HostCommand::SendToPane { pane_id, text } => {
-                    log::info!("pane_ipc: kind=send_to_pane pane_id={pane_id} len={}", text.len());
+                crate::app_protocol::HostCommand::SendToPane { pane_id, text, response_file } => {
+                    log::info!("pane_ipc: kind=send_to_pane pane_id={pane_id} len={} response_file={response_file:?}", text.len());
                     let text_with_newlines = text.replace("\\n", "\n");
                     let active = self.active_window;
-                    if let Some(term) = self.windows[active]
+                    let result = if let Some(term) = self.windows[active]
                         .panes
                         .get_mut(pane_id)
                         .and_then(|p| p.as_terminal_mut())
@@ -944,9 +944,19 @@ impl PlexiApp {
                         term.backend.process_command(egui_term::BackendCommand::Write(
                             text_with_newlines.into_bytes(),
                         ));
+                        Ok(())
                     } else {
                         log::warn!("pane_ipc: send_to_pane: pane_id={pane_id} not found or not a terminal");
-                        eprintln!("error: pane {pane_id} not found or is not a terminal pane");
+                        Err(format!("pane {pane_id} not found or is not a terminal pane"))
+                    };
+                    if let Some(rf) = response_file {
+                        let json = match result {
+                            Ok(()) => r#"{"ok":true}"#.to_string(),
+                            Err(ref msg) => format!("{{\"error\":{}}}", serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))),
+                        };
+                        if let Err(e) = std::fs::write(rf, &json) {
+                            log::error!("pane_ipc: send_to_pane: could not write response file: {e}");
+                        }
                     }
                 }
                 crate::app_protocol::HostCommand::Notify {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -921,9 +921,33 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id}");
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, response_file, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} response_file={response_file:?}");
+                    let new_pane_id = self.host.next_pane_id();
                     self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                    if let Some(rf) = response_file {
+                        let json = format!("{{\"pane_id\":{new_pane_id}}}");
+                        if let Err(e) = std::fs::write(rf, &json) {
+                            log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
+                        }
+                    }
+                }
+                crate::app_protocol::HostCommand::SendToPane { pane_id, text } => {
+                    log::info!("pane_ipc: kind=send_to_pane pane_id={pane_id} len={}", text.len());
+                    let text_with_newlines = text.replace("\\n", "\n");
+                    let active = self.active_window;
+                    if let Some(term) = self.windows[active]
+                        .panes
+                        .get_mut(pane_id)
+                        .and_then(|p| p.as_terminal_mut())
+                    {
+                        term.backend.process_command(egui_term::BackendCommand::Write(
+                            text_with_newlines.into_bytes(),
+                        ));
+                    } else {
+                        log::warn!("pane_ipc: send_to_pane: pane_id={pane_id} not found or not a terminal");
+                        eprintln!("error: pane {pane_id} not found or is not a terminal pane");
+                    }
                 }
                 crate::app_protocol::HostCommand::Notify {
                     level, title, body, kind, options, input_prompt,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -912,6 +912,8 @@ pub enum HostCommand {
         from_pane_id: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         request_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
@@ -934,6 +936,13 @@ pub enum HostCommand {
     /// Close a pane by PaneId. Sent by `plexi pane close`. Fire-and-forget.
     ClosePane {
         pane_id: u64,
+    },
+
+    /// Write text to a running pane's PTY stdin. Sent by `plexi pane send`.
+    /// `\n` in text (literal backslash-n) is interpreted as Enter.
+    SendToPane {
+        pane_id: u64,
+        text: String,
     },
 
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
@@ -2521,7 +2530,7 @@ mod tests {
         let json = r#"{"type":"spawn_pane","type_id":"snake","layout":"split_v","args":["--foo"],"pipe_id":"p1"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Host(HostCommand::SpawnPane { type_id, layout, args, pipe_id, from_pane_id, request_id }) => {
+            DrawCommand::Host(HostCommand::SpawnPane { type_id, layout, args, pipe_id, from_pane_id, request_id, .. }) => {
                 assert_eq!(type_id, "snake");
                 assert_eq!(layout, "split_v");
                 assert_eq!(args, &["--foo"]);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -940,9 +940,12 @@ pub enum HostCommand {
 
     /// Write text to a running pane's PTY stdin. Sent by `plexi pane send`.
     /// `\n` in text (literal backslash-n) is interpreted as Enter.
+    /// Host writes `{"ok":true}` or `{"error":"..."}` to `response_file` when set.
     SendToPane {
         pane_id: u64,
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
     },
 
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1429,15 +1429,56 @@ pub fn pane_close_cli(pane_id: u64) -> i32 {
 
 /// `plexi pane send <pane_id> <text>`
 ///
-/// Writes text to the target pane's PTY stdin. Fire-and-forget.
+/// Writes text to the target pane's PTY stdin. Polls a response file to
+/// surface errors (e.g. pane not found) back to the caller.
 /// Returns 0 on success, 1 on error.
 pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
-    log::info!("pane_send:cli: pane_id={pane_id} len={}", text.len());
-    send_to_socket(serde_json::json!({
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("send-to-pane-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+    log::info!("pane_send:cli: pane_id={pane_id} len={} response_file={response_file:?}", text.len());
+    let code = send_to_socket(serde_json::json!({
         "type": "send_to_pane",
         "pane_id": pane_id,
         "text": text,
-    }))
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            return 0;
+                        }
+                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                            eprintln!("error: {msg}");
+                            return 1;
+                        }
+                    }
+                    return 0;
+                }
+                Err(e) => {
+                    log::warn!("pane_send:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane send response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
 }
 
 /// `plexi open <type_id> [args...] [--layout=X]`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1427,6 +1427,19 @@ pub fn pane_close_cli(pane_id: u64) -> i32 {
     }))
 }
 
+/// `plexi pane send <pane_id> <text>`
+///
+/// Writes text to the target pane's PTY stdin. Fire-and-forget.
+/// Returns 0 on success, 1 on error.
+pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
+    log::info!("pane_send:cli: pane_id={pane_id} len={}", text.len());
+    send_to_socket(serde_json::json!({
+        "type": "send_to_pane",
+        "pane_id": pane_id,
+        "text": text,
+    }))
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a
@@ -1439,21 +1452,58 @@ pub fn pane_close_cli(pane_id: u64) -> i32 {
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
     let layout_str = layout.unwrap_or("split_v");
-    let payload = serde_json::json!({
-        "type": "spawn_pane",
-        "type_id": type_id,
-        "args": args,
-        "layout": layout_str,
-    });
 
     // Socket path is set when running inside a Plexi pane — use it directly so
     // the command reaches the correct running instance regardless of channel.
     if std::env::var("PLEXI_SOCKET").is_ok() {
+        let id = uuid::Uuid::new_v4();
+        let response_file = crate::config::config_dir()
+            .join(format!("spawn-pane-response-{id}.json"))
+            .to_string_lossy()
+            .into_owned();
+        let payload = serde_json::json!({
+            "type": "spawn_pane",
+            "type_id": type_id,
+            "args": args,
+            "layout": layout_str,
+            "response_file": response_file,
+        });
+        log::info!("open:cli: sending via socket response_file={response_file:?}");
         let code = send_to_socket(payload);
-        if code == 0 {
-            println!("opened: {type_id}");
+        if code != 0 {
+            return code;
         }
-        return code;
+        let response_path = std::path::PathBuf::from(&response_file);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if response_path.exists() {
+                match std::fs::read_to_string(&response_path) {
+                    Ok(content) => {
+                        let _ = std::fs::remove_file(&response_path);
+                        // Parse {"pane_id": N} and print just the number
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+                                println!("{pid}");
+                                return 0;
+                            }
+                        }
+                        // Fallback: print raw content
+                        print!("{content}");
+                        return 0;
+                    }
+                    Err(e) => {
+                        log::warn!("open:cli: could not read response file: {e}");
+                        eprintln!("error: could not read response file: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("error: timed out waiting for open response");
+                return 1;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 
     // Fallback: write to the spawn-queue for the channel this binary belongs to.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -218,6 +218,17 @@ pub enum PaneCmd {
         /// Pane ID (from `plexi pane list`)
         pane_id: u64,
     },
+    /// Send text to a running pane's PTY stdin [requires PLEXI_SOCKET — run inside a Plexi pane]
+    ///
+    /// Use `\n` in the text to send Enter (submits the command).
+    ///
+    /// Example: plexi pane send 42 "git status\n"
+    Send {
+        /// Pane ID (from `plexi pane list`)
+        pane_id: u64,
+        /// Text to inject (use \n for Enter)
+        text: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,7 @@ fn main() -> eframe::Result {
                         PaneCmd::List => std::process::exit(cli::pane_list_cli()),
                         PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
                         PaneCmd::Close { pane_id } => std::process::exit(cli::pane_close_cli(pane_id)),
+                        PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
                     },
                     Commands::Open { type_id, layout, extra_args } => {
                         std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref()));

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -677,6 +677,7 @@ mod tests {
             pipe_id: None,
             from_pane_id: None,
             request_id: None,
+            response_file: None,
         });
         h.run_frames(2);
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -756,6 +756,7 @@ impl ProcessApp {
                 pipe_id,
                 from_pane_id,
                 request_id,
+                response_file: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)
@@ -1441,6 +1442,12 @@ impl ProcessApp {
             HostCommand::ClosePane { .. } => {
                 log::warn!(
                     "ProcessApp[{}]: received ClosePane over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            HostCommand::SendToPane { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received SendToPane over PGAP — ignored (use PLEXI_SOCKET instead)",
                     self.type_id
                 );
             }


### PR DESCRIPTION
## Summary

- `plexi open terminal` (and `plexi open <app>`) now prints the new pane's ID on stdout. Uses the `response_file` polling pattern already established by `pane list`.
- New `plexi pane send <pane_id> <text>` subcommand writes text directly to a running pane's PTY stdin. Literal `\n` in the text is interpreted as Enter.

## Usage

```bash
# Spawn a pane and capture its ID
PANE=$(plexi open terminal)
plexi pane focus $PANE

# Send a command to a running pane (submits immediately due to \n)
plexi pane send 42 "git status\n"

# Stage text without executing (no \n)
plexi pane send 42 "git status"
```

## Test plan

- [ ] `plexi open terminal` prints a numeric pane ID on stdout
- [ ] `plexi open <app-id>` prints a numeric pane ID on stdout
- [ ] `plexi pane send <id> "text\n"` injects text and submits it (Enter)
- [ ] `plexi pane send <id> "text"` stages text without submitting
- [ ] `plexi pane send <invalid-id> "text"` prints an error message
- [ ] `plexi pane --help` shows the `send` subcommand
- [ ] `plexi open --help` still works

Closes #839