### PR TITLE
fix(context): Cmd+Shift+R renames correct context

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2136,7 +2136,14 @@ impl eframe::App for PlexiApp {
                     self.open_secrets_manager();
                 }
                 Action::RenameContext => {
-                    self.renaming_window = Some(self.active_window);
+                    let ctx_idx = self.router.active_idx();
+                    self.rename_buffer = self.router.active().name.clone();
+                    self.renaming_window = Some(ctx_idx);
+                    log::info!(
+                        "RenameContext: opening rename for context {:?} (idx {})",
+                        self.router.active().name,
+                        ctx_idx
+                    );
                 }
                 Action::ToggleNotificationModal => {
                     if self.show_notification_modal {


### PR DESCRIPTION
## Summary
- Fixes `Action::RenameContext` to store `router.active_idx()` instead of `active_window` — these index different collections (`router.contexts` vs `windows`) and diverge when context count differs from window count
- Pre-populates `rename_buffer` with the active context's current name (mirrors `RenamePane` pattern)
- Adds `log::info!` trace confirming which context index is targeted on rename

Closes #820

## Test plan
- [ ] Open Plexi with 2+ contexts in the sidebar
- [ ] Navigate to a context that is NOT the first
- [ ] Press Cmd+Shift+R — confirm rename modal opens pre-filled with that context's name
- [ ] Type a new name and confirm — the correct (active) context is renamed