### PR TITLE
fix(sdk): expose from_pane_id + request_id on RenderContext.spawn_pane()

### DIFF
--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -528,9 +528,12 @@ class RenderContext:
 
     def spawn_pane(self, type_id: str, layout: str = "split_v",
                    args: "list[str] | None" = None,
-                   pipe_id: "str | None" = None) -> None:
+                   pipe_id: "str | None" = None,
+                   from_pane_id: "int | None" = None,
+                   request_id: "str | None" = None) -> None:
         """Request the host to open a new pane. Requires panes.spawn capability."""
-        self.emit.spawn_pane(type_id, layout=layout, args=args, pipe_id=pipe_id)
+        self.emit.spawn_pane(type_id, layout=layout, args=args, pipe_id=pipe_id,
+                             from_pane_id=from_pane_id, request_id=request_id)
 
     def frame_done(self) -> None:
         self._buf.append(json.dumps({"type": "frame_done", "frame_id": self.frame_id}) + "\n")


### PR DESCRIPTION
Completes #752 — one field missed from PR #830.

`ctx.spawn_pane()` (the `RenderContext` convenience method) wasn't passing `from_pane_id` or `request_id` through to `_emitter.spawn_pane()`. Apps using the high-level method couldn't access the new fields added in #830.

## Change

`sdk/python/plexi_sdk/_render_context.py` — add `from_pane_id` and `request_id` params to `spawn_pane()` and forward to emitter.

**Breaks if:** `ctx.spawn_pane("snake", from_pane_id=X)` still splits relative to the coordinator instead of pane X.