### PR TITLE
fix(logging): demote per-app AppRegistry load logs from info to debug

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -345,7 +345,7 @@ impl AppRegistry {
                 Ok(installed) => {
                     let id = installed.manifest.id.clone();
                     if let Some(existing) = self.apps.get(&id) {
-                        log::info!(
+                        log::debug!(
                             "AppRegistry: {} entry '{}' (from {:?}) shadows {} entry from {:?}",
                             source.label(),
                             id,
@@ -354,7 +354,7 @@ impl AppRegistry {
                             existing.bin_path.parent().unwrap_or(&existing.bin_path),
                         );
                     } else {
-                        log::info!(
+                        log::debug!(
                             "AppRegistry: loaded {} entry '{}' from {:?}",
                             source.label(),
                             id,
@@ -424,7 +424,7 @@ impl AppRegistry {
         let bin_path = resolve_entry(app_dir, &manifest.app.entry)?;
 
         for (name, decl) in &manifest.secrets {
-            log::info!(
+            log::debug!(
                 "AppRegistry: {} declares secret '{name}' (required={}, description=\"{}\")",
                 manifest.app.id,
                 decl.required,


### PR DESCRIPTION
Fixes #835.

## What

Demotes 3 `log::info!` calls in `AppRegistry` scan loop to `log::debug!`:
- Per-app "loaded entry" line (fires for every app discovered)
- Per-app "shadows entry" line (fires when a local entry overrides global)
- Per-secret "declares secret" line (fires for each secret in each manifest)

Launch-time logs remain at `info` — those fire once per user action and are diagnostically useful.

## Why

With 35+ apps, `plexi app list` / `plexi install` dumped 30–70 `[INFO]` lines to stderr before printing any output. The actual table was buried.

## Done when

`plexi app list` prints only the apps table (or empty-state hint) with no log lines intermixed.

**Breaks if:** `plexi app list` output contains `[INFO]` lines from the registry load path.