### PR TITLE
fix(docs): mark pseudocode doctest as ignore — closes #815

### DIFF
--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -18,7 +18,7 @@
 //!
 //! # Example app (pseudocode)
 //!
-//! ```no_run
+//! ```ignore
 //! let init = read_json_line(stdin);  // PlexiEvent::Init
 //! write_json(DrawCommand::Ready { sdk: "my-sdk/1.0.0".into(), features_used: vec![] });
 //! loop {


### PR DESCRIPTION
## Summary

- The `plexi_app` field feature (issue #815) was already fully implemented and merged via PRs #831 and #836
- This PR closes the issue by fixing a pre-existing broken doctest in `src/app_protocol.rs`: the module-level example was pseudocode using undefined helpers (`read_json_line`, `write_json`) that cargo was trying to compile
- Marking the block `ignore` stops rustdoc from compiling it; all 302 lib tests pass

## Verification

`cargo test` passes: 302 tests ok, 0 failed.

Closes #815