### PR TITLE
feat(permissions): add PermissionStore + three-state model

### DIFF
--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -21,7 +21,7 @@ class PermissionTestApp(App):
     def __init__(self):
         self.result = None  # None = pending, True = granted, False = denied
 
-    def on_init(self, ctx: RenderContext) -> None:
+    def on_init(self, _ctx: RenderContext) -> None:
         self.emit.info("permission-test: requesting net.http capability")
         granted = self.emit.capability_request("net.http")
         self.result = granted
@@ -31,7 +31,7 @@ class PermissionTestApp(App):
             self.emit.info("permission-test: net.http DENIED (or permanently blocked)")
 
     def render(self, ctx: RenderContext) -> None:
-        ctx.clear()
+        ctx.clear("#1e1e2e")
         cx = ctx.w / 2
         cy = ctx.h / 2
 

--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""permission-test — POC app for PermissionStore testing (issue #426).
+
+Requests net.http at runtime (not declared in manifest) so the grant/deny
+modal fires immediately on launch. Displays the decision result so the tester
+can confirm it was received. On relaunch with a Red entry in permissions.toml
+the host auto-denies without showing the modal.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
+
+from plexi_sdk import App, RenderContext
+
+GRAY = "#6c7086"
+GREEN = "#a6e3a1"
+RED = "#f38ba8"
+WHITE = "#cdd6f4"
+
+class PermissionTestApp(App):
+    def __init__(self):
+        self.result = None      # None = pending, True = granted, False = denied
+        self.requested = False
+
+    def on_init(self, ctx, emit):
+        emit.info("permission-test: requesting net.http capability")
+        granted = emit.capability_request("net.http")
+        self.result = granted
+        self.requested = True
+        if granted:
+            emit.info("permission-test: net.http GRANTED")
+        else:
+            emit.info("permission-test: net.http DENIED (or permanently blocked)")
+
+    def render(self, ctx: RenderContext, emit):
+        ctx.clear()
+        w, h = ctx.width, ctx.height
+        cx = w / 2
+        cy = h / 2
+
+        ctx.text(cx, cy - 30, "Permission Test", color=WHITE, size=18,
+                 align="center", bold=True)
+        ctx.text(cx, cy - 10, "Requested: net.http", color=GRAY, size=13,
+                 align="center")
+
+        if self.result is True:
+            ctx.text(cx, cy + 15, "GRANTED", color=GREEN, size=16,
+                     align="center", bold=True)
+            ctx.text(cx, cy + 35,
+                     "Check ~/.plexi-pr-860/permissions.toml for a 'green' entry.",
+                     color=GRAY, size=11, align="center")
+        elif self.result is False:
+            ctx.text(cx, cy + 15, "DENIED / BLOCKED", color=RED, size=16,
+                     align="center", bold=True)
+            ctx.text(cx, cy + 35,
+                     "Check ~/.plexi-pr-860/permissions.toml for a 'red' entry.",
+                     color=GRAY, size=11, align="center")
+        else:
+            ctx.text(cx, cy + 15, "Waiting for decision...", color=GRAY,
+                     size=13, align="center")
+
+if __name__ == "__main__":
+    PermissionTestApp().run()

--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -18,10 +18,8 @@ RED = "#f38ba8"
 WHITE = "#cdd6f4"
 
 class PermissionTestApp(App):
-    def __init__(self):
-        self.result = None  # None = pending, True = granted, False = denied
-
     def on_init(self, _ctx: RenderContext) -> None:
+        self.result = None
         self.emit.info("permission-test: requesting net.http capability")
         granted = self.emit.capability_request("net.http")
         self.result = granted

--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -18,10 +18,10 @@ RED = "#f38ba8"
 WHITE = "#cdd6f4"
 
 class PermissionTestApp(App):
-    def on_init(self, _ctx: RenderContext) -> None:
+    async def on_init(self, _ctx: RenderContext) -> None:
         self.result = None
         self.emit.info("permission-test: requesting net.http capability")
-        granted = self.emit.capability_request("net.http")
+        granted = await self.emit.capability_request("net.http")
         self.result = granted
         if granted:
             self.emit.info("permission-test: net.http GRANTED")

--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -2,9 +2,9 @@
 """permission-test — POC app for PermissionStore testing (issue #426).
 
 Requests net.http at runtime (not declared in manifest) so the grant/deny
-modal fires immediately on launch. Displays the decision result so the tester
-can confirm it was received. On relaunch with a Red entry in permissions.toml
-the host auto-denies without showing the modal.
+modal fires immediately on launch. Displays the decision so the tester can
+confirm it was received. On relaunch with a Red entry in permissions.toml the
+host auto-denies without showing the modal.
 """
 import sys
 import os
@@ -19,24 +19,21 @@ WHITE = "#cdd6f4"
 
 class PermissionTestApp(App):
     def __init__(self):
-        self.result = None      # None = pending, True = granted, False = denied
-        self.requested = False
+        self.result = None  # None = pending, True = granted, False = denied
 
-    def on_init(self, ctx, emit):
-        emit.info("permission-test: requesting net.http capability")
-        granted = emit.capability_request("net.http")
+    def on_init(self, ctx: RenderContext) -> None:
+        self.emit.info("permission-test: requesting net.http capability")
+        granted = self.emit.capability_request("net.http")
         self.result = granted
-        self.requested = True
         if granted:
-            emit.info("permission-test: net.http GRANTED")
+            self.emit.info("permission-test: net.http GRANTED")
         else:
-            emit.info("permission-test: net.http DENIED (or permanently blocked)")
+            self.emit.info("permission-test: net.http DENIED (or permanently blocked)")
 
-    def render(self, ctx: RenderContext, emit):
+    def render(self, ctx: RenderContext) -> None:
         ctx.clear()
-        w, h = ctx.width, ctx.height
-        cx = w / 2
-        cy = h / 2
+        cx = ctx.w / 2
+        cy = ctx.h / 2
 
         ctx.text(cx, cy - 30, "Permission Test", color=WHITE, size=18,
                  align="center", bold=True)

--- a/examples/permission-test/manifest.toml
+++ b/examples/permission-test/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "permission-test"
+type = "app"
+name = "Permission Test"
+version = "0.1.0"
+description = "Tests PermissionStore persistence — requests net.http at runtime to trigger the grant/deny modal."
+entry = "main.py"
+
+[app.capabilities]
+capabilities = []
+
+[launch]
+layout_hint = { side = "right", split = 0.4 }

--- a/src/app_permissions.rs
+++ b/src/app_permissions.rs
@@ -7,9 +7,10 @@
 //! by a `HashSet<Capability>`.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::convert::TryFrom;
+use std::path::{Path, PathBuf};
 
 // ── Capability enum ───────────────────────────────────────────────────────────
 
@@ -138,6 +139,18 @@ impl fmt::Display for UnknownCapability {
 
 impl std::error::Error for UnknownCapability {}
 
+/// Three-state capability approval model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PermissionState {
+    /// Permanently granted — no prompt on use.
+    Green,
+    /// Ask on every use — routes through the prompt modal.
+    Yellow,
+    /// Permanently blocked — auto-deny without prompt.
+    Red,
+}
+
 impl<'a> TryFrom<&'a str> for Capability {
     type Error = UnknownCapability;
 
@@ -173,6 +186,9 @@ impl<'a> TryFrom<&'a str> for Capability {
 pub struct AppPermissions {
     /// Granted capabilities for this app in this workspace.
     pub capabilities: HashSet<Capability>,
+    /// Permanently blocked capabilities — auto-denied without a modal.
+    #[serde(default)]
+    pub blocked: HashSet<Capability>,
     /// True when this is a built-in app; bypasses all capability checks.
     #[serde(default)]
     pub is_builtin: bool,
@@ -186,6 +202,7 @@ impl AppPermissions {
     pub fn builtin() -> Self {
         Self {
             capabilities: HashSet::new(), // not needed — is_builtin bypasses checks
+            blocked: HashSet::new(),
             is_builtin: true,
             allowed_hosts: vec![],
         }
@@ -209,6 +226,7 @@ impl AppPermissions {
         }
         Self {
             capabilities,
+            blocked: HashSet::new(),
             is_builtin: false,
             allowed_hosts: vec![],
         }
@@ -247,6 +265,128 @@ pub fn check(perms: &AppPermissions, cap: Capability) -> PermissionCheck {
             "App does not have the '{}' capability. Use CapabilityRequest to prompt the user.",
             cap
         ))
+    }
+}
+
+/// Returns true if this capability is permanently blocked for this app.
+/// Callers should check this before adding to pending_prompts — blocked
+/// caps should be auto-denied without showing a modal.
+pub fn is_blocked(perms: &AppPermissions, cap: Capability) -> bool {
+    !perms.is_builtin && perms.blocked.contains(&cap)
+}
+
+// ── PermissionStore ───────────────────────────────────────────────────────────
+
+/// Serializable data stored in `permissions.toml`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct PermissionStoreData {
+    /// Flat map: key = "app_id::workspace_path::capability_str" → state.
+    pub entries: HashMap<String, PermissionState>,
+}
+
+/// Loads, mutates, and persists `permissions.toml` in the Plexi config dir.
+#[derive(Debug)]
+pub struct PermissionStore {
+    data: PermissionStoreData,
+    path: PathBuf,
+}
+
+impl Default for PermissionStore {
+    fn default() -> Self {
+        Self { data: PermissionStoreData::default(), path: PathBuf::new() }
+    }
+}
+
+impl PermissionStore {
+    fn entry_key(app_id: &str, workspace_root: &Path, cap: Capability) -> String {
+        format!("{}::{}::{}", app_id, workspace_root.display(), cap.as_str())
+    }
+
+    /// Load from `config_dir/permissions.toml`. Returns empty store on missing/corrupt file.
+    pub fn load_or_default(config_dir: &Path) -> Self {
+        let path = config_dir.join("permissions.toml");
+        let data = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| toml::from_str::<PermissionStoreData>(&s).ok())
+            .unwrap_or_default();
+        log::info!(
+            "permission_store: loaded {} entries from {}",
+            data.entries.len(),
+            path.display()
+        );
+        Self { data, path }
+    }
+
+    /// Get the stored state for a (app, workspace, capability) triple.
+    pub fn get(&self, app_id: &str, workspace_root: &Path, cap: Capability) -> Option<PermissionState> {
+        self.data.entries.get(&Self::entry_key(app_id, workspace_root, cap)).copied()
+    }
+
+    /// Set the state for a (app, workspace, capability) triple.
+    pub fn set(&mut self, app_id: &str, workspace_root: &Path, cap: Capability, state: PermissionState) {
+        self.data.entries.insert(Self::entry_key(app_id, workspace_root, cap), state);
+    }
+
+    /// Atomically write to disk (temp file + rename).
+    pub fn save(&self) {
+        if self.path.as_os_str().is_empty() {
+            return; // test store with no path — skip
+        }
+        match toml::to_string_pretty(&self.data) {
+            Ok(s) => {
+                let tmp = self.path.with_extension("toml.tmp");
+                if let Err(e) = std::fs::write(&tmp, &s).and_then(|_| std::fs::rename(&tmp, &self.path)) {
+                    log::error!("permission_store: failed to save {}: {e}", self.path.display());
+                } else {
+                    log::info!("permission_store: saved {}", self.path.display());
+                }
+            }
+            Err(e) => log::error!("permission_store: serialize error: {e}"),
+        }
+    }
+
+    /// Apply stored state for a set of declared capabilities.
+    /// Returns `(capabilities, blocked)` sets for constructing AppPermissions.
+    /// - Declared + not stored or Green → granted (capabilities set)
+    /// - Declared + Yellow → not pre-granted (will prompt on CapabilityRequest)
+    /// - Declared + Red → blocked (blocked set)
+    /// - Previously runtime-granted (Green, not in declared) → also added to capabilities
+    pub fn build_permission_sets(
+        &self,
+        app_id: &str,
+        workspace_root: &Path,
+        declared: &HashSet<Capability>,
+    ) -> (HashSet<Capability>, HashSet<Capability>) {
+        let mut capabilities = HashSet::new();
+        let mut blocked = HashSet::new();
+
+        // Apply stored state to declared capabilities
+        for &cap in declared {
+            match self.get(app_id, workspace_root, cap) {
+                Some(PermissionState::Yellow) => {}  // will prompt on use
+                Some(PermissionState::Red) => { blocked.insert(cap); }
+                _ => { capabilities.insert(cap); }  // Green or not stored → grant
+            }
+        }
+
+        // Also restore any runtime-granted capabilities from previous sessions
+        let prefix_green = format!("{}::{}", app_id, workspace_root.display());
+        for (key, &state) in &self.data.entries {
+            if !key.starts_with(&prefix_green) { continue; }
+            let cap_str = match key.split("::").nth(2) {
+                Some(s) => s,
+                None => continue,
+            };
+            let Ok(cap) = Capability::try_from(cap_str) else { continue };
+            if declared.contains(&cap) { continue; } // already handled above
+            match state {
+                PermissionState::Green => { capabilities.insert(cap); }
+                PermissionState::Red => { blocked.insert(cap); }
+                PermissionState::Yellow => {}
+            }
+        }
+
+        (capabilities, blocked)
     }
 }
 
@@ -362,5 +502,56 @@ mod tests {
             }
             PermissionCheck::Allowed => panic!("must be denied without manifest declaration"),
         }
+    }
+
+    #[test]
+    fn permission_store_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = std::path::Path::new("/test/project");
+        let mut store = PermissionStore::load_or_default(tmp.path());
+        store.set("my-app", workspace, Capability::FsRead, PermissionState::Green);
+        store.set("my-app", workspace, Capability::NetHttp, PermissionState::Red);
+        store.save();
+
+        let reloaded = PermissionStore::load_or_default(tmp.path());
+        assert_eq!(reloaded.get("my-app", workspace, Capability::FsRead), Some(PermissionState::Green));
+        assert_eq!(reloaded.get("my-app", workspace, Capability::NetHttp), Some(PermissionState::Red));
+        assert_eq!(reloaded.get("my-app", workspace, Capability::FsWrite), None);
+    }
+
+    #[test]
+    fn build_permission_sets_applies_stored_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = std::path::Path::new("/test/project");
+        let mut store = PermissionStore::load_or_default(tmp.path());
+        store.set("my-app", workspace, Capability::NetHttp, PermissionState::Red);
+        store.set("my-app", workspace, Capability::FsWrite, PermissionState::Yellow);
+
+        let declared: HashSet<Capability> = [Capability::FsRead, Capability::NetHttp, Capability::FsWrite].into();
+        let (caps, blocked) = store.build_permission_sets("my-app", workspace, &declared);
+
+        // FsRead: not stored → granted
+        assert!(caps.contains(&Capability::FsRead));
+        // NetHttp: Red → blocked, not in caps
+        assert!(blocked.contains(&Capability::NetHttp));
+        assert!(!caps.contains(&Capability::NetHttp));
+        // FsWrite: Yellow → not pre-granted, not blocked
+        assert!(!caps.contains(&Capability::FsWrite));
+        assert!(!blocked.contains(&Capability::FsWrite));
+    }
+
+    #[test]
+    fn is_blocked_returns_true_for_blocked_cap() {
+        let mut perms = AppPermissions::default();
+        perms.blocked.insert(Capability::NetHttp);
+        assert!(is_blocked(&perms, Capability::NetHttp));
+        assert!(!is_blocked(&perms, Capability::FsRead));
+    }
+
+    #[test]
+    fn is_blocked_always_false_for_builtin() {
+        let mut perms = AppPermissions::builtin();
+        perms.blocked.insert(Capability::NetHttp); // even if manually set
+        assert!(!is_blocked(&perms, Capability::NetHttp));
     }
 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -135,6 +135,8 @@ pub struct ProcessApp {
     pub(crate) workspace_root: PathBuf,
     /// Granted capabilities for this app instance.
     pub(crate) permissions: AppPermissions,
+    /// Persisted three-state permission store. Updated on grant/deny decisions.
+    pub(crate) permission_store: crate::app_permissions::PermissionStore,
     /// Typed pipe registry.
     pub(crate) pipe_registry: Arc<Mutex<TypedPipeRegistry>>,
     pub(crate) run_registry: RunRegistry,
@@ -518,8 +520,16 @@ impl ProcessApp {
             })
             .expect("failed to spawn app-reaper thread");
 
+        let config_dir = crate::config::config_dir();
+        let store = crate::app_permissions::PermissionStore::load_or_default(&config_dir);
+        let (granted_caps, blocked_caps) = store.build_permission_sets(
+            &type_id,
+            &workspace_root,
+            &capabilities,
+        );
         let permissions = AppPermissions {
-            capabilities,
+            capabilities: granted_caps,
+            blocked: blocked_caps,
             is_builtin: false,
             allowed_hosts: vec![],
         };
@@ -552,6 +562,7 @@ impl ProcessApp {
             features_used: Vec::new(),
             workspace_root,
             permissions,
+            permission_store: store,
             pipe_registry: Arc::new(Mutex::new(TypedPipeRegistry::new())),
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
@@ -669,6 +680,7 @@ impl ProcessApp {
             features_used: Vec::new(),
             workspace_root: std::env::temp_dir(),
             permissions,
+            permission_store: crate::app_permissions::PermissionStore::default(),
             pipe_registry: Arc::new(Mutex::new(TypedPipeRegistry::new())),
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
@@ -1345,8 +1357,10 @@ impl App for ProcessApp {
             let mut outbound_events = std::mem::take(&mut self.outbound_events);
             let mut permissions = std::mem::take(&mut self.permissions);
             let mut secret_input_buf = std::mem::take(&mut self.secret_input_buf);
+            let mut permission_store = std::mem::take(&mut self.permission_store);
             let type_id = self.type_id.clone();
             let workspace_root = self.workspace_root.clone();
+            let config_dir = crate::config::config_dir();
             prompts::show_prompt_modal(
                 ui,
                 &mut pending_prompts,
@@ -1355,11 +1369,14 @@ impl App for ProcessApp {
                 &type_id,
                 &workspace_root,
                 &mut secret_input_buf,
+                &config_dir,
+                &mut permission_store,
             );
             self.pending_prompts = pending_prompts;
             self.outbound_events = outbound_events;
             self.permissions = permissions;
             self.secret_input_buf = secret_input_buf;
+            self.permission_store = permission_store;
         }
 
         // Render the current committed frame.

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -87,6 +87,8 @@ pub(super) fn show_prompt_modal(
     type_id: &str,
     workspace_root: &Path,
     secret_input_buf: &mut String,
+    _config_dir: &Path,
+    permission_store: &mut crate::app_permissions::PermissionStore,
 ) {
     let Some(prompt) = pending_prompts.front() else {
         return;
@@ -142,12 +144,29 @@ pub(super) fn show_prompt_modal(
                     match Capability::try_from(capability.as_str()) {
                         Ok(cap) => {
                             permissions.capabilities.insert(cap);
+                            permission_store.set(type_id, workspace_root, cap, crate::app_permissions::PermissionState::Green);
+                            permission_store.save();
+                            log::info!(
+                                "permission_store: granted {} for {} in {}",
+                                cap, type_id, workspace_root.display()
+                            );
                         }
                         Err(e) => {
                             log::warn!(
                                 "prompts: cannot grant {e}; capability string not recognized"
                             );
                         }
+                    }
+                }
+                if denied {
+                    if let Ok(cap) = Capability::try_from(capability.as_str()) {
+                        permissions.blocked.insert(cap);
+                        permission_store.set(type_id, workspace_root, cap, crate::app_permissions::PermissionState::Red);
+                        permission_store.save();
+                        log::info!(
+                            "permission_store: permanently blocked {} for {} in {}",
+                            cap, type_id, workspace_root.display()
+                        );
                     }
                 }
                 event_log::emit(HostEvent::PermissionDecision {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -3,7 +3,7 @@
 //! All visual draw commands stay in the frame pipeline; only control commands
 //! (media, pipes, capabilities, secrets, runs, notifications) are routed here.
 
-use crate::app_permissions::{check, Capability, PermissionCheck};
+use crate::app_permissions::{check, is_blocked, Capability, PermissionCheck};
 use crate::app_protocol::{AudioDeviceWire, HostCommand, MidiPortWire, PlexiEvent, StreamChannel};
 use crate::app_trait::AppCommand;
 use crate::audio::AudioCaptureRequest;
@@ -34,6 +34,16 @@ impl ProcessApp {
                                 .push_back(PlexiEvent::CapabilityDecision {
                                     request_id,
                                     granted: true,
+                                });
+                        } else if is_blocked(&self.permissions, cap) {
+                            log::info!(
+                                "ProcessApp[{}]: {} permanently blocked — auto-denying",
+                                self.type_id, cap
+                            );
+                            self.outbound_events
+                                .push_back(PlexiEvent::CapabilityDecision {
+                                    request_id,
+                                    granted: false,
                                 });
                         } else {
                             self.pending_prompts


### PR DESCRIPTION
## Summary
- Adds `PermissionStore` persisting decisions to `~/.plexi-alpha/permissions.toml` keyed by `app_id::workspace_root::capability`
- Three states: **Green** (permanently granted, pre-loaded on launch), **Yellow** (ask every time), **Red** (permanently blocked, auto-deny without modal)
- Grant/deny decisions in the prompt modal now call `permission_store.set()` + `.save()` — decisions survive restarts
- `is_blocked()` added; `CapabilityRequest` router now auto-denies Red caps without showing a modal

## Test plan
- [ ] Install an app, trigger a capability prompt, deny it → relaunch the app → capability auto-denied without a modal appearing
- [ ] Trigger a capability prompt, grant it → relaunch → capability pre-granted (no prompt)
- [ ] Confirm `~/.plexi-alpha/permissions.toml` exists after a grant/deny decision with correct content
- [ ] `cargo test -- app_permissions` passes (9 tests)

Closes #426