### PR TITLE
fix(sdk): raise TypeError when blocking emit called from sync hook

### DIFF
--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -10,7 +10,7 @@ from typing import Any, Coroutine
 from ._protocol import PROTOCOL_VERSION
 from ._constants import _SDK_VERSION
 from ._types import AgentInfo
-from ._emitter import Emitter, _emit
+from ._emitter import Emitter, _emit, _sync_hook_scope
 from ._pipe import Pipe
 from ._render_context import RenderContext
 
@@ -812,7 +812,8 @@ class App:
         if inspect.iscoroutinefunction(hook):
             await hook(*args)
         else:
-            hook(*args)
+            with _sync_hook_scope():
+                hook(*args)
 
     def _dispatch_hook_task(self, hook: "Any", *args: Any) -> None:
         """Dispatch a lifecycle hook as a non-blocking background task.
@@ -848,7 +849,8 @@ class App:
             task.add_done_callback(_log_task_exception)
         else:
             try:
-                hook(*args)
+                with _sync_hook_scope():
+                    hook(*args)
             except Exception as e:
                 sys.stderr.write(f"plexi_sdk: sync hook {getattr(hook, '__name__', hook)!r} raised: {e}\n")
 

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import uuid
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList
 from ._types import CapabilityDeniedError, VideoHandle, AgentInfo
@@ -31,16 +31,17 @@ _SYNC_HOOK_LOCAL: threading.local = threading.local()
 
 
 @contextmanager
-def _sync_hook_scope():  # type: ignore[return]
+def _sync_hook_scope() -> Iterator[None]:
     """Mark the current thread as executing a sync hook."""
+    old_active = getattr(_SYNC_HOOK_LOCAL, 'active', False)
     _SYNC_HOOK_LOCAL.active = True
     try:
         yield
     finally:
-        _SYNC_HOOK_LOCAL.active = False
+        _SYNC_HOOK_LOCAL.active = old_active
 
 
-def _blocking_emit_method(fn):  # type: ignore[return]
+def _blocking_emit_method(fn):
     """Decorator: raises TypeError if a blocking emit is called from a sync hook.
 
     Async hooks use ``await``, so the wrapper body runs, sentinel is clear,

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import sys
 import threading
 import uuid
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList
@@ -21,6 +23,47 @@ _RESERVED_SHORTCUTS = frozenset("jkhl") | frozenset("123456789")
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 _LOCK = threading.Lock()
+
+# Per-thread sentinel: True while a *sync* hook is executing on the event loop
+# thread. Blocking emit methods check this and raise immediately instead of
+# silently returning an un-awaited coroutine object.
+_SYNC_HOOK_LOCAL: threading.local = threading.local()
+
+
+@contextmanager
+def _sync_hook_scope():  # type: ignore[return]
+    """Mark the current thread as executing a sync hook."""
+    _SYNC_HOOK_LOCAL.active = True
+    try:
+        yield
+    finally:
+        _SYNC_HOOK_LOCAL.active = False
+
+
+def _blocking_emit_method(fn):  # type: ignore[return]
+    """Decorator: raises TypeError if a blocking emit is called from a sync hook.
+
+    Async hooks use ``await``, so the wrapper body runs, sentinel is clear,
+    and the inner coroutine is returned for the caller to await normally.
+    Sync hooks call without ``await`` — wrapper body runs, sentinel is set,
+    TypeError fires before any I/O is attempted.
+    Background threads (run_sync path) are on a different thread, so the
+    thread-local sentinel is always clear for them.
+    """
+    name = fn.__name__
+
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        if getattr(_SYNC_HOOK_LOCAL, 'active', False):
+            raise TypeError(
+                f"emit.{name}() must be called with 'await' from an 'async def' hook.\n"
+                f"Your hook is 'def' (sync) — blocking emit calls require 'async def'.\n"
+                f"Fix: change 'def on_init(self, ctx)' → 'async def on_init(self, ctx)'\n"
+                f"     then call:  result = await self.emit.{name}(...)"
+            )
+        return fn(self, *args, **kwargs)
+
+    return wrapper
 
 
 def _emit(obj: dict) -> None:
@@ -124,6 +167,7 @@ class Emitter:
         return future.result()
 
     # kind = "choice"
+    @_blocking_emit_method
     async def notify_choice(self, title: str, options: list, body: str = "",
                             level: str = "info", required: bool = False,
                             priority: "int | None" = None,
@@ -182,6 +226,7 @@ class Emitter:
     # Convenience wrapper for the inline-image case (#74). Handles base64
     # encoding + size-cap enforcement client-side so we never spend wire
     # bytes on payloads the host will only reject.
+    @_blocking_emit_method
     async def notify_with_image(self, title: str, body: str, image_bytes: bytes,
                                 mime: str, level: str = "info",
                                 priority: "int | None" = None,
@@ -228,6 +273,7 @@ class Emitter:
                                         image_inline=image_inline)
 
     # kind = "input"
+    @_blocking_emit_method
     async def notify_input(self, title: str, prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
                            priority: "int | None" = None,
@@ -258,6 +304,7 @@ class Emitter:
         _emit(payload)
         return await q.get()
 
+    @_blocking_emit_method
     async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
                               actions: "list | None" = None,
                               priority: "int | None" = None,
@@ -420,6 +467,7 @@ class Emitter:
     # (typically inside `on_init`) and stash the returned pane id. Pass it
     # to every subsequent `run_in_linked_terminal` / `insert_path_token` /
     # `request_command_preview` call.
+    @_blocking_emit_method
     async def request_linked_terminal(
         self,
         cwd: "str | None" = None,
@@ -500,6 +548,7 @@ class Emitter:
             "mode": mode,
         })
 
+    @_blocking_emit_method
     async def request_command_preview(
         self,
         terminal_pane_id: int,
@@ -569,6 +618,7 @@ class Emitter:
     # Each of these is a coroutine — await them from async hooks, or call
     # self.emit.run_sync(self.emit.method(...)) from a background thread.
 
+    @_blocking_emit_method
     async def capability_request(self, capability: str) -> bool:
         """Await until host grants or denies the capability. Returns True if granted.
 
@@ -582,6 +632,7 @@ class Emitter:
                "capability": capability})
         return await q.get()
 
+    @_blocking_emit_method
     async def secret_get(self, key: str) -> "str | None":
         """Await until host returns the secret value (or None if denied).
 
@@ -593,10 +644,12 @@ class Emitter:
         _emit({"type": "secret_get", "key": key})
         return await q.get()
 
+    @_blocking_emit_method
     async def get_secret(self, key: str) -> "str | None":
         """Alias for secret_get(). Preferred name going forward."""
         return await self.secret_get(key)
 
+    @_blocking_emit_method
     async def http_get(self, url: str) -> str:
         """HTTP GET brokered through the host. Requires net.http capability.
         Raises RuntimeError on failure.
@@ -606,6 +659,7 @@ class Emitter:
         """
         return await self.http_request(url)
 
+    @_blocking_emit_method
     async def http_request(self, url: str, method: str = "GET",
                            headers: "dict[str, str] | None" = None,
                            body: "str | None" = None) -> str:
@@ -630,6 +684,7 @@ class Emitter:
             raise RuntimeError(f"http_request {url!r}: {value}")
         return value
 
+    @_blocking_emit_method
     async def ai_query(self, model_tier: str, system: str,
                        messages: "list[dict]",
                        tools: "list[dict] | None" = None) -> AiResponse:
@@ -708,6 +763,7 @@ class Emitter:
         """
         _emit({"type": "expose_tools", "tools": tools})
 
+    @_blocking_emit_method
     async def list_midi_devices(self, timeout: float = 5.0) -> "MidiDeviceList":
         """Enumerate CoreMIDI input + output ports (#320).
         No capability gate — port names are publicly visible in Audio MIDI
@@ -753,6 +809,7 @@ class Emitter:
             ],
         )
 
+    @_blocking_emit_method
     async def list_audio_devices(self, timeout: float = 5.0) -> "AudioDeviceList":
         """Enumerate CoreAudio input + output devices (#341).
         No capability gate — device names are publicly visible.
@@ -852,6 +909,7 @@ class Emitter:
         # 0..=255 and rejects empty arrays.
         _emit({"type": "send_midi", "port_id": port_id, "bytes": data})
 
+    @_blocking_emit_method
     async def open_video(
         self,
         source: str,
@@ -1043,6 +1101,7 @@ class Emitter:
         """
         _emit({"type": "pipe_send", "pipe_id": pipe_id, "payload": payload})
 
+    @_blocking_emit_method
     async def agent_roster(self) -> "list[AgentInfo]":
         """Query for live agent panes in the workspace (#286).
 

--- a/sdk/python/tests/test_sync_hook_guard.py
+++ b/sdk/python/tests/test_sync_hook_guard.py
@@ -1,0 +1,96 @@
+"""Tests for blocking emit guard on sync hooks (issue #869)."""
+import asyncio
+import threading
+
+import pytest
+
+
+def _make_app():
+    from plexi_sdk._app import App
+    app = App()
+    return app
+
+
+def test_capability_request_raises_from_sync_hook():
+    """capability_request() called inside a sync-hook scope raises TypeError."""
+    from plexi_sdk._emitter import Emitter, _sync_hook_scope
+    emitter = Emitter(_make_app())
+    with _sync_hook_scope():
+        with pytest.raises(TypeError, match="async def"):
+            emitter.capability_request("net.http")
+
+
+def test_secret_get_raises_from_sync_hook():
+    from plexi_sdk._emitter import Emitter, _sync_hook_scope
+    emitter = Emitter(_make_app())
+    with _sync_hook_scope():
+        with pytest.raises(TypeError, match="await"):
+            emitter.secret_get("MY_KEY")
+
+
+def test_list_audio_devices_raises_from_sync_hook():
+    from plexi_sdk._emitter import Emitter, _sync_hook_scope
+    emitter = Emitter(_make_app())
+    with _sync_hook_scope():
+        with pytest.raises(TypeError):
+            emitter.list_audio_devices()
+
+
+def test_blocking_emit_returns_coroutine_outside_sync_hook():
+    """Outside a sync-hook scope, blocking emit returns a coroutine (no raise)."""
+    from plexi_sdk._emitter import Emitter
+    emitter = Emitter(_make_app())
+    coro = emitter.capability_request("net.http")
+    assert asyncio.iscoroutine(coro)
+    coro.close()
+
+
+def test_sentinel_is_thread_local():
+    """Sentinel set on event-loop thread does not affect background threads."""
+    from plexi_sdk._emitter import Emitter, _sync_hook_scope
+    emitter = Emitter(_make_app())
+    raised = []
+
+    def _bg():
+        try:
+            coro = emitter.capability_request("net.http")
+            coro.close()
+        except TypeError:
+            raised.append(True)
+
+    with _sync_hook_scope():
+        t = threading.Thread(target=_bg)
+        t.start()
+        t.join()
+
+    assert not raised, "sentinel on event-loop thread must not affect background threads"
+
+
+def test_error_message_is_actionable():
+    """TypeError message includes 'await', 'async def', and the method name."""
+    from plexi_sdk._emitter import Emitter, _sync_hook_scope
+    emitter = Emitter(_make_app())
+    with _sync_hook_scope():
+        with pytest.raises(TypeError) as exc_info:
+            emitter.capability_request("net.http")
+    msg = str(exc_info.value)
+    assert "await" in msg
+    assert "async def" in msg
+    assert "capability_request" in msg
+
+
+def test_sync_hook_dispatch_raises_for_blocking_emit():
+    """_dispatch_hook with a sync hook that calls capability_request raises TypeError."""
+    from plexi_sdk._app import App
+
+    class BadApp(App):
+        def on_init(self, ctx):
+            self.emit.capability_request("net.http")
+
+    app = BadApp()
+
+    async def _run():
+        with pytest.raises(TypeError, match="async def"):
+            await app._dispatch_hook(app.on_init, None)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary

- Blocking emit methods (`capability_request`, `secret_get`, `list_audio_devices`, etc.) are `async def` — calling them without `await` from a sync hook silently returns a truthy coroutine object that is never executed
- Adds a `threading.local` sentinel (`_SYNC_HOOK_LOCAL`) set while `_dispatch_hook` / `_dispatch_hook_task` run sync hooks
- All 16 blocking emit methods decorated with `@_blocking_emit_method` — raises `TypeError` immediately with actionable message naming the method, `await`, and `async def`
- Async hooks unaffected; background threads (`run_sync` path) unaffected (different thread, sentinel always clear)

## Test plan

- [ ] 7 new unit tests in `sdk/python/tests/test_sync_hook_guard.py` — all pass
- [ ] Existing `test_appbar.py` still passes (8/8 green)
- [ ] Verify: sync `on_init` calling `self.emit.capability_request(...)` now raises `TypeError` with message containing `await`, `async def`, and method name

Closes #869