### PR TITLE
feat(cli): plexi app render — headless app screenshot via offscreen egui/wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "egui-wgpu",
  "egui_commonmark",
  "egui_term",
  "egui_tiles",
@@ -3560,6 +3561,8 @@ dependencies = [
  "objc2-core-video",
  "objc2-foundation 0.2.2",
  "objc2-foundation 0.3.2",
+ "png 0.17.16",
+ "pollster",
  "rfd",
  "rodio",
  "schemars",
@@ -3572,6 +3575,7 @@ dependencies = [
  "toml",
  "ureq",
  "uuid",
+ "wgpu",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ notify = { version = "8", default-features = false, features = ["macos_fsevent"]
 egui_commonmark = "0.20"
 # Native file picker dialog (#514). Uses NSOpenPanel on macOS.
 rfd = "0.15"
+# Headless app render (#850). Already transitive via eframe; declared directly for explicit use.
+pollster = "0.4"
+wgpu = { version = "24", default-features = false, features = ["wgsl", "metal"] }
+egui-wgpu = "0.31"
+png = "0.17"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Keychain access via Security.framework C API — no subprocess, distinct error

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -1,0 +1,312 @@
+//! Headless app rendering — spawns an app process, collects one frame, renders to PNG.
+//!
+//! Used by `plexi app render <id>` to produce screenshots without a display.
+
+use crate::app_protocol::{ControlCommand, DrawCommand, PlexiEvent, Rect as ProtoRect, RenderCommand};
+use crate::theme::Colors;
+use egui::Color32;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write as IoWrite};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const BOOT_TIMEOUT: Duration = Duration::from_secs(10);
+const FRAME_TIMEOUT: Duration = Duration::from_secs(10);
+const PROTOCOL: &str = "pgap/3";
+
+/// Spawn the app at `bin_path`, collect one frame at `width`×`height`, render to PNG bytes.
+pub fn render_app_to_png(app_id: &str, bin_path: &Path, width: u32, height: u32) -> Result<Vec<u8>, String> {
+    let commands = spawn_and_collect_frame(app_id, bin_path, width, height)?;
+    log::info!("app_render[{app_id}]: collected {} render commands for {width}×{height}", commands.len());
+    render_commands_to_png(&commands, width, height)
+}
+
+/// Spawn the app, exchange Init/Ready, send one Render, collect until FrameDone.
+fn spawn_and_collect_frame(
+    app_id: &str,
+    bin_path: &Path,
+    width: u32,
+    height: u32,
+) -> Result<Vec<RenderCommand>, String> {
+    let mut child = Command::new(bin_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn '{app_id}' at {}: {e}", bin_path.display()))?;
+
+    let mut stdin = child.stdin.take().ok_or("no stdin")?;
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    let mut reader = BufReader::new(stdout);
+
+    // Send Init
+    let init = PlexiEvent::Init {
+        protocol: PROTOCOL.to_string(),
+        app_id: app_id.to_string(),
+        workspace_root: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+        capabilities: vec![],
+        feature_flags: vec![],
+    };
+    let init_json = serde_json::to_string(&init)
+        .map_err(|e| format!("failed to serialize Init: {e}"))?;
+    writeln!(stdin, "{init_json}").map_err(|e| format!("failed to write Init: {e}"))?;
+    log::info!("app_render[{app_id}]: sent Init");
+
+    // Wait for Ready
+    let deadline = Instant::now() + BOOT_TIMEOUT;
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            return Err(format!("app '{app_id}' did not send Ready within {BOOT_TIMEOUT:?}"));
+        }
+        let mut line = String::new();
+        reader.read_line(&mut line).map_err(|e| format!("read error waiting for Ready: {e}"))?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<DrawCommand>(line) {
+            Ok(DrawCommand::Control(ControlCommand::Ready { .. })) => {
+                log::info!("app_render[{app_id}]: got Ready");
+                break;
+            }
+            Ok(_) => { /* ignore other commands before Ready */ }
+            Err(e) => {
+                log::warn!("app_render[{app_id}]: parse error before Ready: {e} (line: {line})");
+            }
+        }
+    }
+
+    // Send Render
+    let render = PlexiEvent::Render {
+        frame_id: 1,
+        rect: ProtoRect { x: 0.0, y: 0.0, w: width as f32, h: height as f32 },
+    };
+    let render_json = serde_json::to_string(&render)
+        .map_err(|e| format!("failed to serialize Render: {e}"))?;
+    writeln!(stdin, "{render_json}").map_err(|e| format!("failed to write Render: {e}"))?;
+    log::info!("app_render[{app_id}]: sent Render {width}×{height}");
+
+    // Collect RenderCommands until FrameDone
+    let mut render_commands: Vec<RenderCommand> = Vec::new();
+    let deadline = Instant::now() + FRAME_TIMEOUT;
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            return Err(format!("app '{app_id}' did not emit FrameDone within {FRAME_TIMEOUT:?}"));
+        }
+        let mut line = String::new();
+        reader.read_line(&mut line).map_err(|e| format!("read error collecting frame: {e}"))?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<DrawCommand>(line) {
+            Ok(DrawCommand::Render(rc)) => {
+                render_commands.push(rc);
+            }
+            Ok(DrawCommand::Control(ControlCommand::FrameDone { .. })) => {
+                log::info!("app_render[{app_id}]: FrameDone — {} commands", render_commands.len());
+                break;
+            }
+            Ok(_) => { /* ignore host/control commands during frame collection */ }
+            Err(e) => {
+                log::warn!("app_render[{app_id}]: parse error in frame: {e}");
+            }
+        }
+    }
+
+    let _ = child.kill();
+    Ok(render_commands)
+}
+
+/// Render RenderCommands to PNG bytes via a headless egui context + wgpu offscreen surface.
+fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -> Result<Vec<u8>, String> {
+    // ── 1. Build egui shapes via a headless egui context ──────────────────
+    let ctx = egui::Context::default();
+    ctx.set_fonts(egui::FontDefinitions::default());
+
+    let rect = egui::Rect::from_min_size(
+        egui::Pos2::ZERO,
+        egui::vec2(width as f32, height as f32),
+    );
+    let mut viewport_info = egui::ViewportInfo::default();
+    viewport_info.native_pixels_per_point = Some(1.0);
+    viewport_info.inner_rect = Some(rect);
+    let viewports: egui::ViewportIdMap<egui::ViewportInfo> =
+        std::iter::once((egui::ViewportId::ROOT, viewport_info)).collect();
+    let raw_input = egui::RawInput {
+        screen_rect: Some(rect),
+        viewports,
+        ..Default::default()
+    };
+
+    let colors = default_colors();
+    let mut cm_cache = egui_commonmark::CommonMarkCache::default();
+    let peaks: HashMap<String, f32> = HashMap::new();
+
+    let full_output = ctx.run(raw_input, |ctx| {
+        egui::CentralPanel::default()
+            .frame(egui::Frame::NONE)
+            .show(ctx, |ui| {
+                crate::process_app::render::render_draw_commands(
+                    ui, rect, commands, &colors, &mut cm_cache, &peaks,
+                );
+            });
+    });
+
+    let pixels_per_point = full_output.pixels_per_point;
+    let clipped_primitives = ctx.tessellate(full_output.shapes, pixels_per_point);
+    let textures_delta = full_output.textures_delta;
+
+    // ── 2. Set up wgpu offscreen ──────────────────────────────────────────
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        ..Default::default()
+    });
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::None,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .ok_or("no wgpu adapter available for headless rendering")?;
+
+    let (device, queue) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: Some("plexi-headless"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            memory_hints: Default::default(),
+        },
+        None,
+    ))
+    .map_err(|e| format!("failed to acquire wgpu device: {e}"))?;
+
+    let texture_format = wgpu::TextureFormat::Rgba8Unorm;
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("plexi-offscreen"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: texture_format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    // ── 3. egui_wgpu renderer ─────────────────────────────────────────────
+    let mut renderer = egui_wgpu::Renderer::new(&device, texture_format, None, 1, false);
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("plexi-render"),
+    });
+
+    for (id, delta) in &textures_delta.set {
+        renderer.update_texture(&device, &queue, *id, delta);
+    }
+
+    let screen_descriptor = egui_wgpu::ScreenDescriptor {
+        size_in_pixels: [width, height],
+        pixels_per_point,
+    };
+    renderer.update_buffers(&device, &queue, &mut encoder, &clipped_primitives, &screen_descriptor);
+
+    {
+        let mut rpass = encoder
+            .begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("plexi-egui"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            })
+            .forget_lifetime();
+        renderer.render(&mut rpass, &clipped_primitives, &screen_descriptor);
+    }
+
+    // ── 4. Readback ───────────────────────────────────────────────────────
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let bytes_per_row_raw = width * 4;
+    let bytes_per_row = bytes_per_row_raw.next_multiple_of(align);
+
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("plexi-readback"),
+        size: (bytes_per_row * height) as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+    );
+    queue.submit([encoder.finish()]);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    readback.slice(..).map_async(wgpu::MapMode::Read, move |r| {
+        let _ = tx.send(r);
+    });
+    device.poll(wgpu::Maintain::Wait);
+    rx.recv()
+        .map_err(|_| "readback channel closed unexpectedly".to_string())?
+        .map_err(|e| format!("GPU readback failed: {e}"))?;
+
+    let mut pixels: Vec<u8> = Vec::with_capacity((width * height * 4) as usize);
+    {
+        let mapped = readback.slice(..).get_mapped_range();
+        for row in 0..height {
+            let start = (row * bytes_per_row) as usize;
+            let end = start + (width * 4) as usize;
+            pixels.extend_from_slice(&mapped[start..end]);
+        }
+    }
+    readback.unmap();
+
+    // ── 5. Encode PNG ─────────────────────────────────────────────────────
+    let mut png_data: Vec<u8> = Vec::new();
+    {
+        let mut enc = png::Encoder::new(&mut png_data, width, height);
+        enc.set_color(png::ColorType::Rgba);
+        enc.set_depth(png::BitDepth::Eight);
+        enc.write_header()
+            .and_then(|mut w| w.write_image_data(&pixels))
+            .map_err(|e| format!("PNG encoding failed: {e}"))?;
+    }
+    log::info!("app_render: encoded {} bytes for {width}×{height}", png_data.len());
+    Ok(png_data)
+}
+
+fn default_colors() -> Colors {
+    Colors {
+        bg_darkest: Color32::from_rgb(0x11, 0x11, 0x1b),
+        bg_sidebar: Color32::from_rgb(0x18, 0x18, 0x25),
+        bg_toolbar: Color32::from_rgb(0x18, 0x18, 0x25),
+        terminal_bg: Color32::from_rgb(0x29, 0x2a, 0x44),
+        bg_hover: Color32::from_rgb(0x2a, 0x2a, 0x3c),
+        bg_active: Color32::from_rgb(0x31, 0x31, 0x44),
+        text_primary: Color32::from_rgb(0xcd, 0xd6, 0xf4),
+        text_dim: Color32::from_rgb(0x6c, 0x70, 0x86),
+        text_section: Color32::from_rgb(0x58, 0x5b, 0x70),
+        accent: Color32::from_rgb(0x89, 0xb4, 0xfa),
+        border: Color32::from_rgb(0x2a, 0x2a, 0x3c),
+        terminal_fg_bytes: [0xe8, 0xe6, 0xed],
+        terminal_bg_bytes: [0x29, 0x2a, 0x44],
+    }
+}

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -29,11 +29,42 @@ fn spawn_and_collect_frame(
     width: u32,
     height: u32,
 ) -> Result<Vec<RenderCommand>, String> {
-    let mut child = Command::new(bin_path)
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+
+    // Mirror the env setup from ProcessApp::launch so Python apps can import plexi_sdk.
+    const ENV_WHITELIST: &[&str] = &["HOME", "PATH", "LANG", "LC_ALL", "TERM", "USER", "SHELL"];
+    let mut cmd = Command::new(bin_path);
+    cmd.current_dir(&cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .spawn()
+        .env_clear();
+    for var in ENV_WHITELIST {
+        if let Ok(v) = std::env::var(var) {
+            cmd.env(var, v);
+        }
+    }
+    for (k, v) in std::env::vars() {
+        if k.starts_with("PLEXI_") {
+            cmd.env(k, v);
+        }
+    }
+    // PYTHONPATH: config-dir SDK first, then bundle SDK if present.
+    let sdk_dir = crate::config::config_dir().join("sdk");
+    let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
+    let bundle_sdk = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
+        .map(|p| p.join("Resources").join("sdk").join("python"))
+        .filter(|p| p.exists());
+    if let Some(bsdk) = bundle_sdk {
+        pythonpath.push(':');
+        pythonpath.push_str(&bsdk.to_string_lossy());
+    }
+    cmd.env("PYTHONPATH", &pythonpath);
+    log::info!("app_render[{app_id}]: PYTHONPATH={pythonpath}");
+
+    let mut child = cmd.spawn()
         .map_err(|e| format!("failed to spawn '{app_id}' at {}: {e}", bin_path.display()))?;
 
     let mut stdin = child.stdin.take().ok_or("no stdin")?;

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -18,7 +18,6 @@ const PROTOCOL: &str = "pgap/3";
 /// Spawn the app at `bin_path`, collect one frame at `width`×`height`, render to PNG bytes.
 pub fn render_app_to_png(app_id: &str, bin_path: &Path, width: u32, height: u32) -> Result<Vec<u8>, String> {
     let commands = spawn_and_collect_frame(app_id, bin_path, width, height)?;
-    log::info!("app_render[{app_id}]: collected {} render commands for {width}×{height}", commands.len());
     render_commands_to_png(&commands, width, height)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -522,6 +522,106 @@ pub fn app_list() -> i32 {
     0
 }
 
+/// `plexi app render <id> --size WxH [--state state.json] [--output path.png]`
+/// Renders an app to PNG headlessly via the offscreen egui/wgpu pipeline.
+pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str>) -> i32 {
+    // Parse WxH
+    let (width, height) = match parse_render_size(size) {
+        Some(v) => v,
+        None => {
+            eprintln!("error: invalid --size format '{size}' — expected WxH (e.g. 500x500)");
+            return 1;
+        }
+    };
+
+    // Optional: pre-seed app state
+    let seeded_path = state.and_then(|s| {
+        let json = match std::fs::read_to_string(s) {
+            Ok(j) => j,
+            Err(e) => {
+                eprintln!("error: could not read state file '{s}': {e}");
+                return None;
+            }
+        };
+        let dest = crate::config::config_dir().join("app_state").join(format!("{id}.json"));
+        if let Some(parent) = dest.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&dest, &json) {
+            eprintln!("error: could not write state to {}: {e}", dest.display());
+            return None;
+        }
+        log::info!("app_render[{id}]: pre-seeded state from '{s}' → {}", dest.display());
+        Some(dest)
+    });
+
+    // Resolve the app binary
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let registry = crate::app_registry::AppRegistry::load(&cwd);
+    let app_bin = match registry.list().into_iter().find(|a| a.manifest.id == id) {
+        Some(a) => a.bin_path.clone(),
+        None => {
+            eprintln!("error: app '{id}' not found — run `plexi app list` to see installed apps");
+            if let Some(path) = seeded_path {
+                let _ = std::fs::remove_file(path);
+            }
+            return 1;
+        }
+    };
+
+    let png_bytes = match crate::app_render::render_app_to_png(id, &app_bin, width, height) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: render failed: {e}");
+            if let Some(path) = seeded_path {
+                let _ = std::fs::remove_file(path);
+            }
+            return 1;
+        }
+    };
+
+    // Clean up seeded state if we wrote it
+    if let Some(ref path) = seeded_path {
+        let _ = std::fs::remove_file(path);
+        log::info!("app_render[{id}]: cleaned up seeded state at {}", path.display());
+    }
+
+    // Write output
+    match output {
+        Some(path) => {
+            if let Err(e) = std::fs::write(path, &png_bytes) {
+                eprintln!("error: could not write output to '{path}': {e}");
+                return 1;
+            }
+            log::info!("app_render[{id}]: wrote {width}×{height} PNG to '{path}'");
+            eprintln!("Wrote {width}×{height} PNG to '{path}'");
+        }
+        None => {
+            use std::io::Write;
+            if let Err(e) = std::io::stdout().write_all(&png_bytes) {
+                eprintln!("error: could not write PNG to stdout: {e}");
+                return 1;
+            }
+            log::info!(
+                "app_render[{id}]: wrote {width}×{height} PNG to stdout ({} bytes)",
+                png_bytes.len()
+            );
+        }
+    }
+
+    0
+}
+
+fn parse_render_size(s: &str) -> Option<(u32, u32)> {
+    let (w, h) = s.split_once('x')?;
+    let w = w.parse::<u32>().ok()?;
+    let h = h.parse::<u32>().ok()?;
+    if w == 0 || h == 0 {
+        return None;
+    }
+    Some((w, h))
+}
+
 // ── Top-level package manager subcommands (#308 Phase 2) ──────────────────────
 
 /// `plexi install <source-spec>[@ref]` — clone + place one app into the

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -177,6 +177,20 @@ pub enum AppCmd {
     },
     /// List installed apps
     List,
+    /// Render an app to PNG headlessly
+    Render {
+        /// App id to render (e.g. "snake")
+        id: String,
+        /// Dimensions as WxH (e.g. 500x500)
+        #[arg(long, default_value = "800x600")]
+        size: String,
+        /// Pre-seed app state from a JSON file before render
+        #[arg(long)]
+        state: Option<String>,
+        /// Output PNG path (default: stdout)
+        #[arg(long)]
+        output: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 mod app;
 mod app_permissions;
 mod app_protocol;
+mod app_render;
 mod app_registry;
 mod app_trait;
 mod audio;
@@ -211,6 +212,9 @@ fn main() -> eframe::Result {
                         AppCmd::Init { name, lang } => std::process::exit(cli::app_init(&name, &lang)),
                         AppCmd::Uninstall { id } => std::process::exit(cli::app_uninstall(&id)),
                         AppCmd::List => std::process::exit(cli::app_list()),
+                        AppCmd::Render { id, size, state, output } => {
+                            std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
+                        }
                     },
                     Commands::Install { spec, pack } => {
                         if let Some(p) = pack {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -13,7 +13,7 @@
 
 mod lifecycle;
 mod prompts;
-mod render;
+pub(crate) mod render;
 mod routing;
 
 pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -29,7 +29,7 @@ use egui::Color32;
 /// process_app paints via `ui.painter()` without allocating, so min_rect
 /// never grows), which clipped every draw to nothing — all apps appeared
 /// blank. Single-source-of-geometry: the caller hands us the rect once.
-pub(super) fn render_draw_commands(
+pub(crate) fn render_draw_commands(
     ui: &mut egui::Ui,
     pane_rect: egui::Rect,
     commands: &[RenderCommand],


### PR DESCRIPTION
## Summary
- Adds `plexi app render <app-id> --size WxH [--state state.json] [--output out.png]`
- Spawns the real app process, speaks PGAP Init→Ready→Render→FrameDone, collects one frame
- Renders via a headless egui context + wgpu offscreen surface (not tiny_skia) — pixel-accurate output

## How it works
1. `app_registry` resolves the app binary by id
2. `spawn_and_collect_frame()` spawns the process, sends Init, waits for Ready, sends Render, reads until FrameDone
3. `render_commands_to_png()` runs egui tessellation → wgpu offscreen (Rgba8Unorm) → MAP_READ readback → PNG
4. Optional `--state` pre-seeds `config_dir/app_state/<id>.json` before spawning, cleans up after
5. Output to `--output path` or stdout (for piping)

## Test plan
- [ ] `plexi-pr-<N> app render snake --size 500x500 --output /tmp/snake.png` produces a valid PNG
- [ ] Open `/tmp/snake.png` — should show the snake app at 500×500 with dark background and game state
- [ ] `plexi-pr-<N> app render snake --size 50x50 --output /tmp/snake-small.png` — undersized, still produces valid PNG
- [ ] `plexi-pr-<N> app render nonexistent-app` exits with error message naming the bad id
- [ ] `plexi-pr-<N> app render --help` shows size/state/output options

Closes #850