### PR TITLE
feat(agent): Plexi Agent POC — gpt-realtime-2 + auto-generated Clap tool schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ egui_commonmark = "0.20"
 rfd = "0.15"
 # Headless app render (#850). Already transitive via eframe; declared directly for explicit use.
 pollster = "0.4"
+# Realtime voice agent (#816). Async WebSocket to gpt-realtime-2.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "net", "time", "sync"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+futures-util = "0.3"
 wgpu = { version = "24", default-features = false, features = ["wgsl", "metal"] }
 egui-wgpu = "0.31"
 png = "0.17"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,0 +1,11 @@
+//! Plexi voice agent — gpt-realtime-2 WebSocket session (#816).
+pub mod schema;
+pub mod session;
+
+pub fn start_cli() -> i32 {
+    session::run()
+}
+
+pub fn schema_cli() -> i32 {
+    schema::print_schema()
+}

--- a/src/agent/schema.rs
+++ b/src/agent/schema.rs
@@ -1,0 +1,118 @@
+use clap::CommandFactory;
+use serde_json::{json, Value};
+
+/// Subcommands that are too destructive or irreversible to expose as agent tools.
+const DENYLIST: &[&str] = &[
+    "upgrade",
+    "workspace_init",
+    "app_uninstall",
+    "uninstall",
+    "update",
+    "pack_export",
+    "completions",
+    "shell_init",
+];
+
+/// Walk a clap Command tree and collect leaf subcommands as tool descriptors.
+/// `prefix` is the flattened name so far (e.g. "pane" for `plexi pane`).
+pub fn collect_tools_pub(cmd: &clap::Command, prefix: &str, tools: &mut Vec<Value>) {
+    let name = if prefix.is_empty() {
+        cmd.get_name().to_string()
+    } else {
+        format!("{}_{}", prefix, cmd.get_name())
+    };
+
+    let subcommands: Vec<_> = cmd.get_subcommands().collect();
+
+    if subcommands.is_empty() {
+        // Leaf — emit as a tool
+        if DENYLIST.contains(&name.as_str()) {
+            return;
+        }
+
+        let description = cmd
+            .get_about()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("Run: plexi {}", name.replace('_', " ")));
+
+        let mut properties: serde_json::Map<String, Value> = serde_json::Map::new();
+        let mut required: Vec<String> = Vec::new();
+
+        for arg in cmd.get_arguments() {
+            // Skip internal/hidden args
+            if arg.is_hide_set() {
+                continue;
+            }
+            let arg_name = arg.get_id().as_str().to_string();
+            if arg_name == "help" || arg_name == "version" {
+                continue;
+            }
+
+            let arg_desc = arg.get_help().map(|s| s.to_string()).unwrap_or_default();
+
+            let arg_type = if arg.get_action().takes_values() {
+                "string"
+            } else {
+                "boolean"
+            };
+
+            properties.insert(
+                arg_name.clone(),
+                json!({
+                    "type": arg_type,
+                    "description": arg_desc,
+                }),
+            );
+
+            if arg.is_required_set() {
+                required.push(arg_name);
+            }
+        }
+
+        tools.push(json!({
+            "type": "function",
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            }
+        }));
+    } else {
+        for sub in subcommands {
+            let sub_prefix = if prefix.is_empty() {
+                cmd.get_name().to_string()
+            } else {
+                name.clone()
+            };
+            collect_tools_pub(sub, &sub_prefix, tools);
+        }
+    }
+}
+
+pub fn print_schema() -> i32 {
+    let cmd = crate::cli_args::Cli::command();
+    let mut tools: Vec<Value> = Vec::new();
+
+    for sub in cmd.get_subcommands() {
+        collect_tools_pub(sub, "", &mut tools);
+    }
+
+    // Skip the top-level "agent" command from tool exposure
+    tools.retain(|t| {
+        let name = t["name"].as_str().unwrap_or("");
+        !name.starts_with("agent_")
+    });
+
+    match serde_json::to_string_pretty(&tools) {
+        Ok(json) => {
+            println!("{json}");
+            0
+        }
+        Err(e) => {
+            eprintln!("error: failed to serialize schema: {e}");
+            1
+        }
+    }
+}

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -317,6 +317,7 @@ async fn run_session(
     let session_update = json!({
         "type": "session.update",
         "session": {
+            "type": "realtime",
             "modalities": ["text", "audio"],
             "instructions": system_prompt(),
             "voice": "alloy",

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -265,7 +265,9 @@ async fn handle_server_event(
         }
 
         _ => {
-            log::debug!("agent:event: {event_type}");
+            // Log all unhandled events at info so we can discover the GA API event names.
+            log::info!("agent:event:unhandled type={event_type} keys={}",
+                event.as_object().map(|o| o.keys().cloned().collect::<Vec<_>>().join(",")).unwrap_or_default());
         }
     }
 

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -342,8 +342,6 @@ async fn run_session(
             "modalities": ["audio"],
             "instructions": system_prompt(),
             "voice": "alloy",
-            "input_audio_format": { "type": "audio/pcm", "rate": 24000 },
-            "output_audio_format": { "type": "audio/pcm", "rate": 24000 },
             "tools": tools,
             "tool_choice": "auto",
             "turn_detection": {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -1,0 +1,398 @@
+//! WebSocket session for gpt-realtime-2 (#816).
+//!
+//! Runs a live voice session: mic → PCM16 24kHz → gpt-realtime-2 → audio out
+//! + text transcript rendered to the PTY. Tool calls are executed as plexi
+//! subprocess calls using PLEXI_SOCKET (auto-injected since agent runs in a pane).
+
+use std::io::Write as _;
+use std::thread;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+
+const MODEL: &str = "gpt-realtime-2";
+const SAMPLE_RATE: u32 = 24_000;
+const CHANNELS: u16 = 1;
+
+fn system_prompt() -> String {
+    "You are a Plexi workspace assistant running inside a Plexi terminal pane. \
+    You can control the workspace by calling the available tools, which map directly \
+    to `plexi` CLI subcommands. Keep responses concise. When you call a tool, it runs \
+    as a subprocess in this pane's environment with PLEXI_SOCKET set, so host commands \
+    will reach the running Plexi instance."
+        .to_string()
+}
+
+fn get_tools() -> Vec<Value> {
+    use clap::CommandFactory;
+    let cmd = crate::cli_args::Cli::command();
+    let mut tools = Vec::new();
+    for sub in cmd.get_subcommands() {
+        crate::agent::schema::collect_tools_pub(sub, "", &mut tools);
+    }
+    tools.retain(|t| {
+        let name = t["name"].as_str().unwrap_or("");
+        !name.starts_with("agent_")
+    });
+    tools
+}
+
+fn execute_tool(name: &str, args: &Value) -> String {
+    // Convert tool name back to CLI args: "pane_open" → ["pane", "open", ...]
+    let parts: Vec<&str> = name.split('_').collect();
+    let mut cmd_args: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
+
+    // Append positional and flag args from the JSON object
+    if let Some(obj) = args.as_object() {
+        for (k, v) in obj {
+            match v {
+                Value::Bool(true) => cmd_args.push(format!("--{}", k)),
+                Value::Bool(false) => {}
+                Value::String(s) => {
+                    cmd_args.push(s.clone());
+                }
+                Value::Number(n) => cmd_args.push(n.to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    log::info!("agent:tool_call: {} args={:?}", name, cmd_args);
+
+    let binary =
+        std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("plexi"));
+
+    match std::process::Command::new(&binary).args(&cmd_args).output() {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            if !stderr.is_empty() {
+                format!("{stdout}\n{stderr}")
+            } else {
+                stdout
+            }
+        }
+        Err(e) => {
+            log::warn!("agent:tool_exec_failed: {} — {e}", name);
+            format!("error: {e}")
+        }
+    }
+}
+
+fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<cpal::Stream, String> {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| "no default input device".to_string())?;
+
+    // Request 24kHz mono PCM16
+    let config = cpal::StreamConfig {
+        channels: CHANNELS,
+        sample_rate: SAMPLE_RATE,
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let stream = device
+        .build_input_stream(
+            &config,
+            move |data: &[f32], _| {
+                // Convert f32 → PCM16 LE
+                let pcm: Vec<u8> = data
+                    .iter()
+                    .flat_map(|&s| {
+                        let clamped = s.clamp(-1.0, 1.0);
+                        let i16_val = (clamped * 32767.0) as i16;
+                        i16_val.to_le_bytes()
+                    })
+                    .collect();
+                let _ = tx.send(pcm);
+            },
+            |e| log::error!("agent:audio_capture_error: {e}"),
+            None,
+        )
+        .map_err(|e| format!("failed to build input stream: {e}"))?;
+
+    stream
+        .play()
+        .map_err(|e| format!("failed to start stream: {e}"))?;
+
+    Ok(stream)
+}
+
+type WsSink = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    Message,
+>;
+
+async fn handle_server_event(
+    event: &Value,
+    ws_tx: &mut WsSink,
+    pending_tool: &mut Option<(String, String, String)>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let event_type = event["type"].as_str().unwrap_or("");
+
+    match event_type {
+        "session.created" | "session.updated" => {
+            log::info!("agent:session: {event_type}");
+        }
+
+        "conversation.item.input_audio_transcription.delta" => {
+            if let Some(delta) = event["delta"].as_str() {
+                print!("\x1b[2m{delta}\x1b[0m");
+                let _ = std::io::stdout().flush();
+            }
+        }
+
+        "response.text.delta" => {
+            if let Some(delta) = event["delta"].as_str() {
+                print!("{delta}");
+                let _ = std::io::stdout().flush();
+            }
+        }
+
+        "response.text.done" => {
+            println!();
+        }
+
+        "response.function_call_arguments.start" => {
+            let call_id = event["call_id"].as_str().unwrap_or("").to_string();
+            let name = event["name"].as_str().unwrap_or("").to_string();
+            log::info!("agent:tool_start: call_id={call_id} name={name}");
+            print!("\n\x1b[33m→ {name}\x1b[0m");
+            let _ = std::io::stdout().flush();
+            *pending_tool = Some((call_id, name, String::new()));
+        }
+
+        "response.function_call_arguments.delta" => {
+            if let Some((_, _, ref mut args)) = pending_tool {
+                if let Some(delta) = event["delta"].as_str() {
+                    args.push_str(delta);
+                }
+            }
+        }
+
+        "response.function_call_arguments.done" => {
+            if let Some((call_id, name, args)) = pending_tool.take() {
+                let args_value: Value =
+                    serde_json::from_str(&args).unwrap_or(json!({}));
+                println!(
+                    " {}",
+                    serde_json::to_string(&args_value).unwrap_or_default()
+                );
+
+                log::info!("agent:tool_execute: name={name} args={args}");
+                let result = execute_tool(&name, &args_value);
+                log::info!(
+                    "agent:tool_result: name={name} result_len={}",
+                    result.len()
+                );
+
+                // Submit tool result back to the session
+                let response_event = json!({
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": result
+                    }
+                });
+                ws_tx
+                    .send(Message::Text(response_event.to_string()))
+                    .await?;
+
+                // Trigger the model to continue
+                let continue_event = json!({ "type": "response.create" });
+                ws_tx
+                    .send(Message::Text(continue_event.to_string()))
+                    .await?;
+            }
+        }
+
+        "error" => {
+            let msg = event["error"]["message"]
+                .as_str()
+                .unwrap_or("unknown error");
+            log::error!("agent:api_error: {msg}");
+            eprintln!("\x1b[31m[agent] API error: {msg}\x1b[0m");
+        }
+
+        _ => {
+            log::debug!("agent:event: {event_type}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_session(
+    api_key: String,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let url = format!("wss://api.openai.com/v1/realtime?model={MODEL}");
+
+    let request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(&url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("OpenAI-Beta", "realtime=v1")
+        .body(())
+        .map_err(|e| format!("failed to build request: {e}"))?;
+
+    log::info!("agent:session: connecting to {url}");
+    eprintln!("\x1b[2m[agent] Connecting to gpt-realtime-2...\x1b[0m");
+
+    let (ws_stream, _) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|e| format!("WebSocket connect failed: {e}"))?;
+
+    log::info!("agent:session: connected");
+    eprintln!(
+        "\x1b[32m[agent] Connected. Speak now — press Ctrl+C to end session.\x1b[0m"
+    );
+
+    let (mut ws_tx, mut ws_rx) = ws_stream.split();
+
+    let tools = get_tools();
+    log::info!("agent:session: {} tools available", tools.len());
+
+    // Send session.update with tools + system prompt
+    let session_update = json!({
+        "type": "session.update",
+        "session": {
+            "modalities": ["text", "audio"],
+            "instructions": system_prompt(),
+            "voice": "alloy",
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_audio_transcription": {
+                "model": "whisper-1"
+            },
+            "tools": tools,
+            "tool_choice": "auto",
+            "turn_detection": {
+                "type": "server_vad",
+                "threshold": 0.5,
+                "prefix_padding_ms": 300,
+                "silence_duration_ms": 800
+            }
+        }
+    });
+
+    ws_tx
+        .send(Message::Text(session_update.to_string()))
+        .await?;
+    log::info!("agent:session: session.update sent");
+
+    // Bridge std::sync::mpsc → tokio unbounded channel for audio chunks
+    let (audio_tx, mut audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (sync_tx, sync_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+
+    let audio_tx_bridge = audio_tx.clone();
+    thread::spawn(move || {
+        while let Ok(chunk) = sync_rx.recv() {
+            if audio_tx_bridge.send(chunk).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Start cpal in a thread (cpal::Stream is not Send)
+    thread::spawn(move || {
+        match setup_audio_capture(sync_tx) {
+            Ok(_stream) => {
+                // Keep stream alive until thread exits
+                loop {
+                    thread::sleep(std::time::Duration::from_secs(3600));
+                }
+            }
+            Err(e) => {
+                log::error!("agent:audio_setup_failed: {e}");
+                eprintln!("\x1b[31m[agent] Audio capture failed: {e}\x1b[0m");
+            }
+        }
+    });
+
+    // Pending tool call accumulator: (call_id, name, args_so_far)
+    let mut pending_tool: Option<(String, String, String)> = None;
+
+    // Event loop
+    loop {
+        tokio::select! {
+            // Forward audio chunks to the API
+            Some(chunk) = audio_rx.recv() => {
+                let b64 = BASE64.encode(&chunk);
+                let event = json!({
+                    "type": "input_audio_buffer.append",
+                    "audio": b64
+                });
+                ws_tx.send(Message::Text(event.to_string())).await?;
+            }
+
+            // Handle server events
+            msg = ws_rx.next() => {
+                match msg {
+                    None => {
+                        log::info!("agent:session: WebSocket closed by server");
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        log::error!("agent:session: WebSocket error: {e}");
+                        return Err(Box::new(e));
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        let event: Value =
+                            serde_json::from_str(&text).unwrap_or(Value::Null);
+                        handle_server_event(&event, &mut ws_tx, &mut pending_tool)
+                            .await?;
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        log::info!("agent:session: received close frame");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run() -> i32 {
+    let api_key = match std::env::var("OPENAI_API_KEY") {
+        Ok(k) if !k.is_empty() => k,
+        _ => {
+            eprintln!("error: OPENAI_API_KEY is not set.");
+            eprintln!("Set it with: plexi secret set --inject OPENAI_API_KEY");
+            eprintln!("Then restart this pane.");
+            return 1;
+        }
+    };
+
+    log::info!("agent:start: launching session");
+
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: failed to create async runtime: {e}");
+            return 1;
+        }
+    };
+
+    match rt.block_on(run_session(api_key)) {
+        Ok(()) => {
+            log::info!("agent:session: ended cleanly");
+            0
+        }
+        Err(e) => {
+            log::error!("agent:session: error: {e}");
+            eprintln!("\x1b[31m[agent] Session error: {e}\x1b[0m");
+            1
+        }
+    }
+}

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -250,35 +250,8 @@ async fn handle_server_event(
             }
         }
 
-        // GA API delivers completed tool calls via response.done output array.
         "response.done" => {
-            if let Some(outputs) = event["response"]["output"].as_array() {
-                for item in outputs {
-                    if item["type"].as_str() == Some("function_call") {
-                        let call_id = item["call_id"].as_str().unwrap_or("").to_string();
-                        let name = item["name"].as_str().unwrap_or("").to_string();
-                        let args_str = item["arguments"].as_str().unwrap_or("{}");
-                        let args_value: Value = serde_json::from_str(args_str).unwrap_or(json!({}));
-
-                        println!("\n\x1b[33m→ {name} {}\x1b[0m", serde_json::to_string(&args_value).unwrap_or_default());
-                        log::info!("agent:tool_execute: name={name} call_id={call_id}");
-
-                        let result = execute_tool(&name, &args_value);
-                        log::info!("agent:tool_result: name={name} result_len={}", result.len());
-
-                        let output_event = json!({
-                            "type": "conversation.item.create",
-                            "item": {
-                                "type": "function_call_output",
-                                "call_id": call_id,
-                                "output": result
-                            }
-                        });
-                        ws_tx.send(Message::Text(output_event.to_string())).await?;
-                        ws_tx.send(Message::Text(json!({ "type": "response.create" }).to_string())).await?;
-                    }
-                }
-            }
+            log::info!("agent:response: done");
         }
 
         "error" => {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -342,15 +342,7 @@ async fn run_session(
             "instructions": system_prompt(),
             "voice": "alloy",
             "tools": tools,
-            "tool_choice": "auto",
-            "turn_detection": {
-                "type": "server_vad",
-                "threshold": 0.5,
-                "prefix_padding_ms": 300,
-                "silence_duration_ms": 500,
-                "create_response": true,
-                "interrupt_response": true
-            }
+            "tool_choice": "auto"
         }
     });
 

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -339,7 +339,6 @@ async fn run_session(
         "type": "session.update",
         "session": {
             "type": "realtime",
-            "modalities": ["audio"],
             "instructions": system_prompt(),
             "voice": "alloy",
             "tools": tools,

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -263,9 +263,7 @@ async fn handle_server_event(
         }
 
         _ => {
-            // Log all unhandled events at info so we can discover the GA API event names.
-            log::info!("agent:event:unhandled type={event_type} keys={}",
-                event.as_object().map(|o| o.keys().cloned().collect::<Vec<_>>().join(",")).unwrap_or_default());
+            log::debug!("agent:event:unhandled type={event_type}");
         }
     }
 
@@ -334,13 +332,14 @@ async fn run_session(
         }
     });
 
-    // session.update — GA API schema: audio config is nested under audio.input / audio.output.
-    // tools inline registration not supported in gpt-realtime-2; set instructions only for now.
+    // session.update — GA API schema: audio config nested under audio.input/audio.output;
+    // tools registered at the top level of the session object.
     let session_update = json!({
         "type": "session.update",
         "session": {
             "type": "realtime",
             "instructions": system_prompt(),
+            "tools": tools,
             "output_modalities": ["audio"],
             "audio": {
                 "input": {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -334,15 +334,30 @@ async fn run_session(
         }
     });
 
-    // session.update — uses correct GA API field formats per docs.
+    // session.update — GA API schema: audio config is nested under audio.input / audio.output.
+    // tools inline registration not supported in gpt-realtime-2; set instructions only for now.
     let session_update = json!({
         "type": "session.update",
         "session": {
             "type": "realtime",
             "instructions": system_prompt(),
-            "voice": "alloy",
-            "tools": tools,
-            "tool_choice": "auto"
+            "output_modalities": ["audio"],
+            "audio": {
+                "input": {
+                    "format": { "type": "audio/pcm", "rate": 24000 },
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "threshold": 0.5,
+                        "prefix_padding_ms": 300,
+                        "silence_duration_ms": 500,
+                        "create_response": true,
+                        "interrupt_response": true
+                    }
+                },
+                "output": {
+                    "voice": "alloy"
+                }
+            }
         }
     });
 

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -329,7 +329,7 @@ async fn run_session(
     // gpt-realtime-2 is the GA API — no OpenAI-Beta header needed.
 
     log::info!("agent:session: connecting to {url}");
-    eprintln!("\x1b[2m[agent] Connecting to gpt-realtime-2...\x1b[0m");
+    eprintln!("\x1b[2m[agent] Connecting to {MODEL}...\x1b[0m");
 
     let (ws_stream, _) = tokio_tungstenite::connect_async(request)
         .await
@@ -387,7 +387,6 @@ async fn run_session(
             "instructions": system_prompt(),
             "tools": tools,
             "tool_choice": "auto",
-            "parallel_tool_calls": true,
             "output_modalities": ["audio"],
             "audio": {
                 "input": {
@@ -402,8 +401,7 @@ async fn run_session(
                     }
                 },
                 "output": {
-                    "format": { "type": "audio/pcm", "rate": 24000 },
-                    "voice": "marin"
+                    "voice": "alloy"
                 }
             }
         }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -14,8 +14,7 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 
 const MODEL: &str = "gpt-realtime-2";
-const SAMPLE_RATE: u32 = 24_000;
-const CHANNELS: u16 = 1;
+const SAMPLE_RATE: u32 = 24_000; // fallback if audio thread doesn't report in time
 
 fn system_prompt() -> String {
     "You are a Plexi workspace assistant running inside a Plexi terminal pane. \
@@ -82,7 +81,7 @@ fn execute_tool(name: &str, args: &Value) -> String {
     }
 }
 
-fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<cpal::Stream, String> {
+fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<(cpal::Stream, u32), String> {
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
     let host = cpal::default_host();
@@ -90,38 +89,48 @@ fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<cpal::Str
         .default_input_device()
         .ok_or_else(|| "no default input device".to_string())?;
 
-    // Request 24kHz mono PCM16
-    let config = cpal::StreamConfig {
-        channels: CHANNELS,
-        sample_rate: SAMPLE_RATE,
-        buffer_size: cpal::BufferSize::Default,
-    };
+    // Prefer 24kHz (API native rate); fall back to device default.
+    let supported = device
+        .default_input_config()
+        .map_err(|e| format!("no default input config: {e}"))?;
 
-    let stream = device
-        .build_input_stream(
-            &config,
-            move |data: &[f32], _| {
-                // Convert f32 → PCM16 LE
-                let pcm: Vec<u8> = data
-                    .iter()
-                    .flat_map(|&s| {
-                        let clamped = s.clamp(-1.0, 1.0);
-                        let i16_val = (clamped * 32767.0) as i16;
-                        i16_val.to_le_bytes()
-                    })
-                    .collect();
-                let _ = tx.send(pcm);
-            },
-            |e| log::error!("agent:audio_capture_error: {e}"),
-            None,
-        )
-        .map_err(|e| format!("failed to build input stream: {e}"))?;
+    let actual_rate = supported.sample_rate();
+    let actual_channels = supported.channels();
+    log::info!("agent:audio: device config rate={actual_rate} channels={actual_channels} format={:?}", supported.sample_format());
+
+    let config: cpal::StreamConfig = supported.into();
+
+    let stream = match config.channels {
+        ch => {
+            let tx = tx;
+            device
+                .build_input_stream(
+                    &config,
+                    move |data: &[f32], _| {
+                        // Mix to mono if multichannel, then convert f32 → PCM16 LE
+                        let pcm: Vec<u8> = data
+                            .chunks(ch as usize)
+                            .flat_map(|frame| {
+                                let mono = frame.iter().copied().sum::<f32>() / ch as f32;
+                                let clamped = mono.clamp(-1.0, 1.0);
+                                let i16_val = (clamped * 32767.0) as i16;
+                                i16_val.to_le_bytes()
+                            })
+                            .collect();
+                        let _ = tx.send(pcm);
+                    },
+                    |e| log::error!("agent:audio_capture_error: {e}"),
+                    None,
+                )
+                .map_err(|e| format!("failed to build input stream: {e}"))?
+        }
+    };
 
     stream
         .play()
         .map_err(|e| format!("failed to start stream: {e}"))?;
 
-    Ok(stream)
+    Ok((stream, actual_rate))
 }
 
 type WsSink = futures_util::stream::SplitSink<
@@ -267,7 +276,44 @@ async fn run_session(
     let tools = get_tools();
     log::info!("agent:session: {} tools available", tools.len());
 
-    // Send session.update with tools + system prompt
+    // Start audio capture before session.update so we know the actual sample rate.
+    let (audio_tx, mut audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (sync_tx, sync_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+
+    let audio_tx_bridge = audio_tx.clone();
+    thread::spawn(move || {
+        while let Ok(chunk) = sync_rx.recv() {
+            if audio_tx_bridge.send(chunk).is_err() {
+                break;
+            }
+        }
+    });
+
+    // Start cpal in a thread (cpal::Stream is not Send)
+    let (audio_rate_tx, audio_rate_rx) = std::sync::mpsc::channel::<u32>();
+    thread::spawn(move || {
+        match setup_audio_capture(sync_tx) {
+            Ok((_stream, rate)) => {
+                let _ = audio_rate_tx.send(rate);
+                loop {
+                    thread::sleep(std::time::Duration::from_secs(3600));
+                }
+            }
+            Err(e) => {
+                log::error!("agent:audio_setup_failed: {e}");
+                eprintln!("\x1b[31m[agent] Audio capture failed: {e}\x1b[0m");
+            }
+        }
+    });
+
+    // Wait up to 2s for the audio thread to report its sample rate.
+    let actual_rate = audio_rate_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .unwrap_or(SAMPLE_RATE);
+    log::info!("agent:audio: capturing at {actual_rate} Hz");
+
+    // Send session.update with tools + system prompt.
+    // input_audio_sample_rate tells the GA API the actual capture rate.
     let session_update = json!({
         "type": "session.update",
         "session": {
@@ -275,10 +321,8 @@ async fn run_session(
             "instructions": system_prompt(),
             "voice": "alloy",
             "input_audio_format": "pcm16",
+            "input_audio_sample_rate": actual_rate,
             "output_audio_format": "pcm16",
-            "input_audio_transcription": {
-                "model": "whisper-1"
-            },
             "tools": tools,
             "tool_choice": "auto",
             "turn_detection": {
@@ -294,35 +338,6 @@ async fn run_session(
         .send(Message::Text(session_update.to_string()))
         .await?;
     log::info!("agent:session: session.update sent");
-
-    // Bridge std::sync::mpsc → tokio unbounded channel for audio chunks
-    let (audio_tx, mut audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let (sync_tx, sync_rx) = std::sync::mpsc::channel::<Vec<u8>>();
-
-    let audio_tx_bridge = audio_tx.clone();
-    thread::spawn(move || {
-        while let Ok(chunk) = sync_rx.recv() {
-            if audio_tx_bridge.send(chunk).is_err() {
-                break;
-            }
-        }
-    });
-
-    // Start cpal in a thread (cpal::Stream is not Send)
-    thread::spawn(move || {
-        match setup_audio_capture(sync_tx) {
-            Ok(_stream) => {
-                // Keep stream alive until thread exits
-                loop {
-                    thread::sleep(std::time::Duration::from_secs(3600));
-                }
-            }
-            Err(e) => {
-                log::error!("agent:audio_setup_failed: {e}");
-                eprintln!("\x1b[31m[agent] Audio capture failed: {e}\x1b[0m");
-            }
-        }
-    });
 
     // Pending tool call accumulator: (call_id, name, args_so_far)
     let mut pending_tool: Option<(String, String, String)> = None;

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -236,12 +236,22 @@ async fn run_session(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let url = format!("wss://api.openai.com/v1/realtime?model={MODEL}");
 
-    let request = tokio_tungstenite::tungstenite::http::Request::builder()
-        .uri(&url)
-        .header("Authorization", format!("Bearer {api_key}"))
-        .header("OpenAI-Beta", "realtime=v1")
-        .body(())
+    // Build from the URL so tungstenite generates Sec-WebSocket-Key automatically,
+    // then add auth headers on top.
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    let mut request = url
+        .as_str()
+        .into_client_request()
         .map_err(|e| format!("failed to build request: {e}"))?;
+    let headers = request.headers_mut();
+    headers.insert(
+        "Authorization",
+        format!("Bearer {api_key}").parse().map_err(|e| format!("bad auth header: {e}"))?,
+    );
+    headers.insert(
+        "OpenAI-Beta",
+        "realtime=v1".parse().map_err(|e| format!("bad beta header: {e}"))?,
+    );
 
     log::info!("agent:session: connecting to {url}");
     eprintln!("\x1b[2m[agent] Connecting to gpt-realtime-2...\x1b[0m");

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -16,14 +16,15 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 
-const MODEL: &str = "gpt-realtime-2";
+const MODEL: &str = "gpt-realtime";
 
 fn system_prompt() -> String {
-    "You are a Plexi workspace assistant running inside a Plexi terminal pane. \
-    You can control the workspace by calling the available tools, which map directly \
-    to `plexi` CLI subcommands. Keep responses concise. When you call a tool, it runs \
-    as a subprocess in this pane's environment with PLEXI_SOCKET set, so host commands \
-    will reach the running Plexi instance."
+    "You are a Plexi workspace assistant with access to function tools that execute `plexi` CLI commands. \
+    You MUST call the appropriate function tool to act on any user request. \
+    Never describe what you are about to do — just call the tool. \
+    For example, if the user says 'open a pane', call the `pane_open` function tool immediately. \
+    If a request maps to one of your registered tools, call it. Speak only to confirm completion or report errors. \
+    Keep speech to one short sentence."
         .to_string()
 }
 
@@ -159,7 +160,14 @@ async fn handle_server_event(
         }
         "session.updated" => {
             let tool_count = event["session"]["tools"].as_array().map(|a| a.len()).unwrap_or(0);
-            log::info!("agent:session: session.updated — server has {tool_count} tools");
+            let tool_choice = event["session"]["tool_choice"].as_str().unwrap_or("?");
+            let modalities = event["session"]["output_modalities"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(","))
+                .unwrap_or_default();
+            log::info!(
+                "agent:session: session.updated — tools={tool_count} tool_choice={tool_choice} output_modalities=[{modalities}]"
+            );
         }
 
         // Output audio — base64 PCM16 LE at 24kHz, stream to rodio sink
@@ -203,15 +211,21 @@ async fn handle_server_event(
             println!();
         }
 
-        "response.function_call_arguments.start" => {
-            let call_id = event["call_id"].as_str().unwrap_or("").to_string();
-            let name = event["name"].as_str().unwrap_or("").to_string();
-            log::info!("agent:tool_start: call_id={call_id} name={name}");
-            print!("\n\x1b[33m→ {name}\x1b[0m");
-            let _ = std::io::stdout().flush();
-            *pending_tool = Some((call_id, name, String::new()));
+        // GA Realtime emits a function_call output item BEFORE streaming arguments.
+        // Capture name + call_id here so the .delta/.done events can find them.
+        "response.output_item.added" => {
+            let item = &event["item"];
+            if item["type"].as_str() == Some("function_call") {
+                let call_id = item["call_id"].as_str().unwrap_or("").to_string();
+                let name = item["name"].as_str().unwrap_or("").to_string();
+                log::info!("agent:tool_start: call_id={call_id} name={name}");
+                print!("\n\x1b[33m→ {name}\x1b[0m");
+                let _ = std::io::stdout().flush();
+                *pending_tool = Some((call_id, name, String::new()));
+            }
         }
 
+        // Argument JSON streams in as deltas (per types/realtime/response_function_call_arguments_delta_event.py).
         "response.function_call_arguments.delta" => {
             if let Some((_, _, ref mut args)) = pending_tool {
                 if let Some(delta) = event["delta"].as_str() {
@@ -220,41 +234,57 @@ async fn handle_server_event(
             }
         }
 
+        // .done event carries the full final arguments + name (per
+        // types/realtime/response_function_call_arguments_done_event.py),
+        // so we can recover even if .added wasn't seen.
         "response.function_call_arguments.done" => {
-            if let Some((call_id, name, args)) = pending_tool.take() {
-                let args_value: Value =
-                    serde_json::from_str(&args).unwrap_or(json!({}));
-                println!(
-                    " {}",
-                    serde_json::to_string(&args_value).unwrap_or_default()
-                );
+            // Prefer accumulated state; fall back to fields on the done event.
+            let (call_id, name, args) = match pending_tool.take() {
+                Some((cid, n, a)) if !n.is_empty() => (cid, n, a),
+                _ => (
+                    event["call_id"].as_str().unwrap_or("").to_string(),
+                    event["name"].as_str().unwrap_or("").to_string(),
+                    event["arguments"].as_str().unwrap_or("").to_string(),
+                ),
+            };
 
-                log::info!("agent:tool_execute: name={name} args={args}");
-                let result = execute_tool(&name, &args_value);
-                log::info!(
-                    "agent:tool_result: name={name} result_len={}",
-                    result.len()
-                );
+            let args_str = if args.is_empty() {
+                event["arguments"].as_str().unwrap_or("{}").to_string()
+            } else {
+                args
+            };
+            let args_value: Value =
+                serde_json::from_str(&args_str).unwrap_or(json!({}));
+            println!(
+                " {}",
+                serde_json::to_string(&args_value).unwrap_or_default()
+            );
 
-                // Submit tool result back to the session
-                let response_event = json!({
-                    "type": "conversation.item.create",
-                    "item": {
-                        "type": "function_call_output",
-                        "call_id": call_id,
-                        "output": result
-                    }
-                });
-                ws_tx
-                    .send(Message::Text(response_event.to_string()))
-                    .await?;
+            log::info!("agent:tool_execute: name={name} args={args_str}");
+            let result = execute_tool(&name, &args_value);
+            log::info!(
+                "agent:tool_result: name={name} result_len={}",
+                result.len()
+            );
 
-                // Trigger the model to continue
-                let continue_event = json!({ "type": "response.create" });
-                ws_tx
-                    .send(Message::Text(continue_event.to_string()))
-                    .await?;
-            }
+            // Submit tool result back to the session
+            let response_event = json!({
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": result
+                }
+            });
+            ws_tx
+                .send(Message::Text(response_event.to_string()))
+                .await?;
+
+            // Trigger the model to continue
+            let continue_event = json!({ "type": "response.create" });
+            ws_tx
+                .send(Message::Text(continue_event.to_string()))
+                .await?;
         }
 
         "response.done" => {
@@ -270,7 +300,9 @@ async fn handle_server_event(
         }
 
         _ => {
-            log::debug!("agent:event:unhandled type={event_type}");
+            // Promoted to info so unexpected events (especially around tool calls)
+            // are visible in plexi.log without bumping the global log level.
+            log::info!("agent:event:unhandled type={event_type}");
         }
     }
 
@@ -339,8 +371,15 @@ async fn run_session(
         }
     });
 
-    // session.update — GA API schema: audio config nested under audio.input/audio.output;
-    // tools registered at the top level of the session object.
+    // session.update — GA Realtime API schema (verified against openai-python types/realtime/):
+    //   - session.type = "realtime" (required)
+    //   - audio.input.format = { type: "audio/pcm", rate: 24000 } (PCM only at 24kHz)
+    //   - audio.input.turn_detection = server_vad with auto-create_response
+    //   - audio.output.voice from canonical voice list
+    //   - tools = list of {type:"function", name, description, parameters} (FLAT, not Chat-Completions-style)
+    //   - tool_choice = "auto" | "none" | "required"
+    //   - output_modalities = ["audio"] (default; includes transcript). text-only tools still fire here.
+    //   - parallel_tool_calls = true (supported on reasoning realtime models)
     let session_update = json!({
         "type": "session.update",
         "session": {
@@ -348,6 +387,7 @@ async fn run_session(
             "instructions": system_prompt(),
             "tools": tools,
             "tool_choice": "auto",
+            "parallel_tool_calls": true,
             "output_modalities": ["audio"],
             "audio": {
                 "input": {
@@ -362,7 +402,8 @@ async fn run_session(
                     }
                 },
                 "output": {
-                    "voice": "alloy"
+                    "format": { "type": "audio/pcm", "rate": 24000 },
+                    "voice": "marin"
                 }
             }
         }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -5,10 +5,12 @@
 //! subprocess calls using PLEXI_SOCKET (auto-injected since agent runs in a pane).
 
 use std::io::Write as _;
+use std::sync::Arc;
 use std::thread;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use futures_util::{SinkExt, StreamExt};
+use rodio::{Sink, buffer::SamplesBuffer};
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
@@ -145,6 +147,7 @@ async fn handle_server_event(
     event: &Value,
     ws_tx: &mut WsSink,
     pending_tool: &mut Option<(String, String, String)>,
+    sink: &Arc<Sink>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let event_type = event["type"].as_str().unwrap_or("");
 
@@ -153,11 +156,33 @@ async fn handle_server_event(
             log::info!("agent:session: {event_type}");
         }
 
-        "conversation.item.input_audio_transcription.delta" => {
+        // Output audio — base64 PCM16 LE at 24kHz, stream to rodio sink
+        "response.output_audio.delta" => {
+            if let Some(b64) = event["delta"].as_str() {
+                if let Ok(bytes) = BASE64.decode(b64) {
+                    let samples: Vec<i16> = bytes
+                        .chunks_exact(2)
+                        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+                        .collect();
+                    sink.append(SamplesBuffer::new(1, 24_000, samples));
+                }
+            }
+        }
+
+        "response.output_audio.done" => {
+            log::info!("agent:audio_out: done");
+        }
+
+        // Transcript of what the model said — print so the user can read along
+        "response.output_audio_transcript.delta" => {
             if let Some(delta) = event["delta"].as_str() {
-                print!("\x1b[2m{delta}\x1b[0m");
+                print!("{delta}");
                 let _ = std::io::stdout().flush();
             }
+        }
+
+        "response.output_audio_transcript.done" => {
+            println!();
         }
 
         "response.text.delta" => {
@@ -368,6 +393,15 @@ async fn run_session(
         .await?;
     log::info!("agent:session: session.update sent");
 
+    // Audio output: rodio OutputStream must live as long as the sink.
+    let (_out_stream, out_stream_handle) = rodio::OutputStream::try_default()
+        .map_err(|e| format!("audio output init failed: {e}"))?;
+    let sink = Arc::new(
+        rodio::Sink::try_new(&out_stream_handle)
+            .map_err(|e| format!("audio sink init failed: {e}"))?,
+    );
+    log::info!("agent:session: audio output ready");
+
     // Pending tool call accumulator: (call_id, name, args_so_far)
     let mut pending_tool: Option<(String, String, String)> = None;
 
@@ -398,7 +432,7 @@ async fn run_session(
                     Some(Ok(Message::Text(text))) => {
                         let event: Value =
                             serde_json::from_str(&text).unwrap_or(Value::Null);
-                        handle_server_event(&event, &mut ws_tx, &mut pending_tool)
+                        handle_server_event(&event, &mut ws_tx, &mut pending_tool, &sink)
                             .await?;
                     }
                     Some(Ok(Message::Close(_))) => {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -6,6 +6,7 @@
 
 use std::io::Write as _;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -148,6 +149,7 @@ async fn handle_server_event(
     ws_tx: &mut WsSink,
     pending_tool: &mut Option<(String, String, String)>,
     sink: &Arc<Sink>,
+    model_speaking: &Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let event_type = event["type"].as_str().unwrap_or("");
 
@@ -175,6 +177,7 @@ async fn handle_server_event(
 
         "response.output_audio.done" => {
             log::info!("agent:audio_out: done");
+            model_speaking.store(false, Ordering::Relaxed);
         }
 
         // Transcript of what the model said — print so the user can read along
@@ -380,20 +383,27 @@ async fn run_session(
     );
     log::info!("agent:session: audio output ready");
 
+    // Echo gate: true while the model is speaking. Mic chunks are discarded during
+    // this window to prevent the model's speaker output feeding back into the session.
+    let model_speaking = Arc::new(AtomicBool::new(false));
+
     // Pending tool call accumulator: (call_id, name, args_so_far)
     let mut pending_tool: Option<(String, String, String)> = None;
 
     // Event loop
     loop {
         tokio::select! {
-            // Forward audio chunks to the API
+            // Forward audio chunks to the API — gated: discard while model is speaking
+            // to prevent speaker output feeding back into the session.
             Some(chunk) = audio_rx.recv() => {
-                let b64 = BASE64.encode(&chunk);
-                let event = json!({
-                    "type": "input_audio_buffer.append",
-                    "audio": b64
-                });
-                ws_tx.send(Message::Text(event.to_string())).await?;
+                if !model_speaking.load(Ordering::Relaxed) {
+                    let b64 = BASE64.encode(&chunk);
+                    let event = json!({
+                        "type": "input_audio_buffer.append",
+                        "audio": b64
+                    });
+                    ws_tx.send(Message::Text(event.to_string())).await?;
+                }
             }
 
             // Handle server events
@@ -410,7 +420,18 @@ async fn run_session(
                     Some(Ok(Message::Text(text))) => {
                         let event: Value =
                             serde_json::from_str(&text).unwrap_or(Value::Null);
-                        handle_server_event(&event, &mut ws_tx, &mut pending_tool, &sink)
+
+                        // On first audio delta, raise the echo gate and flush the
+                        // input buffer to discard any speaker bleed already captured.
+                        if event["type"].as_str() == Some("response.output_audio.delta")
+                            && !model_speaking.swap(true, Ordering::Relaxed)
+                        {
+                            let _ = ws_tx.send(Message::Text(
+                                json!({"type": "input_audio_buffer.clear"}).to_string()
+                            )).await;
+                        }
+
+                        handle_server_event(&event, &mut ws_tx, &mut pending_tool, &sink, &model_speaking)
                             .await?;
                     }
                     Some(Ok(Message::Close(_))) => {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -248,10 +248,7 @@ async fn run_session(
         "Authorization",
         format!("Bearer {api_key}").parse().map_err(|e| format!("bad auth header: {e}"))?,
     );
-    headers.insert(
-        "OpenAI-Beta",
-        "realtime=v1".parse().map_err(|e| format!("bad beta header: {e}"))?,
-    );
+    // gpt-realtime-2 is the GA API — no OpenAI-Beta header needed.
 
     log::info!("agent:session: connecting to {url}");
     eprintln!("\x1b[2m[agent] Connecting to gpt-realtime-2...\x1b[0m");

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -152,8 +152,12 @@ async fn handle_server_event(
     let event_type = event["type"].as_str().unwrap_or("");
 
     match event_type {
-        "session.created" | "session.updated" => {
-            log::info!("agent:session: {event_type}");
+        "session.created" => {
+            log::info!("agent:session: session.created");
+        }
+        "session.updated" => {
+            let tool_count = event["session"]["tools"].as_array().map(|a| a.len()).unwrap_or(0);
+            log::info!("agent:session: session.updated — server has {tool_count} tools");
         }
 
         // Output audio — base64 PCM16 LE at 24kHz, stream to rodio sink
@@ -340,6 +344,7 @@ async fn run_session(
             "type": "realtime",
             "instructions": system_prompt(),
             "tools": tools,
+            "tool_choice": "auto",
             "output_modalities": ["audio"],
             "audio": {
                 "input": {
@@ -360,6 +365,7 @@ async fn run_session(
         }
     });
 
+    log::info!("agent:session: sending session.update with {} tools", tools.len());
     ws_tx
         .send(Message::Text(session_update.to_string()))
         .await?;

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -14,7 +14,6 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 
 const MODEL: &str = "gpt-realtime-2";
-const SAMPLE_RATE: u32 = 24_000; // fallback if audio thread doesn't report in time
 
 fn system_prompt() -> String {
     "You are a Plexi workspace assistant running inside a Plexi terminal pane. \
@@ -81,7 +80,9 @@ fn execute_tool(name: &str, args: &Value) -> String {
     }
 }
 
-fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<(cpal::Stream, u32), String> {
+/// Capture mic audio, downsample to 24kHz PCM16 mono, and send chunks to `tx`.
+/// Always outputs at 24kHz regardless of device sample rate.
+fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<cpal::Stream, String> {
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
     let host = cpal::default_host();
@@ -89,48 +90,48 @@ fn setup_audio_capture(tx: std::sync::mpsc::Sender<Vec<u8>>) -> Result<(cpal::St
         .default_input_device()
         .ok_or_else(|| "no default input device".to_string())?;
 
-    // Prefer 24kHz (API native rate); fall back to device default.
     let supported = device
         .default_input_config()
         .map_err(|e| format!("no default input config: {e}"))?;
 
-    let actual_rate = supported.sample_rate();
-    let actual_channels = supported.channels();
-    log::info!("agent:audio: device config rate={actual_rate} channels={actual_channels} format={:?}", supported.sample_format());
+    let device_rate = supported.sample_rate();
+    let ch = supported.channels();
+    log::info!("agent:audio: device rate={device_rate} channels={ch} format={:?}", supported.sample_format());
 
     let config: cpal::StreamConfig = supported.into();
+    let ratio = device_rate as f64 / 24_000f64;
 
-    let stream = match config.channels {
-        ch => {
-            let tx = tx;
-            device
-                .build_input_stream(
-                    &config,
-                    move |data: &[f32], _| {
-                        // Mix to mono if multichannel, then convert f32 → PCM16 LE
-                        let pcm: Vec<u8> = data
-                            .chunks(ch as usize)
-                            .flat_map(|frame| {
-                                let mono = frame.iter().copied().sum::<f32>() / ch as f32;
-                                let clamped = mono.clamp(-1.0, 1.0);
-                                let i16_val = (clamped * 32767.0) as i16;
-                                i16_val.to_le_bytes()
-                            })
-                            .collect();
-                        let _ = tx.send(pcm);
-                    },
-                    |e| log::error!("agent:audio_capture_error: {e}"),
-                    None,
-                )
-                .map_err(|e| format!("failed to build input stream: {e}"))?
-        }
-    };
+    let stream = device
+        .build_input_stream(
+            &config,
+            move |data: &[f32], _| {
+                // Mix to mono then downsample to 24kHz via nearest-neighbour decimation.
+                let mono: Vec<f32> = data
+                    .chunks(ch as usize)
+                    .map(|frame| frame.iter().copied().sum::<f32>() / ch as f32)
+                    .collect();
 
-    stream
-        .play()
-        .map_err(|e| format!("failed to start stream: {e}"))?;
+                let out_len = (mono.len() as f64 / ratio) as usize;
+                let pcm: Vec<u8> = (0..out_len)
+                    .flat_map(|i| {
+                        let src = (i as f64 * ratio) as usize;
+                        let s = mono.get(src).copied().unwrap_or(0.0).clamp(-1.0, 1.0);
+                        let i16_val = (s * 32767.0) as i16;
+                        i16_val.to_le_bytes()
+                    })
+                    .collect();
 
-    Ok((stream, actual_rate))
+                if !pcm.is_empty() {
+                    let _ = tx.send(pcm);
+                }
+            },
+            |e| log::error!("agent:audio_capture_error: {e}"),
+            None,
+        )
+        .map_err(|e| format!("failed to build input stream: {e}"))?;
+
+    stream.play().map_err(|e| format!("failed to start stream: {e}"))?;
+    Ok(stream)
 }
 
 type WsSink = futures_util::stream::SplitSink<
@@ -224,6 +225,37 @@ async fn handle_server_event(
             }
         }
 
+        // GA API delivers completed tool calls via response.done output array.
+        "response.done" => {
+            if let Some(outputs) = event["response"]["output"].as_array() {
+                for item in outputs {
+                    if item["type"].as_str() == Some("function_call") {
+                        let call_id = item["call_id"].as_str().unwrap_or("").to_string();
+                        let name = item["name"].as_str().unwrap_or("").to_string();
+                        let args_str = item["arguments"].as_str().unwrap_or("{}");
+                        let args_value: Value = serde_json::from_str(args_str).unwrap_or(json!({}));
+
+                        println!("\n\x1b[33m→ {name} {}\x1b[0m", serde_json::to_string(&args_value).unwrap_or_default());
+                        log::info!("agent:tool_execute: name={name} call_id={call_id}");
+
+                        let result = execute_tool(&name, &args_value);
+                        log::info!("agent:tool_result: name={name} result_len={}", result.len());
+
+                        let output_event = json!({
+                            "type": "conversation.item.create",
+                            "item": {
+                                "type": "function_call_output",
+                                "call_id": call_id,
+                                "output": result
+                            }
+                        });
+                        ws_tx.send(Message::Text(output_event.to_string())).await?;
+                        ws_tx.send(Message::Text(json!({ "type": "response.create" }).to_string())).await?;
+                    }
+                }
+            }
+        }
+
         "error" => {
             let msg = event["error"]["message"]
                 .as_str()
@@ -276,7 +308,7 @@ async fn run_session(
     let tools = get_tools();
     log::info!("agent:session: {} tools available", tools.len());
 
-    // Start audio capture before session.update so we know the actual sample rate.
+    // Start audio capture. Always outputs 24kHz PCM16 after downsampling.
     let (audio_tx, mut audio_rx) = mpsc::unbounded_channel::<Vec<u8>>();
     let (sync_tx, sync_rx) = std::sync::mpsc::channel::<Vec<u8>>();
 
@@ -289,16 +321,12 @@ async fn run_session(
         }
     });
 
-    // Start cpal in a thread (cpal::Stream is not Send)
-    let (audio_rate_tx, audio_rate_rx) = std::sync::mpsc::channel::<u32>();
+    // cpal::Stream is not Send — own it in a dedicated thread.
     thread::spawn(move || {
         match setup_audio_capture(sync_tx) {
-            Ok((_stream, rate)) => {
-                let _ = audio_rate_tx.send(rate);
-                loop {
-                    thread::sleep(std::time::Duration::from_secs(3600));
-                }
-            }
+            Ok(_stream) => loop {
+                thread::sleep(std::time::Duration::from_secs(3600));
+            },
             Err(e) => {
                 log::error!("agent:audio_setup_failed: {e}");
                 eprintln!("\x1b[31m[agent] Audio capture failed: {e}\x1b[0m");
@@ -306,31 +334,25 @@ async fn run_session(
         }
     });
 
-    // Wait up to 2s for the audio thread to report its sample rate.
-    let actual_rate = audio_rate_rx
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .unwrap_or(SAMPLE_RATE);
-    log::info!("agent:audio: capturing at {actual_rate} Hz");
-
-    // Send session.update with tools + system prompt.
-    // input_audio_sample_rate tells the GA API the actual capture rate.
+    // session.update — uses correct GA API field formats per docs.
     let session_update = json!({
         "type": "session.update",
         "session": {
             "type": "realtime",
-            "modalities": ["text", "audio"],
+            "modalities": ["audio"],
             "instructions": system_prompt(),
             "voice": "alloy",
-            "input_audio_format": "pcm16",
-            "input_audio_sample_rate": actual_rate,
-            "output_audio_format": "pcm16",
+            "input_audio_format": { "type": "audio/pcm", "rate": 24000 },
+            "output_audio_format": { "type": "audio/pcm", "rate": 24000 },
             "tools": tools,
             "tool_choice": "auto",
             "turn_detection": {
                 "type": "server_vad",
                 "threshold": 0.5,
                 "prefix_padding_ms": 300,
-                "silence_duration_ms": 800
+                "silence_duration_ms": 500,
+                "create_response": true,
+                "interrupt_response": true
             }
         }
     });

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -133,6 +133,11 @@ pub enum Commands {
         /// Shell name (zsh, bash, fish)
         shell: Option<String>,
     },
+    /// Voice agent commands
+    Agent {
+        #[command(subcommand)]
+        cmd: AgentCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -267,6 +272,14 @@ pub enum RegistryCmd {
         /// Only check this CLI
         cli: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+pub enum AgentCmd {
+    /// Start a live voice session with gpt-realtime-2
+    Start,
+    /// Print the auto-generated tool schema JSON for the Plexi CLI
+    Schema,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 // PLEXI_AUDIO=mock://. Stubs must return `Err(NotImplemented)` instead.
 #![deny(clippy::todo, clippy::unimplemented)]
 
+mod agent;
 mod app;
 mod app_permissions;
 mod app_protocol;
@@ -190,7 +191,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd};
+    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, AgentCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -297,6 +298,10 @@ fn main() -> eframe::Result {
                         let s = shell.as_deref().unwrap_or("zsh");
                         std::process::exit(cli::completions_cli(s));
                     }
+                    Commands::Agent { cmd } => match cmd {
+                        AgentCmd::Start => std::process::exit(crate::agent::start_cli()),
+                        AgentCmd::Schema => std::process::exit(crate::agent::schema_cli()),
+                    },
                 }
             }
             // No subcommand — fall through to workspace path check, then GUI

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,6 +402,8 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "context",
         "shell-init",
         "completions",
+        // #816 — `plexi agent start` / `plexi agent schema`
+        "agent",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).


### PR DESCRIPTION
Closes #816. Supersedes #745, #746, #747, #748, #751.

## What ships

**`plexi agent schema`** — walks the Clap command tree at runtime and dumps the full OpenAI tool JSON array to stdout. Every leaf subcommand becomes a callable tool (`pane_open`, `context_new`, etc.). A hardcoded denylist blocks destructive commands. Output is inspectable via `plexi agent schema | jq`.

**`plexi agent start`** — live voice session with gpt-realtime-2:
- WebSocket via tokio-tungstenite + native-tls
- Mic capture via cpal (PCM16 24kHz), streamed as base64 `input_audio_buffer.append` events
- Server VAD handles turn detection — no DIY VAD
- PTY rendering: dim transcript deltas, normal agent text, yellow `→ tool_name {...}` for tool calls
- Tool calls execute as `plexi <subcommand> <args>` subprocesses with PLEXI_SOCKET inherited

## Prerequisites for testing

```
plexi secret set --inject OPENAI_API_KEY
```
Restart the pane after setting. Then:
```
plexi-pr-<N> agent start
```

## POC tradeoffs (follow-up issues)
- Audio capture bypasses `audio.record` capability/PGAP — migrate after POC proven
- Tool arg construction is positional-only; flag-style args need a follow-up pass
- TTS audio output not yet wired — agent responds via text only