### PR TITLE
feat(snake): increase grid to 26×20 with 18px cells

### DIFF
--- a/examples/snake/snake.py
+++ b/examples/snake/snake.py
@@ -14,10 +14,10 @@ import time
 from plexi_sdk import App, RenderContext, BG, ACCENT, FG, RED, GREEN, MUTED
 from plexi_sdk._pipe import Pipe
 
-CELL = 20.0          # cell size in logical px
+CELL = 18.0          # cell size in logical px
 TICK = 0.15          # seconds per game tick
-COLS = 20
-ROWS = 16
+COLS = 26
+ROWS = 20
 
 DIR_MAP = {
     "up":    (0, -1),


### PR DESCRIPTION
Closes #884

## What changed
- `COLS` 20 → 26
- `ROWS` 16 → 20
- `CELL` 20 → 18 px (keeps total visual footprint close to original while adding ~62% more cells)

The grid is centered in whatever space the pane provides, so four-pane snake-race tiling is unaffected.

## Breaks if
Snake grid appears the same size as before (constants not picked up) or panes clip the grid in the 2×2 snake-race layout.