### PR TITLE
feat(cli): pane list — add context_id, context_name, window_id, cwd

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -883,13 +883,21 @@ impl PlexiApp {
                             .and_then(|tile| {
                                 if let egui_tiles::Tile::Pane(id) = tile { Some(*id) } else { None }
                             });
+                        let context_name = self.router.iter()
+                            .find(|ctx| ctx.context_id == win.context_id)
+                            .map(|ctx| ctx.name.clone())
+                            .unwrap_or_default();
                         for (pane_id, pane) in &win.panes {
-                            let (pane_type, title) = match pane {
+                            let (pane_type, title, cwd) = match pane {
                                 crate::pane::Pane::Terminal(t) => {
-                                    ("terminal", t.name.clone().unwrap_or_else(|| "terminal".to_string()))
+                                    let name = t.name.clone().unwrap_or_else(|| "terminal".to_string());
+                                    let cwd = crate::shell::get_pid_cwd(t.backend.child_pid())
+                                        .map(|p| p.to_string_lossy().into_owned());
+                                    ("terminal", name, cwd)
                                 }
                                 crate::pane::Pane::App(a) => {
-                                    ("app", a.name.clone())
+                                    let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
+                                    ("app", a.name.clone(), cwd)
                                 }
                             };
                             let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
@@ -898,6 +906,10 @@ impl PlexiApp {
                                 "type": pane_type,
                                 "title": title,
                                 "focused": focused,
+                                "context_id": win.context_id,
+                                "context_name": context_name,
+                                "window_id": win.window_id,
+                                "cwd": cwd,
                             }));
                         }
                     }


### PR DESCRIPTION
Closes #822.

## What changed

`plexi pane list` output now includes four additional fields per pane:

```json
{
  "id": 52,
  "type": "terminal",
  "title": "…",
  "focused": false,
  "context_id": 3,
  "context_name": "PLEXI",
  "window_id": 7,
  "cwd": "/Users/ianburke/Documents/GitHub/PLEXI"
}
```

- `context_id` — from `win.context_id` (already on the struct)
- `window_id` — from `win.window_id` (already on the struct)
- `context_name` — looked up via `self.router.iter().find(|ctx| ctx.context_id == win.context_id)`
- `cwd` — `shell::get_pid_cwd(terminal.backend.child_pid())` for terminals; `app.workspace_root` for app panes; `null` if unavailable

**Breaks if:** `plexi pane list | jq '.[0]'` does not include `context_id`, `context_name`, `window_id`, and `cwd` keys.