### PR TITLE
feat(cli): plexi pane info — dump current pane context as JSON

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -906,6 +906,61 @@ impl PlexiApp {
                         log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
                     }
                 }
+                crate::app_protocol::HostCommand::GetPaneInfo { pane_id, response_file } => {
+                    log::info!("pane_ipc: kind=get_pane_info pane_id={pane_id} response_file={:?}", response_file);
+                    let active_win = self.active_window;
+                    let mut found = false;
+                    'outer: for (win_idx, win) in self.windows.iter().enumerate() {
+                        let focused_pane_id = win.focused_pane
+                            .and_then(|t| win.tree.tiles.get(t))
+                            .and_then(|tile| {
+                                if let egui_tiles::Tile::Pane(id) = tile { Some(*id) } else { None }
+                            });
+                        if let Some(pane) = win.panes.get(pane_id) {
+                            let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
+                            let info = match pane {
+                                crate::pane::Pane::Terminal(t) => {
+                                    let cwd = crate::shell::get_pid_cwd(t.backend.child_pid())
+                                        .map(|p| p.to_string_lossy().into_owned());
+                                    serde_json::json!({
+                                        "id": pane_id,
+                                        "type": "terminal",
+                                        "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
+                                        "focused": focused,
+                                        "context_id": win.context_id,
+                                        "window_id": win.window_id,
+                                        "cwd": cwd,
+                                    })
+                                }
+                                crate::pane::Pane::App(a) => {
+                                    serde_json::json!({
+                                        "id": pane_id,
+                                        "type": "app",
+                                        "title": a.name.clone(),
+                                        "focused": focused,
+                                        "context_id": win.context_id,
+                                        "window_id": win.window_id,
+                                        "cwd": a.workspace_root.to_string_lossy().as_ref(),
+                                        "manifest_id": a.manifest_id.clone(),
+                                    })
+                                }
+                            };
+                            let json_str = serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
+                            if let Err(e) = std::fs::write(response_file, &json_str) {
+                                log::error!("pane_ipc: get_pane_info: could not write response file {:?}: {e}", response_file);
+                            }
+                            found = true;
+                            break 'outer;
+                        }
+                    }
+                    if !found {
+                        log::warn!("pane_ipc: get_pane_info: pane_id={pane_id} not found");
+                        let json_str = format!("{{\"error\":\"pane {pane_id} not found\"}}");
+                        if let Err(e) = std::fs::write(response_file, &json_str) {
+                            log::error!("pane_ipc: get_pane_info: could not write error response: {e}");
+                        }
+                    }
+                }
                 crate::app_protocol::HostCommand::FocusPane { pane_id } => {
                     log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
                     if !self.pane_navigate(*pane_id) {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -930,6 +930,13 @@ pub enum HostCommand {
         response_file: String,
     },
 
+    /// Query info for a specific pane by ID. Host writes JSON object to `response_file`.
+    /// Sent by `plexi pane info`.
+    GetPaneInfo {
+        pane_id: u64,
+        response_file: String,
+    },
+
     /// Move UI focus to a pane by PaneId. Sent by `plexi pane focus`. Fire-and-forget.
     FocusPane {
         pane_id: u64,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1505,6 +1505,96 @@ pub fn pane_list_cli() -> i32 {
     }
 }
 
+/// `plexi pane info`
+///
+/// Sends a `get_pane_info` command to PLEXI_SOCKET for the current pane
+/// (identified by PLEXI_PANE_ID). Merges in client-side fields (socket, channel)
+/// and pretty-prints the result as JSON. Returns 0 on success, 1 on error.
+pub fn pane_info_cli() -> i32 {
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let socket_path = match std::env::var("PLEXI_SOCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let pane_id: u64 = match pane_id_str.parse() {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+            return 1;
+        }
+    };
+
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-info-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    let payload = serde_json::json!({
+        "type": "get_pane_info",
+        "pane_id": pane_id,
+        "response_file": response_file,
+    });
+
+    log::info!("pane_info:cli: pane_id={pane_id} response_file={:?}", response_file);
+
+    let code = send_to_socket(payload);
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                            eprintln!("error: {err}");
+                            return 1;
+                        }
+                        let mut obj = v;
+                        obj["socket"] = serde_json::Value::String(socket_path.clone());
+                        let channel = crate::config::build_channel().unwrap_or_else(|| "stable".to_string());
+                        obj["channel"] = serde_json::Value::String(channel);
+                        match serde_json::to_string_pretty(&obj) {
+                            Ok(pretty) => { println!("{pretty}"); return 0; }
+                            Err(e) => {
+                                eprintln!("error: could not serialize response: {e}");
+                                return 1;
+                            }
+                        }
+                    } else {
+                        eprintln!("error: invalid JSON from host: {content}");
+                        return 1;
+                    }
+                }
+                Err(e) => {
+                    log::warn!("pane_info:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane info response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 /// `plexi pane focus <pane_id>`
 ///
 /// Sends a `focus_pane` command to PLEXI_SOCKET. Fire-and-forget.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -243,6 +243,8 @@ pub enum PaneCmd {
         /// Text to inject (use \n for Enter)
         text: String,
     },
+    /// Print JSON info for the current pane [requires PLEXI_PANE_ID]
+    Info,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
                         PaneCmd::Close { pane_id } => std::process::exit(cli::pane_close_cli(pane_id)),
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
+                        PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },
                     Commands::Open { type_id, layout, extra_args } => {
                         std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref()));

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1494,6 +1494,12 @@ impl ProcessApp {
                     }
                 }
             }
+            HostCommand::GetPaneInfo { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: GetPaneInfo pane_id={pane_id} received in app routing — ignored (host-only command)",
+                    self.type_id
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #891.

Adds `plexi pane info` with no arguments. Inside a Plexi terminal pane it prints a JSON object like:

```json
{
  "id": 3,
  "type": "terminal",
  "title": "terminal",
  "focused": true,
  "context_id": 1,
  "window_id": 1,
  "cwd": "/Users/ianburke/Documents/GitHub/PLEXI",
  "socket": "/var/folders/.../plexi-alpha.sock",
  "channel": "alpha"
}
```

App panes include `manifest_id` in place of nothing extra. Running outside a pane exits 1 with a clear error.

## Implementation
- `GetPaneInfo { pane_id, response_file }` HostCommand (serde snake_case tag)
- Host handler: looks up pane across all windows, writes JSON to response file; `get_pid_cwd` for terminal CWD, `workspace_root` for app CWD
- CLI: reads `PLEXI_PANE_ID` + `PLEXI_SOCKET`, sends command, polls response, merges `socket` and `channel` client-side, pretty-prints
- Exhaustive match in `process_app/routing.rs` covered with warn-and-ignore (host-only command)

## Test plan
- [ ] Run `plexi-pr-<N> pane info` inside a terminal pane — JSON with all required fields printed
- [ ] Run outside a pane (no `PLEXI_PANE_ID`) — exits 1 with clear error