### PR TITLE
fix(pane): closing a pane focuses the pane to the right (or below)

### DIFF
--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -476,10 +476,10 @@ impl PlexiApp {
                         .iter()
                         .position(|&c| c == child_in_parent)
                         .map(|pos| {
-                            let sibling = if pos > 0 {
-                                children[pos - 1]
-                            } else {
+                            let sibling = if pos + 1 < children.len() {
                                 children[pos + 1]
+                            } else {
+                                children[pos - 1]
                             };
                             let is_tabs = matches!(container, Container::Tabs(_));
                             let is_linear = matches!(container, Container::Linear(_));
@@ -537,6 +537,7 @@ impl PlexiApp {
                 all_panes_must_have_tabs: true,
                 ..SimplificationOptions::default()
             });
+            log::info!("close_tile: focus -> {:?}", next);
             ctx.focused_pane = next;
 
             removed


### PR DESCRIPTION
Closes #892.

## What

Reverses sibling selection in `close_tile` — after closing a pane, focus lands on the pane to the right (or below for vertical splits), falling back to left/above only when the closed pane was the last child.

## Why

Reading order is left-to-right / top-to-bottom. The previous behavior jumped focus backward, which felt like Backspace moving the cursor back two words.

## Change

Single 2-line change in `src/pane_ops/layout.rs` `close_tile`:

```rust
// before
let sibling = if pos > 0 { children[pos - 1] } else { children[pos + 1] };

// after
let sibling = if pos + 1 < children.len() { children[pos + 1] } else { children[pos - 1] };
```

Also added `log::info!("close_tile: focus -> {:?}", next)` for observability.

## Breaks if

Focus after pane close lands on the left/above pane when a right/below sibling exists.