### PR TITLE
feat(cli): plexi pane close — no-arg form closes current pane via PLEXI_PANE_ID

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -245,10 +245,10 @@ pub enum PaneCmd {
         /// Pane ID (from `plexi pane list`)
         pane_id: u64,
     },
-    /// Close a pane by ID
+    /// Close a pane. Omit <pane_id> to close the current pane via PLEXI_PANE_ID.
     Close {
-        /// Pane ID (from `plexi pane list`)
-        pane_id: u64,
+        /// Pane ID (from `plexi pane list`). Defaults to PLEXI_PANE_ID if not given.
+        pane_id: Option<u64>,
     },
     /// Send text to a running pane's PTY stdin [requires PLEXI_SOCKET — run inside a Plexi pane]
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,29 @@ fn main() -> eframe::Result {
                         }
                         PaneCmd::List => std::process::exit(cli::pane_list_cli()),
                         PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
-                        PaneCmd::Close { pane_id } => std::process::exit(cli::pane_close_cli(pane_id)),
+                        PaneCmd::Close { pane_id } => {
+                            let id = match pane_id {
+                                Some(id) => id,
+                                None => {
+                                    let s = match std::env::var("PLEXI_PANE_ID") {
+                                        Ok(s) => s,
+                                        Err(_) => {
+                                            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane or pass a pane ID explicitly");
+                                            std::process::exit(1);
+                                        }
+                                    };
+                                    match s.parse::<u64>() {
+                                        Ok(id) => id,
+                                        Err(_) => {
+                                            eprintln!("error: PLEXI_PANE_ID is not a valid number: {s}");
+                                            std::process::exit(1);
+                                        }
+                                    }
+                                }
+                            };
+                            log::info!("pane_close:cli: pane_id={id}");
+                            std::process::exit(cli::pane_close_cli(id));
+                        }
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },


### PR DESCRIPTION
Closes #864

## What

`plexi pane close` now accepts an optional `<pane_id>`. When omitted, it resolves the pane ID from `PLEXI_PANE_ID` (set automatically inside any Plexi terminal pane).

## Changes

- `src/cli_args.rs` — `PaneCmd::Close.pane_id: u64` → `Option<u64>`
- `src/main.rs` — resolve from env when `None`; clear error if `PLEXI_PANE_ID` is not set

## Breaks if

`plexi pane close` (no args) inside a Plexi pane does not close the pane, or exits with a non-zero code unexpectedly.