### PR TITLE
fix(palette): Cmd+P bypasses keyboard capture so palette always opens

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2760,6 +2760,15 @@ impl eframe::App for PlexiApp {
 
         self.draw_feature_effects(ctx);
 
+        // Re-request focus for the palette search field after all pane rendering.
+        // App panes call request_focus() on their TextInput widgets during
+        // CentralPanel rendering, and egui focus is last-write-wins — without
+        // this, a keyboard-capture app pane steals focus from the palette every
+        // frame, making the search field non-typeable even though it's visible.
+        if self.show_command_palette {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("palette_search")));
+        }
+
         let frame_ms = _frame_start.elapsed().as_millis();
         if frame_ms > 50 {
             log::warn!("slow frame: {}ms", frame_ms);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -121,8 +121,8 @@ pub enum Action {
 ///
 /// `app_active` — focused pane has an active app surface (affects Escape/Tab).
 /// `keyboard_capture_active` — focused app declared `keyboard_capture = true` in its manifest.
-///   When true, all host shortcuts are suppressed *except* Cmd+Q (quit) and Cmd+W (close pane),
-///   which are structural safety operations that must always work.
+///   When true, all host shortcuts are suppressed *except* Cmd+Q (quit), Cmd+W (close pane),
+///   and Cmd+P (command palette) — structural safety operations that must always work.
 pub fn poll_actions(
     ctx: &egui::Context,
     app_active: bool,
@@ -145,6 +145,12 @@ pub fn poll_actions(
         // Close pane (Cmd+W) — always active, even in keyboard capture mode.
         if input.consume_key(egui::Modifiers::COMMAND, egui::Key::W) {
             actions.push(Action::ClosePane);
+        }
+
+        // Command palette (Cmd+P) — always active, even in keyboard capture mode.
+        // The palette is a host-level UI surface; apps cannot block access to it.
+        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::P) {
+            actions.push(Action::ToggleCommandPalette);
         }
 
         // All remaining shortcuts are suppressed when an app has declared keyboard capture.
@@ -243,11 +249,6 @@ pub fn poll_actions(
         // Toggle shortcuts overlay (Cmd+/)
         if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Slash) {
             actions.push(Action::ToggleShortcuts);
-        }
-
-        // Command palette (Cmd+P)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::P) {
-            actions.push(Action::ToggleCommandPalette);
         }
 
         // Rename context (Cmd+Shift+R) vs rename pane (Cmd+R). Check shifted


### PR DESCRIPTION
## Summary

- Cmd+P was placed after the `keyboard_capture_active` early return in `poll_actions`, so any app with `keyboard_capture: true` in its manifest silently swallowed it
- Most visible when the keyboard-capture app is zoomed (Cmd+Enter) — the palette was completely unreachable
- Fix: hoisted the `ToggleCommandPalette` check above the guard, same pattern as Cmd+Q and Cmd+W; removed the now-duplicate check below the guard

Closes #799

## Test plan

- [ ] Launch any app with `keyboard_capture: true` in its manifest, zoom it (Cmd+Enter), press Cmd+P — palette should open
- [ ] Palette accepts keyboard input normally while zoomed app is behind it
- [ ] Cmd+P still works with non-keyboard-capture apps and terminals (regression check)
- [ ] Pressing Cmd+P again closes the palette

**Breaks if:** Cmd+P does nothing while a keyboard-capture app is focused or zoomed

🤖 Generated with [Claude Code](https://claude.com/claude-code)