### PR TITLE
feat(cli): promote plexi terminal as top-level command

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1137,6 +1137,7 @@ impl PlexiApp {
                 continue;
             }
             let layout = val["layout"].as_str().map(|s| s.to_string());
+            let ephemeral = val["ephemeral"].as_bool().unwrap_or(false);
             let args: Vec<String> = val["args"]
                 .as_array()
                 .map(|a| {
@@ -1145,8 +1146,15 @@ impl PlexiApp {
                         .collect()
                 })
                 .unwrap_or_default();
-            log::info!("spawn-queue: launching '{type_id}' layout={layout:?}");
-            self.launch_app_by_id_with_layout(&type_id, layout, &args);
+            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral}");
+            if type_id == "terminal" {
+                let layout_str = layout.as_deref().unwrap_or("split_v");
+                let vertical = matches!(layout_str, "split_h" | "split_above");
+                let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+                self.split_focused(vertical, initial_cmd.as_deref(), ephemeral);
+            } else {
+                self.launch_app_by_id_with_layout(&type_id, layout, &args);
+            }
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -988,10 +988,17 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, response_file, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} response_file={response_file:?}");
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} ephemeral={ephemeral} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
-                    self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                    if type_id == "terminal" {
+                        let vertical = matches!(layout.as_str(), "split_h" | "split_above");
+                        let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+                        log::info!("pane_ipc: spawn_pane terminal vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                        self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
+                    } else {
+                        self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                    }
                     if let Some(rf) = response_file {
                         let json = format!("{{\"pane_id\":{new_pane_id}}}");
                         if let Err(e) = std::fs::write(rf, &json) {
@@ -1565,7 +1572,7 @@ impl eframe::App for PlexiApp {
                         log::info!(
                             "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
                         );
-                        self.split_focused(vertical, initial_cmd.as_deref());
+                        self.split_focused(vertical, initial_cmd.as_deref(), false);
                     } else {
                         self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
@@ -2020,12 +2027,12 @@ impl eframe::App for PlexiApp {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
-                    self.split_focused(false, None);
+                    self.split_focused(false, None, false);
                     self.save_workspace();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].zoomed_pane = None;
-                    self.split_focused(true, None);
+                    self.split_focused(true, None, false);
                     self.save_workspace();
                 }
                 Action::SplitRight => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1572,7 +1572,9 @@ impl eframe::App for PlexiApp {
                         log::info!(
                             "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
                         );
-                        self.split_focused(vertical, initial_cmd.as_deref(), false);
+                        // SDK-spawned terminal with a cmd closes on exit (matches historical behavior).
+                        // CLI terminal uses the ephemeral flag exclusively — cmd alone does not close.
+                        self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some());
                     } else {
                         self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -916,6 +916,8 @@ pub enum HostCommand {
         request_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         response_file: Option<String>,
+        #[serde(default, skip_serializing_if = "is_false")]
+        ephemeral: bool,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
@@ -1514,6 +1516,10 @@ pub struct ListItem {
 
 fn default_spawn_layout() -> String {
     "split_v".to_string()
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 fn default_stroke_width() -> f32 {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1691,6 +1691,10 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
     let layout_str = layout.unwrap_or("split_v");
+    if type_id == "terminal" {
+        log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
+        eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
+    }
 
     // Socket path is set when running inside a Plexi pane — use it directly so
     // the command reaches the correct running instance regardless of channel.
@@ -1767,6 +1771,95 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
     }
     log::info!("cli: open queued: type_id={type_id}");
     println!("queued: open {type_id}");
+    println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
+    0
+}
+
+/// `plexi terminal [cmd] [--ephemeral] [--layout=X]`
+///
+/// Opens a terminal pane. Supports the --ephemeral flag which closes the pane when the
+/// process exits.
+pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>) -> i32 {
+    let layout_str = layout.unwrap_or("split_v");
+    let args: Vec<String> = cmd.map(|c| vec![c.to_string()]).unwrap_or_default();
+
+    if std::env::var("PLEXI_SOCKET").is_ok() {
+        let id = uuid::Uuid::new_v4();
+        let response_file = crate::config::config_dir()
+            .join(format!("spawn-pane-response-{id}.json"))
+            .to_string_lossy()
+            .into_owned();
+        let mut payload = serde_json::json!({
+            "type": "spawn_pane",
+            "type_id": "terminal",
+            "args": args,
+            "layout": layout_str,
+            "response_file": response_file,
+        });
+        if ephemeral {
+            payload["ephemeral"] = serde_json::Value::Bool(true);
+        }
+        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} response_file={response_file:?}");
+        let code = send_to_socket(payload);
+        if code != 0 {
+            return code;
+        }
+        let response_path = std::path::PathBuf::from(&response_file);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if response_path.exists() {
+                match std::fs::read_to_string(&response_path) {
+                    Ok(content) => {
+                        let _ = std::fs::remove_file(&response_path);
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+                                println!("{pid}");
+                                return 0;
+                            }
+                        }
+                        print!("{content}");
+                        return 0;
+                    }
+                    Err(e) => {
+                        log::warn!("terminal:cli: could not read response file: {e}");
+                        eprintln!("error: could not read response file: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("error: timed out waiting for terminal response");
+                return 1;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    // Fallback: spawn-queue (outside a Plexi pane)
+    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
+        eprintln!("error: could not create spawn queue: {e}");
+        return 1;
+    }
+    let id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut queue_payload = serde_json::json!({
+        "type_id": "terminal",
+        "args": args,
+        "layout": layout_str,
+    });
+    if ephemeral {
+        queue_payload["ephemeral"] = serde_json::Value::Bool(true);
+    }
+    let file = queue_dir.join(format!("{id}.json"));
+    if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
+        eprintln!("error: could not write spawn request: {e}");
+        return 1;
+    }
+    log::info!("terminal:cli: queued ephemeral={ephemeral}");
+    println!("queued: open terminal");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0
 }
@@ -2746,7 +2839,8 @@ _plexi() {
         'pack:Pack management'
         'notify:Send a notification'
         'pane:Pane management'
-        'open:Open an app or terminal pane'
+        'terminal:Open a terminal pane'
+        'open:Open an app pane'
         'descriptor:Descriptor probe'
         'registry:CLI registry'
         'context:Context management'
@@ -2786,6 +2880,11 @@ _plexi() {
           local subcmds
           subcmds=('set-title:Set the title of a pane (current or by ID)')
           _describe 'subcommand' subcmds
+          ;;
+        terminal)
+          _arguments \
+            '--ephemeral[Close the pane when the process exits]' \
+            '--layout[Layout hint]:layout:(split_v split_h split_above)'
           ;;
         descriptor)
           local subcmds
@@ -2836,7 +2935,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
   local cur prev words cword
   _init_completion || return
 
-  local commands="run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions"
+  local commands="run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions"
 
   if [[ $cword -eq 1 ]]; then
     COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -2862,6 +2961,13 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       ;;
     pane)
       COMPREPLY=($(compgen -W "set-title" -- "$cur"))
+      ;;
+    terminal)
+      if [[ $prev == "--layout" ]]; then
+        COMPREPLY=($(compgen -W "split_v split_h split_above" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "--ephemeral --layout" -- "$cur"))
+      fi
       ;;
     descriptor)
       COMPREPLY=($(compgen -W "probe" -- "$cur"))
@@ -2903,24 +3009,25 @@ complete -F _plexi_completions plexi
 
 const FISH_COMPLETION: &str = r#"# Plexi shell completions for fish
 
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a run -d "Run a named command"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a workspace -d "Workspace management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a secret -d "Secret management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a app -d "App management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a install -d "Install an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a uninstall -d "Uninstall an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a update -d "Update apps or self"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a list -d "List installed apps"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a validate -d "Validate a Plexi app directory"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a pack -d "Pack management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a notify -d "Send a notification"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a pane -d "Pane management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a open -d "Open an app or terminal pane"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a descriptor -d "Descriptor probe"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a registry -d "CLI registry"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a context -d "Context management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a shell-init -d "Print shell integration snippet"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane open descriptor registry context shell-init completions" -a completions -d "Print shell completion script"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a run -d "Run a named command"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a workspace -d "Workspace management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a secret -d "Secret management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a app -d "App management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a install -d "Install an app"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a uninstall -d "Uninstall an app"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a update -d "Update apps or self"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a list -d "List installed apps"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a validate -d "Validate a Plexi app directory"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a pack -d "Pack management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a notify -d "Send a notification"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a pane -d "Pane management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a terminal -d "Open a terminal pane"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a open -d "Open an app pane"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a descriptor -d "Descriptor probe"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a registry -d "CLI registry"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a context -d "Context management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a shell-init -d "Print shell integration snippet"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context shell-init completions" -a completions -d "Print shell completion script"
 
 # secret subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from secret" -a set -d "Store a secret"
@@ -2974,6 +3081,10 @@ complete -c plexi -n "__fish_seen_subcommand_from shell-init" -l shell -d "Shell
 
 # completions args
 complete -c plexi -f -n "__fish_seen_subcommand_from completions" -a "zsh bash fish"
+
+# terminal flags
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -l ephemeral -d "Close the pane when the process exits"
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_v split_h split_above"
 "#;
 
 #[cfg(test)]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -94,7 +94,18 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PaneCmd,
     },
-    /// Open an app or terminal pane
+    /// Open a terminal pane
+    Terminal {
+        /// Optional command to run in the terminal
+        cmd: Option<String>,
+        /// Close the pane when the process exits
+        #[arg(long)]
+        ephemeral: bool,
+        /// Layout hint (split_v, split_h, split_above)
+        #[arg(long)]
+        layout: Option<String>,
+    },
+    /// Open an app pane
     Open {
         /// App or pane type id
         type_id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,6 +281,9 @@ fn main() -> eframe::Result {
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },
+                    Commands::Terminal { cmd, ephemeral, layout } => {
+                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref()));
+                    }
                     Commands::Open { type_id, layout, extra_args } => {
                         std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref()));
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "workspace",
         "notify",
         "pane",
+        "terminal",
         "open",
         "--render",
         // #308 Phase 2 — top-level package manager subcommands

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -463,8 +463,8 @@ impl PlexiApp {
         args: &[String],
     ) {
         // "terminal" is a builtin pane type, not in the app registry.
-        // All dispatch paths (socket IPC, spawn-queue, in-process) must share
-        // this early-return so `plexi open terminal` works from any context.
+        // Reached via SDK AppCommand::SpawnApp("terminal", ...) and legacy paths.
+        // Socket IPC and spawn-queue handle terminal inline in app/mod.rs.
         if id == "terminal" {
             let layout_str = layout.as_deref().unwrap_or("split_v");
             let vertical = matches!(layout_str, "split_h" | "split_above");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -472,7 +472,7 @@ impl PlexiApp {
             log::info!(
                 "SpawnPane: terminal layout='{layout_str}' vertical={vertical} initial_cmd={initial_cmd:?}"
             );
-            self.split_focused(vertical, initial_cmd.as_deref());
+            self.split_focused(vertical, initial_cmd.as_deref(), false);
             return;
         }
 
@@ -678,6 +678,7 @@ mod tests {
             from_pane_id: None,
             request_id: None,
             response_file: None,
+            ephemeral: false,
         });
         h.run_frames(2);
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -182,7 +182,7 @@ impl PlexiApp {
         match kind {
             Kind::Terminal => {
                 // Reuse the existing terminal split path.
-                self.split_focused(vertical, None);
+                self.split_focused(vertical, None, false);
             }
             Kind::App(manifest_id) => {
                 // Fresh instance of the same app at the requested placement.
@@ -199,7 +199,7 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>) {
+    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool) {
         let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
@@ -248,6 +248,7 @@ impl PlexiApp {
             log::error!("Failed to create new terminal pane");
             return;
         };
+        pane.close_on_exit = close_on_exit;
         self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -767,6 +767,7 @@ impl ProcessApp {
                 from_pane_id,
                 request_id,
                 response_file: _,
+                ephemeral: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)


### PR DESCRIPTION
Closes #846

## Summary

- Adds `plexi terminal [cmd] [--ephemeral] [--layout]` as a top-level command — the canonical way to open PTY terminal panes
- `plexi open <app-id>` now purely means "launch a PGAP app" (description updated)
- `plexi open terminal` still works but emits a deprecation warning to stderr
- `--ephemeral` flag threads through the `spawn_pane` protocol (`HostCommand::SpawnPane.ephemeral`) so a pane auto-closes on exit even without an initial command
- Shell completions updated for zsh, bash, and fish
- `plexi-cli` skill updated with new canonical forms

## Test plan

- [ ] `plexi terminal` opens a new terminal pane
- [ ] `plexi terminal "echo hello"` opens a terminal and injects the command
- [ ] `plexi terminal --ephemeral "echo done"` opens a pane that closes after the command runs
- [ ] `plexi terminal --layout split_h` opens below
- [ ] `plexi open terminal` still opens a pane but prints a deprecation warning to stderr
- [ ] `plexi open snake` (or any app) works unchanged
- [ ] `plexi terminal --help` shows correct flags
- [ ] `cargo test` passes (310 tests)