### PR TITLE
feat(apps): default launch layout to overlay instead of split_v

### DIFF
--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1515,7 +1515,7 @@ pub struct ListItem {
 }
 
 fn default_spawn_layout() -> String {
-    "split_v".to_string()
+    "overlay".to_string()
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2561,12 +2561,12 @@ mod tests {
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(serialised.contains(r#""type":"spawn_pane""#), "wire tag missing: {serialised}");
 
-        // defaults: layout defaults to "split_v", args to [], pipe_id absent
+        // defaults: layout defaults to "overlay", args to [], pipe_id absent
         let minimal = r#"{"type":"spawn_pane","type_id":"snake"}"#;
         let cmd2: DrawCommand = serde_json::from_str(minimal).expect("deserialise minimal");
         match &cmd2 {
             DrawCommand::Host(HostCommand::SpawnPane { layout, args, pipe_id, from_pane_id, request_id, .. }) => {
-                assert_eq!(layout, "split_v");
+                assert_eq!(layout, "overlay");
                 assert!(args.is_empty());
                 assert!(pipe_id.is_none());
                 assert!(from_pane_id.is_none());

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -175,7 +175,7 @@ pub struct LaunchSection {
     /// Convention: "cwd" for generic directory-synced apps.
     #[serde(default)]
     pub join_group: Option<String>,
-    /// Preferred pane layout. Default: `LayoutHint { side: "right", split: 0.5 }`.
+    /// Preferred pane layout. When absent, the host defaults to `overlay` (full pane takeover).
     #[serde(default)]
     pub layout_hint: Option<LayoutHint>,
     /// If true, this app captures all keyboard input when focused. Host

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1690,7 +1690,7 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
 ///
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>) -> i32 {
-    let layout_str = layout.unwrap_or("split_v");
+    let layout_str = layout.unwrap_or("overlay");
     if type_id == "terminal" {
         log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
         eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -453,9 +453,9 @@ impl PlexiApp {
 
     /// Launch an installed app with an explicit layout and args override.
     /// `layout` overrides the manifest's `layout_hint` when `Some`.
-    ///   "split_v" (default) — vertical split, new pane below
+    ///   "overlay" (default) — full pane takeover; Esc restores the original pane
+    ///   "split_v"           — vertical split, new pane below
     ///   "split_h"           — horizontal split, new pane to the right
-    ///   "overlay"           — full pane, no terminal split
     pub(crate) fn launch_app_by_id_with_layout(
         &mut self,
         id: &str,
@@ -482,7 +482,12 @@ impl PlexiApp {
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
         let group = self.registry.group_for(id);
-        let hint = layout.or_else(|| self.registry.layout_hint_for(id));
+        let hint = layout
+            .or_else(|| self.registry.layout_hint_for(id))
+            .or_else(|| {
+                log::info!("app::{id}: no layout_hint — defaulting to overlay");
+                Some("overlay".to_string())
+            });
 
         // Re-attach a parked background app if one is waiting
         if let Some(mut parked) = self.background_apps.remove(id) {


### PR DESCRIPTION
Closes #902

## What
Apps that omit `layout_hint` in their manifest now open as `overlay` (full focused-pane takeover) instead of `split_v`. Esc restores the original pane underneath.

Apps that want split behavior explicitly declare it:
```toml
[launch]
layout_hint = { side = "below", split = 0.5 }
```

## What's unchanged
- Terminal pane launch path keeps `split_v` (early-return untouched)
- Caller-provided `layout` argument still wins over manifest and default
- Manifest `layout_hint` still wins over default
- All existing shipped example apps have explicit `layout_hint` — none affected

## Files changed
- `src/pane_ops/create.rs` — default hint to `"overlay"` when layout arg and registry both return `None`; updated comment block
- `src/app_registry.rs` — updated `layout_hint` doc comment to reflect new default