### PR TITLE
fix(sdk): ctx.clear() default fill, add width/height aliases

### DIFF
--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -46,8 +46,16 @@ class RenderContext:
         """Buffer a render command for batch flush at frame_done()."""
         self._buf.append(json.dumps(obj) + "\n")
 
+    @property
+    def width(self) -> float:
+        return self.w
+
+    @property
+    def height(self) -> float:
+        return self.h
+
     # ── Visual primitives ──
-    def clear(self, fill: str) -> None:
+    def clear(self, fill: str = "#000000") -> None:
         """Fill the entire pane with a single color. Shorthand for a full-size rect."""
         self._queue({"type": "rect", "x": 0.0, "y": 0.0, "w": self.w, "h": self.h,
                      "fill": fill, "radius": 0.0})


### PR DESCRIPTION
Closes #871.

## Changes

- `ctx.clear()` now defaults `fill` to `"#000000"` — calling it without arguments no longer raises `TypeError`
- Added `ctx.width` and `ctx.height` properties that alias `ctx.w` and `ctx.h` — first-attempt code using the longer names now works

No breaking changes. Diff-verifiable.