### PR TITLE
feat(cli): notify --choice accepts 4-segment key:Label:action:arg format

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1264,6 +1264,36 @@ pub fn pack_export_cli(dest_path: &str) -> i32 {
     }
 }
 
+/// Parse a single `--choice` argument into `(key, label, host_action)`.
+///
+/// Accepted formats:
+/// - `key:Label`                            → (key, Label, None)
+/// - `Label:action_type:action_arg`         → (Label, Label, Some("action_type:action_arg"))
+/// - `key:Label:action_type:action_arg`     → (key, Label, Some("action_type:action_arg"))
+///
+/// Any other segment count is rejected with a clear error string.
+pub(crate) fn parse_notify_choice(raw: &str) -> Result<(String, String, Option<String>), String> {
+    let segments: Vec<&str> = raw.splitn(5, ':').collect();
+    match segments.len() {
+        4 => Ok((
+            segments[0].to_string(),
+            segments[1].to_string(),
+            Some(format!("{}:{}", segments[2], segments[3])),
+        )),
+        3 => {
+            let label = segments[0].to_string();
+            let host_action = format!("{}:{}", segments[1], segments[2]);
+            Ok((label.clone(), label, Some(host_action)))
+        }
+        2 => Ok((segments[0].to_string(), segments[1].to_string(), None)),
+        n => Err(format!(
+            "error: --choice requires 2, 3, or 4 colon-separated segments \
+             (key:Label / Label:action:arg / key:Label:action:arg) — got {n} in {:?}",
+            raw
+        )),
+    }
+}
+
 /// Entry point for `plexi notify --title <text> --body <text> [--level info|warn|error]
 ///   [--choice key:Label]... [--timeout N]`.
 ///
@@ -2953,7 +2983,7 @@ _plexi() {
             '--title[Notification title]:title:' \
             '--body[Notification body]:body:' \
             '--level[Level]:level:(info warn error)' \
-            '--choice[Choice option (key:Label or Label:pane_focus:<id>)]:choice:' \
+            '--choice[Choice option (key:Label / Label:action:arg / key:Label:action:arg)]:choice:' \
             '--timeout[Timeout in seconds]:seconds:'
           ;;
         install)
@@ -3114,7 +3144,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from context" -a set-root -d "Se
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l title -d "Notification title"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l body -d "Notification body"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l level -d "Level" -a "info warn error"
-complete -c plexi -n "__fish_seen_subcommand_from notify" -l choice -d "Choice option (key:Label or Label:pane_focus:<id>)"
+complete -c plexi -n "__fish_seen_subcommand_from notify" -l choice -d "Choice option (key:Label / Label:action:arg / key:Label:action:arg)"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l timeout -d "Timeout in seconds"
 
 # install flags
@@ -3136,14 +3166,50 @@ complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout
 
 #[cfg(test)]
 mod notify_tests {
-    use super::notify_cli;
+    use super::{notify_cli, parse_notify_choice};
 
     /// Without PLEXI_SOCKET set, notify_cli must fail fast (exit 1) rather than panic.
     #[test]
     fn notify_cli_no_socket_returns_one() {
-        // Ensure env var is unset for this test.
         std::env::remove_var("PLEXI_SOCKET");
         let code = notify_cli("Test title", "Test body", "info", &[], 0);
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn parse_choice_two_segment() {
+        let (key, label, action) = parse_notify_choice("open_pr:Open PR").unwrap();
+        assert_eq!(key, "open_pr");
+        assert_eq!(label, "Open PR");
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn parse_choice_three_segment_host_action() {
+        let (key, label, action) = parse_notify_choice("Talk to Claude:pane_focus:188").unwrap();
+        assert_eq!(key, "Talk to Claude");
+        assert_eq!(label, "Talk to Claude");
+        assert_eq!(action.as_deref(), Some("pane_focus:188"));
+    }
+
+    #[test]
+    fn parse_choice_four_segment_key_label_action() {
+        let (key, label, action) =
+            parse_notify_choice("c:Talk to Claude:pane_focus:188").unwrap();
+        assert_eq!(key, "c");
+        assert_eq!(label, "Talk to Claude");
+        assert_eq!(action.as_deref(), Some("pane_focus:188"));
+    }
+
+    #[test]
+    fn parse_choice_five_segment_is_error() {
+        let err = parse_notify_choice("a:b:c:d:e").unwrap_err();
+        assert!(err.contains("5"), "error should mention segment count: {err}");
+    }
+
+    #[test]
+    fn parse_choice_one_segment_is_error() {
+        let err = parse_notify_choice("nocolon").unwrap_err();
+        assert!(err.contains("1"), "error should mention segment count: {err}");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1274,21 +1274,21 @@ pub fn pack_export_cli(dest_path: &str) -> i32 {
 /// Any other segment count is rejected with a clear error string.
 pub(crate) fn parse_notify_choice(raw: &str) -> Result<(String, String, Option<String>), String> {
     let segments: Vec<&str> = raw.splitn(5, ':').collect();
-    match segments.len() {
-        4 => Ok((
-            segments[0].to_string(),
-            segments[1].to_string(),
-            Some(format!("{}:{}", segments[2], segments[3])),
+    match segments.as_slice() {
+        [key, label, action_type, action_arg] => Ok((
+            key.to_string(),
+            label.to_string(),
+            Some(format!("{action_type}:{action_arg}")),
         )),
-        3 => {
-            let label = segments[0].to_string();
-            let host_action = format!("{}:{}", segments[1], segments[2]);
-            Ok((label.clone(), label, Some(host_action)))
+        [label, action_type, action_arg] => {
+            let label_str = label.to_string();
+            Ok((label_str.clone(), label_str, Some(format!("{action_type}:{action_arg}"))))
         }
-        2 => Ok((segments[0].to_string(), segments[1].to_string(), None)),
-        n => Err(format!(
+        [key, label] => Ok((key.to_string(), label.to_string(), None)),
+        _ => Err(format!(
             "error: --choice requires 2, 3, or 4 colon-separated segments \
-             (key:Label / Label:action:arg / key:Label:action:arg) — got {n} in {:?}",
+             (key:Label / Label:action:arg / key:Label:action:arg) — got {} in {:?}",
+            segments.len(),
             raw
         )),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,20 +241,11 @@ fn main() -> eframe::Result {
                     Commands::Notify { title, body, level, choices, timeout } => {
                         let mut parsed_choices: Vec<(String, String, Option<String>)> = Vec::new();
                         for raw in &choices {
-                            let segments: Vec<&str> = raw.splitn(3, ':').collect();
-                            match segments.len() {
-                                3 => {
-                                    // Label:action_type:action_arg — host-side action
-                                    let label = segments[0].to_string();
-                                    let host_action = format!("{}:{}", segments[1], segments[2]);
-                                    parsed_choices.push((label.clone(), label, Some(host_action)));
-                                }
-                                2 => {
-                                    // key:Label — existing format
-                                    parsed_choices.push((segments[0].to_string(), segments[1].to_string(), None));
-                                }
-                                _ => {
-                                    eprintln!("error: --choice must be key:Label or Label:action_type:action_arg");
+                            match cli::parse_notify_choice(raw) {
+                                Ok(choice) => parsed_choices.push(choice),
+                                Err(msg) => {
+                                    log::warn!("notify:cli: {msg}");
+                                    eprintln!("{msg}");
                                     std::process::exit(1);
                                 }
                             }


### PR DESCRIPTION
Closes #912

## What

Extends `plexi notify --choice` to accept a combined 4-segment format:

```
key:Label:action_type:action_arg
```

Returns `key` to the caller (clean for `case` branching), displays `Label` in the notification UI, and runs the host-side action (e.g. `pane_focus`).

Previously, `splitn(3, ':')` silently turned `c:Talk to Claude:pane_focus:188` into key=`c`, action=`Talk to Claude:pane_focus` (unknown) — the button rendered as `c` and the action silently failed.

## Changes

- `src/cli.rs` — `parse_notify_choice(raw)` extracted as `pub(crate)` function; handles 2-, 3-, and 4-segment formats; rejects 5+ with `exit 1` + `log::warn!`
- `src/main.rs` — `Commands::Notify` dispatch calls `parse_notify_choice` instead of inline `splitn(3)`
- 5 unit tests covering all segment counts
- Completion strings updated

## Breaks if

`plexi notify --choice "a:b:c:d:e"` exits 0 or renders silently — should now exit 1 with a clear error message.