### PR TITLE
fix(cli): shell_join preserves quoted multi-word args for terminal -c

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -993,7 +993,7 @@ impl PlexiApp {
                     let new_pane_id = self.host.next_pane_id();
                     if type_id == "terminal" {
                         let vertical = matches!(layout.as_str(), "split_h" | "split_above");
-                        let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+                        let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(args)) };
                         log::info!("pane_ipc: spawn_pane terminal vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
                         self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
                     } else {
@@ -1150,7 +1150,7 @@ impl PlexiApp {
             if type_id == "terminal" {
                 let layout_str = layout.as_deref().unwrap_or("split_v");
                 let vertical = matches!(layout_str, "split_h" | "split_above");
-                let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+                let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(&args)) };
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral);
             } else {
                 self.launch_app_by_id_with_layout(&type_id, layout, &args);
@@ -1578,7 +1578,7 @@ impl eframe::App for PlexiApp {
                         let initial_cmd = if effective_args.is_empty() {
                             None
                         } else {
-                            Some(effective_args.join(" "))
+                            Some(crate::shell::shell_join(&effective_args))
                         };
                         log::info!(
                             "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -468,7 +468,7 @@ impl PlexiApp {
         if id == "terminal" {
             let layout_str = layout.as_deref().unwrap_or("split_v");
             let vertical = matches!(layout_str, "split_h" | "split_above");
-            let initial_cmd = if args.is_empty() { None } else { Some(args.join(" ")) };
+            let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(args)) };
             log::info!(
                 "SpawnPane: terminal layout='{layout_str}' vertical={vertical} initial_cmd={initial_cmd:?}"
             );
@@ -713,6 +713,7 @@ mod tests {
             from_pane_id: None,
             request_id: None,
             response_file: None,
+            ephemeral: false,
         });
         h.run_frames(2);
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -343,3 +343,88 @@ precmd_functions+=(__plexi_precmd)
     Ok(zsh_dir)
 }
 
+/// Join args into a single shell-safe string for passing to `sh -c` / `zsh -c`.
+///
+/// Plain `args.join(" ")` loses quote structure — `["c", "ship it"]` becomes
+/// `"c ship it"` which zsh re-tokenizes into three words. This function wraps
+/// any arg containing whitespace or shell metacharacters in single quotes,
+/// with inner `'` escaped as `'\''`.
+pub fn shell_join(args: &[String]) -> String {
+    args.iter().map(|a| shell_quote(a)).collect::<Vec<_>>().join(" ")
+}
+
+fn shell_quote(s: &str) -> String {
+    let needs_quoting = s.is_empty()
+        || s.chars().any(|c| {
+            matches!(
+                c,
+                ' ' | '\t'
+                    | '\n'
+                    | '"'
+                    | '\''
+                    | '\\'
+                    | '!'
+                    | '#'
+                    | '$'
+                    | '&'
+                    | '('
+                    | ')'
+                    | '*'
+                    | ';'
+                    | '<'
+                    | '>'
+                    | '?'
+                    | '['
+                    | ']'
+                    | '^'
+                    | '{'
+                    | '|'
+                    | '}'
+                    | '~'
+                    | '`'
+            )
+        });
+    if !needs_quoting {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', r"'\''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_join_plain_args_no_quoting() {
+        let args = vec!["claude".to_string(), "--version".to_string()];
+        assert_eq!(shell_join(&args), "claude --version");
+    }
+
+    #[test]
+    fn shell_join_multi_word_arg_single_quoted() {
+        // Regression: args.join(" ") on ["c", "ship something useful"] → "c ship something useful"
+        // zsh re-tokenizes this to 4 words. shell_join must produce "c 'ship something useful'".
+        let args = vec!["c".to_string(), "ship something useful".to_string()];
+        assert_eq!(shell_join(&args), "c 'ship something useful'");
+    }
+
+    #[test]
+    fn shell_join_single_quote_in_arg_escaped() {
+        let args = vec!["echo".to_string(), "it's alive".to_string()];
+        assert_eq!(shell_join(&args), r"echo 'it'\''s alive'");
+    }
+
+    #[test]
+    fn shell_join_empty_arg_quoted() {
+        let args = vec!["echo".to_string(), String::new()];
+        assert_eq!(shell_join(&args), "echo ''");
+    }
+
+    #[test]
+    fn shell_join_special_chars_quoted() {
+        let args = vec!["echo".to_string(), "$HOME".to_string()];
+        assert_eq!(shell_join(&args), "echo '$HOME'");
+    }
+}
+


### PR DESCRIPTION
## What

Fixes `plexi open terminal -- c "ship something useful"` losing the quoted structure of multi-word args.

## Root Cause

Four sites used `args.join(" ")` to build the `initial_cmd` string passed to `zsh -i -l -c`. When args arrived correctly as `["c", "ship something useful"]`, the join produced the flat string `"c ship something useful"` — and zsh re-tokenized that into four words on the next parse.

## Fix

Added `shell::shell_join(args)` which single-quotes any arg containing whitespace or shell metacharacters before joining, using the POSIX-safe `'\''` escape for inner single quotes.

Fixed all four join sites:
- `src/app/mod.rs` — socket IPC `SpawnPane` handler (×2)
- `src/app/mod.rs` — spawn-queue handler  
- `src/pane_ops/create.rs` — `launch_app_by_id_with_layout` SDK path

Also fixes a pre-existing test compile error: `spawn_pane_terminal_with_initial_cmd_creates_persistent_pane` was missing the `ephemeral` field added in the previous refactor.

## Done When

`plexi open terminal -- claude "ship something useful"` → Claude receives `ship something useful` as a single prompt string.

Closes #913

**Breaks if:** `plexi open terminal -- c "ship something useful"` inside a Plexi pane splits the quoted string into separate tokens — observable by Claude receiving only `ship` as its prompt.