### PR TITLE
feat(file-browser): open as overlay + sync CWD back to terminal on close

### DIFF
--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -195,6 +195,12 @@ pub trait App: Send {
     /// Apps that track directories (like the file browser) should update.
     fn sync_cwd(&mut self, _new_cwd: &std::path::Path) {}
 
+    /// Returns the app's current working directory, if it tracks one.
+    /// Used to sync CWD back to the terminal when an overlay app closes.
+    fn current_cwd(&self) -> Option<std::path::PathBuf> {
+        None
+    }
+
     /// Queue a PlexiEvent to be sent to the app on the next flush.
     /// Used to deliver host-originated events (e.g. AppSpawned) back to
     /// external process apps. Built-in apps ignore this by default.

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -872,6 +872,10 @@ impl App for FileBrowserApp {
         self.sync_cwd(new_cwd.to_path_buf());
     }
 
+    fn current_cwd(&self) -> Option<std::path::PathBuf> {
+        Some(self.cwd.clone())
+    }
+
     fn serialize_state(&self) -> Option<serde_json::Value> {
         Some(serde_json::json!({
             "cwd": self.cwd.display().to_string(),

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -152,6 +152,13 @@ impl AppRuntime {
         }
     }
 
+    pub fn current_cwd(&self) -> Option<std::path::PathBuf> {
+        match self {
+            AppRuntime::Process(app) => app.current_cwd(),
+            AppRuntime::Builtin(app) => app.current_cwd(),
+        }
+    }
+
     pub fn type_id(&self) -> &'static str {
         match self {
             AppRuntime::Process(app) => app.type_id(),

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -424,8 +424,8 @@ impl PlexiApp {
             perms,
             cwd,
             Some("cwd".to_string()),
-            Some("split_above"),
-            Some(0.75),
+            Some("overlay"),
+            None,
         );
     }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -21,27 +21,31 @@ pub(crate) enum SwapResult {
 /// If `pane_id` is an app pane that was opened as an overlay over another
 /// pane (`hint = Some("overlay")`), restore the original pane and return
 /// `true`. Otherwise return `false` and leave the map unchanged.
+/// Restores the pane hidden by an overlay app.
+/// Returns `Some(cwd)` if an overlay was restored and the closed app reported a CWD to sync,
+/// `Some(None)` if restored with no CWD to sync, or `None` if this was not an overlay.
 pub(super) fn restore_overlay_replacement(
     panes: &mut HashMap<PaneId, Pane>,
     pane_id: PaneId,
-) -> bool {
+) -> Option<Option<std::path::PathBuf>> {
     let Some(pane) = panes.remove(&pane_id) else {
-        return false;
+        return None;
     };
 
     match pane {
         Pane::App(mut app) => {
             if let Some(replaced) = app.overlay_replaced.take() {
+                let cwd = app.runtime.current_cwd();
                 panes.insert(pane_id, *replaced);
-                true
+                Some(cwd)
             } else {
                 panes.insert(pane_id, Pane::App(app));
-                false
+                None
             }
         }
         other => {
             panes.insert(pane_id, other);
-            false
+            None
         }
     }
 }
@@ -450,7 +454,27 @@ impl PlexiApp {
                 _ => None,
             });
         if let Some(pane_id) = focused_pane_id {
-            if restore_overlay_replacement(&mut self.windows[self.active_window].panes, pane_id) {
+            if let Some(maybe_cwd) =
+                restore_overlay_replacement(&mut self.windows[self.active_window].panes, pane_id)
+            {
+                if let Some(cwd) = maybe_cwd {
+                    let escaped = cwd.to_string_lossy().replace('\'', "'\\''");
+                    let cd_cmd = format!("cd '{}'\n", escaped);
+                    if let Some(t) = self.windows[self.active_window]
+                        .panes
+                        .get_mut(&pane_id)
+                        .and_then(|p| p.as_terminal_mut())
+                    {
+                        t.backend.process_command(egui_term::BackendCommand::Write(
+                            cd_cmd.as_bytes().to_vec(),
+                        ));
+                        log::info!(
+                            "file_browser: synced cwd '{}' to terminal pane {}",
+                            cwd.display(),
+                            pane_id
+                        );
+                    }
+                }
                 return;
             }
         }
@@ -698,7 +722,27 @@ impl PlexiApp {
         else {
             return;
         };
-        if restore_overlay_replacement(&mut self.windows[active].panes, pane_id) {
+        if let Some(maybe_cwd) =
+            restore_overlay_replacement(&mut self.windows[active].panes, pane_id)
+        {
+            if let Some(cwd) = maybe_cwd {
+                let escaped = cwd.to_string_lossy().replace('\'', "'\\''");
+                let cd_cmd = format!("cd '{}'\n", escaped);
+                if let Some(t) = self.windows[active]
+                    .panes
+                    .get_mut(&pane_id)
+                    .and_then(|p| p.as_terminal_mut())
+                {
+                    t.backend.process_command(egui_term::BackendCommand::Write(
+                        cd_cmd.as_bytes().to_vec(),
+                    ));
+                    log::info!(
+                        "file_browser: synced cwd '{}' to terminal pane {}",
+                        cwd.display(),
+                        pane_id
+                    );
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
## What

Two connected changes to the file browser (Cmd+E):

1. **Opens as overlay** — takes over the focused terminal pane in-place, no layout disruption.
2. **Syncs CWD back to terminal on close** — navigating in the file browser then pressing Esc `cd`s the restored terminal to wherever the file browser was.

## How

- `src/pane_ops/create.rs` — changed `open_file_browser` from `split_above` to `overlay` (no fraction)
- `src/app_trait.rs` — added `App::current_cwd() -> Option<PathBuf>` with default `None`
- `src/pane.rs` — added `AppRuntime::current_cwd()` dispatch
- `src/file_browser/mod.rs` — implemented `current_cwd()` returning `Some(self.cwd.clone())`
- `src/pane_ops/layout.rs` — changed `restore_overlay_replacement` to return `Option<Option<PathBuf>>`; both callers write a `cd` command to the restored terminal PTY when a CWD is present

**Breaks if:** Cmd+E opens a split instead of overlay, or terminal CWD is unchanged after navigating in the file browser and pressing Esc.

Closes #903