### PR TITLE
chore: bundle small fixes (#814, #682, #743, #809, #842)

### DIFF
--- a/examples/github-tree/manifest.toml
+++ b/examples/github-tree/manifest.toml
@@ -12,4 +12,4 @@ entry = "commit_graph.py"
 capabilities = []
 
 [launch]
-layout_hint = { side = "above", split = 0.5 }
+layout_hint = { side = "above", split = 0.75 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1375,6 +1375,9 @@ pub fn notify_cli(
 
     // Fire-and-forget path — command is delivered, nothing to wait for.
     let Some(response_file) = response_file_str else {
+        if timeout_secs > 0 {
+            eprintln!("warning: --timeout has no effect without --choice (notification queued without auto-dismiss)");
+        }
         println!("notification queued");
         return 0;
     };

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -117,6 +117,7 @@ pub enum Commands {
         extra_args: Vec<String>,
     },
     /// Descriptor probe
+    #[command(hide = true)]
     Descriptor {
         #[command(subcommand)]
         cmd: DescriptorCmd,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,8 +17,6 @@ use std::time::{Duration, Instant};
 const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 /// How often the watchdog samples the frame counter. Short enough to catch brief freezes.
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
-/// How many sample intervals between full heartbeat log lines (1s × 30 = 30s).
-const HEARTBEAT_EVERY_N_SAMPLES: u64 = 30;
 /// UI thread is considered frozen after this many seconds without a frame tick.
 /// Lowered from 5s — real stalls of 3–4s (enough for the macOS spinning ball)
 /// were silently missed by the old threshold.
@@ -112,9 +110,6 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
     std::thread::Builder::new()
         .name("plexi-heartbeat".into())
         .spawn(move || {
-            let born = Instant::now();
-            let mut beat: u64 = 0;
-            let mut sample: u64 = 0;
             let mut last_tick = frame_tick.load(Ordering::Relaxed);
             // Track when we last saw the frame counter advance so freeze duration is accurate.
             let mut last_tick_seen_at = Instant::now();
@@ -122,7 +117,6 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
 
             loop {
                 std::thread::sleep(SAMPLE_INTERVAL);
-                sample += 1;
 
                 let now_tick = frame_tick.load(Ordering::Relaxed);
                 let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
@@ -136,10 +130,6 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
                         freeze_reported = true;
                         lines.push_str(&format!(
                             "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s\n"
-                        ));
-                    } else if frozen_secs >= FREEZE_THRESHOLD_SECS {
-                        lines.push_str(&format!(
-                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] still frozen — {frozen_secs}s unresponsive\n"
                         ));
                     }
                 } else {
@@ -155,25 +145,15 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
                     last_tick_seen_at = Instant::now();
                 }
 
-                // Write a full heartbeat line every 30s (every Nth sample).
-                if sample % HEARTBEAT_EVERY_N_SAMPLES == 0 {
-                    beat += 1;
-                    let uptime = born.elapsed().as_secs();
-                    let h = uptime / 3600;
-                    let m = (uptime % 3600) / 60;
-                    let s = uptime % 60;
-                    lines.push_str(&format!(
-                        "[{now}] [INFO] [plexi::heartbeat] beat={beat} uptime={h:02}:{m:02}:{s:02}\n"
-                    ));
-                }
-
-                if let Ok(mut f) = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&log_path)
-                {
-                    use std::io::Write;
-                    let _ = f.write_all(lines.as_bytes());
+                if !lines.is_empty() {
+                    if let Ok(mut f) = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&log_path)
+                    {
+                        use std::io::Write;
+                        let _ = f.write_all(lines.as_bytes());
+                    }
                 }
             }
         })

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1859,7 +1859,7 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
             },
         }
     }
-    log::debug!("load_app_state[{type_id}]: no valid state file loaded, returning empty state");
+    log::debug!("load_app_state[{type_id}]: no usable state file found, starting empty");
     serde_json::Value::Object(serde_json::Map::new())
 }
 

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1827,21 +1827,39 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
     let filename = format!("{type_id}.json");
     let workspace_path = workspace_root.join(".plexi").join("app_state").join(&filename);
     if workspace_path.exists() {
-        if let Ok(bytes) = std::fs::read(&workspace_path) {
-            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) {
-                log::info!("load_app_state[{type_id}]: loaded workspace state from {}", workspace_path.display());
-                return val;
+        match std::fs::read(&workspace_path) {
+            Err(e) => {
+                log::warn!("load_app_state[{type_id}]: could not read workspace state {}: {e}", workspace_path.display());
             }
+            Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Err(e) => {
+                    log::warn!("load_app_state[{type_id}]: could not parse workspace state {}: {e}", workspace_path.display());
+                }
+                Ok(val) => {
+                    log::info!("load_app_state[{type_id}]: loaded workspace state from {}", workspace_path.display());
+                    return val;
+                }
+            },
         }
     }
     let global_path = crate::config::config_dir().join("app_state").join(&filename);
     if global_path.exists() {
-        if let Ok(bytes) = std::fs::read(&global_path) {
-            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) {
-                log::info!("load_app_state[{type_id}]: loaded global state from {}", global_path.display());
-                return val;
+        match std::fs::read(&global_path) {
+            Err(e) => {
+                log::warn!("load_app_state[{type_id}]: could not read global state {}: {e}", global_path.display());
             }
+            Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Err(e) => {
+                    log::warn!("load_app_state[{type_id}]: could not parse global state {}: {e}", global_path.display());
+                }
+                Ok(val) => {
+                    log::info!("load_app_state[{type_id}]: loaded global state from {}", global_path.display());
+                    return val;
+                }
+            },
         }
+    } else {
+        log::debug!("load_app_state[{type_id}]: no state file found, starting empty");
     }
     serde_json::Value::Object(serde_json::Map::new())
 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1858,9 +1858,8 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
                 }
             },
         }
-    } else {
-        log::debug!("load_app_state[{type_id}]: no state file found, starting empty");
     }
+    log::debug!("load_app_state[{type_id}]: no valid state file loaded, returning empty state");
     serde_json::Value::Object(serde_json::Map::new())
 }
 


### PR DESCRIPTION
Batches 5 small, diff-verifiable fixes into a single maintenance PR.

## Changes

- **#814** `src/cli_args.rs` — `#[command(hide = true)]` on `Descriptor` variant; hides plumbing subcommand from `plexi --help`
- **#682** `src/cli.rs` — warn to stderr when `--timeout` passed to `plexi notify` without `--choice` (flag is silently ignored on fire-and-forget path)
- **#743** `examples/github-tree/manifest.toml` — `split = 0.5` → `split = 0.75`; commit graph was illegible when compressed to half height
- **#809** `src/logging.rs` — remove `[FREEZE] still frozen` repeat lines and periodic `beat=N uptime=...` heartbeat lines; guard file open behind `!lines.is_empty()`
- **#842** `src/process_app/mod.rs` — add `warn` on read/parse failure and `debug` on no-state-file path in `load_app_state`; previously all miss/failure cases were silent

## Verification

All changes verifiable by diff alone — no install required. `cargo build` clean.

**Breaks if:**
- `plexi --help` still shows `descriptor` as a top-level subcommand
- `plexi notify --title "x" --timeout 5` does not print a warning to stderr
- Commit Graph app launches occupying only ~50% of context height instead of ~75%
- `grep "\[FREEZE\] still frozen" ~/.plexi-alpha/plexi.log` returns hits after a UI hang (repeat lines should be gone)
- `grep "beat=" ~/.plexi-alpha/plexi.log` returns hits after 30s of runtime (heartbeat lines should be gone)
- An app opening with no saved state produces no `debug`-level log line in `plexi.log`

Closes #814, #682, #743, #809, #842