### PR TITLE
fix(file-browser): prefix PTY cd write with Ctrl-U to clear readline buffer

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1612,7 +1612,7 @@ impl eframe::App for PlexiApp {
                 AppCommand::CdRequest { cwd, sender_pane_id } => {
                     let active = self.active_window;
                     let escaped = cwd.replace('\'', "'\\''");
-                    let cd_cmd = format!("cd '{}'\n", escaped);
+                    let cd_cmd = format!("\x15cd '{}'\n", escaped);
                     let linked_id = self.windows[active]
                         .panes
                         .get(&sender_pane_id)
@@ -1627,6 +1627,11 @@ impl eframe::App for PlexiApp {
                             t.backend.process_command(egui_term::BackendCommand::Write(
                                 cd_cmd.as_bytes().to_vec(),
                             ));
+                            log::info!(
+                                "file_browser: CdRequest synced cwd '{}' to terminal pane {}",
+                                cwd,
+                                tid
+                            );
                         }
                     }
                 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -459,7 +459,7 @@ impl PlexiApp {
             {
                 if let Some(cwd) = maybe_cwd {
                     let escaped = cwd.to_string_lossy().replace('\'', "'\\''");
-                    let cd_cmd = format!("cd '{}'\n", escaped);
+                    let cd_cmd = format!("\x15cd '{}'\n", escaped);
                     if let Some(t) = self.windows[self.active_window]
                         .panes
                         .get_mut(&pane_id)
@@ -727,7 +727,7 @@ impl PlexiApp {
         {
             if let Some(cwd) = maybe_cwd {
                 let escaped = cwd.to_string_lossy().replace('\'', "'\\''");
-                let cd_cmd = format!("cd '{}'\n", escaped);
+                let cd_cmd = format!("\x15cd '{}'\n", escaped);
                 if let Some(t) = self.windows[active]
                     .panes
                     .get_mut(&pane_id)


### PR DESCRIPTION
## Summary

- All three `BackendCommand::Write` sites that inject a `cd 'path'\n` into the terminal PTY now prefix the command with `\x15` (Ctrl-U / VKILL)
- Ctrl-U clears readline's current line buffer in both zsh and bash before the `cd` is written — eliminates the partial-input race where the `c` of `cd` was consumed by existing buffer state
- Adds a missing `log::info!` to the `CdRequest` arm for observability

**Breaks if:** After opening the file browser, navigating to a subdirectory, and pressing Esc, the terminal shows `d '/path'` or `zsh: command not found: d` — meaning the Ctrl-U prefix is not being sent or is not clearing the buffer.

Fixes #921

## Test plan

- [ ] Open file browser (Cmd+B or equivalent), navigate to a different directory, press Esc — terminal should `cd` correctly, no truncated command
- [ ] Repeat 5+ consecutive open→navigate→close cycles — no failure
- [ ] Test with partial input already at the shell prompt before opening the file browser — Ctrl-U should clear it, then `cd` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)