### PR TITLE
feat(sdk): App __init__ guard + AppHarness headless subprocess runner (#870 #865)

### DIFF
--- a/docs/sdk-ui-guide.md
+++ b/docs/sdk-ui-guide.md
@@ -153,3 +153,43 @@ Contribute it back to `sdk/python/plexi_sdk/ui.py` once it proves useful in two 
 - **Scrolling containers beyond `ScrollLog`.** A general `Scroll` container is future work.
 
 Add these when the need exists. Don't speculatively invent components — the cost of a bad API in the SDK is rewrites across every app.
+
+---
+
+## Testing Apps with AppHarness
+
+`AppHarness` in `plexi_sdk.testing` spawns a real Python Plexi app subprocess and lets you drive it headlessly — no running Plexi instance or display required.
+
+```python
+from plexi_sdk.testing import AppHarness
+
+with AppHarness("my_app.py", width=400, height=300) as h:
+    cmds = h.run(1)                     # step one render frame
+    h.key("enter")                      # inject a key event
+    cmds = h.run(1)                     # render again to see effects
+    assert any(c.get("type") == "text" for c in cmds)
+```
+
+### Methods
+
+- `run(n_frames=1)` — step N render frames; returns draw commands from the last frame
+- `key(key, modifiers=None)` — inject a synthetic key event (e.g. `"enter"`, `"a"`)
+- `screenshot()` — render draw commands to PNG bytes (requires `plexi` binary or `PLEXI_RENDER_BIN`)
+- `assert_pixel(x, y, expected, tolerance=4)` — assert a pixel color in the last rendered frame
+- `save_snapshot(path)` — write the last rendered frame to a PNG file
+- `close()` — shut down the subprocess; also called by `__exit__`
+
+### CI usage
+
+`AppHarness` runs without a display. Pixel assertions via `screenshot()` require the `plexi` binary; skip them in CI by guarding with:
+
+```python
+import os
+if os.environ.get("PLEXI_RENDER_BIN") or Path("target/release/plexi").exists():
+    h.assert_pixel(10, 10, "#ff0000")
+```
+
+Run the full test suite with:
+```
+cd sdk/python && uv run pytest tests/
+```

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -73,6 +73,7 @@ class App:
     """
 
     def __init__(self) -> None:
+        self._sdk_initialized: bool = True
         self.app_id: str = ""
         self.workspace_root: str = ""
         self.capabilities: list[str] = []
@@ -138,6 +139,16 @@ class App:
         self._mx: float = 0.0
         self._my: float = 0.0
         self._click_buf: list[tuple[float, float]] = []
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        orig_init = cls.__dict__.get("__init__")
+        if orig_init is not None:
+            def wrapped(self_inner: "App", *args: Any, _orig: Any = orig_init, **kw: Any) -> None:
+                if not getattr(self_inner, "_sdk_initialized", False):
+                    App.__init__(self_inner)
+                _orig(self_inner, *args, **kw)
+            cls.__init__ = wrapped  # type: ignore[method-assign]
 
     # ── Override these ──────────────────────────────────────────────────────
     # All hooks may be overridden as either `def` (sync) or `async def`.

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -6,8 +6,12 @@ reads back PNG bytes. Provides pixel-level assertions and snapshot file helpers.
 
 import json
 import os
+import queue
 import struct
 import subprocess
+import sys
+import threading
+import time
 import zlib
 from pathlib import Path
 
@@ -289,3 +293,155 @@ def save_snapshot(png_bytes: bytes, path: str | Path) -> None:
         p.write_bytes(png_bytes)
     except OSError as e:
         raise RuntimeError(f"Failed to save snapshot to {p}: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# AppHarness — headless Python app subprocess runner (issue #865)
+# ---------------------------------------------------------------------------
+
+
+class AppHarness:
+    """Headless runner for Plexi Python apps.
+
+    Spawns the app script as a subprocess, communicates over stdin/stdout
+    using the PGAP v3 protocol. No display or running Plexi host required.
+
+    Usage::
+
+        with AppHarness("my_app.py", width=400, height=300) as h:
+            cmds = h.run(1)                  # step one render frame
+            h.key("enter")                   # inject a key event
+            cmds = h.run(1)                  # render again to see effects
+            h.assert_pixel(10, 10, "#1e1e2e")  # pixel assertion (needs plexi binary)
+    """
+
+    def __init__(self, app_path: "str | Path", width: int = 800, height: int = 600,
+                 timeout: float = 5.0) -> None:
+        self._width = width
+        self._height = height
+        self._timeout = timeout
+        self._draw_commands: "list[dict]" = []
+        self._frame_id = 0
+        self._stdout_q: "queue.Queue[str | None]" = queue.Queue()
+
+        import os
+        import subprocess as _subprocess
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+
+        self._proc = _subprocess.Popen(
+            [sys.executable, str(app_path)],
+            stdin=_subprocess.PIPE,
+            stdout=_subprocess.PIPE,
+            stderr=_subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+
+        # Handshake
+        self._send({"type": "init", "protocol": "pgap/3", "app_id": "test-harness",
+                    "workspace_root": "/tmp", "capabilities": [], "feature_flags": []})
+        ev = self._wait_for(lambda e: e.get("type") == "ready")
+        if ev is None:
+            stderr = self._proc.stderr.read() if self._proc.stderr else ""
+            raise RuntimeError(
+                f"AppHarness: app did not send 'ready' within {timeout}s. "
+                f"stderr: {stderr[:500]!r}"
+            )
+
+    def _read_stdout(self) -> None:
+        assert self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if line:
+                self._stdout_q.put(line)
+        self._stdout_q.put(None)  # EOF sentinel
+
+    def _next_event(self, timeout: float) -> "dict | None":
+        try:
+            line = self._stdout_q.get(timeout=timeout)
+        except queue.Empty:
+            return None
+        if line is None:
+            return None
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            return None
+
+    def _wait_for(self, predicate, timeout=None) -> "dict | None":
+        deadline = time.monotonic() + (timeout if timeout is not None else self._timeout)
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            ev = self._next_event(timeout=max(0.05, remaining))
+            if ev is not None and predicate(ev):
+                return ev
+        return None
+
+    def _send(self, event: dict) -> None:
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(json.dumps(event) + "\n")
+        self._proc.stdin.flush()
+
+    def run(self, n_frames: int = 1) -> "list[dict]":
+        """Step N render frames. Returns draw commands from the last frame."""
+        cmds: "list[dict]" = []
+        for _ in range(n_frames):
+            self._frame_id += 1
+            self._send({
+                "type": "render",
+                "frame_id": self._frame_id,
+                "rect": {"x": 0.0, "y": 0.0, "w": float(self._width), "h": float(self._height)},
+            })
+            cmds = []
+            deadline = time.monotonic() + self._timeout
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                ev = self._next_event(timeout=max(0.05, remaining))
+                if ev is None:
+                    continue
+                if ev.get("type") == "frame_done":
+                    break
+                cmds.append(ev)
+        self._draw_commands = cmds
+        return cmds
+
+    def key(self, key: str, modifiers: "dict | None" = None) -> None:
+        """Inject a synthetic key event."""
+        self._send({"type": "key", "key": key, "modifiers": modifiers or {}})
+
+    def screenshot(self) -> bytes:
+        """Render current draw commands to PNG. Requires the plexi binary."""
+        return render_draw_commands(self._draw_commands, self._width, self._height)
+
+    def assert_pixel(self, x: int, y: int,
+                     expected: "str | tuple[int, int, int, int]",
+                     tolerance: int = 4) -> None:
+        """Assert pixel color at (x, y) against the last rendered frame."""
+        assert_pixel(self.screenshot(), x, y, expected, tolerance)
+
+    def save_snapshot(self, path: "str | Path") -> None:
+        """Save the last rendered frame as a PNG file."""
+        save_snapshot(self.screenshot(), path)
+
+    def close(self) -> None:
+        """Shut down the app subprocess cleanly."""
+        import subprocess as _subprocess
+        try:
+            if self._proc.stdin:
+                self._proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            self._proc.wait(timeout=5.0)
+        except _subprocess.TimeoutExpired:
+            self._proc.kill()
+
+    def __enter__(self) -> "AppHarness":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/sdk/python/tests/test_app_harness.py
+++ b/sdk/python/tests/test_app_harness.py
@@ -1,0 +1,69 @@
+"""Integration tests for AppHarness — headless Python app subprocess runner."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from plexi_sdk.testing import AppHarness
+
+# Minimal test app — counts Enter key presses
+_COUNTER_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+
+    class CounterApp(App):
+        def on_init(self, ctx: RenderContext) -> None:
+            self._count = 0
+
+        def on_render(self, ctx: RenderContext) -> None:
+            ctx.status_summary(f"count={self._count}")
+            ctx.rect(0, 0, 100, 50, fill="#ff0000")
+            ctx.text(10, 10, f"count={self._count}", size=14, color="#ffffff")
+
+        def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+            if key == "enter":
+                self._count += 1
+
+    CounterApp().run()
+""").lstrip()
+
+
+@pytest.fixture
+def counter_app(tmp_path: Path) -> Path:
+    app_file = tmp_path / "counter_app.py"
+    app_file.write_text(_COUNTER_APP)
+    return app_file
+
+
+def test_appharness_boots_and_renders(counter_app: Path) -> None:
+    """AppHarness boots the app and returns draw commands on the first render."""
+    with AppHarness(counter_app) as h:
+        cmds = h.run(1)
+    assert len(cmds) > 0, "Expected at least one draw command from first render"
+
+
+def test_appharness_key_changes_render_output(counter_app: Path) -> None:
+    """Injecting a key event changes the draw command output on the next render."""
+    with AppHarness(counter_app) as h:
+        cmds_before = h.run(1)
+        h.key("enter")
+        cmds_after = h.run(1)
+
+    # The text command should now show count=1 instead of count=0
+    def text_contents(cmds):
+        return [c.get("text", "") for c in cmds if c.get("type") == "text"]
+
+    texts_before = text_contents(cmds_before)
+    texts_after = text_contents(cmds_after)
+
+    assert "count=0" in texts_before, f"Expected 'count=0' in first render, got: {texts_before}"
+    assert "count=1" in texts_after, f"Expected 'count=1' after Enter key, got: {texts_after}"
+
+
+def test_appharness_context_manager_closes_cleanly(counter_app: Path) -> None:
+    """AppHarness.__exit__ shuts down the subprocess without hanging."""
+    with AppHarness(counter_app) as h:
+        h.run(1)
+        proc = h._proc
+    # After __exit__, process should be terminated
+    assert proc.poll() is not None, "Subprocess should have exited after close()"

--- a/sdk/python/tests/test_sdk_init.py
+++ b/sdk/python/tests/test_sdk_init.py
@@ -1,0 +1,45 @@
+"""Tests that App subclasses work when __init__ omits super().__init__()."""
+
+from plexi_sdk import App, RenderContext
+
+
+def test_subclass_without_super_init_has_sdk_state() -> None:
+    """A subclass that defines __init__ without super() must still have all SDK attributes."""
+    class MyApp(App):
+        def __init__(self) -> None:
+            self.custom_value = 42  # no super().__init__()
+
+    app = MyApp()
+    # Core SDK attributes must exist without AttributeError
+    assert isinstance(app._rect, dict)
+    assert isinstance(app._pipes, dict)
+    assert isinstance(app._pending_capability, dict)
+    assert app._loop is None
+    assert isinstance(app._background_tasks, set)
+    assert app.custom_value == 42
+
+
+def test_subclass_with_super_init_still_works() -> None:
+    """A subclass that calls super().__init__() must still work (no double-init issues)."""
+    class MyApp(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.custom_value = 99
+
+    app = MyApp()
+    assert isinstance(app._rect, dict)
+    assert app.custom_value == 99
+
+
+def test_no_super_subclass_runs_without_error() -> None:
+    """Instantiating App subclass without super() must not raise any error."""
+    class MyApp(App):
+        def __init__(self) -> None:
+            self.name = "hello"
+        def on_render(self, _ctx: RenderContext) -> None:
+            pass
+
+    # Should not raise AttributeError or any other error
+    app = MyApp()
+    assert app.name == "hello"
+    assert hasattr(app, "emit")


### PR DESCRIPTION
## Summary

- **#870** — `App.__init_subclass__` wraps any user-defined `__init__` that omits `super().__init__()`, so SDK internal state is always bootstrapped. No more `AttributeError: 'MyApp' object has no attribute '_rect'` at runtime.
- **#865** — `AppHarness` in `plexi_sdk.testing` spawns a Python Plexi app as a real subprocess, drives it over PGAP v3 stdin/stdout, and exposes `run()`, `key()`, `screenshot()`, `assert_pixel()`, `save_snapshot()`. No display or running Plexi host required.

## Changes

- `sdk/python/plexi_sdk/_app.py` — `_sdk_initialized` flag + `__init_subclass__` guard
- `sdk/python/plexi_sdk/testing.py` — `AppHarness` class (156 lines)
- `sdk/python/tests/test_sdk_init.py` — 3 tests for #870
- `sdk/python/tests/test_app_harness.py` — 3 integration tests for #865
- `docs/sdk-ui-guide.md` — AppHarness testing section

## Test plan

- [ ] `cd sdk/python && uv run pip install -e . && uv run pytest tests/test_sdk_init.py tests/test_app_harness.py -v` → 6 passed
- [ ] Verify no regression: `uv run pytest tests/` → all pass

**Breaks if:** a subclass that previously failed with `AttributeError` on `_rect`/`_pipes` still fails, or `AppHarness("my_app.py").run(1)` raises `RuntimeError: app did not send 'ready'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)