### PR TITLE
feat(registry): add CLI descriptors for git, docker, kubectl, brew, uv, rg, fzf

### DIFF
--- a/registry/brew/4.2.0.json
+++ b/registry/brew/4.2.0.json
@@ -1,0 +1,152 @@
+{
+  "plexi_version": "0.1",
+  "name": "brew",
+  "version": "4.2.0",
+  "description": "The Missing Package Manager for macOS",
+  "icon": "🍺",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "install",
+      "description": "Install a formula or cask",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "formula", "type": "string", "required": true, "description": "Formula or cask name(s)"}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false, "description": "Install as a cask (macOS app)"},
+        {"name": "--formula", "type": "bool", "default": false, "description": "Treat as a formula"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Install without checking if already installed"}
+      ]
+    },
+    {
+      "name": "uninstall",
+      "description": "Uninstall a formula or cask",
+      "args": [
+        {"name": "formula", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false},
+        {"name": "--force", "type": "bool", "default": false, "description": "Delete even if used by dependent formulae"}
+      ]
+    },
+    {
+      "name": "update",
+      "description": "Fetch latest version of Homebrew and formulae",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "upgrade",
+      "description": "Upgrade outdated casks and outdated, unpinned formulae",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "formula", "type": "string", "required": false, "description": "Formula(e) to upgrade (default: all outdated)"}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false, "description": "Upgrade casks only"},
+        {"name": "--formula", "type": "bool", "default": false, "description": "Upgrade formulae only"},
+        {"name": "--dry-run", "type": "bool", "default": false, "description": "Show what would be upgraded without upgrading"}
+      ]
+    },
+    {
+      "name": "search",
+      "description": "Perform a substring search of cask tokens and formula names",
+      "ui_hint": "list",
+      "args": [
+        {"name": "text", "type": "string", "required": false, "description": "Search query (omit to list all formulae)"}
+      ],
+      "flags": [
+        {"name": "--casks", "type": "bool", "default": false, "description": "Search casks only"},
+        {"name": "--formulae", "type": "bool", "default": false, "description": "Search formulae only"}
+      ]
+    },
+    {
+      "name": "info",
+      "description": "Display brief statistics for a formula or cask",
+      "ui_hint": "output",
+      "args": [
+        {"name": "formula", "type": "string", "required": false, "description": "Formula or cask name"}
+      ],
+      "flags": [
+        {"name": "--json", "type": "bool", "default": false, "description": "Output in JSON format"},
+        {"name": "--installed", "type": "bool", "default": false, "description": "Print JSON of all installed formulae"}
+      ]
+    },
+    {
+      "name": "list",
+      "description": "List installed formulae and casks",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--casks", "type": "bool", "default": false},
+        {"name": "--formulae", "type": "bool", "default": false},
+        {"name": "--versions", "type": "bool", "default": false, "description": "Show the version number for installed formulae"}
+      ]
+    },
+    {
+      "name": "services",
+      "description": "Manage background services",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "list",
+          "description": "List all managed services",
+          "ui_hint": "list"
+        },
+        {
+          "name": "start",
+          "description": "Start the service formula immediately and register it to launch at login",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "stop",
+          "description": "Stop the service formula immediately and unregister it from launching at login",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "restart",
+          "description": "Stop and then start the service formula",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tap",
+      "description": "Tap a formula repository",
+      "args": [
+        {"name": "user-repo", "type": "string", "required": false, "description": "Tap name in user/repo format"}
+      ],
+      "flags": [
+        {"name": "--list-pinned", "type": "bool", "default": false, "description": "List pinned taps"}
+      ]
+    },
+    {
+      "name": "untap",
+      "description": "Remove a tapped formula repository",
+      "args": [
+        {"name": "tap", "type": "string", "required": true}
+      ]
+    },
+    {
+      "name": "doctor",
+      "description": "Check your system for potential problems",
+      "ui_hint": "output"
+    },
+    {
+      "name": "cleanup",
+      "description": "Remove stale lock files and outdated downloads",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false, "description": "List files that would be removed"},
+        {"name": "--prune", "type": "string", "description": "Remove all cache files older than specified days"}
+      ]
+    }
+  ]
+}

--- a/registry/brew/4.2.0.json
+++ b/registry/brew/4.2.0.json
@@ -145,7 +145,7 @@
       "description": "Remove stale lock files and outdated downloads",
       "flags": [
         {"name": "--dry-run", "type": "bool", "default": false, "description": "List files that would be removed"},
-        {"name": "--prune", "type": "string", "description": "Remove all cache files older than specified days"}
+        {"name": "--prune", "type": "int", "description": "Remove all cache files older than specified days"}
       ]
     }
   ]

--- a/registry/brew/latest.json
+++ b/registry/brew/latest.json
@@ -1,0 +1,152 @@
+{
+  "plexi_version": "0.1",
+  "name": "brew",
+  "version": "4.2.0",
+  "description": "The Missing Package Manager for macOS",
+  "icon": "🍺",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "install",
+      "description": "Install a formula or cask",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "formula", "type": "string", "required": true, "description": "Formula or cask name(s)"}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false, "description": "Install as a cask (macOS app)"},
+        {"name": "--formula", "type": "bool", "default": false, "description": "Treat as a formula"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Install without checking if already installed"}
+      ]
+    },
+    {
+      "name": "uninstall",
+      "description": "Uninstall a formula or cask",
+      "args": [
+        {"name": "formula", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false},
+        {"name": "--force", "type": "bool", "default": false, "description": "Delete even if used by dependent formulae"}
+      ]
+    },
+    {
+      "name": "update",
+      "description": "Fetch latest version of Homebrew and formulae",
+      "ui_hint": "stream",
+      "streaming": true
+    },
+    {
+      "name": "upgrade",
+      "description": "Upgrade outdated casks and outdated, unpinned formulae",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "formula", "type": "string", "required": false, "description": "Formula(e) to upgrade (default: all outdated)"}
+      ],
+      "flags": [
+        {"name": "--cask", "type": "bool", "default": false, "description": "Upgrade casks only"},
+        {"name": "--formula", "type": "bool", "default": false, "description": "Upgrade formulae only"},
+        {"name": "--dry-run", "type": "bool", "default": false, "description": "Show what would be upgraded without upgrading"}
+      ]
+    },
+    {
+      "name": "search",
+      "description": "Perform a substring search of cask tokens and formula names",
+      "ui_hint": "list",
+      "args": [
+        {"name": "text", "type": "string", "required": false, "description": "Search query (omit to list all formulae)"}
+      ],
+      "flags": [
+        {"name": "--casks", "type": "bool", "default": false, "description": "Search casks only"},
+        {"name": "--formulae", "type": "bool", "default": false, "description": "Search formulae only"}
+      ]
+    },
+    {
+      "name": "info",
+      "description": "Display brief statistics for a formula or cask",
+      "ui_hint": "output",
+      "args": [
+        {"name": "formula", "type": "string", "required": false, "description": "Formula or cask name"}
+      ],
+      "flags": [
+        {"name": "--json", "type": "bool", "default": false, "description": "Output in JSON format"},
+        {"name": "--installed", "type": "bool", "default": false, "description": "Print JSON of all installed formulae"}
+      ]
+    },
+    {
+      "name": "list",
+      "description": "List installed formulae and casks",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--casks", "type": "bool", "default": false},
+        {"name": "--formulae", "type": "bool", "default": false},
+        {"name": "--versions", "type": "bool", "default": false, "description": "Show the version number for installed formulae"}
+      ]
+    },
+    {
+      "name": "services",
+      "description": "Manage background services",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "list",
+          "description": "List all managed services",
+          "ui_hint": "list"
+        },
+        {
+          "name": "start",
+          "description": "Start the service formula immediately and register it to launch at login",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "stop",
+          "description": "Stop the service formula immediately and unregister it from launching at login",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "restart",
+          "description": "Stop and then start the service formula",
+          "args": [
+            {"name": "formula", "type": "string", "required": true}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tap",
+      "description": "Tap a formula repository",
+      "args": [
+        {"name": "user-repo", "type": "string", "required": false, "description": "Tap name in user/repo format"}
+      ],
+      "flags": [
+        {"name": "--list-pinned", "type": "bool", "default": false, "description": "List pinned taps"}
+      ]
+    },
+    {
+      "name": "untap",
+      "description": "Remove a tapped formula repository",
+      "args": [
+        {"name": "tap", "type": "string", "required": true}
+      ]
+    },
+    {
+      "name": "doctor",
+      "description": "Check your system for potential problems",
+      "ui_hint": "output"
+    },
+    {
+      "name": "cleanup",
+      "description": "Remove stale lock files and outdated downloads",
+      "flags": [
+        {"name": "--dry-run", "type": "bool", "default": false, "description": "List files that would be removed"},
+        {"name": "--prune", "type": "string", "description": "Remove all cache files older than specified days"}
+      ]
+    }
+  ]
+}

--- a/registry/brew/latest.json
+++ b/registry/brew/latest.json
@@ -145,7 +145,7 @@
       "description": "Remove stale lock files and outdated downloads",
       "flags": [
         {"name": "--dry-run", "type": "bool", "default": false, "description": "List files that would be removed"},
-        {"name": "--prune", "type": "string", "description": "Remove all cache files older than specified days"}
+        {"name": "--prune", "type": "int", "description": "Remove all cache files older than specified days"}
       ]
     }
   ]

--- a/registry/docker/26.1.0.json
+++ b/registry/docker/26.1.0.json
@@ -1,0 +1,178 @@
+{
+  "plexi_version": "0.1",
+  "name": "docker",
+  "version": "26.1.0",
+  "description": "Container platform for building and running applications",
+  "icon": "🐳",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "build",
+      "description": "Build an image from a Dockerfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "path", "type": "path", "required": true, "description": "Build context path (usually .)"}
+      ],
+      "flags": [
+        {"name": "--tag", "type": "string", "required": true, "description": "Name and optionally tag in name:tag format"},
+        {"name": "--file", "type": "path", "description": "Name of the Dockerfile (default: PATH/Dockerfile)"},
+        {"name": "--no-cache", "type": "bool", "default": false, "description": "Do not use cache when building the image"},
+        {"name": "--platform", "type": "string", "description": "Set target platform for build (e.g. linux/amd64)"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a command in a new container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name (and optional tag)"},
+        {"name": "command", "type": "string", "required": false, "description": "Command to run inside the container"}
+      ],
+      "flags": [
+        {"name": "--rm", "type": "bool", "default": false, "description": "Automatically remove the container when it exits"},
+        {"name": "--interactive", "type": "bool", "default": false, "description": "Keep STDIN open"},
+        {"name": "--tty", "type": "bool", "default": false, "description": "Allocate a pseudo-TTY"},
+        {"name": "--name", "type": "string", "description": "Assign a name to the container"},
+        {"name": "--env", "type": "string", "description": "Set environment variables"},
+        {"name": "--volume", "type": "string", "description": "Bind mount a volume (host:container)"},
+        {"name": "--publish", "type": "string", "description": "Publish container port(s) to the host (host:container)"},
+        {"name": "--detach", "type": "bool", "default": false, "description": "Run container in background"}
+      ]
+    },
+    {
+      "name": "pull",
+      "description": "Download an image from a registry",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name (and optional tag)"}
+      ]
+    },
+    {
+      "name": "push",
+      "description": "Upload an image to a registry",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true}
+      ]
+    },
+    {
+      "name": "images",
+      "description": "List images",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Show all images (default hides intermediate)"},
+        {"name": "--format", "type": "string", "description": "Format output using a Go template or 'json'"},
+        {"name": "--filter", "type": "string", "description": "Filter output based on conditions (e.g. dangling=true)"}
+      ]
+    },
+    {
+      "name": "ps",
+      "description": "List containers",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Show all containers (default shows running only)"},
+        {"name": "--format", "type": "string", "description": "Format output using a Go template or 'json'"},
+        {"name": "--filter", "type": "string", "description": "Filter output based on conditions"}
+      ]
+    },
+    {
+      "name": "stop",
+      "description": "Stop one or more running containers",
+      "args": [
+        {"name": "container", "type": "string", "required": true, "description": "Container name or ID"}
+      ],
+      "flags": [
+        {"name": "--time", "type": "int", "description": "Seconds to wait for stop before killing (default 10)"}
+      ]
+    },
+    {
+      "name": "rm",
+      "description": "Remove one or more containers",
+      "args": [
+        {"name": "container", "type": "string", "required": true, "description": "Container name or ID"}
+      ],
+      "flags": [
+        {"name": "--force", "type": "bool", "default": false, "description": "Force removal of a running container"},
+        {"name": "--volumes", "type": "bool", "default": false, "description": "Remove anonymous volumes associated with the container"}
+      ]
+    },
+    {
+      "name": "rmi",
+      "description": "Remove one or more images",
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name or ID"}
+      ],
+      "flags": [
+        {"name": "--force", "type": "bool", "default": false, "description": "Force removal of the image"}
+      ]
+    },
+    {
+      "name": "exec",
+      "description": "Run a command in a running container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "container", "type": "string", "required": true},
+        {"name": "command", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--interactive", "type": "bool", "default": false},
+        {"name": "--tty", "type": "bool", "default": false}
+      ]
+    },
+    {
+      "name": "logs",
+      "description": "Fetch the logs of a container",
+      "ui_hint": "output",
+      "args": [
+        {"name": "container", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--follow", "type": "bool", "default": false, "description": "Follow log output"},
+        {"name": "--tail", "type": "string", "description": "Number of lines from the end to show (e.g. 100)"},
+        {"name": "--timestamps", "type": "bool", "default": false, "description": "Show timestamps"}
+      ]
+    },
+    {
+      "name": "compose",
+      "description": "Define and run multi-container applications",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "up",
+          "description": "Create and start containers",
+          "ui_hint": "stream",
+          "streaming": true,
+          "flags": [
+            {"name": "--detach", "type": "bool", "default": false, "description": "Run containers in background"},
+            {"name": "--build", "type": "bool", "default": false, "description": "Build images before starting containers"}
+          ]
+        },
+        {
+          "name": "down",
+          "description": "Stop and remove containers, networks",
+          "flags": [
+            {"name": "--volumes", "type": "bool", "default": false, "description": "Remove named volumes declared in the compose file"}
+          ]
+        },
+        {
+          "name": "ps",
+          "description": "List containers defined by the compose file",
+          "ui_hint": "list"
+        },
+        {
+          "name": "logs",
+          "description": "View output from containers",
+          "ui_hint": "output",
+          "flags": [
+            {"name": "--follow", "type": "bool", "default": false}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/docker/latest.json
+++ b/registry/docker/latest.json
@@ -1,0 +1,178 @@
+{
+  "plexi_version": "0.1",
+  "name": "docker",
+  "version": "26.1.0",
+  "description": "Container platform for building and running applications",
+  "icon": "🐳",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "build",
+      "description": "Build an image from a Dockerfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "path", "type": "path", "required": true, "description": "Build context path (usually .)"}
+      ],
+      "flags": [
+        {"name": "--tag", "type": "string", "required": true, "description": "Name and optionally tag in name:tag format"},
+        {"name": "--file", "type": "path", "description": "Name of the Dockerfile (default: PATH/Dockerfile)"},
+        {"name": "--no-cache", "type": "bool", "default": false, "description": "Do not use cache when building the image"},
+        {"name": "--platform", "type": "string", "description": "Set target platform for build (e.g. linux/amd64)"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a command in a new container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name (and optional tag)"},
+        {"name": "command", "type": "string", "required": false, "description": "Command to run inside the container"}
+      ],
+      "flags": [
+        {"name": "--rm", "type": "bool", "default": false, "description": "Automatically remove the container when it exits"},
+        {"name": "--interactive", "type": "bool", "default": false, "description": "Keep STDIN open"},
+        {"name": "--tty", "type": "bool", "default": false, "description": "Allocate a pseudo-TTY"},
+        {"name": "--name", "type": "string", "description": "Assign a name to the container"},
+        {"name": "--env", "type": "string", "description": "Set environment variables"},
+        {"name": "--volume", "type": "string", "description": "Bind mount a volume (host:container)"},
+        {"name": "--publish", "type": "string", "description": "Publish container port(s) to the host (host:container)"},
+        {"name": "--detach", "type": "bool", "default": false, "description": "Run container in background"}
+      ]
+    },
+    {
+      "name": "pull",
+      "description": "Download an image from a registry",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name (and optional tag)"}
+      ]
+    },
+    {
+      "name": "push",
+      "description": "Upload an image to a registry",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "image", "type": "string", "required": true}
+      ]
+    },
+    {
+      "name": "images",
+      "description": "List images",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Show all images (default hides intermediate)"},
+        {"name": "--format", "type": "string", "description": "Format output using a Go template or 'json'"},
+        {"name": "--filter", "type": "string", "description": "Filter output based on conditions (e.g. dangling=true)"}
+      ]
+    },
+    {
+      "name": "ps",
+      "description": "List containers",
+      "ui_hint": "list",
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Show all containers (default shows running only)"},
+        {"name": "--format", "type": "string", "description": "Format output using a Go template or 'json'"},
+        {"name": "--filter", "type": "string", "description": "Filter output based on conditions"}
+      ]
+    },
+    {
+      "name": "stop",
+      "description": "Stop one or more running containers",
+      "args": [
+        {"name": "container", "type": "string", "required": true, "description": "Container name or ID"}
+      ],
+      "flags": [
+        {"name": "--time", "type": "int", "description": "Seconds to wait for stop before killing (default 10)"}
+      ]
+    },
+    {
+      "name": "rm",
+      "description": "Remove one or more containers",
+      "args": [
+        {"name": "container", "type": "string", "required": true, "description": "Container name or ID"}
+      ],
+      "flags": [
+        {"name": "--force", "type": "bool", "default": false, "description": "Force removal of a running container"},
+        {"name": "--volumes", "type": "bool", "default": false, "description": "Remove anonymous volumes associated with the container"}
+      ]
+    },
+    {
+      "name": "rmi",
+      "description": "Remove one or more images",
+      "args": [
+        {"name": "image", "type": "string", "required": true, "description": "Image name or ID"}
+      ],
+      "flags": [
+        {"name": "--force", "type": "bool", "default": false, "description": "Force removal of the image"}
+      ]
+    },
+    {
+      "name": "exec",
+      "description": "Run a command in a running container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "container", "type": "string", "required": true},
+        {"name": "command", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--interactive", "type": "bool", "default": false},
+        {"name": "--tty", "type": "bool", "default": false}
+      ]
+    },
+    {
+      "name": "logs",
+      "description": "Fetch the logs of a container",
+      "ui_hint": "output",
+      "args": [
+        {"name": "container", "type": "string", "required": true}
+      ],
+      "flags": [
+        {"name": "--follow", "type": "bool", "default": false, "description": "Follow log output"},
+        {"name": "--tail", "type": "string", "description": "Number of lines from the end to show (e.g. 100)"},
+        {"name": "--timestamps", "type": "bool", "default": false, "description": "Show timestamps"}
+      ]
+    },
+    {
+      "name": "compose",
+      "description": "Define and run multi-container applications",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "up",
+          "description": "Create and start containers",
+          "ui_hint": "stream",
+          "streaming": true,
+          "flags": [
+            {"name": "--detach", "type": "bool", "default": false, "description": "Run containers in background"},
+            {"name": "--build", "type": "bool", "default": false, "description": "Build images before starting containers"}
+          ]
+        },
+        {
+          "name": "down",
+          "description": "Stop and remove containers, networks",
+          "flags": [
+            {"name": "--volumes", "type": "bool", "default": false, "description": "Remove named volumes declared in the compose file"}
+          ]
+        },
+        {
+          "name": "ps",
+          "description": "List containers defined by the compose file",
+          "ui_hint": "list"
+        },
+        {
+          "name": "logs",
+          "description": "View output from containers",
+          "ui_hint": "output",
+          "flags": [
+            {"name": "--follow", "type": "bool", "default": false}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/fzf/0.51.0.json
+++ b/registry/fzf/0.51.0.json
@@ -1,0 +1,44 @@
+{
+  "plexi_version": "0.1",
+  "name": "fzf",
+  "version": "0.51.0",
+  "description": "A command-line fuzzy finder",
+  "icon": "🔎",
+  "default_view": "output",
+  "commands": [
+    {
+      "name": "fzf",
+      "description": "Fuzzy-search over stdin and output selected items to stdout",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--query", "type": "string", "description": "Start the finder with the given query"},
+        {"name": "--filter", "type": "string", "description": "Filter mode: apply the query and exit without interactive UI"},
+        {"name": "--multi", "type": "bool", "default": false, "description": "Enable multi-select with Tab/Shift-Tab"},
+        {"name": "--no-sort", "type": "bool", "default": false, "description": "Do not sort the result"},
+        {"name": "--reverse", "type": "bool", "default": false, "description": "Display in reverse order (prompt at top)"},
+        {"name": "--exact", "type": "bool", "default": false, "description": "Enable exact-match"},
+        {"name": "--case-sensitive", "type": "bool", "default": false},
+        {"name": "--ignore-case", "type": "bool", "default": false},
+        {"name": "--delimiter", "type": "string", "description": "Field delimiter regex for nth and with-nth (default: AWK-style)"},
+        {"name": "--nth", "type": "string", "description": "Comma-separated list of field index expressions for search scope"},
+        {"name": "--with-nth", "type": "string", "description": "Transform presentation of each line using field index expressions"},
+        {"name": "--prompt", "type": "string", "description": "Input prompt (default: '> ')"},
+        {"name": "--header", "type": "string", "description": "String to print as sticky header"},
+        {"name": "--header-lines", "type": "int", "description": "Treat N lines of input as sticky header"},
+        {"name": "--preview", "type": "string", "description": "Command to execute as preview for the focused item (use {} as placeholder)"},
+        {"name": "--preview-window", "type": "string", "description": "Preview window layout (e.g. right:50%:wrap)"},
+        {"name": "--bind", "type": "string", "description": "Custom key binding (key:action, e.g. ctrl-a:select-all)"},
+        {"name": "--height", "type": "string", "description": "Display fzf window below the cursor with the given height (e.g. 40%)"},
+        {"name": "--min-height", "type": "int", "description": "Minimum height when --height is given as a percent"},
+        {"name": "--border", "type": "string", "description": "Draw border around the finder: rounded, sharp, bold, block, etc."},
+        {"name": "--ansi", "type": "bool", "default": false, "description": "Enable processing of ANSI color codes in input"},
+        {"name": "--color", "type": "string", "description": "Color scheme (e.g. dark, light, 16, bw, or custom fg:N,bg:N)"},
+        {"name": "--no-mouse", "type": "bool", "default": false, "description": "Disable mouse"},
+        {"name": "--print0", "type": "bool", "default": false, "description": "Separate output items with NUL instead of newline"},
+        {"name": "--read0", "type": "bool", "default": false, "description": "Read input items delimited by NUL instead of newline"},
+        {"name": "--select-1", "type": "bool", "default": false, "description": "Automatically select the only match"},
+        {"name": "--exit-0", "type": "bool", "default": false, "description": "Exit immediately when there's no match"}
+      ]
+    }
+  ]
+}

--- a/registry/fzf/latest.json
+++ b/registry/fzf/latest.json
@@ -1,0 +1,44 @@
+{
+  "plexi_version": "0.1",
+  "name": "fzf",
+  "version": "0.51.0",
+  "description": "A command-line fuzzy finder",
+  "icon": "🔎",
+  "default_view": "output",
+  "commands": [
+    {
+      "name": "fzf",
+      "description": "Fuzzy-search over stdin and output selected items to stdout",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--query", "type": "string", "description": "Start the finder with the given query"},
+        {"name": "--filter", "type": "string", "description": "Filter mode: apply the query and exit without interactive UI"},
+        {"name": "--multi", "type": "bool", "default": false, "description": "Enable multi-select with Tab/Shift-Tab"},
+        {"name": "--no-sort", "type": "bool", "default": false, "description": "Do not sort the result"},
+        {"name": "--reverse", "type": "bool", "default": false, "description": "Display in reverse order (prompt at top)"},
+        {"name": "--exact", "type": "bool", "default": false, "description": "Enable exact-match"},
+        {"name": "--case-sensitive", "type": "bool", "default": false},
+        {"name": "--ignore-case", "type": "bool", "default": false},
+        {"name": "--delimiter", "type": "string", "description": "Field delimiter regex for nth and with-nth (default: AWK-style)"},
+        {"name": "--nth", "type": "string", "description": "Comma-separated list of field index expressions for search scope"},
+        {"name": "--with-nth", "type": "string", "description": "Transform presentation of each line using field index expressions"},
+        {"name": "--prompt", "type": "string", "description": "Input prompt (default: '> ')"},
+        {"name": "--header", "type": "string", "description": "String to print as sticky header"},
+        {"name": "--header-lines", "type": "int", "description": "Treat N lines of input as sticky header"},
+        {"name": "--preview", "type": "string", "description": "Command to execute as preview for the focused item (use {} as placeholder)"},
+        {"name": "--preview-window", "type": "string", "description": "Preview window layout (e.g. right:50%:wrap)"},
+        {"name": "--bind", "type": "string", "description": "Custom key binding (key:action, e.g. ctrl-a:select-all)"},
+        {"name": "--height", "type": "string", "description": "Display fzf window below the cursor with the given height (e.g. 40%)"},
+        {"name": "--min-height", "type": "int", "description": "Minimum height when --height is given as a percent"},
+        {"name": "--border", "type": "string", "description": "Draw border around the finder: rounded, sharp, bold, block, etc."},
+        {"name": "--ansi", "type": "bool", "default": false, "description": "Enable processing of ANSI color codes in input"},
+        {"name": "--color", "type": "string", "description": "Color scheme (e.g. dark, light, 16, bw, or custom fg:N,bg:N)"},
+        {"name": "--no-mouse", "type": "bool", "default": false, "description": "Disable mouse"},
+        {"name": "--print0", "type": "bool", "default": false, "description": "Separate output items with NUL instead of newline"},
+        {"name": "--read0", "type": "bool", "default": false, "description": "Read input items delimited by NUL instead of newline"},
+        {"name": "--select-1", "type": "bool", "default": false, "description": "Automatically select the only match"},
+        {"name": "--exit-0", "type": "bool", "default": false, "description": "Exit immediately when there's no match"}
+      ]
+    }
+  ]
+}

--- a/registry/git/2.44.0.json
+++ b/registry/git/2.44.0.json
@@ -1,0 +1,249 @@
+{
+  "plexi_version": "0.1",
+  "name": "git",
+  "version": "2.44.0",
+  "description": "Distributed version control system",
+  "icon": "🌿",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "clone",
+      "description": "Clone a repository into a new directory",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "repository", "type": "string", "required": true, "description": "Repository URL or path"},
+        {"name": "directory", "type": "path", "required": false, "description": "Target directory name"}
+      ],
+      "flags": [
+        {"name": "--depth", "type": "int", "description": "Create a shallow clone with history truncated to N commits"},
+        {"name": "--branch", "type": "string", "description": "Point HEAD at this branch instead of the default"},
+        {"name": "--single-branch", "type": "bool", "default": false, "description": "Clone only history leading to the tip of a single branch"}
+      ],
+      "writes": ["<directory>/"]
+    },
+    {
+      "name": "init",
+      "description": "Create an empty Git repository or reinitialize an existing one",
+      "ui_hint": "form",
+      "args": [
+        {"name": "directory", "type": "path", "required": false}
+      ],
+      "flags": [
+        {"name": "--bare", "type": "bool", "default": false, "description": "Create a bare repository"},
+        {"name": "--initial-branch", "type": "string", "description": "Initial branch name"}
+      ]
+    },
+    {
+      "name": "add",
+      "description": "Add file contents to the index",
+      "ui_hint": "form",
+      "args": [
+        {"name": "pathspec", "type": "path", "required": true, "description": "Files to stage"}
+      ],
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Stage all changes including deletions"},
+        {"name": "--patch", "type": "bool", "default": false, "description": "Interactively choose hunks to stage"}
+      ]
+    },
+    {
+      "name": "commit",
+      "description": "Record changes to the repository",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--message", "type": "string", "required": true, "description": "Commit message"},
+        {"name": "--all", "type": "bool", "default": false, "description": "Stage all tracked modifications before committing"},
+        {"name": "--amend", "type": "bool", "default": false, "description": "Replace the tip of the current branch"}
+      ]
+    },
+    {
+      "name": "push",
+      "description": "Update remote refs along with associated objects",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false, "description": "Remote name (default: origin)"},
+        {"name": "refspec", "type": "string", "required": false, "description": "Branch or ref to push"}
+      ],
+      "flags": [
+        {"name": "--force-with-lease", "type": "bool", "default": false, "description": "Safer force push; aborts if remote has new commits"},
+        {"name": "--set-upstream", "type": "bool", "default": false, "description": "Set upstream tracking for the branch"},
+        {"name": "--tags", "type": "bool", "default": false, "description": "Push all tags"}
+      ]
+    },
+    {
+      "name": "pull",
+      "description": "Fetch from and integrate with another repository or branch",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false},
+        {"name": "branch", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--rebase", "type": "bool", "default": false, "description": "Rebase instead of merge"},
+        {"name": "--ff-only", "type": "bool", "default": false, "description": "Refuse to merge; only fast-forward"}
+      ]
+    },
+    {
+      "name": "fetch",
+      "description": "Download objects and refs from another repository",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--prune", "type": "bool", "default": false, "description": "Remove remote-tracking branches no longer on the remote"},
+        {"name": "--all", "type": "bool", "default": false, "description": "Fetch all remotes"}
+      ]
+    },
+    {
+      "name": "status",
+      "description": "Show the working tree status",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--short", "type": "bool", "default": false, "description": "Give output in short format"},
+        {"name": "--porcelain", "type": "bool", "default": false, "description": "Machine-readable output"}
+      ]
+    },
+    {
+      "name": "log",
+      "description": "Show commit logs",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--oneline", "type": "bool", "default": false, "description": "Show each commit on one line"},
+        {"name": "--graph", "type": "bool", "default": false, "description": "Draw a text-based graph of commits"},
+        {"name": "--decorate", "type": "bool", "default": false, "description": "Print ref names alongside commits"},
+        {"name": "--author", "type": "string", "description": "Filter commits by author"}
+      ]
+    },
+    {
+      "name": "diff",
+      "description": "Show changes between commits, commit and working tree, etc.",
+      "ui_hint": "output",
+      "args": [
+        {"name": "commit", "type": "string", "required": false, "description": "Commit, branch, or ref to diff against"}
+      ],
+      "flags": [
+        {"name": "--staged", "type": "bool", "default": false, "description": "Compare staged changes to last commit"},
+        {"name": "--stat", "type": "bool", "default": false, "description": "Show diffstat summary only"}
+      ]
+    },
+    {
+      "name": "checkout",
+      "description": "Switch branches or restore working tree files",
+      "ui_hint": "form",
+      "args": [
+        {"name": "branch-or-path", "type": "string", "required": true, "description": "Branch name, tag, or file path"}
+      ],
+      "flags": [
+        {"name": "--branch", "type": "string", "description": "Create and check out a new branch"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Proceed even if index or working tree differs from HEAD"}
+      ]
+    },
+    {
+      "name": "branch",
+      "description": "List, create, or delete branches",
+      "ui_hint": "list",
+      "args": [
+        {"name": "branchname", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--delete", "type": "string", "description": "Delete the named branch"},
+        {"name": "--all", "type": "bool", "default": false, "description": "List both remote-tracking and local branches"},
+        {"name": "--move", "type": "string", "description": "Rename the current branch"}
+      ]
+    },
+    {
+      "name": "merge",
+      "description": "Join two or more development histories together",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "branch", "type": "string", "required": true, "description": "Branch to merge into HEAD"}
+      ],
+      "flags": [
+        {"name": "--no-ff", "type": "bool", "default": false, "description": "Create a merge commit even for fast-forward cases"},
+        {"name": "--squash", "type": "bool", "default": false, "description": "Squash all merged commits into a single working tree change"},
+        {"name": "--abort", "type": "bool", "default": false, "description": "Abort an in-progress merge"}
+      ]
+    },
+    {
+      "name": "rebase",
+      "description": "Reapply commits on top of another base tip",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "upstream", "type": "string", "required": false, "description": "Branch or commit to rebase onto"}
+      ],
+      "flags": [
+        {"name": "--abort", "type": "bool", "default": false, "description": "Abort the current rebase operation"},
+        {"name": "--continue", "type": "bool", "default": false, "description": "Restart after resolving a conflict"},
+        {"name": "--skip", "type": "bool", "default": false, "description": "Skip the current conflicting patch"}
+      ]
+    },
+    {
+      "name": "stash",
+      "description": "Stash the changes in a dirty working directory away",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "push",
+          "description": "Save local modifications to a new stash entry",
+          "flags": [
+            {"name": "--message", "type": "string", "description": "Stash description"},
+            {"name": "--include-untracked", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "pop",
+          "description": "Apply a stash and remove it from the stash list"
+        },
+        {
+          "name": "list",
+          "description": "List stash entries",
+          "ui_hint": "output"
+        },
+        {
+          "name": "drop",
+          "description": "Remove a stash entry",
+          "args": [
+            {"name": "stash", "type": "string", "required": false, "description": "Stash ref (default: stash@{0})"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "remote",
+      "description": "Manage set of tracked repositories",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "add",
+          "description": "Add a remote named <name> for the repository at <url>",
+          "ui_hint": "form",
+          "args": [
+            {"name": "name", "type": "string", "required": true},
+            {"name": "url", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "remove",
+          "description": "Remove the remote named <name>",
+          "args": [
+            {"name": "name", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "get-url",
+          "description": "Retrieve the URL for a remote",
+          "ui_hint": "output",
+          "args": [
+            {"name": "name", "type": "string", "required": true}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/git/2.44.0.json
+++ b/registry/git/2.44.0.json
@@ -146,13 +146,10 @@
       "name": "branch",
       "description": "List, create, or delete branches",
       "ui_hint": "list",
-      "args": [
-        {"name": "branchname", "type": "string", "required": false}
-      ],
       "flags": [
-        {"name": "--delete", "type": "string", "description": "Delete the named branch"},
+        {"name": "--delete", "type": "string", "description": "Delete the named branch (pass branch name as value)"},
         {"name": "--all", "type": "bool", "default": false, "description": "List both remote-tracking and local branches"},
-        {"name": "--move", "type": "string", "description": "Rename the current branch"}
+        {"name": "--move", "type": "string", "description": "Rename current branch to the given name"}
       ]
     },
     {

--- a/registry/git/latest.json
+++ b/registry/git/latest.json
@@ -1,0 +1,249 @@
+{
+  "plexi_version": "0.1",
+  "name": "git",
+  "version": "2.44.0",
+  "description": "Distributed version control system",
+  "icon": "🌿",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "clone",
+      "description": "Clone a repository into a new directory",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "repository", "type": "string", "required": true, "description": "Repository URL or path"},
+        {"name": "directory", "type": "path", "required": false, "description": "Target directory name"}
+      ],
+      "flags": [
+        {"name": "--depth", "type": "int", "description": "Create a shallow clone with history truncated to N commits"},
+        {"name": "--branch", "type": "string", "description": "Point HEAD at this branch instead of the default"},
+        {"name": "--single-branch", "type": "bool", "default": false, "description": "Clone only history leading to the tip of a single branch"}
+      ],
+      "writes": ["<directory>/"]
+    },
+    {
+      "name": "init",
+      "description": "Create an empty Git repository or reinitialize an existing one",
+      "ui_hint": "form",
+      "args": [
+        {"name": "directory", "type": "path", "required": false}
+      ],
+      "flags": [
+        {"name": "--bare", "type": "bool", "default": false, "description": "Create a bare repository"},
+        {"name": "--initial-branch", "type": "string", "description": "Initial branch name"}
+      ]
+    },
+    {
+      "name": "add",
+      "description": "Add file contents to the index",
+      "ui_hint": "form",
+      "args": [
+        {"name": "pathspec", "type": "path", "required": true, "description": "Files to stage"}
+      ],
+      "flags": [
+        {"name": "--all", "type": "bool", "default": false, "description": "Stage all changes including deletions"},
+        {"name": "--patch", "type": "bool", "default": false, "description": "Interactively choose hunks to stage"}
+      ]
+    },
+    {
+      "name": "commit",
+      "description": "Record changes to the repository",
+      "ui_hint": "form",
+      "flags": [
+        {"name": "--message", "type": "string", "required": true, "description": "Commit message"},
+        {"name": "--all", "type": "bool", "default": false, "description": "Stage all tracked modifications before committing"},
+        {"name": "--amend", "type": "bool", "default": false, "description": "Replace the tip of the current branch"}
+      ]
+    },
+    {
+      "name": "push",
+      "description": "Update remote refs along with associated objects",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false, "description": "Remote name (default: origin)"},
+        {"name": "refspec", "type": "string", "required": false, "description": "Branch or ref to push"}
+      ],
+      "flags": [
+        {"name": "--force-with-lease", "type": "bool", "default": false, "description": "Safer force push; aborts if remote has new commits"},
+        {"name": "--set-upstream", "type": "bool", "default": false, "description": "Set upstream tracking for the branch"},
+        {"name": "--tags", "type": "bool", "default": false, "description": "Push all tags"}
+      ]
+    },
+    {
+      "name": "pull",
+      "description": "Fetch from and integrate with another repository or branch",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false},
+        {"name": "branch", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--rebase", "type": "bool", "default": false, "description": "Rebase instead of merge"},
+        {"name": "--ff-only", "type": "bool", "default": false, "description": "Refuse to merge; only fast-forward"}
+      ]
+    },
+    {
+      "name": "fetch",
+      "description": "Download objects and refs from another repository",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "remote", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--prune", "type": "bool", "default": false, "description": "Remove remote-tracking branches no longer on the remote"},
+        {"name": "--all", "type": "bool", "default": false, "description": "Fetch all remotes"}
+      ]
+    },
+    {
+      "name": "status",
+      "description": "Show the working tree status",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--short", "type": "bool", "default": false, "description": "Give output in short format"},
+        {"name": "--porcelain", "type": "bool", "default": false, "description": "Machine-readable output"}
+      ]
+    },
+    {
+      "name": "log",
+      "description": "Show commit logs",
+      "ui_hint": "output",
+      "flags": [
+        {"name": "--oneline", "type": "bool", "default": false, "description": "Show each commit on one line"},
+        {"name": "--graph", "type": "bool", "default": false, "description": "Draw a text-based graph of commits"},
+        {"name": "--decorate", "type": "bool", "default": false, "description": "Print ref names alongside commits"},
+        {"name": "--author", "type": "string", "description": "Filter commits by author"}
+      ]
+    },
+    {
+      "name": "diff",
+      "description": "Show changes between commits, commit and working tree, etc.",
+      "ui_hint": "output",
+      "args": [
+        {"name": "commit", "type": "string", "required": false, "description": "Commit, branch, or ref to diff against"}
+      ],
+      "flags": [
+        {"name": "--staged", "type": "bool", "default": false, "description": "Compare staged changes to last commit"},
+        {"name": "--stat", "type": "bool", "default": false, "description": "Show diffstat summary only"}
+      ]
+    },
+    {
+      "name": "checkout",
+      "description": "Switch branches or restore working tree files",
+      "ui_hint": "form",
+      "args": [
+        {"name": "branch-or-path", "type": "string", "required": true, "description": "Branch name, tag, or file path"}
+      ],
+      "flags": [
+        {"name": "--branch", "type": "string", "description": "Create and check out a new branch"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Proceed even if index or working tree differs from HEAD"}
+      ]
+    },
+    {
+      "name": "branch",
+      "description": "List, create, or delete branches",
+      "ui_hint": "list",
+      "args": [
+        {"name": "branchname", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--delete", "type": "string", "description": "Delete the named branch"},
+        {"name": "--all", "type": "bool", "default": false, "description": "List both remote-tracking and local branches"},
+        {"name": "--move", "type": "string", "description": "Rename the current branch"}
+      ]
+    },
+    {
+      "name": "merge",
+      "description": "Join two or more development histories together",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "branch", "type": "string", "required": true, "description": "Branch to merge into HEAD"}
+      ],
+      "flags": [
+        {"name": "--no-ff", "type": "bool", "default": false, "description": "Create a merge commit even for fast-forward cases"},
+        {"name": "--squash", "type": "bool", "default": false, "description": "Squash all merged commits into a single working tree change"},
+        {"name": "--abort", "type": "bool", "default": false, "description": "Abort an in-progress merge"}
+      ]
+    },
+    {
+      "name": "rebase",
+      "description": "Reapply commits on top of another base tip",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "upstream", "type": "string", "required": false, "description": "Branch or commit to rebase onto"}
+      ],
+      "flags": [
+        {"name": "--abort", "type": "bool", "default": false, "description": "Abort the current rebase operation"},
+        {"name": "--continue", "type": "bool", "default": false, "description": "Restart after resolving a conflict"},
+        {"name": "--skip", "type": "bool", "default": false, "description": "Skip the current conflicting patch"}
+      ]
+    },
+    {
+      "name": "stash",
+      "description": "Stash the changes in a dirty working directory away",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "push",
+          "description": "Save local modifications to a new stash entry",
+          "flags": [
+            {"name": "--message", "type": "string", "description": "Stash description"},
+            {"name": "--include-untracked", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "pop",
+          "description": "Apply a stash and remove it from the stash list"
+        },
+        {
+          "name": "list",
+          "description": "List stash entries",
+          "ui_hint": "output"
+        },
+        {
+          "name": "drop",
+          "description": "Remove a stash entry",
+          "args": [
+            {"name": "stash", "type": "string", "required": false, "description": "Stash ref (default: stash@{0})"}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "remote",
+      "description": "Manage set of tracked repositories",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "add",
+          "description": "Add a remote named <name> for the repository at <url>",
+          "ui_hint": "form",
+          "args": [
+            {"name": "name", "type": "string", "required": true},
+            {"name": "url", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "remove",
+          "description": "Remove the remote named <name>",
+          "args": [
+            {"name": "name", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "get-url",
+          "description": "Retrieve the URL for a remote",
+          "ui_hint": "output",
+          "args": [
+            {"name": "name", "type": "string", "required": true}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/git/latest.json
+++ b/registry/git/latest.json
@@ -146,13 +146,10 @@
       "name": "branch",
       "description": "List, create, or delete branches",
       "ui_hint": "list",
-      "args": [
-        {"name": "branchname", "type": "string", "required": false}
-      ],
       "flags": [
-        {"name": "--delete", "type": "string", "description": "Delete the named branch"},
+        {"name": "--delete", "type": "string", "description": "Delete the named branch (pass branch name as value)"},
         {"name": "--all", "type": "bool", "default": false, "description": "List both remote-tracking and local branches"},
-        {"name": "--move", "type": "string", "description": "Rename the current branch"}
+        {"name": "--move", "type": "string", "description": "Rename current branch to the given name"}
       ]
     },
     {

--- a/registry/kubectl/1.30.0.json
+++ b/registry/kubectl/1.30.0.json
@@ -1,0 +1,193 @@
+{
+  "plexi_version": "0.1",
+  "name": "kubectl",
+  "version": "1.30.0",
+  "description": "Kubernetes command-line tool",
+  "icon": "☸️",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "get",
+      "description": "Display one or many resources",
+      "ui_hint": "list",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type (pods, deployments, services, nodes, etc.)"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name (omit to list all)"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string", "description": "Namespace to query (default: current context)"},
+        {"name": "--all-namespaces", "type": "bool", "default": false, "description": "Query across all namespaces"},
+        {"name": "--output", "type": "string", "description": "Output format: json, yaml, wide, name, jsonpath=..."},
+        {"name": "--selector", "type": "string", "description": "Label selector to filter resources"},
+        {"name": "--watch", "type": "bool", "default": false, "description": "Watch for changes to the resource"}
+      ]
+    },
+    {
+      "name": "describe",
+      "description": "Show detailed state of one or many resources",
+      "ui_hint": "output",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "apply",
+      "description": "Apply a configuration to a resource by file or stdin",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--filename", "type": "path", "required": true, "description": "File, directory, or URL to apply"},
+        {"name": "--namespace", "type": "string"},
+        {"name": "--dry-run", "type": "string", "description": "Dry run mode: none, client, or server"},
+        {"name": "--recursive", "type": "bool", "default": false, "description": "Recursively apply all files in the directory"}
+      ]
+    },
+    {
+      "name": "delete",
+      "description": "Delete resources by file names, stdin, resource and names",
+      "ui_hint": "form",
+      "args": [
+        {"name": "resource", "type": "string", "required": false, "description": "Resource type"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name"}
+      ],
+      "flags": [
+        {"name": "--filename", "type": "path", "description": "File containing resource to delete"},
+        {"name": "--namespace", "type": "string"},
+        {"name": "--grace-period", "type": "int", "description": "Period of time in seconds given to the resource to terminate"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Force immediate deletion (bypasses graceful termination)"}
+      ]
+    },
+    {
+      "name": "logs",
+      "description": "Print the logs for a container in a pod",
+      "ui_hint": "output",
+      "args": [
+        {"name": "pod", "type": "string", "required": true, "description": "Pod name"}
+      ],
+      "flags": [
+        {"name": "--container", "type": "string", "description": "Container name (if pod has multiple)"},
+        {"name": "--follow", "type": "bool", "default": false, "description": "Stream the logs"},
+        {"name": "--previous", "type": "bool", "default": false, "description": "Print logs from a previously terminated container"},
+        {"name": "--tail", "type": "int", "description": "Lines of recent log output to show"},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "exec",
+      "description": "Execute a command in a container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "pod", "type": "string", "required": true},
+        {"name": "command", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--container", "type": "string"},
+        {"name": "--stdin", "type": "bool", "default": false},
+        {"name": "--tty", "type": "bool", "default": false},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "port-forward",
+      "description": "Forward one or more local ports to a pod",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Pod, deployment, or service to forward to"},
+        {"name": "ports", "type": "string", "required": true, "description": "Local:remote port mapping (e.g. 8080:80)"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "rollout",
+      "description": "Manage the rollout of a resource",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "status",
+          "description": "Show the status of the rollout",
+          "ui_hint": "output",
+          "args": [
+            {"name": "resource", "type": "string", "required": true, "description": "Deployment or daemonset name"}
+          ]
+        },
+        {
+          "name": "restart",
+          "description": "Restart a resource",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "undo",
+          "description": "Undo a previous rollout",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ],
+          "flags": [
+            {"name": "--to-revision", "type": "int", "description": "Revision to roll back to"}
+          ]
+        },
+        {
+          "name": "history",
+          "description": "View rollout history",
+          "ui_hint": "output",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "scale",
+      "description": "Set a new size for a deployment, replica set, or stateful set",
+      "ui_hint": "form",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type/name (e.g. deployment/myapp)"}
+      ],
+      "flags": [
+        {"name": "--replicas", "type": "int", "required": true, "description": "Number of replicas"},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "config",
+      "description": "Modify kubeconfig files",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "get-contexts",
+          "description": "List available kubeconfig contexts",
+          "ui_hint": "list"
+        },
+        {
+          "name": "use-context",
+          "description": "Switch to a different kubeconfig context",
+          "ui_hint": "form",
+          "args": [
+            {"name": "context", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "current-context",
+          "description": "Display the current context",
+          "ui_hint": "output"
+        },
+        {
+          "name": "set-namespace",
+          "description": "Set the default namespace in the current context",
+          "args": [
+            {"name": "namespace", "type": "string", "required": true}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/kubectl/1.30.0.json
+++ b/registry/kubectl/1.30.0.json
@@ -42,7 +42,7 @@
       "flags": [
         {"name": "--filename", "type": "path", "required": true, "description": "File, directory, or URL to apply"},
         {"name": "--namespace", "type": "string"},
-        {"name": "--dry-run", "type": "string", "description": "Dry run mode: none, client, or server"},
+        {"name": "--dry-run", "type": "enum", "enum_values": ["none", "client", "server"], "default": "none", "description": "Dry run mode: none, client, or server"},
         {"name": "--recursive", "type": "bool", "default": false, "description": "Recursively apply all files in the directory"}
       ]
     },

--- a/registry/kubectl/latest.json
+++ b/registry/kubectl/latest.json
@@ -1,0 +1,193 @@
+{
+  "plexi_version": "0.1",
+  "name": "kubectl",
+  "version": "1.30.0",
+  "description": "Kubernetes command-line tool",
+  "icon": "☸️",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "get",
+      "description": "Display one or many resources",
+      "ui_hint": "list",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type (pods, deployments, services, nodes, etc.)"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name (omit to list all)"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string", "description": "Namespace to query (default: current context)"},
+        {"name": "--all-namespaces", "type": "bool", "default": false, "description": "Query across all namespaces"},
+        {"name": "--output", "type": "string", "description": "Output format: json, yaml, wide, name, jsonpath=..."},
+        {"name": "--selector", "type": "string", "description": "Label selector to filter resources"},
+        {"name": "--watch", "type": "bool", "default": false, "description": "Watch for changes to the resource"}
+      ]
+    },
+    {
+      "name": "describe",
+      "description": "Show detailed state of one or many resources",
+      "ui_hint": "output",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "apply",
+      "description": "Apply a configuration to a resource by file or stdin",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--filename", "type": "path", "required": true, "description": "File, directory, or URL to apply"},
+        {"name": "--namespace", "type": "string"},
+        {"name": "--dry-run", "type": "string", "description": "Dry run mode: none, client, or server"},
+        {"name": "--recursive", "type": "bool", "default": false, "description": "Recursively apply all files in the directory"}
+      ]
+    },
+    {
+      "name": "delete",
+      "description": "Delete resources by file names, stdin, resource and names",
+      "ui_hint": "form",
+      "args": [
+        {"name": "resource", "type": "string", "required": false, "description": "Resource type"},
+        {"name": "name", "type": "string", "required": false, "description": "Resource name"}
+      ],
+      "flags": [
+        {"name": "--filename", "type": "path", "description": "File containing resource to delete"},
+        {"name": "--namespace", "type": "string"},
+        {"name": "--grace-period", "type": "int", "description": "Period of time in seconds given to the resource to terminate"},
+        {"name": "--force", "type": "bool", "default": false, "description": "Force immediate deletion (bypasses graceful termination)"}
+      ]
+    },
+    {
+      "name": "logs",
+      "description": "Print the logs for a container in a pod",
+      "ui_hint": "output",
+      "args": [
+        {"name": "pod", "type": "string", "required": true, "description": "Pod name"}
+      ],
+      "flags": [
+        {"name": "--container", "type": "string", "description": "Container name (if pod has multiple)"},
+        {"name": "--follow", "type": "bool", "default": false, "description": "Stream the logs"},
+        {"name": "--previous", "type": "bool", "default": false, "description": "Print logs from a previously terminated container"},
+        {"name": "--tail", "type": "int", "description": "Lines of recent log output to show"},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "exec",
+      "description": "Execute a command in a container",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "pod", "type": "string", "required": true},
+        {"name": "command", "type": "string", "required": false}
+      ],
+      "flags": [
+        {"name": "--container", "type": "string"},
+        {"name": "--stdin", "type": "bool", "default": false},
+        {"name": "--tty", "type": "bool", "default": false},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "port-forward",
+      "description": "Forward one or more local ports to a pod",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Pod, deployment, or service to forward to"},
+        {"name": "ports", "type": "string", "required": true, "description": "Local:remote port mapping (e.g. 8080:80)"}
+      ],
+      "flags": [
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "rollout",
+      "description": "Manage the rollout of a resource",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "status",
+          "description": "Show the status of the rollout",
+          "ui_hint": "output",
+          "args": [
+            {"name": "resource", "type": "string", "required": true, "description": "Deployment or daemonset name"}
+          ]
+        },
+        {
+          "name": "restart",
+          "description": "Restart a resource",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "undo",
+          "description": "Undo a previous rollout",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ],
+          "flags": [
+            {"name": "--to-revision", "type": "int", "description": "Revision to roll back to"}
+          ]
+        },
+        {
+          "name": "history",
+          "description": "View rollout history",
+          "ui_hint": "output",
+          "args": [
+            {"name": "resource", "type": "string", "required": true}
+          ]
+        }
+      ]
+    },
+    {
+      "name": "scale",
+      "description": "Set a new size for a deployment, replica set, or stateful set",
+      "ui_hint": "form",
+      "args": [
+        {"name": "resource", "type": "string", "required": true, "description": "Resource type/name (e.g. deployment/myapp)"}
+      ],
+      "flags": [
+        {"name": "--replicas", "type": "int", "required": true, "description": "Number of replicas"},
+        {"name": "--namespace", "type": "string"}
+      ]
+    },
+    {
+      "name": "config",
+      "description": "Modify kubeconfig files",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "get-contexts",
+          "description": "List available kubeconfig contexts",
+          "ui_hint": "list"
+        },
+        {
+          "name": "use-context",
+          "description": "Switch to a different kubeconfig context",
+          "ui_hint": "form",
+          "args": [
+            {"name": "context", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "current-context",
+          "description": "Display the current context",
+          "ui_hint": "output"
+        },
+        {
+          "name": "set-namespace",
+          "description": "Set the default namespace in the current context",
+          "args": [
+            {"name": "namespace", "type": "string", "required": true}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/kubectl/latest.json
+++ b/registry/kubectl/latest.json
@@ -42,7 +42,7 @@
       "flags": [
         {"name": "--filename", "type": "path", "required": true, "description": "File, directory, or URL to apply"},
         {"name": "--namespace", "type": "string"},
-        {"name": "--dry-run", "type": "string", "description": "Dry run mode: none, client, or server"},
+        {"name": "--dry-run", "type": "enum", "enum_values": ["none", "client", "server"], "default": "none", "description": "Dry run mode: none, client, or server"},
         {"name": "--recursive", "type": "bool", "default": false, "description": "Recursively apply all files in the directory"}
       ]
     },

--- a/registry/rg/14.1.0.json
+++ b/registry/rg/14.1.0.json
@@ -1,0 +1,45 @@
+{
+  "plexi_version": "0.1",
+  "name": "rg",
+  "version": "14.1.0",
+  "description": "ripgrep — fast recursive search tool respecting .gitignore",
+  "icon": "🔍",
+  "default_view": "output",
+  "commands": [
+    {
+      "name": "rg",
+      "description": "Search for PATTERN in files",
+      "ui_hint": "output",
+      "args": [
+        {"name": "pattern", "type": "string", "required": true, "description": "Regular expression to search for"},
+        {"name": "path", "type": "path", "required": false, "description": "Directory or file to search (default: current directory)"}
+      ],
+      "flags": [
+        {"name": "--type", "type": "string", "description": "Search only files matching this type (e.g. rust, py, js)"},
+        {"name": "--glob", "type": "string", "description": "Include or exclude files matching this glob pattern"},
+        {"name": "--hidden", "type": "bool", "default": false, "description": "Search hidden files and directories"},
+        {"name": "--no-ignore", "type": "bool", "default": false, "description": "Do not respect .gitignore and similar files"},
+        {"name": "--case-sensitive", "type": "bool", "default": false, "description": "Search case-sensitively"},
+        {"name": "--ignore-case", "type": "bool", "default": false, "description": "Search case-insensitively"},
+        {"name": "--smart-case", "type": "bool", "default": false, "description": "Case-insensitive if pattern is lowercase, otherwise sensitive"},
+        {"name": "--fixed-strings", "type": "bool", "default": false, "description": "Treat pattern as literal string, not regex"},
+        {"name": "--line-number", "type": "bool", "default": false, "description": "Show line numbers (default in terminal)"},
+        {"name": "--column", "type": "bool", "default": false, "description": "Show column numbers"},
+        {"name": "--count", "type": "bool", "default": false, "description": "Show count of matching lines per file"},
+        {"name": "--files-with-matches", "type": "bool", "default": false, "description": "Print only filenames with matches"},
+        {"name": "--files-without-match", "type": "bool", "default": false, "description": "Print only filenames with no matches"},
+        {"name": "--word-regexp", "type": "bool", "default": false, "description": "Match only whole words"},
+        {"name": "--multiline", "type": "bool", "default": false, "description": "Enable multiline matching"},
+        {"name": "--context", "type": "int", "description": "Show NUM lines before and after each match"},
+        {"name": "--before-context", "type": "int", "description": "Show NUM lines before each match"},
+        {"name": "--after-context", "type": "int", "description": "Show NUM lines after each match"},
+        {"name": "--max-depth", "type": "int", "description": "Limit search depth in directory traversal"},
+        {"name": "--max-count", "type": "int", "description": "Stop after NUM matches per file"},
+        {"name": "--follow", "type": "bool", "default": false, "description": "Follow symbolic links"},
+        {"name": "--json", "type": "bool", "default": false, "description": "Output results in JSON format"},
+        {"name": "--replace", "type": "string", "description": "Replace each match with the given text in output"},
+        {"name": "--only-matching", "type": "bool", "default": false, "description": "Print only the matched parts of each matching line"}
+      ]
+    }
+  ]
+}

--- a/registry/rg/latest.json
+++ b/registry/rg/latest.json
@@ -1,0 +1,45 @@
+{
+  "plexi_version": "0.1",
+  "name": "rg",
+  "version": "14.1.0",
+  "description": "ripgrep — fast recursive search tool respecting .gitignore",
+  "icon": "🔍",
+  "default_view": "output",
+  "commands": [
+    {
+      "name": "rg",
+      "description": "Search for PATTERN in files",
+      "ui_hint": "output",
+      "args": [
+        {"name": "pattern", "type": "string", "required": true, "description": "Regular expression to search for"},
+        {"name": "path", "type": "path", "required": false, "description": "Directory or file to search (default: current directory)"}
+      ],
+      "flags": [
+        {"name": "--type", "type": "string", "description": "Search only files matching this type (e.g. rust, py, js)"},
+        {"name": "--glob", "type": "string", "description": "Include or exclude files matching this glob pattern"},
+        {"name": "--hidden", "type": "bool", "default": false, "description": "Search hidden files and directories"},
+        {"name": "--no-ignore", "type": "bool", "default": false, "description": "Do not respect .gitignore and similar files"},
+        {"name": "--case-sensitive", "type": "bool", "default": false, "description": "Search case-sensitively"},
+        {"name": "--ignore-case", "type": "bool", "default": false, "description": "Search case-insensitively"},
+        {"name": "--smart-case", "type": "bool", "default": false, "description": "Case-insensitive if pattern is lowercase, otherwise sensitive"},
+        {"name": "--fixed-strings", "type": "bool", "default": false, "description": "Treat pattern as literal string, not regex"},
+        {"name": "--line-number", "type": "bool", "default": false, "description": "Show line numbers (default in terminal)"},
+        {"name": "--column", "type": "bool", "default": false, "description": "Show column numbers"},
+        {"name": "--count", "type": "bool", "default": false, "description": "Show count of matching lines per file"},
+        {"name": "--files-with-matches", "type": "bool", "default": false, "description": "Print only filenames with matches"},
+        {"name": "--files-without-match", "type": "bool", "default": false, "description": "Print only filenames with no matches"},
+        {"name": "--word-regexp", "type": "bool", "default": false, "description": "Match only whole words"},
+        {"name": "--multiline", "type": "bool", "default": false, "description": "Enable multiline matching"},
+        {"name": "--context", "type": "int", "description": "Show NUM lines before and after each match"},
+        {"name": "--before-context", "type": "int", "description": "Show NUM lines before each match"},
+        {"name": "--after-context", "type": "int", "description": "Show NUM lines after each match"},
+        {"name": "--max-depth", "type": "int", "description": "Limit search depth in directory traversal"},
+        {"name": "--max-count", "type": "int", "description": "Stop after NUM matches per file"},
+        {"name": "--follow", "type": "bool", "default": false, "description": "Follow symbolic links"},
+        {"name": "--json", "type": "bool", "default": false, "description": "Output results in JSON format"},
+        {"name": "--replace", "type": "string", "description": "Replace each match with the given text in output"},
+        {"name": "--only-matching", "type": "bool", "default": false, "description": "Print only the matched parts of each matching line"}
+      ]
+    }
+  ]
+}

--- a/registry/uv/0.4.0.json
+++ b/registry/uv/0.4.0.json
@@ -1,0 +1,202 @@
+{
+  "plexi_version": "0.1",
+  "name": "uv",
+  "version": "0.4.0",
+  "description": "An extremely fast Python package and project manager",
+  "icon": "⚡",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "init",
+      "description": "Create a new Python project",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": false, "description": "Path to initialize the project at (default: current directory)"}
+      ],
+      "flags": [
+        {"name": "--name", "type": "string", "description": "Project name (default: directory name)"},
+        {"name": "--lib", "type": "bool", "default": false, "description": "Set up the project as a library"},
+        {"name": "--script", "type": "bool", "default": false, "description": "Set up as a single-file script"},
+        {"name": "--no-readme", "type": "bool", "default": false, "description": "Do not create a README.md"}
+      ],
+      "writes": ["pyproject.toml", "src/"]
+    },
+    {
+      "name": "add",
+      "description": "Add dependencies to the project",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "packages", "type": "string", "required": true, "description": "Package(s) to add"}
+      ],
+      "flags": [
+        {"name": "--dev", "type": "bool", "default": false, "description": "Add as a development dependency"},
+        {"name": "--optional", "type": "string", "description": "Add to a named optional dependency group"},
+        {"name": "--editable", "type": "bool", "default": false, "description": "Add as an editable install from a local path"}
+      ]
+    },
+    {
+      "name": "remove",
+      "description": "Remove dependencies from the project",
+      "args": [
+        {"name": "packages", "type": "string", "required": true, "description": "Package(s) to remove"}
+      ],
+      "flags": [
+        {"name": "--dev", "type": "bool", "default": false}
+      ]
+    },
+    {
+      "name": "sync",
+      "description": "Sync the project environment with the lockfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--frozen", "type": "bool", "default": false, "description": "Sync without updating the lockfile"},
+        {"name": "--no-dev", "type": "bool", "default": false, "description": "Omit development dependencies"},
+        {"name": "--extra", "type": "string", "description": "Include optional dependency group"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a command in the project environment",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "command", "type": "string", "required": true, "description": "Command to run (e.g. python, pytest, myapp)"}
+      ],
+      "flags": [
+        {"name": "--with", "type": "string", "description": "Run with additional packages installed"},
+        {"name": "--python", "type": "string", "description": "Python interpreter to use"}
+      ]
+    },
+    {
+      "name": "tool",
+      "description": "Run and install commands provided by Python packages",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install a tool",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "package", "type": "string", "required": true}
+          ],
+          "flags": [
+            {"name": "--force", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "run",
+          "description": "Run a tool without installing it permanently",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "command", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "uninstall",
+          "description": "Uninstall a tool",
+          "args": [
+            {"name": "package", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List installed tools",
+          "ui_hint": "list"
+        }
+      ]
+    },
+    {
+      "name": "pip",
+      "description": "Manage packages in a virtual environment",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install packages",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "packages", "type": "string", "required": false, "description": "Package(s) to install"}
+          ],
+          "flags": [
+            {"name": "--requirement", "type": "path", "description": "Install from requirements file"},
+            {"name": "--editable", "type": "path", "description": "Install in editable mode from path"},
+            {"name": "--upgrade", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "uninstall",
+          "description": "Uninstall packages",
+          "args": [
+            {"name": "packages", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List installed packages",
+          "ui_hint": "list",
+          "flags": [
+            {"name": "--outdated", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "freeze",
+          "description": "Output installed packages in requirements format",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "venv",
+      "description": "Create a virtual environment",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": false, "description": "Path to create the environment (default: .venv)"}
+      ],
+      "flags": [
+        {"name": "--python", "type": "string", "description": "Python interpreter version (e.g. 3.11)"},
+        {"name": "--seed", "type": "bool", "default": false, "description": "Prepopulate with pip, setuptools, and wheel"}
+      ],
+      "writes": [".venv/"]
+    },
+    {
+      "name": "lock",
+      "description": "Update the project's lockfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--upgrade", "type": "bool", "default": false, "description": "Allow package upgrades"},
+        {"name": "--upgrade-package", "type": "string", "description": "Allow upgrades for a specific package only"}
+      ],
+      "writes": ["uv.lock"]
+    },
+    {
+      "name": "python",
+      "description": "Manage Python installations",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install a Python version",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "version", "type": "string", "required": true, "description": "Python version (e.g. 3.11, 3.12)"}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List available and installed Python versions",
+          "ui_hint": "list",
+          "flags": [
+            {"name": "--only-installed", "type": "bool", "default": false}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/registry/uv/latest.json
+++ b/registry/uv/latest.json
@@ -1,0 +1,202 @@
+{
+  "plexi_version": "0.1",
+  "name": "uv",
+  "version": "0.4.0",
+  "description": "An extremely fast Python package and project manager",
+  "icon": "⚡",
+  "default_view": "list",
+  "commands": [
+    {
+      "name": "init",
+      "description": "Create a new Python project",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": false, "description": "Path to initialize the project at (default: current directory)"}
+      ],
+      "flags": [
+        {"name": "--name", "type": "string", "description": "Project name (default: directory name)"},
+        {"name": "--lib", "type": "bool", "default": false, "description": "Set up the project as a library"},
+        {"name": "--script", "type": "bool", "default": false, "description": "Set up as a single-file script"},
+        {"name": "--no-readme", "type": "bool", "default": false, "description": "Do not create a README.md"}
+      ],
+      "writes": ["pyproject.toml", "src/"]
+    },
+    {
+      "name": "add",
+      "description": "Add dependencies to the project",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "packages", "type": "string", "required": true, "description": "Package(s) to add"}
+      ],
+      "flags": [
+        {"name": "--dev", "type": "bool", "default": false, "description": "Add as a development dependency"},
+        {"name": "--optional", "type": "string", "description": "Add to a named optional dependency group"},
+        {"name": "--editable", "type": "bool", "default": false, "description": "Add as an editable install from a local path"}
+      ]
+    },
+    {
+      "name": "remove",
+      "description": "Remove dependencies from the project",
+      "args": [
+        {"name": "packages", "type": "string", "required": true, "description": "Package(s) to remove"}
+      ],
+      "flags": [
+        {"name": "--dev", "type": "bool", "default": false}
+      ]
+    },
+    {
+      "name": "sync",
+      "description": "Sync the project environment with the lockfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--frozen", "type": "bool", "default": false, "description": "Sync without updating the lockfile"},
+        {"name": "--no-dev", "type": "bool", "default": false, "description": "Omit development dependencies"},
+        {"name": "--extra", "type": "string", "description": "Include optional dependency group"}
+      ]
+    },
+    {
+      "name": "run",
+      "description": "Run a command in the project environment",
+      "ui_hint": "stream",
+      "streaming": true,
+      "args": [
+        {"name": "command", "type": "string", "required": true, "description": "Command to run (e.g. python, pytest, myapp)"}
+      ],
+      "flags": [
+        {"name": "--with", "type": "string", "description": "Run with additional packages installed"},
+        {"name": "--python", "type": "string", "description": "Python interpreter to use"}
+      ]
+    },
+    {
+      "name": "tool",
+      "description": "Run and install commands provided by Python packages",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install a tool",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "package", "type": "string", "required": true}
+          ],
+          "flags": [
+            {"name": "--force", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "run",
+          "description": "Run a tool without installing it permanently",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "command", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "uninstall",
+          "description": "Uninstall a tool",
+          "args": [
+            {"name": "package", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List installed tools",
+          "ui_hint": "list"
+        }
+      ]
+    },
+    {
+      "name": "pip",
+      "description": "Manage packages in a virtual environment",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install packages",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "packages", "type": "string", "required": false, "description": "Package(s) to install"}
+          ],
+          "flags": [
+            {"name": "--requirement", "type": "path", "description": "Install from requirements file"},
+            {"name": "--editable", "type": "path", "description": "Install in editable mode from path"},
+            {"name": "--upgrade", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "uninstall",
+          "description": "Uninstall packages",
+          "args": [
+            {"name": "packages", "type": "string", "required": true}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List installed packages",
+          "ui_hint": "list",
+          "flags": [
+            {"name": "--outdated", "type": "bool", "default": false}
+          ]
+        },
+        {
+          "name": "freeze",
+          "description": "Output installed packages in requirements format",
+          "ui_hint": "output"
+        }
+      ]
+    },
+    {
+      "name": "venv",
+      "description": "Create a virtual environment",
+      "ui_hint": "form",
+      "args": [
+        {"name": "path", "type": "path", "required": false, "description": "Path to create the environment (default: .venv)"}
+      ],
+      "flags": [
+        {"name": "--python", "type": "string", "description": "Python interpreter version (e.g. 3.11)"},
+        {"name": "--seed", "type": "bool", "default": false, "description": "Prepopulate with pip, setuptools, and wheel"}
+      ],
+      "writes": [".venv/"]
+    },
+    {
+      "name": "lock",
+      "description": "Update the project's lockfile",
+      "ui_hint": "stream",
+      "streaming": true,
+      "flags": [
+        {"name": "--upgrade", "type": "bool", "default": false, "description": "Allow package upgrades"},
+        {"name": "--upgrade-package", "type": "string", "description": "Allow upgrades for a specific package only"}
+      ],
+      "writes": ["uv.lock"]
+    },
+    {
+      "name": "python",
+      "description": "Manage Python installations",
+      "ui_hint": "list",
+      "commands": [
+        {
+          "name": "install",
+          "description": "Install a Python version",
+          "ui_hint": "stream",
+          "streaming": true,
+          "args": [
+            {"name": "version", "type": "string", "required": true, "description": "Python version (e.g. 3.11, 3.12)"}
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List available and installed Python versions",
+          "ui_hint": "list",
+          "flags": [
+            {"name": "--only-installed", "type": "bool", "default": false}
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #354.

Adds full Plexi descriptors for the remaining 7 CLIs from the initial set:

| CLI | Version | Commands |
|-----|---------|----------|
| git | 2.44.0 | clone, init, add, commit, push, pull, fetch, status, log, diff, checkout, branch, merge, rebase, stash, remote |
| docker | 26.1.0 | build, run, pull, push, images, ps, stop, rm, rmi, exec, logs, compose |
| kubectl | 1.30.0 | get, describe, apply, delete, logs, exec, port-forward, rollout, scale, config |
| brew | 4.2.0 | install, uninstall, update, upgrade, search, info, list, services, tap, untap, doctor, cleanup |
| uv | 0.4.0 | init, add, remove, sync, run, tool, pip, venv, lock, python |
| rg | 14.1.0 | rg (with full flag set) |
| fzf | 0.51.0 | fzf (with full flag set) |

Each CLI has a versioned JSON file and a `latest.json`. All 8 `cli_registry` tests pass including `embedded_registry_round_trips_through_parser`.