### PR TITLE
chore: remove dead agent infrastructure

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -451,11 +451,11 @@ from ._constants import (
     rgba, dim,
 )
 from ._types import (
-    CapabilityDeniedError, VideoHandle, AgentInfo,
+    CapabilityDeniedError, VideoHandle,
     RectCommand, TextCommand, BadgeCommand, TextInputSpec, ShortcutPair, NotifyOption,
 )
 from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList, PROTOCOL_VERSION
 from ._emitter import Emitter, _emit, _make_async_queue, _LOCK
 from ._pipe import Pipe
 from ._render_context import RenderContext
-from ._app import App, Agent
+from ._app import App

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -4,12 +4,10 @@ import asyncio
 import inspect
 import json
 import sys
-import uuid
 from typing import Any, Coroutine
 
 from ._protocol import PROTOCOL_VERSION
 from ._constants import _SDK_VERSION
-from ._types import AgentInfo
 from ._emitter import Emitter, _emit, _sync_hook_scope
 from ._pipe import Pipe
 from ._render_context import RenderContext
@@ -101,9 +99,6 @@ class App:
         # VideoOpenError keyed on request_id. Each entry is consumed by a
         # single open_video() call.
         self._pending_video_open: "dict[str, asyncio.Queue]" = {}
-        # v3.3 P2 agents.list (#286): awaits PlexiEvent::AgentRoster keyed
-        # on request_id. Each entry is consumed by a single agent_roster() call.
-        self._pending_agent_roster: "dict[str, asyncio.Queue]" = {}
         self._pending_notify: "dict[str, asyncio.Queue]" = {}
         # v3.5 Canvas Terminal Binding Primitives (#78). Two response shapes:
         # `linked_terminal_ready` carries an int pane_id; `command_preview`
@@ -254,11 +249,6 @@ class App:
             return fn
         return decorator
 
-    # ── Agent-as-app hooks (#338, type = "agent" manifests only) ────────────
-    # `Agent` subclass wires these. Plain `App` subclasses get no-op defaults
-    # so a misclassified manifest doesn't crash on the host's emit.
-    def on_agent_init(self, _system_prompt: "str | None") -> None: pass
-    def on_user_message(self, _ctx: "RenderContext", _text: str) -> None: pass
     def on_suspend(self) -> None: pass
     def on_resume(self) -> None: pass
     def on_shutdown(self) -> None: pass
@@ -482,17 +472,6 @@ class App:
                             str(ev.get("would_run_in_cwd", "")),
                         ))
 
-                elif t == "agent_roster":
-                    # v3.3 P2 agents.list (#286). The `agents` field is always
-                    # a list (empty when the app lacks the `agents.list`
-                    # capability — the host returns an empty roster, not an
-                    # error). Forwarded as-is to the queue waiting in
-                    # `Emitter.agent_roster`.
-                    req_id = ev.get("request_id", "")
-                    q = self._pending_agent_roster.pop(req_id, None)
-                    if q:
-                        q.put_nowait(ev.get("agents", []) or [])
-
                 elif t == "notify_action":
                     # notify_choice / notify_input: put the value back.
                     # notify / notify_and_wait: put action_label back.
@@ -702,20 +681,6 @@ class App:
                         str(ev.get("port_name", "")),
                     )
 
-                elif t == "agent_init":
-                    # v3.3 agent-as-app (#338): the host forwards the manifest's
-                    # `[launch].system_prompt` once at startup. Apps that subclass
-                    # `Agent` consume this in `_on_agent_init`; plain App
-                    # subclasses can override `on_agent_init` to receive it.
-                    await self._dispatch_hook(self.on_agent_init, ev.get("system_prompt"))
-
-                elif t == "user_message":
-                    # v3.3 agent-as-app (#338): the user submitted text in the
-                    # host-rendered conversation input box. Forwarded to
-                    # `on_user_message`. Only delivered to type=agent panes.
-                    ctx = self._make_ctx()
-                    self._dispatch_hook_task(self.on_user_message, ctx, ev.get("text", ""))
-
                 elif t == "timer":
                     timer_id = ev.get("timer_id", "")
                     ctx = self._make_ctx()
@@ -864,147 +829,6 @@ class App:
                     hook(*args)
             except Exception as e:
                 sys.stderr.write(f"plexi_sdk: sync hook {getattr(hook, '__name__', hook)!r} raised: {e}\n")
-
-
-# ── Agent base class (issue #338) ────────────────────────────────────────────
-
-class Agent(App):
-    """Subclass for `type = "agent"` manifests. Wires the conversation loop.
-
-    The host renders the conversation UI (history scrollback + input box).
-    The agent owns the dialogue logic. The contract is symmetric:
-
-        Host → Agent      PlexiEvent::AgentInit  { system_prompt }   (once)
-        Host → Agent      PlexiEvent::UserMessage { text }            (per submit)
-        Agent → Host      DrawCommand::AppendConversation { role, content }
-
-    Author writes a single `on_user_message(text) -> str | None` callback.
-    Returning a string auto-emits an assistant `AppendConversation`. Returning
-    `None` means "I'll append manually" — useful for agents that emit
-    multiple rows per turn (tool use, partial replies).
-
-    Conversation history (`self.history`) is auto-built from `append_*`
-    helpers — pass it directly to `emit.ai_query(...)` for multi-turn.
-
-    Example:
-
-        class JokeAgent(Agent):
-            def on_user_message(self, text: str) -> str:
-                resp = self.emit.ai_query(
-                    model_tier="medium",
-                    system=self.system_prompt or "",
-                    messages=self.history,
-                )
-                return resp.content
-
-        if __name__ == "__main__":
-            JokeAgent().run()
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        # Populated by AgentInit. None until the host emits it (or forever
-        # if the manifest omits `[launch].system_prompt`).
-        self.system_prompt: "str | None" = None
-        # Conversation history in Anthropic Messages shape — built by the
-        # `append_*` helpers and passed straight to `emit.ai_query`.
-        self.history: list = []
-
-    # ── Wire-up (do not override) ───────────────────────────────────────────
-    def on_agent_init(self, system_prompt: "str | None") -> None:  # type: ignore[override]
-        self.system_prompt = system_prompt
-        self.emit.info(
-            f"agent: AgentInit received (system_prompt={'set' if system_prompt else 'unset'})"
-        )
-
-    async def on_user_message(self, ctx: "RenderContext", text: str) -> None:  # type: ignore[override]
-        # Append the user turn before invoking the override so `self.history`
-        # already contains it when the override calls `emit.ai_query`.
-        self.append_user_message(text)
-        try:
-            if inspect.iscoroutinefunction(self.respond):
-                reply = await self.respond(text)  # type: ignore[misc]
-            else:
-                reply = self.respond(text)
-        except Exception as e:
-            self.emit.error(f"agent: respond() raised: {e}")
-            self.append_system_message(f"Error: {e}")
-            return
-        # `None` means "I'll handle appends myself" — common for agents that
-        # stream multiple rows (tool use, partial replies). A returned string
-        # is the conventional one-shot reply path.
-        if reply is not None:
-            self.append_assistant_message(reply)
-
-    # ── User override ───────────────────────────────────────────────────────
-    def respond(self, _text: str) -> "str | None":
-        """Override this. Called once per `user_message` event.
-
-        May be a regular ``def`` or ``async def``. Return a string to
-        auto-append as the assistant turn. Return ``None`` if you've already
-        called ``append_assistant_message`` (or other ``append_*`` helpers)
-        yourself — useful for tool-use loops.
-        """
-        raise NotImplementedError(
-            "Agent subclasses must override `respond(text) -> str | None`"
-        )
-
-    # ── Conversation surface ────────────────────────────────────────────────
-    def append_user_message(self, text: str) -> None:
-        """Append a user row to the transcript. Updates `self.history` so the
-        next `emit.ai_query` call sees the turn."""
-        self.history.append({"role": "user", "content": text})
-        _emit({"type": "append_conversation", "role": "user", "content": text})
-
-    def append_assistant_message(self, text: str) -> None:
-        """Append an assistant row. Mirrors into `self.history`."""
-        self.history.append({"role": "assistant", "content": text})
-        _emit({"type": "append_conversation", "role": "assistant", "content": text})
-
-    def append_tool_message(self, text: str) -> None:
-        """Append a tool-use status row. Tool messages are NOT mirrored into
-        `self.history` (they're not part of the LLM-visible conversation)."""
-        _emit({"type": "append_conversation", "role": "tool", "content": text})
-
-    def append_system_message(self, text: str) -> None:
-        """Append a system / error status row. NOT mirrored into history."""
-        _emit({"type": "append_conversation", "role": "system", "content": text})
-
-    # ── Inter-agent helpers (#286) ──────────────────────────────────────────
-    async def list_agents(self) -> "list[AgentInfo]":
-        """Return the workspace's live agent roster. Use with ``await``.
-
-        Thin wrapper around ``await self.emit.agent_roster()``. Apps without
-        the `agents.list` capability receive an EMPTY list (not an error).
-
-        Pass an entry's `pane_id` to `open_pipe_to(pane_id, ...)` to start
-        an inter-agent channel.
-        """
-        return await self.emit.agent_roster()
-
-    def open_pipe_to(self, pane_id: int, pipe_id: "str | None" = None) -> Pipe:
-        """Open a duplex JSON pipe to another agent pane (#286).
-
-        `pipe_id` defaults to a fresh uuid4 — pass an explicit id only when
-        both ends agreed on one out-of-band. The pipe is duplex; either
-        side calls `pipe.send(payload)` and the other receives it via
-        `on_pipe_message(ctx, pipe_id, payload)`.
-
-        Capability: `pipe.open`.
-        """
-        pid = pipe_id or f"agent-{uuid.uuid4()}"
-        return self.emit.pipe_open_directed(pid, int(pane_id))
-
-    def on_pipe_message(self, ctx: RenderContext, pipe_id: str, payload: Any) -> "Coroutine[Any, Any, None] | None":
-        """Override to receive directed inter-agent messages.
-
-        The default `App.on_pipe_message` is a no-op. Override on `Agent`
-        subclasses that act as workers / fan-out targets to handle
-        delegated requests.
-        """
-        # Same default as App.on_pipe_message — overridable by subclasses.
-        del ctx, pipe_id, payload
-        return None
 
 
 # SDK_ID used in the ready handshake. Derived from the version constant so

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Iterator
 
 from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo, AudioDeviceList
-from ._types import CapabilityDeniedError, VideoHandle, AgentInfo
+from ._types import CapabilityDeniedError, VideoHandle
 
 if TYPE_CHECKING:
     from ._app import App
@@ -1090,12 +1090,9 @@ class Emitter:
         only the caller and `target_pane_id` see traffic on `pipe_id` —
         peers that coincidentally `pipe_open` the same id stay isolated.
         Always JSON-mode duplex; `pipe.send(payload)` is symmetric on
-        either end. Used to wire inter-agent channels after discovering
-        a target via `emit.agent_roster()`.
+        either end.
 
-        Capability: `pipe.open` (same as `pipe_open`). The target pane
-        does NOT need `agents.list` to be subscribed — only to be
-        addressable via the roster.
+        Capability: `pipe.open` (same as `pipe_open`).
         """
         from ._pipe import Pipe
         p = Pipe(pipe_id=pipe_id, mode="json", direction="duplex", app=self._app)
@@ -1118,32 +1115,3 @@ class Emitter:
         """
         _emit({"type": "pipe_send", "pipe_id": pipe_id, "payload": payload})
 
-    @_blocking_emit_method
-    async def agent_roster(self) -> "list[AgentInfo]":
-        """Query for live agent panes in the workspace (#286).
-
-        Returns a list of `AgentInfo` rows sorted by `pane_id` ascending.
-        Each row carries `pane_id`, `app_id`, and `name`. Pass the
-        `pane_id` back to `pipe_open_directed(...)` to address an
-        inter-agent pipe.
-
-        Capability: `agents.list`. Apps without it receive an EMPTY
-        list (NOT an error) — the host returns an empty roster on the
-        wire so the caller can't probe the workspace via this surface.
-
-        From background threads:
-        ``self.emit.run_sync(self.emit.agent_roster())``.
-        """
-        req_id = str(uuid.uuid4())
-        q: asyncio.Queue[list[dict]] = _make_async_queue()
-        self._app._pending_agent_roster[req_id] = q
-        _emit({"type": "agent_roster_get", "request_id": req_id})
-        rows = await q.get()
-        return [
-            AgentInfo(
-                pane_id=int(r.get("pane_id", 0)),
-                app_id=str(r.get("app_id", "")),
-                name=str(r.get("name", "")),
-            )
-            for r in rows
-        ]

--- a/sdk/python/plexi_sdk/_types.py
+++ b/sdk/python/plexi_sdk/_types.py
@@ -26,22 +26,6 @@ class VideoHandle:
     pipe: "object"  # Pipe — avoid circular import; typed as object here
 
 
-# ── agents.list (#286) types ──────────────────────────────────────────────────
-
-@dataclass
-class AgentInfo:
-    """One row of the agent roster returned by `Emitter.agent_roster`.
-
-    `pane_id` is the host's stable id for the agent pane; pass it to
-    `Emitter.pipe_open_directed(pipe_id, pane_id)` to wire an inter-agent
-    channel. `app_id` is the manifest id for subprocess agents (or the
-    sentinel `"iq"` for the legacy in-process Cmd+I agent backend).
-    """
-    pane_id: int
-    app_id: str
-    name: str
-
-
 # ── Typed draw command dataclasses (#627) ─────────────────────────────────────
 
 _VALID_TEXT_ALIGN = {"top_left", "center", "top_center", "right"}

--- a/src/app_permissions.rs
+++ b/src/app_permissions.rs
@@ -51,11 +51,6 @@ pub enum Capability {
     /// host CoreMIDI broker (#320). Per-port; the SendMidi dispatch validates
     /// the gate.
     MidiOut,
-    /// Query the workspace-scoped agent roster (`agents.list`, #286). Allows an
-    /// app to discover other live agent panes via `DrawCommand::AgentRosterGet`.
-    /// Apps without this capability receive an EMPTY roster (per spec) — not
-    /// a denial error. Pair with `pipe.open` to open directed inter-agent pipes.
-    AgentsList,
     /// Drive a linked terminal pane via the v3.5 Canvas Terminal Binding
     /// Primitives (`terminal.bindings`, #78). Covers all of:
     /// `RequestLinkedTerminal`, `RunInLinkedTerminal`, `InsertPathToken`,
@@ -94,7 +89,6 @@ impl Capability {
             Self::AiQuery => "ai.query",
             Self::MidiIn => "midi.in",
             Self::MidiOut => "midi.out",
-            Self::AgentsList => "agents.list",
             Self::TerminalBindings => "terminal.bindings",
             Self::FsPick => "fs.pick",
             Self::PanesSpawn => "panes.spawn",
@@ -117,7 +111,6 @@ impl Capability {
             "ai.query",
             "midi.in",
             "midi.out",
-            "agents.list",
             "terminal.bindings",
             "fs.pick",
             "panes.spawn",
@@ -170,7 +163,6 @@ impl<'a> TryFrom<&'a str> for Capability {
             "ai.query" => Ok(Self::AiQuery),
             "midi.in" => Ok(Self::MidiIn),
             "midi.out" => Ok(Self::MidiOut),
-            "agents.list" => Ok(Self::AgentsList),
             "terminal.bindings" => Ok(Self::TerminalBindings),
             "fs.pick" => Ok(Self::FsPick),
             "panes.spawn" => Ok(Self::PanesSpawn),
@@ -438,29 +430,6 @@ mod tests {
         );
         assert!(matches!(
             check(&perms, Capability::AiQuery),
-            PermissionCheck::Allowed
-        ));
-    }
-
-    #[test]
-    fn agents_list_capability_recognized() {
-        // The new v3.3 P2 capability (#286) must round-trip through
-        // `Capability::try_from` / `as_str` and end up in the granted set
-        // when declared. Note: the *runtime* contract for an undeclared
-        // `agents.list` is "empty roster" (not denial) — that is enforced
-        // in the routing layer, not here. This test pins only the parser
-        // layer recognising the capability string.
-        let parsed = Capability::try_from("agents.list").expect("agents.list must parse");
-        assert_eq!(parsed, Capability::AgentsList);
-        assert_eq!(parsed.as_str(), "agents.list");
-
-        let perms = AppPermissions::from_capability_strings(&["agents.list".to_string()]);
-        assert!(
-            perms.capabilities.contains(&Capability::AgentsList),
-            "agents.list must end up in granted capabilities"
-        );
-        assert!(matches!(
-            check(&perms, Capability::AgentsList),
             PermissionCheck::Allowed
         ));
     }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -177,8 +177,6 @@ pub enum PlexiEvent {
     /// buffer for `id` after emitting this event so the field is empty for
     /// the next input.
     TextSubmitted { id: String, value: String },
-    /// User submitted text in the focused app pane.
-    UserMessage { text: String },
     /// Clipboard paste forwarded into the focused app pane.
     ///
     /// Emitted whenever the host observes `egui::Event::Paste(text)` while an
@@ -1330,22 +1328,6 @@ pub enum ControlCommand {
         #[serde(default)]
         monospace: bool,
     },
-    /// Append a row to the host-owned conversation history of an agent pane.
-    ///
-    /// Only meaningful for panes whose manifest declares `[app] type = "agent"`.
-    /// The host renders the conversation history as the pane's primary surface;
-    /// the agent emits one of these per logical turn boundary (user echo,
-    /// assistant reply, tool result, system note).
-    ///
-    /// `role` is one of `"user"` | `"assistant"` | `"tool"` | `"system"`. Other
-    /// values are accepted at the wire level (forward-compatibility) but the
-    /// host renders unknown roles as plain text. Required field — no
-    /// `serde(default)`.
-    ///
-    /// `content` is the plain-text body of the row. Required field. Empty
-    /// strings are valid (e.g. a placeholder turn while a stream is in flight)
-    /// but discouraged — emit on completion, not on dispatch.
-    AppendConversation { role: String, content: String },
 }
 
 /// Top-level wire type. The `type` field is globally unique across all three
@@ -1707,75 +1689,6 @@ mod tests {
             }
             other => panic!("expected AiResponse, got {other:?}"),
         }
-    }
-
-    // ── v3.3 agent-as-app wire shape (#285) ──────────────────────────────
-    // Pin the on-the-wire shape for the three new variants. All fields are
-    // required — no `serde(default)`.
-
-    #[test]
-    fn user_message_event_round_trips_serde() {
-        let json = r#"{"type":"user_message","text":"tell me a joke"}"#;
-        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
-        match &event {
-            PlexiEvent::UserMessage { text } => assert_eq!(text, "tell me a joke"),
-            other => panic!("expected UserMessage, got {other:?}"),
-        }
-        let serialised = serde_json::to_string(&event).expect("serialise");
-        assert!(
-            serialised.contains(r#""type":"user_message""#),
-            "wire tag missing: {serialised}"
-        );
-        assert!(
-            serialised.contains(r#""text":"tell me a joke""#),
-            "text missing: {serialised}"
-        );
-    }
-
-    #[test]
-    fn user_message_missing_text_fails_deserialise() {
-        // No `text` field — must fail because the field is required (no
-        // `serde(default)`).
-        let json = r#"{"type":"user_message"}"#;
-        let result: Result<PlexiEvent, _> = serde_json::from_str(json);
-        assert!(
-            result.is_err(),
-            "deserialise should fail without `text` field"
-        );
-    }
-
-    #[test]
-    fn append_conversation_drawcommand_round_trips() {
-        let json =
-            r#"{"type":"append_conversation","role":"assistant","content":"Hello!"}"#;
-        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
-        match &cmd {
-            DrawCommand::Control(ControlCommand::AppendConversation { role, content }) => {
-                assert_eq!(role, "assistant");
-                assert_eq!(content, "Hello!");
-            }
-            other => panic!("expected AppendConversation, got {other:?}"),
-        }
-        let serialised = serde_json::to_string(&cmd).expect("serialise");
-        assert!(
-            serialised.contains(r#""type":"append_conversation""#),
-            "wire tag missing: {serialised}"
-        );
-        assert!(
-            serialised.contains(r#""role":"assistant""#),
-            "role missing: {serialised}"
-        );
-    }
-
-    #[test]
-    fn append_conversation_missing_content_fails_deserialise() {
-        // No `content` field — must fail. Required.
-        let json = r#"{"type":"append_conversation","role":"user"}"#;
-        let result: Result<DrawCommand, _> = serde_json::from_str(json);
-        assert!(
-            result.is_err(),
-            "deserialise should fail without `content` field"
-        );
     }
 
     #[test]

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -84,11 +84,6 @@ pub struct AppManifestApp {
     /// - `App` (`type = "app"`): the host renders the app's draw canvas. The
     ///   default for nearly every Plexi app — UI is freeform, the app emits
     ///   `Rect`/`Text`/etc.
-    /// - `Agent` (`type = "agent"`): the host renders a conversation UI
-    ///   (history scrollback + input box), and the agent subprocess emits
-    ///   `AppendConversation` rows in response to `UserMessage` events. The
-    ///   manifest may also declare `[launch].system_prompt` which the host
-    ///   forwards via `AgentInit` at startup.
     ///
     /// No `serde(default)` — every manifest must declare its type explicitly.
     /// Discipline matches `schema_version` (issue #308 Phase 2).
@@ -120,9 +115,6 @@ pub struct AppManifestApp {
 pub enum ManifestType {
     /// Standard draw-canvas app. Host renders whatever the app draws.
     App,
-    /// Conversation agent. Host renders a chat UI; agent subprocess emits
-    /// `AppendConversation` and reads `UserMessage` / `AgentInit`.
-    Agent,
 }
 
 /// Newtype for `[launch] notification_scope` in manifest.toml. Deserialises
@@ -188,12 +180,6 @@ pub struct LaunchSection {
     /// instead it parks the process in a background registry keyed by app_id.
     #[serde(default)]
     pub background: bool,
-    /// Agent system prompt — only meaningful when `[app] type = "agent"`.
-    /// Forwarded to the agent subprocess via `PlexiEvent::AgentInit` once at
-    /// startup. The agent decides how to use it (typically as the `system`
-    /// field on `iq.query`). Optional — `None` when the manifest omits it.
-    #[serde(default)]
-    pub system_prompt: Option<String>,
     /// Where this app's notifications surface. `"window"` (default) shows
     /// notifications only when the app's window is active. `"context"` shows
     /// them whenever the user is in the same sidebar context. `"global"` always
@@ -527,20 +513,7 @@ impl AppRegistry {
         let keyboard_capture = installed.launch.keyboard_capture;
         let default_scope = self.default_notification_scope_for(id);
 
-        // Log manifest type + system_prompt presence for observability. The
-        // host integration that consumes these to switch pane rendering and
-        // forward `AgentInit` lands in the follow-up to #285; logging here
-        // makes the manifest contract visible from day one.
-        log::info!(
-            "AppRegistry: launching '{id}' as type={:?}, system_prompt={}",
-            installed.manifest.manifest_type,
-            installed
-                .launch
-                .system_prompt
-                .as_deref()
-                .map(|s| format!("set ({} chars)", s.len()))
-                .unwrap_or_else(|| "unset".to_string()),
-        );
+        log::info!("AppRegistry: launching '{id}' as type={:?}", installed.manifest.manifest_type);
 
         // Issue #322: log declared-but-routed status for visibility. The
         // missing-secret prompt fires lazily on first `ctx.secret(...)` call —
@@ -657,7 +630,6 @@ mod tests {
     /// Create a manifest + executable entry under `dir/<id>/`.
     /// `name` is what shows up in the manifest's `[app].name` so tests can
     /// distinguish two entries with the same id but different content.
-    /// Defaults to `type = "app"` — use `write_app_with_type` for agents.
     fn write_app(dir: &Path, id: &str, name: &str) {
         write_app_with_type(dir, id, name, "app");
     }
@@ -817,19 +789,6 @@ entry = "run.sh"
     }
 
     #[test]
-    fn manifest_with_type_agent_loads() {
-        let global = tempfile::tempdir().unwrap();
-        let bare = tempfile::tempdir().unwrap();
-        write_app_with_type(global.path(), "research-agent", "Research", "agent");
-
-        let registry = AppRegistry::load_with_global(bare.path(), global.path());
-        let entry = registry
-            .get("research-agent")
-            .expect("type=agent manifest should load");
-        assert_eq!(entry.manifest.manifest_type, ManifestType::Agent);
-    }
-
-    #[test]
     fn manifest_missing_type_field_errors() {
         // No `type` field — must fail to parse. Required field, no
         // `serde(default)`. Discipline matches `schema_version`.
@@ -851,8 +810,8 @@ entry = "run.sh"
 
     #[test]
     fn manifest_with_unknown_type_errors() {
-        // `type = "wizard"` — must fail to parse. Only `app` and `agent` are
-        // valid; unknown values should not silently fall back.
+        // `type = "wizard"` — must fail to parse. Only `app` is valid; `agent`
+        // and other values should not silently fall back.
         let raw = r#"
 schema_version = 1
 
@@ -867,47 +826,6 @@ entry = "run.sh"
         assert!(
             parsed.is_err(),
             "manifest with unknown type variant must be rejected, got: {parsed:?}"
-        );
-    }
-
-    #[test]
-    fn agent_manifest_with_system_prompt_loads() {
-        let global = tempfile::tempdir().unwrap();
-        let bare = tempfile::tempdir().unwrap();
-        let app_dir = global.path().join("prompted-agent");
-        fs::create_dir_all(&app_dir).unwrap();
-        let manifest = "\
-schema_version = 1
-
-[app]
-id = \"prompted-agent\"
-type = \"agent\"
-name = \"Prompted\"
-version = \"0.0.1\"
-entry = \"run.sh\"
-
-[launch]
-system_prompt = \"You are terse.\"
-";
-        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
-        let entry = app_dir.join("run.sh");
-        fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
-
-        let registry = AppRegistry::load_with_global(bare.path(), global.path());
-        let agent = registry
-            .get("prompted-agent")
-            .expect("agent manifest should load");
-        assert_eq!(agent.manifest.manifest_type, ManifestType::Agent);
-        assert_eq!(
-            agent.launch.system_prompt.as_deref(),
-            Some("You are terse."),
-            "system_prompt must round-trip from manifest"
         );
     }
 

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1220,10 +1220,6 @@ impl ProcessApp {
                         height: sz.y,
                     });
             }
-            // AppendConversation is a host-side no-op — it is intended as a
-            // signal to the SDK for conversation-history management. The host
-            // acknowledges receipt silently.
-            ControlCommand::AppendConversation { .. } => {}
         }
     }
 }


### PR DESCRIPTION
Closes #934

Removes partial agent infrastructure from #285/#338 that was never completed. No live apps use any of this — all apps subclass `App`, not `Agent`.

## What's removed

**Host (Rust):**
- `ManifestType::Agent` variant — `type = "agent"` manifests now fail to parse
- `LaunchSection::system_prompt` field
- `PlexiEvent::UserMessage` variant
- `ControlCommand::AppendConversation` variant + no-op match arm in `ProcessApp`
- `Capability::AgentsList` (`agents.list` permission string)

**SDK (Python):**
- `Agent` base class
- `AgentInfo` type
- `Emitter.agent_roster()`
- `_pending_agent_roster` dict on `App`
- `on_agent_init` / `on_user_message` no-op stubs on `App`
- All related event dispatcher branches (`agent_roster`, `agent_init`, `user_message`)

## Verification
- `cargo build` passes, `cargo test` (326 tests) passes
- `grep -r "AppendConversation\|UserMessage\|AgentInit\|AgentsList\|agent_roster" src/` — no code hits, only removed comments
- `from plexi_sdk import Agent` raises `ImportError`
- Existing apps (voice-agent, calendar, etc.) unaffected — they use `App` only

**Breaks if:** any app tries to subclass `Agent` or import `AgentInfo` — will get `ImportError`. Expected: no current app does this.