### PR TITLE
fix(background-apps): notifications route to park-time context

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -529,9 +529,15 @@ After user confirms pass. Run without stopping:
 
 1. Restore any pr-install Cargo.toml artifact on alpha, then sync:
    ```bash
-   git restore Cargo.toml           # discard pr-install artifact if present
-   git pull --rebase origin alpha   # from the repo root
+   git restore Cargo.toml                       # discard pr-install artifact if present
+   DIRTY=$(git status --porcelain | grep "^ M\|^M " | grep -v "Cargo.toml")
+   if [ -n "$DIRTY" ]; then
+     git add -u && git commit -m "chore: commit alpha changes before phase 5 rebase"
+   fi
+   git pull --rebase origin alpha               # from the repo root
    ```
+   > **Why:** Skill files and other tracked files may have been modified during the cycle (e.g. ship-issue SKILL.md self-updates). `git restore Cargo.toml` alone won't clear them, causing `git pull --rebase` to fail with "unstaged changes".
+
    This handles all cases: behind (fast-forward replay), ahead (push after), diverged (rebase). If a rebase conflict occurs in GOTCHAS.md, keep all entries, newest-first.
 
 2. Rebase the feature branch on origin/alpha and push:

--- a/examples/context-notifier-poc/context_notifier_poc.py
+++ b/examples/context-notifier-poc/context_notifier_poc.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""POC for #879: parks immediately, fires a notification every 5s.
+
+Test procedure:
+1. Open this app in context 1. Its pane shows "Parked — notifying every 5s".
+2. Close the pane to park it.
+3. Switch to a different context (e.g. context 3).
+4. Within 5s, a notification badge should appear on context 1 — not context 3.
+
+Before the fix, the badge always appeared on context 0.
+"""
+
+from plexi_sdk import App, RenderContext, PRIORITY_HIGH
+from plexi_sdk.ui import Column, AppBar, Label, Spacer  # noqa: F401 (used in on_render)
+
+TIMER_ID = "notify-tick"
+INTERVAL_MS = 5_000
+
+
+class ContextNotifierApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._count = 0
+        ctx.set_timer(TIMER_ID, INTERVAL_MS)
+        self.emit.info("context-notifier-poc started")
+
+    def on_timer(self, ctx: RenderContext, timer_id: str) -> None:
+        if timer_id != TIMER_ID:
+            return
+        self._count += 1
+        ctx.notify(
+            title="Context Notifier",
+            body=f"#{self._count} — badge should be on the context where this app was parked",
+            level="info",
+            priority=PRIORITY_HIGH,
+        )
+        self.emit.info(f"context-notifier-poc fired notification #{self._count}")
+        ctx.set_timer(TIMER_ID, INTERVAL_MS)
+        self.emit.schedule_render(after_ms=100)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.render(Column([
+            AppBar(title="Context Notifier (POC)"),
+            Spacer(),
+            Label("Fires a notification every 5 seconds."),
+            Label("Close this pane to park the app, then switch contexts."),
+            Label(f"Notifications sent: {self._count}"),
+            Spacer(),
+        ]))
+
+
+ContextNotifierApp().run()

--- a/examples/context-notifier-poc/manifest.toml
+++ b/examples/context-notifier-poc/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "context-notifier-poc"
+type = "app"
+name = "Context Notifier (POC)"
+version = "0.1.0"
+description = "POC for #879: parks immediately and fires a notification every 5s to verify context routing."
+entry = "context_notifier_poc.py"
+
+[app.capabilities]
+capabilities = ["timer"]
+
+[launch]
+background = true

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -4,6 +4,66 @@ use crate::app_trait::{App, AppCommand};
 
 use super::PlexiApp;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_permissions::AppPermissions;
+    use crate::app_protocol::{NotifyKind, NotifyScope};
+    use crate::process_app::ProcessApp;
+    use crate::testing::HostHarness;
+    /// Regression guard for issue #879: parked background app notifications
+    /// hardcoded `source_context: 0`. Verify that the context index recorded
+    /// at park time propagates to the `ShowNotification` command.
+    #[test]
+    fn parked_app_notification_uses_park_context() {
+        let mut h = HostHarness::new();
+
+        // Seed a ShowNotification on a fresh ProcessApp's pending_commands,
+        // then insert it into background_apps with park_ctx = 2.
+        let (mut process_app, _draw_tx) =
+            ProcessApp::new_for_test(999, AppPermissions::builtin());
+
+        process_app.pending_commands.push(AppCommand::ShowNotification {
+            notify_id: "test-notify".to_string(),
+            sender_pane_id: 0,
+            source_context: 0, // pre-filled stub value; drain should overwrite
+            level: "info".to_string(),
+            title: "hello from context 2".to_string(),
+            body: String::new(),
+            kind: NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            priority: 0,
+            scope: NotifyScope::Context,
+            image_inline: None,
+            image_pipe_id: None,
+            timeout_secs: None,
+            on_dismiss: None,
+        });
+
+        let park_ctx: usize = 2;
+        h.app
+            .background_apps
+            .insert("test-app".to_string(), (park_ctx, Box::new(process_app)));
+
+        let cmds = h.app.drain_all_app_commands();
+
+        let notification = cmds.iter().find(|c| {
+            matches!(c, AppCommand::ShowNotification { notify_id, .. } if notify_id == "test-notify")
+        });
+
+        let Some(AppCommand::ShowNotification { source_context, .. }) = notification else {
+            panic!("expected ShowNotification in drained commands — not found");
+        };
+
+        assert_eq!(
+            *source_context, park_ctx,
+            "source_context should be the park-time context ({park_ctx}), not hardcoded 0"
+        );
+    }
+}
+
 impl PlexiApp {
     /// Feed keyboard input to the focused app pane. Keys only go to the
     /// focused pane (that's the whole point of focus). Command drain
@@ -74,19 +134,20 @@ impl PlexiApp {
         // Mirrors the headless tick above but operates on self.background_apps
         // instead of context panes. Without this, timers stop and notifications
         // never fire the moment the pane is closed.
-        let parked: Vec<(String, Vec<AppCommand>)> = self
+        // Collect (type_id, park_context_idx, commands) for each parked app.
+        let parked: Vec<(String, usize, Vec<AppCommand>)> = self
             .background_apps
             .iter_mut()
-            .map(|(type_id, app)| {
+            .map(|(type_id, (park_ctx, app))| {
                 app.background_tick();
                 let cmds = app.take_pending_commands();
-                (type_id.to_owned(), cmds)
+                (type_id.to_owned(), *park_ctx, cmds)
             })
             .collect();
 
         let mut deferred = Vec::new();
 
-        for (type_id, cmds) in &parked {
+        for (type_id, park_ctx, cmds) in &parked {
             let resolved_scope = self.registry.default_notification_scope_for(type_id);
             for cmd in cmds.iter() {
                 match cmd {
@@ -107,13 +168,13 @@ impl PlexiApp {
                         ..
                     } => {
                         log::info!(
-                            "parked background app '{}' notification: {}",
-                            type_id, title
+                            "parked background app '{}' notification: {} (routing to context {})",
+                            type_id, title, park_ctx
                         );
                         deferred.push(AppCommand::ShowNotification {
                             notify_id: notify_id.clone(),
                             sender_pane_id: 0, // no live pane — tombstone won't fire
-                            source_context: 0,
+                            source_context: *park_ctx,
                             level: level.clone(),
                             title: title.clone(),
                             body: body.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -216,8 +216,10 @@ pub struct PlexiApp {
     pub(crate) host: crate::host::model::HostModel,
     pub(crate) host_services: crate::host::services::HostServices,
     /// Parked background ProcessApps — kept alive when their pane is closed.
-    /// Keyed by app type_id. Re-attached by B3 when the app is reopened.
-    pub(crate) background_apps: HashMap<String, Box<crate::process_app::ProcessApp>>,
+    /// Keyed by app type_id. Value is `(park_context_idx, app)` where
+    /// `park_context_idx` is the window index the app was running in when its
+    /// pane was closed. Used to route notifications to the correct context.
+    pub(crate) background_apps: HashMap<String, (usize, Box<crate::process_app::ProcessApp>)>,
     /// Directed inter-agent / inter-app pipes (#286). Keyed by `pipe_id`,
     /// value is the `(sender_pane_id, target_pane_id)` pair the host must
     /// scope `PipeMessage` deliveries to. `DeliverPipeMessage` consults this

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -490,7 +490,7 @@ impl PlexiApp {
             });
 
         // Re-attach a parked background app if one is waiting
-        if let Some(mut parked) = self.background_apps.remove(id) {
+        if let Some((_park_ctx, mut parked)) = self.background_apps.remove(id) {
             log::info!("re-attaching background app '{id}'");
             parked.send_event(&crate::app_protocol::PlexiEvent::Resume);
             self.open_process_app_pane(id, *parked, cwd, group, hint.as_deref());

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -589,8 +589,9 @@ impl PlexiApp {
                     let type_id = process_app.type_id.clone();
                     if self.registry.is_background(&type_id) {
                         process_app.send_event(&crate::app_protocol::PlexiEvent::Suspend);
-                        log::info!("parking background app '{type_id}'");
-                        self.background_apps.insert(type_id, process_app);
+                        let park_ctx = self.active_window;
+                        log::info!("parking background app '{type_id}' in context {park_ctx}");
+                        self.background_apps.insert(type_id, (park_ctx, process_app));
                     }
                     // else: process_app drops here — Drop impl sends Shutdown + kills process
                 }


### PR DESCRIPTION
Closes #879

## Root cause
`dispatch.rs:116` hardcoded `source_context: 0` for all parked-app notifications, routing every notification to context 0 regardless of which context the app was running in when its pane was closed.

## Fix
Changed `background_apps: HashMap<String, Box<ProcessApp>>` to `HashMap<String, (usize, Box<ProcessApp>)>`. The `usize` is the window index captured at park time in `close_tile`. `drain_all_app_commands` now uses that stored index as `source_context` instead of 0.

## Semantic decision
Routed to park-time context — an app parked in context 1 notifies context 1, matching expected user mental model.

## Test
Added `parked_app_notification_uses_park_context` in `src/app/dispatch.rs`: seeds a `ShowNotification` on a parked app with `park_ctx=2`, calls `drain_all_app_commands`, asserts `source_context == 2`.

**Breaks if:** A parked background app's notification badge appears in context 0 when the app was parked in a different context.

🤖 Generated with Claude Code