### PR TITLE
fix(zoom): show pane name bar and tab dots in full-screen overlay

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2583,7 +2583,7 @@ impl eframe::App for PlexiApp {
                                                 .map(|n| HashMap::from([(pane_id, n.clone())]))
                                                 .unwrap_or_default();
                                             if zoomed_pane_name.is_some() || zoomed_tab_info.is_some() {
-                                                log::info!(
+                                                log::debug!(
                                                     "zoom: rendering name bar — pane={pane_id:?} name={zoomed_pane_name:?} tabs={zoomed_tab_info:?}"
                                                 );
                                             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2520,6 +2520,7 @@ impl eframe::App for PlexiApp {
                         let pane_id = *pane_id;
                         let panel_rect = ui.max_rect();
                         let zoomed_tab_info = behavior.tab_info.get(&zoomed_tile).copied();
+                        let zoomed_pane_name = behavior.pane_names.get(&pane_id).cloned();
 
                         // Drop behavior to release the mutable borrow on ctx.panes
                         drop(behavior);
@@ -2572,6 +2573,30 @@ impl eframe::App for PlexiApp {
                                         if dropped_to_zoom {
                                             crate::tiling::write_dropped_paths_to_terminal(ui, t);
                                         }
+                                        // Render name bar + tab dots — mirrors the non-zoomed path
+                                        {
+                                            use std::collections::HashMap;
+                                            let tab_info_map = zoomed_tab_info
+                                                .map(|ti| HashMap::from([(zoomed_tile, ti)]))
+                                                .unwrap_or_default();
+                                            let pane_names_map = zoomed_pane_name.as_ref()
+                                                .map(|n| HashMap::from([(pane_id, n.clone())]))
+                                                .unwrap_or_default();
+                                            if zoomed_pane_name.is_some() || zoomed_tab_info.is_some() {
+                                                log::info!(
+                                                    "zoom: rendering name bar — pane={pane_id:?} name={zoomed_pane_name:?} tabs={zoomed_tab_info:?}"
+                                                );
+                                            }
+                                            crate::render::terminal_pane::render_name_bar_and_dots(
+                                                ui,
+                                                zoomed_tile,
+                                                &pane_id,
+                                                &tab_info_map,
+                                                &pane_names_map,
+                                                &self.colors,
+                                                false,
+                                            );
+                                        }
                                         if t.exited {
                                             let rect = ui.max_rect();
                                             ui.painter().rect_filled(
@@ -2613,12 +2638,6 @@ impl eframe::App for PlexiApp {
                                                 },
                                             );
                                         } else {
-                                            // Reserve space for tab dots if in a tab group
-                                            if zoomed_tab_info.is_some() {
-                                                ui.add_space(
-                                                    crate::tiling::TAB_DOT_RESERVED_HEIGHT,
-                                                );
-                                            }
                                             let font_size = t.font_size;
                                             log::debug!("[DRAG] zoom overlay: TerminalView render start");
                                             let terminal = TerminalView::new(ui, &mut t.backend)
@@ -2640,19 +2659,6 @@ impl eframe::App for PlexiApp {
                                     }
                                 }
 
-                                // Draw tab indicator dots (same style as tiling.rs)
-                                if let Some((active_idx, count)) = zoomed_tab_info {
-                                    let rect = ui.max_rect();
-                                    crate::tiling::paint_tab_dots(
-                                        ui.painter(),
-                                        rect.left(),
-                                        rect.top() + 2.0 + 4.0, // 4.0 = dot radius
-                                        active_idx,
-                                        count,
-                                        self.colors.accent,
-                                        self.colors.bg_active,
-                                    );
-                                }
                             });
                     } else {
                         drop(behavior);

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -91,7 +91,7 @@ pub fn render(
 /// terminal in full-pane mode. When `outside_workspace` is true, paint a
 /// small right-aligned "↗ outside workspace" badge so the user can see the
 /// scope drift without it being intrusive.
-fn render_name_bar_and_dots(
+pub(crate) fn render_name_bar_and_dots(
     ui: &mut egui::Ui,
     tile_id: TileId,
     pane_id: &PaneId,


### PR DESCRIPTION
Fixes #861.

## What

The zoom overlay rendered terminal content directly, bypassing the `render_name_bar_and_dots` call that the normal `pane_ui` path makes. This left the name bar and tab dots invisible whenever a pane was zoomed to full-screen.

## How

- Made `render_name_bar_and_dots` `pub(crate)` so the zoom overlay in `app/mod.rs` can call it directly.
- Capture `zoomed_pane_name` from `behavior.pane_names` before dropping `behavior`, alongside the already-captured `zoomed_tab_info`.
- Call `render_name_bar_and_dots` at the start of the terminal arm (before the exited/hover/normal split), constructing minimal single-entry HashMaps from the captured values.
- Remove the now-redundant `add_space(TAB_DOT_RESERVED_HEIGHT)` and `paint_tab_dots` blocks that were partial stand-ins.

## Breaks if

Named pane in zoom overlay shows no title text, or tab dots disappear from zoomed panes with multiple tabs.