### PR TITLE
fix(sidebar): always show notification badge regardless of hover state

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -137,7 +137,7 @@ impl PlexiApp {
                 ui,
                 egui::Id::new(("ctx", i)),
                 &self.colors,
-                |row_ui, hovered| {
+                |row_ui, _hovered| {
                     row_ui.add_space(20.0);
                     if i < 9 {
                         row_ui.label(

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -148,8 +148,7 @@ impl PlexiApp {
                         egui::Label::new(RichText::new(&ctx_name).size(12.0).color(text_color))
                             .selectable(false),
                     );
-                    // Badge — only when not hovering (X button takes that space on hover)
-                    if badge_count > 0 && !hovered {
+                    if badge_count > 0 {
                         row_ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                             ui.add_space(8.0);
                             let badge_text = if badge_count > 9 { "9+".to_string() } else { badge_count.to_string() };


### PR DESCRIPTION
Fixes #961.

## What

Removes the `&& !hovered` guard that was hiding the notification badge on context hover.

## Why

`RowLayout` carves non-overlapping zones at construction time: the `content` rect ends at `action.min.x` (right 30px reserved for the X delete glyph). Badge renders in `content` zone via right-to-left layout; X glyph renders in `action` zone. They never share pixels — the guard was wrong.

## Diff

One line deleted from `sidebar.rs`.