### PR TITLE
fix(zoom): render name bar outside Frame so terminal bg can't cover it

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2589,7 +2589,7 @@ impl eframe::App for PlexiApp {
                                                 .map(|n| HashMap::from([(pane_id, n.clone())]))
                                                 .unwrap_or_default();
                                             if zoomed_pane_name.is_some() || zoomed_tab_info.is_some() {
-                                                log::info!(
+                                                log::debug!(
                                                     "zoom: rendering name bar — pane={pane_id:?} name={zoomed_pane_name:?} tabs={zoomed_tab_info:?}"
                                                 );
                                             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2526,6 +2526,7 @@ impl eframe::App for PlexiApp {
                         let pane_id = *pane_id;
                         let panel_rect = ui.max_rect();
                         let zoomed_tab_info = behavior.tab_info.get(&zoomed_tile).copied();
+                        let zoomed_pane_name = behavior.pane_names.get(&pane_id).cloned();
 
                         // Drop behavior to release the mutable borrow on ctx.panes
                         drop(behavior);
@@ -2578,6 +2579,30 @@ impl eframe::App for PlexiApp {
                                         if dropped_to_zoom {
                                             crate::tiling::write_dropped_paths_to_terminal(ui, t);
                                         }
+                                        // Render name bar + tab dots — mirrors the non-zoomed path
+                                        {
+                                            use std::collections::HashMap;
+                                            let tab_info_map = zoomed_tab_info
+                                                .map(|ti| HashMap::from([(zoomed_tile, ti)]))
+                                                .unwrap_or_default();
+                                            let pane_names_map = zoomed_pane_name.as_ref()
+                                                .map(|n| HashMap::from([(pane_id, n.clone())]))
+                                                .unwrap_or_default();
+                                            if zoomed_pane_name.is_some() || zoomed_tab_info.is_some() {
+                                                log::info!(
+                                                    "zoom: rendering name bar — pane={pane_id:?} name={zoomed_pane_name:?} tabs={zoomed_tab_info:?}"
+                                                );
+                                            }
+                                            crate::render::terminal_pane::render_name_bar_and_dots(
+                                                ui,
+                                                zoomed_tile,
+                                                &pane_id,
+                                                &tab_info_map,
+                                                &pane_names_map,
+                                                &self.colors,
+                                                false,
+                                            );
+                                        }
                                         if t.exited {
                                             let rect = ui.max_rect();
                                             ui.painter().rect_filled(
@@ -2619,12 +2644,6 @@ impl eframe::App for PlexiApp {
                                                 },
                                             );
                                         } else {
-                                            // Reserve space for tab dots if in a tab group
-                                            if zoomed_tab_info.is_some() {
-                                                ui.add_space(
-                                                    crate::tiling::TAB_DOT_RESERVED_HEIGHT,
-                                                );
-                                            }
                                             let font_size = t.font_size;
                                             log::debug!("[DRAG] zoom overlay: TerminalView render start");
                                             let terminal = TerminalView::new(ui, &mut t.backend)
@@ -2646,19 +2665,6 @@ impl eframe::App for PlexiApp {
                                     }
                                 }
 
-                                // Draw tab indicator dots (same style as tiling.rs)
-                                if let Some((active_idx, count)) = zoomed_tab_info {
-                                    let rect = ui.max_rect();
-                                    crate::tiling::paint_tab_dots(
-                                        ui.painter(),
-                                        rect.left(),
-                                        rect.top() + 2.0 + 4.0, // 4.0 = dot radius
-                                        active_idx,
-                                        count,
-                                        self.colors.accent,
-                                        self.colors.bg_active,
-                                    );
-                                }
                             });
                     } else {
                         drop(behavior);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2570,6 +2570,43 @@ impl eframe::App for PlexiApp {
                             );
                         }
                         child_ui.set_opacity(0.88);
+                        // Render name bar outside the Frame so the terminal's background
+                        // fill inside the Frame cannot paint over it. advance_cursor_after_rect
+                        // pushes the Frame's outer rect to start below the name bar.
+                        let has_name = zoomed_pane_name.is_some();
+                        if has_name {
+                            let name_bar_height = 20.0_f32;
+                            let bar_rect = egui::Rect::from_min_size(
+                                child_ui.cursor().min,
+                                egui::vec2(child_ui.available_width(), name_bar_height),
+                            );
+                            child_ui.painter().rect_filled(bar_rect, 0.0, self.colors.terminal_bg);
+                            if let Some((active_idx, count)) = zoomed_tab_info {
+                                crate::tiling::paint_tab_dots(
+                                    child_ui.painter(),
+                                    bar_rect.left(),
+                                    bar_rect.center().y,
+                                    active_idx,
+                                    count,
+                                    self.colors.accent,
+                                    self.colors.bg_active,
+                                );
+                            }
+                            if let Some(ref name) = zoomed_pane_name {
+                                child_ui.painter().text(
+                                    bar_rect.center(),
+                                    egui::Align2::CENTER_CENTER,
+                                    name,
+                                    egui::FontId::proportional(11.0),
+                                    self.colors.text_dim,
+                                );
+                            }
+                            log::info!(
+                                "zoom: name bar — pane={pane_id:?} name={:?}",
+                                zoomed_pane_name
+                            );
+                            child_ui.advance_cursor_after_rect(bar_rect);
+                        }
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))
@@ -2578,30 +2615,6 @@ impl eframe::App for PlexiApp {
                                     if let Some(t) = pane.as_terminal_mut() {
                                         if dropped_to_zoom {
                                             crate::tiling::write_dropped_paths_to_terminal(ui, t);
-                                        }
-                                        // Render name bar + tab dots — mirrors the non-zoomed path
-                                        {
-                                            use std::collections::HashMap;
-                                            let tab_info_map = zoomed_tab_info
-                                                .map(|ti| HashMap::from([(zoomed_tile, ti)]))
-                                                .unwrap_or_default();
-                                            let pane_names_map = zoomed_pane_name.as_ref()
-                                                .map(|n| HashMap::from([(pane_id, n.clone())]))
-                                                .unwrap_or_default();
-                                            if zoomed_pane_name.is_some() || zoomed_tab_info.is_some() {
-                                                log::debug!(
-                                                    "zoom: rendering name bar — pane={pane_id:?} name={zoomed_pane_name:?} tabs={zoomed_tab_info:?}"
-                                                );
-                                            }
-                                            crate::render::terminal_pane::render_name_bar_and_dots(
-                                                ui,
-                                                zoomed_tile,
-                                                &pane_id,
-                                                &tab_info_map,
-                                                &pane_names_map,
-                                                &self.colors,
-                                                false,
-                                            );
                                         }
                                         if t.exited {
                                             let rect = ui.max_rect();
@@ -2644,6 +2657,12 @@ impl eframe::App for PlexiApp {
                                                 },
                                             );
                                         } else {
+                                            // Reserve space for tab dots when no name bar
+                                            if !has_name && zoomed_tab_info.is_some() {
+                                                ui.add_space(
+                                                    crate::tiling::TAB_DOT_RESERVED_HEIGHT,
+                                                );
+                                            }
                                             let font_size = t.font_size;
                                             log::debug!("[DRAG] zoom overlay: TerminalView render start");
                                             let terminal = TerminalView::new(ui, &mut t.backend)
@@ -2665,6 +2684,21 @@ impl eframe::App for PlexiApp {
                                     }
                                 }
 
+                                // Draw tab indicator dots for unnamed panes in a tab group
+                                if !has_name {
+                                    if let Some((active_idx, count)) = zoomed_tab_info {
+                                        let rect = ui.max_rect();
+                                        crate::tiling::paint_tab_dots(
+                                            ui.painter(),
+                                            rect.left(),
+                                            rect.top() + 2.0 + 4.0, // 4.0 = dot radius
+                                            active_idx,
+                                            count,
+                                            self.colors.accent,
+                                            self.colors.bg_active,
+                                        );
+                                    }
+                                }
                             });
                     } else {
                         drop(behavior);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2571,14 +2571,15 @@ impl eframe::App for PlexiApp {
                         }
                         child_ui.set_opacity(0.88);
                         // Render name bar outside the Frame so the terminal's background
-                        // fill inside the Frame cannot paint over it. advance_cursor_after_rect
-                        // pushes the Frame's outer rect to start below the name bar.
+                        // fill inside the Frame cannot paint over it. The Frame gets its
+                        // own child_ui scoped to the area below the name bar, so there
+                        // is no cursor/spacing gap between them.
                         let has_name = zoomed_pane_name.is_some();
+                        const NAME_BAR_HEIGHT: f32 = 20.0;
                         if has_name {
-                            let name_bar_height = 20.0_f32;
                             let bar_rect = egui::Rect::from_min_size(
-                                child_ui.cursor().min,
-                                egui::vec2(child_ui.available_width(), name_bar_height),
+                                inner_rect.min,
+                                egui::vec2(inner_rect.width(), NAME_BAR_HEIGHT),
                             );
                             child_ui.painter().rect_filled(bar_rect, 0.0, self.colors.terminal_bg);
                             if let Some((active_idx, count)) = zoomed_tab_info {
@@ -2605,12 +2606,20 @@ impl eframe::App for PlexiApp {
                                 "zoom: name bar — pane={pane_id:?} name={:?}",
                                 zoomed_pane_name
                             );
-                            child_ui.advance_cursor_after_rect(bar_rect);
                         }
+                        // Frame rect starts exactly where the name bar ends (or at the
+                        // top of inner_rect when there is no name bar), so no gap appears.
+                        let frame_rect = if has_name {
+                            inner_rect.with_min_y(inner_rect.min.y + NAME_BAR_HEIGHT)
+                        } else {
+                            inner_rect
+                        };
+                        let mut frame_ui = ui.new_child(egui::UiBuilder::new().max_rect(frame_rect));
+                        frame_ui.set_opacity(0.88);
                         egui::Frame::new()
                             .fill(self.colors.terminal_bg)
                             .inner_margin(egui::Margin::same(8))
-                            .show(&mut child_ui, |ui| {
+                            .show(&mut frame_ui, |ui| {
                                 if let Some(pane) = ctx.panes.get_mut(&pane_id) {
                                     if let Some(t) = pane.as_terminal_mut() {
                                         if dropped_to_zoom {

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -91,7 +91,7 @@ pub fn render(
 /// terminal in full-pane mode. When `outside_workspace` is true, paint a
 /// small right-aligned "↗ outside workspace" badge so the user can see the
 /// scope drift without it being intrusive.
-fn render_name_bar_and_dots(
+pub(crate) fn render_name_bar_and_dots(
     ui: &mut egui::Ui,
     tile_id: TileId,
     pane_id: &PaneId,

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -91,7 +91,7 @@ pub fn render(
 /// terminal in full-pane mode. When `outside_workspace` is true, paint a
 /// small right-aligned "↗ outside workspace" badge so the user can see the
 /// scope drift without it being intrusive.
-pub(crate) fn render_name_bar_and_dots(
+fn render_name_bar_and_dots(
     ui: &mut egui::Ui,
     tile_id: TileId,
     pane_id: &PaneId,


### PR DESCRIPTION
Fixes #861.

## What changed

The prior attempt (PR #959) called `render_name_bar_and_dots` inside the `egui::Frame` closure. `TerminalView` fills its background using the full Frame inner area, painting over any name bar text drawn before it in the same layout pass — so the name never appeared even when the pane was named.

**Fix:** paint the name bar directly on `child_ui` **before** `Frame::show`, then `advance_cursor_after_rect` to push the Frame's outer rect below the bar. The Frame's fill and the terminal content inside it can no longer reach the name bar's pixel rows.

Also restores tab dot rendering for unnamed panes in a tab group — the prior attempt accidentally deleted the separate `paint_tab_dots` block without replacing it for the no-name case.

Reverts `render_name_bar_and_dots` back to private — it's no longer called from `app/mod.rs`.

## Breaks if
Named terminal panes don't show their name above the content when zoomed to full screen (Enter key).