### PR TITLE
feat(mcp): PGAP↔MCP bridge — consume any MCP server as a Plexi app; expose any Plexi app as an MCP server

### DIFF
--- a/examples/mcp-demo/manifest.toml
+++ b/examples/mcp-demo/manifest.toml
@@ -1,0 +1,34 @@
+schema_version = 1
+
+[app]
+id = "mcp-demo"
+type = "app"
+name = "MCP Demo"
+version = "0.1.0"
+description = "Demo: expose tools via [app.mcp] and use them from Claude Desktop or any MCP client"
+entry = "mcp_demo.py"
+
+[app.capabilities]
+capabilities = []
+
+[launch]
+layout_hint = { side = "right", split = 0.5 }
+notification_scope = "context"
+
+[app.mcp]
+description = "A demo note-taking app"
+
+[[app.mcp.tools]]
+name = "add_note"
+description = "Add a new note"
+input_schema = { type = "object", properties = { text = { type = "string", description = "Note content" } }, required = ["text"] }
+
+[[app.mcp.tools]]
+name = "list_notes"
+description = "List all notes"
+input_schema = { type = "object", properties = {} }
+
+[[app.mcp.tools]]
+name = "clear_notes"
+description = "Delete all notes"
+input_schema = { type = "object", properties = {} }

--- a/examples/mcp-demo/mcp_demo.py
+++ b/examples/mcp-demo/mcp_demo.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""mcp-demo — a note-taking app that exposes tools via [app.mcp] (#958).
+
+Tools exposed:
+  add_note(text)   — append a note
+  list_notes()     — return all notes
+  clear_notes()    — delete all notes
+
+Connect Claude Desktop by adding to claude_desktop_config.json:
+  { "mcpServers": { "mcp-demo": { "url": "http://localhost:<PLEXI_MCP_PORT>/mcp" } } }
+"""
+
+import os
+from plexi_sdk import App, RenderContext, BG, FG, SURFACE, ACCENT, MUTED, HEADING, BODY, CAPTION, HINT, PAD, HEADER_H
+
+BTN_H = 44.0
+FIELD_H = 36.0
+ROW_H = BTN_H + 8.0
+
+
+class McpDemoApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._notes: list[str] = []
+        self._mcp_port: str = os.environ.get("PLEXI_MCP_PORT", "not set")
+        self.emit.info(f"mcp-demo: started, PLEXI_MCP_PORT={self._mcp_port}")
+        ctx.status_summary(f"MCP Demo  ·  port {self._mcp_port}")
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.rect(0, 0, ctx.w, ctx.h, BG)
+        y = self._render_header(ctx)
+        y = self._render_mcp_info(ctx, y)
+        y = self._render_input(ctx, y)
+        self._render_notes(ctx, y)
+
+    def _render_header(self, ctx: RenderContext) -> float:
+        ctx.rect(0, 0, ctx.w, HEADER_H, SURFACE)
+        ctx.text(x=PAD, y=HEADER_H/2, text="MCP Demo Notes", size=HEADING, color=FG, bold=True, align="left_center")
+        ctx.text(x=ctx.w-PAD, y=HEADER_H/2, text=f"{len(self._notes)} notes", size=HINT, color=MUTED, align="right_center")
+        return HEADER_H + PAD
+
+    def _render_mcp_info(self, ctx: RenderContext, y: float) -> float:
+        ctx.rect(PAD, y, ctx.w - PAD*2, 56, SURFACE, radius=6.0)
+        ctx.text(x=PAD+12, y=y+14, text="MCP endpoint", size=HINT, color=MUTED)
+        url = f"http://localhost:{self._mcp_port}/mcp" if self._mcp_port != "not set" else "(launch via Plexi to get port)"
+        ctx.text(x=PAD+12, y=y+38, text=url, size=CAPTION, color=ACCENT, monospace=True)
+        return y + 56 + 12
+
+    def _render_input(self, ctx: RenderContext, y: float) -> float:
+        btn_w = ctx.w - PAD*2
+        ctx.text(x=PAD, y=y, text="New note *", size=HINT, color=MUTED)
+        y += 18
+        submitted = ctx.text_input(id="draft", x=PAD, y=y, w=btn_w, placeholder="Type a note…")
+        if submitted is not None:
+            self._add_note(submitted)
+        y += FIELD_H + 8
+        ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
+        ctx.text(x=PAD + btn_w/2, y=y+BTN_H/2, text="Add Note", size=BODY, color=BG, bold=True, align="center")
+        return y + BTN_H + 16
+
+    def _render_notes(self, ctx: RenderContext, y0: float) -> None:
+        btn_w = ctx.w - PAD*2
+        if not self._notes:
+            ctx.text(x=ctx.w/2, y=y0+40, text="No notes yet", size=CAPTION, color=MUTED, align="center")
+            return
+        y = y0
+        for note in reversed(self._notes):
+            ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
+            ctx.text(x=PAD+12, y=y+BTN_H/2, text=note, size=BODY, color=FG, align="left_center",
+                     max_width=btn_w-24, elide=True)
+            y += ROW_H
+            if y > ctx.h:
+                break
+
+    def _add_note(self, text: str) -> None:
+        text = text.strip()
+        if text:
+            self._notes.append(text)
+            self.emit.info(f"mcp-demo: add_note text={text!r}")
+            self.emit.schedule_render(after_ms=16)
+
+    def on_mcp_call(self, _ctx: RenderContext, tool_name: str, arguments: dict) -> dict:
+        self.emit.info(f"mcp-demo: on_mcp_call tool={tool_name!r} args={arguments!r}")
+        if tool_name == "add_note":
+            text = arguments.get("text", "").strip()
+            if not text:
+                return {"content": [{"type": "text", "text": "error: text is required"}]}
+            self._notes.append(text)
+            self.emit.schedule_render(after_ms=16)
+            return {"content": [{"type": "text", "text": f"Added note: {text!r}"}]}
+        elif tool_name == "list_notes":
+            if not self._notes:
+                return {"content": [{"type": "text", "text": "No notes."}]}
+            lines = "\n".join(f"{i+1}. {n}" for i, n in enumerate(self._notes))
+            return {"content": [{"type": "text", "text": lines}]}
+        elif tool_name == "clear_notes":
+            count = len(self._notes)
+            self._notes.clear()
+            self.emit.schedule_render(after_ms=16)
+            return {"content": [{"type": "text", "text": f"Cleared {count} note(s)."}]}
+        else:
+            return {"content": [{"type": "text", "text": f"Unknown tool: {tool_name}"}]}
+
+
+if __name__ == "__main__":
+    McpDemoApp().run()

--- a/examples/mcp-renderer/manifest.toml
+++ b/examples/mcp-renderer/manifest.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+
+[app]
+id = "mcp-renderer"
+type = "app"
+name = "MCP Renderer"
+version = "0.1.0"
+description = "Wraps any stdio MCP server as a navigable tool UI"
+entry = "mcp_renderer.py"
+
+[app.capabilities]
+capabilities = ["terminal.bindings", "spawn.app"]
+
+[launch]
+notification_scope = "context"
+background = false

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -13,6 +13,7 @@ Result view: Shows tool call output inline. Escape or Back returns to list.
 """
 
 import json
+import select
 import subprocess
 import sys
 import threading
@@ -53,10 +54,18 @@ class McpClient:
             self._cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
         )
         self._stdin = self._proc.stdin
         self._stdout = self._proc.stdout
+        # Drain stderr in background so it doesn't block; last line kept for diagnostics.
+        self._last_stderr: str = ""
+        stderr_pipe = self._proc.stderr
+        def _drain_stderr() -> None:
+            assert stderr_pipe is not None
+            for line in stderr_pipe:
+                self._last_stderr = line.decode(errors="replace").rstrip()
+        threading.Thread(target=_drain_stderr, daemon=True).start()
 
     def _send(self, msg: dict) -> None:
         assert self._stdin is not None
@@ -65,9 +74,12 @@ class McpClient:
             self._stdin.write(line.encode())
             self._stdin.flush()
 
-    def _recv(self) -> dict:
+    def _recv(self, timeout: float = 30.0) -> dict:
         assert self._stdout is not None
         while True:
+            ready, _, _ = select.select([self._stdout], [], [], timeout)
+            if not ready:
+                raise TimeoutError(f"MCP server did not respond within {timeout:.0f}s")
             raw = self._stdout.readline()
             if not raw:
                 raise EOFError("MCP server closed stdout")
@@ -109,6 +121,9 @@ class McpClient:
         if self._proc is not None:
             try:
                 self._proc.terminate()
+                self._proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
             except Exception:
                 pass
 
@@ -147,7 +162,12 @@ class McpRendererApp(App):
 
         ctx.status_summary("mcp-renderer: connecting…")
         self.emit.info(f"mcp-renderer: spawning {argv!r}")
-        threading.Thread(target=self._connect, args=(argv,), daemon=True).start()
+        try:
+            threading.Thread(target=self._connect, args=(argv,), daemon=True).start()
+        except RuntimeError as e:
+            self._error = f"Failed to start connection thread: {e}"
+            self._view = "error"
+            self.emit.warn(f"mcp-renderer: thread spawn failed: {e}")
 
     def _connect(self, cmd: list[str]) -> None:
         try:

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -80,7 +80,7 @@ class McpClient:
             ready, _, _ = select.select([self._stdout], [], [], timeout)
             if not ready:
                 raise TimeoutError(f"MCP server did not respond within {timeout:.0f}s")
-            raw = self._stdout.readline()
+            raw = self._stdout.readline(65536)
             if not raw:
                 raise EOFError("MCP server closed stdout")
             raw = raw.strip()

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""mcp-renderer — wraps any stdio MCP server as a navigable tool UI.
+
+Takes the MCP server command as argv:
+    mcp_renderer.py npx @modelcontextprotocol/server-filesystem /path
+
+List view:   j/k or ↑/↓ move selection; Enter opens; Escape goes back.
+             Selected row is highlighted. Scroll auto-tracks the cursor.
+Form view:   host-managed text_input per field; first field auto-focused;
+             Tab cycles fields; Enter on last field runs the tool call.
+             Escape returns to list.
+Result view: Shows tool call output inline. Escape or Back returns to list.
+"""
+
+import json
+import subprocess
+import sys
+import threading
+from typing import IO
+
+from plexi_sdk import (
+    App, RenderContext,
+    BG, FG, SURFACE, HIGHLIGHT, ACCENT, MUTED, RED,
+    HEADING, BODY, CAPTION, HINT,
+    PAD, HEADER_H,
+)
+
+# ── Layout constants ───────────────────────────────────────────────────────────
+
+BTN_H: float = 44.0
+BTN_GAP: float = 8.0
+FIELD_H: float = 36.0
+FIELD_GAP: float = 24.0  # label (16px) + gap below field
+ROW_H: float = BTN_H + BTN_GAP
+RESULT_LINE_H: float = 20.0
+
+
+# ── MCP stdio protocol ────────────────────────────────────────────────────────
+
+class McpClient:
+    """Minimal MCP stdio client — JSON-RPC 2.0 over subprocess stdin/stdout."""
+
+    def __init__(self, cmd: list[str]) -> None:
+        self._cmd = cmd
+        self._proc: subprocess.Popen | None = None
+        self._stdin: IO[bytes] | None = None
+        self._stdout: IO[bytes] | None = None
+        self._next_id: int = 1
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        self._proc = subprocess.Popen(
+            self._cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        self._stdin = self._proc.stdin
+        self._stdout = self._proc.stdout
+
+    def _send(self, msg: dict) -> None:
+        assert self._stdin is not None
+        line = json.dumps(msg) + "\n"
+        with self._lock:
+            self._stdin.write(line.encode())
+            self._stdin.flush()
+
+    def _recv(self) -> dict:
+        assert self._stdout is not None
+        while True:
+            raw = self._stdout.readline()
+            if not raw:
+                raise EOFError("MCP server closed stdout")
+            raw = raw.strip()
+            if not raw:
+                continue
+            return json.loads(raw)
+
+    def _call(self, method: str, params: dict) -> dict:
+        msg_id = self._next_id
+        self._next_id += 1
+        self._send({"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params})
+        while True:
+            resp = self._recv()
+            # Skip notifications (no id or id is None)
+            if resp.get("id") == msg_id:
+                if "error" in resp:
+                    raise RuntimeError(f"MCP error: {resp['error']}")
+                return resp.get("result", {})
+
+    def initialize(self) -> None:
+        self._call("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "mcp-renderer", "version": "0.1.0"},
+        })
+        # Send initialized notification (no id, no response expected)
+        self._send({"jsonrpc": "2.0", "id": None, "method": "notifications/initialized", "params": {}})
+
+    def list_tools(self) -> list[dict]:
+        result = self._call("tools/list", {})
+        return result.get("tools", [])
+
+    def call_tool(self, name: str, arguments: dict) -> list[dict]:
+        result = self._call("tools/call", {"name": name, "arguments": arguments})
+        return result.get("content", [])
+
+    def close(self) -> None:
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:
+                pass
+
+
+# ── App ────────────────────────────────────────────────────────────────────────
+
+class McpRendererApp(App):
+
+    def on_init(self, ctx: RenderContext) -> None:
+        self._view: str = "loading"   # loading | error | list | form | result
+        self._error: str = ""
+        self._tools: list[dict] = []
+        self._selected_idx: int = 0
+        self._scroll_offset: int = 0
+        self._list_y0: float = 0.0
+        # Form state
+        self._active_tool: dict = {}
+        self._fields: list[dict] = []
+        self._field_values: dict[str, str] = {}
+        # Result state
+        self._result_lines: list[str] = []
+        self._result_scroll: int = 0
+        self._calling: bool = False
+        # Hit regions: (y_top, y_bot, tag)
+        self._hits: list[tuple[float, float, object]] = []
+        # MCP client
+        self._client: McpClient | None = None
+        self._tools_ready = threading.Event()
+
+        argv = sys.argv[1:]
+        if not argv:
+            self._error = "Usage: mcp_renderer.py <command> [args...]\nExample: mcp_renderer.py npx -y @modelcontextprotocol/server-filesystem /tmp"
+            self._view = "error"
+            ctx.status_summary("mcp-renderer: no command")
+            return
+
+        ctx.status_summary("mcp-renderer: connecting…")
+        self.emit.info(f"mcp-renderer: spawning {argv!r}")
+        threading.Thread(target=self._connect, args=(argv,), daemon=True).start()
+
+    def _connect(self, cmd: list[str]) -> None:
+        try:
+            client = McpClient(cmd)
+            client.start()
+            client.initialize()
+            tools = client.list_tools()
+            self._client = client
+            self._tools = tools
+            self._view = "list"
+            self.emit.info(f"mcp-renderer: got {len(tools)} tools")
+        except Exception as e:
+            self._error = f"Failed to connect to MCP server:\n{e}"
+            self._view = "error"
+            self.emit.warn(f"mcp-renderer: connect failed: {e}")
+        self._tools_ready.set()
+        self.emit.schedule_render(after_ms=16)
+
+    def _call_tool_bg(self, name: str, arguments: dict) -> None:
+        assert self._client is not None
+        try:
+            content = self._client.call_tool(name, arguments)
+            lines: list[str] = []
+            for item in content:
+                t = item.get("type", "")
+                if t == "text":
+                    lines.extend(item.get("text", "").splitlines())
+                elif t == "image":
+                    lines.append("[Image — open in terminal to view]")
+                else:
+                    lines.append(json.dumps(item))
+            self._result_lines = lines
+            self.emit.info(f"mcp-renderer: tool {name!r} returned {len(lines)} lines")
+        except Exception as e:
+            self._result_lines = [f"Error: {e}"]
+            self.emit.warn(f"mcp-renderer: tool call failed: {e}")
+        finally:
+            self._calling = False
+            self._view = "result"
+            self._result_scroll = 0
+        self.emit.schedule_render(after_ms=16)
+
+    # ── Render ────────────────────────────────────────────────────────────────
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.rect(0, 0, ctx.w, ctx.h, BG)
+
+        if self._view == "loading":
+            ctx.text(x=ctx.w / 2, y=ctx.h / 2, text="Connecting to MCP server…",
+                     size=BODY, color=MUTED, align="center")
+            return
+
+        if self._view == "error":
+            self._render_error(ctx)
+            return
+
+        y = self._render_header(ctx)
+
+        if self._view == "list":
+            self._list_y0 = y
+            self._render_list(ctx, y)
+        elif self._view == "form":
+            self._render_form(ctx, y)
+        elif self._view == "result":
+            self._render_result(ctx, y)
+
+    def _render_header(self, ctx: RenderContext) -> float:
+        h = HEADER_H
+        ctx.rect(0, 0, ctx.w, h, SURFACE)
+        cmd_name = sys.argv[1] if len(sys.argv) > 1 else "mcp"
+        ctx.text(x=PAD, y=h / 2, text=f"MCP · {cmd_name}",
+                 size=HEADING, color=FG, bold=True, align="left_center")
+        tool_count = len(self._tools)
+        if tool_count:
+            ctx.text(x=ctx.w - PAD, y=h / 2,
+                     text=f"{tool_count} tool{'s' if tool_count != 1 else ''}",
+                     size=HINT, color=MUTED, align="right_center")
+        return h + PAD
+
+    def _render_error(self, ctx: RenderContext) -> None:
+        box_h = 100.0
+        ctx.rect(PAD, PAD, ctx.w - PAD * 2, box_h, SURFACE, radius=6.0)
+        ctx.text(x=PAD + 14, y=PAD + 22, text="Error", size=HEADING, color=RED, bold=True)
+        for i, line in enumerate(self._error.splitlines()):
+            ctx.text(x=PAD + 14, y=PAD + 48 + i * 20, text=line,
+                     size=CAPTION, color=FG, max_width=ctx.w - PAD * 2 - 28, elide=True)
+
+    def _render_list(self, ctx: RenderContext, y0: float) -> None:
+        btn_w = ctx.w - PAD * 2
+        self._hits = []
+        y = y0
+
+        if not self._tools:
+            ctx.text(x=ctx.w / 2, y=ctx.h / 2, text="No tools found",
+                     size=BODY, color=MUTED, align="center")
+            return
+
+        for i, tool in enumerate(self._tools):
+            by = y + (i - self._scroll_offset) * ROW_H
+            self._hits.append((by, by + BTN_H, i))
+            if by + BTN_H <= y0 or by >= ctx.h:
+                continue
+
+            selected = (i == self._selected_idx)
+            bg = HIGHLIGHT if selected else SURFACE
+            name_color = ACCENT if selected else FG
+            name = tool.get("name", "?")
+            desc = tool.get("description", "")
+
+            ctx.rect(PAD, by, btn_w, BTN_H, bg, radius=6.0)
+            label_y = by + (BTN_H * 0.38 if desc else BTN_H / 2)
+            ctx.text(x=PAD + 14, y=label_y, text=name,
+                     size=BODY, color=name_color, bold=True, align="left_center")
+            if desc:
+                ctx.text(x=PAD + 14, y=by + BTN_H * 0.72, text=desc,
+                         size=HINT, color=MUTED, align="left_center",
+                         max_width=btn_w - 28, elide=True)
+
+        visible_rows = max(1, int((ctx.h - y0) / ROW_H))
+        if len(self._tools) > visible_rows:
+            ctx.text(x=ctx.w / 2, y=ctx.h - 16,
+                     text=f"j/k  ·  {self._selected_idx + 1} / {len(self._tools)}",
+                     size=HINT, color=MUTED, align="center")
+
+    def _render_form(self, ctx: RenderContext, y0: float) -> None:
+        btn_w = ctx.w - PAD * 2
+        self._hits = []
+        y = y0
+
+        # Back button
+        ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
+        ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back",
+                 size=BODY, color=ACCENT, bold=True, align="left_center")
+        self._hits.append((y, y + BTN_H, "back"))
+        y += BTN_H + BTN_GAP
+
+        # Tool name
+        tool_name = self._active_tool.get("name", "")
+        ctx.text(x=PAD, y=y, text=tool_name, size=HEADING, color=FG, bold=True)
+        y += 28
+
+        tool_desc = self._active_tool.get("description", "")
+        if tool_desc:
+            ctx.text(x=PAD, y=y, text=tool_desc, size=CAPTION, color=MUTED,
+                     max_width=btn_w, elide=False)
+            y += 22
+
+        y += 8
+
+        if not self._fields:
+            # No args needed — just a Run button
+            ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
+            ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Call Tool",
+                     size=BODY, color=BG, bold=True, align="center")
+            self._hits.append((y, y + BTN_H, "run"))
+        else:
+            for field in self._fields:
+                name = field["name"]
+                req = " *" if field.get("required") else ""
+                ctx.text(x=PAD, y=y, text=f"{name}{req}", size=HINT, color=MUTED)
+                y += 18
+                submitted = ctx.text_input(
+                    id=name, x=PAD, y=y, w=btn_w,
+                    placeholder=field.get("placeholder", ""),
+                )
+                if submitted is not None:
+                    self._field_values[name] = submitted
+                    if name == self._fields[-1]["name"]:
+                        self._run_tool()
+                self._hits.append((y, y + FIELD_H, name))
+                y += FIELD_H + FIELD_GAP
+
+            if self._calling:
+                ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
+                ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="Calling…",
+                         size=BODY, color=MUTED, align="center")
+            else:
+                ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
+                ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Call Tool",
+                         size=BODY, color=BG, bold=True, align="center")
+                self._hits.append((y, y + BTN_H, "run"))
+
+    def _render_result(self, ctx: RenderContext, y0: float) -> None:
+        btn_w = ctx.w - PAD * 2
+        self._hits = []
+        y = y0
+
+        # Back button
+        ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
+        ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back to Tools",
+                 size=BODY, color=ACCENT, bold=True, align="left_center")
+        self._hits.append((y, y + BTN_H, "back"))
+        y += BTN_H + BTN_GAP
+
+        # Result label
+        tool_name = self._active_tool.get("name", "result")
+        ctx.text(x=PAD, y=y, text=f"Result: {tool_name}", size=HEADING, color=FG, bold=True)
+        y += 28
+
+        # Scrollable result lines
+        result_area_h = ctx.h - y - PAD
+        visible_lines = max(1, int(result_area_h / RESULT_LINE_H))
+        lines = self._result_lines
+        total = len(lines)
+
+        for i in range(visible_lines):
+            line_idx = i + self._result_scroll
+            if line_idx >= total:
+                break
+            line = lines[line_idx]
+            ctx.text(x=PAD, y=y + i * RESULT_LINE_H, text=line,
+                     size=CAPTION, color=FG, monospace=True,
+                     max_width=btn_w, elide=True)
+
+        if total > visible_lines:
+            ctx.text(x=ctx.w / 2, y=ctx.h - 16,
+                     text=f"↑/↓  ·  line {self._result_scroll + 1} / {total}",
+                     size=HINT, color=MUTED, align="center")
+
+    # ── Interaction ───────────────────────────────────────────────────────────
+
+    def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
+        if button != "primary":
+            return
+        for (y_top, y_bot, tag) in self._hits:
+            if y_top <= y < y_bot:
+                if isinstance(tag, int) and self._view == "list":
+                    self._selected_idx = tag
+                self._handle(tag)
+                self.emit.schedule_render(after_ms=16)
+                return
+
+    def _handle(self, tag: object) -> None:
+        if tag == "back":
+            if self._view in ("form", "result"):
+                self._view = "list"
+                self._selected_idx = 0
+                self._scroll_offset = 0
+            return
+
+        if tag == "run":
+            self._run_tool()
+            return
+
+        if isinstance(tag, int) and self._view == "list":
+            if 0 <= tag < len(self._tools):
+                self._enter_form(self._tools[tag])
+
+    def _enter_form(self, tool: dict) -> None:
+        self._active_tool = tool
+        self._field_values = {}
+        self._fields = []
+        schema = tool.get("inputSchema", {})
+        props = schema.get("properties", {})
+        required_set = set(schema.get("required", []))
+        for prop_name, prop_schema in props.items():
+            self._fields.append({
+                "name": prop_name,
+                "type": prop_schema.get("type", "string"),
+                "required": prop_name in required_set,
+                "placeholder": prop_schema.get("description", prop_schema.get("title", "")),
+            })
+        self._view = "form"
+
+    def _run_tool(self) -> None:
+        if self._calling or self._client is None:
+            return
+        self._calling = True
+        arguments: dict = {}
+        for field in self._fields:
+            val = self._field_values.get(field["name"], "").strip()
+            if val:
+                # Coerce to int/float if schema says so
+                ftype = field.get("type", "string")
+                if ftype == "integer":
+                    try:
+                        arguments[field["name"]] = int(val)
+                    except ValueError:
+                        arguments[field["name"]] = val
+                elif ftype == "number":
+                    try:
+                        arguments[field["name"]] = float(val)
+                    except ValueError:
+                        arguments[field["name"]] = val
+                elif ftype == "boolean":
+                    arguments[field["name"]] = val.lower() in ("true", "1", "yes")
+                else:
+                    arguments[field["name"]] = val
+        tool_name = self._active_tool.get("name", "")
+        self.emit.info(f"mcp-renderer: calling tool {tool_name!r} with {arguments!r}")
+        threading.Thread(
+            target=self._call_tool_bg,
+            args=(tool_name, arguments),
+            daemon=True,
+        ).start()
+
+    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+        if self._view == "list":
+            total = len(self._tools)
+            visible_rows = max(1, int((ctx.h - self._list_y0) / ROW_H))
+
+            if key in ("down", "j"):
+                self._selected_idx = min(self._selected_idx + 1, total - 1)
+                self._clamp_scroll(visible_rows)
+                self.emit.schedule_render(after_ms=16)
+            elif key in ("up", "k"):
+                self._selected_idx = max(self._selected_idx - 1, 0)
+                self._clamp_scroll(visible_rows)
+                self.emit.schedule_render(after_ms=16)
+            elif key in ("Return", "Enter"):
+                self._handle(self._selected_idx)
+                self.emit.schedule_render(after_ms=16)
+
+        elif self._view == "form":
+            if key == "Escape":
+                self._view = "list"
+                self._selected_idx = 0
+                self._scroll_offset = 0
+                self.emit.schedule_render(after_ms=16)
+
+        elif self._view == "result":
+            total = len(self._result_lines)
+            if key in ("down", "j"):
+                self._result_scroll = min(self._result_scroll + 1, max(0, total - 1))
+                self.emit.schedule_render(after_ms=16)
+            elif key in ("up", "k"):
+                self._result_scroll = max(self._result_scroll - 1, 0)
+                self.emit.schedule_render(after_ms=16)
+            elif key == "Escape":
+                self._view = "list"
+                self._selected_idx = 0
+                self._scroll_offset = 0
+                self.emit.schedule_render(after_ms=16)
+
+    def _clamp_scroll(self, visible_rows: int) -> None:
+        if self._selected_idx < self._scroll_offset:
+            self._scroll_offset = self._selected_idx
+        elif self._selected_idx >= self._scroll_offset + visible_rows:
+            self._scroll_offset = self._selected_idx - visible_rows + 1
+
+
+if __name__ == "__main__":
+    McpRendererApp().run()

--- a/registry/mcp/brave-search.json
+++ b/registry/mcp/brave-search.json
@@ -1,0 +1,8 @@
+{
+  "name": "brave-search",
+  "description": "Brave Search API via MCP",
+  "command": ["npx", "-y", "@modelcontextprotocol/server-brave-search"],
+  "version": "2024-11-05",
+  "source": { "type": "npm", "package": "@modelcontextprotocol/server-brave-search" },
+  "pgap_app": "mcp-renderer"
+}

--- a/registry/mcp/filesystem.json
+++ b/registry/mcp/filesystem.json
@@ -1,0 +1,8 @@
+{
+  "name": "filesystem",
+  "description": "Read and write files via MCP",
+  "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem"],
+  "version": "2024-11-05",
+  "source": { "type": "npm", "package": "@modelcontextprotocol/server-filesystem" },
+  "pgap_app": "mcp-renderer"
+}

--- a/registry/mcp/git.json
+++ b/registry/mcp/git.json
@@ -1,0 +1,8 @@
+{
+  "name": "git",
+  "description": "Git repository operations via MCP",
+  "command": ["uvx", "mcp-server-git"],
+  "version": "2024-11-05",
+  "source": { "type": "pypi", "package": "mcp-server-git" },
+  "pgap_app": "mcp-renderer"
+}

--- a/registry/mcp/github.json
+++ b/registry/mcp/github.json
@@ -1,0 +1,8 @@
+{
+  "name": "github",
+  "description": "GitHub API operations via MCP",
+  "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+  "version": "2024-11-05",
+  "source": { "type": "npm", "package": "@modelcontextprotocol/server-github" },
+  "pgap_app": "mcp-renderer"
+}

--- a/registry/mcp/postgres.json
+++ b/registry/mcp/postgres.json
@@ -1,0 +1,8 @@
+{
+  "name": "postgres",
+  "description": "PostgreSQL database queries via MCP",
+  "command": ["npx", "-y", "@modelcontextprotocol/server-postgres"],
+  "version": "2024-11-05",
+  "source": { "type": "npm", "package": "@modelcontextprotocol/server-postgres" },
+  "pgap_app": "mcp-renderer"
+}

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -199,6 +199,15 @@ class App:
     vertical offset in logical pixels. Override to re-render content at the
     new position.
     """
+    def on_mcp_call(self, _ctx: RenderContext, _tool_name: str, _arguments: dict) -> "dict | Coroutine[Any, Any, dict] | None":
+        """Called when an external MCP client calls a tool declared in [app.mcp].
+
+        Override to handle the call and return a result dict. The result should
+        follow MCP CallToolResult schema: ``{"content": [{"type": "text", "text": "..."}]}``.
+        Return ``None`` to respond with a generic 'not implemented' error.
+        """
+        return None
+
     def on_midi_input_opened(
         self,
         _pipe_id: str,
@@ -307,6 +316,43 @@ class App:
                 "call_id": call_id,
                 "output_json": None,
                 "error": f"tool_handler_error: {exc}",
+            })
+
+    async def _handle_mcp_tool_call(self, ev: dict) -> None:
+        """Dispatch a PlexiEvent::McpToolCall to on_mcp_call."""
+        call_id: str = ev.get("call_id", "")
+        tool_name: str = ev.get("tool_name", "")
+        arguments: dict = ev.get("arguments", {})
+
+        try:
+            import inspect as _inspect
+            if _inspect.iscoroutinefunction(self.on_mcp_call):
+                result = await self.on_mcp_call(self._make_ctx(), tool_name, arguments)
+            else:
+                result = self.on_mcp_call(self._make_ctx(), tool_name, arguments)
+
+            if result is None:
+                _emit({
+                    "type": "mcp_tool_result",
+                    "call_id": call_id,
+                    "result": None,
+                    "error": f"tool_not_implemented: {tool_name!r}",
+                })
+            else:
+                _emit({
+                    "type": "mcp_tool_result",
+                    "call_id": call_id,
+                    "result": result,
+                    "error": None,
+                })
+        except Exception as exc:
+            import traceback as _tb
+            _tb.print_exc()
+            _emit({
+                "type": "mcp_tool_result",
+                "call_id": call_id,
+                "result": None,
+                "error": f"mcp_tool_handler_error: {exc}",
             })
 
     def _take_text_submission(self, id: str) -> "str | None":
@@ -750,6 +796,10 @@ class App:
                     # a registered tool. Dispatched as a background task so it
                     # doesn't block the event loop while the handler runs.
                     self._dispatch_hook_task(self._handle_tool_call, ev)
+
+                elif t == "mcp_tool_call":
+                    # MCP bridge (#958). External MCP client called a tool — dispatch to on_mcp_call.
+                    self._dispatch_hook_task(self._handle_mcp_tool_call, ev)
 
         reader_task = asyncio.create_task(_reader())
         try:

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -749,6 +749,20 @@ class Emitter:
             tokens_out=int(ev.get("tokens_out", 0) or 0),
         )
 
+    def mcp_tool_result(self, call_id: str, result: "dict | None" = None, error: "str | None" = None) -> None:
+        """Send a McpToolResult response for a pending McpToolCall.
+
+        One of ``result`` or ``error`` must be provided.
+        ``result`` should be a MCP CallToolResult dict, e.g.:
+        ``{"content": [{"type": "text", "text": "done"}]}``.
+        """
+        _emit({
+            "type": "mcp_tool_result",
+            "call_id": call_id,
+            "result": result,
+            "error": error,
+        })
+
     def expose_tools(self, tools: "list[dict]") -> None:
         """Declare callable tools to the host (#398, #399).
 

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -752,10 +752,14 @@ class Emitter:
     def mcp_tool_result(self, call_id: str, result: "dict | None" = None, error: "str | None" = None) -> None:
         """Send a McpToolResult response for a pending McpToolCall.
 
-        One of ``result`` or ``error`` must be provided.
+        One of ``result`` or ``error`` must be provided (not both, not neither).
         ``result`` should be a MCP CallToolResult dict, e.g.:
         ``{"content": [{"type": "text", "text": "done"}]}``.
         """
+        if result is None and error is None:
+            raise ValueError("mcp_tool_result: either 'result' or 'error' must be provided")
+        if result is not None and error is not None:
+            raise ValueError("mcp_tool_result: 'result' and 'error' are mutually exclusive")
         _emit({
             "type": "mcp_tool_result",
             "call_id": call_id,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -211,6 +211,13 @@ pub enum PlexiEvent {
         name: String,
         input_json: String,
     },
+    /// External MCP client called a tool declared in `[app.mcp]`. The app must
+    /// reply with `DrawCommand::Host(HostCommand::McpToolResult { call_id, … })`.
+    McpToolCall {
+        call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
     /// Response to a `DrawCommand::ListAudioDevices` request (#277).
     /// Both vectors are always present — empty when enumeration finds no
     /// devices of that direction. `error` is set only when device
@@ -1019,6 +1026,16 @@ pub enum HostCommand {
         call_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output_json: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// App returns the result of a `PlexiEvent::McpToolCall` invocation.
+    /// `call_id` must match the `call_id` from the `McpToolCall` event.
+    /// Either `result` or `error` must be set.
+    McpToolResult {
+        call_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result: Option<serde_json::Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -106,6 +106,10 @@ pub struct AppManifestApp {
     /// `serde(default)`, which would conflate "absent" with "false" at the
     /// type level and lose the diagnostic that the field was never set.
     pub watch: Option<bool>,
+    /// Optional `[app.mcp]` section. When present the host starts an HTTP MCP server
+    /// on a dynamic port and injects PLEXI_MCP_PORT into the app's environment.
+    #[serde(default)]
+    pub mcp: Option<McpSection>,
 }
 
 /// Manifest `[app] type` field — chooses the host rendering surface for
@@ -137,6 +141,23 @@ impl From<DefaultNotifyScope> for crate::app_protocol::NotifyScope {
             DefaultNotifyScope::Global => crate::app_protocol::NotifyScope::Global,
         }
     }
+}
+
+/// Manifest `[app.mcp.tools]` entry — one tool the app exposes to external MCP clients.
+#[derive(Deserialize, Debug, Clone)]
+pub struct McpTool {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+/// Manifest `[app.mcp]` section. Presence means the host starts an HTTP MCP server.
+#[derive(Deserialize, Debug, Clone)]
+pub struct McpSection {
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub tools: Vec<McpTool>,
 }
 
 /// v3 capability section — `[app.capabilities]`. Holds only the capability
@@ -303,8 +324,6 @@ impl AppRegistry {
     }
 
     /// Look up an installed entry by id (returns `None` if not discovered).
-    /// Test-only — runtime code uses `launch` / `is_background` etc.
-    #[cfg(test)]
     pub fn get(&self, id: &str) -> Option<&InstalledApp> {
         self.apps.get(id)
     }
@@ -540,6 +559,7 @@ impl AppRegistry {
             cwd.clone(),
             caps,
             keyboard_capture,
+            installed.manifest.mcp.as_ref(),
         ) {
             Ok(app) => {
                 log::info!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -522,6 +522,44 @@ pub fn app_uninstall(id: &str) -> i32 {
     0
 }
 
+/// `plexi app info <id>` — show manifest info for an installed app, including MCP URL if applicable.
+pub fn app_info(id: &str) -> i32 {
+    let registry =
+        crate::app_registry::AppRegistry::load(&std::env::current_dir().unwrap_or_default());
+    let Some(installed) = registry.get(id) else {
+        eprintln!("error: app '{id}' not found — run `plexi app list` to see installed apps");
+        return 1;
+    };
+    let m = &installed.manifest;
+    println!("id:          {}", m.id);
+    println!("name:        {}", m.name);
+    println!("version:     {}", m.version);
+    println!("description: {}", m.description);
+    if let Some(mcp) = &m.mcp {
+        if !mcp.description.is_empty() {
+            println!("mcp_desc:    {}", mcp.description);
+        }
+        let tool_names: Vec<&str> = mcp.tools.iter().map(|t| t.name.as_str()).collect();
+        println!(
+            "mcp_tools:   {}",
+            if tool_names.is_empty() {
+                "(none declared)".to_string()
+            } else {
+                tool_names.join(", ")
+            }
+        );
+        println!("mcp_url:     http://localhost:${{PLEXI_MCP_PORT}}/mcp  (port assigned at runtime)");
+        println!();
+        println!("Claude Desktop config:");
+        println!("  {{");
+        println!("    \"mcpServers\": {{");
+        println!("      \"{}\": {{ \"url\": \"http://localhost:${{PLEXI_MCP_PORT}}/mcp\" }}", m.id);
+        println!("    }}");
+        println!("  }}");
+    }
+    0
+}
+
 /// `plexi app list` — list installed apps.
 pub fn app_list() -> i32 {
     let registry =

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -204,6 +204,10 @@ pub enum AppCmd {
         #[arg(long)]
         output: Option<String>,
     },
+    /// Show app info (id, name, version, MCP tools if any)
+    Info {
+        id: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,7 @@ fn main() -> eframe::Result {
                         AppCmd::Render { id, size, state, output } => {
                             std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
                         }
+                        AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                     },
                     Commands::Install { spec, pack } => {
                         if let Some(p) = pack {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -563,6 +563,7 @@ impl PlexiApp {
             cwd.clone(),
             caps,
             false, // keyboard_capture
+            None,  // mcp: CLI-spawned apps have no manifest [app.mcp]
         ) {
             Ok(app) => {
                 log::info!(

--- a/src/process_app/mcp_server.rs
+++ b/src/process_app/mcp_server.rs
@@ -1,0 +1,294 @@
+//! Minimal HTTP/1.1 MCP server for the Plexi app MCP bridge (#958).
+//!
+//! When an app manifest declares `[app.mcp]`, the host calls `start_mcp_server`
+//! which binds a TCP listener on `127.0.0.1:0` (OS-assigned port), spawns a
+//! background accept thread, and returns a `McpServerHandle` carrying the port
+//! and a shared call queue.
+//!
+//! Each frame, `ProcessApp::poll_mcp_calls` drains the queue, serialises
+//! `PlexiEvent::McpToolCall` events to the app's stdin, and stores the
+//! response channel in `mcp_pending`. When the app replies with
+//! `HostCommand::McpToolResult`, the routing layer looks up the call_id,
+//! sends the result, and the blocked HTTP handler thread unblocks and writes
+//! the JSON-RPC response to the client.
+
+use crate::app_registry::McpTool;
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A pending MCP tool-call request queued for delivery to the app.
+pub struct McpCallRequest {
+    pub call_id: String,
+    pub tool_name: String,
+    pub arguments: serde_json::Value,
+    /// The HTTP handler thread blocks on this channel waiting for the app's reply.
+    pub response_tx: std::sync::mpsc::SyncSender<McpToolResponse>,
+}
+
+/// The app's reply to a `PlexiEvent::McpToolCall`.
+pub struct McpToolResponse {
+    pub result: Option<serde_json::Value>,
+    pub error: Option<String>,
+}
+
+/// Handle returned by `start_mcp_server`. Kept alive in `ProcessApp`.
+pub struct McpServerHandle {
+    /// The OS-assigned port. Injected as `PLEXI_MCP_PORT` into the app process.
+    pub port: u16,
+    /// Pending tool-call requests from external MCP clients, drained each frame
+    /// by `ProcessApp::poll_mcp_calls`.
+    pub call_queue: Arc<Mutex<VecDeque<McpCallRequest>>>,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Start the HTTP/SSE MCP server for `tools`. Returns the handle with the
+/// bound port and the shared call queue.
+pub fn start_mcp_server(tools: Vec<McpTool>) -> std::io::Result<McpServerHandle> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let call_queue: Arc<Mutex<VecDeque<McpCallRequest>>> =
+        Arc::new(Mutex::new(VecDeque::new()));
+    let queue_clone = Arc::clone(&call_queue);
+    let tools = Arc::new(tools);
+
+    std::thread::Builder::new()
+        .name(format!("mcp-accept-{port}"))
+        .spawn(move || {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        let tools = Arc::clone(&tools);
+                        let queue = Arc::clone(&queue_clone);
+                        std::thread::Builder::new()
+                            .name("mcp-conn".to_string())
+                            .spawn(move || {
+                                if let Err(e) = handle_connection(stream, &tools, &queue) {
+                                    log::warn!("mcp_server: connection error: {e}");
+                                }
+                            })
+                            .ok();
+                    }
+                    Err(e) => {
+                        log::warn!("mcp_server: accept error: {e}");
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    log::info!("mcp_server: started on port {port}");
+    Ok(McpServerHandle { port, call_queue })
+}
+
+// ---------------------------------------------------------------------------
+// Connection handler
+// ---------------------------------------------------------------------------
+
+fn handle_connection(
+    stream: std::net::TcpStream,
+    tools: &[McpTool],
+    queue: &Arc<Mutex<VecDeque<McpCallRequest>>>,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut write_stream = stream;
+
+    // Read HTTP request line (e.g. "POST /mcp HTTP/1.1")
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line)? == 0 {
+        return Ok(());
+    }
+
+    // We only handle POST /mcp
+    let is_post_mcp = request_line.starts_with("POST") && request_line.contains("/mcp");
+
+    // Read headers, find Content-Length
+    let mut content_length: usize = 0;
+    loop {
+        let mut header = String::new();
+        match reader.read_line(&mut header)? {
+            0 => return Ok(()),
+            _ => {
+                let trimmed = header.trim_end_matches(|c| c == '\r' || c == '\n');
+                if trimmed.is_empty() {
+                    break; // blank line = end of headers
+                }
+                let lower = trimmed.to_lowercase();
+                if let Some(rest) = lower.strip_prefix("content-length:") {
+                    content_length = rest.trim().parse().unwrap_or(0);
+                }
+            }
+        }
+    }
+
+    if !is_post_mcp || content_length == 0 {
+        write_http_response(&mut write_stream, 405, b"{\"error\":\"method not allowed\"}")?;
+        return Ok(());
+    }
+
+    // Read body (content_length bytes)
+    let mut buf = vec![0u8; content_length];
+    {
+        use std::io::Read;
+        reader.read_exact(&mut buf)?;
+    }
+    let body = buf;
+
+    let json: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("mcp_server: invalid JSON body: {e}");
+            write_http_response(&mut write_stream, 400, b"{\"error\":\"invalid json\"}")?;
+            return Ok(());
+        }
+    };
+
+    let id = json.get("id").cloned().unwrap_or(serde_json::Value::Null);
+    let method = json.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+    let response_body = match method {
+        "initialize" => serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "plexi-mcp-bridge", "version": "1.0.0" }
+            }
+        }),
+
+        "notifications/initialized" => serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": serde_json::Value::Null,
+            "result": serde_json::Value::Null
+        }),
+
+        "tools/list" => {
+            let tool_list: Vec<serde_json::Value> = tools
+                .iter()
+                .map(|t| {
+                    serde_json::json!({
+                        "name": t.name,
+                        "description": t.description,
+                        "inputSchema": t.input_schema,
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "tools": tool_list }
+            })
+        }
+
+        "tools/call" => {
+            let params = json.get("params").cloned().unwrap_or_default();
+            let tool_name = params
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_string();
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Object(Default::default()));
+
+            let call_id = uuid_v4();
+            let (response_tx, response_rx) =
+                std::sync::mpsc::sync_channel::<McpToolResponse>(1);
+
+            {
+                let mut q = queue.lock().unwrap();
+                q.push_back(McpCallRequest {
+                    call_id: call_id.clone(),
+                    tool_name: tool_name.clone(),
+                    arguments,
+                    response_tx,
+                });
+            }
+
+            log::info!("mcp_server: tool_call call_id={call_id} tool={tool_name}");
+
+            match response_rx.recv_timeout(Duration::from_secs(30)) {
+                Ok(resp) => {
+                    if let Some(result) = resp.result {
+                        serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": result
+                        })
+                    } else {
+                        let msg = resp.error.unwrap_or_else(|| "tool call failed".to_string());
+                        serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": { "code": -32603, "message": msg }
+                        })
+                    }
+                }
+                Err(_) => {
+                    log::warn!("mcp_server: tool call {call_id} timed out after 30s");
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": { "code": -32603, "message": "tool call timed out" }
+                    })
+                }
+            }
+        }
+
+        other => {
+            log::warn!("mcp_server: unknown method '{other}'");
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32601, "message": format!("method not found: {other}") }
+            })
+        }
+    };
+
+    let body_bytes = serde_json::to_vec(&response_body)
+        .unwrap_or_else(|_| b"{}".to_vec());
+    write_http_response(&mut write_stream, 200, &body_bytes)?;
+    Ok(())
+}
+
+fn write_http_response(
+    stream: &mut impl Write,
+    status: u16,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let status_text = if status == 200 { "OK" } else { "Error" };
+    write!(
+        stream,
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    stream.write_all(body)?;
+    stream.flush()
+}
+
+/// Generate a simple pseudo-UUID v4 using random bytes from the OS.
+fn uuid_v4() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    // Use time + thread id as entropy source — no uuid crate dependency needed.
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    let tid = std::thread::current().id();
+    format!("{t:08x}-{tid:?}-mcp")
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-')
+        .collect()
+}

--- a/src/process_app/mcp_server.rs
+++ b/src/process_app/mcp_server.rs
@@ -109,8 +109,9 @@ fn handle_connection(
         return Ok(());
     }
 
-    // We only handle POST /mcp
-    let is_post_mcp = request_line.starts_with("POST") && request_line.contains("/mcp");
+    // Only handle POST /mcp (exact path match)
+    let mut req_parts = request_line.split_whitespace();
+    let is_post_mcp = req_parts.next() == Some("POST") && req_parts.next() == Some("/mcp");
 
     // Read headers, find Content-Length
     let mut content_length: usize = 0;
@@ -136,6 +137,12 @@ fn handle_connection(
         return Ok(());
     }
 
+    // Cap body size to prevent OOM from a crafted Content-Length header.
+    const MAX_BODY: usize = 10 * 1024 * 1024; // 10 MB
+    if content_length > MAX_BODY {
+        write_http_response(&mut write_stream, 413, b"{\"error\":\"payload too large\"}")?;
+        return Ok(());
+    }
     // Read body (content_length bytes)
     let mut buf = vec![0u8; content_length];
     {
@@ -203,7 +210,7 @@ fn handle_connection(
                 .cloned()
                 .unwrap_or(serde_json::Value::Object(Default::default()));
 
-            let call_id = uuid_v4();
+            let call_id = generate_call_id();
             let (response_tx, response_rx) =
                 std::sync::mpsc::sync_channel::<McpToolResponse>(1);
 
@@ -271,15 +278,15 @@ fn write_http_response(
     let status_text = if status == 200 { "OK" } else { "Error" };
     write!(
         stream,
-        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n",
         body.len()
     )?;
     stream.write_all(body)?;
     stream.flush()
 }
 
-/// Generate a simple pseudo-UUID v4 using random bytes from the OS.
-fn uuid_v4() -> String {
+/// Generate a unique call ID using time + thread ID as entropy (no uuid crate dependency).
+fn generate_call_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     // Use time + thread id as entropy source — no uuid crate dependency needed.
     let t = SystemTime::now()

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -12,6 +12,7 @@
 //! - `prompts.rs`  — `show_prompt_modal()`: capability/secret grant UI
 
 mod lifecycle;
+pub(crate) mod mcp_server;
 mod prompts;
 pub(crate) mod render;
 mod routing;
@@ -270,6 +271,11 @@ pub struct ProcessApp {
     /// before spawn, decremented when the thread exits. Capped at
     /// `MAX_STREAM_THREADS` to bound peak stack memory.
     pub(crate) active_stream_threads: Arc<AtomicUsize>,
+    /// MCP server handle — `Some` when the app has `[app.mcp]` in its manifest.
+    mcp_server: Option<mcp_server::McpServerHandle>,
+    /// Pending MCP tool call responses awaiting `HostCommand::McpToolResult`.
+    /// Key = call_id, value = channel to the blocked HTTP handler thread.
+    pub(crate) mcp_pending: std::collections::HashMap<String, std::sync::mpsc::SyncSender<mcp_server::McpToolResponse>>,
 }
 
 impl ProcessApp {
@@ -286,6 +292,7 @@ impl ProcessApp {
         workspace_root: PathBuf,
         capabilities: std::collections::HashSet<Capability>,
         keyboard_capture: bool,
+        mcp: Option<&crate::app_registry::McpSection>,
     ) -> Result<Self, std::io::Error> {
         let type_id: String = type_id.into();
         let display_name: String = display_name.into();
@@ -347,6 +354,20 @@ impl ProcessApp {
         // is never present via PLEXI_* passthrough above.
         let socket_path = crate::config::config_dir().join("notify.sock");
         cmd.env("PLEXI_SOCKET", &socket_path);
+
+        // Start the MCP server when the manifest declares [app.mcp].
+        let mcp_server_handle = mcp.map(|section| {
+            match mcp_server::start_mcp_server(section.tools.clone()) {
+                Ok(handle) => {
+                    cmd.env("PLEXI_MCP_PORT", handle.port.to_string());
+                    Some(handle)
+                }
+                Err(e) => {
+                    log::error!("ProcessApp[{type_id}]: failed to start MCP server: {e}");
+                    None
+                }
+            }
+        }).flatten();
         // Prepend the bundled Python interpreter's bin/ dir to PATH so that
         // Python app shebangs (`#!/usr/bin/env python3`) resolve to our hermetic
         // Python 3.12, not whatever the host machine happens to have installed.
@@ -612,6 +633,8 @@ impl ProcessApp {
             exposed_tools: Vec::new(),
             stream_handles: HashMap::new(),
             active_stream_threads: Arc::new(AtomicUsize::new(0)),
+            mcp_server: mcp_server_handle,
+            mcp_pending: std::collections::HashMap::new(),
         })
     }
 
@@ -730,6 +753,8 @@ impl ProcessApp {
             active_stream_threads: Arc::new(AtomicUsize::new(0)),
             file_picker_tx,
             file_picker_rx,
+            mcp_server: None,
+            mcp_pending: std::collections::HashMap::new(),
         };
         (app, draw_tx)
     }
@@ -788,6 +813,28 @@ impl ProcessApp {
                 }
             }
             Err(e) => log::error!("ProcessApp: failed to serialize event: {e}"),
+        }
+    }
+
+    /// Drain the MCP call queue and forward each request to the app as a
+    /// `PlexiEvent::McpToolCall`. Called each frame (both `ui()` and
+    /// `background_tick()`) so tool calls are processed even for background apps.
+    pub(crate) fn poll_mcp_calls(&mut self) {
+        let Some(mcp) = &self.mcp_server else { return };
+        let requests: Vec<_> = mcp.call_queue.lock().unwrap().drain(..).collect();
+        for req in requests {
+            let call_id = req.call_id.clone();
+            log::info!(
+                "ProcessApp[{}]: dispatching McpToolCall call_id={call_id} tool={}",
+                self.type_id,
+                req.tool_name,
+            );
+            self.mcp_pending.insert(call_id.clone(), req.response_tx);
+            self.outbound_events.push_back(PlexiEvent::McpToolCall {
+                call_id,
+                tool_name: req.tool_name,
+                arguments: req.arguments,
+            });
         }
     }
 
@@ -1129,6 +1176,7 @@ impl ProcessApp {
         while let Ok(event) = self.file_picker_rx.try_recv() {
             self.outbound_events.push_back(event);
         }
+        self.poll_mcp_calls();
         self.flush_outbound_events();
         for cmd in self.drain_draw_commands() {
             match cmd {
@@ -1244,6 +1292,7 @@ impl App for ProcessApp {
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         let size = ui.available_size();
 
+        self.poll_mcp_calls();
         self.flush_outbound_events();
 
         // Lifecycle: track user-input recency on this pane. Only required

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1409,6 +1409,30 @@ impl ProcessApp {
                 );
             }
 
+            // App returns the result of an McpToolCall from an external MCP client.
+            HostCommand::McpToolResult {
+                call_id,
+                result,
+                error,
+            } => {
+                log::info!(
+                    "ProcessApp[{}]: McpToolResult call_id={call_id:?} ok={}",
+                    self.type_id,
+                    result.is_some(),
+                );
+                if let Some(tx) = self.mcp_pending.remove(&call_id) {
+                    let _ = tx.send(crate::process_app::mcp_server::McpToolResponse {
+                        result,
+                        error,
+                    });
+                } else {
+                    log::warn!(
+                        "ProcessApp[{}]: McpToolResult for unknown call_id={call_id:?}",
+                        self.type_id
+                    );
+                }
+            }
+
             // SetPaneTitle is only valid over PLEXI_SOCKET; an app sending it
             // via PGAP is a protocol error — log and drop.
             HostCommand::SetPaneTitle { pane_id, .. } => {


### PR DESCRIPTION
Closes #958

## Summary

- **Direction 1 (Consume):** `mcp-renderer` Python app wraps any stdio MCP server as a navigable form UI. Launched with the server command as argv. Seeds `registry/mcp/` with 5 entries (filesystem, github, postgres, brave-search, git).
- **Direction 2 (Expose):** Apps declare `[app.mcp]` in `manifest.toml`. Host starts an HTTP/SSE MCP server (Streamable HTTP, JSON-RPC 2.0) on a dynamic port. Port injected as `PLEXI_MCP_PORT`. External MCP clients call `tools/list`/`tools/call`; host routes as `PlexiEvent::McpToolCall` → app's `on_mcp_call()` hook → `McpToolResult` back to caller.
- **New wire protocol:** `PlexiEvent::McpToolCall { call_id, tool_name, arguments }` + `HostCommand::McpToolResult { call_id, result, error }`
- **Python SDK:** `App.on_mcp_call(ctx, tool_name, arguments)` hook + `Emitter.mcp_tool_result()`
- **CLI:** `plexi app info <id>` shows `mcp_url` when `[app.mcp]` is declared
- **Example:** `examples/mcp-demo/` — note-taking app that exposes 3 MCP tools and shows the `PLEXI_MCP_PORT` URL for pasting into Claude Desktop config

## Test plan

- [ ] Install PR build: `just pr-install <N>` from feature worktree
- [ ] Open `mcp-demo` app — confirm pane renders with MCP endpoint URL visible
- [ ] Run `plexi-pr-<N> app info mcp-demo` — confirm shows `mcp_tools:` and `mcp_url:` lines
- [ ] Run `plexi-pr-<N> app info todo` (no mcp section) — confirm shows name/version only, no crash
- [ ] Open `mcp-renderer` with `npx @modelcontextprotocol/server-filesystem /tmp` — confirm tool list renders
- [ ] `cargo test` passes

**Breaks if:** `mcp-demo` pane fails to render, or `plexi app info` crashes for apps without `[app.mcp]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)