### PR TITLE
refactor(notifications): replace source_context index with stable source_context_id

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -12,21 +12,21 @@ mod tests {
     use crate::process_app::ProcessApp;
     use crate::testing::HostHarness;
     /// Regression guard for issue #879: parked background app notifications
-    /// hardcoded `source_context: 0`. Verify that the context index recorded
+    /// hardcoded `source_context_id: 0`. Verify that the context_id recorded
     /// at park time propagates to the `ShowNotification` command.
     #[test]
     fn parked_app_notification_uses_park_context() {
         let mut h = HostHarness::new();
 
         // Seed a ShowNotification on a fresh ProcessApp's pending_commands,
-        // then insert it into background_apps with park_ctx = 2.
+        // then insert it into background_apps with park_context_id = 42.
         let (mut process_app, _draw_tx) =
             ProcessApp::new_for_test(999, AppPermissions::builtin());
 
         process_app.pending_commands.push(AppCommand::ShowNotification {
             notify_id: "test-notify".to_string(),
             sender_pane_id: 0,
-            source_context: 0, // pre-filled stub value; drain should overwrite
+            source_context_id: 0, // pre-filled stub value; drain should overwrite
             level: "info".to_string(),
             title: "hello from context 2".to_string(),
             body: String::new(),
@@ -42,10 +42,10 @@ mod tests {
             on_dismiss: None,
         });
 
-        let park_ctx: usize = 2;
+        let park_context_id: u64 = 42;
         h.app
             .background_apps
-            .insert("test-app".to_string(), (park_ctx, Box::new(process_app)));
+            .insert("test-app".to_string(), (park_context_id, Box::new(process_app)));
 
         let cmds = h.app.drain_all_app_commands();
 
@@ -53,13 +53,13 @@ mod tests {
             matches!(c, AppCommand::ShowNotification { notify_id, .. } if notify_id == "test-notify")
         });
 
-        let Some(AppCommand::ShowNotification { source_context, .. }) = notification else {
+        let Some(AppCommand::ShowNotification { source_context_id, .. }) = notification else {
             panic!("expected ShowNotification in drained commands — not found");
         };
 
         assert_eq!(
-            *source_context, park_ctx,
-            "source_context should be the park-time context ({park_ctx}), not hardcoded 0"
+            *source_context_id, park_context_id,
+            "source_context_id should be the park-time context_id ({park_context_id}), not hardcoded 0"
         );
     }
 }
@@ -135,19 +135,19 @@ impl PlexiApp {
         // instead of context panes. Without this, timers stop and notifications
         // never fire the moment the pane is closed.
         // Collect (type_id, park_context_idx, commands) for each parked app.
-        let parked: Vec<(String, usize, Vec<AppCommand>)> = self
+        let parked: Vec<(String, u64, Vec<AppCommand>)> = self
             .background_apps
             .iter_mut()
-            .map(|(type_id, (park_ctx, app))| {
+            .map(|(type_id, (park_context_id, app))| {
                 app.background_tick();
                 let cmds = app.take_pending_commands();
-                (type_id.to_owned(), *park_ctx, cmds)
+                (type_id.to_owned(), *park_context_id, cmds)
             })
             .collect();
 
         let mut deferred = Vec::new();
 
-        for (type_id, park_ctx, cmds) in &parked {
+        for (type_id, park_context_id, cmds) in &parked {
             let resolved_scope = self.registry.default_notification_scope_for(type_id);
             for cmd in cmds.iter() {
                 match cmd {
@@ -168,13 +168,13 @@ impl PlexiApp {
                         ..
                     } => {
                         log::info!(
-                            "parked background app '{}' notification: {} (routing to context {})",
-                            type_id, title, park_ctx
+                            "parked background app '{}' notification: {} (routing to context_id {})",
+                            type_id, title, park_context_id
                         );
                         deferred.push(AppCommand::ShowNotification {
                             notify_id: notify_id.clone(),
                             sender_pane_id: 0, // no live pane — tombstone won't fire
-                            source_context: *park_ctx,
+                            source_context_id: *park_context_id,
                             level: level.clone(),
                             title: title.clone(),
                             body: body.clone(),
@@ -247,13 +247,11 @@ impl PlexiApp {
                         on_dismiss,
                         ..
                     } => {
-                        let ws_idx = self.windows.get(ctx_idx)
-                            .and_then(|w| self.router.position(|c| c.context_id == w.context_id))
-                            .unwrap_or(0);
+                        let context_id = self.windows.get(ctx_idx).map(|w| w.context_id).unwrap_or(0);
                         deferred.push(AppCommand::ShowNotification {
                             notify_id,
                             sender_pane_id: pane_id,
-                            source_context: ws_idx,
+                            source_context_id: context_id,
                             level,
                             title,
                             body,

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -103,14 +103,15 @@ impl PlexiApp {
     /// Parked background apps (pane closed, process alive) are also ticked so
     /// their timers and notifications keep firing while detached.
     pub(super) fn drain_all_app_commands(&mut self) -> Vec<AppCommand> {
-        // Collect (ctx_idx, pane_id, type_id, commands) per pane. We capture
-        // type_id here because the manifest-declared notification scope is
-        // looked up from the registry by type_id, and we can't hold a
-        // mutable borrow on contexts + a shared borrow on the registry at
-        // the same time during the match below.
+        // Collect (context_id, pane_id, type_id, commands) per pane. We capture
+        // context_id (stable u64) and type_id here because the manifest-declared
+        // notification scope is looked up from the registry by type_id, and we
+        // can't hold a mutable borrow on contexts + a shared borrow on the
+        // registry at the same time during the match below.
         let active = self.active_window;
-        let mut per_pane: Vec<(usize, u64, String, Vec<AppCommand>)> = Vec::new();
+        let mut per_pane: Vec<(u64, u64, String, Vec<AppCommand>)> = Vec::new();
         for (ctx_idx, context) in self.windows.iter_mut().enumerate() {
+            let context_id = context.context_id;
             for (pane_id, pane) in context.panes.iter_mut() {
                 if let Some(app_pane) = pane.as_app_mut() {
                     // Active-context panes are already fully updated by ui()
@@ -123,7 +124,7 @@ impl PlexiApp {
                     let type_id = app_pane.runtime.type_id().to_string();
                     let cmds = app_pane.runtime.take_pending_commands();
                     if !cmds.is_empty() {
-                        per_pane.push((ctx_idx, *pane_id, type_id, cmds));
+                        per_pane.push((context_id, *pane_id, type_id, cmds));
                     }
                     continue;
                 }
@@ -201,7 +202,7 @@ impl PlexiApp {
             }
         }
 
-        for (ctx_idx, pane_id, type_id, cmds) in per_pane {
+        for (context_id, pane_id, type_id, cmds) in per_pane {
             // Scope is a per-app user-facing policy declared in the app's
             // manifest.toml. Apps never set it — the host resolves it once
             // per notification here. Defaults to `Context` when the manifest
@@ -247,7 +248,6 @@ impl PlexiApp {
                         on_dismiss,
                         ..
                     } => {
-                        let context_id = self.windows.get(ctx_idx).map(|w| w.context_id).unwrap_or(0);
                         deferred.push(AppCommand::ShowNotification {
                             notify_id,
                             sender_pane_id: pane_id,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -55,8 +55,8 @@ pub(crate) enum FocusLayer {
 pub(crate) struct PendingNotification {
     pub notify_id: String,
     pub sender_pane_id: u64,
-    /// Context index the notification originated from (stamped at drain time).
-    pub source_context: usize,
+    /// Stable context identity the notification originated from (stamped at drain time).
+    pub source_context_id: u64,
     pub level: String,
     pub title: String,
     pub body: String,
@@ -216,10 +216,10 @@ pub struct PlexiApp {
     pub(crate) host: crate::host::model::HostModel,
     pub(crate) host_services: crate::host::services::HostServices,
     /// Parked background ProcessApps — kept alive when their pane is closed.
-    /// Keyed by app type_id. Value is `(park_context_idx, app)` where
-    /// `park_context_idx` is the window index the app was running in when its
+    /// Keyed by app type_id. Value is `(park_context_id, app)` where
+    /// `park_context_id` is the context_id the app was running in when its
     /// pane was closed. Used to route notifications to the correct context.
-    pub(crate) background_apps: HashMap<String, (usize, Box<crate::process_app::ProcessApp>)>,
+    pub(crate) background_apps: HashMap<String, (u64, Box<crate::process_app::ProcessApp>)>,
     /// Directed inter-agent / inter-app pipes (#286). Keyed by `pipe_id`,
     /// value is the `(sender_pane_id, target_pane_id)` pair the host must
     /// scope `PipeMessage` deliveries to. `DeliverPipeMessage` consults this
@@ -1062,7 +1062,7 @@ impl PlexiApp {
                     self.pending_notifications.push(PendingNotification {
                         notify_id: internal_id.clone(),
                         sender_pane_id: 0,
-                        source_context: self.router.active_idx(),
+                        source_context_id: self.router.active().context_id,
                         scope: crate::app_protocol::NotifyScope::Global,
                         level: level.clone(),
                         title: title.clone(),
@@ -1226,7 +1226,7 @@ impl PlexiApp {
             crate::app_protocol::NotifyScope::Global => true,
             crate::app_protocol::NotifyScope::Window
             | crate::app_protocol::NotifyScope::Context => {
-                n.source_context == self.router.active_idx()
+                n.source_context_id == self.router.active().context_id
             }
         }
     }
@@ -1351,10 +1351,11 @@ impl PlexiApp {
         }
     }
 
-    /// Count of window- or context-scoped notifications whose source_context == ctx_idx.
+    /// Count of window- or context-scoped notifications whose source_context_id == the id of ctx_idx.
     /// Used for per-context sidebar badges on inactive contexts. Global notifications
     /// are excluded — they already appear everywhere via notification_is_visible.
     pub(crate) fn context_notification_count(&self, ctx_idx: usize) -> usize {
+        let ctx_id = self.router.get(ctx_idx).context_id;
         self.pending_notifications
             .iter()
             .filter(|n| {
@@ -1363,7 +1364,7 @@ impl PlexiApp {
                     crate::app_protocol::NotifyScope::Window
                         | crate::app_protocol::NotifyScope::Context
                 )
-                && n.source_context == ctx_idx
+                && n.source_context_id == ctx_id
             })
             .count()
     }
@@ -1645,7 +1646,7 @@ impl eframe::App for PlexiApp {
                 AppCommand::ShowNotification {
                     notify_id,
                     sender_pane_id,
-                    source_context,
+                    source_context_id,
                     level,
                     title,
                     body,
@@ -1665,9 +1666,9 @@ impl eframe::App for PlexiApp {
                         continue;
                     }
                     let new_id = notify_id.clone();
-                    // Capture scope/source_context before they move into the struct.
+                    // Capture scope/source_context_id before they move into the struct.
                     let notif_scope = scope;
-                    let notif_source_ctx = source_context;
+                    let notif_source_ctx = source_context_id;
                     // Strip any per-option shortcut that conflicts with navigation keys.
                     let options: Vec<crate::app_protocol::NotifyOption> = options.into_iter().map(|mut opt| {
                         if let Some(ref sc) = opt.shortcut.clone() {
@@ -1684,7 +1685,7 @@ impl eframe::App for PlexiApp {
                     self.pending_notifications.push(PendingNotification {
                         notify_id,
                         sender_pane_id,
-                        source_context,
+                        source_context_id,
                         level,
                         title,
                         body,
@@ -1704,7 +1705,7 @@ impl eframe::App for PlexiApp {
                     });
                     // Auto-open rules:
                     //   1. Visibility — Global always; Window/Context only when
-                    //      source_context == active context.
+                    //      source_context_id == active context id.
                     //   2. focus_mode off — the global mute gate.
                     //   3. priority >= interrupt_threshold — don't
                     //      auto-open low-urgency notifications like
@@ -1715,7 +1716,7 @@ impl eframe::App for PlexiApp {
                         crate::app_protocol::NotifyScope::Global => true,
                         crate::app_protocol::NotifyScope::Window
                         | crate::app_protocol::NotifyScope::Context => {
-                            notif_source_ctx == self.router.active_idx()
+                            notif_source_ctx == self.router.active().context_id
                         }
                     };
                     let should_auto_open = is_visible

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -58,9 +58,8 @@ pub enum AppCommand {
     ShowNotification {
         notify_id: String,
         sender_pane_id: u64,
-        /// Context index the notification originated from. Stamped by
-        /// `drain_all_app_commands` with the index of the originating context.
-        source_context: usize,
+        /// Stable context identity the notification originated from.
+        source_context_id: u64,
         level: String,
         title: String,
         body: String,

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -490,7 +490,7 @@ impl PlexiApp {
             });
 
         // Re-attach a parked background app if one is waiting
-        if let Some((_park_ctx, mut parked)) = self.background_apps.remove(id) {
+        if let Some((_park_context_id, mut parked)) = self.background_apps.remove(id) {
             log::info!("re-attaching background app '{id}'");
             parked.send_event(&crate::app_protocol::PlexiEvent::Resume);
             self.open_process_app_pane(id, *parked, cwd, group, hint.as_deref());

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -589,7 +589,7 @@ impl PlexiApp {
                     let type_id = process_app.type_id.clone();
                     if self.registry.is_background(&type_id) {
                         process_app.send_event(&crate::app_protocol::PlexiEvent::Suspend);
-                        let park_context_id = self.windows[self.active_window].context_id;
+                        let park_context_id = self.windows[ctx_idx].context_id;
                         log::info!("parking background app '{type_id}' in context_id {park_context_id}");
                         self.background_apps.insert(type_id, (park_context_id, process_app));
                     }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -589,9 +589,9 @@ impl PlexiApp {
                     let type_id = process_app.type_id.clone();
                     if self.registry.is_background(&type_id) {
                         process_app.send_event(&crate::app_protocol::PlexiEvent::Suspend);
-                        let park_ctx = self.active_window;
-                        log::info!("parking background app '{type_id}' in context {park_ctx}");
-                        self.background_apps.insert(type_id, (park_ctx, process_app));
+                        let park_context_id = self.windows[self.active_window].context_id;
+                        log::info!("parking background app '{type_id}' in context_id {park_context_id}");
+                        self.background_apps.insert(type_id, (park_context_id, process_app));
                     }
                     // else: process_app drops here — Drop impl sends Shutdown + kills process
                 }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -139,7 +139,7 @@ impl PlexiApp {
         // Notifications scoped to this context are dropped.
         self.pending_notifications.retain(|n| {
             !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
-                && n.source_context == ws_index)
+                && n.source_context_id == ws_id)
         });
         if let Some(ref id) = self.current_notify_id.clone() {
             let still_present = self.pending_notifications.iter().any(|n| &n.notify_id == id);

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -366,7 +366,7 @@ impl ProcessApp {
                 self.pending_commands.push(AppCommand::ShowNotification {
                     notify_id: panel_id,
                     sender_pane_id: 0, // stamped by dispatch.rs with the real pane_id
-                    source_context: 0, // stamped by dispatch.rs with the real ctx_idx
+                    source_context_id: 0, // stamped by dispatch.rs with the real context_id
                     level,
                     title,
                     body,


### PR DESCRIPTION
Fixes #962.

## What changed

`PendingNotification.source_context: usize` stored a positional index that silently migrated notifications to the wrong context whenever contexts were reordered (swap, move-to-top, drag).

Replaced with `source_context_id: u64` — the stable monotonic `Context.context_id` that is never reused or shifted by reorders. Same fix applied to `background_apps: HashMap<String, (usize, Box<...>)>` → `(u64, Box<...>)` so parked-app context association is equally stable.

## Sites changed (7 files, 41+/43-)

- `src/app_trait.rs` — `AppCommand::ShowNotification` variant field renamed
- `src/app/mod.rs` — struct field, `background_apps` tuple type, stamp site, `notification_is_visible`, `context_notification_count`, match arm
- `src/app/dispatch.rs` — live-pane stamp uses `window.context_id` directly (drops the `router.position()` lookup); parked-app stamp uses stored `park_context_id`; regression test updated
- `src/pane_ops/layout.rs` — park stamp stores `context_id` not window index
- `src/pane_ops/workspace.rs` — delete_context filter matches by `ws_id` (already resolved, not the shifting index)
- `src/process_app/routing.rs` — stub placeholder renamed
- `src/pane_ops/create.rs` — unused binding renamed

## Testing

327 tests pass. The existing regression test (`parked_app_notification_uses_park_context`) was updated to assert on `source_context_id` with a stable u64 park id.

No binary behavior change is verifiable without a running host + context reorder. The fix is structural — all comparisons now use stable ids so reordering contexts cannot affect notification attribution.