### PR TITLE
feat(cli): plexi terminal <cmd> stays alive by default; --ephemeral opts into exit-on-complete

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,17 @@ pub(crate) mod notification_image;
 mod sync;
 
 /// Returns true for old auto-generated window names ("Page 3,1", "Context 2")
+/// Build a shell command string from an args list for passing to `zsh -c <cmd>`.
+/// A single arg is used as-is (it's already a shell expression — CLI path).
+/// Multiple args are joined with shell quoting so word-splitting is preserved.
+fn cmd_from_args(args: &[String]) -> Option<String> {
+    match args {
+        [] => None,
+        [single] => Some(single.clone()),
+        multiple => Some(crate::shell::shell_join(multiple)),
+    }
+}
+
 /// written before windows defaulted to an empty name. Stripped on load so they
 /// don't appear as user-given names in the command palette.
 fn is_auto_window_name(name: &str) -> bool {
@@ -995,7 +1006,7 @@ impl PlexiApp {
                     let new_pane_id = self.host.next_pane_id();
                     if type_id == "terminal" {
                         let vertical = matches!(layout.as_str(), "split_h" | "split_above");
-                        let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(args)) };
+                        let initial_cmd = cmd_from_args(args);
                         log::info!("pane_ipc: spawn_pane terminal vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
                         self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
                     } else {
@@ -1156,7 +1167,7 @@ impl PlexiApp {
             if type_id == "terminal" {
                 let layout_str = layout.as_deref().unwrap_or("split_v");
                 let vertical = matches!(layout_str, "split_h" | "split_above");
-                let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(&args)) };
+                let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral);
             } else {
                 self.launch_app_by_id_with_layout(&type_id, layout, &args);
@@ -1582,11 +1593,7 @@ impl eframe::App for PlexiApp {
                         //   split_focused(true)  → insert_vertical_tile   → stacked (BELOW)
                         // So: split_v (right) → false, split_h/split_above (below) → true.
                         let vertical = matches!(layout.as_str(), "split_h" | "split_above");
-                        let initial_cmd = if effective_args.is_empty() {
-                            None
-                        } else {
-                            Some(crate::shell::shell_join(&effective_args))
-                        };
+                        let initial_cmd = cmd_from_args(&effective_args);
                         log::info!(
                             "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
                         );

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -228,18 +228,28 @@ impl PlexiApp {
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors);
         if let Some(cmd) = initial_cmd {
-            log::info!("split_focused: initial_cmd={cmd:?}");
+            log::info!("split_focused: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             let shell_name = std::path::Path::new(&settings.shell)
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("");
+            // When staying alive (not ephemeral), append `; exec $SHELL -i -l` so the pane
+            // drops into an interactive shell after the command completes instead of dying.
             // `-i` sources ~/.zshrc so PATH additions (Homebrew, nvm, etc.) are
             // visible. Fish uses different flags; for other POSIX shells we use
             // the safe no-interactive fallback.
+            let effective_cmd: String = if !close_on_exit {
+                match shell_name {
+                    "fish" => format!("{cmd}; exec $SHELL --login -i"),
+                    _ => format!("{cmd}; exec $SHELL -i -l"),
+                }
+            } else {
+                cmd.to_string()
+            };
             settings.args = match shell_name {
-                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), cmd.to_string()],
-                "fish" => vec!["--login".to_string(), "-c".to_string(), cmd.to_string()],
-                _ => vec!["-l".to_string(), "-c".to_string(), cmd.to_string()],
+                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
+                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
+                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
             };
         }
         let Some(mut pane) = TerminalPane::new(

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -233,15 +233,20 @@ impl PlexiApp {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("");
-            // When staying alive (not ephemeral), append `; exec $SHELL -i -l` so the pane
+            // When staying alive (not ephemeral), append `; exec <shell> -i -l` so the pane
             // drops into an interactive shell after the command completes instead of dying.
+            // Use the absolute shell path from settings (already resolved) rather than $SHELL
+            // to guarantee the right shell. Trim trailing semicolons to avoid `;;` syntax errors.
             // `-i` sources ~/.zshrc so PATH additions (Homebrew, nvm, etc.) are
             // visible. Fish uses different flags; for other POSIX shells we use
             // the safe no-interactive fallback.
             let effective_cmd: String = if !close_on_exit {
+                let shell_path = &settings.shell;
+                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
+                let sep = if trimmed.is_empty() { "" } else { "; " };
                 match shell_name {
-                    "fish" => format!("{cmd}; exec $SHELL --login -i"),
-                    _ => format!("{cmd}; exec $SHELL -i -l"),
+                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
+                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
                 }
             } else {
                 cmd.to_string()


### PR DESCRIPTION
Closes #980

## Changes

Single change in `split_focused` (`src/pane_ops/layout.rs`): when `initial_cmd` is set and `close_on_exit` is false (the default for CLI-spawned terminals), the command string is suffixed with `; exec $SHELL -i -l` before being passed to the shell. This means after the command completes, a new interactive shell is launched in the same pane rather than the PTY dying.

When `close_on_exit` is true (`--ephemeral`), the command is left as-is — the pane closes when the process exits.

SDK-spawned terminals (`SpawnPane` via PGAP) are unaffected — they already pass `initial_cmd.is_some()` as `close_on_exit`, so they always get the old behavior.

## Done when

- `plexi terminal 'echo hello'` opens a pane, prints "hello", and leaves an interactive shell prompt
- `plexi terminal --ephemeral 'echo hello'` opens a pane, prints "hello", and closes
- `plexi terminal` (no cmd) behaviour is unchanged