### PR TITLE
chore: reset version scheme to 0.0.100

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.5.90"
+version = "0.0.100"
 edition = "2021"
 
 [package.metadata.bundle]


### PR DESCRIPTION
## Summary
- Resets `Cargo.toml` version from `3.5.90` → `0.0.100`
- The `3.x` scheme overstated stability; `0.0.x` signals pre-release more honestly

## Test plan
- [ ] `plexi --version` returns `plexi 0.0.100` after install

Closes #821