### PR TITLE
feat(cli): plexi app link/unlink — register local app dirs with workspace

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -323,7 +323,7 @@ impl AppRegistry {
                 registry.scan_dir(&local_agents, RegistrySource::LocalAgent);
             }
             // Linked apps — registered via `plexi app link`, stored as absolute paths in
-            // `.plexi/links.toml`. Scanned after local_apps/agents so agents still shadow.
+            // `.plexi/links.toml`. Scanned last — linked entries shadow all other sources.
             let links_path = root.join(".plexi").join("links.toml");
             if links_path.exists() {
                 registry.scan_links(&links_path);
@@ -416,6 +416,10 @@ impl AppRegistry {
         };
         for raw_path in &parsed.links {
             let app_dir = PathBuf::from(raw_path);
+            if !app_dir.is_absolute() {
+                log::warn!("AppRegistry: skipping relative path in links.toml: {:?} (must be absolute)", raw_path);
+                continue;
+            }
             match self.load_app(&app_dir) {
                 Ok(installed) => {
                     let id = installed.manifest.id.clone();

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -5,6 +5,7 @@
 //! 1. `~/.plexi-<channel>/apps/<id>/manifest.toml` — global apps (lowest priority)
 //! 2. `<workspace_root>/.plexi/apps/<id>/manifest.toml` — local app (overrides global)
 //! 3. `<workspace_root>/.plexi/agents/<id>/manifest.toml` — local agent (overrides above)
+//! 4. `<linked_path>/manifest.toml` — linked apps (`.plexi/links.toml`)
 //!
 //! `workspace_root` is the nearest ancestor of the current working directory that
 //! contains a `.plexi/` directory; if none is found, only global apps are loaded.
@@ -243,6 +244,8 @@ pub enum RegistrySource {
     LocalApp,
     /// `<workspace_root>/.plexi/agents/<id>/`
     LocalAgent,
+    /// Linked via `.plexi/links.toml` — absolute path registered by `plexi app link`
+    Linked,
 }
 
 impl RegistrySource {
@@ -251,6 +254,7 @@ impl RegistrySource {
             RegistrySource::Global => "global",
             RegistrySource::LocalApp => "local-app",
             RegistrySource::LocalAgent => "local-agent",
+            RegistrySource::Linked => "linked",
         }
     }
 }
@@ -318,6 +322,12 @@ impl AppRegistry {
             if local_agents.is_dir() {
                 registry.scan_dir(&local_agents, RegistrySource::LocalAgent);
             }
+            // Linked apps — registered via `plexi app link`, stored as absolute paths in
+            // `.plexi/links.toml`. Scanned after local_apps/agents so agents still shadow.
+            let links_path = root.join(".plexi").join("links.toml");
+            if links_path.exists() {
+                registry.scan_links(&links_path);
+            }
         }
 
         registry
@@ -374,6 +384,63 @@ impl AppRegistry {
                 }
                 Err(e) => {
                     log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());
+                }
+            }
+        }
+    }
+
+    /// Parse `.plexi/links.toml` and load each listed absolute path as a linked app.
+    /// links.toml format:
+    /// ```toml
+    /// links = ["/abs/path/to/app1", "/abs/path/to/app2"]
+    /// ```
+    fn scan_links(&mut self, links_path: &Path) {
+        let content = match std::fs::read_to_string(links_path) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("AppRegistry: failed to read {:?}: {e}", links_path);
+                return;
+            }
+        };
+        #[derive(serde::Deserialize)]
+        struct LinksFile {
+            #[serde(default)]
+            links: Vec<String>,
+        }
+        let parsed: LinksFile = match toml::from_str(&content) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("AppRegistry: failed to parse {:?}: {e}", links_path);
+                return;
+            }
+        };
+        for raw_path in &parsed.links {
+            let app_dir = PathBuf::from(raw_path);
+            match self.load_app(&app_dir) {
+                Ok(installed) => {
+                    let id = installed.manifest.id.clone();
+                    if let Some(existing) = self.apps.get(&id) {
+                        log::debug!(
+                            "AppRegistry: linked entry '{}' (from {:?}) shadows {} entry from {:?}",
+                            id,
+                            app_dir,
+                            existing.source.label(),
+                            existing.bin_path.parent().unwrap_or(&existing.bin_path),
+                        );
+                    } else {
+                        log::debug!(
+                            "AppRegistry: loaded linked entry '{}' from {:?}",
+                            id,
+                            app_dir,
+                        );
+                    }
+                    for ext in &installed.manifest.capabilities.file_types {
+                        self.extension_map.insert(ext.to_lowercase(), id.clone());
+                    }
+                    self.apps.insert(id, InstalledApp { source: RegistrySource::Linked, ..installed });
+                }
+                Err(e) => {
+                    log::warn!("AppRegistry: skipping linked path {:?}: {e}", app_dir);
                 }
             }
         }
@@ -983,6 +1050,48 @@ notification_scope = \"global\"
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         let scope = registry.default_notification_scope_for("stand-up");
         assert_eq!(scope, crate::app_protocol::NotifyScope::Global);
+    }
+
+    #[test]
+    fn linked_app_appears_in_registry() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        // Create workspace .plexi dir
+        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
+        // Create app directory outside .plexi/ — write_app creates <parent>/<id>/ subdir
+        let apps_parent = workspace.path().join("apps");
+        fs::create_dir_all(&apps_parent).unwrap();
+        write_app(&apps_parent, "linked-app", "Linked App");
+        let app_dir = apps_parent.join("linked-app");
+        // Write links.toml
+        let links_toml = format!("links = [{:?}]\n", app_dir.to_string_lossy());
+        fs::write(workspace.path().join(".plexi").join("links.toml"), links_toml).unwrap();
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let app = registry.get("linked-app").expect("linked app must appear in registry");
+        assert_eq!(app.source, RegistrySource::Linked);
+    }
+
+    #[test]
+    fn linked_app_shadows_global_with_same_id() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        // Global install of "my-app"
+        write_app(global.path(), "my-app", "Global My App");
+        // Workspace .plexi dir
+        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
+        // Linked version of same id — write_app creates <parent>/<id>/ subdir
+        let apps_parent = workspace.path().join("apps");
+        fs::create_dir_all(&apps_parent).unwrap();
+        write_app(&apps_parent, "my-app", "Linked My App");
+        let linked_app = apps_parent.join("my-app");
+        let links_toml = format!("links = [{:?}]\n", linked_app.to_string_lossy());
+        fs::write(workspace.path().join(".plexi").join("links.toml"), links_toml).unwrap();
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let app = registry.get("my-app").expect("my-app must be in registry");
+        assert_eq!(app.source, RegistrySource::Linked, "linked must shadow global");
+        assert_eq!(app.manifest.name, "Linked My App");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -463,7 +463,9 @@ pub fn workspace_secret_delete(friendly: &str) -> i32 {
 
 // ── plexi app subcommands ─────────────────────────────────────────────────────
 
-/// `plexi app init [--lang python|rust] <name>` — scaffold a new app in `.plexi/apps/<name>/`.
+/// `plexi app init [--lang python|rust] <name>` — scaffold a new app.
+/// Inside a workspace: scaffolds in `./apps/<name>/` and auto-links.
+/// Without a workspace: scaffolds in `./<name>/`.
 pub fn app_init(name: &str, lang: &str) -> i32 {
     if name.is_empty() {
         eprintln!("Usage: plexi app init [--lang python|rust] <name>");
@@ -478,7 +480,13 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
         }
     };
 
-    let app_dir = cwd.join(".plexi").join("apps").join(name);
+    let workspace_root = crate::app_registry::resolve_workspace_root(&cwd);
+    let (app_dir, should_link) = if workspace_root.is_some() {
+        (cwd.join("apps").join(name), true)
+    } else {
+        (cwd.join(name), false)
+    };
+
     if app_dir.exists() {
         eprintln!("error: {} already exists", app_dir.display());
         return 1;
@@ -497,6 +505,13 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
     match result {
         Ok(()) => {
             println!("Created app '{name}' at {}", app_dir.display());
+            if should_link {
+                let path_str = app_dir.to_string_lossy().to_string();
+                let rc = app_link(&path_str);
+                if rc != 0 {
+                    eprintln!("warning: created app but auto-link failed (run `plexi app link {}` manually)", app_dir.display());
+                }
+            }
             if lang == "rust" {
                 println!("\nNext steps:");
                 println!("  cd {}", app_dir.display());
@@ -593,6 +608,171 @@ pub fn app_uninstall(id: &str) -> i32 {
         return 1;
     }
     println!("Uninstalled '{id}'.");
+    0
+}
+
+/// `plexi app link <path>` — register a local app directory with the nearest workspace.
+pub fn app_link(path: &str) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: {e}"); return 1; }
+    };
+    let app_dir = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        cwd.join(path)
+    };
+    let app_dir = match app_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {path}: {e}");
+            return 1;
+        }
+    };
+    // Validate manifest.toml exists and is parseable
+    let manifest_path = app_dir.join("manifest.toml");
+    if !manifest_path.exists() {
+        eprintln!("error: no manifest.toml found in {}", app_dir.display());
+        eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
+        return 1;
+    }
+    let manifest_str = match std::fs::read_to_string(&manifest_path) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not read manifest.toml: {e}"); return 1; }
+    };
+    let manifest: toml::Value = match toml::from_str(&manifest_str) {
+        Ok(v) => v,
+        Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
+    };
+    let app_id = manifest
+        .get("app")
+        .and_then(|a| a.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+
+    let workspace_root = match crate::app_registry::resolve_workspace_root(&cwd) {
+        Some(r) => r,
+        None => {
+            eprintln!("error: no .plexi/ workspace found at or above {}.", cwd.display());
+            eprintln!("  Run `plexi workspace init` first.");
+            return 1;
+        }
+    };
+
+    log::info!(
+        "app_link:cli: linking {} as app '{}' in workspace {}",
+        app_dir.display(), app_id, workspace_root.display()
+    );
+
+    let links_path = workspace_root.join(".plexi").join("links.toml");
+    let abs_path = app_dir.to_string_lossy().to_string();
+
+    // Read existing links (or start fresh)
+    let mut links: Vec<String> = if links_path.exists() {
+        let content = match std::fs::read_to_string(&links_path) {
+            Ok(s) => s,
+            Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
+        };
+        #[derive(serde::Deserialize)]
+        struct LinksFile { #[serde(default)] links: Vec<String> }
+        match toml::from_str::<LinksFile>(&content) {
+            Ok(f) => f.links,
+            Err(e) => { eprintln!("error: could not parse links.toml: {e}"); return 1; }
+        }
+    } else {
+        Vec::new()
+    };
+
+    if links.contains(&abs_path) {
+        println!("Already linked: {}", app_dir.display());
+        return 0;
+    }
+
+    links.push(abs_path);
+
+    // Serialize back as TOML
+    let new_content = {
+        let entries: Vec<String> = links.iter().map(|p| format!("  {:?}", p)).collect();
+        format!("links = [\n{},\n]\n", entries.join(",\n"))
+    };
+
+    if let Err(e) = std::fs::write(&links_path, new_content) {
+        eprintln!("error: could not write links.toml: {e}");
+        return 1;
+    }
+
+    println!("Linked '{}' from {}", app_id, app_dir.display());
+    println!("  App will appear in the run palette on next launch or reload.");
+    0
+}
+
+/// `plexi app unlink <path>` — remove a linked app directory from the workspace registry.
+pub fn app_unlink(path: &str) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: {e}"); return 1; }
+    };
+    let app_dir = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        cwd.join(path)
+    };
+    // Try to canonicalize; fall back to the raw path if it doesn't exist
+    let app_dir = app_dir.canonicalize().unwrap_or(app_dir);
+    let abs_path = app_dir.to_string_lossy().to_string();
+
+    let workspace_root = match crate::app_registry::resolve_workspace_root(&cwd) {
+        Some(r) => r,
+        None => {
+            eprintln!("error: no .plexi/ workspace found at or above {}.", cwd.display());
+            eprintln!("  Run `plexi workspace init` first.");
+            return 1;
+        }
+    };
+
+    log::info!(
+        "app_unlink:cli: unlinking {} from workspace {}",
+        app_dir.display(), workspace_root.display()
+    );
+
+    let links_path = workspace_root.join(".plexi").join("links.toml");
+    if !links_path.exists() {
+        println!("Not linked (no links.toml found).");
+        return 0;
+    }
+
+    let content = match std::fs::read_to_string(&links_path) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
+    };
+    #[derive(serde::Deserialize)]
+    struct LinksFile { #[serde(default)] links: Vec<String> }
+    let mut links: Vec<String> = match toml::from_str::<LinksFile>(&content) {
+        Ok(f) => f.links,
+        Err(e) => { eprintln!("error: could not parse links.toml: {e}"); return 1; }
+    };
+
+    let before = links.len();
+    links.retain(|p| p != &abs_path);
+    if links.len() == before {
+        println!("Not found in links.toml: {}", app_dir.display());
+        return 0;
+    }
+
+    let new_content = if links.is_empty() {
+        "links = []\n".to_string()
+    } else {
+        let entries: Vec<String> = links.iter().map(|p| format!("  {:?}", p)).collect();
+        format!("links = [\n{},\n]\n", entries.join(",\n"))
+    };
+
+    if let Err(e) = std::fs::write(&links_path, new_content) {
+        eprintln!("error: could not write links.toml: {e}");
+        return 1;
+    }
+
+    println!("Unlinked: {}", app_dir.display());
     0
 }
 
@@ -1356,7 +1536,8 @@ pub fn list_cli() -> i32 {
         match app.source {
             crate::app_registry::RegistrySource::Global => globals.push(row),
             crate::app_registry::RegistrySource::LocalApp
-            | crate::app_registry::RegistrySource::LocalAgent => workspace.push(row),
+            | crate::app_registry::RegistrySource::LocalAgent
+            | crate::app_registry::RegistrySource::Linked => workspace.push(row),
         }
     }
     if !globals.is_empty() {
@@ -3075,7 +3256,7 @@ _plexi() {
           ;;
         app)
           local subcmds
-          subcmds=('init:Scaffold a new app' 'install:Install an app from GitHub' 'uninstall:Uninstall an app' 'list:List installed apps')
+          subcmds=('init:Scaffold a new app' 'install:Install an app from GitHub' 'uninstall:Uninstall an app' 'list:List installed apps' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
           _describe 'subcommand' subcmds
           ;;
         workspace)
@@ -3259,6 +3440,8 @@ complete -c plexi -f -n "__fish_seen_subcommand_from app" -a init -d "Scaffold a
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a install -d "Install an app from GitHub"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a uninstall -d "Uninstall an app"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a list -d "List installed apps"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a link -d "Register a local app directory with the workspace"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a unlink -d "Remove a linked app directory from the workspace"
 
 # workspace subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from workspace" -a init -d "Initialise a .plexi/ workspace"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -644,12 +644,13 @@ pub fn app_link(path: &str) -> i32 {
         Ok(v) => v,
         Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
     };
-    let app_id = manifest
-        .get("app")
-        .and_then(|a| a.get("id"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("<unknown>")
-        .to_string();
+    let app_id = match manifest.get("app").and_then(|a| a.get("id")).and_then(|v| v.as_str()) {
+        Some(id) if !id.is_empty() => id.to_string(),
+        _ => {
+            eprintln!("error: manifest.toml is missing a valid [app].id");
+            return 1;
+        }
+    };
 
     let workspace_root = match crate::app_registry::resolve_workspace_root(&cwd) {
         Some(r) => r,
@@ -668,14 +669,15 @@ pub fn app_link(path: &str) -> i32 {
     let links_path = workspace_root.join(".plexi").join("links.toml");
     let abs_path = app_dir.to_string_lossy().to_string();
 
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct LinksFile { #[serde(default)] links: Vec<String> }
+
     // Read existing links (or start fresh)
     let mut links: Vec<String> = if links_path.exists() {
         let content = match std::fs::read_to_string(&links_path) {
             Ok(s) => s,
             Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
         };
-        #[derive(serde::Deserialize)]
-        struct LinksFile { #[serde(default)] links: Vec<String> }
         match toml::from_str::<LinksFile>(&content) {
             Ok(f) => f.links,
             Err(e) => { eprintln!("error: could not parse links.toml: {e}"); return 1; }
@@ -691,10 +693,9 @@ pub fn app_link(path: &str) -> i32 {
 
     links.push(abs_path);
 
-    // Serialize back as TOML
-    let new_content = {
-        let entries: Vec<String> = links.iter().map(|p| format!("  {:?}", p)).collect();
-        format!("links = [\n{},\n]\n", entries.join(",\n"))
+    let new_content = match toml::to_string_pretty(&LinksFile { links }) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not serialize links.toml: {e}"); return 1; }
     };
 
     if let Err(e) = std::fs::write(&links_path, new_content) {
@@ -746,7 +747,7 @@ pub fn app_unlink(path: &str) -> i32 {
         Ok(s) => s,
         Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
     };
-    #[derive(serde::Deserialize)]
+    #[derive(serde::Deserialize, serde::Serialize)]
     struct LinksFile { #[serde(default)] links: Vec<String> }
     let mut links: Vec<String> = match toml::from_str::<LinksFile>(&content) {
         Ok(f) => f.links,
@@ -760,11 +761,9 @@ pub fn app_unlink(path: &str) -> i32 {
         return 0;
     }
 
-    let new_content = if links.is_empty() {
-        "links = []\n".to_string()
-    } else {
-        let entries: Vec<String> = links.iter().map(|p| format!("  {:?}", p)).collect();
-        format!("links = [\n{},\n]\n", entries.join(",\n"))
+    let new_content = match toml::to_string_pretty(&LinksFile { links }) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not serialize links.toml: {e}"); return 1; }
     };
 
     if let Err(e) = std::fs::write(&links_path, new_content) {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -226,6 +226,16 @@ pub enum AppCmd {
     Info {
         id: String,
     },
+    /// Register a local app directory with the workspace (does not move files)
+    Link {
+        /// Path to the app directory containing manifest.toml
+        path: String,
+    },
+    /// Remove a linked app directory from the workspace registry
+    Unlink {
+        /// Path to the app directory (same path used with `link`)
+        path: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,8 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
                         }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
+                        AppCmd::Link { path } => std::process::exit(cli::app_link(&path)),
+                        AppCmd::Unlink { path } => std::process::exit(cli::app_unlink(&path)),
                     },
                     Commands::Install { spec, pack } => {
                         if let Some(p) = pack {


### PR DESCRIPTION
## Summary

- `plexi app link <path>` — registers any directory with a `manifest.toml` with the nearest `.plexi/` workspace by writing an absolute path pointer into `.plexi/links.toml`. Validates the manifest exists and is parseable. Idempotent.
- `plexi app unlink <path>` — removes the pointer; does not delete files.
- `plexi app init` inside a workspace now scaffolds in `./apps/<name>/` and auto-links. Outside a workspace, scaffolds in `./<name>/`.
- `AppRegistry` gains a `RegistrySource::Linked` tier scanned from `.plexi/links.toml`. Linked apps shadow global installs and appear in `plexi app list` under "Workspace apps". Hot reload works for linked apps when `watch = true` in manifest.
- Completions updated (zsh + fish).

## links.toml format
\`\`\`toml
links = [
  "/abs/path/to/my-project/apps/color-grader",
]
\`\`\`

## Test plan
- [ ] \`plexi app link ./apps/my-app\` inside a workspace → app appears in \`plexi app list\`
- [ ] \`plexi app unlink ./apps/my-app\` → app disappears from list
- [ ] \`plexi app link <path-with-no-manifest>\` → clear error
- [ ] \`plexi app init my-app\` inside a workspace → scaffolds in \`./apps/my-app/\` and auto-links
- [ ] \`plexi app init my-app\` outside a workspace → scaffolds in \`./my-app/\`
- [ ] \`cargo test --lib\` passes (46 tests)

Closes #969