### PR TITLE
feat(config): user-configurable keybindings in config.toml

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -171,6 +171,7 @@ pub struct PlexiApp {
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
+    pub(crate) key_bindings: crate::keys::KeyBindings,
     pub(crate) voice_config: crate::config::VoiceConfig,
     pub(crate) renaming_window: Option<usize>,
     pub(crate) rename_buffer: String,
@@ -352,6 +353,7 @@ impl PlexiApp {
         // project fields preserve the global value.
         let active_workspace = config::active_workspace_root();
         let config = config::PlexiConfig::load_with_workspace(active_workspace.as_deref());
+        let key_bindings = crate::keys::build_key_bindings(config.keybindings.as_ref());
         let voice_config = config::VoiceConfig::load_with_workspace(active_workspace.as_deref());
         log::info!(
             "voice: config loaded at startup — enabled={}",
@@ -593,6 +595,7 @@ impl PlexiApp {
                     quit_press_count: 0,
                     quit_last_press: None,
                     config: config.clone(),
+                    key_bindings: key_bindings.clone(),
                     voice_config: voice_config.clone(),
                     pending_close: false,
                     frame_tick: frame_tick.clone(),
@@ -684,6 +687,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             config,
+            key_bindings,
             voice_config,
             pending_close: false,
             frame_tick,
@@ -739,6 +743,7 @@ impl PlexiApp {
         frame_tick: crate::logging::FrameTick,
     ) -> (Self, std::sync::mpsc::Sender<crate::app_protocol::HostCommand>) {
         let config = config::PlexiConfig::default();
+        let key_bindings = crate::keys::build_key_bindings(config.keybindings.as_ref());
         let theme_cfg = Self::resolve_theme_config(&config);
         let colors = Colors::from_config(&theme_cfg);
         configure_egui_ctx(&ctx, &colors);
@@ -784,6 +789,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             config,
+            key_bindings,
             voice_config: config::VoiceConfig::default(),
             pending_close: false,
             frame_tick,
@@ -2055,7 +2061,7 @@ impl eframe::App for PlexiApp {
 
         // Handle keyboard shortcuts
         let modal_open = self.show_notification_modal;
-        for action in keys::poll_actions(ctx, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
+        for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
@@ -2980,6 +2986,8 @@ impl PlexiApp {
 
         // Replace the cached config
         self.config = fresh;
+        self.key_bindings = crate::keys::build_key_bindings(self.config.keybindings.as_ref());
+        log::info!("keybindings: rebuilt after config reload");
 
         // Voice config
         let fresh_voice =

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,111 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+/// Per-action keybinding overrides. Each field is the name of an action;
+/// the value is a key combo string like `"cmd+d"` or `"cmd+shift+d"`.
+/// Omitting a field preserves the default binding for that action.
+/// Format: `[modifier+]...[modifier+]key` (case-insensitive).
+/// Modifiers: cmd/command, shift, ctrl/control, alt/opt/option.
+/// Keys: a-z, 0-9, enter, escape/esc, tab, space, backspace, up, down,
+///   left, right, [ ] \ / , . = + - and named aliases.
+#[derive(Deserialize, Default, Clone)]
+pub struct KeybindingsConfig {
+    pub quit: Option<String>,
+    pub close_pane: Option<String>,
+    pub toggle_command_palette: Option<String>,
+    pub split_horizontal: Option<String>,
+    pub split_vertical: Option<String>,
+    pub split_right: Option<String>,
+    pub split_down: Option<String>,
+    pub page_left: Option<String>,
+    pub page_down: Option<String>,
+    pub page_up: Option<String>,
+    pub page_right: Option<String>,
+    pub swap_pane_left: Option<String>,
+    pub swap_pane_down: Option<String>,
+    pub swap_pane_up: Option<String>,
+    pub swap_pane_right: Option<String>,
+    pub navigate_left: Option<String>,
+    pub navigate_down: Option<String>,
+    pub navigate_up: Option<String>,
+    pub navigate_right: Option<String>,
+    pub new_tab: Option<String>,
+    pub next_tab: Option<String>,
+    pub nav_back: Option<String>,
+    pub toggle_sidebar: Option<String>,
+    pub toggle_zoom: Option<String>,
+    pub toggle_shortcuts: Option<String>,
+    pub rename_context: Option<String>,
+    pub rename_pane: Option<String>,
+    pub new_context: Option<String>,
+    pub new_page_right: Option<String>,
+    pub toggle_minimap: Option<String>,
+    pub scroll_up: Option<String>,
+    pub scroll_down: Option<String>,
+    pub increase_font_size: Option<String>,
+    pub decrease_font_size: Option<String>,
+    pub open_file_browser: Option<String>,
+    pub open_quick_note: Option<String>,
+    pub open_config: Option<String>,
+    pub reload_config: Option<String>,
+    pub open_secrets_manager: Option<String>,
+    pub force_reload_app: Option<String>,
+    pub toggle_notification_modal: Option<String>,
+}
+
+impl KeybindingsConfig {
+    fn overlay(&mut self, other: Self) {
+        macro_rules! overlay_field {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field;
+                }
+            };
+        }
+        overlay_field!(quit);
+        overlay_field!(close_pane);
+        overlay_field!(toggle_command_palette);
+        overlay_field!(split_horizontal);
+        overlay_field!(split_vertical);
+        overlay_field!(split_right);
+        overlay_field!(split_down);
+        overlay_field!(page_left);
+        overlay_field!(page_down);
+        overlay_field!(page_up);
+        overlay_field!(page_right);
+        overlay_field!(swap_pane_left);
+        overlay_field!(swap_pane_down);
+        overlay_field!(swap_pane_up);
+        overlay_field!(swap_pane_right);
+        overlay_field!(navigate_left);
+        overlay_field!(navigate_down);
+        overlay_field!(navigate_up);
+        overlay_field!(navigate_right);
+        overlay_field!(new_tab);
+        overlay_field!(next_tab);
+        overlay_field!(nav_back);
+        overlay_field!(toggle_sidebar);
+        overlay_field!(toggle_zoom);
+        overlay_field!(toggle_shortcuts);
+        overlay_field!(rename_context);
+        overlay_field!(rename_pane);
+        overlay_field!(new_context);
+        overlay_field!(new_page_right);
+        overlay_field!(toggle_minimap);
+        overlay_field!(scroll_up);
+        overlay_field!(scroll_down);
+        overlay_field!(increase_font_size);
+        overlay_field!(decrease_font_size);
+        overlay_field!(open_file_browser);
+        overlay_field!(open_quick_note);
+        overlay_field!(open_config);
+        overlay_field!(reload_config);
+        overlay_field!(open_secrets_manager);
+        overlay_field!(force_reload_app);
+        overlay_field!(toggle_notification_modal);
+    }
+}
+
 #[derive(Deserialize, Default, Clone)]
 pub struct PlexiConfig {
     pub font_size: Option<f32>,
@@ -14,6 +119,7 @@ pub struct PlexiConfig {
     pub confirm_quit: Option<bool>,
     /// Set to false to close panes immediately on Cmd+W without a confirmation dialog (default: true).
     pub confirm_close: Option<bool>,
+    pub keybindings: Option<KeybindingsConfig>,
 }
 
 /// Plexi AI broker configuration (`ai.query` capability).
@@ -452,6 +558,56 @@ model_high   = "anthropic/claude-opus-4-7"
 # ── Logging ────────────────────────────────────────────────────
 # [log]
 # level = "info"   # error | warn | info | debug  (default: info)
+
+# ── Keybindings ────────────────────────────────────────────────
+# Override any default keybinding. Format: "modifier+key" (case-insensitive).
+# Modifiers: cmd, shift, ctrl, alt (aliases: command, control, opt, option).
+# Keys: a-z, 0-9, enter, escape, tab, space, backspace, up, down,
+#   left, right, open_bracket, close_bracket, backslash, slash, comma,
+#   period, equals, minus.
+# Unknown keys or conflicting overrides log an error at startup.
+# [keybindings]
+# quit                    = "cmd+q"
+# close_pane              = "cmd+w"
+# toggle_command_palette  = "cmd+p"
+# split_horizontal        = "cmd+d"
+# split_vertical          = "cmd+shift+d"
+# split_right             = "cmd+backslash"
+# split_down              = "cmd+shift+backslash"
+# navigate_left           = "cmd+h"
+# navigate_down           = "cmd+j"
+# navigate_up             = "cmd+k"
+# navigate_right          = "cmd+l"
+# page_left               = "cmd+shift+h"
+# page_down               = "cmd+shift+j"
+# page_up                 = "cmd+shift+k"
+# page_right              = "cmd+shift+l"
+# swap_pane_left          = "cmd+ctrl+h"
+# swap_pane_down          = "cmd+ctrl+j"
+# swap_pane_up            = "cmd+ctrl+k"
+# swap_pane_right         = "cmd+ctrl+l"
+# new_tab                 = "cmd+t"
+# next_tab                = "cmd+close_bracket"
+# nav_back                = "cmd+open_bracket"
+# toggle_sidebar          = "cmd+b"
+# toggle_zoom             = "cmd+enter"
+# toggle_shortcuts        = "cmd+slash"
+# rename_pane             = "cmd+r"
+# rename_context          = "cmd+shift+r"
+# new_page_right          = "cmd+n"
+# new_context             = "cmd+shift+n"
+# toggle_minimap          = "cmd+shift+m"
+# scroll_up               = "cmd+up"
+# scroll_down             = "cmd+down"
+# increase_font_size      = "cmd+equals"
+# decrease_font_size      = "cmd+minus"
+# open_file_browser       = "cmd+e"
+# open_quick_note         = "cmd+0"
+# open_config             = "cmd+comma"
+# reload_config           = "cmd+shift+comma"
+# open_secrets_manager    = "cmd+shift+s"
+# force_reload_app        = "cmd+alt+r"
+# toggle_notification_modal = "cmd+shift+a"
 "##;
 
 pub fn open_config_file() {
@@ -562,6 +718,11 @@ impl PlexiConfig {
         match (self.ai.as_mut(), other.ai) {
             (Some(existing), Some(incoming)) => existing.overlay(incoming),
             (None, Some(incoming)) => self.ai = Some(incoming),
+            _ => {}
+        }
+        match (self.keybindings.as_mut(), other.keybindings) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.keybindings = Some(incoming),
             _ => {}
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,9 @@ use std::path::{Path, PathBuf};
 /// Omitting a field preserves the default binding for that action.
 /// Format: `[modifier+]...[modifier+]key` (case-insensitive).
 /// Modifiers: cmd/command, shift, ctrl/control, alt/opt/option.
-/// Keys: a-z, 0-9, enter, escape/esc, tab, space, backspace, up, down,
-///   left, right, [ ] \ / , . = + - and named aliases.
+/// Keys: a-z, 0-9, enter, escape, tab, space, backspace, delete, up, down,
+///   left, right, open_bracket, close_bracket, backslash, slash, comma,
+///   period, equals, minus (and symbol aliases like "[", "]", "\\", etc.).
 #[derive(Deserialize, Default, Clone)]
 pub struct KeybindingsConfig {
     pub quit: Option<String>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -273,7 +273,8 @@ fn parse_key_combo(s: &str) -> Option<(egui::Modifiers, egui::Key)> {
         "escape" | "esc" => egui::Key::Escape,
         "tab" => egui::Key::Tab,
         "space" => egui::Key::Space,
-        "backspace" | "delete" => egui::Key::Backspace,
+        "backspace" => egui::Key::Backspace,
+        "delete" | "del" => egui::Key::Delete,
         "up" | "arrowup" => egui::Key::ArrowUp,
         "down" | "arrowdown" => egui::Key::ArrowDown,
         "left" | "arrowleft" => egui::Key::ArrowLeft,
@@ -312,11 +313,13 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         return bindings;
     };
 
+    let mut override_count: usize = 0;
     macro_rules! apply_override {
         ($field:ident, $name:expr) => {
             if let Some(ref s) = cfg.$field {
                 if let Some(combo) = parse_key_combo(s) {
                     bindings.$field = combo;
+                    override_count += 1;
                 } else {
                     log::warn!("keybindings: invalid combo '{}' for '{}' — keeping default", s, $name);
                 }
@@ -365,26 +368,6 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(open_secrets_manager, "open_secrets_manager");
     apply_override!(force_reload_app, "force_reload_app");
     apply_override!(toggle_notification_modal, "toggle_notification_modal");
-
-    // Count overrides applied
-    let mut override_count: usize = 0;
-    macro_rules! count_field {
-        ($field:ident) => { if cfg.$field.is_some() { override_count += 1; } };
-    }
-    count_field!(quit); count_field!(close_pane); count_field!(toggle_command_palette);
-    count_field!(split_horizontal); count_field!(split_vertical); count_field!(split_right);
-    count_field!(split_down); count_field!(page_left); count_field!(page_down);
-    count_field!(page_up); count_field!(page_right); count_field!(swap_pane_left);
-    count_field!(swap_pane_down); count_field!(swap_pane_up); count_field!(swap_pane_right);
-    count_field!(navigate_left); count_field!(navigate_down); count_field!(navigate_up);
-    count_field!(navigate_right); count_field!(new_tab); count_field!(next_tab);
-    count_field!(nav_back); count_field!(toggle_sidebar); count_field!(toggle_zoom);
-    count_field!(toggle_shortcuts); count_field!(rename_context); count_field!(rename_pane);
-    count_field!(new_context); count_field!(new_page_right); count_field!(toggle_minimap);
-    count_field!(scroll_up); count_field!(scroll_down); count_field!(increase_font_size);
-    count_field!(decrease_font_size); count_field!(open_file_browser); count_field!(open_quick_note);
-    count_field!(open_config); count_field!(reload_config); count_field!(open_secrets_manager);
-    count_field!(force_reload_app); count_field!(toggle_notification_modal);
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -559,7 +542,7 @@ pub fn poll_actions(
         // Rename context before rename pane — check shifted variant first.
         if input.consume_key(bindings.rename_context.0, bindings.rename_context.1) {
             actions.push(Action::RenameContext);
-        } else if !input.modifiers.alt
+        } else if input.modifiers == bindings.rename_pane.0
             && input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1)
         {
             actions.push(Action::RenamePane);
@@ -590,10 +573,10 @@ pub fn poll_actions(
             actions.push(Action::ScrollDown);
         }
 
-        if !input.modifiers.shift && input.consume_key(bindings.increase_font_size.0, bindings.increase_font_size.1) {
+        if input.modifiers == bindings.increase_font_size.0 && input.consume_key(bindings.increase_font_size.0, bindings.increase_font_size.1) {
             actions.push(Action::IncreasePaneFontSize);
         }
-        if !input.modifiers.shift && input.consume_key(bindings.decrease_font_size.0, bindings.decrease_font_size.1) {
+        if input.modifiers == bindings.decrease_font_size.0 && input.consume_key(bindings.decrease_font_size.0, bindings.decrease_font_size.1) {
             actions.push(Action::DecreasePaneFontSize);
         }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,3 +1,5 @@
+use crate::config::KeybindingsConfig;
+
 // ─── Reserved Plexi shortcuts (apps must NOT consume these) ───────────────
 //
 // Cmd+D / Cmd+Shift+D       — split horizontal / vertical (terminal)
@@ -117,6 +119,331 @@ pub enum Action {
     SwapPane(Direction),
 }
 
+/// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
+/// Built once at startup from defaults + config overrides via `build_key_bindings`.
+#[derive(Clone)]
+pub struct KeyBindings {
+    pub quit: (egui::Modifiers, egui::Key),
+    pub close_pane: (egui::Modifiers, egui::Key),
+    pub toggle_command_palette: (egui::Modifiers, egui::Key),
+    pub split_horizontal: (egui::Modifiers, egui::Key),
+    pub split_vertical: (egui::Modifiers, egui::Key),
+    pub split_right: (egui::Modifiers, egui::Key),
+    pub split_down: (egui::Modifiers, egui::Key),
+    pub page_left: (egui::Modifiers, egui::Key),
+    pub page_down: (egui::Modifiers, egui::Key),
+    pub page_up: (egui::Modifiers, egui::Key),
+    pub page_right: (egui::Modifiers, egui::Key),
+    pub swap_pane_left: (egui::Modifiers, egui::Key),
+    pub swap_pane_down: (egui::Modifiers, egui::Key),
+    pub swap_pane_up: (egui::Modifiers, egui::Key),
+    pub swap_pane_right: (egui::Modifiers, egui::Key),
+    pub navigate_left: (egui::Modifiers, egui::Key),
+    pub navigate_down: (egui::Modifiers, egui::Key),
+    pub navigate_up: (egui::Modifiers, egui::Key),
+    pub navigate_right: (egui::Modifiers, egui::Key),
+    pub new_tab: (egui::Modifiers, egui::Key),
+    pub next_tab: (egui::Modifiers, egui::Key),
+    pub nav_back: (egui::Modifiers, egui::Key),
+    pub toggle_sidebar: (egui::Modifiers, egui::Key),
+    pub toggle_zoom: (egui::Modifiers, egui::Key),
+    pub toggle_shortcuts: (egui::Modifiers, egui::Key),
+    pub rename_context: (egui::Modifiers, egui::Key),
+    pub rename_pane: (egui::Modifiers, egui::Key),
+    pub new_context: (egui::Modifiers, egui::Key),
+    pub new_page_right: (egui::Modifiers, egui::Key),
+    pub toggle_minimap: (egui::Modifiers, egui::Key),
+    pub scroll_up: (egui::Modifiers, egui::Key),
+    pub scroll_down: (egui::Modifiers, egui::Key),
+    pub increase_font_size: (egui::Modifiers, egui::Key),
+    pub decrease_font_size: (egui::Modifiers, egui::Key),
+    pub open_file_browser: (egui::Modifiers, egui::Key),
+    pub open_quick_note: (egui::Modifiers, egui::Key),
+    pub open_config: (egui::Modifiers, egui::Key),
+    pub reload_config: (egui::Modifiers, egui::Key),
+    pub open_secrets_manager: (egui::Modifiers, egui::Key),
+    pub force_reload_app: (egui::Modifiers, egui::Key),
+    pub toggle_notification_modal: (egui::Modifiers, egui::Key),
+}
+
+fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
+fn cmd_shift() -> egui::Modifiers {
+    egui::Modifiers { shift: true, ..egui::Modifiers::COMMAND }
+}
+fn cmd_ctrl() -> egui::Modifiers {
+    egui::Modifiers { ctrl: true, ..egui::Modifiers::COMMAND }
+}
+fn cmd_alt() -> egui::Modifiers {
+    egui::Modifiers { alt: true, ..egui::Modifiers::COMMAND }
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        Self {
+            quit:                      (cmd(),       egui::Key::Q),
+            close_pane:                (cmd(),       egui::Key::W),
+            toggle_command_palette:    (cmd(),       egui::Key::P),
+            split_horizontal:          (cmd(),       egui::Key::D),
+            split_vertical:            (cmd_shift(), egui::Key::D),
+            split_right:               (cmd(),       egui::Key::Backslash),
+            split_down:                (cmd_shift(), egui::Key::Backslash),
+            page_left:                 (cmd_shift(), egui::Key::H),
+            page_down:                 (cmd_shift(), egui::Key::J),
+            page_up:                   (cmd_shift(), egui::Key::K),
+            page_right:                (cmd_shift(), egui::Key::L),
+            swap_pane_left:            (cmd_ctrl(),  egui::Key::H),
+            swap_pane_down:            (cmd_ctrl(),  egui::Key::J),
+            swap_pane_up:              (cmd_ctrl(),  egui::Key::K),
+            swap_pane_right:           (cmd_ctrl(),  egui::Key::L),
+            navigate_left:             (cmd(),       egui::Key::H),
+            navigate_down:             (cmd(),       egui::Key::J),
+            navigate_up:               (cmd(),       egui::Key::K),
+            navigate_right:            (cmd(),       egui::Key::L),
+            new_tab:                   (cmd(),       egui::Key::T),
+            next_tab:                  (cmd(),       egui::Key::CloseBracket),
+            nav_back:                  (cmd(),       egui::Key::OpenBracket),
+            toggle_sidebar:            (cmd(),       egui::Key::B),
+            toggle_zoom:               (cmd(),       egui::Key::Enter),
+            toggle_shortcuts:          (cmd(),       egui::Key::Slash),
+            rename_context:            (cmd_shift(), egui::Key::R),
+            rename_pane:               (cmd(),       egui::Key::R),
+            new_context:               (cmd_shift(), egui::Key::N),
+            new_page_right:            (cmd(),       egui::Key::N),
+            toggle_minimap:            (cmd_shift(), egui::Key::M),
+            scroll_up:                 (cmd(),       egui::Key::ArrowUp),
+            scroll_down:               (cmd(),       egui::Key::ArrowDown),
+            increase_font_size:        (cmd(),       egui::Key::Equals),
+            decrease_font_size:        (cmd(),       egui::Key::Minus),
+            open_file_browser:         (cmd(),       egui::Key::E),
+            open_quick_note:           (cmd(),       egui::Key::Num0),
+            open_config:               (cmd(),       egui::Key::Comma),
+            reload_config:             (cmd_shift(), egui::Key::Comma),
+            open_secrets_manager:      (cmd_shift(), egui::Key::S),
+            force_reload_app:          (cmd_alt(),   egui::Key::R),
+            toggle_notification_modal: (cmd_shift(), egui::Key::A),
+        }
+    }
+}
+
+/// Parse a key combo string like `"cmd+shift+d"` into `(Modifiers, Key)`.
+/// Returns `None` and logs a warning if the string is malformed or the key is unknown.
+fn parse_key_combo(s: &str) -> Option<(egui::Modifiers, egui::Key)> {
+    let parts: Vec<&str> = s.split('+').map(|p| p.trim()).collect();
+    if parts.is_empty() {
+        return None;
+    }
+    let (modifier_parts, key_part) = parts.split_at(parts.len() - 1);
+    let key_str = key_part[0].to_lowercase();
+
+    let mut mods = egui::Modifiers::NONE;
+    for m in modifier_parts {
+        match m.to_lowercase().as_str() {
+            "cmd" | "command" | "super" => mods.command = true,
+            "shift" => mods.shift = true,
+            "ctrl" | "control" => mods.ctrl = true,
+            "alt" | "opt" | "option" => mods.alt = true,
+            other => {
+                log::warn!("keybindings: unknown modifier '{other}' in '{s}'");
+                return None;
+            }
+        }
+    }
+
+    let key = match key_str.as_str() {
+        "a" => egui::Key::A, "b" => egui::Key::B, "c" => egui::Key::C,
+        "d" => egui::Key::D, "e" => egui::Key::E, "f" => egui::Key::F,
+        "g" => egui::Key::G, "h" => egui::Key::H, "i" => egui::Key::I,
+        "j" => egui::Key::J, "k" => egui::Key::K, "l" => egui::Key::L,
+        "m" => egui::Key::M, "n" => egui::Key::N, "o" => egui::Key::O,
+        "p" => egui::Key::P, "q" => egui::Key::Q, "r" => egui::Key::R,
+        "s" => egui::Key::S, "t" => egui::Key::T, "u" => egui::Key::U,
+        "v" => egui::Key::V, "w" => egui::Key::W, "x" => egui::Key::X,
+        "y" => egui::Key::Y, "z" => egui::Key::Z,
+        "0" | "num0" => egui::Key::Num0,
+        "1" | "num1" => egui::Key::Num1,
+        "2" | "num2" => egui::Key::Num2,
+        "3" | "num3" => egui::Key::Num3,
+        "4" | "num4" => egui::Key::Num4,
+        "5" | "num5" => egui::Key::Num5,
+        "6" | "num6" => egui::Key::Num6,
+        "7" | "num7" => egui::Key::Num7,
+        "8" | "num8" => egui::Key::Num8,
+        "9" | "num9" => egui::Key::Num9,
+        "enter" | "return" => egui::Key::Enter,
+        "escape" | "esc" => egui::Key::Escape,
+        "tab" => egui::Key::Tab,
+        "space" => egui::Key::Space,
+        "backspace" | "delete" => egui::Key::Backspace,
+        "up" | "arrowup" => egui::Key::ArrowUp,
+        "down" | "arrowdown" => egui::Key::ArrowDown,
+        "left" | "arrowleft" => egui::Key::ArrowLeft,
+        "right" | "arrowright" => egui::Key::ArrowRight,
+        "[" | "open_bracket" | "openbracket" => egui::Key::OpenBracket,
+        "]" | "close_bracket" | "closebracket" => egui::Key::CloseBracket,
+        "\\" | "backslash" => egui::Key::Backslash,
+        "/" | "slash" => egui::Key::Slash,
+        "," | "comma" => egui::Key::Comma,
+        "." | "period" => egui::Key::Period,
+        "=" | "equals" | "plus" => egui::Key::Equals,
+        "-" | "minus" => egui::Key::Minus,
+        other => {
+            log::warn!("keybindings: unknown key '{other}' in '{s}'");
+            return None;
+        }
+    };
+
+    Some((mods, key))
+}
+
+/// Opaque repr for conflict detection: modifier bits + key discriminant.
+fn binding_id(mods: egui::Modifiers, key: egui::Key) -> u64 {
+    let mod_bits = (mods.command as u64)
+        | ((mods.shift as u64) << 1)
+        | ((mods.ctrl as u64) << 2)
+        | ((mods.alt as u64) << 3);
+    (mod_bits << 32) | (key as u64)
+}
+
+/// Build the effective `KeyBindings` from defaults + optional config overrides.
+/// Logs `warn` for unparseable overrides (preserves default) and `error` for conflicts.
+pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings {
+    let mut bindings = KeyBindings::default();
+    let Some(cfg) = overrides else {
+        return bindings;
+    };
+
+    macro_rules! apply_override {
+        ($field:ident, $name:expr) => {
+            if let Some(ref s) = cfg.$field {
+                if let Some(combo) = parse_key_combo(s) {
+                    bindings.$field = combo;
+                } else {
+                    log::warn!("keybindings: invalid combo '{}' for '{}' — keeping default", s, $name);
+                }
+            }
+        };
+    }
+
+    apply_override!(quit, "quit");
+    apply_override!(close_pane, "close_pane");
+    apply_override!(toggle_command_palette, "toggle_command_palette");
+    apply_override!(split_horizontal, "split_horizontal");
+    apply_override!(split_vertical, "split_vertical");
+    apply_override!(split_right, "split_right");
+    apply_override!(split_down, "split_down");
+    apply_override!(page_left, "page_left");
+    apply_override!(page_down, "page_down");
+    apply_override!(page_up, "page_up");
+    apply_override!(page_right, "page_right");
+    apply_override!(swap_pane_left, "swap_pane_left");
+    apply_override!(swap_pane_down, "swap_pane_down");
+    apply_override!(swap_pane_up, "swap_pane_up");
+    apply_override!(swap_pane_right, "swap_pane_right");
+    apply_override!(navigate_left, "navigate_left");
+    apply_override!(navigate_down, "navigate_down");
+    apply_override!(navigate_up, "navigate_up");
+    apply_override!(navigate_right, "navigate_right");
+    apply_override!(new_tab, "new_tab");
+    apply_override!(next_tab, "next_tab");
+    apply_override!(nav_back, "nav_back");
+    apply_override!(toggle_sidebar, "toggle_sidebar");
+    apply_override!(toggle_zoom, "toggle_zoom");
+    apply_override!(toggle_shortcuts, "toggle_shortcuts");
+    apply_override!(rename_context, "rename_context");
+    apply_override!(rename_pane, "rename_pane");
+    apply_override!(new_context, "new_context");
+    apply_override!(new_page_right, "new_page_right");
+    apply_override!(toggle_minimap, "toggle_minimap");
+    apply_override!(scroll_up, "scroll_up");
+    apply_override!(scroll_down, "scroll_down");
+    apply_override!(increase_font_size, "increase_font_size");
+    apply_override!(decrease_font_size, "decrease_font_size");
+    apply_override!(open_file_browser, "open_file_browser");
+    apply_override!(open_quick_note, "open_quick_note");
+    apply_override!(open_config, "open_config");
+    apply_override!(reload_config, "reload_config");
+    apply_override!(open_secrets_manager, "open_secrets_manager");
+    apply_override!(force_reload_app, "force_reload_app");
+    apply_override!(toggle_notification_modal, "toggle_notification_modal");
+
+    // Count overrides applied
+    let mut override_count: usize = 0;
+    macro_rules! count_field {
+        ($field:ident) => { if cfg.$field.is_some() { override_count += 1; } };
+    }
+    count_field!(quit); count_field!(close_pane); count_field!(toggle_command_palette);
+    count_field!(split_horizontal); count_field!(split_vertical); count_field!(split_right);
+    count_field!(split_down); count_field!(page_left); count_field!(page_down);
+    count_field!(page_up); count_field!(page_right); count_field!(swap_pane_left);
+    count_field!(swap_pane_down); count_field!(swap_pane_up); count_field!(swap_pane_right);
+    count_field!(navigate_left); count_field!(navigate_down); count_field!(navigate_up);
+    count_field!(navigate_right); count_field!(new_tab); count_field!(next_tab);
+    count_field!(nav_back); count_field!(toggle_sidebar); count_field!(toggle_zoom);
+    count_field!(toggle_shortcuts); count_field!(rename_context); count_field!(rename_pane);
+    count_field!(new_context); count_field!(new_page_right); count_field!(toggle_minimap);
+    count_field!(scroll_up); count_field!(scroll_down); count_field!(increase_font_size);
+    count_field!(decrease_font_size); count_field!(open_file_browser); count_field!(open_quick_note);
+    count_field!(open_config); count_field!(reload_config); count_field!(open_secrets_manager);
+    count_field!(force_reload_app); count_field!(toggle_notification_modal);
+
+    // Conflict detection
+    let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
+        ("quit",                      bindings.quit),
+        ("close_pane",                bindings.close_pane),
+        ("toggle_command_palette",    bindings.toggle_command_palette),
+        ("split_horizontal",          bindings.split_horizontal),
+        ("split_vertical",            bindings.split_vertical),
+        ("split_right",               bindings.split_right),
+        ("split_down",                bindings.split_down),
+        ("page_left",                 bindings.page_left),
+        ("page_down",                 bindings.page_down),
+        ("page_up",                   bindings.page_up),
+        ("page_right",                bindings.page_right),
+        ("swap_pane_left",            bindings.swap_pane_left),
+        ("swap_pane_down",            bindings.swap_pane_down),
+        ("swap_pane_up",              bindings.swap_pane_up),
+        ("swap_pane_right",           bindings.swap_pane_right),
+        ("navigate_left",             bindings.navigate_left),
+        ("navigate_down",             bindings.navigate_down),
+        ("navigate_up",               bindings.navigate_up),
+        ("navigate_right",            bindings.navigate_right),
+        ("new_tab",                   bindings.new_tab),
+        ("next_tab",                  bindings.next_tab),
+        ("nav_back",                  bindings.nav_back),
+        ("toggle_sidebar",            bindings.toggle_sidebar),
+        ("toggle_zoom",               bindings.toggle_zoom),
+        ("toggle_shortcuts",          bindings.toggle_shortcuts),
+        ("rename_context",            bindings.rename_context),
+        ("rename_pane",               bindings.rename_pane),
+        ("new_context",               bindings.new_context),
+        ("new_page_right",            bindings.new_page_right),
+        ("toggle_minimap",            bindings.toggle_minimap),
+        ("scroll_up",                 bindings.scroll_up),
+        ("scroll_down",               bindings.scroll_down),
+        ("increase_font_size",        bindings.increase_font_size),
+        ("decrease_font_size",        bindings.decrease_font_size),
+        ("open_file_browser",         bindings.open_file_browser),
+        ("open_quick_note",           bindings.open_quick_note),
+        ("open_config",               bindings.open_config),
+        ("reload_config",             bindings.reload_config),
+        ("open_secrets_manager",      bindings.open_secrets_manager),
+        ("force_reload_app",          bindings.force_reload_app),
+        ("toggle_notification_modal", bindings.toggle_notification_modal),
+    ];
+
+    let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
+    for (name, (mods, key)) in named {
+        let id = binding_id(*mods, *key);
+        if let Some(other) = seen.insert(id, name) {
+            log::error!("keybindings: conflict — '{}' and '{}' share the same key combo", other, name);
+        }
+    }
+
+    log::info!("keybindings: {} override(s) applied from config", override_count);
+
+    bindings
+}
+
 /// Poll global keyboard actions.
 ///
 /// `app_active` — focused pane has an active app surface (affects Escape/Tab).
@@ -125,31 +452,22 @@ pub enum Action {
 ///   and Cmd+P (command palette) — structural safety operations that must always work.
 pub fn poll_actions(
     ctx: &egui::Context,
+    bindings: &KeyBindings,
     app_active: bool,
     keyboard_capture_active: bool,
     notification_modal_open: bool,
     shortcuts_overlay_open: bool,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
-    let cmd_shift = egui::Modifiers {
-        shift: true,
-        ..egui::Modifiers::COMMAND
-    };
 
     ctx.input_mut(|input| {
-        // Quit (Cmd+Q) — always active, even in keyboard capture mode.
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Q) {
+        if input.consume_key(bindings.quit.0, bindings.quit.1) {
             actions.push(Action::Quit);
         }
-
-        // Close pane (Cmd+W) — always active, even in keyboard capture mode.
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::W) {
+        if input.consume_key(bindings.close_pane.0, bindings.close_pane.1) {
             actions.push(Action::ClosePane);
         }
-
-        // Command palette (Cmd+P) — always active, even in keyboard capture mode.
-        // The palette is a host-level UI surface; apps cannot block access to it.
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::P) {
+        if input.consume_key(bindings.toggle_command_palette.0, bindings.toggle_command_palette.1) {
             actions.push(Action::ToggleCommandPalette);
         }
 
@@ -158,77 +476,69 @@ pub fn poll_actions(
             return;
         }
 
-        // Check Cmd+Shift+D before Cmd+D (more specific first)
-        if input.consume_key(cmd_shift, egui::Key::D) {
+        // Check split_vertical (Cmd+Shift+D) before split_horizontal (Cmd+D) — more specific first.
+        if input.consume_key(bindings.split_vertical.0, bindings.split_vertical.1) {
             actions.push(Action::SplitVertical);
-        } else if input.consume_key(egui::Modifiers::COMMAND, egui::Key::D) {
+        } else if input.consume_key(bindings.split_horizontal.0, bindings.split_horizontal.1) {
             actions.push(Action::SplitHorizontal);
         }
 
-        // Page navigation (Shift+Cmd+HJKL) — check before plain Cmd+HJKL
-        // so the shifted variants are matched first. These now navigate the
-        // spatial grid rather than doing lateral focus jumps within a page.
-        if input.consume_key(cmd_shift, egui::Key::H) {
+        // Page navigation — check before plain pane navigation so shifted variants match first.
+        if input.consume_key(bindings.page_left.0, bindings.page_left.1) {
             actions.push(Action::PageLeft);
         }
-        if input.consume_key(cmd_shift, egui::Key::J) {
+        if input.consume_key(bindings.page_down.0, bindings.page_down.1) {
             actions.push(Action::PageDown);
         }
-        if input.consume_key(cmd_shift, egui::Key::K) {
+        if input.consume_key(bindings.page_up.0, bindings.page_up.1) {
             actions.push(Action::PageUp);
         }
-        if input.consume_key(cmd_shift, egui::Key::L) {
+        if input.consume_key(bindings.page_right.0, bindings.page_right.1) {
             actions.push(Action::PageRight);
         }
 
-        // Pane swap (Cmd+Ctrl+HJKL) — check before plain Cmd+HJKL
-        let cmd_ctrl = egui::Modifiers {
-            ctrl: true,
-            ..egui::Modifiers::COMMAND
-        };
-        if input.consume_key(cmd_ctrl, egui::Key::H) {
+        // Pane swap — check before plain pane navigation.
+        if input.consume_key(bindings.swap_pane_left.0, bindings.swap_pane_left.1) {
             actions.push(Action::SwapPane(Direction::Left));
         }
-        if input.consume_key(cmd_ctrl, egui::Key::J) {
+        if input.consume_key(bindings.swap_pane_down.0, bindings.swap_pane_down.1) {
             actions.push(Action::SwapPane(Direction::Down));
         }
-        if input.consume_key(cmd_ctrl, egui::Key::K) {
+        if input.consume_key(bindings.swap_pane_up.0, bindings.swap_pane_up.1) {
             actions.push(Action::SwapPane(Direction::Up));
         }
-        if input.consume_key(cmd_ctrl, egui::Key::L) {
+        if input.consume_key(bindings.swap_pane_right.0, bindings.swap_pane_right.1) {
             actions.push(Action::SwapPane(Direction::Right));
         }
 
-        // Focus navigation (Cmd+HJKL)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::H) {
+        // Focus navigation
+        if input.consume_key(bindings.navigate_left.0, bindings.navigate_left.1) {
             actions.push(Action::Navigate(Direction::Left));
         }
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::J) {
+        if input.consume_key(bindings.navigate_down.0, bindings.navigate_down.1) {
             actions.push(Action::Navigate(Direction::Down));
         }
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::K) {
+        if input.consume_key(bindings.navigate_up.0, bindings.navigate_up.1) {
             actions.push(Action::Navigate(Direction::Up));
         }
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::L) {
+        if input.consume_key(bindings.navigate_right.0, bindings.navigate_right.1) {
             actions.push(Action::Navigate(Direction::Right));
         }
 
-        // New tab (Cmd+T)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::T) {
+        if input.consume_key(bindings.new_tab.0, bindings.new_tab.1) {
             actions.push(Action::NewTab);
         }
 
-        // Cycle tabs (Cmd+] / Cmd+[). When the notification modal is open,
-        // these cycle through the pending-notifications queue instead — the
-        // modal is the active context.
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::CloseBracket) {
+        // Cycle tabs. When the notification modal is open, these cycle through
+        // the pending-notifications queue instead.
+        if input.consume_key(bindings.next_tab.0, bindings.next_tab.1) {
             actions.push(if notification_modal_open {
                 Action::NotificationCycleNext
             } else {
                 Action::NextTab
             });
         }
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::OpenBracket) {
+        if input.consume_key(bindings.nav_back.0, bindings.nav_back.1) {
             actions.push(if notification_modal_open {
                 Action::NotificationCyclePrev
             } else {
@@ -236,67 +546,54 @@ pub fn poll_actions(
             });
         }
 
-        // Toggle sidebar (Cmd+B)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::B) {
+        if input.consume_key(bindings.toggle_sidebar.0, bindings.toggle_sidebar.1) {
             actions.push(Action::ToggleSidebar);
         }
-
-        // Toggle zoom (Cmd+Enter)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Enter) {
+        if input.consume_key(bindings.toggle_zoom.0, bindings.toggle_zoom.1) {
             actions.push(Action::ToggleZoom);
         }
-
-        // Toggle shortcuts overlay (Cmd+/)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Slash) {
+        if input.consume_key(bindings.toggle_shortcuts.0, bindings.toggle_shortcuts.1) {
             actions.push(Action::ToggleShortcuts);
         }
 
-        // Rename context (Cmd+Shift+R) vs rename pane (Cmd+R). Check shifted
-        // first so Cmd+Shift+R doesn't fall through to the Cmd+R branch.
-        if input.consume_key(cmd_shift, egui::Key::R) {
+        // Rename context before rename pane — check shifted variant first.
+        if input.consume_key(bindings.rename_context.0, bindings.rename_context.1) {
             actions.push(Action::RenameContext);
         } else if !input.modifiers.alt
-            && input.consume_key(egui::Modifiers::COMMAND, egui::Key::R)
+            && input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1)
         {
             actions.push(Action::RenamePane);
         }
 
-        // Pane split (Cmd+\ = right, Cmd+Shift+\ = below). Mirror focused
-        // pane's type. Check Cmd+Shift+\ before Cmd+\ so the shifted variant
-        // is matched first.
-        if input.consume_key(cmd_shift, egui::Key::Backslash) {
+        // Split down before split right — check shifted variant first.
+        if input.consume_key(bindings.split_down.0, bindings.split_down.1) {
             actions.push(Action::SplitDown);
-        } else if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Backslash) {
+        } else if input.consume_key(bindings.split_right.0, bindings.split_right.1) {
             actions.push(Action::SplitRight);
         }
 
-        // New context (Cmd+Shift+N) vs new spatial page (Cmd+N). Check shifted
-        // first so Cmd+Shift+N doesn't fall through to the Cmd+N branch.
-        if input.consume_key(cmd_shift, egui::Key::N) {
+        // New context before new page right — check shifted variant first.
+        if input.consume_key(bindings.new_context.0, bindings.new_context.1) {
             actions.push(Action::NewContext);
-        } else if input.consume_key(egui::Modifiers::COMMAND, egui::Key::N) {
+        } else if input.consume_key(bindings.new_page_right.0, bindings.new_page_right.1) {
             actions.push(Action::NewPageRight);
         }
 
-        // Minimap toggle (Cmd+Shift+M).
-        if input.consume_key(cmd_shift, egui::Key::M) {
+        if input.consume_key(bindings.toggle_minimap.0, bindings.toggle_minimap.1) {
             actions.push(Action::ToggleMinimap);
         }
 
-        // Scrollback (Cmd+Up / Cmd+Down)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::ArrowUp) {
+        if input.consume_key(bindings.scroll_up.0, bindings.scroll_up.1) {
             actions.push(Action::ScrollUp);
         }
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::ArrowDown) {
+        if input.consume_key(bindings.scroll_down.0, bindings.scroll_down.1) {
             actions.push(Action::ScrollDown);
         }
 
-        // Per-pane font size (Cmd+= / Cmd+-)
-        let cmd_only = egui::Modifiers::COMMAND;
-        if !input.modifiers.shift && input.consume_key(cmd_only, egui::Key::Equals) {
+        if !input.modifiers.shift && input.consume_key(bindings.increase_font_size.0, bindings.increase_font_size.1) {
             actions.push(Action::IncreasePaneFontSize);
         }
-        if !input.modifiers.shift && input.consume_key(cmd_only, egui::Key::Minus) {
+        if !input.modifiers.shift && input.consume_key(bindings.decrease_font_size.0, bindings.decrease_font_size.1) {
             actions.push(Action::DecreasePaneFontSize);
         }
 
@@ -314,58 +611,35 @@ pub fn poll_actions(
             }
         }
 
-        // Open file browser (Cmd+E)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::E) {
+        if input.consume_key(bindings.open_file_browser.0, bindings.open_file_browser.1) {
             actions.push(Action::OpenFileBrowser);
         }
-
-        // Open quick note (Cmd+0)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Num0) {
+        if input.consume_key(bindings.open_quick_note.0, bindings.open_quick_note.1) {
             actions.push(Action::OpenQuickNote);
         }
-
-        // Open config (Cmd+,)
-        if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Comma) {
+        if input.consume_key(bindings.open_config.0, bindings.open_config.1) {
             actions.push(Action::OpenConfig);
         }
-
-        // Reload configuration (Cmd+Shift+,)
-        if input.consume_key(cmd_shift, egui::Key::Comma) {
+        if input.consume_key(bindings.reload_config.0, bindings.reload_config.1) {
             actions.push(Action::ReloadConfig);
         }
-
-        // Open secrets manager (Cmd+Shift+S)
-        if input.consume_key(cmd_shift, egui::Key::S) {
+        if input.consume_key(bindings.open_secrets_manager.0, bindings.open_secrets_manager.1) {
             actions.push(Action::OpenSecretsManager);
         }
-
-        // Force-reload focused app (Cmd+Option+R, #83). The Cmd+R branch above
-        // guards with `!input.modifiers.alt` so this variant is still reached.
-        let cmd_alt = egui::Modifiers {
-            alt: true,
-            ..egui::Modifiers::COMMAND
-        };
-        if input.consume_key(cmd_alt, egui::Key::R) {
+        // Force-reload focused app. The rename_pane branch above guards with
+        // `!input.modifiers.alt` so Cmd+Alt+R still reaches this branch.
+        if input.consume_key(bindings.force_reload_app.0, bindings.force_reload_app.1) {
             actions.push(Action::ForceReloadApp);
         }
-
-        // Notification modal (Cmd+Shift+A) — opens the queue on the front item,
-        // or closes the modal if already open.
-        if input.consume_key(cmd_shift, egui::Key::A) {
+        if input.consume_key(bindings.toggle_notification_modal.0, bindings.toggle_notification_modal.1) {
             actions.push(Action::ToggleNotificationModal);
         }
 
-        // Switch context (Cmd+1 through Cmd+9)
+        // Switch context (Cmd+1 through Cmd+9) — these remain hardcoded for now.
         let num_keys = [
-            egui::Key::Num1,
-            egui::Key::Num2,
-            egui::Key::Num3,
-            egui::Key::Num4,
-            egui::Key::Num5,
-            egui::Key::Num6,
-            egui::Key::Num7,
-            egui::Key::Num8,
-            egui::Key::Num9,
+            egui::Key::Num1, egui::Key::Num2, egui::Key::Num3,
+            egui::Key::Num4, egui::Key::Num5, egui::Key::Num6,
+            egui::Key::Num7, egui::Key::Num8, egui::Key::Num9,
         ];
         for (i, key) in num_keys.into_iter().enumerate() {
             if input.consume_key(egui::Modifiers::COMMAND, key) {


### PR DESCRIPTION
Closes #972

## Summary
- Adds `[keybindings]` section to `config.toml` with 41 named actions, each overridable via a key combo string (e.g. `split_horizontal = "cmd+shift+x"`)
- Key parser handles `cmd`/`shift`/`ctrl`/`alt` modifiers and all common egui keys; unknown strings log `warn` and preserve the default
- Conflict detection at startup: if two actions share a key combo, `log::error!` is emitted
- Bindings rebuild on `Cmd+Shift+,` config reload — no restart required
- Config template updated with all 41 defaults documented as commented-out examples

## Test plan
- [ ] Install PR build: `just pr-install <N>` from the feature worktree
- [ ] Add a `[keybindings]` override to `~/.plexi-pr-<N>/config.toml` remapping one binding (e.g. `toggle_sidebar = "cmd+shift+b"`)
- [ ] Verify the new binding works and the old `cmd+b` no longer triggers sidebar toggle
- [ ] Add an invalid key string and verify `warn` appears in `~/.plexi-pr-<N>/plexi.log`
- [ ] Add a conflicting pair and verify `error` appears in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)