### PR TITLE
feat(notify): add --host-action flag for fire-and-forget choice actions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3043,6 +3043,7 @@ _plexi() {
             '--body[Notification body]:body:' \
             '--level[Level]:level:(info warn error)' \
             '--choice[Choice option (key:Label / Label:action:arg / key:Label:action:arg)]:choice:' \
+            '--host-action[Host-side action for a choice key (key:action_type:action_arg)]:host_action:' \
             '--timeout[Timeout in seconds]:seconds:'
           ;;
         open)
@@ -3127,7 +3128,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       if [[ $prev == "--level" ]]; then
         COMPREPLY=($(compgen -W "info warn error" -- "$cur"))
       else
-        COMPREPLY=($(compgen -W "--title --body --level --choice --timeout" -- "$cur"))
+        COMPREPLY=($(compgen -W "--title --body --level --choice --host-action --timeout" -- "$cur"))
       fi
       ;;
     install)
@@ -3205,6 +3206,7 @@ complete -c plexi -n "__fish_seen_subcommand_from notify" -l title -d "Notificat
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l body -d "Notification body"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l level -d "Level" -a "info warn error"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l choice -d "Choice option (key:Label / Label:action:arg / key:Label:action:arg)"
+complete -c plexi -n "__fish_seen_subcommand_from notify" -l host-action -d "Host-side action for a choice key (key:action_type:action_arg)"
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l timeout -d "Timeout in seconds"
 
 # install flags
@@ -3272,6 +3274,33 @@ mod notify_tests {
     fn parse_choice_one_segment_is_error() {
         let err = parse_notify_choice("nocolon").unwrap_err();
         assert!(err.contains("1"), "error should mention segment count: {err}");
+    }
+
+    /// --host-action merges into a clean key:Label choice.
+    #[test]
+    fn host_action_merges_into_clean_choice() {
+        let (key, label, embedded) = parse_notify_choice("view:View results").unwrap();
+        assert!(embedded.is_none());
+        // Simulate the merge: host_action_map has "view" → "pane_focus:99"
+        let merged_action = Some("pane_focus:99".to_string());
+        let action = Some(merged_action.unwrap());
+        assert_eq!(key, "view");
+        assert_eq!(label, "View results");
+        assert_eq!(action.as_deref(), Some("pane_focus:99"));
+    }
+
+    /// --host-action overrides an embedded action in a 4-segment --choice.
+    #[test]
+    fn host_action_overrides_embedded_choice_action() {
+        let (key, label, embedded) =
+            parse_notify_choice("a:Talk to Claude:pane_focus:OLD").unwrap();
+        assert_eq!(embedded.as_deref(), Some("pane_focus:OLD"));
+        // host_action_map contains key "a" → "pane_focus:NEW"
+        let override_action = Some("pane_focus:NEW".to_string());
+        let final_action = override_action.map(Some).unwrap_or(embedded);
+        assert_eq!(key, "a");
+        assert_eq!(label, "Talk to Claude");
+        assert_eq!(final_action.as_deref(), Some("pane_focus:NEW"));
     }
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -85,6 +85,11 @@ pub enum Commands {
         /// Repeatable.
         #[arg(long = "choice")]
         choices: Vec<String>,
+        /// Host-side action for a choice key. Format: `key:action_type:action_arg`.
+        /// Repeatable. The host performs this action when the user clicks the matching
+        /// choice, even if the spawner has already exited.
+        #[arg(long = "host-action")]
+        host_actions: Vec<String>,
         /// Timeout in seconds (0 = no timeout)
         #[arg(long, default_value = "0")]
         timeout: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,11 +239,42 @@ fn main() -> eframe::Result {
                     Commands::Pack { cmd } => match cmd {
                         PackCmd::Export { path } => std::process::exit(cli::pack_export_cli(&path)),
                     },
-                    Commands::Notify { title, body, level, choices, timeout } => {
+                    Commands::Notify { title, body, level, choices, host_actions, timeout } => {
+                        // Parse --host-action flags into a key → "action_type:action_arg" map.
+                        let mut host_action_map: std::collections::HashMap<String, String> =
+                            std::collections::HashMap::new();
+                        for raw in &host_actions {
+                            let parts: Vec<&str> = raw.splitn(3, ':').collect();
+                            match parts.as_slice() {
+                                [key, action_type, action_arg] => {
+                                    host_action_map.insert(
+                                        key.to_string(),
+                                        format!("{action_type}:{action_arg}"),
+                                    );
+                                }
+                                _ => {
+                                    let msg = format!(
+                                        "error: --host-action requires 3 colon-separated segments \
+                                         (key:action_type:action_arg) — got {:?}",
+                                        raw
+                                    );
+                                    log::warn!("notify:cli: {msg}");
+                                    eprintln!("{msg}");
+                                    std::process::exit(1);
+                                }
+                            }
+                        }
                         let mut parsed_choices: Vec<(String, String, Option<String>)> = Vec::new();
                         for raw in &choices {
                             match cli::parse_notify_choice(raw) {
-                                Ok(choice) => parsed_choices.push(choice),
+                                Ok((key, label, existing_action)) => {
+                                    // --host-action overrides any action embedded in --choice.
+                                    let action = host_action_map
+                                        .remove(&key)
+                                        .map(Some)
+                                        .unwrap_or(existing_action);
+                                    parsed_choices.push((key, label, action));
+                                }
                                 Err(msg) => {
                                     log::warn!("notify:cli: {msg}");
                                     eprintln!("{msg}");
@@ -251,6 +282,20 @@ fn main() -> eframe::Result {
                                 }
                             }
                         }
+                        // Any --host-action keys not matched to a --choice are an error.
+                        for (key, _) in &host_action_map {
+                            let msg = format!(
+                                "error: --host-action key {:?} does not match any --choice key",
+                                key
+                            );
+                            log::warn!("notify:cli: {msg}");
+                            eprintln!("{msg}");
+                            std::process::exit(1);
+                        }
+                        log::info!(
+                            "notify:cli: host_actions={} merged into choices",
+                            host_actions.len()
+                        );
                         std::process::exit(cli::notify_cli(&title, &body, &level, &parsed_choices, timeout));
                     }
                     Commands::Pane { cmd } => match cmd {


### PR DESCRIPTION
Closes #837

## What

Adds `--host-action key:action_type:action_arg` flag to `plexi notify`. Decouples host-side actions from choice labels so `--choice` stays as clean `key:Label` throughout.

## Before / After

**Before** (action embedded in --choice, key equals label for 3-seg form):
```bash
plexi notify --title "Done" \
  --choice "a:Talk to Claude:pane_focus:300" \
  --choice "b:View PR"
```

**After** (clean separation):
```bash
plexi notify --title "Done" \
  --choice "a:Talk to Claude" \
  --host-action "a:pane_focus:300" \
  --choice "b:View PR"
```

## Behaviour

- `--host-action key:action_type:action_arg` — registers a host action for the given choice key
- Multiple `--host-action` flags supported (one per key)
- `--host-action` overrides any action embedded in the corresponding `--choice`
- Error if a `--host-action` key doesn't match any `--choice` key (typo guard)
- All existing 3/4-segment `--choice` formats continue to work unchanged

## Acceptance criteria

- [x] `--host-action key:action_type:action_arg` is a valid flag
- [x] Multiple `--host-action` flags supported
- [x] Clicking a choice with a registered host action triggers it
- [x] `key:Label` choices without a `--host-action` entry behave exactly as today
- [x] 3-segment `Label:action_type:action_arg` form continues to work