### PR TITLE
feat(pane): show pending notification badge in app pane chrome

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2416,6 +2416,27 @@ impl eframe::App for PlexiApp {
                     return;
                 }
 
+                // Build per-pane notification counts before `ctx` mutably borrows
+                // `self.windows`. Inline the notification_is_visible logic to
+                // avoid a borrow conflict with the mutable ctx reference below.
+                let notify_counts: std::collections::HashMap<u64, usize> = {
+                    let active_context_id = self.router.active().context_id;
+                    let mut counts = std::collections::HashMap::new();
+                    for n in &self.pending_notifications {
+                        let visible = match n.scope {
+                            crate::app_protocol::NotifyScope::Global => true,
+                            crate::app_protocol::NotifyScope::Window
+                            | crate::app_protocol::NotifyScope::Context => {
+                                n.source_context_id == active_context_id
+                            }
+                        };
+                        if visible {
+                            *counts.entry(n.sender_pane_id).or_insert(0) += 1;
+                        }
+                    }
+                    counts
+                };
+
                 let ctx = &mut self.windows[self.active_window];
 
                 // Resolve focused_pane if simplifier moved the tile
@@ -2499,6 +2520,16 @@ impl eframe::App for PlexiApp {
                 } else {
                     let hover_id = egui::Id::new("drag_hover_was_active");
                     ui.ctx().data_mut(|d| d.insert_temp(hover_id, false));
+                }
+
+                // Propagate pre-computed notification counts into each app pane so
+                // ProcessApp can render the per-pane chrome badge without
+                // holding a reference to PlexiApp.
+                for pane in ctx.panes.values_mut() {
+                    if let Some(app_pane) = pane.as_app_mut() {
+                        let count = notify_counts.get(&app_pane.id).copied().unwrap_or(0);
+                        app_pane.runtime.set_pending_notification_count(count);
+                    }
                 }
 
                 let mut behavior = PlexiBehavior {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -207,6 +207,12 @@ impl AppRuntime {
             AppRuntime::Builtin(_) => String::new(),
         }
     }
+
+    pub(crate) fn set_pending_notification_count(&mut self, count: usize) {
+        if let AppRuntime::Process(app) = self {
+            app.pending_notification_count = count;
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -232,6 +232,10 @@ pub struct ProcessApp {
     crashed_at: Option<std::time::SystemTime>,
     /// Deadline for showing "✓ copied" overlay feedback. None = "C — copy report".
     copied_feedback_until: Option<std::time::Instant>,
+    /// Count of pending notifications originating from this pane. Updated
+    /// each frame by `PlexiApp` before tiling renders. Zero when no
+    /// notifications are pending.
+    pub(crate) pending_notification_count: usize,
     /// When true, `PlexiEvent::MouseMove` is delivered to the app every frame
     /// that the pointer moves over the pane. Controlled by
     /// `DrawCommand::SetMouseTracking { enabled }`. Off by default to avoid
@@ -630,6 +634,7 @@ impl ProcessApp {
             show_stderr_overlay: false,
             crashed_at: None,
             copied_feedback_until: None,
+            pending_notification_count: 0,
             mouse_tracking_enabled: false,
             text_input_buffers: HashMap::new(),
             text_input_visible_prev: std::collections::HashSet::new(),
@@ -750,6 +755,7 @@ impl ProcessApp {
             show_stderr_overlay: false,
             crashed_at: None,
             copied_feedback_until: None,
+            pending_notification_count: 0,
             mouse_tracking_enabled: false,
             text_input_buffers: HashMap::new(),
             text_input_visible_prev: std::collections::HashSet::new(),
@@ -957,6 +963,39 @@ impl ProcessApp {
         // interaction widget. type_id is unique-per-pane in practice.
         let id = ui.id().with(("lifecycle_pill", &self.type_id));
         Some(ui.interact(pill_rect, id, egui::Sense::click()))
+    }
+
+    /// Draw a small notification badge in the top-left corner of `pane_rect`
+    /// when there are pending notifications from this pane. Uses the theme
+    /// accent color to visually match the sidebar badge style. Shows count if
+    /// > 1, "1" if exactly one.
+    fn draw_notification_indicator(
+        &self,
+        ui: &mut egui::Ui,
+        pane_rect: egui::Rect,
+        count: usize,
+        colors: &crate::theme::Colors,
+    ) {
+        let label = if count > 9 { "9+".to_string() } else { count.to_string() };
+        let font_size = 11.0;
+        let radius = 6.0;
+        let inset = 8.0;
+        let font_id = egui::FontId::proportional(font_size);
+        let fg_color = egui::Color32::from_rgb(0x1e, 0x1e, 0x2e);
+        let galley = ui.fonts(|f| f.layout_no_wrap(label.clone(), font_id, fg_color));
+        let text_w = galley.size().x;
+        let text_h = galley.size().y;
+        let pill_w = (text_w + crate::style::BADGE_PAD_H * 2.0).max(crate::style::BADGE_MIN_W);
+        let pill_h = text_h + crate::style::BADGE_PAD_V * 2.0;
+        let pill_rect = egui::Rect::from_min_size(
+            egui::pos2(pane_rect.min.x + inset, pane_rect.min.y + inset),
+            egui::vec2(pill_w, pill_h),
+        );
+        let painter = ui.painter().with_clip_rect(pane_rect);
+        painter.rect_filled(pill_rect, radius, colors.accent);
+        let text_x = pill_rect.center().x - text_w / 2.0;
+        let text_y = pill_rect.center().y - text_h / 2.0;
+        painter.galley(egui::pos2(text_x, text_y), galley, fg_color);
     }
 
     /// Render every `DrawCommand::TextInput` in `frame` as a real egui
@@ -1643,6 +1682,17 @@ impl App for ProcessApp {
         // ── Lifecycle pill ──────────────────────────────────────────────────
         // Top-right corner. Hidden in Running. Click toggles the stderr
         // overlay (in addition to the auto-overlay rules above).
+        // Notification badge: top-left corner of pane chrome. Only visible
+        // when this pane has pending choice notifications awaiting input.
+        if self.pending_notification_count > 0 {
+            log::debug!(
+                "pane::{}: notification_indicator count={}",
+                self.type_id,
+                self.pending_notification_count
+            );
+            self.draw_notification_indicator(ui, pane_rect, self.pending_notification_count, ctx.colors);
+        }
+
         let pill_response = self.draw_lifecycle_pill(ui, pane_rect, lifecycle_state);
         let pill_consumed_click = if let Some(response) = pill_response {
             if response.clicked() {


### PR DESCRIPTION
## Summary
- Adds `pending_notification_count: usize` field to `ProcessApp`, updated each frame before tiling by `PlexiApp`
- Renders a small accent-colored badge in the top-left corner of app pane chrome when count > 0
- Badge shows the count (capped at "9+"), disappears instantly when notifications are dismissed
- Terminal panes unaffected; Builtin app runtimes ignore the count silently

## How it works
`PlexiApp` builds a `sender_pane_id → count` map from `pending_notifications` (filtered by `notification_is_visible`) before the tiling render, then pushes counts into each `ProcessApp`. The badge is drawn by a new `draw_notification_indicator` method using the same `render_badge` geometry and the theme accent color.

**Breaks if:** An app pane with a pending `plexi notify --choice` shows no badge in its top-left corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)