### PR TITLE
fix(open): use registry layout_hint when no --layout passed to plexi open

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -108,7 +108,7 @@ Handle each state automatically — do not stop and ask:
 Mark the issue in progress, capture the origin pane ID, and update the pane title:
 ```bash
 gh issue edit <number> --add-label "in progress"
-SHIP_PANE=$(plexi pane list | python3 -c "import json,sys; print(next(p['id'] for p in json.load(sys.stdin) if p['focused']))")
+SHIP_PANE=$PLEXI_PANE_ID
 plexi pane set-title "#<number> — <short-title>"
 ```
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1008,15 +1008,16 @@ impl PlexiApp {
                     }
                 }
                 crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} ephemeral={ephemeral} response_file={response_file:?}");
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
                     if type_id == "terminal" {
-                        let vertical = matches!(layout.as_str(), "split_h" | "split_above");
+                        let layout_str = layout.as_deref().unwrap_or("split_v");
+                        let vertical = matches!(layout_str, "split_h" | "split_above");
                         let initial_cmd = cmd_from_args(args);
-                        log::info!("pane_ipc: spawn_pane terminal vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
                         self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
                     } else {
-                        self.launch_app_by_id_with_layout(type_id, Some(layout.clone()), args);
+                        self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
                     }
                     if let Some(rf) = response_file {
                         let json = format!("{{\"pane_id\":{new_pane_id}}}");

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -909,8 +909,8 @@ pub enum HostCommand {
     ///               `PlexiEvent::PaneSpawnError { reason }` on failure.
     SpawnPane {
         type_id: String,
-        #[serde(default = "default_spawn_layout")]
-        layout: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layout: Option<String>,
         #[serde(default)]
         args: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1511,10 +1511,6 @@ pub struct ListItem {
     pub icon: Option<String>, // reserved for future use
     #[serde(default)]
     pub is_dir: bool,
-}
-
-fn default_spawn_layout() -> String {
-    "overlay".to_string()
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2480,7 +2476,7 @@ mod tests {
         match &cmd {
             DrawCommand::Host(HostCommand::SpawnPane { type_id, layout, args, pipe_id, from_pane_id, request_id, .. }) => {
                 assert_eq!(type_id, "snake");
-                assert_eq!(layout, "split_v");
+                assert_eq!(layout.as_deref(), Some("split_v"));
                 assert_eq!(args, &["--foo"]);
                 assert_eq!(pipe_id.as_deref(), Some("p1"));
                 assert!(from_pane_id.is_none());
@@ -2491,12 +2487,12 @@ mod tests {
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(serialised.contains(r#""type":"spawn_pane""#), "wire tag missing: {serialised}");
 
-        // defaults: layout defaults to "overlay", args to [], pipe_id absent
+        // defaults: layout is None (absent from wire), args to [], pipe_id absent
         let minimal = r#"{"type":"spawn_pane","type_id":"snake"}"#;
         let cmd2: DrawCommand = serde_json::from_str(minimal).expect("deserialise minimal");
         match &cmd2 {
             DrawCommand::Host(HostCommand::SpawnPane { layout, args, pipe_id, from_pane_id, request_id, .. }) => {
-                assert_eq!(layout, "overlay");
+                assert!(layout.is_none(), "absent layout must deserialise to None");
                 assert!(args.is_empty());
                 assert!(pipe_id.is_none());
                 assert!(from_pane_id.is_none());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1827,7 +1827,6 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
 ///
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
-    let layout_str = layout.unwrap_or("overlay");
     if type_id == "terminal" {
         log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
         eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
@@ -1845,7 +1844,7 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
             "type": "spawn_pane",
             "type_id": type_id,
             "args": args,
-            "layout": layout_str,
+            "layout": layout,
             "response_file": response_file,
         });
         if let Some(pid) = from_pane_id {
@@ -1906,7 +1905,7 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
     let queue_payload = serde_json::json!({
         "type_id": type_id,
         "args": args,
-        "layout": layout_str,
+        "layout": layout,
     });
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -686,7 +686,7 @@ mod tests {
 
         h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
             type_id: "terminal".to_string(),
-            layout: "split_v".to_string(),
+            layout: Some("split_v".to_string()),
             args: vec![],
             pipe_id: None,
             from_pane_id: None,
@@ -721,7 +721,7 @@ mod tests {
 
         h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
             type_id: "terminal".to_string(),
-            layout: "split_v".to_string(),
+            layout: Some("split_v".to_string()),
             args: vec!["echo".to_string(), "hello".to_string()],
             pipe_id: None,
             from_pane_id: None,
@@ -741,6 +741,43 @@ mod tests {
         assert!(
             snap.pane_titles.values().any(|t| t == "Terminal"),
             "expected a Terminal pane after SpawnPane with args, got: {:?}",
+            snap.pane_titles,
+        );
+    }
+
+    /// Regression guard for issue #992: SpawnPane with layout=None (omitted from IPC)
+    /// must still open a terminal pane — the host must not treat None as a missing
+    /// layout and silently skip the pane. Without the fix, the IPC handler would have
+    /// called `matches!(layout.as_str(), ...)` on a String "overlay" (the old serde
+    /// default), meaning apps always opened as overlay regardless of registry hint.
+    #[test]
+    fn spawn_pane_terminal_with_null_layout_still_opens_pane() {
+        let mut h = HostHarness::new();
+        let _pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile after add_test_pane");
+        h.app.windows[0].focused_pane = Some(root);
+
+        h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
+            type_id: "terminal".to_string(),
+            layout: None,
+            args: vec![],
+            pipe_id: None,
+            from_pane_id: None,
+            request_id: None,
+            response_file: None,
+            ephemeral: false,
+        });
+        h.run_frames(2);
+
+        let snap = h.state();
+        assert!(
+            snap.open_panes.len() > 1,
+            "SpawnPane terminal with null layout must open a new pane (got {:?})",
+            snap.pane_titles,
+        );
+        assert!(
+            snap.pane_titles.values().any(|t| t == "Terminal"),
+            "expected a Terminal pane with null layout, got: {:?}",
             snap.pane_titles,
         );
     }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -777,13 +777,14 @@ impl ProcessApp {
                         .push_back(PlexiEvent::PaneSpawnError { reason, request_id });
                     return;
                 }
+                let layout_str = layout.unwrap_or_else(|| "overlay".to_string());
                 log::info!(
-                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout}' args={args:?} pipe_id={pipe_id:?} from_pane_id={from_pane_id:?} request_id={request_id:?}",
+                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout_str}' args={args:?} pipe_id={pipe_id:?} from_pane_id={from_pane_id:?} request_id={request_id:?}",
                     self.type_id
                 );
                 self.pending_commands.push(AppCommand::SpawnPane {
                     type_id,
-                    layout,
+                    layout: layout_str,
                     args,
                     pipe_id,
                     from_pane_id,


### PR DESCRIPTION
Fixes #992.

## Root cause

`open_cli` unconditionally defaulted `layout` to `"overlay"` before sending the IPC
`spawn_pane` message. The host received `Some("overlay")` and passed it directly to
`launch_app_by_id_with_layout`, short-circuiting the `registry.layout_hint_for(id)`
fallback entirely.

The spawn-queue path (`drain_spawn_queue`) already handled this correctly — it parsed
`layout` as `Option<String>` from JSON and passed `None` when omitted. The IPC path
was the only broken caller.

## Fix

- `HostCommand::SpawnPane.layout`: `String` → `Option<String>` (absent/null on wire → `None`)
- IPC handler (`app/mod.rs`): pass `layout.clone()` directly (now `Option<String>`) so `None` reaches `launch_app_by_id_with_layout` and triggers the registry fallback
- `open_cli` (`cli.rs`): removed `layout.unwrap_or("overlay")` — CLI now sends `null` when no `--layout` flag is given
- `routing.rs`: SDK-spawned `SpawnPane` path converts `Option<String>` back to `String` with `"overlay"` default (SDK apps always provide a layout explicitly)
- Updated all `HostCommand::SpawnPane` struct literals in tests to use `Some("split_v")` / `None`
- Added regression test `spawn_pane_terminal_with_null_layout_still_opens_pane`

## Breaks if

`plexi open <app>` opens full-screen (overlay) even when `manifest.toml` declares a non-overlay `layout_hint`.