### PR TITLE
feat(secrets): plexi secret get — read secret value to stdout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,6 +359,74 @@ pub fn workspace_secret_list() -> i32 {
     }
 }
 
+/// `plexi secret get <friendly-name>` — print the resolved secret value to stdout.
+///
+/// Resolution order (unless --global):
+///   1. Workspace-scoped Keychain entry (nearest .plexi/ workspace)
+///   2. Global user-scoped Keychain entry (fallback)
+///
+/// `--global` skips the workspace lookup entirely.
+pub fn workspace_secret_get(friendly: &str, global: bool) -> i32 {
+    log::info!("secret_get:cli: friendly={friendly} global={global}");
+
+    #[cfg(target_os = "macos")]
+    {
+        use crate::workspace_secrets::{keychain_user_name, keychain_workspace_name, MacKeychain, SecretStore};
+        let store = MacKeychain::new();
+
+        if global {
+            let account = keychain_user_name(friendly);
+            return match store.get(&account) {
+                Some(value) => {
+                    log::info!("secret_get:cli: found globally account={account}");
+                    println!("{}", value.as_str());
+                    0
+                }
+                None => {
+                    log::warn!("secret_get:cli: not found friendly={friendly}");
+                    eprintln!("error: secret '{friendly}' not found");
+                    1
+                }
+            };
+        }
+
+        // Try workspace-scoped first, then global fallback.
+        if let Ok((root, cfg)) = require_workspace() {
+            let account = keychain_workspace_name(&cfg.id, friendly);
+            if let Some(value) = store.get(&account) {
+                log::info!(
+                    "secret_get:cli: found workspace_id={} account={account} root={}",
+                    cfg.id,
+                    root.display()
+                );
+                println!("{}", value.as_str());
+                return 0;
+            }
+        }
+
+        // Global fallback.
+        let user_account = keychain_user_name(friendly);
+        match store.get(&user_account) {
+            Some(value) => {
+                log::info!("secret_get:cli: found globally account={user_account}");
+                println!("{}", value.as_str());
+                0
+            }
+            None => {
+                log::warn!("secret_get:cli: not found friendly={friendly}");
+                eprintln!("error: secret '{friendly}' not found");
+                1
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (friendly, global);
+        eprintln!("error: keychain not available on this platform");
+        1
+    }
+}
+
 /// `plexi secret delete <friendly-name>` — remove the workspace-scoped
 /// Keychain entry and update the index.
 pub fn workspace_secret_delete(friendly: &str) -> i32 {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -172,6 +172,17 @@ pub enum SecretCmd {
         #[arg(long)]
         global: bool,
     },
+    /// Read a secret value to stdout
+    ///
+    /// Walks up to nearest .plexi/ workspace, resolves from there first, then falls back to global.
+    /// Use --global to read from the global store only.
+    Get {
+        /// Name of the secret
+        friendly_name: String,
+        /// Read from global store only (skip workspace lookup)
+        #[arg(long)]
+        global: bool,
+    },
     /// List stored secrets
     List,
     /// Delete a secret

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,7 @@ fn main() -> eframe::Result {
                     },
                     Commands::Secret { cmd } => match cmd {
                         SecretCmd::Set { friendly_name, from_env, global } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global)),
+                        SecretCmd::Get { friendly_name, global } => std::process::exit(cli::workspace_secret_get(&friendly_name, global)),
                         SecretCmd::List => std::process::exit(cli::workspace_secret_list()),
                         SecretCmd::Delete { friendly_name } => std::process::exit(cli::workspace_secret_delete(&friendly_name)),
                     },


### PR DESCRIPTION
## Summary
- Adds `plexi secret get <name>` subcommand that prints the resolved secret value to stdout
- Workspace-scoped lookup first, then global fallback — mirrors the scoping logic of `secret set`
- `--global` flag to skip workspace lookup and read from global store only
- Exit 0 on found (bare value to stdout), exit 1 with `error: secret 'FOO' not found` to stderr on miss
- Pipes cleanly: `export FOO=$(plexi secret get FOO)`

## Test plan
- [ ] `plexi-pr-<N> secret get <name>` in a workspace dir returns the stored value
- [ ] `plexi-pr-<N> secret get <name> --global` reads from global store
- [ ] `plexi-pr-<N> secret get nonexistent` exits 1 with clear error message

Closes #966