### PR TITLE
feat(cli): rename pane set-title → pane name

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3095,7 +3095,7 @@ _plexi() {
           ;;
         pane)
           local subcmds
-          subcmds=('set-title:Set the title of a pane (current or by ID)')
+          subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)')
           _describe 'subcommand' subcmds
           ;;
         terminal)
@@ -3181,7 +3181,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "export" -- "$cur"))
       ;;
     pane)
-      COMPREPLY=($(compgen -W "set-title" -- "$cur"))
+      COMPREPLY=($(compgen -W "name set-title" -- "$cur"))
       ;;
     terminal)
       if [[ $prev == "--layout" ]]; then
@@ -3270,7 +3270,8 @@ complete -c plexi -f -n "__fish_seen_subcommand_from update" -a apps -d "Update 
 complete -c plexi -f -n "__fish_seen_subcommand_from pack" -a export -d "Export current apps as a pack file"
 
 # pane subcommands
-complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a set-title -d "Set the title of a pane (current or by ID)"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a name -d "Set the name of a pane (current or by ID)"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a set-title -d "Set the name of a pane (deprecated: use name)"
 
 # descriptor subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from descriptor" -a probe -d "Probe a CLI for its Plexi descriptor"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -247,11 +247,19 @@ pub enum PackCmd {
 
 #[derive(Subcommand)]
 pub enum PaneCmd {
-    /// Set the title of a pane
+    /// Set the name of a pane
     ///
     /// Usage:
-    ///   plexi pane set-title <title>           — renames the current (focused) pane
-    ///   plexi pane set-title <pane-id> <title> — renames an arbitrary pane by ID
+    ///   plexi pane name <title>           — renames the current (focused) pane
+    ///   plexi pane name <pane-id> <title> — renames an arbitrary pane by ID
+    Name {
+        /// Pane ID (from `plexi pane list`) or title when used alone
+        first: String,
+        /// Title when pane-id is given as the first argument
+        second: Option<String>,
+    },
+    /// Deprecated: use `pane name` instead
+    #[command(hide = true)]
     SetTitle {
         /// Pane ID (from `plexi pane list`) or title when used alone
         first: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,7 +314,21 @@ fn main() -> eframe::Result {
                         std::process::exit(cli::notify_cli(&title, &body, &level, &parsed_choices, timeout, parsed_scope));
                     }
                     Commands::Pane { cmd } => match cmd {
+                        PaneCmd::Name { first, second } => {
+                            let (pane_id, name) = match second {
+                                Some(title) => match first.parse::<u64>() {
+                                    Ok(id) => (Some(id), title),
+                                    Err(_) => {
+                                        eprintln!("error: expected a numeric pane ID as first argument, got {:?}", first);
+                                        std::process::exit(1);
+                                    }
+                                },
+                                None => (None, first),
+                            };
+                            std::process::exit(cli::pane_set_title_cli(pane_id, &name))
+                        }
                         PaneCmd::SetTitle { first, second } => {
+                            eprintln!("warning: `pane set-title` is deprecated — use `pane name` instead");
                             let (pane_id, name) = match second {
                                 Some(title) => match first.parse::<u64>() {
                                     Ok(id) => (Some(id), title),


### PR DESCRIPTION
Closes #800

## What

Adds `plexi pane name` as the canonical subcommand for setting a pane's title. The old `plexi pane set-title` continues to work but prints a deprecation warning to stderr.

## Changes

- `src/cli_args.rs` — `Name` variant added as canonical; `SetTitle` marked `#[command(hide = true)]`
- `src/main.rs` — `Name` dispatch arm added; `SetTitle` arm prints deprecation warning before delegating
- `src/cli.rs` — zsh, bash, and fish completions updated to surface `name` and demote `set-title`

## Test

```
plexi pane name "my title"          # sets title, no warning
plexi pane set-title "my title"     # sets title + prints deprecation warning to stderr
```