### PR TITLE
feat(notify): add --scope flag to plexi notify CLI (window|context|global)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1060,7 +1060,7 @@ impl PlexiApp {
                 crate::app_protocol::HostCommand::Notify {
                     level, title, body, kind, options, input_prompt,
                     required, priority, image_inline, image_pipe_id,
-                    timeout_secs, on_dismiss, response_file, ..
+                    timeout_secs, on_dismiss, response_file, scope, ..
                 } => {
                     if !self.notifications_enabled {
                         log::info!("pane_ipc: notify dropped — notifications disabled");
@@ -1074,14 +1074,14 @@ impl PlexiApp {
                             .unwrap_or(0)
                     );
                     log::info!(
-                        "pane_ipc: kind=notify title={:?} choices={} response_file={:?}",
-                        title, options.len(), response_file
+                        "pane_ipc: kind=notify title={:?} choices={} scope={:?} response_file={:?}",
+                        title, options.len(), scope, response_file
                     );
                     self.pending_notifications.push(PendingNotification {
                         notify_id: internal_id.clone(),
                         sender_pane_id: 0,
                         source_context_id: self.router.active().context_id,
-                        scope: crate::app_protocol::NotifyScope::Global,
+                        scope: scope.unwrap_or(crate::app_protocol::NotifyScope::Global),
                         level: level.clone(),
                         title: title.clone(),
                         body: body.clone(),

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -844,6 +844,11 @@ pub enum HostCommand {
         /// result to the blocking CLI process. Never set by app SDK.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         response_file: Option<String>,
+        /// CLI-only: notification visibility scope. Apps never set this — their
+        /// scope comes from `manifest.toml::[launch] notification_scope`.
+        /// Omit for backwards-compatible global behaviour.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scope: Option<NotifyScope>,
     },
     /// Open a typed pipe.
     /// mode: "json" | "binary"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1439,6 +1439,7 @@ pub fn notify_cli(
     level: &str,
     choices: &[(String, String, Option<String>)],
     timeout_secs: u64,
+    scope: Option<crate::app_protocol::NotifyScope>,
 ) -> i32 {
     let socket_path = match std::env::var("PLEXI_SOCKET") {
         Ok(v) => v,
@@ -1483,10 +1484,18 @@ pub fn notify_cli(
     if let Some(ref rf) = response_file_str {
         payload["response_file"] = serde_json::Value::String(rf.clone());
     }
+    if let Some(s) = scope {
+        let s_str = match s {
+            crate::app_protocol::NotifyScope::Window => "window",
+            crate::app_protocol::NotifyScope::Context => "context",
+            crate::app_protocol::NotifyScope::Global => "global",
+        };
+        payload["scope"] = serde_json::Value::String(s_str.to_string());
+    }
 
     log::info!(
-        "notify:cli: sending via socket choices={} response_file={:?}",
-        choices.len(), response_file_str
+        "notify:cli: sending via socket choices={} scope={:?} response_file={:?}",
+        choices.len(), scope, response_file_str
     );
 
     use std::io::Write;
@@ -3308,7 +3317,7 @@ mod notify_tests {
     #[test]
     fn notify_cli_no_socket_returns_one() {
         std::env::remove_var("PLEXI_SOCKET");
-        let code = notify_cli("Test title", "Test body", "info", &[], 0);
+        let code = notify_cli("Test title", "Test body", "info", &[], 0, None);
         assert_eq!(code, 1);
     }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -93,6 +93,9 @@ pub enum Commands {
         /// Timeout in seconds (0 = no timeout)
         #[arg(long, default_value = "0")]
         timeout: u64,
+        /// Notification visibility scope: window, context, or global. Default: global.
+        #[arg(long, value_name = "SCOPE")]
+        scope: Option<String>,
     },
     /// Pane management [requires PLEXI_SOCKET — run inside a Plexi pane]
     Pane {

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ fn main() -> eframe::Result {
                     Commands::Pack { cmd } => match cmd {
                         PackCmd::Export { path } => std::process::exit(cli::pack_export_cli(&path)),
                     },
-                    Commands::Notify { title, body, level, choices, host_actions, timeout } => {
+                    Commands::Notify { title, body, level, choices, host_actions, timeout, scope } => {
                         // Parse --host-action flags into a key → "action_type:action_arg" map.
                         let mut host_action_map: std::collections::HashMap<String, String> =
                             std::collections::HashMap::new();
@@ -293,11 +293,25 @@ fn main() -> eframe::Result {
                             eprintln!("{msg}");
                             std::process::exit(1);
                         }
+                        let parsed_scope: Option<crate::app_protocol::NotifyScope> = match scope.as_deref() {
+                            None | Some("global") => None,
+                            Some("window") => Some(crate::app_protocol::NotifyScope::Window),
+                            Some("context") => Some(crate::app_protocol::NotifyScope::Context),
+                            Some(other) => {
+                                let msg = format!(
+                                    "error: --scope must be window, context, or global — got {:?}",
+                                    other
+                                );
+                                log::warn!("notify:cli: {msg}");
+                                eprintln!("{msg}");
+                                std::process::exit(1);
+                            }
+                        };
                         log::info!(
                             "notify:cli: host_actions={} merged into choices",
                             host_actions.len()
                         );
-                        std::process::exit(cli::notify_cli(&title, &body, &level, &parsed_choices, timeout));
+                        std::process::exit(cli::notify_cli(&title, &body, &level, &parsed_choices, timeout, parsed_scope));
                     }
                     Commands::Pane { cmd } => match cmd {
                         PaneCmd::SetTitle { first, second } => {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -269,6 +269,7 @@ impl ProcessApp {
                 timeout_secs,
                 on_dismiss,
                 response_file: _,
+                scope: _,
             } => {
                 let notif_id = format!("{}-{}", self.type_id, event_log::now_timestamp());
                 log::info!(


### PR DESCRIPTION
Closes #994

## What

Adds `--scope <window|context|global>` to `plexi notify`. When omitted, behaviour is unchanged (global). When specified, the notification is scoped accordingly.

## How

- Added `scope: Option<NotifyScope>` field to `HostCommand::Notify` in `app_protocol.rs` — CLI-only, serde-optional for backwards compat
- Added `--scope SCOPE` arg to `Notify` variant in `cli_args.rs`
- `notify_cli()` accepts and serializes scope into the JSON payload
- Socket handler in `app/mod.rs` reads scope from the deserialized command instead of hardcoding `NotifyScope::Global`
- `main.rs` parses and validates the scope string; invalid values exit 1 with a clear error

## Test plan

- [ ] `plexi-pr-<N> notify --title "Test" --body "no scope"` → fires global notification (no regression)
- [ ] `plexi-pr-<N> notify --title "Test" --body "context scoped" --scope context` → notification visible only when source context is active
- [ ] `plexi-pr-<N> notify --title "Test" --body "bad scope" --scope invalid` → exits 1 with error message
- [ ] `cargo test` green (3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)