### PR TITLE
feat(create-app): scaffold + open + hot-reload skill

### DIFF
--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: create-app
+description: Scaffold a new Plexi app, install it, open it in a pane, and activate hot reload — all in one command. Use when the user says "build me an app", "create a Plexi app", or "make an app that does X".
+skill_version: "3.5.88"
+source: local
+date_added: "2026-05-09"
+---
+
+# Create App
+
+Scaffold a minimal working Plexi app, open it in a live pane, and enable hot reload so the agent can edit it immediately.
+
+---
+
+## Step 1 — Gather requirements
+
+Ask (in a single message, not separately):
+
+1. **App name** — a short slug (`snake_case`, no spaces). This becomes the app ID and directory name.
+2. **One-sentence description** — what it does. Used in the manifest and as the initial render hint.
+
+If the user already provided both (e.g. "make an app called `notes` that shows a text editor"), extract them and skip asking.
+
+---
+
+## Step 2 — Validate environment
+
+```bash
+# Must be inside a Plexi pane
+if [ -z "$PLEXI_SOCKET" ]; then
+  echo "error: PLEXI_SOCKET not set — run this inside a Plexi terminal pane"
+  exit 1
+fi
+echo "PLEXI_SOCKET is set: $PLEXI_SOCKET"
+```
+
+```bash
+# Must have a workspace (CWD or ancestor has .plexi/)
+plexi workspace init 2>/dev/null || true   # no-op if already initialised
+```
+
+> If the user is in their home directory (`$HOME`), stop and ask them to `cd` into a project directory first. `plexi workspace init` must never run from `~` — it would collide with the global profile dir.
+
+---
+
+## Step 3 — Scaffold
+
+```bash
+APP_NAME="<name>"
+plexi app init "$APP_NAME"
+```
+
+This creates:
+```
+.plexi/apps/<name>/
+  manifest.toml
+  main.py
+  plexi_sdk.py
+```
+
+---
+
+## Step 4 — Patch manifest
+
+Add `watch = true` to `[app]` so hot reload activates when the pane opens. Also inject the user's description.
+
+Read the generated manifest:
+```bash
+cat ".plexi/apps/$APP_NAME/manifest.toml"
+```
+
+Edit it in-place — use the Read + Edit tools (not sed). The `[app]` section should become:
+
+```toml
+[app]
+id = "<name>"
+name = "<Display Name>"
+entry = "main.py"
+version = "0.1.0"
+description = "<user's description>"
+watch = true
+```
+
+Do NOT add any other fields or change the schema.
+
+---
+
+## Step 5 — Open the pane
+
+```bash
+PANE_ID=$(plexi open "$APP_NAME")
+echo "Opened pane: $PANE_ID"
+```
+
+The host rescans the app registry on cache miss (added in v3.5.89), so newly scaffolded apps are discoverable without restarting Plexi.
+
+If `plexi open` prints nothing or exits non-zero:
+1. Check `~/.plexi-alpha/plexi.log` (or the channel-appropriate log) for errors
+2. Verify the manifest is valid: `plexi validate ".plexi/apps/$APP_NAME"`
+3. Report the error — do not silently continue
+
+---
+
+## Step 6 — Report
+
+Output exactly this block so the user can navigate immediately:
+
+```
+App created: <name>
+Directory:   .plexi/apps/<name>/
+Pane ID:     <PANE_ID>
+Hot reload:  active (watch = true)
+
+Edit main.py to update the app live. No restart needed.
+```
+
+---
+
+## What the agent does next
+
+After reporting, the agent is in the live-edit loop:
+
+- Read `.plexi/apps/<name>/main.py`
+- Edit it to implement what the user asked for
+- The pane updates automatically on save (hot reload is active)
+- Run `plexi validate ".plexi/apps/$APP_NAME"` if the pane goes blank (manifest issue)
+
+---
+
+## Skill constraints
+
+- **One app per invocation** — if the user asks for multiple apps, create them sequentially, not in parallel (each `plexi open` returns a pane ID that must be captured before the next)
+- **Never run `plexi workspace init` from `~`** — check `pwd` first
+- **`plexi open` must be run from inside a Plexi pane** — `PLEXI_SOCKET` must be set, or the call queues to the spawn-queue without returning a pane ID
+- **The app ID must be unique** — if `.plexi/apps/<name>/` already exists, `plexi app init` will exit with an error; surface it to the user and ask for a different name
+- **Do not modify `plexi_sdk.py`** — it is generated from the host's embedded SDK; editing it will be overwritten on the next install

--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -80,6 +80,7 @@ Edit it in-place — use the Read + Edit tools (not sed). The `[app]` section sh
 [app]
 id = "<name>"
 name = "<Display Name>"
+type = "app"
 entry = "main.py"
 version = "0.1.0"
 description = "<user's description>"

--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-app
 description: Scaffold a new Plexi app, install it, open it in a pane, and activate hot reload — all in one command. Use when the user says "build me an app", "create a Plexi app", or "make an app that does X".
-skill_version: "3.5.89"
+skill_version: "3.5.101"
 source: local
 date_added: "2026-05-09"
 ---

--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-app
 description: Scaffold a new Plexi app, install it, open it in a pane, and activate hot reload — all in one command. Use when the user says "build me an app", "create a Plexi app", or "make an app that does X".
-skill_version: "3.5.88"
+skill_version: "3.5.89"
 source: local
 date_added: "2026-05-09"
 ---
@@ -35,11 +35,16 @@ echo "PLEXI_SOCKET is set: $PLEXI_SOCKET"
 ```
 
 ```bash
+# Must not be in home directory — workspace init from ~ collides with the global profile dir
+if [ "$PWD" = "$HOME" ]; then
+  echo "error: cannot create a Plexi app from the home directory"
+  echo "Please cd into a project directory first"
+  exit 1
+fi
+
 # Must have a workspace (CWD or ancestor has .plexi/)
 plexi workspace init 2>/dev/null || true   # no-op if already initialised
 ```
-
-> If the user is in their home directory (`$HOME`), stop and ask them to `cd` into a project directory first. `plexi workspace init` must never run from `~` — it would collide with the global profile dir.
 
 ---
 
@@ -92,7 +97,7 @@ PANE_ID=$(plexi open "$APP_NAME")
 echo "Opened pane: $PANE_ID"
 ```
 
-The host rescans the app registry on cache miss (added in v3.5.89), so newly scaffolded apps are discoverable without restarting Plexi.
+The host rescans the app registry on cache miss (v3.5.89+), so newly scaffolded apps are discoverable without restarting Plexi.
 
 If `plexi open` prints nothing or exits non-zero:
 1. Check `~/.plexi-alpha/plexi.log` (or the channel-appropriate log) for errors

--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -48,7 +48,7 @@ plexi workspace init 2>/dev/null || true   # no-op if already initialised
 
 ---
 
-## Step 3 — Scaffold
+## Step 3 — Scaffold and open
 
 ```bash
 APP_NAME="<name>"
@@ -58,57 +58,47 @@ plexi app init "$APP_NAME"
 This creates:
 ```
 .plexi/apps/<name>/
-  manifest.toml
+  manifest.toml   (includes watch = true — hot reload active by default)
   main.py
 ```
 
 The host injects `plexi_sdk` via `PYTHONPATH` at launch — no local copy is needed or created.
 
----
-
-## Step 4 — Patch manifest
-
-Add `watch = true` to `[app]` so hot reload activates when the pane opens. Also inject the user's description.
-
-Read the generated manifest:
-```bash
-cat ".plexi/apps/$APP_NAME/manifest.toml"
-```
-
-Edit it in-place — use the Read + Edit tools (not sed). The `[app]` section should become:
-
-```toml
-[app]
-id = "<name>"
-name = "<Display Name>"
-type = "app"
-entry = "main.py"
-version = "0.1.0"
-description = "<user's description>"
-watch = true
-```
-
-Do NOT add any other fields or change the schema.
-
----
-
-## Step 5 — Open the pane
+When run inside a Plexi pane (`PLEXI_SOCKET` is set), `plexi app init` automatically opens the app and prints the new pane ID on the last line of stdout. Capture it:
 
 ```bash
+PANE_ID=$(plexi app init "$APP_NAME" 2>/dev/null | tail -1)
+echo "Opened pane: $PANE_ID"
+```
+
+If `PLEXI_SOCKET` is not set (running outside a Plexi pane), open manually after init:
+
+```bash
+plexi app init "$APP_NAME"
 PANE_ID=$(plexi open "$APP_NAME")
 echo "Opened pane: $PANE_ID"
 ```
 
-The host rescans the app registry on cache miss (v3.5.89+), so newly scaffolded apps are discoverable without restarting Plexi.
+The host rescans the app registry on cache miss (v3.5.92+), so newly scaffolded apps are discoverable without restarting Plexi.
 
-If `plexi open` prints nothing or exits non-zero:
+If the open fails or pane ID is empty:
 1. Check `~/.plexi-alpha/plexi.log` (or the channel-appropriate log) for errors
 2. Verify the manifest is valid: `plexi validate ".plexi/apps/$APP_NAME"`
 3. Report the error — do not silently continue
 
+## Step 4 — Patch description
+
+Edit the manifest in-place to inject the user's description — use the Read + Edit tools (not sed):
+
+```toml
+description = "<user's one-sentence description>"
+```
+
+Leave all other fields unchanged. `watch = true` is already present from the scaffold.
+
 ---
 
-## Step 6 — Report
+## Step 5 — Report
 
 Output exactly this block so the user can navigate immediately:
 
@@ -123,7 +113,7 @@ Edit main.py to update the app live. No restart needed.
 
 ---
 
-## What the agent does next
+## Step 6 — What the agent does next
 
 After reporting, the agent is in the live-edit loop:
 

--- a/.claude/skills/create-app/SKILL.md
+++ b/.claude/skills/create-app/SKILL.md
@@ -60,8 +60,9 @@ This creates:
 .plexi/apps/<name>/
   manifest.toml
   main.py
-  plexi_sdk.py
 ```
+
+The host injects `plexi_sdk` via `PYTHONPATH` at launch — no local copy is needed or created.
 
 ---
 
@@ -139,4 +140,4 @@ After reporting, the agent is in the live-edit loop:
 - **Never run `plexi workspace init` from `~`** — check `pwd` first
 - **`plexi open` must be run from inside a Plexi pane** — `PLEXI_SOCKET` must be set, or the call queues to the spawn-queue without returning a pane ID
 - **The app ID must be unique** — if `.plexi/apps/<name>/` already exists, `plexi app init` will exit with an error; surface it to the user and ask for a different name
-- **Do not modify `plexi_sdk.py`** — it is generated from the host's embedded SDK; editing it will be overwritten on the next install
+- **Do not add `plexi_sdk.py` manually** — the host injects PYTHONPATH at launch; a local copy breaks the package's relative imports

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -440,7 +440,7 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 // apps are immediately openable without restarting Plexi.
                 if std::env::var("PLEXI_SOCKET").is_ok() {
                     log::info!("app_init: auto-opening '{name}' via socket");
-                    let exit_code = crate::cli::open_cli(name, &[], None);
+                    let exit_code = crate::cli::open_cli(name, &[], None, None);
                     if exit_code != 0 {
                         eprintln!("warning: app created but could not auto-open '{name}' (exit {exit_code}) — run: plexi open {name}");
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -472,7 +472,8 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
     // do NOT copy plexi_sdk.py alongside (the package uses relative imports
     // that break when imported as a flat single file).
     let main_py = format!(
-        "#!/usr/bin/env python3\nfrom plexi_sdk import App\n\napp = App()\n\n@app.on_render\ndef render(ctx):\n    ctx.rect(0, 0, ctx.width, ctx.height, fill=\"#1e1e2e\")\n    ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n    ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n@app.on_key\ndef on_key(key, mods, emit):\n    pass\n\napp.run()\n",
+        "#!/usr/bin/env python3\nfrom plexi_sdk import App, RenderContext\n\n\nclass {class_name}(App):\n    def on_render(self, ctx: RenderContext) -> None:\n        ctx.rect(0, 0, ctx.width, ctx.height, fill=\"#1e1e2e\")\n        ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n        ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:\n        pass\n\n\n{class_name}().run()\n",
+        class_name = to_struct_name(name),
         display = to_title_case(name),
     );
     let main_path = app_dir.join("main.py");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -472,7 +472,7 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
     // do NOT copy plexi_sdk.py alongside (the package uses relative imports
     // that break when imported as a flat single file).
     let main_py = format!(
-        "#!/usr/bin/env python3\nfrom plexi_sdk import App, RenderContext\n\n\nclass {class_name}(App):\n    def on_render(self, ctx: RenderContext) -> None:\n        ctx.rect(0, 0, ctx.width, ctx.height, fill=\"#1e1e2e\")\n        ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n        ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:\n        pass\n\n\n{class_name}().run()\n",
+        "#!/usr/bin/env python3\nfrom plexi_sdk import App, RenderContext\n\n\nclass {class_name}(App):\n    def on_render(self, ctx: RenderContext) -> None:\n        ctx.rect(0, 0, ctx.w, ctx.h, fill=\"#1e1e2e\")\n        ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n        ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:\n        pass\n\n\n{class_name}().run()\n",
         class_name = to_struct_name(name),
         display = to_title_case(name),
     );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -463,7 +463,7 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
 
     // manifest.toml
     std::fs::write(app_dir.join("manifest.toml"), format!(
-        "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
+        "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\nwatch = true\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
         name = name,
         display = to_title_case(name),
     ))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -457,7 +457,7 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
 
     // manifest.toml
     std::fs::write(app_dir.join("manifest.toml"), format!(
-        "schema_version = 1\ntype = \"app\"\n\n[app]\nid = \"{name}\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
+        "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
         name = name,
         display = to_title_case(name),
     ))?;
@@ -484,7 +484,7 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
 fn scaffold_rust_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> {
     // manifest.toml
     std::fs::write(app_dir.join("manifest.toml"), format!(
-        "schema_version = 1\ntype = \"app\"\n\n[app]\nid = \"{name}\"\nname = \"{display}\"\nentry = \"bin/plexi-app\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
+        "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"bin/plexi-app\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = [\"fs.read\"]\n\n[launch]\nlayout_hint = {{ side = \"right\", split = 0.5 }}\n",
         name = name,
         display = to_title_case(name),
     ))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,10 +6,6 @@ use std::process::Command;
 const APP_ID: &str = "plexi-run";
 const COMMANDS_FILE: &str = ".plexi/commands.toml";
 
-// Embed the Python SDK at compile time so `plexi app init` can write it out.
-// Source is now sdk/python/plexi_sdk/__init__.py (package layout); the file
-// written into scaffolded apps remains plexi_sdk.py for flat single-file import.
-const PYTHON_SDK: &str = include_str!("../sdk/python/plexi_sdk/__init__.py");
 
 /// Parsed .plexi/commands.toml
 #[derive(Deserialize)]
@@ -437,11 +433,21 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 println!("\nNext steps:");
                 println!("  cd {}", app_dir.display());
                 println!("  cargo build --release");
-                println!("  # then open a file in Plexi or run: plexi app launch {name}");
+                println!("  # then run: plexi open {name}");
             } else {
-                println!("\nNext steps:");
-                println!("  edit {}/main.py", app_dir.display());
-                println!("  # Plexi will pick it up on next launch (or reload)");
+                // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
+                // The host rescans the registry on cache miss, so newly scaffolded
+                // apps are immediately openable without restarting Plexi.
+                if std::env::var("PLEXI_SOCKET").is_ok() {
+                    log::info!("app_init: auto-opening '{name}' via socket");
+                    let exit_code = crate::cli::open_cli(name, &[], None);
+                    if exit_code != 0 {
+                        eprintln!("warning: app created but could not auto-open '{name}' (exit {exit_code}) — run: plexi open {name}");
+                    }
+                } else {
+                    println!("\nRun inside a Plexi pane to open it immediately:");
+                    println!("  plexi open {name}");
+                }
             }
             0
         }
@@ -462,12 +468,11 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
         display = to_title_case(name),
     ))?;
 
-    // plexi_sdk.py — embedded at compile time
-    std::fs::write(app_dir.join("plexi_sdk.py"), PYTHON_SDK)?;
-
-    // main.py
+    // main.py — plexi_sdk is injected via PYTHONPATH by the host at launch;
+    // do NOT copy plexi_sdk.py alongside (the package uses relative imports
+    // that break when imported as a flat single file).
     let main_py = format!(
-        "#!/usr/bin/env python3\nimport sys, os\nsys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))\nfrom plexi_sdk import App\n\napp = App()\n\n@app.on_render\ndef render(ctx):\n    ctx.rect(0, 0, ctx.width, ctx.height, fill=\"#1e1e2e\")\n    ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n    ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n@app.on_key\ndef on_key(key, mods, emit):\n    pass  # handle key events here\n\napp.run()\n",
+        "#!/usr/bin/env python3\nfrom plexi_sdk import App\n\napp = App()\n\n@app.on_render\ndef render(ctx):\n    ctx.rect(0, 0, ctx.width, ctx.height, fill=\"#1e1e2e\")\n    ctx.text(20, 20, \"{display}\", size=16, color=\"#cdd6f4\", bold=True)\n    ctx.text(20, 50, \"Edit main.py to build your app.\", size=13, color=\"#6c7086\")\n\n@app.on_key\ndef on_key(key, mods, emit):\n    pass\n\napp.run()\n",
         display = to_title_case(name),
     );
     let main_path = app_dir.join("main.py");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -505,8 +505,16 @@ impl PlexiApp {
             return;
         }
 
-        // Try registry first; if it returns None, fall through to Tier 4.
+        // Try registry first; if it returns None, rescan from disk (supports
+        // apps created mid-session via `plexi app init`) then fall through to Tier 4.
         let registry_process = self.registry.launch_process(id, &cwd, args);
+        let registry_process = if registry_process.is_none() {
+            log::info!("launch_app_by_id: '{id}' not in startup registry — rescanning from disk");
+            self.registry = crate::app_registry::AppRegistry::load(&cwd);
+            self.registry.launch_process(id, &cwd, args)
+        } else {
+            registry_process
+        };
         if let Some(process) = registry_process {
             if cli_binary_in_path(id) {
                 log::warn!(

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -489,18 +489,17 @@ impl PlexiApp {
             .and_then(|fp| self.windows[self.active_window].get_focused_pane_cwd(fp))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
-        let group = self.registry.group_for(id);
-        let hint = layout
-            .or_else(|| self.registry.layout_hint_for(id))
-            .or_else(|| {
-                log::info!("app::{id}: no layout_hint — defaulting to overlay");
-                Some("overlay".to_string())
-            });
-
         // Re-attach a parked background app if one is waiting
         if let Some((_park_context_id, mut parked)) = self.background_apps.remove(id) {
             log::info!("re-attaching background app '{id}'");
             parked.send_event(&crate::app_protocol::PlexiEvent::Resume);
+            let group = self.registry.group_for(id);
+            let hint = layout
+                .or_else(|| self.registry.layout_hint_for(id))
+                .or_else(|| {
+                    log::info!("app::{id}: no layout_hint — defaulting to overlay");
+                    Some("overlay".to_string())
+                });
             self.open_process_app_pane(id, *parked, cwd, group, hint.as_deref());
             return;
         }
@@ -515,6 +514,15 @@ impl PlexiApp {
         } else {
             registry_process
         };
+        // Query group/hint after any registry reload so metadata reflects the
+        // actual registry that found the app.
+        let group = self.registry.group_for(id);
+        let hint = layout
+            .or_else(|| self.registry.layout_hint_for(id))
+            .or_else(|| {
+                log::info!("app::{id}: no layout_hint — defaulting to overlay");
+                Some("overlay".to_string())
+            });
         if let Some(process) = registry_process {
             if cli_binary_in_path(id) {
                 log::warn!(


### PR DESCRIPTION
Closes #974.

## What

Three host fixes + one new skill:

1. **Manifest type placement** — `type = "app"` was at the root TOML level; moved inside `[app]` section where `AppManifestApp` serde expects it. Root-level placement silently failed validation ("missing field type").

2. **SDK copy removed** — `plexi_sdk.py` was embedded into every scaffold but the SDK now uses relative imports (`from ._constants import …`) which break when copied as a flat file. The host already injects PYTHONPATH at launch — no local copy needed.

3. **Registry rescan on cache miss** — apps created mid-session via `plexi app init` are unknown to the startup registry. `launch_app_by_id_with_layout` now reloads the registry from disk on a miss before falling through to Tier 4, so newly scaffolded apps are openable immediately without restarting Plexi.

4. **Auto-open** — `app_init` calls `open_cli` immediately after scaffold when `PLEXI_SOCKET` is set, printing the pane ID on the last line of stdout.

5. **`.claude/skills/create-app/SKILL.md`** — new skill that wraps the above into a single Claude Code command.

Also adds `watch = true` to default scaffold manifest (hot reload active by default) and switches the Python template to the class-based `App` subclass pattern matching the current SDK API.

## Breaks if

`plexi app init <name>` from inside a Plexi pane fails to open the app, OR the app opens but takes the full screen instead of a right-side split.