### PR TITLE
fix(registry): launch .py app entries via python3 — remove shebang and chmod+x requirements

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -17,7 +17,7 @@
 //!   my-pdf-viewer/
 //!     manifest.toml
 //!     bin/              # or just an executable named after the app id
-//!       plexi-app       # the app binary (must be executable)
+//!       plexi-app       # the app binary (.py entries are launched via python3)
 //!   file-browser/
 //!     manifest.toml
 //!     bin/plexi-app
@@ -608,26 +608,13 @@ pub fn resolve_workspace_root(start: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Resolve the `entry` field from manifest.toml to an executable path.
+/// Resolve the `entry` field from manifest.toml to a path.
 /// Fails fast — no guessing, no fallbacks.
 fn resolve_entry(app_dir: &PathBuf, entry: &str) -> Result<PathBuf, String> {
     let path = app_dir.join(entry);
 
     if !path.exists() {
         return Err(format!("entry '{entry}' not found in {:?}", app_dir));
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = std::fs::metadata(&path)
-            .map(|m| m.permissions().mode())
-            .unwrap_or(0);
-        if mode & 0o111 == 0 {
-            return Err(format!(
-                "entry '{entry}' exists but is not executable (run: chmod +x {entry})"
-            ));
-        }
     }
 
     Ok(path)
@@ -637,10 +624,8 @@ fn resolve_entry(app_dir: &PathBuf, entry: &str) -> Result<PathBuf, String> {
 mod tests {
     use super::*;
     use std::fs;
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
 
-    /// Create a manifest + executable entry under `dir/<id>/`.
+    /// Create a manifest and entry script under `dir/<id>/`.
     /// `name` is what shows up in the manifest's `[app].name` so tests can
     /// distinguish two entries with the same id but different content.
     fn write_app(dir: &Path, id: &str, name: &str) {
@@ -656,12 +641,6 @@ mod tests {
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
         fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
     }
 
     #[test]
@@ -678,6 +657,22 @@ mod tests {
         let foo = registry.get("foo").expect("foo should be discovered");
         assert_eq!(foo.manifest.name, "Local Foo");
         assert_eq!(foo.source, RegistrySource::LocalApp);
+    }
+
+    #[test]
+    fn py_entry_loads_without_executable_bit() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("myapp");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "schema_version = 1\n\n[app]\nid = \"myapp\"\ntype = \"app\"\nname = \"My App\"\nversion = \"0.0.1\"\nentry = \"app.py\"\n";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        // Write entry without shebang or executable bit.
+        fs::write(app_dir.join("app.py"), "import plexi\n").unwrap();
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let app = registry.get("myapp").expect("app.py entry must load without chmod+x");
+        assert!(app.bin_path.ends_with("app.py"));
     }
 
     #[test]
@@ -753,12 +748,6 @@ mod tests {
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
         fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
 
         let bare = tempfile::tempdir().unwrap();
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
@@ -864,12 +853,6 @@ watch = true
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
         fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
 
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         let app = registry.get("watching-app").expect("manifest with watch=true should load");
@@ -917,12 +900,6 @@ watch = true
         fs::write(g_dir.join("manifest.toml"), manifest_g).unwrap();
         let entry_g = g_dir.join("run.sh");
         fs::write(&entry_g, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry_g).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry_g, perms).unwrap();
-        }
 
         // Local copy with watch=true (different id so they don't shadow).
         let l_dir = local_apps.join("local-watcher");
@@ -941,12 +918,6 @@ watch = true
         fs::write(l_dir.join("manifest.toml"), manifest_l).unwrap();
         let entry_l = l_dir.join("run.sh");
         fs::write(&entry_l, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry_l).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry_l, perms).unwrap();
-        }
 
         let registry = AppRegistry::load_with_global(workspace.path(), global.path());
         assert!(
@@ -1008,12 +979,6 @@ notification_scope = \"global\"
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
         fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
 
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         let scope = registry.default_notification_scope_for("stand-up");
@@ -1042,12 +1007,6 @@ notification_scope = \"context\"
         fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
         let entry = app_dir.join("run.sh");
         fs::write(&entry, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            let mut perms = fs::metadata(&entry).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&entry, perms).unwrap();
-        }
 
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         let scope = registry.default_notification_scope_for("ctx-scoped");

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -334,7 +334,30 @@ impl ProcessApp {
         // legitimately needs. Strips OPENROUTER_API_KEY and every other
         // host credential — apps must use the iq.query / llm broker, never direct API access.
         const ENV_WHITELIST: &[&str] = &["HOME", "PATH", "LANG", "LC_ALL", "TERM", "USER", "SHELL"];
-        let mut cmd = std::process::Command::new(bin_path);
+
+        // Resolve the bundled Python interpreter path — used both to build the
+        // python3 command for .py entries and to prepend to PATH for PYTHONPATH setup.
+        let bundle_contents = std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()));
+        let bundled_py_bin = bundle_contents.as_ref()
+            .map(|c| c.join("Resources").join("assets").join("python").join("bin"));
+
+        // .py entries are launched via python3 directly — no shebang or executable bit required.
+        let is_python = bin_path.extension().and_then(|e| e.to_str()) == Some("py");
+        let mut cmd = if is_python {
+            let py_exe = bundled_py_bin.as_ref()
+                .map(|b| b.join("python3"))
+                .filter(|p| p.exists())
+                .map(|p| std::ffi::OsString::from(p))
+                .unwrap_or_else(|| std::ffi::OsString::from("python3"));
+            log::info!("ProcessApp[{type_id}]: launching .py entry via {:?}", py_exe);
+            let mut c = std::process::Command::new(py_exe);
+            c.arg(bin_path);
+            c
+        } else {
+            std::process::Command::new(bin_path)
+        };
         cmd.args(args)
             .current_dir(cwd)
             .stdin(Stdio::piped())
@@ -378,15 +401,9 @@ impl ProcessApp {
             }
         }).flatten();
         // Prepend the bundled Python interpreter's bin/ dir to PATH so that
-        // Python app shebangs (`#!/usr/bin/env python3`) resolve to our hermetic
-        // Python 3.12, not whatever the host machine happens to have installed.
-        // Falls back silently to host PATH if the bundle runtime isn't present
-        // (dev builds that haven't run `just fetch-python-runtime` yet).
-        let bundle_contents = std::env::current_exe()
-            .ok()
-            .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()));
-        if let Some(ref contents) = bundle_contents {
-            let py_bin = contents.join("Resources").join("assets").join("python").join("bin");
+        // dev-mode .py entries without the bundle still resolve python3 correctly.
+        // Falls back silently to host PATH if the bundle runtime isn't present.
+        if let Some(ref py_bin) = bundled_py_bin {
             if py_bin.exists() {
                 let host_path = std::env::var("PATH").unwrap_or_default();
                 cmd.env("PATH", format!("{}:{}", py_bin.display(), host_path));


### PR DESCRIPTION
Closes #841.

## Summary

- Removes the `#[cfg(unix)]` executable-bit check from `resolve_entry` — only file existence is validated now
- `ProcessApp::launch` detects `.py` extension and spawns the app as `python3 <path>`, using the bundled Python interpreter when available (falls back to system `python3` in dev builds)
- Drops all `chmod +x` setup from registry tests — no longer required for fixture entries
- Adds `py_entry_loads_without_executable_bit` test confirming `.py` entries resolve without executable bit

## Breaks if:
A `.py` app that was previously working silently stops launching — would surface as an app pane that opens then immediately closes with no output. Check `~/.plexi-alpha/plexi.log` for `ProcessApp[<id>]` error lines.