### PR TITLE
feat: transparent titlebar — toolbar color bleeds into macOS title bar area

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2381,7 +2381,7 @@ impl eframe::App for PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_toolbar)
                     .inner_margin(egui::Margin {
-                        left: 8,
+                        left: 80,
                         right: 8,
                         top: 4,
                         bottom: 4,

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,7 +452,9 @@ fn main() -> eframe::Result {
             .with_inner_size([1400.0, 900.0])
             .with_min_inner_size([400.0, 300.0])
             .with_title(env!("PLEXI_APP_TITLE"))
-            .with_icon(icon),
+            .with_icon(icon)
+            .with_fullsize_content_view(true)
+            .with_titlebar_shown(false),
         ..Default::default()
     };
 


### PR DESCRIPTION
## What

Enables a colored macOS title bar by extending the egui content view to fill behind the native titlebar area.

Two viewport flags added to `NativeOptions`:
- `with_fullsize_content_view(true)` — draws egui content under the title bar
- `with_titlebar_shown(false)` — makes the title bar chrome transparent

The toolbar's `bg_toolbar` color now fills the title bar region, giving the window a unified color from top to bottom.

**Toolbar left margin** increased from 8→80px so workspace dots (and future toolbar elements) start after the traffic light buttons.

## Visual result

The macOS close/minimize/zoom buttons float over the toolbar background. The title bar has the same color as the toolbar — no OS chrome visible.

## Test

Install PR build: `just pr-install <N>`

Launch `plexi-pr-<N>` and verify:
- Title bar area matches the toolbar background color (dark theme: same dark gray; light theme: same light gray)
- Traffic light buttons are visible and functional
- No toolbar content is obscured by the traffic lights
- Window is draggable by clicking the title bar area