### PR TITLE
feat(cli): reinstate `plexi app install <path>` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -611,6 +611,84 @@ pub fn app_uninstall(id: &str) -> i32 {
     0
 }
 
+/// `plexi app install <path>` — copy a local app directory into the channel's app store.
+pub fn app_install(path: &str) -> i32 {
+    let src = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d.join(path),
+            Err(e) => { eprintln!("error: {e}"); return 1; }
+        }
+    };
+    let src = match src.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {path}: {e}");
+            return 1;
+        }
+    };
+
+    let manifest_path = src.join("manifest.toml");
+    if !manifest_path.exists() {
+        eprintln!("error: no manifest.toml found in {}", src.display());
+        eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
+        return 1;
+    }
+    let manifest_str = match std::fs::read_to_string(&manifest_path) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not read manifest.toml: {e}"); return 1; }
+    };
+    let manifest: toml::Value = match toml::from_str(&manifest_str) {
+        Ok(v) => v,
+        Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
+    };
+    let app_section = match manifest.get("app") {
+        Some(a) => a,
+        None => { eprintln!("error: manifest.toml is missing [app] section"); return 1; }
+    };
+    let app_id = match app_section.get("id").and_then(|v| v.as_str()) {
+        Some(id) if !id.is_empty() => id.to_string(),
+        _ => { eprintln!("error: manifest.toml is missing a valid [app].id"); return 1; }
+    };
+    let app_version = app_section.get("version").and_then(|v| v.as_str()).unwrap_or("?");
+
+    let dest = crate::app_registry::apps_dir().join(&app_id);
+
+    // Remove existing install (idempotent overwrite).
+    if dest.exists() {
+        if let Err(e) = std::fs::remove_dir_all(&dest) {
+            eprintln!("error: could not remove existing install at {}: {e}", dest.display());
+            return 1;
+        }
+    }
+
+    if let Err(e) = copy_dir_all(&src, &dest) {
+        eprintln!("error: could not copy {} to {}: {e}", src.display(), dest.display());
+        return 1;
+    }
+
+    log::info!("app::install: installed {app_id} v{app_version} from {}", src.display());
+    println!("Installed '{app_id}' v{app_version} from {}.", src.display());
+    println!("Run `plexi open {app_id}` to launch it.");
+    0
+}
+
+fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            std::fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
+}
+
 /// `plexi app link <path>` — register a local app directory with the nearest workspace.
 pub fn app_link(path: &str) -> i32 {
     let cwd = match std::env::current_dir() {
@@ -3255,7 +3333,7 @@ _plexi() {
           ;;
         app)
           local subcmds
-          subcmds=('init:Scaffold a new app' 'install:Install an app from GitHub' 'uninstall:Uninstall an app' 'list:List installed apps' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
+          subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Uninstall an app' 'list:List installed apps' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
           _describe 'subcommand' subcmds
           ;;
         workspace)
@@ -3436,7 +3514,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from secret" -a delete -d "Delet
 
 # app subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a init -d "Scaffold a new app"
-complete -c plexi -f -n "__fish_seen_subcommand_from app" -a install -d "Install an app from GitHub"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a install -d "Install a local app directory"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a uninstall -d "Uninstall an app"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a list -d "List installed apps"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a link -d "Register a local app directory with the workspace"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -613,15 +613,7 @@ pub fn app_uninstall(id: &str) -> i32 {
 
 /// `plexi app install <path>` — copy a local app directory into the channel's app store.
 pub fn app_install(path: &str) -> i32 {
-    let src = if std::path::Path::new(path).is_absolute() {
-        std::path::PathBuf::from(path)
-    } else {
-        match std::env::current_dir() {
-            Ok(d) => d.join(path),
-            Err(e) => { eprintln!("error: {e}"); return 1; }
-        }
-    };
-    let src = match src.canonicalize() {
+    let src = match std::path::Path::new(path).canonicalize() {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error: could not resolve {path}: {e}");
@@ -643,13 +635,29 @@ pub fn app_install(path: &str) -> i32 {
         Ok(v) => v,
         Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
     };
+
+    let schema_version = manifest.get("schema_version").and_then(|v| v.as_integer()).unwrap_or(0);
+    if schema_version > crate::app_registry::MANIFEST_SCHEMA_VERSION as i64 {
+        eprintln!(
+            "error: manifest.toml schema_version {schema_version} is newer than supported (max {})",
+            crate::app_registry::MANIFEST_SCHEMA_VERSION
+        );
+        return 1;
+    }
+
     let app_section = match manifest.get("app") {
         Some(a) => a,
         None => { eprintln!("error: manifest.toml is missing [app] section"); return 1; }
     };
     let app_id = match app_section.get("id").and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id.to_string(),
-        _ => { eprintln!("error: manifest.toml is missing a valid [app].id"); return 1; }
+        Some(id) if !id.is_empty() && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') => {
+            id.to_string()
+        }
+        _ => {
+            eprintln!("error: manifest.toml is missing a valid [app].id");
+            eprintln!("  (IDs must be non-empty and contain only alphanumeric characters, dashes, or underscores)");
+            return 1;
+        }
     };
     let app_version = app_section.get("version").and_then(|v| v.as_str()).unwrap_or("?");
 
@@ -678,12 +686,12 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> 
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
-        let ty = entry.file_type()?;
+        let entry_path = entry.path();
         let dst_path = dst.join(entry.file_name());
-        if ty.is_dir() {
-            copy_dir_all(&entry.path(), &dst_path)?;
+        if entry_path.is_dir() {
+            copy_dir_all(&entry_path, &dst_path)?;
         } else {
-            std::fs::copy(entry.path(), dst_path)?;
+            std::fs::copy(entry_path, dst_path)?;
         }
     }
     Ok(())

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -226,6 +226,11 @@ pub enum AppCmd {
     Info {
         id: String,
     },
+    /// Install a local app directory into the channel's app store
+    Install {
+        /// Path to the app directory containing manifest.toml
+        path: String,
+    },
     /// Register a local app directory with the workspace (does not move files)
     Link {
         /// Path to the app directory containing manifest.toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,7 @@ fn main() -> eframe::Result {
                     },
                     Commands::App { cmd } => match cmd {
                         AppCmd::Init { name, lang } => std::process::exit(cli::app_init(&name, &lang)),
+                        AppCmd::Install { path } => std::process::exit(cli::app_install(&path)),
                         AppCmd::Uninstall { id } => std::process::exit(cli::app_uninstall(&id)),
                         AppCmd::List => std::process::exit(cli::app_list()),
                         AppCmd::Render { id, size, state, output } => {


### PR DESCRIPTION
Restores `plexi app install <path>` — removed in PR #956 along with the balls demo, its absence was noticed in issue #990.

## What changed

- Added `AppCmd::Install { path }` variant to the clap enum
- Added `app_install()` function: reads manifest.toml, extracts `[app].id` and version, copies the directory into `config_dir()/apps/<id>/`, idempotent (overwrites existing), fails fast with clear errors
- Wired dispatch in `main.rs`
- Updated zsh/fish completion descriptions from "Install an app from GitHub" → "Install a local app directory"

## Done when

```
plexi-alpha app install examples/balls
plexi-alpha app list | grep balls
plexi-alpha open balls
```

Closes #1008