### PR TITLE
fix(typing-tutor): correct key name strings to match host delivery format

### DIFF
--- a/examples/typing-tutor/main.py
+++ b/examples/typing-tutor/main.py
@@ -157,13 +157,13 @@ class TypingTutorApp(App):
 
     def _key_select(self, key: str) -> None:
         n = len(LEVELS)
-        if key in ("h", "ArrowLeft"):
+        if key in ("h", "left"):
             self._selected = max(0, self._selected - 1)
-        elif key in ("l", "ArrowRight"):
+        elif key in ("l", "right"):
             self._selected = min(n - 1, self._selected + 1)
-        elif key in ("k", "ArrowUp"):
+        elif key in ("k", "up"):
             self._selected = max(0, self._selected - 5)
-        elif key in ("j", "ArrowDown"):
+        elif key in ("j", "down"):
             self._selected = min(n - 1, self._selected + 5)
         elif key in (" ", "Enter"):
             if _is_unlocked(self._selected, self._level_stars):

--- a/examples/typing-tutor/main.py
+++ b/examples/typing-tutor/main.py
@@ -157,15 +157,15 @@ class TypingTutorApp(App):
 
     def _key_select(self, key: str) -> None:
         n = len(LEVELS)
-        if key in ("h", "left"):
+        if key in ("h", "ArrowLeft"):
             self._selected = max(0, self._selected - 1)
-        elif key in ("l", "right"):
+        elif key in ("l", "ArrowRight"):
             self._selected = min(n - 1, self._selected + 1)
-        elif key in ("k", "up"):
+        elif key in ("k", "ArrowUp"):
             self._selected = max(0, self._selected - 5)
-        elif key in ("j", "down"):
+        elif key in ("j", "ArrowDown"):
             self._selected = min(n - 1, self._selected + 5)
-        elif key in ("return", "space", "Enter"):
+        elif key in (" ", "Enter"):
             if _is_unlocked(self._selected, self._level_stars):
                 self._start_level(self._selected)
 
@@ -173,12 +173,12 @@ class TypingTutorApp(App):
         level = LEVELS[self._play_level]
         text = level.text
 
-        if key == "escape":
+        if key == "Escape":
             self.emit.info(f"typing-tutor: aborted level={self._play_level + 1}")
             self._screen = Screen.LEVEL_SELECT
             return
 
-        if key == "backspace":
+        if key == "Backspace":
             if self._typed > 0:
                 self._typed -= 1
                 self._errors.discard(self._typed)
@@ -200,7 +200,7 @@ class TypingTutorApp(App):
             self._go_result(ctx, timed_out=False)
 
     def _key_result(self, key: str) -> None:
-        if key in ("return", "Enter", "space"):
+        if key in (" ", "Enter"):
             self._screen = Screen.LEVEL_SELECT
         elif key == "r":
             self._start_level(self._play_level)
@@ -280,7 +280,7 @@ class TypingTutorApp(App):
 
         # Footer hints
         ctx.text(pad, ctx.h - 18,
-                 "h/← l/→ k/↑ j/↓ navigate   Enter/Space launch",
+                 "h/← l/→ k/↑ j/↓   Enter/Space launch",
                  size=HINT, color=MUTED)
 
     def _render_play(self, ctx: RenderContext) -> None:


### PR DESCRIPTION
## Summary

- Fixes `"escape"` → `"Escape"` and `"backspace"` → `"Backspace"` in `_key_play` — these are the two primary bugs from #940
- Fixes arrow key names: `"left"/"right"/"up"/"down"` → `"ArrowLeft"/"ArrowRight"/"ArrowUp"/"ArrowDown"` in `_key_select`
- Fixes space handling: the space bar arrives as Text event `" "` (single char), not the string `"space"`; updated `_key_select` and `_key_result` accordingly
- Removes dead `"return"` checks (only `"Enter"` is ever delivered by the host)

**Root cause:** The host forwards non-printable keys using `format!("{key:?}")` (Rust Debug format of `egui::Key`), producing `"Escape"`, `"Backspace"`, `"ArrowLeft"`, etc. The app was checking lowercase/abbreviated variants that never matched. Printable keys (letters, digits, punctuation) arrive via the Text event as their character string, so space arrives as `" "` not `"space"`.

Closes #940

## Test plan

- [ ] Open Typing Tutor on the alpha build
- [ ] Navigate level selector with arrow keys (should work now) and h/j/k/l
- [ ] Launch a level with Space or Enter
- [ ] During play: press Escape — should return to level selector
- [ ] During play: type some chars then press Backspace — should rewind one character