### PR TITLE
feat(navigation): Cmd+HJKL falls through to window nav at pane boundary

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2399,18 +2399,6 @@ impl eframe::App for PlexiApp {
                     self.new_context();
                     self.save_workspace();
                 }
-                Action::PageLeft => {
-                    self.navigate_or_create_page(-1, 0);
-                }
-                Action::PageRight => {
-                    self.navigate_or_create_page(1, 0);
-                }
-                Action::PageUp => {
-                    self.navigate_or_create_page(0, -1);
-                }
-                Action::PageDown => {
-                    self.navigate_or_create_page(0, 1);
-                }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();
                 }
@@ -3801,5 +3789,57 @@ mod tests {
             h.app.pending_notifications.len(), 1,
             "snoozed notification must survive tick_notification_timeouts"
         );
+    }
+
+    /// Build a second window in the SAME workspace (context_id = 1) placed
+    /// directly below window 0 on the spatial grid (grid_y = 1).
+    /// This is different from `second_window()` which uses context_id = 2
+    /// (a separate workspace used for cross-context tests).
+    fn same_workspace_window_below(window_id: u64, pane_id: u64) -> Window {
+        let mut tree = egui_tiles::Tree::empty("test_tree_below");
+        let tile = tree.tiles.insert_pane(pane_id);
+        tree.root = Some(tile);
+        Window {
+            name: "Test".into(),
+            path: std::env::temp_dir(),
+            tree,
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 1,
+            window_id,
+            context_id: 1, // same workspace as window 0
+        }
+    }
+
+    /// Regression guard for #863: navigate() at the pane boundary of window 0
+    /// must fall through to navigate_page() and switch active_window to window 1.
+    #[test]
+    fn navigate_at_pane_boundary_falls_through_to_page_navigation() {
+        let mut h = HostHarness::new();
+        let pane_a = h.add_test_pane();
+        // Window 1 is directly below window 0 on the spatial grid, same workspace.
+        h.app.windows.push(same_workspace_window_below(2, 9910));
+
+        // Establish focus on window 0's pane so navigate() enters the pane-lookup branch.
+        assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
+        assert_eq!(h.app.active_window, 0);
+        // Direction::Down with no pane below in the same window should fall through.
+        h.app.navigate(crate::keys::Direction::Down);
+        assert_eq!(h.app.active_window, 1, "navigate() at boundary must switch active_window via page navigation");
+    }
+
+    /// Regression guard for #863: navigate() at the boundary of the bottommost
+    /// window must be a silent no-op (no crash, active_window unchanged).
+    #[test]
+    fn navigate_at_grid_boundary_is_noop() {
+        let mut h = HostHarness::new();
+        let pane_a = h.add_test_pane();
+        // Only one window — no neighbor below.
+        assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
+        assert_eq!(h.app.active_window, 0);
+        h.app.navigate(crate::keys::Direction::Down);
+        assert_eq!(h.app.active_window, 0, "navigate() at grid boundary must not change active_window");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,6 @@ pub struct KeybindingsConfig {
     pub split_vertical: Option<String>,
     pub split_right: Option<String>,
     pub split_down: Option<String>,
-    pub page_left: Option<String>,
-    pub page_down: Option<String>,
-    pub page_up: Option<String>,
-    pub page_right: Option<String>,
     pub swap_pane_left: Option<String>,
     pub swap_pane_down: Option<String>,
     pub swap_pane_up: Option<String>,
@@ -70,10 +66,6 @@ impl KeybindingsConfig {
         overlay_field!(split_vertical);
         overlay_field!(split_right);
         overlay_field!(split_down);
-        overlay_field!(page_left);
-        overlay_field!(page_down);
-        overlay_field!(page_up);
-        overlay_field!(page_right);
         overlay_field!(swap_pane_left);
         overlay_field!(swap_pane_down);
         overlay_field!(swap_pane_up);
@@ -581,10 +573,6 @@ model_high   = "anthropic/claude-opus-4-7"
 # navigate_down           = "cmd+j"
 # navigate_up             = "cmd+k"
 # navigate_right          = "cmd+l"
-# page_left               = "cmd+shift+h"
-# page_down               = "cmd+shift+j"
-# page_up                 = "cmd+shift+k"
-# page_right              = "cmd+shift+l"
 # swap_pane_left          = "cmd+ctrl+h"
 # swap_pane_down          = "cmd+ctrl+j"
 # swap_pane_up            = "cmd+ctrl+k"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,8 +8,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+N                       — new window to the right on the current grid row
 // Cmd+Shift+N                 — new context (sidebar item)
 // Cmd+W                       — close pane
-// Cmd+H/J/K/L                 — navigate panes
-// Cmd+Shift+H/J/K/L           — navigate to adjacent window (spatial grid)
+// Cmd+H/J/K/L                 — navigate panes (falls through to adjacent window at boundary)
 // Cmd+Ctrl+H/J/K/L            — swap focused pane with neighbor in direction
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
@@ -100,12 +99,6 @@ pub enum Action {
     /// Create a new context (sidebar item) and immediately open the rename modal.
     /// Bound to Cmd+Shift+N.
     NewContext,
-    /// Navigate to the adjacent window in the spatial grid. Bound to
-    /// Cmd+Shift+H/J/K/L (left/down/up/right).
-    PageLeft,
-    PageDown,
-    PageUp,
-    PageRight,
     /// Toggle the minimap overlay. Bound to Cmd+Shift+M.
     ToggleMinimap,
     /// Reload configuration from disk. Bound to Cmd+Shift+,.
@@ -130,10 +123,6 @@ pub struct KeyBindings {
     pub split_vertical: (egui::Modifiers, egui::Key),
     pub split_right: (egui::Modifiers, egui::Key),
     pub split_down: (egui::Modifiers, egui::Key),
-    pub page_left: (egui::Modifiers, egui::Key),
-    pub page_down: (egui::Modifiers, egui::Key),
-    pub page_up: (egui::Modifiers, egui::Key),
-    pub page_right: (egui::Modifiers, egui::Key),
     pub swap_pane_left: (egui::Modifiers, egui::Key),
     pub swap_pane_down: (egui::Modifiers, egui::Key),
     pub swap_pane_up: (egui::Modifiers, egui::Key),
@@ -187,10 +176,6 @@ impl Default for KeyBindings {
             split_vertical:            (cmd_shift(), egui::Key::D),
             split_right:               (cmd(),       egui::Key::Backslash),
             split_down:                (cmd_shift(), egui::Key::Backslash),
-            page_left:                 (cmd_shift(), egui::Key::H),
-            page_down:                 (cmd_shift(), egui::Key::J),
-            page_up:                   (cmd_shift(), egui::Key::K),
-            page_right:                (cmd_shift(), egui::Key::L),
             swap_pane_left:            (cmd_ctrl(),  egui::Key::H),
             swap_pane_down:            (cmd_ctrl(),  egui::Key::J),
             swap_pane_up:              (cmd_ctrl(),  egui::Key::K),
@@ -334,10 +319,6 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(split_vertical, "split_vertical");
     apply_override!(split_right, "split_right");
     apply_override!(split_down, "split_down");
-    apply_override!(page_left, "page_left");
-    apply_override!(page_down, "page_down");
-    apply_override!(page_up, "page_up");
-    apply_override!(page_right, "page_right");
     apply_override!(swap_pane_left, "swap_pane_left");
     apply_override!(swap_pane_down, "swap_pane_down");
     apply_override!(swap_pane_up, "swap_pane_up");
@@ -378,10 +359,6 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("split_vertical",            bindings.split_vertical),
         ("split_right",               bindings.split_right),
         ("split_down",                bindings.split_down),
-        ("page_left",                 bindings.page_left),
-        ("page_down",                 bindings.page_down),
-        ("page_up",                   bindings.page_up),
-        ("page_right",                bindings.page_right),
         ("swap_pane_left",            bindings.swap_pane_left),
         ("swap_pane_down",            bindings.swap_pane_down),
         ("swap_pane_up",              bindings.swap_pane_up),
@@ -464,20 +441,6 @@ pub fn poll_actions(
             actions.push(Action::SplitVertical);
         } else if input.consume_key(bindings.split_horizontal.0, bindings.split_horizontal.1) {
             actions.push(Action::SplitHorizontal);
-        }
-
-        // Page navigation — check before plain pane navigation so shifted variants match first.
-        if input.consume_key(bindings.page_left.0, bindings.page_left.1) {
-            actions.push(Action::PageLeft);
-        }
-        if input.consume_key(bindings.page_down.0, bindings.page_down.1) {
-            actions.push(Action::PageDown);
-        }
-        if input.consume_key(bindings.page_up.0, bindings.page_up.1) {
-            actions.push(Action::PageUp);
-        }
-        if input.consume_key(bindings.page_right.0, bindings.page_right.1) {
-            actions.push(Action::PageRight);
         }
 
         // Pane swap — check before plain pane navigation.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -233,20 +233,7 @@ impl PlexiApp {
                                         colors,
                                     );
                                     ui.label(
-                                        RichText::new("Move between panes")
-                                            .size(style::TEXT_HINT)
-                                            .color(colors.text_dim),
-                                    );
-                                    ui.end_row();
-
-                                    crate::widgets::key_combo_list(
-                                        ui,
-                                        &[&["\u{2318}", "\u{21E7}"], &["H", "J", "K", "L"]],
-                                        None,
-                                        colors,
-                                    );
-                                    ui.label(
-                                        RichText::new("Navigate windows")
+                                        RichText::new("Move focus (panes & windows)")
                                             .size(style::TEXT_HINT)
                                             .color(colors.text_dim),
                                     );

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1907,8 +1907,7 @@ impl PlexiApp {
                     let shortcuts: &[(&[&str], &str)] = &[
                         (&["⌘", "N"], "new terminal"),
                         (&["⌘", "⇧", "N"], "new context"),
-                        (&["⌘", "H", "J", "K", "L"], "move between panes"),
-                        (&["⌘", "⇧", "H", "J", "K", "L"], "move between windows"),
+                        (&["⌘", "H", "J", "K", "L"], "move focus (panes & windows)"),
                         (&["⌘", "/"], "keyboard shortcuts"),
                     ];
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -661,6 +661,15 @@ impl PlexiApp {
                         }
                     }
                 }
+            } else {
+                let (dx, dy) = match dir {
+                    Direction::Left  => (-1,  0),
+                    Direction::Right => ( 1,  0),
+                    Direction::Up    => ( 0, -1),
+                    Direction::Down  => ( 0,  1),
+                };
+                log::info!("navigate({:?}): at pane boundary, falling through to page navigation", dir);
+                self.navigate_page(dx, dy);
             }
         }
     }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -643,34 +643,36 @@ impl PlexiApp {
         let effects = self.submit(HostCommand::Navigate(dir));
         log::debug!("navigate({:?}) effects: {:?}", dir, effects);
 
+        let (dx, dy) = match dir {
+            Direction::Left  => (-1,  0),
+            Direction::Right => ( 1,  0),
+            Direction::Up    => ( 0, -1),
+            Direction::Down  => ( 0,  1),
+        };
+
         let ctx = &self.windows[self.active_window];
-        if let Some(focused) = ctx.focused_pane {
-            if let Some(target) = ctx.find_pane_in_direction_from(focused, dir) {
-                self.windows[self.active_window].focused_pane = Some(target);
-                // Signal the newly-focused pane so render_text_inputs auto-focuses
-                // the first TextInput on the next frame.
-                if let Some(egui_tiles::Tile::Pane(pane_id)) =
-                    self.windows[self.active_window].tree.tiles.get(target)
-                {
-                    let pane_id = *pane_id;
-                    if let Some(pane) = self.windows[self.active_window].panes.get_mut(&pane_id) {
-                        if let Some(app) = pane.as_app_mut() {
-                            if let crate::pane::AppRuntime::Process(ref mut proc_app) = app.runtime {
-                                proc_app.pane_just_focused = true;
-                            }
+        let pane_neighbor = ctx.focused_pane
+            .and_then(|focused| ctx.find_pane_in_direction_from(focused, dir));
+
+        if let Some(target) = pane_neighbor {
+            self.windows[self.active_window].focused_pane = Some(target);
+            // Signal the newly-focused pane so render_text_inputs auto-focuses
+            // the first TextInput on the next frame.
+            if let Some(egui_tiles::Tile::Pane(pane_id)) =
+                self.windows[self.active_window].tree.tiles.get(target)
+            {
+                let pane_id = *pane_id;
+                if let Some(pane) = self.windows[self.active_window].panes.get_mut(&pane_id) {
+                    if let Some(app) = pane.as_app_mut() {
+                        if let crate::pane::AppRuntime::Process(ref mut proc_app) = app.runtime {
+                            proc_app.pane_just_focused = true;
                         }
                     }
                 }
-            } else {
-                let (dx, dy) = match dir {
-                    Direction::Left  => (-1,  0),
-                    Direction::Right => ( 1,  0),
-                    Direction::Up    => ( 0, -1),
-                    Direction::Down  => ( 0,  1),
-                };
-                log::info!("navigate({:?}): at pane boundary, falling through to page navigation", dir);
-                self.navigate_page(dx, dy);
             }
+        } else {
+            log::info!("navigate({:?}): falling through to page navigation", dir);
+            self.navigate_page(dx, dy);
         }
     }
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -11,9 +11,9 @@
 //!
 //! `navigate_page` is a **pure navigation** function: it only switches
 //! `active_context` to an *existing* page. It never creates. The creation
-//! policy (e.g. "new rows start at column 0") lives exclusively in
-//! `navigate_page`. Never put creation semantics into `navigate_page` or
-//! `find_navigation_target`.
+//! policy (e.g. "new rows start at column 0") lives in
+//! `pane_ops/workspace.rs` (`create_page_at`). Never put creation semantics
+//! into `navigate_page` or `find_navigation_target`.
 //!
 //! This separation is enforced by `find_navigation_target` being a free
 //! function with no access to `&mut PlexiApp`. Unit tests in this module

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -12,8 +12,8 @@
 //! `navigate_page` is a **pure navigation** function: it only switches
 //! `active_context` to an *existing* page. It never creates. The creation
 //! policy (e.g. "new rows start at column 0") lives exclusively in
-//! `navigate_or_create_page`. Never put creation semantics into
-//! `navigate_page` or `find_navigation_target`.
+//! `navigate_page`. Never put creation semantics into `navigate_page` or
+//! `find_navigation_target`.
 //!
 //! This separation is enforced by `find_navigation_target` being a free
 //! function with no access to `&mut PlexiApp`. Unit tests in this module
@@ -78,8 +78,7 @@ impl PlexiApp {
     /// **Vertical**: closest-by-column in the target row, biased toward the
     /// most recently visited column in that row (`last_page_x_per_row`).
     ///
-    /// Does **not** create pages. For create-if-missing behaviour see
-    /// [`navigate_or_create_page`].
+    /// Does **not** create pages — silently no-ops at the grid boundary.
     pub(crate) fn navigate_page(&mut self, dx: i32, dy: i32) {
         let cur_x = self.windows[self.active_window].grid_x;
         let cur_y = self.windows[self.active_window].grid_y;
@@ -108,36 +107,6 @@ impl PlexiApp {
             self.context_active_window.insert(ws_id, w.window_id);
             let wid = w.window_id;
             self.record_context_visit(wid);
-        }
-    }
-
-    /// Navigate to the adjacent page, creating one at the target coordinates
-    /// if none exists.
-    ///
-    /// Creation policy: vertical moves start new rows at **column 0**;
-    /// horizontal moves extend the current row at the adjacent column.
-    pub(crate) fn navigate_or_create_page(&mut self, dx: i32, dy: i32) {
-        let cur_x = self.windows[self.active_window].grid_x;
-        let cur_y = self.windows[self.active_window].grid_y;
-
-        let tx = cur_x as i32 + dx;
-        let ty = cur_y as i32 + dy;
-        if tx < 0 || ty < 0 {
-            return;
-        }
-
-        let before = self.active_window;
-        self.navigate_page(dx, dy);
-        if self.active_window == before {
-            // Vertical: new rows always start at column 0.
-            // Horizontal: extend the current row at the adjacent column.
-            let create_x = if dy != 0 { 0 } else { tx as u32 };
-            self.create_page_at(create_x, ty as u32);
-            // Record the created page's position so no stale trail lingers on
-            // the source page. Without this, navigate_page's post-insert never
-            // fires (navigation failed), leaving last_page_x_per_row at the
-            // source's x — which renders the source cell as a trail indicator.
-            self.last_page_x_per_row.insert(ty as u32, create_x);
         }
     }
 
@@ -172,8 +141,8 @@ impl PlexiApp {
 // changed a documented behaviour — update the test intentionally rather than
 // silently.
 //
-// Creation policy (e.g. "vertical creates start at col 0") is NOT tested here
-// because it lives in `navigate_or_create_page`, not in this function.
+// Creation policy (e.g. "vertical creates start at col 0") lives in
+// `pane_ops/workspace.rs` (create_page_at), not in this function.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #863

## What

Removes the separate `Cmd+Shift+H/J/K/L` window navigation bindings. Instead, `Cmd+H/J/K/L` transparently falls through to `navigate_page()` when there is no pane neighbor in the given direction — one gesture, one mental model.

- **`src/pane_ops/layout.rs`** — `navigate()` now calls `navigate_page(dx, dy)` in the `None` branch instead of stopping
- **`src/keys.rs`** — removed `PageLeft/Down/Up/Right` from `Action` enum, `page_*` from `KeyBindings` struct/defaults/overrides/all-bindings/polling
- **`src/config.rs`** — removed `page_*` fields, `overlay_field!` calls, config template comments
- **`src/app/mod.rs`** — removed `Action::Page*` match arms; added 2 regression tests
- **`src/overlays.rs`** — removed Cmd+Shift+HJKL row; updated Cmd+HJKL label to "Move focus (panes & windows)"
- **`src/spatial.rs`** — removed `navigate_or_create_page()` (now dead code)

At the spatial grid boundary, `navigate_page()` is already a pure no-op — so the gesture is silently ignored with no new window created.

## Tests

- `navigate_at_pane_boundary_falls_through_to_page_navigation` — verifies `active_window` switches when at a pane boundary with a window below
- `navigate_at_grid_boundary_is_noop` — verifies no crash/change at the bottommost window

## Breaks if

`Cmd+J` on the bottom pane of a window does not move focus to the window below when one exists in the spatial grid.