### PR TITLE
fix(bundle): keyboard_capture for input-inspector + rename app_state dir

### DIFF
--- a/examples/input-inspector/manifest.toml
+++ b/examples/input-inspector/manifest.toml
@@ -12,4 +12,5 @@ entry = "input_inspector.py"
 capabilities = []
 
 [launch]
+keyboard_capture = true
 layout_hint = { side = "right", split = 0.6 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -939,7 +939,7 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
                 return None;
             }
         };
-        let dest = crate::config::config_dir().join("app_state").join(format!("{id}.json"));
+        let dest = crate::config::config_dir().join("app_states").join(format!("{id}.json"));
         if let Some(parent) = dest.parent() {
             let _ = std::fs::create_dir_all(parent);
         }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2030,9 +2030,34 @@ fn default_midi_device() -> Arc<dyn MidiDevice> {
     Arc::new(crate::midi::MockMidiDevice::new())
 }
 
+/// Migrate a single `app_state/` directory to `app_states/` if the old path exists and the new
+/// one does not yet. Logs a warning so operators know migration occurred.
+fn migrate_app_state_dir(old_dir: &std::path::Path, new_dir: &std::path::Path) {
+    if old_dir.exists() && !new_dir.exists() {
+        match std::fs::rename(old_dir, new_dir) {
+            Ok(()) => log::warn!(
+                "load_app_state: migrated {} → {} (one-time rename)",
+                old_dir.display(),
+                new_dir.display()
+            ),
+            Err(e) => log::warn!(
+                "load_app_state: could not migrate {} → {}: {e}",
+                old_dir.display(),
+                new_dir.display()
+            ),
+        }
+    }
+}
+
 fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json::Value {
     let filename = format!("{type_id}.json");
-    let workspace_path = workspace_root.join(".plexi").join("app_state").join(&filename);
+
+    // Migrate old app_state/ → app_states/ on first access (workspace).
+    let ws_old = workspace_root.join(".plexi").join("app_state");
+    let ws_new = workspace_root.join(".plexi").join("app_states");
+    migrate_app_state_dir(&ws_old, &ws_new);
+
+    let workspace_path = ws_new.join(&filename);
     if workspace_path.exists() {
         match std::fs::read(&workspace_path) {
             Err(e) => {
@@ -2049,7 +2074,13 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
             },
         }
     }
-    let global_path = crate::config::config_dir().join("app_state").join(&filename);
+
+    // Migrate old app_state/ → app_states/ on first access (global).
+    let global_old = crate::config::config_dir().join("app_state");
+    let global_new = crate::config::config_dir().join("app_states");
+    migrate_app_state_dir(&global_old, &global_new);
+
+    let global_path = global_new.join(&filename);
     if global_path.exists() {
         match std::fs::read(&global_path) {
             Err(e) => {
@@ -3543,12 +3574,26 @@ mod app_state_tests {
     #[test]
     fn load_app_state_reads_workspace_file_over_global() {
         let ws_dir = tempfile::tempdir().expect("workspace tempdir");
-        let state_dir = ws_dir.path().join(".plexi").join("app_state");
+        let state_dir = ws_dir.path().join(".plexi").join("app_states");
         std::fs::create_dir_all(&state_dir).expect("mkdir");
         let state_path = state_dir.join("my-app.json");
         std::fs::write(&state_path, r#"{"interval_idx":3}"#).expect("write");
 
         let result = load_app_state("my-app", ws_dir.path());
         assert_eq!(result["interval_idx"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn load_app_state_migrates_old_app_state_dir() {
+        let ws_dir = tempfile::tempdir().expect("workspace tempdir");
+        let old_dir = ws_dir.path().join(".plexi").join("app_state");
+        std::fs::create_dir_all(&old_dir).expect("mkdir");
+        std::fs::write(old_dir.join("my-app.json"), r#"{"migrated":true}"#).expect("write");
+
+        let result = load_app_state("my-app", ws_dir.path());
+        assert_eq!(result["migrated"], serde_json::json!(true));
+        // Old dir must be gone, new dir must exist.
+        assert!(!old_dir.exists(), "old app_state dir should have been renamed");
+        assert!(ws_dir.path().join(".plexi").join("app_states").exists());
     }
 }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1494,9 +1494,9 @@ impl ProcessApp {
                 let filename = format!("{}.json", self.type_id);
                 let workspace_toml = self.workspace_root.join(".plexi").join("workspace.toml");
                 let state_path = if workspace_toml.exists() {
-                    self.workspace_root.join(".plexi").join("app_state").join(&filename)
+                    self.workspace_root.join(".plexi").join("app_states").join(&filename)
                 } else {
-                    crate::config::config_dir().join("app_state").join(&filename)
+                    crate::config::config_dir().join("app_states").join(&filename)
                 };
                 if let Some(dir) = state_path.parent() {
                     if let Err(e) = std::fs::create_dir_all(dir) {


### PR DESCRIPTION
Closes #907, closes #851.

## Changes

**#907 — input-inspector keyboard_capture**
- `examples/input-inspector/manifest.toml`: added `keyboard_capture = true` to `[launch]`. The input-inspector POC receives all key events (including Cmd+H/J/K/L) now instead of the host consuming them for pane navigation.

**#851 — rename app_state → app_states directory**
- `src/process_app/mod.rs`, `src/process_app/routing.rs`, `src/cli.rs`: all read/write path segments changed from `app_state/` to `app_states/`.
- Automatic one-time migration: on first `load_app_state` call, if the old `app_state/` directory exists and `app_states/` does not, the directory is renamed atomically. A `warn`-level log line fires so operators know migration occurred. No data loss.
- New `load_app_state_migrates_old_app_state_dir` unit test verifies migration logic end-to-end.

## Breaks if
- App state previously saved under `app_state/` is lost on upgrade — should not happen; migration renames the directory on first load.
- `keyboard_capture = true` in input-inspector manifest breaks other manifests — manifest field is per-app and isolated.

## Verification (diff-only)
- `examples/input-inspector/manifest.toml` contains `keyboard_capture = true`
- No `"app_states"` path literals reference the old name in read/write paths
- `cargo build` passes