### PR TITLE
feat(notify): snooze choice — defer notification by N seconds

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1350,14 +1350,26 @@ impl PlexiApp {
 
     /// Check every pending notification for expiry. For each that has exceeded
     /// its `timeout_secs`, deliver a `NotifyAction` dismiss event and remove it.
-    /// Called once per second from `update()`.
+    /// Also wakes snoozed notifications whose `deliver_after` has elapsed and
+    /// auto-reopens the modal when a high-priority one wakes. Called once per
+    /// second from `update()`.
     pub(crate) fn tick_notification_timeouts(&mut self) {
         let now = std::time::Instant::now();
+        let threshold = self.notifications_interrupt_threshold;
+        let focus_mode = self.notifications_focus_mode;
         let mut expired_ids: Vec<String> = Vec::new();
-        for n in &self.pending_notifications {
-            // Don't time out while snoozed — the user asked for a delay.
-            if n.deliver_after.map_or(false, |t| t > now) {
-                continue;
+        let mut woken_priority_met = false;
+        // Single mutable pass: wake snoozed entries, collect expired ids.
+        for n in &mut self.pending_notifications {
+            if let Some(t) = n.deliver_after {
+                if t > now {
+                    continue; // still snoozed — skip timeout check too
+                }
+                if !focus_mode && n.priority >= threshold {
+                    woken_priority_met = true;
+                }
+                log::info!("notify:snooze: woke notify_id={}", n.notify_id);
+                n.deliver_after = None;
             }
             if let Some(timeout) = n.timeout_secs {
                 if n.enqueued_at.elapsed() >= std::time::Duration::from_secs(timeout) {
@@ -1365,29 +1377,10 @@ impl PlexiApp {
                 }
             }
         }
-        // Auto-reopen the modal if any snoozed notifications just woke up.
-        let woken = self.pending_notifications.iter().any(|n| {
-            n.deliver_after.map_or(false, |t| t <= now)
-        });
-        if woken {
-            let priority_met = self.pending_notifications.iter().any(|n| {
-                n.deliver_after.map_or(false, |t| t <= now)
-                    && !self.notifications_focus_mode
-                    && n.priority >= self.notifications_interrupt_threshold
-            });
-            if priority_met {
-                self.show_notification_modal = true;
-                if self.current_notify_id.is_none() {
-                    self.current_notify_id = self.select_highest_priority();
-                }
-            }
-            // Clear deliver_after so the woken notification is no longer
-            // treated as freshly-woken on subsequent ticks.
-            for n in &mut self.pending_notifications {
-                if n.deliver_after.map_or(false, |t| t <= now) {
-                    log::info!("notify:snooze: woke notify_id={}", n.notify_id);
-                    n.deliver_after = None;
-                }
+        if woken_priority_met {
+            self.show_notification_modal = true;
+            if self.current_notify_id.is_none() {
+                self.current_notify_id = self.select_highest_priority();
             }
         }
         for id in expired_ids {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,6 +103,9 @@ pub(crate) struct PendingNotification {
     /// True when the originating app pane has exited. The notification stays
     /// in the queue so the user can read it, but action buttons are hidden.
     pub tombstoned: bool,
+    /// When `Some(t)`, the notification is invisible and exempt from timeout
+    /// until `t` has elapsed (snooze). `None` means deliver immediately.
+    pub deliver_after: Option<std::time::Instant>,
 }
 
 /// Render state for a notification's image attachment. Computed once and
@@ -1124,6 +1127,7 @@ impl PlexiApp {
                         on_dismiss: on_dismiss.clone(),
                         enqueued_at: std::time::Instant::now(),
                         tombstoned: false,
+                        deliver_after: None,
                     });
                     let should_auto_open = !self.notifications_focus_mode
                         && *priority >= self.notifications_interrupt_threshold;
@@ -1267,6 +1271,9 @@ impl PlexiApp {
 
     /// True when this notification should appear in the current workspace view.
     pub(crate) fn notification_is_visible(&self, n: &PendingNotification) -> bool {
+        if n.deliver_after.map_or(false, |t| t > std::time::Instant::now()) {
+            return false;
+        }
         match n.scope {
             crate::app_protocol::NotifyScope::Global => true,
             crate::app_protocol::NotifyScope::Window
@@ -1345,11 +1352,41 @@ impl PlexiApp {
     /// its `timeout_secs`, deliver a `NotifyAction` dismiss event and remove it.
     /// Called once per second from `update()`.
     pub(crate) fn tick_notification_timeouts(&mut self) {
+        let now = std::time::Instant::now();
         let mut expired_ids: Vec<String> = Vec::new();
         for n in &self.pending_notifications {
+            // Don't time out while snoozed — the user asked for a delay.
+            if n.deliver_after.map_or(false, |t| t > now) {
+                continue;
+            }
             if let Some(timeout) = n.timeout_secs {
                 if n.enqueued_at.elapsed() >= std::time::Duration::from_secs(timeout) {
                     expired_ids.push(n.notify_id.clone());
+                }
+            }
+        }
+        // Auto-reopen the modal if any snoozed notifications just woke up.
+        let woken = self.pending_notifications.iter().any(|n| {
+            n.deliver_after.map_or(false, |t| t <= now)
+        });
+        if woken {
+            let priority_met = self.pending_notifications.iter().any(|n| {
+                n.deliver_after.map_or(false, |t| t <= now)
+                    && !self.notifications_focus_mode
+                    && n.priority >= self.notifications_interrupt_threshold
+            });
+            if priority_met {
+                self.show_notification_modal = true;
+                if self.current_notify_id.is_none() {
+                    self.current_notify_id = self.select_highest_priority();
+                }
+            }
+            // Clear deliver_after so the woken notification is no longer
+            // treated as freshly-woken on subsequent ticks.
+            for n in &mut self.pending_notifications {
+                if n.deliver_after.map_or(false, |t| t <= now) {
+                    log::info!("notify:snooze: woke notify_id={}", n.notify_id);
+                    n.deliver_after = None;
                 }
             }
         }
@@ -1743,6 +1780,7 @@ impl eframe::App for PlexiApp {
                         on_dismiss,
                         enqueued_at: std::time::Instant::now(),
                         tombstoned: false,
+                        deliver_after: None,
                     });
                     // Auto-open rules:
                     //   1. Visibility — Global always; Window/Context only when
@@ -3585,5 +3623,83 @@ mod tests {
         }
 
         let _ = std::fs::remove_file(&resp_file);
+    }
+
+    /// #840: A snoozed notification must become invisible immediately after
+    /// deliver_after is set, and visible again once the instant has elapsed.
+    #[test]
+    fn snoozed_notification_invisible_then_visible() {
+        let mut h = HostHarness::new();
+
+        // Push a notification that is already past its snooze window.
+        let wake_past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+        h.app.pending_notifications.push(PendingNotification {
+            notify_id: "snoozed-woken".into(),
+            sender_pane_id: 0,
+            source_context_id: h.app.router.active().context_id,
+            level: "info".into(),
+            title: "Snoozed".into(),
+            body: "body".into(),
+            kind: crate::app_protocol::NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            priority: 100,
+            scope: crate::app_protocol::NotifyScope::Global,
+            image_inline: None,
+            image_pipe_id: None,
+            response_file: None,
+            timeout_secs: None,
+            on_dismiss: None,
+            enqueued_at: std::time::Instant::now(),
+            tombstoned: false,
+            deliver_after: Some(wake_past), // already elapsed → visible
+        });
+
+        assert_eq!(h.app.visible_notification_count(), 1, "past-snooze notification must be visible");
+
+        // Now set deliver_after to the future (active snooze).
+        let wake_future = std::time::Instant::now() + std::time::Duration::from_secs(300);
+        h.app.pending_notifications[0].deliver_after = Some(wake_future);
+
+        assert_eq!(h.app.visible_notification_count(), 0, "future-snooze notification must be invisible");
+    }
+
+    /// #840: tick_notification_timeouts must not time out a snoozed notification.
+    #[test]
+    fn snoozed_notification_exempt_from_timeout() {
+        let mut h = HostHarness::new();
+
+        let sender_id = h.add_test_pane();
+        // Enqueued 10 minutes ago with a 60s timeout, but snoozed into the future.
+        h.app.pending_notifications.push(PendingNotification {
+            notify_id: "snoozed-no-timeout".into(),
+            sender_pane_id: sender_id,
+            source_context_id: h.app.router.active().context_id,
+            level: "info".into(),
+            title: "ShouldNotTimeout".into(),
+            body: "body".into(),
+            kind: crate::app_protocol::NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            priority: 100,
+            scope: crate::app_protocol::NotifyScope::Global,
+            image_inline: None,
+            image_pipe_id: None,
+            response_file: None,
+            timeout_secs: Some(60),
+            on_dismiss: None,
+            enqueued_at: std::time::Instant::now() - std::time::Duration::from_secs(600),
+            tombstoned: false,
+            deliver_after: Some(std::time::Instant::now() + std::time::Duration::from_secs(300)),
+        });
+
+        h.app.tick_notification_timeouts();
+
+        assert_eq!(
+            h.app.pending_notifications.len(), 1,
+            "snoozed notification must survive tick_notification_timeouts"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1668,6 +1668,10 @@ pub fn pack_export_cli(dest_path: &str) -> i32 {
 /// - `Label:action_type:action_arg`         → (Label, Label, Some("action_type:action_arg"))
 /// - `key:Label:action_type:action_arg`     → (key, Label, Some("action_type:action_arg"))
 ///
+/// Supported host action types:
+/// - `pane_focus:<pane_id>` — navigate to the given pane when clicked
+/// - `snooze:<seconds>`     — re-deliver the notification after N seconds (CLI stays blocked)
+///
 /// Any other segment count is rejected with a clear error string.
 pub(crate) fn parse_notify_choice(raw: &str) -> Result<(String, String, Option<String>), String> {
     let segments: Vec<&str> = raw.splitn(5, ':').collect();
@@ -3687,6 +3691,26 @@ mod notify_tests {
         assert_eq!(key, "a");
         assert_eq!(label, "Talk to Claude");
         assert_eq!(final_action.as_deref(), Some("pane_focus:NEW"));
+    }
+
+    /// #840: snooze action type parses to the correct host_action string.
+    #[test]
+    fn parse_choice_snooze_action() {
+        let (key, label, action) =
+            parse_notify_choice("snooze5:Remind me in 5 min:snooze:300").unwrap();
+        assert_eq!(key, "snooze5");
+        assert_eq!(label, "Remind me in 5 min");
+        assert_eq!(action.as_deref(), Some("snooze:300"));
+    }
+
+    /// #840: three-segment form also works for snooze.
+    #[test]
+    fn parse_choice_snooze_three_segment() {
+        let (key, label, action) =
+            parse_notify_choice("Snooze 5min:snooze:300").unwrap();
+        assert_eq!(key, "Snooze 5min");
+        assert_eq!(label, "Snooze 5min");
+        assert_eq!(action.as_deref(), Some("snooze:300"));
     }
 }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1567,23 +1567,53 @@ impl PlexiApp {
         }
 
         if let Some(cmd) = action_cmd {
-            // Acknowledgment / option-select / input-submit — the user gave
-            // a real answer. Remove the notification by id, deliver the
-            // NotifyAction to the originating app, then pick the next
-            // highest-priority remaining from whatever's in the queue
-            // right now (not a pre-frozen list).
-            self.pending_notifications
-                .retain(|n| n.notify_id != current_id);
-            self.modal_focused_option = 0;
-            self.modal_input_buffer.clear();
-            self.modal_state_notify_id.clear();
-            if self.pending_notifications.is_empty() {
-                self.show_notification_modal = false;
-                self.current_notify_id = None;
+            use crate::app_trait::AppCommand;
+            // Check for snooze before removing from queue. Snooze sets
+            // deliver_after in place — the notification stays but becomes
+            // invisible and no DeliverNotifyAction is sent to the app (the
+            // CLI stays blocked until the user picks a non-snooze choice).
+            let snooze_secs = if let AppCommand::DeliverNotifyAction { ref host_action, .. } = cmd {
+                host_action.as_deref()
+                    .and_then(|a| a.strip_prefix("snooze:"))
+                    .and_then(|s| s.parse::<u64>().ok())
             } else {
-                self.current_notify_id = self.select_highest_priority();
+                None
+            };
+
+            if let Some(delay_secs) = snooze_secs {
+                let wake = std::time::Instant::now() + std::time::Duration::from_secs(delay_secs);
+                if let Some(n) = self.pending_notifications.iter_mut()
+                    .find(|n| n.notify_id == current_id)
+                {
+                    n.deliver_after = Some(wake);
+                    log::info!("notify:snooze: notify_id={} delay={}s", current_id, delay_secs);
+                }
+                self.modal_focused_option = 0;
+                self.modal_input_buffer.clear();
+                self.modal_state_notify_id.clear();
+                let next = self.select_highest_priority();
+                if next.is_some() {
+                    self.current_notify_id = next;
+                } else {
+                    self.show_notification_modal = false;
+                    self.current_notify_id = None;
+                }
+            } else {
+                // Acknowledgment / option-select / input-submit — real answer.
+                // Remove the notification, deliver the NotifyAction, pick next.
+                self.pending_notifications
+                    .retain(|n| n.notify_id != current_id);
+                self.modal_focused_option = 0;
+                self.modal_input_buffer.clear();
+                self.modal_state_notify_id.clear();
+                if self.pending_notifications.is_empty() {
+                    self.show_notification_modal = false;
+                    self.current_notify_id = None;
+                } else {
+                    self.current_notify_id = self.select_highest_priority();
+                }
+                cmds.push(cmd);
             }
-            cmds.push(cmd);
         }
 
         cmds

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1567,52 +1567,46 @@ impl PlexiApp {
         }
 
         if let Some(cmd) = action_cmd {
-            use crate::app_trait::AppCommand;
             // Check for snooze before removing from queue. Snooze sets
             // deliver_after in place — the notification stays but becomes
             // invisible and no DeliverNotifyAction is sent to the app (the
             // CLI stays blocked until the user picks a non-snooze choice).
-            let snooze_secs = if let AppCommand::DeliverNotifyAction { ref host_action, .. } = cmd {
-                host_action.as_deref()
+            let is_snooze = if let AppCommand::DeliverNotifyAction { ref host_action, .. } = cmd {
+                if let Some(delay_secs) = host_action.as_deref()
                     .and_then(|a| a.strip_prefix("snooze:"))
                     .and_then(|s| s.parse::<u64>().ok())
+                {
+                    let wake = std::time::Instant::now() + std::time::Duration::from_secs(delay_secs);
+                    if let Some(n) = self.pending_notifications.iter_mut()
+                        .find(|n| n.notify_id == current_id)
+                    {
+                        n.deliver_after = Some(wake);
+                        log::info!("notify:snooze: notify_id={} delay={}s", current_id, delay_secs);
+                    }
+                    true
+                } else {
+                    false
+                }
             } else {
-                None
+                false
             };
 
-            if let Some(delay_secs) = snooze_secs {
-                let wake = std::time::Instant::now() + std::time::Duration::from_secs(delay_secs);
-                if let Some(n) = self.pending_notifications.iter_mut()
-                    .find(|n| n.notify_id == current_id)
-                {
-                    n.deliver_after = Some(wake);
-                    log::info!("notify:snooze: notify_id={} delay={}s", current_id, delay_secs);
-                }
-                self.modal_focused_option = 0;
-                self.modal_input_buffer.clear();
-                self.modal_state_notify_id.clear();
-                let next = self.select_highest_priority();
-                if next.is_some() {
-                    self.current_notify_id = next;
-                } else {
-                    self.show_notification_modal = false;
-                    self.current_notify_id = None;
-                }
-            } else {
-                // Acknowledgment / option-select / input-submit — real answer.
-                // Remove the notification, deliver the NotifyAction, pick next.
-                self.pending_notifications
-                    .retain(|n| n.notify_id != current_id);
-                self.modal_focused_option = 0;
-                self.modal_input_buffer.clear();
-                self.modal_state_notify_id.clear();
-                if self.pending_notifications.is_empty() {
-                    self.show_notification_modal = false;
-                    self.current_notify_id = None;
-                } else {
-                    self.current_notify_id = self.select_highest_priority();
-                }
+            self.modal_focused_option = 0;
+            self.modal_input_buffer.clear();
+            self.modal_state_notify_id.clear();
+
+            if !is_snooze {
+                // Real answer: remove from queue and deliver NotifyAction to app.
+                self.pending_notifications.retain(|n| n.notify_id != current_id);
                 cmds.push(cmd);
+            }
+
+            match self.select_highest_priority() {
+                Some(next) => self.current_notify_id = Some(next),
+                None => {
+                    self.show_notification_modal = false;
+                    self.current_notify_id = None;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Adds `snooze:<seconds>` host action type for `plexi notify --choice` choices
- When the user clicks a snooze option, the notification re-appears after the specified delay without writing to the response file (the blocking CLI stays alive until they pick a real choice)
- Works alongside `pane_focus` and plain choices in the same notification

## Implementation
- `PendingNotification` gains `deliver_after: Option<Instant>` — notification stays in queue but is invisible while snoozed
- `notification_is_visible()` gates on `deliver_after`
- `tick_notification_timeouts()` skips snoozed entries and auto-reopens the modal when snooze expires
- `draw_notification_modal()` intercepts `snooze:` host_action before the normal remove-and-dispatch path (no `DeliverNotifyAction` dispatched to app)
- 4 new tests: 2 `HostHarness` tests (invisible while snoozed, exempt from timeout) + 2 `parse_notify_choice` round-trip tests

## Usage
```bash
plexi notify --title "PR #825 ready for review" \
  --choice "focus:Go to pane:pane_focus:<id>" \
  --choice "snooze5:Remind me in 5 min:snooze:300" \
  --choice "snooze30:Remind me in 30 min:snooze:1800"
```

## Test plan
- [ ] Diff review: snooze handling in `draw_notification_modal` intercepts before remove-and-dispatch
- [ ] `deliver_after` field added to `PendingNotification` with `None` at both construction sites
- [ ] `notification_is_visible` correctly gates on `deliver_after`
- [ ] `tick_notification_timeouts` skips snoozed entries and clears `deliver_after` on wake
- [ ] All 4 new tests pass; `dispatch_notify_action_pane_focus_navigates` regression still green

Closes #840