### PR TITLE
feat(cli): inject PLEXI_CONTEXT_ID/NAME env vars + context current command

### DIFF
--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -64,7 +64,9 @@ impl PlexiApp {
 
         // Allocate the terminal pane.
         let new_id = self.host.alloc_pane_id();
-        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors);
+        let ctx_id = self.windows[active].context_id;
+        let ctx_name = self.context_name_for(ctx_id);
+        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors, ctx_id, &ctx_name);
         let Some(term) = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -408,6 +408,9 @@ impl PlexiApp {
         // Try to load saved workspace
         if let Some(ws) = WorkspaceFile::load() {
             let mut windows = Vec::new();
+            let ctx_name_map: std::collections::HashMap<u64, String> = ws.contexts.iter()
+                .map(|c| (c.context_id, c.name.clone()))
+                .collect();
             for saved_win in ws.windows {
                 let mut panes = HashMap::new();
                 for saved_pane in &saved_win.panes {
@@ -504,7 +507,8 @@ impl PlexiApp {
                     }
 
                     if pane_entry.is_none() {
-                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors);
+                        let ctx_name = ctx_name_map.get(&saved_win.context_id).cloned().unwrap_or_default();
+                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name);
                         if let Some(mut pane) = TerminalPane::new(
                             saved_pane.id,
                             cc.egui_ctx.clone(),
@@ -855,7 +859,10 @@ impl PlexiApp {
         pane_id: u64,
         working_directory: Option<PathBuf>,
         colors: &Colors,
+        context_id: u64,
+        context_name: &str,
     ) -> BackendSettings {
+        log::info!("make_backend_settings: pane_id={pane_id} context_id={context_id} context_name={context_name:?}");
         let mut env = shell::build_env();
         env.insert("PLEXI_PANE_ID".into(), pane_id.to_string());
         let socket = crate::config::config_dir()
@@ -863,6 +870,8 @@ impl PlexiApp {
             .to_string_lossy()
             .into_owned();
         env.insert("PLEXI_SOCKET".into(), socket);
+        env.insert("PLEXI_CONTEXT_ID".into(), context_id.to_string());
+        env.insert("PLEXI_CONTEXT_NAME".into(), context_name.to_string());
         BackendSettings {
             shell: shell::detect_shell(),
             args: vec!["-l".to_string()],
@@ -870,6 +879,13 @@ impl PlexiApp {
             dynamic_colors: theme::terminal_dynamic_colors(colors),
             working_directory,
         }
+    }
+
+    pub(crate) fn context_name_for(&self, context_id: u64) -> String {
+        self.router.iter()
+            .find(|c| c.context_id == context_id)
+            .map(|c| c.name.clone())
+            .unwrap_or_default()
     }
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3294,7 +3294,13 @@ pub fn context_current_cli() -> i32 {
         }
     };
     let context_name = std::env::var("PLEXI_CONTEXT_NAME").unwrap_or_default();
-    let id_num: u64 = context_id.parse().unwrap_or(0);
+    let id_num: u64 = match context_id.parse() {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("error: PLEXI_CONTEXT_ID is not a valid number: {context_id}");
+            return 1;
+        }
+    };
     let json = serde_json::json!({
         "context_id": id_num,
         "context_name": context_name,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3281,6 +3281,28 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
     }))
 }
 
+/// `plexi context current`
+///
+/// Prints the context ID and name for the current pane as JSON.
+/// Reads PLEXI_CONTEXT_ID and PLEXI_CONTEXT_NAME set at pane spawn time.
+pub fn context_current_cli() -> i32 {
+    let context_id = match std::env::var("PLEXI_CONTEXT_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_CONTEXT_ID is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let context_name = std::env::var("PLEXI_CONTEXT_NAME").unwrap_or_default();
+    let id_num: u64 = context_id.parse().unwrap_or(0);
+    let json = serde_json::json!({
+        "context_id": id_num,
+        "context_name": context_name,
+    });
+    println!("{}", serde_json::to_string_pretty(&json).unwrap_or_default());
+    0
+}
+
 /// `plexi completions <shell>`
 ///
 /// Prints a static shell completion script to stdout. Pipe to the appropriate
@@ -3382,7 +3404,7 @@ _plexi() {
           ;;
         context)
           local subcmds
-          subcmds=('new:Create a new context' 'open:Open a context at a path' 'set-root:Set the root directory')
+          subcmds=('new:Create a new context' 'open:Open a context at a path' 'set-root:Set the root directory' 'current:Print current context as JSON')
           _describe 'subcommand' subcmds
           ;;
         notify)
@@ -3470,7 +3492,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "watch" -- "$cur"))
       ;;
     context)
-      COMPREPLY=($(compgen -W "new open set-root" -- "$cur"))
+      COMPREPLY=($(compgen -W "new open set-root current" -- "$cur"))
       ;;
     notify)
       if [[ $prev == "--level" ]]; then
@@ -3551,6 +3573,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from registry" -a watch -d "Watc
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a new -d "Create a new context"
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a open -d "Open a context at a path"
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a set-root -d "Set the root directory"
+complete -c plexi -f -n "__fish_seen_subcommand_from context" -a current -d "Print current context as JSON"
 
 # notify flags
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l title -d "Notification title"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3305,7 +3305,13 @@ pub fn context_current_cli() -> i32 {
         "context_id": id_num,
         "context_name": context_name,
     });
-    println!("{}", serde_json::to_string_pretty(&json).unwrap_or_default());
+    match serde_json::to_string_pretty(&json) {
+        Ok(s) => println!("{s}"),
+        Err(e) => {
+            eprintln!("error: failed to serialize context JSON: {e}");
+            return 1;
+        }
+    }
     0
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -350,4 +350,6 @@ pub enum ContextCmd {
     SetRoot {
         path: Option<String>,
     },
+    /// Print the context ID and name for the current pane as JSON
+    Current,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ fn main() -> eframe::Result {
                         ContextCmd::New { path } => std::process::exit(cli::context_new_cli(path.as_deref())),
                         ContextCmd::Open { path } => std::process::exit(cli::context_open_cli(path.as_deref())),
                         ContextCmd::SetRoot { path } => std::process::exit(cli::context_set_root_cli(path.as_deref())),
+                        ContextCmd::Current => std::process::exit(cli::context_current_cli()),
                     },
                     Commands::Completions { shell } => {
                         let s = shell.as_deref().unwrap_or("zsh");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -373,7 +373,9 @@ impl PlexiApp {
     ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.host.alloc_pane_id();
 
-        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
+        let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
+        let ctx_name = self.context_name_for(ctx_id);
+        let settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         let pane = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -226,7 +226,9 @@ impl PlexiApp {
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors);
+        let ctx_id = self.windows[self.active_window].context_id;
+        let ctx_name = self.context_name_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         if let Some(cmd) = initial_cmd {
             log::info!("split_focused: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             let shell_name = std::path::Path::new(&settings.shell)
@@ -339,7 +341,9 @@ impl PlexiApp {
         // Empty context (welcome screen): create the first pane as tree root.
         if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
-            let settings = Self::make_backend_settings(new_id, None, &self.colors);
+            let ctx_id = self.windows[self.active_window].context_id;
+            let ctx_name = self.context_name_for(ctx_id);
+            let settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
             let Some(pane) = TerminalPane::new(
                 new_id,
                 self.ctx.clone(),
@@ -366,7 +370,9 @@ impl PlexiApp {
         let new_id = self.host.alloc_pane_id();
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let settings = Self::make_backend_settings(new_id, cwd, &self.colors);
+        let ctx_id = self.windows[self.active_window].context_id;
+        let ctx_name = self.context_name_for(ctx_id);
+        let settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         let Some(pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -226,7 +226,7 @@ impl PlexiApp {
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let ctx_id = self.windows[self.active_window].context_id;
+        let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         if let Some(cmd) = initial_cmd {
@@ -341,7 +341,7 @@ impl PlexiApp {
         // Empty context (welcome screen): create the first pane as tree root.
         if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
-            let ctx_id = self.windows[self.active_window].context_id;
+            let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
             let ctx_name = self.context_name_for(ctx_id);
             let settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
             let Some(pane) = TerminalPane::new(
@@ -370,7 +370,7 @@ impl PlexiApp {
         let new_id = self.host.alloc_pane_id();
 
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
-        let ctx_id = self.windows[self.active_window].context_id;
+        let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         let Some(pane) = TerminalPane::new(


### PR DESCRIPTION
## Summary
- Every new terminal pane now receives `PLEXI_CONTEXT_ID` and `PLEXI_CONTEXT_NAME` in its environment at spawn time
- `plexi context current` prints the current context as JSON, reading those env vars
- All shell completions (zsh/bash/fish) updated to include `context current`

## How it works
`make_backend_settings` now takes `context_id` and `context_name` parameters. A new `context_name_for(context_id)` helper on `PlexiApp` looks up the name from the workspace router. All 6 call sites pass the active window's context info.

For workspace restore (in `new()`), a `ctx_name_map` is pre-built from saved context data before the window loop.

## Test plan
- [ ] Open a terminal pane inside a context — run `echo $PLEXI_CONTEXT_ID` and `echo $PLEXI_CONTEXT_NAME` to verify they're set
- [ ] Run `plexi-pr-<N> context current` — verify JSON output with correct id/name
- [ ] Open a second context, open a pane there — verify different `PLEXI_CONTEXT_ID`
- [ ] Run `plexi-pr-<N> context current` outside a Plexi pane — verify error message

Closes #845