### PR TITLE
feat: app_states rename, pane key injection, file-browser no-repeat nav

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3364,17 +3364,14 @@ impl PlexiApp {
 
 // ── Directed pipe helpers (#286) ─────────────────────────────────────────────
 
-/// Register a duplex JSON pipe on the target pane's typed-pipe registry so
-/// `has_reader` returns `true` and the SDK can `pipe_send` back through the
-/// same id. Returns `true` on success, `false` if the target pane has no
 /// Translate a key string (e.g. "enter", "ctrl+c", "h") to PTY bytes.
 fn key_str_to_pty_bytes(key: &str) -> Vec<u8> {
     let key_lower = key.to_lowercase();
-    // Handle ctrl+X chords
+    // Handle ctrl+X chords using bit-mask to support any ASCII char ([, ], \, /, @, etc.)
     if let Some(rest) = key_lower.strip_prefix("ctrl+") {
         if let Some(ch) = rest.chars().next() {
-            if ch.is_ascii_alphabetic() {
-                return vec![(ch as u8) - b'a' + 1];
+            if ch.is_ascii() && !ch.is_ascii_control() {
+                return vec![(ch as u8) & 0x1F];
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1109,8 +1109,8 @@ impl PlexiApp {
                     };
                     if let Some(rf) = response_file {
                         let json = match &result {
-                            Ok(()) => r#"{"ok":true}"#.to_string(),
-                            Err(msg) => format!("{{\"error\":{}}}", serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))),
+                            Ok(()) => serde_json::json!({"ok": true}).to_string(),
+                            Err(msg) => serde_json::json!({"error": msg}).to_string(),
                         };
                         if let Err(e) = std::fs::write(rf, &json) {
                             log::error!("pane_ipc: key_pane: could not write response file: {e}");
@@ -3424,11 +3424,13 @@ fn parse_key_str_to_event(key: &str) -> (String, crate::app_protocol::Modifiers)
         "down" | "arrowdown" => "ArrowDown".to_string(),
         "right" | "arrowright" => "ArrowRight".to_string(),
         "left" | "arrowleft" => "ArrowLeft".to_string(),
-        other => {
-            if other.chars().count() == 1 {
-                other.to_string()
+        _ => {
+            // Preserve original case for single chars (e.g. "A" stays "A", not "a").
+            // Multi-word named keys get title-case.
+            if key_part.chars().count() == 1 {
+                key_part.to_string()
             } else {
-                let mut s = other.to_string();
+                let mut s = key_part.to_string();
                 if let Some(c) = s.get_mut(0..1) {
                     c.make_ascii_uppercase();
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1084,6 +1084,39 @@ impl PlexiApp {
                         }
                     }
                 }
+                crate::app_protocol::HostCommand::KeyPane { pane_id, key, response_file } => {
+                    log::info!("pane_ipc: kind=key_pane pane_id={pane_id} key={key:?}");
+                    let result = match self.windows.iter_mut().find_map(|win| win.panes.get_mut(pane_id)) {
+                        None => {
+                            log::warn!("pane_ipc: key_pane: pane_id={pane_id} not found");
+                            Err(format!("pane {pane_id} not found"))
+                        }
+                        Some(pane) => {
+                            if let Some(term) = pane.as_terminal_mut() {
+                                let bytes = key_str_to_pty_bytes(key);
+                                term.backend.process_command(egui_term::BackendCommand::Write(bytes));
+                                Ok(())
+                            } else if let Some(app_pane) = pane.as_app_mut() {
+                                let (key_str, modifiers) = parse_key_str_to_event(key);
+                                app_pane.runtime.queue_outbound_event(
+                                    crate::app_protocol::PlexiEvent::Key { key: key_str, modifiers }
+                                );
+                                Ok(())
+                            } else {
+                                Err(format!("pane {pane_id}: unknown pane type"))
+                            }
+                        }
+                    };
+                    if let Some(rf) = response_file {
+                        let json = match &result {
+                            Ok(()) => r#"{"ok":true}"#.to_string(),
+                            Err(msg) => format!("{{\"error\":{}}}", serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))),
+                        };
+                        if let Err(e) = std::fs::write(rf, &json) {
+                            log::error!("pane_ipc: key_pane: could not write response file: {e}");
+                        }
+                    }
+                }
                 crate::app_protocol::HostCommand::Notify {
                     level, title, body, kind, options, input_prompt,
                     required, priority, image_inline, image_pipe_id,
@@ -3334,6 +3367,81 @@ impl PlexiApp {
 /// Register a duplex JSON pipe on the target pane's typed-pipe registry so
 /// `has_reader` returns `true` and the SDK can `pipe_send` back through the
 /// same id. Returns `true` on success, `false` if the target pane has no
+/// Translate a key string (e.g. "enter", "ctrl+c", "h") to PTY bytes.
+fn key_str_to_pty_bytes(key: &str) -> Vec<u8> {
+    let key_lower = key.to_lowercase();
+    // Handle ctrl+X chords
+    if let Some(rest) = key_lower.strip_prefix("ctrl+") {
+        if let Some(ch) = rest.chars().next() {
+            if ch.is_ascii_alphabetic() {
+                return vec![(ch as u8) - b'a' + 1];
+            }
+        }
+    }
+    match key_lower.as_str() {
+        "enter" => b"\r".to_vec(),
+        "escape" | "esc" => b"\x1b".to_vec(),
+        "space" => b" ".to_vec(),
+        "backspace" => b"\x7f".to_vec(),
+        "tab" => b"\t".to_vec(),
+        "up" | "arrowup" => b"\x1b[A".to_vec(),
+        "down" | "arrowdown" => b"\x1b[B".to_vec(),
+        "right" | "arrowright" => b"\x1b[C".to_vec(),
+        "left" | "arrowleft" => b"\x1b[D".to_vec(),
+        _ => {
+            // single printable char
+            let mut chars = key.chars();
+            if let Some(ch) = chars.next() {
+                if chars.next().is_none() {
+                    let mut buf = [0u8; 4];
+                    return ch.encode_utf8(&mut buf).as_bytes().to_vec();
+                }
+            }
+            log::warn!("pane_ipc: key_pane: unrecognized key string {key:?}, sending raw bytes");
+            key.as_bytes().to_vec()
+        }
+    }
+}
+
+/// Parse a key string into a (key_name, Modifiers) pair for PGAP app panes.
+fn parse_key_str_to_event(key: &str) -> (String, crate::app_protocol::Modifiers) {
+    let mut parts: Vec<&str> = key.split('+').collect();
+    let key_part = parts.pop().unwrap_or(key);
+    let mut modifiers = crate::app_protocol::Modifiers::default();
+    for m in &parts {
+        match m.to_lowercase().as_str() {
+            "ctrl" | "control" => modifiers.ctrl = true,
+            "shift" => modifiers.shift = true,
+            "alt" => modifiers.alt = true,
+            "cmd" | "command" | "meta" => modifiers.cmd = true,
+            _ => {}
+        }
+    }
+    let key_str = match key_part.to_lowercase().as_str() {
+        "enter" | "return" => "Enter".to_string(),
+        "escape" | "esc" => "Escape".to_string(),
+        "space" => " ".to_string(),
+        "backspace" => "Backspace".to_string(),
+        "tab" => "Tab".to_string(),
+        "up" | "arrowup" => "ArrowUp".to_string(),
+        "down" | "arrowdown" => "ArrowDown".to_string(),
+        "right" | "arrowright" => "ArrowRight".to_string(),
+        "left" | "arrowleft" => "ArrowLeft".to_string(),
+        other => {
+            if other.chars().count() == 1 {
+                other.to_string()
+            } else {
+                let mut s = other.to_string();
+                if let Some(c) = s.get_mut(0..1) {
+                    c.make_ascii_uppercase();
+                }
+                s
+            }
+        }
+    };
+    (key_str, modifiers)
+}
+
 /// process-app registry to register against (terminals — should never reach
 /// this path; logged at the call site).
 fn register_directed_pipe_on_target(pane: &mut crate::pane::Pane, pipe_id: &str) -> bool {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -969,6 +969,19 @@ pub enum HostCommand {
         response_file: Option<String>,
     },
 
+    /// Deliver a synthetic key event to any pane. Sent by `plexi pane key`.
+    /// For terminal panes, the key is translated to PTY bytes.
+    /// For PGAP app panes, a `PlexiEvent::Key` is delivered.
+    /// Host writes `{"ok":true}` or `{"error":"..."}` to `response_file` when set.
+    KeyPane {
+        pane_id: u64,
+        /// Key string: single char ("h"), named key ("enter", "escape", "up", "down",
+        /// "left", "right", "space", "backspace"), or chord ("ctrl+c", "ctrl+d").
+        key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
+    },
+
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
     CreateContext {
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -2625,4 +2625,37 @@ mod tests {
         // Empty is not reserved
         assert!(!is_reserved_shortcut(""));
     }
+
+    #[test]
+    fn key_pane_drawcommand_round_trips_serde() {
+        let json = r#"{"type":"key_pane","pane_id":42,"key":"enter","response_file":"result.json"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::KeyPane { pane_id, key, response_file }) => {
+                assert_eq!(*pane_id, 42);
+                assert_eq!(key, "enter");
+                assert_eq!(response_file.as_deref(), Some("result.json"));
+            }
+            other => panic!("expected KeyPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"key_pane""#), "wire tag missing: {serialised}");
+
+        // Optional field: response_file absent → None
+        let minimal = r#"{"type":"key_pane","pane_id":1,"key":"h"}"#;
+        let cmd2: DrawCommand = serde_json::from_str(minimal).expect("deserialise minimal");
+        match &cmd2 {
+            DrawCommand::Host(HostCommand::KeyPane { response_file, .. }) => {
+                assert!(response_file.is_none(), "absent response_file must deserialise to None");
+            }
+            other => panic!("expected KeyPane, got {other:?}"),
+        }
+
+        // Required-field discipline: missing key field must fail
+        let bad = r#"{"type":"key_pane","pane_id":1}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without required key field"
+        );
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2165,6 +2165,59 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
     }
 }
 
+/// `plexi pane key <pane_id> <key>`
+///
+/// Sends `key_pane` command to PLEXI_SOCKET. Waits for response.
+/// Returns 0 on success, 1 on error.
+pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-key-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+    log::info!("pane_key:cli: pane_id={pane_id} key={key:?} response_file={response_file:?}");
+    let code = send_to_socket(serde_json::json!({
+        "type": "key_pane",
+        "pane_id": pane_id,
+        "key": key,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            return 0;
+                        }
+                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                            eprintln!("error: {msg}");
+                            return 1;
+                        }
+                    }
+                    return 0;
+                }
+                Err(e) => {
+                    log::warn!("pane_key:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane key response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a
@@ -3395,7 +3448,7 @@ _plexi() {
           ;;
         pane)
           local subcmds
-          subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)')
+          subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)' 'key:Inject a synthetic key event into a pane')
           _describe 'subcommand' subcmds
           ;;
         terminal)
@@ -3481,7 +3534,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "export" -- "$cur"))
       ;;
     pane)
-      COMPREPLY=($(compgen -W "name set-title" -- "$cur"))
+      COMPREPLY=($(compgen -W "name set-title key" -- "$cur"))
       ;;
     terminal)
       if [[ $prev == "--layout" ]]; then
@@ -3574,6 +3627,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pack" -a export -d "Export 
 # pane subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a name -d "Set the name of a pane (current or by ID)"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a set-title -d "Set the name of a pane (deprecated: use name)"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a synthetic key event into a pane"
 
 # descriptor subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from descriptor" -a probe -d "Probe a CLI for its Plexi descriptor"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -310,6 +310,21 @@ pub enum PaneCmd {
     },
     /// Print JSON info for the current pane [requires PLEXI_PANE_ID]
     Info,
+    /// Deliver a synthetic key event to a pane [requires PLEXI_SOCKET]
+    ///
+    /// For terminal panes, injects as PTY keystroke.
+    /// For app panes, delivers a structured key event.
+    ///
+    /// Key format: single char ("h"), named key ("enter", "escape", "space",
+    /// "up", "down", "left", "right", "backspace"), or chord ("ctrl+c").
+    ///
+    /// Example: plexi pane key 42 enter
+    Key {
+        /// Pane ID (from `plexi pane list`)
+        pane_id: u64,
+        /// Key to inject
+        key: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -310,7 +310,7 @@ pub enum PaneCmd {
     },
     /// Print JSON info for the current pane [requires PLEXI_PANE_ID]
     Info,
-    /// Deliver a synthetic key event to a pane [requires PLEXI_SOCKET]
+    /// Deliver a synthetic key event to a pane [requires PLEXI_SOCKET — run inside a Plexi pane]
     ///
     /// For terminal panes, injects as PTY keystroke.
     /// For app panes, delivers a structured key event.

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1101,8 +1101,9 @@ mod tests {
         let after_classify = &src[classify_start..handle_key_start];
         // classify_key should contain key_pressed calls (for scroll keys)
         assert!(after_classify.contains("key_pressed"), "classify_key must contain key_pressed calls");
-        // classify_key must also use key_pressed_no_repeat for navigation keys
-        assert!(after_classify.contains("key_pressed_no_repeat"), "classify_key must use key_pressed_no_repeat for navigation keys");
+        // classify_key must also use key_pressed_no_repeat for action/activation keys (Escape, Enter, etc.)
+        // scroll keys (ArrowDown, ArrowUp, j, k) still use key_pressed to allow repeating
+        assert!(after_classify.contains("key_pressed_no_repeat"), "classify_key must use key_pressed_no_repeat for action/activation keys");
         // handle_key body must not contain key_pressed calls
         let handle_body_end = handle_key_body[10..].find("fn ").map(|i| i + 10).unwrap_or(handle_key_body.len());
         let handle_body = &handle_key_body[..handle_body_end];

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -40,11 +40,17 @@ enum FileBrowserAction {
     AppendText(String),
 }
 
+fn key_pressed_no_repeat(input: &egui::InputState, key: egui::Key) -> bool {
+    input.events.iter().any(|e| {
+        matches!(e, egui::Event::Key { key: k, pressed: true, repeat: false, .. } if *k == key)
+    })
+}
+
 fn classify_key(input: &egui::InputState) -> Option<FileBrowserAction> {
-    if input.key_pressed(egui::Key::Escape) {
+    if key_pressed_no_repeat(input, egui::Key::Escape) {
         return Some(FileBrowserAction::Escape);
     }
-    if input.key_pressed(egui::Key::Backspace) {
+    if key_pressed_no_repeat(input, egui::Key::Backspace) {
         return Some(FileBrowserAction::Backspace);
     }
     if input.key_pressed(egui::Key::ArrowDown)
@@ -70,25 +76,25 @@ fn classify_key(input: &egui::InputState) -> Option<FileBrowserAction> {
         return Some(FileBrowserAction::PageUp);
     }
     if !input.modifiers.command
-        && (input.key_pressed(egui::Key::Enter)
-            || input.key_pressed(egui::Key::ArrowRight)
-            || input.key_pressed(egui::Key::L))
+        && (key_pressed_no_repeat(input, egui::Key::Enter)
+            || key_pressed_no_repeat(input, egui::Key::ArrowRight)
+            || key_pressed_no_repeat(input, egui::Key::L))
     {
         return Some(FileBrowserAction::Activate);
     }
     if !input.modifiers.command
-        && (input.key_pressed(egui::Key::ArrowLeft)
-            || input.key_pressed(egui::Key::H))
+        && (key_pressed_no_repeat(input, egui::Key::ArrowLeft)
+            || key_pressed_no_repeat(input, egui::Key::H))
     {
         return Some(FileBrowserAction::NavigateUp);
     }
-    if input.key_pressed(egui::Key::Slash) && !input.modifiers.command {
+    if key_pressed_no_repeat(input, egui::Key::Slash) && !input.modifiers.command {
         return Some(FileBrowserAction::EnterSearch);
     }
-    if input.key_pressed(egui::Key::S) && !input.modifiers.any() {
+    if key_pressed_no_repeat(input, egui::Key::S) && !input.modifiers.any() {
         return Some(FileBrowserAction::ToggleSort);
     }
-    if input.key_pressed(egui::Key::R) && !input.modifiers.any() {
+    if key_pressed_no_repeat(input, egui::Key::R) && !input.modifiers.any() {
         return Some(FileBrowserAction::Refresh);
     }
     let mut text = String::new();
@@ -1093,11 +1099,40 @@ mod tests {
         let handle_key_start = src.find("fn handle_key").expect("handle_key must exist");
         let handle_key_body = &src[handle_key_start..];
         let after_classify = &src[classify_start..handle_key_start];
-        // classify_key should contain key_pressed calls
+        // classify_key should contain key_pressed calls (for scroll keys)
         assert!(after_classify.contains("key_pressed"), "classify_key must contain key_pressed calls");
+        // classify_key must also use key_pressed_no_repeat for navigation keys
+        assert!(after_classify.contains("key_pressed_no_repeat"), "classify_key must use key_pressed_no_repeat for navigation keys");
         // handle_key body must not contain key_pressed calls
         let handle_body_end = handle_key_body[10..].find("fn ").map(|i| i + 10).unwrap_or(handle_key_body.len());
         let handle_body = &handle_key_body[..handle_body_end];
         assert!(!handle_body.contains("key_pressed"), "handle_key must not contain key_pressed calls — they belong in classify_key");
+    }
+
+    #[test]
+    fn key_pressed_no_repeat_requires_non_repeat_event() {
+        // key_pressed_no_repeat returns false when no events are present.
+        let ctx = egui::Context::default();
+        let _ = ctx.run(RawInput::default(), |ctx| {
+            ctx.input(|i| {
+                assert!(!super::key_pressed_no_repeat(i, Key::ArrowRight));
+            });
+        });
+    }
+
+    #[test]
+    fn key_pressed_no_repeat_returns_true_for_fresh_press() {
+        // egui marks the first press of a key (repeat=false), so key_pressed_no_repeat
+        // must return true for a fresh key press event.
+        let ctx = egui::Context::default();
+        let raw = RawInput {
+            events: vec![key_event(Key::ArrowRight, Modifiers::default())],
+            ..Default::default()
+        };
+        let _ = ctx.run(raw, |ctx| {
+            ctx.input(|i| {
+                assert!(super::key_pressed_no_repeat(i, Key::ArrowRight));
+            });
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,6 +370,7 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::pane_close_cli(id));
                         }
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
+                        PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id } => {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2058,6 +2058,8 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
     migrate_app_state_dir(&ws_old, &ws_new);
 
     let workspace_path = ws_new.join(&filename);
+    // Fallback: if migration failed (e.g. permission error), still read from old location
+    let workspace_path_legacy = ws_old.join(&filename);
     if workspace_path.exists() {
         match std::fs::read(&workspace_path) {
             Err(e) => {
@@ -2073,6 +2075,21 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
                 }
             },
         }
+    } else if workspace_path_legacy.exists() {
+        match std::fs::read(&workspace_path_legacy) {
+            Err(e) => {
+                log::warn!("load_app_state[{type_id}]: could not read legacy workspace state {}: {e}", workspace_path_legacy.display());
+            }
+            Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Err(e) => {
+                    log::warn!("load_app_state[{type_id}]: could not parse legacy workspace state {}: {e}", workspace_path_legacy.display());
+                }
+                Ok(val) => {
+                    log::info!("load_app_state[{type_id}]: loaded workspace state from legacy path {}", workspace_path_legacy.display());
+                    return val;
+                }
+            },
+        }
     }
 
     // Migrate old app_state/ → app_states/ on first access (global).
@@ -2081,6 +2098,8 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
     migrate_app_state_dir(&global_old, &global_new);
 
     let global_path = global_new.join(&filename);
+    // Fallback: if migration failed (e.g. permission error), still read from old location
+    let global_path_legacy = global_old.join(&filename);
     if global_path.exists() {
         match std::fs::read(&global_path) {
             Err(e) => {
@@ -2092,6 +2111,21 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
                 }
                 Ok(val) => {
                     log::info!("load_app_state[{type_id}]: loaded global state from {}", global_path.display());
+                    return val;
+                }
+            },
+        }
+    } else if global_path_legacy.exists() {
+        match std::fs::read(&global_path_legacy) {
+            Err(e) => {
+                log::warn!("load_app_state[{type_id}]: could not read legacy global state {}: {e}", global_path_legacy.display());
+            }
+            Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Err(e) => {
+                    log::warn!("load_app_state[{type_id}]: could not parse legacy global state {}: {e}", global_path_legacy.display());
+                }
+                Ok(val) => {
+                    log::info!("load_app_state[{type_id}]: loaded global state from legacy path {}", global_path_legacy.display());
                     return val;
                 }
             },

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1488,6 +1488,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            HostCommand::KeyPane { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received KeyPane over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
 
             // ── App state save ─────────────────────────────────────────────
             HostCommand::SaveAppState { payload } => {


### PR DESCRIPTION
Bundles three independent P3/P4 ready issues.

## #851 — `app_state/` → `app_states/` rename
- All read/write paths updated (`process_app`, `routing`, `cli`)
- `try_migrate_app_state_dir()` auto-renames the old dir on first launch — no data loss

## #847 — `plexi pane key <id> <key>`
- New `KeyPane` HostCommand dispatched over PLEXI_SOCKET
- Terminal panes: key string → PTY bytes (`enter` → `\r`, `ctrl+c` → `\x03`, `up` → `ESC[A`, etc.)
- PGAP app panes: delivers `PlexiEvent::Key { key, modifiers }`
- Supports: single chars, named keys, `ctrl+X` chords

## #929 — file-browser nav key debounce
- `key_pressed_no_repeat()` helper checks `repeat: false` in raw events
- Navigation keys (enter, arrow nav, h/l, slash, s, r, escape) use it — one dir level per press
- Scroll keys (j/k, page/home/end) still repeat as intended

## Test plan
- [ ] Diff review: all `app_state` → `app_states` path strings updated, migration helper present
- [ ] `plexi pane key <terminal-id> h` injects `h` keystroke into terminal
- [ ] `plexi pane key <app-id> enter` delivers Enter to a PGAP app
- [ ] Holding ArrowRight in file browser navigates exactly one level