### PR TITLE
fix(keybindings): Cmd+R rename-pane and font-size bindings broken by exact-modifier guard

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -542,7 +542,7 @@ pub fn poll_actions(
         // Rename context before rename pane — check shifted variant first.
         if input.consume_key(bindings.rename_context.0, bindings.rename_context.1) {
             actions.push(Action::RenameContext);
-        } else if input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1) {
+        } else if !input.modifiers.alt && input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1) {
             actions.push(Action::RenamePane);
         }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -542,9 +542,7 @@ pub fn poll_actions(
         // Rename context before rename pane — check shifted variant first.
         if input.consume_key(bindings.rename_context.0, bindings.rename_context.1) {
             actions.push(Action::RenameContext);
-        } else if input.modifiers == bindings.rename_pane.0
-            && input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1)
-        {
+        } else if input.consume_key(bindings.rename_pane.0, bindings.rename_pane.1) {
             actions.push(Action::RenamePane);
         }
 
@@ -573,10 +571,10 @@ pub fn poll_actions(
             actions.push(Action::ScrollDown);
         }
 
-        if input.modifiers == bindings.increase_font_size.0 && input.consume_key(bindings.increase_font_size.0, bindings.increase_font_size.1) {
+        if input.consume_key(bindings.increase_font_size.0, bindings.increase_font_size.1) {
             actions.push(Action::IncreasePaneFontSize);
         }
-        if input.modifiers == bindings.decrease_font_size.0 && input.consume_key(bindings.decrease_font_size.0, bindings.decrease_font_size.1) {
+        if input.consume_key(bindings.decrease_font_size.0, bindings.decrease_font_size.1) {
             actions.push(Action::DecreasePaneFontSize);
         }
 


### PR DESCRIPTION
## Summary

Removes the spurious `input.modifiers == <binding>.0 &&` equality check that was added in #985 for `rename_pane`, `increase_font_size`, and `decrease_font_size`. The check fails on macOS due to egui normalising `mac_cmd` vs `command` differently, so these bindings never fired. Every other binding uses plain `consume_key` — this restores consistency.

**Files changed:** `src/keys.rs` — 3 lines removed (one per affected binding)

## Test plan
- [ ] Press **Cmd+R** with a pane focused → rename modal opens
- [ ] Press **Cmd+=** → font size increases
- [ ] Press **Cmd+-** → font size decreases
- [ ] Cmd+Shift+R still opens rename context

Fixes #1021