### PR TITLE
feat(logging): date-based log rotation with configurable retention

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,7 @@ pub struct NotificationsConfig {
 #[derive(Deserialize, Default, Clone)]
 pub struct LogConfig {
     pub level: Option<String>,
+    pub retention_days: Option<u32>,
 }
 
 impl LogConfig {
@@ -558,7 +559,8 @@ model_high   = "anthropic/claude-opus-4-7"
 
 # ── Logging ────────────────────────────────────────────────────
 # [log]
-# level = "info"   # error | warn | info | debug  (default: info)
+# level = "info"          # error | warn | info | debug  (default: info)
+# retention_days = 30     # days to keep dated log archives (default: 30)
 
 # ── Keybindings ────────────────────────────────────────────────
 # Override any default keybinding. Format: "modifier+key" (case-insensitive).
@@ -786,6 +788,9 @@ impl LogConfig {
     fn overlay(&mut self, other: Self) {
         if other.level.is_some() {
             self.level = other.level;
+        }
+        if other.retention_days.is_some() {
+            self.retention_days = other.retention_days;
         }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,18 +3,20 @@
 //! Writes to `~/.plexi-alpha/plexi.log` (or the appropriate config dir) and
 //! also mirrors output to stderr so `cargo run` / CLI invocations stay usable.
 //!
-//! Rolling on startup: if `plexi.log` exists and is over 10 MB, it is renamed
-//! to `plexi.log.1` (overwriting any previous backup) before the new log is opened.
+//! Date-based rotation on startup: if `plexi.log` exists and is non-empty and
+//! was last written on a previous calendar day, it is renamed to
+//! `plexi-YYYY-MM-DD.log` (the modification date). Same-day restarts continue
+//! appending to `plexi.log`. Files older than `retention_days` (default 30)
+//! are pruned automatically on each startup.
 //!
 //! Third-party crates (egui, wgpu, winit, etc.) are clamped to `warn` to avoid
 //! noise; everything under `plexi::` logs at the caller-supplied level.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 /// How often the watchdog samples the frame counter. Short enough to catch brief freezes.
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 /// UI thread is considered frozen after this many seconds without a frame tick.
@@ -27,10 +29,103 @@ pub fn log_path() -> PathBuf {
     crate::config::config_dir().join("plexi.log")
 }
 
-/// Initialise the logger.  Must be called before any `log::` macro is used.
+/// Rotate `log_path` to a dated archive if it was last modified on a prior day,
+/// then prune any dated files older than `cutoff` (`today - retention_days`).
+/// Returns informational messages to be emitted after the logger initialises.
+fn rotate_and_prune(
+    log_path: &Path,
+    config_dir: &Path,
+    today: chrono::NaiveDate,
+    retention_days: u32,
+) -> Vec<String> {
+    let mut messages = Vec::new();
+
+    // Rotation: rename plexi.log → plexi-PREV-DATE.log if modified on a prior day.
+    if let Ok(meta) = std::fs::metadata(log_path) {
+        if meta.len() > 0 {
+            let prev_date = meta
+                .modified()
+                .ok()
+                .map(|mtime| chrono::DateTime::<chrono::Local>::from(mtime).date_naive());
+
+            if let Some(prev_date) = prev_date {
+                if prev_date < today {
+                    let dated = config_dir
+                        .join(format!("plexi-{}.log", prev_date.format("%Y-%m-%d")));
+                    if !dated.exists() {
+                        if let Err(e) = std::fs::rename(log_path, &dated) {
+                            eprintln!(
+                                "[plexi::logging] could not rotate log to {dated:?}: {e}"
+                            );
+                        } else {
+                            messages.push(format!(
+                                "rotated log → plexi-{}.log",
+                                prev_date.format("%Y-%m-%d")
+                            ));
+                        }
+                    } else {
+                        // Dated file already exists — append plexi.log content to it.
+                        match (
+                            std::fs::read(log_path),
+                            std::fs::OpenOptions::new().append(true).open(&dated),
+                        ) {
+                            (Ok(content), Ok(mut dst)) => {
+                                use std::io::Write;
+                                if dst.write_all(&content).is_ok() {
+                                    let _ = std::fs::remove_file(log_path);
+                                    messages.push(format!(
+                                        "appended and rotated log → plexi-{}.log",
+                                        prev_date.format("%Y-%m-%d")
+                                    ));
+                                }
+                            }
+                            _ => eprintln!(
+                                "[plexi::logging] could not append to existing dated log {dated:?}"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Pruning: delete dated files whose name-date is before the cutoff.
+    let cutoff = today - chrono::Duration::days(retention_days as i64);
+    if let Ok(entries) = std::fs::read_dir(config_dir) {
+        let mut pruned = 0u32;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if let Some(date_str) = name_str
+                .strip_prefix("plexi-")
+                .and_then(|s| s.strip_suffix(".log"))
+            {
+                if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+                    if date < cutoff {
+                        if let Err(e) = std::fs::remove_file(entry.path()) {
+                            eprintln!("[plexi::logging] could not prune {name_str}: {e}");
+                        } else {
+                            pruned += 1;
+                        }
+                    }
+                }
+            }
+        }
+        if pruned > 0 {
+            messages.push(format!(
+                "pruned {pruned} log file(s) older than {retention_days} days"
+            ));
+        }
+    }
+
+    messages
+}
+
+/// Initialise the logger. Must be called before any `log::` macro is used.
 /// If the log file cannot be opened, falls back to stderr-only and logs a warning.
-pub fn init(level: log::LevelFilter) {
+pub fn init(level: log::LevelFilter, retention_days: u32) {
     let log_file_path = log_path();
+    let config_dir = crate::config::config_dir();
 
     // Ensure the config directory exists.
     if let Some(parent) = log_file_path.parent() {
@@ -39,15 +134,8 @@ pub fn init(level: log::LevelFilter) {
         }
     }
 
-    // Rolling: if the file exists and is over 10 MB, rotate it.
-    if let Ok(meta) = std::fs::metadata(&log_file_path) {
-        if meta.len() > MAX_LOG_BYTES {
-            let backup = log_file_path.with_extension("log.1");
-            if let Err(e) = std::fs::rename(&log_file_path, &backup) {
-                eprintln!("[plexi::logging] could not rotate log: {e}");
-            }
-        }
-    }
+    let today = chrono::Local::now().date_naive();
+    let deferred = rotate_and_prune(&log_file_path, &config_dir, today, retention_days);
 
     // Build format: [YYYY-MM-DD HH:MM:SS] [LEVEL] [target] message
     let formatter =
@@ -87,6 +175,11 @@ pub fn init(level: log::LevelFilter) {
 
     if let Err(e) = dispatch.apply() {
         eprintln!("[plexi::logging] failed to install logger: {e}");
+    }
+
+    // Emit rotation/pruning messages now that the logger is running.
+    for msg in deferred {
+        log::info!(target: "plexi::logging", "{msg}");
     }
 }
 
@@ -158,4 +251,131 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
             }
         })
         .expect("failed to spawn heartbeat thread");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use std::fs;
+
+    fn today_plus(days: i64) -> NaiveDate {
+        chrono::Local::now().date_naive() + chrono::Duration::days(days)
+    }
+
+    #[test]
+    fn rotates_previous_day_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        fs::write(&log_path, b"session data\n").unwrap();
+
+        // Advance "today" by 1 day — the file's mtime (real today) becomes "yesterday".
+        let simulated_today = today_plus(1);
+        let expected_prev = today_plus(0);
+        let expected_name = format!("plexi-{}.log", expected_prev.format("%Y-%m-%d"));
+
+        let msgs = rotate_and_prune(&log_path, dir.path(), simulated_today, 30);
+
+        assert!(
+            dir.path().join(&expected_name).exists(),
+            "should have rotated to {expected_name}"
+        );
+        assert!(!log_path.exists(), "plexi.log should have been renamed");
+        assert!(msgs.iter().any(|m| m.contains("rotated")));
+    }
+
+    #[test]
+    fn no_rotation_same_day() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        fs::write(&log_path, b"session data\n").unwrap();
+
+        // "Today" is the real today — file mtime equals today, no rotation.
+        let msgs = rotate_and_prune(&log_path, dir.path(), today_plus(0), 30);
+
+        assert!(log_path.exists(), "plexi.log should not have been renamed");
+        assert!(!msgs.iter().any(|m| m.contains("rotated")));
+    }
+
+    #[test]
+    fn appends_when_dated_file_already_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        let real_today = today_plus(0);
+        let simulated_today = today_plus(1);
+
+        // plexi.log has content from "today" (mtime = now).
+        fs::write(&log_path, b"evening session\n").unwrap();
+        // A dated file for real_today already exists (morning rotation already ran).
+        let dated = dir
+            .path()
+            .join(format!("plexi-{}.log", real_today.format("%Y-%m-%d")));
+        fs::write(&dated, b"morning session\n").unwrap();
+
+        let msgs = rotate_and_prune(&log_path, dir.path(), simulated_today, 30);
+
+        assert!(!log_path.exists(), "plexi.log should have been removed");
+        let content = fs::read_to_string(&dated).unwrap();
+        assert!(content.contains("morning session"), "original content preserved");
+        assert!(content.contains("evening session"), "new content appended");
+        assert!(msgs.iter().any(|m| m.contains("appended")));
+    }
+
+    #[test]
+    fn no_rotation_when_log_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        fs::write(&log_path, b"").unwrap();
+
+        let msgs = rotate_and_prune(&log_path, dir.path(), today_plus(1), 30);
+
+        assert!(log_path.exists(), "empty plexi.log should not be renamed");
+        assert!(!msgs.iter().any(|m| m.contains("rotated")));
+    }
+
+    #[test]
+    fn prunes_old_dated_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        let today = NaiveDate::from_ymd_opt(2026, 5, 10).unwrap();
+
+        // 40 days old — should be pruned (retention = 30).
+        fs::write(dir.path().join("plexi-2026-03-31.log"), b"old").unwrap();
+        // 10 days old — should be kept.
+        fs::write(dir.path().join("plexi-2026-04-30.log"), b"recent").unwrap();
+        // Non-log file — not touched.
+        fs::write(dir.path().join("config.toml"), b"[log]").unwrap();
+
+        let msgs = rotate_and_prune(&log_path, dir.path(), today, 30);
+
+        assert!(
+            !dir.path().join("plexi-2026-03-31.log").exists(),
+            "40-day-old file should be pruned"
+        );
+        assert!(
+            dir.path().join("plexi-2026-04-30.log").exists(),
+            "10-day-old file should be kept"
+        );
+        assert!(
+            dir.path().join("config.toml").exists(),
+            "non-log files must not be touched"
+        );
+        assert!(msgs.iter().any(|m| m.contains("pruned 1")));
+    }
+
+    #[test]
+    fn respects_custom_retention_days() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("plexi.log");
+        let today = NaiveDate::from_ymd_opt(2026, 5, 10).unwrap();
+
+        // 8 days old — pruned with retention=7, kept with retention=30.
+        fs::write(dir.path().join("plexi-2026-05-02.log"), b"old").unwrap();
+
+        rotate_and_prune(&log_path, dir.path(), today, 7);
+        assert!(
+            !dir.path().join("plexi-2026-05-02.log").exists(),
+            "8-day-old file should be pruned with 7-day retention"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,11 +128,12 @@ fn main() -> eframe::Result {
     let merged_config_root = adopted_root
         .clone()
         .or_else(|| crate::config::active_workspace_root());
-    let log_level = crate::config::PlexiConfig::load_with_workspace(merged_config_root.as_deref())
+    let log_config = crate::config::PlexiConfig::load_with_workspace(merged_config_root.as_deref())
         .log
-        .and_then(|l| l.level_filter())
-        .unwrap_or(log::LevelFilter::Info);
-    crate::logging::init(log_level);
+        .unwrap_or_default();
+    let log_level = log_config.level_filter().unwrap_or(log::LevelFilter::Info);
+    let retention_days = log_config.retention_days.unwrap_or(30);
+    crate::logging::init(log_level, retention_days);
     let frame_tick = crate::logging::new_frame_tick();
     // Note: spawn_heartbeat is deferred to just before eframe::run_native so
     // the shell probes below don't trigger false FREEZE alerts. The heartbeat


### PR DESCRIPTION
## Summary

Closes #811.

Replaces the size-based (10 MB / single-backup) rotation with **daily date-stamped archives** and a configurable retention window.

- On startup, `plexi.log` is renamed to `plexi-YYYY-MM-DD.log` (using the file's modification date) when the modification date is a prior calendar day. Same-day restarts continue appending to `plexi.log`.
- If a dated file for that day already exists (unusual double-rotation case), the active log is appended to it and then deleted.
- Files older than `retention_days` days are pruned on each startup.
- `LogConfig` gains `retention_days: Option<u32>` (default 30).
- Default `config.toml` template now shows the `retention_days` comment.
- No new crate dependencies — uses `chrono` (already a dep) and `std::fs`.

## Tests

6 unit tests cover:
- Cross-day rotation (rename `plexi.log` → dated file)
- Same-day no-op (no rename when mtime = today)
- Append-on-collision (dated file already exists for that day)
- Empty-file no-op
- Pruning files older than retention window
- Custom `retention_days` setting

## Breaks if

`ls ~/.plexi-alpha/` after two restarts across a day boundary still shows only `plexi.log` with no dated archives.