### PR TITLE
feat(quick-note): destination picker UI stub

### DIFF
--- a/src/quick_note_app.rs
+++ b/src/quick_note_app.rs
@@ -140,6 +140,7 @@ impl QuickNoteApp {
         if esc {
             log::info!("QuickNote: destination picker dismissed, back to composing");
             self.phase = Phase::Composing;
+            self.focus_set = false;
             return;
         }
 
@@ -178,8 +179,8 @@ impl QuickNoteApp {
         // --- Note preview (dimmed) ---
         let preview = {
             let t = self.text.trim();
-            if t.len() > 80 {
-                format!("{}…", &t[..80])
+            if let Some((idx, _)) = t.char_indices().nth(80) {
+                format!("{}…", &t[..idx])
             } else {
                 t.to_string()
             }

--- a/src/quick_note_app.rs
+++ b/src/quick_note_app.rs
@@ -1,11 +1,34 @@
 use crate::app_trait::{App, AppCommand, AppRenderContext};
+use crate::style;
+use crate::widgets;
 use std::path::PathBuf;
+
+#[derive(Default)]
+enum Phase {
+    #[default]
+    Composing,
+    PickingDestination,
+}
+
+struct Destination {
+    key: &'static str,
+    label: &'static str,
+}
+
+const DESTINATIONS: &[Destination] = &[
+    Destination { key: "0", label: "Backlog" },
+    Destination { key: "1", label: "Project backlog" },
+    Destination { key: "2", label: "Claude Code — current dir" },
+    Destination { key: "3", label: "Claude Code — workspace" },
+    Destination { key: "4", label: "GitHub issue" },
+];
 
 pub struct QuickNoteApp {
     text: String,
     saved: bool,
     pending_cmds: Vec<AppCommand>,
     focus_set: bool,
+    phase: Phase,
     /// Set to true after save — signals the host to close the app.
     pub should_close: bool,
 }
@@ -17,6 +40,7 @@ impl QuickNoteApp {
             saved: false,
             pending_cmds: Vec::new(),
             focus_set: false,
+            phase: Phase::Composing,
             should_close: false,
         }
     }
@@ -59,6 +83,149 @@ impl QuickNoteApp {
             }
         }
     }
+
+    fn draw_composing(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+
+        // Only intercept plain Enter (no shift) to advance to destination picker.
+        // Shift+Enter passes through to TextEdit which handles newlines naturally.
+        let plain_enter = ui.input_mut(|i| {
+            if !i.modifiers.shift && !i.modifiers.command {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+            } else {
+                false
+            }
+        });
+
+        if plain_enter && !self.text.trim().is_empty() {
+            log::info!("QuickNote: showing destination picker");
+            self.phase = Phase::PickingDestination;
+            return;
+        }
+
+        // Subtle hint
+        ui.label(
+            egui::RichText::new("Enter to send · Shift+Enter for new line · Esc to discard")
+                .color(colors.text_dim.linear_multiply(0.4))
+                .size(style::TEXT_HINT)
+                .family(egui::FontFamily::Monospace),
+        );
+        ui.add_space(style::SPACE_SM);
+
+        // Text box
+        let response = ui.add_sized(
+            ui.available_size(),
+            egui::TextEdit::multiline(&mut self.text)
+                .font(egui::FontId::monospace(style::TEXT_BODY))
+                .text_color(colors.text_primary)
+                .desired_width(f32::INFINITY)
+                .frame(false)
+                .hint_text(
+                    egui::RichText::new("What's on your mind?")
+                        .color(colors.text_dim.linear_multiply(0.3))
+                        .size(style::TEXT_BODY),
+                ),
+        );
+
+        if !self.focus_set {
+            response.request_focus();
+            self.focus_set = true;
+        }
+    }
+
+    fn draw_destination_picker(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+
+        let esc = ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+        if esc {
+            log::info!("QuickNote: destination picker dismissed, back to composing");
+            self.phase = Phase::Composing;
+            return;
+        }
+
+        let enter = ui.input_mut(|i| {
+            if !i.modifiers.shift && !i.modifiers.command {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+            } else {
+                false
+            }
+        });
+
+        // Digit keys 0–4 select a destination; bare Enter routes to destination 0.
+        let selected_key = ui.input_mut(|i| {
+            let digits = [
+                (egui::Key::Num0, "0"),
+                (egui::Key::Num1, "1"),
+                (egui::Key::Num2, "2"),
+                (egui::Key::Num3, "3"),
+                (egui::Key::Num4, "4"),
+            ];
+            for (key, label) in digits {
+                if i.consume_key(egui::Modifiers::NONE, key) {
+                    return Some(label);
+                }
+            }
+            None
+        });
+
+        if enter || selected_key.is_some() {
+            let dest = selected_key.unwrap_or("0");
+            log::info!("QuickNote: destination selected: {dest}");
+            self.save();
+            return;
+        }
+
+        // --- Note preview (dimmed) ---
+        let preview = {
+            let t = self.text.trim();
+            if t.len() > 80 {
+                format!("{}…", &t[..80])
+            } else {
+                t.to_string()
+            }
+        };
+        ui.label(
+            egui::RichText::new(&preview)
+                .color(colors.text_dim.linear_multiply(0.5))
+                .size(style::TEXT_BODY)
+                .family(egui::FontFamily::Monospace),
+        );
+
+        ui.add_space(style::SPACE_XL);
+
+        // --- Heading ---
+        ui.label(
+            egui::RichText::new("Send to…")
+                .color(colors.text_primary)
+                .size(style::TEXT_BODY),
+        );
+
+        ui.add_space(style::SPACE_MD);
+
+        // --- Destination rows ---
+        for dest in DESTINATIONS {
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                widgets::key_chip(ui, dest.key, colors);
+                ui.label(
+                    egui::RichText::new(dest.label)
+                        .color(colors.text_dim)
+                        .size(style::TEXT_BODY),
+                );
+            });
+            ui.add_space(style::SPACE_SM);
+        }
+
+        ui.add_space(style::SPACE_XL);
+
+        // --- Footer hint ---
+        ui.label(
+            egui::RichText::new("Esc to go back")
+                .color(colors.text_dim.linear_multiply(0.4))
+                .size(style::TEXT_HINT)
+                .family(egui::FontFamily::Monospace),
+        );
+    }
 }
 
 impl App for QuickNoteApp {
@@ -76,7 +243,6 @@ impl App for QuickNoteApp {
         let rect = ui.max_rect();
         ui.painter().rect_filled(rect, 0.0, colors.terminal_bg);
 
-        // Center the text box vertically and horizontally with generous margins.
         let margin_x = (rect.width() * 0.15).max(32.0);
         let margin_top = (rect.height() * 0.3).max(40.0);
         let inner = egui::Rect::from_min_max(
@@ -85,50 +251,9 @@ impl App for QuickNoteApp {
         );
 
         let mut child = ui.new_child(egui::UiBuilder::new().max_rect(inner));
-        child.vertical_centered(|ui| {
-            // Only intercept plain Enter (no shift) for save.
-            // Shift+Enter passes through to TextEdit which handles newlines naturally.
-            let plain_enter = ui.input_mut(|i| {
-                if !i.modifiers.shift && !i.modifiers.command {
-                    i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
-                } else {
-                    false
-                }
-            });
-
-            if plain_enter && !self.text.trim().is_empty() {
-                self.save();
-                return;
-            }
-
-            // Subtle hint
-            ui.label(
-                egui::RichText::new("Enter to save · Shift+Enter for new line · Esc to discard")
-                    .color(colors.text_dim.linear_multiply(0.4))
-                    .size(10.0)
-                    .family(egui::FontFamily::Monospace),
-            );
-            ui.add_space(8.0);
-
-            // Text box
-            let response = ui.add_sized(
-                ui.available_size(),
-                egui::TextEdit::multiline(&mut self.text)
-                    .font(egui::FontId::monospace(14.0))
-                    .text_color(colors.text_primary)
-                    .desired_width(f32::INFINITY)
-                    .frame(false)
-                    .hint_text(
-                        egui::RichText::new("What's on your mind?")
-                            .color(colors.text_dim.linear_multiply(0.3))
-                            .size(14.0),
-                    ),
-            );
-
-            if !self.focus_set {
-                response.request_focus();
-                self.focus_set = true;
-            }
+        child.vertical_centered(|ui| match &self.phase {
+            Phase::Composing => self.draw_composing(ui, ctx),
+            Phase::PickingDestination => self.draw_destination_picker(ui, ctx),
         });
     }
 
@@ -137,7 +262,6 @@ impl App for QuickNoteApp {
     }
 
     fn handle_key(&mut self, _input: &egui::InputState) -> bool {
-        // All key handling is done in ui() before TextEdit.
         false
     }
 


### PR DESCRIPTION
## Summary
- Enter on non-empty QuickNote text now transitions to a destination picker phase instead of saving immediately
- Shows 5 hardcoded destinations (Backlog, Project backlog, Claude Code ×2, GitHub issue) with key chip labels
- Digit keys 0–4 or bare Enter save to backlog (all stub-routed for now); Esc returns to compose

## Scope
UI scaffolding only — no config, no routing, no FocusLayer modal. Backend wiring is deferred to #491.

**Breaks if:** QuickNote Enter immediately saves without showing a destination picker.

Closes #491 (partial — UI stub; full implementation deferred)