### PR TITLE
fix(deps): disable eframe accesskit to eliminate accesskit_consumer panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 egui = "0.31"
-eframe = { version = "0.31", features = ["default_fonts", "wgpu"] }
+eframe = { version = "0.31", default-features = false, features = ["default_fonts", "wgpu"] }
 egui_tiles = { version = "0.12.0", features = ["serde"] }
 egui_term = { path = "deps/egui_term" }
 dirs = "6"


### PR DESCRIPTION
Fixes #1032.

## What

Adds `default-features = false` to the `eframe` dependency and keeps only the features Plexi actually uses (`default_fonts`, `wgpu`). This removes the `accesskit` feature flag and its full dependency chain including `accesskit_consumer`, `accesskit_macos`, `accesskit_winit`.

## Why

`accesskit_consumer` v0.26.0 panics at `tree.rs:34` when:
1. A widget with egui focus is removed from the accessibility tree (e.g. by zoom toggle)
2. macOS accessibility (VoiceOver, Accessibility Inspector) subsequently requests the tree

Plexi does not intentionally support VoiceOver. Removing the feature eliminates the crash class entirely.

## Verification

`cargo tree | grep accesskit` returns no results. `cargo build` clean.