### PR TITLE
fix(mcp-renderer): use plexi open syntax in no-command error message

### DIFF
--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -155,7 +155,7 @@ class McpRendererApp(App):
 
         argv = sys.argv[1:]
         if not argv:
-            self._error = "Usage: mcp_renderer.py <command> [args...]\nExample: mcp_renderer.py npx -y @modelcontextprotocol/server-filesystem /tmp"
+            self._error = "Usage: plexi open mcp-renderer <command> [args...]\nExample: plexi open mcp-renderer npx -y @modelcontextprotocol/server-filesystem /tmp"
             self._view = "error"
             ctx.status_summary("mcp-renderer: no command")
             return


### PR DESCRIPTION
Closes #1040

When mcp-renderer is launched without an MCP server command, the error message previously said:

```
Usage: mcp_renderer.py <command> [args...]
```

Users don't run `mcp_renderer.py` directly — they use `plexi open`. Updated to:

```
Usage: plexi open mcp-renderer <command> [args...]
Example: plexi open mcp-renderer npx -y @modelcontextprotocol/server-filesystem /tmp
```

**Breaks if:** Launching mcp-renderer with no args still shows the old `mcp_renderer.py` prefix in the error box.