### PR TITLE
feat(cli): cli_help_parser — parse_help_to_descriptor

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -336,6 +336,9 @@ pub enum DescriptorCmd {
         no_registry: bool,
         #[arg(long = "no-crawl")]
         no_crawl: bool,
+        /// Output raw descriptor JSON (fresh --help parse, no cache)
+        #[arg(long = "json")]
+        json: bool,
         /// Extra args forwarded to the probed CLI
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,

--- a/src/cli_crawl.rs
+++ b/src/cli_crawl.rs
@@ -163,7 +163,7 @@ pub(crate) fn crawl_with_runner(
 // ── parsing ───────────────────────────────────────────────────────────────────
 
 /// Synthesise a `PlexiDescriptor` by parsing `--help` output.
-fn parse_help(cli_name: &str, text: &str, version: Option<String>) -> PlexiDescriptor {
+pub(crate) fn parse_help(cli_name: &str, text: &str, version: Option<String>) -> PlexiDescriptor {
     let commands = extract_commands(text);
     let description = extract_description(text);
 

--- a/src/cli_help_parser.rs
+++ b/src/cli_help_parser.rs
@@ -102,35 +102,7 @@ fn run_with_timeout(binary: &str, arg: &str) -> Result<String, CliParseError> {
 }
 
 fn run_version(binary: &str) -> Option<String> {
-    use std::sync::mpsc;
-    use std::process::Stdio;
-
-    let child = std::process::Command::new(binary)
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .ok()?;
-
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
-
-    let timeout = Duration::from_secs(TIMEOUT_SECS);
-    let output = match rx.recv_timeout(timeout) {
-        Ok(Ok(o)) => o,
-        _ => {
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
-            }
-            return None;
-        }
-    };
-
-    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    let text = run_with_timeout(binary, "--version").ok()?;
     text.lines().next().map(|l| l.trim().to_string())
 }
 

--- a/src/cli_help_parser.rs
+++ b/src/cli_help_parser.rs
@@ -1,0 +1,149 @@
+//! Standalone `--help` parser that converts any CLI's help output into a
+//! descriptor JSON string compatible with `descriptor-renderer`.
+//!
+//! Unlike `cli_crawl`, this module never caches — it always re-runs the
+//! subprocess. Use it when you need a one-shot, fresh parse (e.g. `plexi open
+//! --cli`). Use `cli_crawl` when you want disk caching between calls.
+
+use std::time::Duration;
+
+// ── public error type ─────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum CliParseError {
+    #[error("binary `{binary}` not found or could not be spawned: {source}")]
+    SpawnFailed {
+        binary: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("`{binary} --help` timed out after {secs}s")]
+    Timeout { binary: String, secs: u64 },
+    #[error("failed to serialize descriptor: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+// ── public entry point ────────────────────────────────────────────────────────
+
+const TIMEOUT_SECS: u64 = 5;
+
+/// Run `<binary> --help`, parse the output, and return a descriptor JSON string
+/// matching the schema expected by `descriptor-renderer`. Never caches.
+pub fn parse_help_to_descriptor(binary: &str) -> Result<String, CliParseError> {
+    log::info!("cli_help_parser: running `{binary} --help`");
+
+    let help_text = run_with_timeout(binary, "--help")?;
+    let version = run_version(binary);
+
+    let descriptor = crate::cli_crawl::parse_help(binary, &help_text, version);
+    let count = descriptor.commands.len();
+
+    let json = serde_json::to_string_pretty(&descriptor)?;
+    log::info!("cli_help_parser: extracted {count} commands from `{binary} --help`");
+    Ok(json)
+}
+
+// ── subprocess helpers ────────────────────────────────────────────────────────
+
+fn run_with_timeout(binary: &str, arg: &str) -> Result<String, CliParseError> {
+    use std::sync::mpsc;
+
+    let binary_owned = binary.to_string();
+    let arg_owned = arg.to_string();
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let result = std::process::Command::new(&binary_owned)
+            .arg(&arg_owned)
+            .output();
+        let _ = tx.send(result);
+    });
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    let output = rx
+        .recv_timeout(timeout)
+        .map_err(|_| CliParseError::Timeout {
+            binary: binary.to_string(),
+            secs: TIMEOUT_SECS,
+        })?
+        .map_err(|source| CliParseError::SpawnFailed {
+            binary: binary.to_string(),
+            source,
+        })?;
+
+    // Many CLIs print help to stderr; prefer stdout, fall back to stderr.
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let text = if stdout.trim().is_empty() {
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    } else {
+        stdout
+    };
+
+    if text.trim().is_empty() {
+        log::warn!("cli_help_parser: `{binary} {arg}` produced no output");
+    }
+
+    Ok(text)
+}
+
+fn run_version(binary: &str) -> Option<String> {
+    use std::sync::mpsc;
+
+    let binary_owned = binary.to_string();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = std::process::Command::new(&binary_owned)
+            .arg("--version")
+            .output();
+        let _ = tx.send(result);
+    });
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    let output = rx.recv_timeout(timeout).ok()?.ok()?;
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.lines().next().map(|l| l.trim().to_string())
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify the returned string is valid JSON with the expected top-level keys.
+    #[test]
+    fn parse_help_to_descriptor_returns_valid_json() {
+        // `echo` is a safe binary guaranteed to exist; its --help may be minimal
+        // but parse_help_to_descriptor must not error — it accepts sparse output.
+        // We test with a known-good binary that always succeeds.
+        let result = parse_help_to_descriptor("cargo");
+        assert!(
+            result.is_ok(),
+            "expected Ok, got: {:?}",
+            result.err()
+        );
+        let json = result.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json)
+            .expect("returned string must be valid JSON");
+        assert!(value.get("name").is_some(), "descriptor must have `name`");
+        assert!(
+            value.get("commands").is_some(),
+            "descriptor must have `commands`"
+        );
+        assert_eq!(
+            value["name"].as_str(),
+            Some("cargo"),
+            "name must match binary"
+        );
+    }
+
+    #[test]
+    fn error_on_nonexistent_binary() {
+        let result = parse_help_to_descriptor("__plexi_test_nonexistent_binary_xyz__");
+        assert!(
+            matches!(result, Err(CliParseError::SpawnFailed { .. })),
+            "expected SpawnFailed, got: {:?}",
+            result
+        );
+    }
+}

--- a/src/cli_help_parser.rs
+++ b/src/cli_help_parser.rs
@@ -47,29 +47,44 @@ pub fn parse_help_to_descriptor(binary: &str) -> Result<String, CliParseError> {
 
 fn run_with_timeout(binary: &str, arg: &str) -> Result<String, CliParseError> {
     use std::sync::mpsc;
+    use std::process::Stdio;
 
-    let binary_owned = binary.to_string();
-    let arg_owned = arg.to_string();
-    let (tx, rx) = mpsc::channel();
-
-    std::thread::spawn(move || {
-        let result = std::process::Command::new(&binary_owned)
-            .arg(&arg_owned)
-            .output();
-        let _ = tx.send(result);
-    });
-
-    let timeout = Duration::from_secs(TIMEOUT_SECS);
-    let output = rx
-        .recv_timeout(timeout)
-        .map_err(|_| CliParseError::Timeout {
-            binary: binary.to_string(),
-            secs: TIMEOUT_SECS,
-        })?
+    let child = std::process::Command::new(binary)
+        .arg(arg)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|source| CliParseError::SpawnFailed {
             binary: binary.to_string(),
             source,
         })?;
+
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    let output = match rx.recv_timeout(timeout) {
+        Ok(result) => result.map_err(|source| CliParseError::SpawnFailed {
+            binary: binary.to_string(),
+            source,
+        })?,
+        Err(_) => {
+            // Kill the subprocess so it doesn't linger after timeout.
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            log::warn!("cli_help_parser: `{binary} {arg}` timed out after {TIMEOUT_SECS}s");
+            return Err(CliParseError::Timeout {
+                binary: binary.to_string(),
+                secs: TIMEOUT_SECS,
+            });
+        }
+    };
 
     // Many CLIs print help to stderr; prefer stdout, fall back to stderr.
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -88,18 +103,33 @@ fn run_with_timeout(binary: &str, arg: &str) -> Result<String, CliParseError> {
 
 fn run_version(binary: &str) -> Option<String> {
     use std::sync::mpsc;
+    use std::process::Stdio;
 
-    let binary_owned = binary.to_string();
+    let child = std::process::Command::new(binary)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let pid = child.id();
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
-        let result = std::process::Command::new(&binary_owned)
-            .arg("--version")
-            .output();
-        let _ = tx.send(result);
+        let _ = tx.send(child.wait_with_output());
     });
 
     let timeout = Duration::from_secs(TIMEOUT_SECS);
-    let output = rx.recv_timeout(timeout).ok()?.ok()?;
+    let output = match rx.recv_timeout(timeout) {
+        Ok(Ok(o)) => o,
+        _ => {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            return None;
+        }
+    };
+
     let text = String::from_utf8_lossy(&output.stdout).into_owned();
     text.lines().next().map(|l| l.trim().to_string())
 }
@@ -113,9 +143,8 @@ mod tests {
     /// Verify the returned string is valid JSON with the expected top-level keys.
     #[test]
     fn parse_help_to_descriptor_returns_valid_json() {
-        // `echo` is a safe binary guaranteed to exist; its --help may be minimal
-        // but parse_help_to_descriptor must not error — it accepts sparse output.
-        // We test with a known-good binary that always succeeds.
+        // cargo is guaranteed to exist in Rust dev environments and always
+        // exits 0 with a rich --help output.
         let result = parse_help_to_descriptor("cargo");
         assert!(
             result.is_ok(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod audio;
 mod cli;
 mod cli_args;
 mod cli_crawl;
+mod cli_help_parser;
 mod cli_registry;
 mod cli_setup;
 mod command_palette;
@@ -381,7 +382,13 @@ fn main() -> eframe::Result {
                         std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref(), from_pane_id));
                     }
                     Commands::Descriptor { cmd } => match cmd {
-                        DescriptorCmd::Probe { command, no_registry, no_crawl, extra_args } => {
+                        DescriptorCmd::Probe { command, no_registry, no_crawl, json, extra_args } => {
+                            if json {
+                                match cli_help_parser::parse_help_to_descriptor(&command) {
+                                    Ok(j) => { println!("{j}"); std::process::exit(0); }
+                                    Err(e) => { eprintln!("error: {e}"); std::process::exit(1); }
+                                }
+                            }
                             let runner = cli::descriptor::RealRunner;
                             let opts = cli::descriptor::ProbeOptions { use_registry: !no_registry, use_crawl: !no_crawl };
                             let extra: Vec<&str> = extra_args.iter().map(|s| s.as_str()).collect();


### PR DESCRIPTION
## Summary

- New `src/cli_help_parser.rs` with `parse_help_to_descriptor(binary) -> Result<String, CliParseError>`
- Runs `<binary> --help` with 5s timeout, parses via `cli_crawl::parse_help` (now `pub(crate)`), returns descriptor JSON
- No caching — always fresh; contrast with `cli_crawl` which caches to disk
- Wired as `plexi descriptor probe --json <binary>` so the function is callable end-to-end
- 2 unit tests: valid JSON shape on `cargo`, `SpawnFailed` on nonexistent binary

## Infrastructure

Part of the `plexi open --mcp` / `plexi open --cli` demo (NEXT.md). The `parse_help_to_descriptor` function is the substrate that future callers will use when they need a one-shot, uncached descriptor.

## Test plan
- [ ] `plexi descriptor probe --json cargo` outputs valid JSON with `name: "cargo"` and a `commands` array
- [ ] `cargo test cli_help_parser` — 2 tests pass

Closes #1035