### PR TITLE
feat(cli): --mcp and --cli flags on plexi open (#1033, #1034)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3488,7 +3488,9 @@ _plexi() {
         open)
           _arguments \
             '--layout[Layout hint]:layout:(split_v split_h split_above overlay)' \
-            '--from-pane-id[Split relative to this pane ID]:pane_id:'
+            '--from-pane-id[Split relative to this pane ID]:pane_id:' \
+            '--mcp[Wrap stdio MCP server command in mcp-renderer]:cmd:' \
+            '--cli[Wrap CLI binary in descriptor-renderer]:binary:_command_names'
           ;;
         install)
           _arguments '--pack[Install from a pack file or core]:pack:'
@@ -3551,7 +3553,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       if [[ $prev == "--layout" ]]; then
         COMPREPLY=($(compgen -W "split_v split_h split_above overlay" -- "$cur"))
       else
-        COMPREPLY=($(compgen -W "--layout --from-pane-id" -- "$cur"))
+        COMPREPLY=($(compgen -W "--layout --from-pane-id --mcp --cli" -- "$cur"))
       fi
       ;;
     descriptor)
@@ -3669,6 +3671,8 @@ complete -c plexi -n "__fish_seen_subcommand_from terminal" -l from-pane-id -d "
 # open flags
 complete -c plexi -n "__fish_seen_subcommand_from open" -l layout -d "Layout hint" -a "split_v split_h split_above overlay"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l from-pane-id -d "Split relative to this pane ID"
+complete -c plexi -n "__fish_seen_subcommand_from open" -l mcp -d "Wrap stdio MCP server command in mcp-renderer"
+complete -c plexi -n "__fish_seen_subcommand_from open" -l cli -d "Wrap CLI binary in descriptor-renderer" -a "(__fish_complete_command)"
 "#;
 
 #[cfg(test)]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -118,15 +118,25 @@ pub enum Commands {
     },
     /// Open an app pane
     Open {
-        /// App or pane type id
-        type_id: String,
+        /// App or pane type id (mutually exclusive with --mcp and --cli)
+        type_id: Option<String>,
+        /// Wrap the given stdio MCP server command in the bundled mcp-renderer
+        ///
+        /// Example: plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp
+        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true)]
+        mcp: Vec<String>,
+        /// Wrap the given CLI binary in the bundled descriptor-renderer
+        ///
+        /// Example: plexi open --cli git
+        #[arg(long, value_name = "BINARY")]
+        cli: Option<String>,
         /// Layout hint
         #[arg(long)]
         layout: Option<String>,
         /// Split relative to this pane ID instead of the focused pane
         #[arg(long)]
         from_pane_id: Option<u64>,
-        /// Extra args passed to the app
+        /// Extra args passed to the app (only valid with type_id)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
     },

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -119,16 +119,17 @@ pub enum Commands {
     /// Open an app pane
     Open {
         /// App or pane type id (mutually exclusive with --mcp and --cli)
+        #[arg(conflicts_with_all = ["mcp", "cli"])]
         type_id: Option<String>,
         /// Wrap the given stdio MCP server command in the bundled mcp-renderer
         ///
         /// Example: plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp
-        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true)]
+        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true, conflicts_with = "cli")]
         mcp: Vec<String>,
         /// Wrap the given CLI binary in the bundled descriptor-renderer
         ///
         /// Example: plexi open --cli git
-        #[arg(long, value_name = "BINARY")]
+        #[arg(long, value_name = "BINARY", conflicts_with = "mcp")]
         cli: Option<String>,
         /// Layout hint
         #[arg(long)]
@@ -137,7 +138,7 @@ pub enum Commands {
         #[arg(long)]
         from_pane_id: Option<u64>,
         /// Extra args passed to the app (only valid with type_id)
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, conflicts_with_all = ["mcp", "cli"])]
         extra_args: Vec<String>,
     },
     /// Descriptor probe

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,8 +378,44 @@ fn main() -> eframe::Result {
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id));
                     }
-                    Commands::Open { type_id, layout, from_pane_id, extra_args } => {
-                        std::process::exit(cli::open_cli(&type_id, &extra_args, layout.as_deref(), from_pane_id));
+                    Commands::Open { type_id, mcp, cli: cli_flag, layout, from_pane_id, extra_args } => {
+                        let mode_count = type_id.is_some() as u8
+                            + (!mcp.is_empty()) as u8
+                            + cli_flag.is_some() as u8;
+                        if mode_count == 0 {
+                            eprintln!("error: one of TYPE_ID, --mcp, or --cli is required");
+                            std::process::exit(2);
+                        }
+                        if mode_count > 1 {
+                            eprintln!("error: TYPE_ID, --mcp, and --cli are mutually exclusive");
+                            std::process::exit(2);
+                        }
+                        if let Some(tid) = type_id {
+                            std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id));
+                        } else if !mcp.is_empty() {
+                            log::info!("open:mcp: launching mcp-renderer with command {:?}", mcp);
+                            std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id));
+                        } else {
+                            let binary = cli_flag.unwrap();
+                            log::info!("open:cli-flag: running --help parser for `{binary}`");
+                            match cli_help_parser::parse_help_to_descriptor(&binary) {
+                                Ok(json) => {
+                                    let tmp = std::env::temp_dir()
+                                        .join(format!("plexi-descriptor-{binary}.json"));
+                                    if let Err(e) = std::fs::write(&tmp, &json) {
+                                        eprintln!("error: could not write descriptor temp file: {e}");
+                                        std::process::exit(1);
+                                    }
+                                    let path = tmp.to_string_lossy().into_owned();
+                                    log::info!("open:cli-flag: launching descriptor-renderer with descriptor at {path}");
+                                    std::process::exit(cli::open_cli("descriptor-renderer", &[path], layout.as_deref(), from_pane_id));
+                                }
+                                Err(e) => {
+                                    eprintln!("error: could not parse --help output for `{binary}`: {e}");
+                                    std::process::exit(1);
+                                }
+                            }
+                        }
                     }
                     Commands::Descriptor { cmd } => match cmd {
                         DescriptorCmd::Probe { command, no_registry, no_crawl, json, extra_args } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,8 +400,13 @@ fn main() -> eframe::Result {
                             log::info!("open:cli-flag: running --help parser for `{binary}`");
                             match cli_help_parser::parse_help_to_descriptor(&binary) {
                                 Ok(json) => {
+                                    let safe_name = std::path::Path::new(&binary)
+                                        .file_name()
+                                        .and_then(|n| n.to_str())
+                                        .unwrap_or("unknown")
+                                        .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_");
                                     let tmp = std::env::temp_dir()
-                                        .join(format!("plexi-descriptor-{binary}.json"));
+                                        .join(format!("plexi-descriptor-{safe_name}.json"));
                                     if let Err(e) = std::fs::write(&tmp, &json) {
                                         eprintln!("error: could not write descriptor temp file: {e}");
                                         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,13 +400,9 @@ fn main() -> eframe::Result {
                             log::info!("open:cli-flag: running --help parser for `{binary}`");
                             match cli_help_parser::parse_help_to_descriptor(&binary) {
                                 Ok(json) => {
-                                    let safe_name = std::path::Path::new(&binary)
-                                        .file_name()
-                                        .and_then(|n| n.to_str())
-                                        .unwrap_or("unknown")
-                                        .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_");
+                                    let id = uuid::Uuid::new_v4();
                                     let tmp = std::env::temp_dir()
-                                        .join(format!("plexi-descriptor-{safe_name}.json"));
+                                        .join(format!("plexi-descriptor-{id}.json"));
                                     if let Err(e) = std::fs::write(&tmp, &json) {
                                         eprintln!("error: could not write descriptor temp file: {e}");
                                         std::process::exit(1);


### PR DESCRIPTION
## Summary

- `plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp` — launches bundled `mcp-renderer` wrapping the given stdio MCP server command
- `plexi open --cli git` — runs `git --help`, parses via `cli_help_parser`, writes descriptor to a temp file, launches bundled `descriptor-renderer`
- `type_id` positional arg is now optional; all three modes (`type_id`, `--mcp`, `--cli`) are mutually exclusive with clear runtime validation errors
- Completions updated for zsh, bash, and fish

## Changes

- `src/cli_args.rs` — `Open` variant: `type_id: String → Option<String>`, added `--mcp Vec<String>` and `--cli Option<String>`
- `src/main.rs` — `Commands::Open` dispatch: handles all three modes with mutual exclusivity check
- `src/cli.rs` — completions: added `--mcp` and `--cli` to zsh/bash/fish

## Test plan

- [ ] `plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp` opens an mcp-renderer pane
- [ ] `plexi open --cli git` opens a descriptor-renderer pane with git's command tree
- [ ] `plexi open my-app` still works (backward compat)
- [ ] `plexi open` (no args) prints error: "one of TYPE_ID, --mcp, or --cli is required"
- [ ] `plexi open --mcp server --cli git` prints error: mutually exclusive

Closes #1033
Closes #1034