### PR TITLE
fix(mcp-renderer): augment PATH when spawning MCP server subprocess

### DIFF
--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -13,6 +13,7 @@ Result view: Shows tool call output inline. Escape or Back returns to list.
 """
 
 import json
+import os
 import select
 import subprocess
 import sys
@@ -50,11 +51,15 @@ class McpClient:
         self._lock = threading.Lock()
 
     def start(self) -> None:
+        env = os.environ.copy()
+        extra = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+        env["PATH"] = extra + ":" + env.get("PATH", "")
         self._proc = subprocess.Popen(
             self._cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
         )
         self._stdin = self._proc.stdin
         self._stdout = self._proc.stdout


### PR DESCRIPTION
## Summary
- App bundle Python inherits a stripped env — `/usr/local/bin` and `/opt/homebrew/bin` are absent
- `npx`, `uvx`, and other user tools can't be found, so the MCP server exits immediately
- Prepend standard tool paths to the inherited env before `Popen`

## Root cause
`plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp` failed with `MCP server closed stdout` because the bundled Python at `/Applications/Plexi Alpha.app/Contents/Resources/assets/python/bin/python3` has a minimal PATH that doesn't include `/usr/local/bin` where `npx` lives.

## Test
```
plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp
```
Should open the MCP renderer with a tool list instead of immediately crashing.

**Breaks if:** mcp-renderer pane opens and immediately exits with "connect failed" in the log.