### PR TITLE
fix(sdk): always re-seed SDK on launch; add AppBar subtitle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 Newest releases appear first.
+## [3.5.123] — 2026-05-11
+
+### Changes
+- fix(mcp-renderer): augment PATH when spawning MCP server subprocess (#1053)
+- feat(examples): migrate csv_viewer file list to ctx.list_view() (#1052)
+- feat(cli): improve app init Python template with SDK primitives (#1049)
+- feat(examples): csv_viewer — browse and inspect CSVs in launch directory (#1046)
+- feat(cli): --mcp and --cli flags on plexi open (#1033, #1034) (#1048)
+- fix(deps): disable eframe accesskit feature to eliminate accesskit_consumer panic (#1039)
+- feat(cli): cli_help_parser — parse_help_to_descriptor (#1042)
+- example(mcp-renderer): add demo_server.py — local MCP server for renderer testing (#1044)
+- fix(mcp-renderer): use plexi open syntax in no-command error message (#1041)
+- chore: commit alpha changes before branching
+- feat(quick-note): destination picker UI stub (#1030)
+- fix(file-browser): verify Enter/l/→ open files via system opener (#138) (#1029)
+- feat(navigation): Cmd+HJKL falls through to window nav at pane boundary (#1017)
+- fix(keybindings): Cmd+R rename-pane and font-size bindings broken by exact-modifier guard (#1027)
+- feat(logging): date-based log rotation with configurable retention (#1028)
+- chore: update ship-issue skill
+- feat: app_states rename, pane key injection, file-browser no-repeat nav (#1026)
+- feat(notify): snooze choice — defer notification by N seconds (#1024)
+- feat(cli): inject PLEXI_CONTEXT_ID/NAME env vars + context current command (#1025)
+- fix(bundle): keyboard_capture for input-inspector + rename app_state dir (#907, #851) (#1023)
+- chore: auto-install after promoting to main
 ## [3.5.122] — 2026-05-11
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.5.122"
+version = "3.5.123"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ version = "3.5.123"
 edition = "2021"
 
 [package.metadata.bundle]
-name = "Plexi"
-identifier = "com.ianjamesburke.plexi"
+name = "Plexi Alpha"
+identifier = "com.ianjamesburke.plexi-alpha"
 icon = ["assets/app-icon.icns"]
 short_description = "Spatial terminal window manager"
 osx_minimum_system_version = "12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.5.122"
+version = "3.5.123"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -324,39 +324,47 @@ class Divider(Component):
 
 @dataclass
 class AppBar(Component):
-    """Thin top-of-pane app bar — single-line title, vertically centred
-    in a fixed band, 1px divider at the bottom edge.
+    """Thin top-of-pane app bar with optional subtitle.
 
-    Replaces the old `Header` two-line block. Apps that need subtitle /
-    metadata text put it in a separate `Label(text, tone="hint")` row
-    below the AppBar — keeps the app bar minimal and predictable.
-
-    Future: an optional `actions` slot for right-aligned menu buttons
-    (e.g. settings, refresh) so apps can grow their own toolbar without
-    each rolling its own layout.
+    Single-line (title only): fixed BAND_H band, title vertically centred.
+    Two-line (title + subtitle): taller BAND_H_DOUBLE band, title/subtitle
+    stacked and centred together.
     """
     title: str
+    subtitle: Optional[str] = None
     accent: str = FG
 
-    TITLE_SIZE = 16.0   # TEXT_HEADING — app-bar scale, not billboard
-    BAND_H = 36.0       # thin band; native-toolbar feel
+    TITLE_SIZE = 16.0
+    SUBTITLE_SIZE = TEXT_HINT
+    BAND_H = 36.0
+    BAND_H_DOUBLE = 52.0
     DIVIDER_H = 1.0
 
+    def _band(self) -> float:
+        return self.BAND_H_DOUBLE if self.subtitle else self.BAND_H
+
     def measure(self, avail_w: float) -> float:
-        return self.BAND_H + self.DIVIDER_H
+        return self._band() + self.DIVIDER_H
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        # Opaque BG backdrop so content scrolled under the AppBar doesn't
-        # bleed through (defensive; the host clip stack makes overdraw
-        # structurally impossible, but the backdrop keeps chrome visually
-        # solid regardless of rendering order).
         ctx.rect(x, y, w, h, BG)
-        # Vertically centre the title in BAND_H.
-        text_y = y + (self.BAND_H - self.TITLE_SIZE) / 2.0
-        ctx.text(x, text_y, self.title,
-                 size=self.TITLE_SIZE, color=self.accent, bold=True,
-                 max_width=w, elide=True)
-        ctx.rect(x, y + self.BAND_H, w, self.DIVIDER_H, HIGHLIGHT)
+        band = self._band()
+        if self.subtitle:
+            block_h = self.TITLE_SIZE + SPACE_XS + self.SUBTITLE_SIZE
+            title_y = y + (band - block_h) / 2.0
+            sub_y = title_y + self.TITLE_SIZE + SPACE_XS
+            ctx.text(x, title_y, self.title,
+                     size=self.TITLE_SIZE, color=self.accent, bold=True,
+                     max_width=w, elide=True)
+            ctx.text(x, sub_y, self.subtitle,
+                     size=self.SUBTITLE_SIZE, color=MUTED,
+                     max_width=w, elide=True)
+        else:
+            text_y = y + (band - self.TITLE_SIZE) / 2.0
+            ctx.text(x, text_y, self.title,
+                     size=self.TITLE_SIZE, color=self.accent, bold=True,
+                     max_width=w, elide=True)
+        ctx.rect(x, y + band, w, self.DIVIDER_H, HIGHLIGHT)
 
 
 @dataclass

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,20 +353,19 @@ pub fn ensure_profile_initialized() {
         );
     }
 
-    // Always ensure the SDK is present — runs on every launch so that
-    // migrated profiles (pre-existing dir) get the SDK on first run.
+    // Always overwrite the SDK on every launch so upgrades always get the
+    // version embedded in the current binary, not a stale copy from a prior install.
     let sdk_dest = dir.join("sdk").join("plexi_sdk");
-    if !sdk_dest.exists() {
-        if let Err(e) = std::fs::create_dir_all(&sdk_dest) {
-            eprintln!("profile init: failed to create sdk dir: {e}");
+    let _ = std::fs::remove_dir_all(&sdk_dest);
+    if let Err(e) = std::fs::create_dir_all(&sdk_dest) {
+        eprintln!("profile init: failed to create sdk dir: {e}");
+    } else {
+        let embedded_sdk =
+            include_dir::include_dir!("$CARGO_MANIFEST_DIR/sdk/python/plexi_sdk");
+        if let Err(e) = embedded_sdk.extract(&sdk_dest) {
+            eprintln!("profile init: failed to seed SDK: {e}");
         } else {
-            let embedded_sdk =
-                include_dir::include_dir!("$CARGO_MANIFEST_DIR/sdk/python/plexi_sdk");
-            if let Err(e) = embedded_sdk.extract(&sdk_dest) {
-                eprintln!("profile init: failed to seed SDK: {e}");
-            } else {
-                log::info!("profile init: seeded SDK to {}", sdk_dest.display());
-            }
+            log::info!("profile init: seeded SDK to {}", sdk_dest.display());
         }
     }
 }


### PR DESCRIPTION
## Changes

**`src/config.rs` — always re-seed SDK on launch**
Previously used `if !sdk_dest.exists()` — upgrading users who already had `~/.plexi/sdk/plexi_sdk/` never got the updated SDK bundled in the new binary. Changed to `remove_dir_all` + re-extract on every launch so the seeded SDK always matches the current binary.

**`sdk/python/plexi_sdk/ui.py` — AppBar subtitle support**
`AppBar` lacked a `subtitle` parameter. The `timer` example calls `AppBar(title="Timer", subtitle=subtitle)` and crashed with `TypeError: AppBar.__init__() got an unexpected keyword argument 'subtitle'`. Added `subtitle: Optional[str] = None` — renders a taller two-line band when provided, single-line band when omitted.

## Breaks if
- SDK files in `~/.plexi-alpha/sdk/` are not refreshed on relaunch after a binary update
- `AppBar(title="x", subtitle="y")` raises `TypeError` in the timer example app