### PR TITLE
feat(examples): timer app with J/K duration and custom notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
 Newest releases appear first.
+## [3.5.124] — 2026-05-11
+
+### Changes
+- fix(sdk): always re-seed SDK on launch; add AppBar subtitle support (#1054)
+- fix(mcp-renderer): augment PATH when spawning MCP server subprocess (#1053)
+- feat(examples): migrate csv_viewer file list to ctx.list_view() (#1052)
+- feat(cli): improve app init Python template with SDK primitives (#1049)
+- feat(examples): csv_viewer — browse and inspect CSVs in launch directory (#1046)
+- feat(cli): --mcp and --cli flags on plexi open (#1033, #1034) (#1048)
+- fix(deps): disable eframe accesskit feature to eliminate accesskit_consumer panic (#1039)
+- feat(cli): cli_help_parser — parse_help_to_descriptor (#1042)
+- example(mcp-renderer): add demo_server.py — local MCP server for renderer testing (#1044)
+- fix(mcp-renderer): use plexi open syntax in no-command error message (#1041)
+- chore: commit alpha changes before branching
+- feat(quick-note): destination picker UI stub (#1030)
+- fix(file-browser): verify Enter/l/→ open files via system opener (#138) (#1029)
+- feat(navigation): Cmd+HJKL falls through to window nav at pane boundary (#1017)
+- fix(keybindings): Cmd+R rename-pane and font-size bindings broken by exact-modifier guard (#1027)
+- feat(logging): date-based log rotation with configurable retention (#1028)
+- chore: update ship-issue skill
+- feat: app_states rename, pane key injection, file-browser no-repeat nav (#1026)
+- feat(notify): snooze choice — defer notification by N seconds (#1024)
+- feat(cli): inject PLEXI_CONTEXT_ID/NAME env vars + context current command (#1025)
+- fix(bundle): keyboard_capture for input-inspector + rename app_state dir (#907, #851) (#1023)
+- chore: auto-install after promoting to main
 ## [3.5.123] — 2026-05-11
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.5.123"
+version = "3.5.124"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ version = "3.5.123"
 edition = "2021"
 
 [package.metadata.bundle]
-name = "Plexi Alpha"
-identifier = "com.ianjamesburke.plexi-alpha"
+name = "Plexi"
+identifier = "com.ianjamesburke.plexi"
 icon = ["assets/app-icon.icns"]
 short_description = "Spatial terminal window manager"
 osx_minimum_system_version = "12.0"

--- a/examples/apps/timer/main.py
+++ b/examples/apps/timer/main.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+import math
+import time
+
+from plexi_sdk import (
+    App, RenderContext,
+    BG, SURFACE, ACCENT, MUTED, FG, GREEN,
+    TITLE, CAPTION,
+    PRIORITY_HIGH,
+)
+from plexi_sdk.ui import Column, AppBar, FooterKeys, Component, Label
+
+DURATIONS = [
+    (30, "30 sec"),
+    (60, "1 min"),
+    (2 * 60, "2 min"),
+    (3 * 60, "3 min"),
+    (5 * 60, "5 min"),
+    (10 * 60, "10 min"),
+    (15 * 60, "15 min"),
+    (20 * 60, "20 min"),
+    (30 * 60, "30 min"),
+    (45 * 60, "45 min"),
+    (60 * 60, "60 min"),
+]
+
+DEFAULT_IDX = 4  # 5 min
+DEFAULT_MSG = "Timer done!"
+TICK_ID = "tick"
+TWO_PI = 2 * math.pi
+
+
+def _fmt(secs: float) -> str:
+    secs = int(max(0, secs))
+    m, s = divmod(secs, 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m:02d}:{s:02d}"
+
+
+class _Face(Component):
+    """Centered arc ring with time text. Grows to fill remaining column space."""
+
+    def __init__(self, app: "TimerApp") -> None:
+        self._app = app
+
+    def measure(self, avail_w: float) -> float:
+        return 0.0
+
+    def is_grow(self) -> bool:
+        return True
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        app = self._app
+        cx = x + w / 2
+        cy = y + h / 2
+        r = min(w, h) * 0.36
+
+        ctx.circle(cx, cy, r, SURFACE)
+
+        if app._state == "running":
+            total = app._total_secs
+            elapsed = time.time() - app._start_at
+            remaining = max(0.0, total - elapsed)
+            frac = remaining / total if total > 0 else 0.0
+            # Background track
+            ctx.arc(cx, cy, r - 6, 0, TWO_PI, MUTED)
+            # Progress arc (from top, clockwise)
+            if frac > 0:
+                start_angle = -math.pi / 2
+                ctx.arc(cx, cy, r - 6, start_angle, start_angle + frac * TWO_PI, ACCENT)
+            label = _fmt(remaining)
+            sub = app._msg.strip() or DEFAULT_MSG
+            color = ACCENT
+
+        elif app._state == "done":
+            ctx.arc(cx, cy, r - 6, 0, TWO_PI, GREEN)
+            label = "✓"
+            sub = app._msg.strip() or DEFAULT_MSG
+            color = GREEN
+
+        else:  # setup
+            ctx.arc(cx, cy, r - 6, 0, TWO_PI, MUTED)
+            label = _fmt(DURATIONS[app._dur_idx][0])
+            if app._editing_msg:
+                sub = f"{app._msg}▌" if app._msg else "▌"
+            elif app._msg:
+                sub = app._msg
+            else:
+                sub = "press m to set message"
+            color = FG
+
+        ctx.text(cx, cy - 14, label, size=TITLE + 8, color=color, bold=True, align="center")
+        ctx.text(cx, cy + 22, sub, size=CAPTION, color=MUTED, align="center",
+                 max_width=r * 1.7)
+
+
+class TimerApp(App):
+
+    def on_init(self, ctx: RenderContext) -> None:
+        self._state: str = "setup"
+        self._dur_idx: int = DEFAULT_IDX
+        self._msg: str = ""
+        self._start_at: float = 0.0
+        self._total_secs: int = DURATIONS[DEFAULT_IDX][0]
+        self._editing_msg: bool = False
+        ctx.status_summary("Timer")
+        self.emit.info("Timer ready")
+
+    # ── timer tick ────────────────────────────────────────────────────────
+
+    def on_timer(self, ctx: RenderContext, timer_id: str) -> None:
+        if timer_id != TICK_ID:
+            return
+        elapsed = time.time() - self._start_at
+        if elapsed >= self._total_secs:
+            self._state = "done"
+            msg = self._msg.strip() or DEFAULT_MSG
+            ctx.notify(title="Timer", body=msg, level="info", priority=PRIORITY_HIGH)
+            ctx.status_summary("Timer — done")
+            self.emit.info(f"Timer fired: {msg!r}")
+        else:
+            ctx.set_timer(TICK_ID, 1000)
+        self.emit.schedule_render(after_ms=50)
+
+    # ── keys ──────────────────────────────────────────────────────────────
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if self._state == "setup":
+            self._setup_key(ctx, key)
+        elif self._state == "running":
+            if key in ("escape", "space", "q"):
+                ctx.cancel_timer(TICK_ID)
+                self._reset(ctx)
+                self.emit.info("Timer cancelled")
+        elif self._state == "done":
+            self._reset(ctx)
+
+    def _setup_key(self, ctx, key: str) -> None:
+        if self._editing_msg:
+            if key in ("return", "escape"):
+                self._editing_msg = False
+                self.emit.info(f"Message set: {self._msg!r}")
+            elif key == "backspace":
+                self._msg = self._msg[:-1]
+            elif key == "space":
+                self._msg += " "
+            elif len(key) == 1:
+                self._msg += key
+            return
+
+        if key == "k":
+            if self._dur_idx < len(DURATIONS) - 1:
+                self._dur_idx += 1
+                self.emit.info(f"Duration → {DURATIONS[self._dur_idx][1]}")
+        elif key == "j":
+            if self._dur_idx > 0:
+                self._dur_idx -= 1
+                self.emit.info(f"Duration → {DURATIONS[self._dur_idx][1]}")
+        elif key in ("m", "e"):
+            self._editing_msg = True
+            self._msg = ""
+        elif key in ("return", "space"):
+            self._total_secs = DURATIONS[self._dur_idx][0]
+            self._start_at = time.time()
+            self._state = "running"
+            ctx.set_timer(TICK_ID, 1000)
+            ctx.status_summary(f"Timer — {DURATIONS[self._dur_idx][1]}")
+            self.emit.info(f"Timer started: {DURATIONS[self._dur_idx][1]}")
+            self.emit.schedule_render(after_ms=50)
+
+    def _reset(self, ctx) -> None:
+        self._state = "setup"
+        self._editing_msg = False
+        ctx.status_summary("Timer")
+        self.emit.schedule_render(after_ms=50)
+
+    # ── render ────────────────────────────────────────────────────────────
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.clear(BG)
+        face = _Face(self)
+
+        if self._state == "setup":
+            if self._editing_msg:
+                status = Label(f"message: {self._msg}▌", tone="caption", color=MUTED)
+                footer = FooterKeys([(["↵", "esc"], "done")])
+            else:
+                status = Label(DURATIONS[self._dur_idx][1], tone="caption", color=MUTED)
+                footer = FooterKeys([
+                    (["j", "k"], "duration"),
+                    (["m"], "message"),
+                    (["↵"], "start"),
+                ])
+            ctx.render(Column([AppBar(title="Timer"), status, face, footer]))
+
+        elif self._state == "running":
+            ctx.render(Column([
+                AppBar(title="Timer"),
+                Label(DURATIONS[self._dur_idx][1], tone="caption", color=MUTED),
+                face,
+                FooterKeys([(["esc"], "cancel")]),
+            ]))
+            self.emit.schedule_render(after_ms=1000)
+
+        elif self._state == "done":
+            ctx.render(Column([
+                AppBar(title="Timer"),
+                Label("done", tone="caption", color=GREEN),
+                face,
+                FooterKeys([(["any key"], "reset")]),
+            ]))
+
+
+TimerApp().run()

--- a/examples/apps/timer/manifest.toml
+++ b/examples/apps/timer/manifest.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+
+[app]
+id = "timer"
+type = "app"
+name = "Timer"
+entry = "main.py"
+version = "0.1.0"
+description = "A Plexi app"
+watch = true
+
+[app.capabilities]
+capabilities = ["fs.read"]
+
+[launch]
+layout_hint = { side = "right", split = 0.5 }


### PR DESCRIPTION
## Summary
- Countdown timer app (`examples/apps/timer/`) using Plexi SDK
- Arc ring UI — fills clockwise as the timer counts down, turns green with ✓ on completion
- `j` / `k` adjusts duration in 11 steps (30 sec → 60 min)
- `m` sets a custom reminder message (typed inline, confirmed with Enter)
- `↵` / `space` starts; `esc` cancels; any key resets from done state
- Fires a `PRIORITY_HIGH` Plexi notification with the custom message on expiry

## Test plan
- `plexi open timer`
- Press `k` a few times — duration label updates
- Press `m`, type a message, press Enter
- Press Enter to start — arc ring animates
- Wait for expiry — Plexi notification fires with your message
- Press any key to reset