### PR TITLE
fix(sdk+timer): key aliases + timer ring rendering

### DIFF
--- a/examples/apps/timer/main.py
+++ b/examples/apps/timer/main.py
@@ -57,31 +57,41 @@ class _Face(Component):
         cy = y + h / 2
         r = min(w, h) * 0.36
 
-        ctx.circle(cx, cy, r, SURFACE)
+        # Ring geometry: outer rim 2px, track 12px, then BG center punch-out.
+        # ctx.arc draws filled pie slices from center, so we layer:
+        #   1. outer circle (SURFACE) at r
+        #   2. full track arc at r-2 (MUTED or GREEN)
+        #   3. progress arc at r-2 (ACCENT) — overlays track for running state
+        #   4. BG circle at r-14 to hollow out the center
+        rim = r - 2
+        hole = r - 14
 
         if app._state == "running":
             total = app._total_secs
             elapsed = time.time() - app._start_at
             remaining = max(0.0, total - elapsed)
             frac = remaining / total if total > 0 else 0.0
-            # Background track
-            ctx.arc(cx, cy, r - 6, 0, TWO_PI, MUTED)
-            # Progress arc (from top, clockwise)
+            ctx.circle(cx, cy, r, SURFACE)
+            ctx.arc(cx, cy, rim, 0, TWO_PI, MUTED)
             if frac > 0:
                 start_angle = -math.pi / 2
-                ctx.arc(cx, cy, r - 6, start_angle, start_angle + frac * TWO_PI, ACCENT)
+                ctx.arc(cx, cy, rim, start_angle, start_angle + frac * TWO_PI, ACCENT)
+            ctx.circle(cx, cy, hole, BG)
             label = _fmt(remaining)
             sub = app._msg.strip() or DEFAULT_MSG
             color = ACCENT
 
         elif app._state == "done":
-            ctx.arc(cx, cy, r - 6, 0, TWO_PI, GREEN)
+            ctx.circle(cx, cy, r, GREEN)
+            ctx.circle(cx, cy, hole, BG)
             label = "✓"
             sub = app._msg.strip() or DEFAULT_MSG
             color = GREEN
 
         else:  # setup
-            ctx.arc(cx, cy, r - 6, 0, TWO_PI, MUTED)
+            ctx.circle(cx, cy, r, SURFACE)
+            ctx.arc(cx, cy, rim, 0, TWO_PI, MUTED)
+            ctx.circle(cx, cy, hole, BG)
             label = _fmt(DURATIONS[app._dur_idx][0])
             if app._editing_msg:
                 sub = f"{app._msg}▌" if app._msg else "▌"

--- a/examples/apps/timer/main.py
+++ b/examples/apps/timer/main.py
@@ -57,14 +57,11 @@ class _Face(Component):
         cy = y + h / 2
         r = min(w, h) * 0.36
 
-        # Ring geometry: outer rim 2px, track 12px, then BG center punch-out.
-        # ctx.arc draws filled pie slices from center, so we layer:
-        #   1. outer circle (SURFACE) at r
-        #   2. full track arc at r-2 (MUTED or GREEN)
-        #   3. progress arc at r-2 (ACCENT) — overlays track for running state
-        #   4. BG circle at r-14 to hollow out the center
-        rim = r - 2
-        hole = r - 14
+        # Ring geometry: 2px outer rim, 12px track, BG center punch-out.
+        # ctx.arc draws filled pie slices from center, so we layer circles
+        # to build a donut: outer circle → track circle → progress arc → hole.
+        rim = r - 2    # inner edge of outer rim / outer edge of track
+        hole = r - 14  # center hole (track width = rim - hole = 12px)
 
         if app._state == "running":
             total = app._total_secs
@@ -72,7 +69,7 @@ class _Face(Component):
             remaining = max(0.0, total - elapsed)
             frac = remaining / total if total > 0 else 0.0
             ctx.circle(cx, cy, r, SURFACE)
-            ctx.arc(cx, cy, rim, 0, TWO_PI, MUTED)
+            ctx.circle(cx, cy, rim, MUTED)
             if frac > 0:
                 start_angle = -math.pi / 2
                 ctx.arc(cx, cy, rim, start_angle, start_angle + frac * TWO_PI, ACCENT)
@@ -82,7 +79,8 @@ class _Face(Component):
             color = ACCENT
 
         elif app._state == "done":
-            ctx.circle(cx, cy, r, GREEN)
+            ctx.circle(cx, cy, r, SURFACE)
+            ctx.circle(cx, cy, rim, GREEN)
             ctx.circle(cx, cy, hole, BG)
             label = "✓"
             sub = app._msg.strip() or DEFAULT_MSG
@@ -90,7 +88,7 @@ class _Face(Component):
 
         else:  # setup
             ctx.circle(cx, cy, r, SURFACE)
-            ctx.arc(cx, cy, rim, 0, TWO_PI, MUTED)
+            ctx.circle(cx, cy, rim, MUTED)
             ctx.circle(cx, cy, hole, BG)
             label = _fmt(DURATIONS[app._dur_idx][0])
             if app._editing_msg:

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -33,6 +33,13 @@ _KEY_ALIASES: "dict[str, str]" = {
     "ArrowRight": "right",
     "ArrowUp": "up",
     "ArrowDown": "down",
+    # egui Debug-format names → SDK canonical names
+    "Enter": "return",
+    "Escape": "escape",
+    "Backspace": "backspace",
+    "Tab": "tab",
+    # Space arrives as Event::Text(" "), not Event::Key
+    " ": "space",
 }
 
 


### PR DESCRIPTION
## Summary

- **SDK**: `_KEY_ALIASES` was missing 5 entries — `Enter→return`, `Escape→escape`, `Backspace→backspace`, `Tab→tab`, `" "→space`. The host sends egui Debug-format names for non-printable keys; without these aliases Enter/Space/Escape/Backspace were silently broken in every app.
- **Timer**: `ctx.arc` draws filled pie slices from center, so the "track ring" was a solid disc. Added a BG circle punch-out after each arc layer to create a proper 12px hollow ring across all three states (setup, running, done).

Fixes #1058, #1059

## Test plan

- [ ] Open timer app; press Enter → timer starts counting down
- [ ] Press Space → also starts timer
- [ ] While running, press Escape → timer cancels
- [ ] Press `m`, type a message, press Backspace → deletes chars
- [ ] Ring shape: setup shows MUTED hollow ring, running shows ACCENT progress on MUTED track, done shows solid GREEN ring — all with hollow center

**Breaks if:** Enter key press in any app is silently dropped (key aliases not loading), or timer face renders as solid disc instead of ring.