### PR TITLE
polish(renderers): migrate mcp-renderer + descriptor-renderer to plexi_sdk.ui

### DIFF
--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -21,7 +21,7 @@ from plexi_sdk import App, RenderContext, CapabilityDeniedError
 from plexi_sdk.ui import (
     Column, AppBar, SelectList, FormField,
     ListItem, Label, Spacer, Card,
-    HIGHLIGHT, ACCENT, MUTED, RED,
+    BG, HIGHLIGHT, ACCENT, MUTED, RED,
     TEXT_HINT,
     SPACE_XS, SPACE_SM, SPACE_MD, SPACE_LG,
     RADIUS_SM,
@@ -209,10 +209,11 @@ class DescriptorRendererApp(App):
             else:
                 self._hits = []
             header_items.append(self._select_list)
-            ctx.render(Column(header_items, padding=0, gap=0))
+            ctx.render(Column(header_items, padding=0, padding_top=0, gap=0))
             return
 
         if self._view == "form":
+            ctx.clear(BG)
             self._render_form(ctx)
 
     def _render_form(self, ctx: RenderContext) -> None:

--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -17,21 +17,15 @@ import sys
 import threading
 from pathlib import Path
 
-from plexi_sdk import (
-    App, RenderContext,
-    BG, FG, SURFACE, HIGHLIGHT, ACCENT, MUTED, RED,
-    HEADING, BODY, CAPTION, HINT,
-    PAD, HEADER_H,
-    CapabilityDeniedError,
+from plexi_sdk import App, RenderContext, CapabilityDeniedError
+from plexi_sdk.ui import (
+    Column, AppBar, SelectList, FormField,
+    ListItem, Label, Spacer, Card,
+    HIGHLIGHT, ACCENT, MUTED, RED,
+    TEXT_HINT,
+    SPACE_XS, SPACE_SM, SPACE_MD, SPACE_LG,
+    RADIUS_SM,
 )
-
-# ── Layout constants ───────────────────────────────────────────────────────────
-
-BTN_H: float = 44.0
-BTN_GAP: float = 8.0
-FIELD_H: float = 36.0
-FIELD_GAP: float = 24.0  # label (16px) + gap below field
-ROW_H: float = BTN_H + BTN_GAP
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -104,14 +98,15 @@ class DescriptorRendererApp(App):
         self._view: str = "loading"   # loading | error | list | form
         self._cmd_path: list[str] = []
         self._selected_idx: int = 0   # cursor in current command list
-        self._scroll_offset: int = 0  # first visible row index (auto-tracked)
-        self._list_y0: float = 0.0    # y where list content starts (set each render)
         # Form state
         self._fields: list[dict] = []
         self._field_values: dict[str, str] = {}
+        self._form_fields: list[FormField] = []
         self._last_run: str = ""
         # Hit regions: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
+        # UI components
+        self._select_list = SelectList([])
 
         path = _parse_descriptor_path(sys.argv[1:])
         if not path:
@@ -163,158 +158,139 @@ class DescriptorRendererApp(App):
     # ── Render ────────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, BG)
-
         if self._view == "loading":
-            ctx.text(x=ctx.w / 2, y=ctx.h / 2, text="Loading…",
-                     size=BODY, color=MUTED, align="center")
+            ctx.render(Column([
+                Spacer(grow=True),
+                Label("Loading…", tone="hint"),
+                Spacer(grow=True),
+            ], padding=0, gap=0))
             return
 
         if self._view == "error":
-            self._render_error(ctx)
+            ctx.render(Column([
+                Spacer(SPACE_LG),
+                Card([
+                    Label("Error", color=RED, bold=True),
+                    Spacer(SPACE_SM),
+                    Label(self._error, tone="caption"),
+                ]),
+            ], padding=SPACE_LG, gap=0))
             return
 
-        y = self._render_header(ctx)
-        y = self._render_breadcrumb(ctx, y)
-
-        if self._view == "list":
-            self._list_y0 = y
-            self._render_list(ctx, y)
-        else:
-            self._render_form(ctx, y)
-
-    def _render_header(self, ctx: RenderContext) -> float:
         assert self._descriptor is not None
-        h = HEADER_H
-        ctx.rect(0, 0, ctx.w, h, SURFACE)
         d = self._descriptor
         icon = d.get("icon", "")
         name = d.get("name", "")
         ver = d.get("version", "")
-        label = f"{icon}  {name}  v{ver}" if icon else f"{name}  v{ver}"
-        ctx.text(x=PAD, y=h / 2, text=label,
-                 size=HEADING, color=FG, bold=True, align="left_center")
+        title = f"{icon}  {name}  v{ver}" if icon else f"{name}  v{ver}"
         desc = d.get("description", "")
-        if desc:
-            ctx.text(x=ctx.w - PAD, y=h / 2, text=desc,
-                     size=HINT, color=MUTED, align="right_center",
-                     max_width=ctx.w * 0.45, elide=True)
-        return h + PAD
 
-    def _render_breadcrumb(self, ctx: RenderContext, y: float) -> float:
+        if self._view == "list":
+            commands = _commands_at(self._descriptor, self._cmd_path)
+            crumb = None
+            if self._cmd_path:
+                crumb = " › ".join([name] + list(self._cmd_path))
+            self._select_list.items = [
+                {
+                    "name": cmd["name"] + (" ›" if cmd.get("commands") else ""),
+                    "description": cmd.get("description") or None,
+                    "leading": cmd.get("icon") or None,
+                }
+                for cmd in commands
+            ]
+            app_bar = AppBar(title, subtitle=crumb or desc or None)
+            app_bar_h = app_bar.measure(ctx.w)
+            header_items: list = [app_bar]
+            if self._cmd_path:
+                back_item = ListItem(title="← Back", selected=False)
+                header_items.append(back_item)
+                back_h = back_item.measure(ctx.w)
+                self._hits = [(app_bar_h, app_bar_h + back_h, "back")]
+            else:
+                self._hits = []
+            header_items.append(self._select_list)
+            ctx.render(Column(header_items, padding=0, gap=0))
+            return
+
+        if self._view == "form":
+            self._render_form(ctx)
+
+    def _render_form(self, ctx: RenderContext) -> None:
         assert self._descriptor is not None
-        if not self._cmd_path:
-            return y
-        cli = self._descriptor.get("name", "?")
-        crumb = " › ".join([cli] + list(self._cmd_path))
-        ctx.text(x=PAD, y=y, text=crumb, size=CAPTION, color=MUTED)
-        return y + 22
+        d = self._descriptor
+        icon = d.get("icon", "")
+        name = d.get("name", "")
+        ver = d.get("version", "")
+        title = f"{icon}  {name}  v{ver}" if icon else f"{name}  v{ver}"
 
-    def _render_error(self, ctx: RenderContext) -> None:
-        ctx.rect(PAD, PAD, ctx.w - PAD * 2, 80.0, SURFACE, radius=6.0)
-        ctx.text(x=PAD + 14, y=PAD + 20, text="Error", size=HEADING, color=RED, bold=True)
-        ctx.text(x=PAD + 14, y=PAD + 52, text=self._error,
-                 size=CAPTION, color=FG, max_width=ctx.w - PAD * 2 - 28, elide=True)
-
-    def _render_list(self, ctx: RenderContext, y0: float) -> None:
-        assert self._descriptor is not None
-        commands = _commands_at(self._descriptor, self._cmd_path)
-        btn_w = ctx.w - PAD * 2
         self._hits = []
-        y = y0
 
-        if self._cmd_path:
-            ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-            ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back",
-                     size=BODY, color=ACCENT, bold=True, align="left_center")
-            self._hits.append((y, y + BTN_H, "back"))
-            y += BTN_H + BTN_GAP
+        # AppBar at top
+        app_bar = AppBar(title)
+        app_bar_h = app_bar.measure(ctx.w)
+        app_bar.render(ctx, 0, 0, ctx.w, app_bar_h)
+        y = app_bar_h
 
-        for i, cmd in enumerate(commands):
-            by = y + (i - self._scroll_offset) * ROW_H
-            self._hits.append((by, by + BTN_H, i))
-            if by + BTN_H <= y0 or by >= ctx.h:
-                continue
+        # Back button
+        back = ListItem(title="← Back", selected=False)
+        back_h = back.measure(ctx.w)
+        back.render(ctx, 0, y, ctx.w, back_h)
+        self._hits.append((y, y + back_h, "back"))
+        y += back_h + SPACE_SM
 
-            selected = (i == self._selected_idx)
-            bg = HIGHLIGHT if selected else SURFACE
-            name_color = ACCENT if selected else FG
-            is_group = bool(cmd.get("commands"))
-            icon = cmd.get("icon", "")
-            name_label = cmd["name"] + (" ›" if is_group else "")
-            display = f"{icon}  {name_label}" if icon else name_label
-            desc_text = cmd.get("description", "")
-
-            ctx.rect(PAD, by, btn_w, BTN_H, bg, radius=6.0)
-            label_y = by + (BTN_H * 0.38 if desc_text else BTN_H / 2)
-            ctx.text(x=PAD + 14, y=label_y, text=display,
-                     size=BODY, color=name_color, bold=True, align="left_center")
-            if desc_text:
-                ctx.text(x=PAD + 14, y=by + BTN_H * 0.72, text=desc_text,
-                         size=HINT, color=MUTED, align="left_center",
-                         max_width=btn_w - 28, elide=True)
-
-        # Hint only when list overflows visible area
-        visible_rows = max(1, int((ctx.h - y) / ROW_H))
-        if len(commands) > visible_rows:
-            ctx.text(x=ctx.w / 2, y=ctx.h - 16,
-                     text=f"j/k  ·  {self._selected_idx + 1} / {len(commands)}",
-                     size=HINT, color=MUTED, align="center")
-
-    def _render_form(self, ctx: RenderContext, y0: float) -> None:
-        btn_w = ctx.w - PAD * 2
-        self._hits = []
-        y = y0
-
-        ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-        ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back",
-                 size=BODY, color=ACCENT, bold=True, align="left_center")
-        self._hits.append((y, y + BTN_H, "back"))
-        y += BTN_H + BTN_GAP
-
-        if not self._fields:
-            ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
-            ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Run",
-                     size=BODY, color=BG, bold=True, align="center")
-            self._hits.append((y, y + BTN_H, "run"))
-            y += BTN_H + BTN_GAP
+        if not self._form_fields:
+            run = ListItem(title="▶  Run", background=ACCENT, selected=False)
+            run_h = run.measure(ctx.w)
+            run.render(ctx, 0, y, ctx.w, run_h)
+            self._hits.append((y, y + run_h, "run"))
+            y += run_h + SPACE_SM
         else:
-            for field in self._fields:
-                name = field["name"]
-                req = " *" if field.get("required") else ""
-                ctx.text(x=PAD, y=y, text=f"{name}{req}", size=HINT, color=MUTED)
-                y += 18
-                submitted = ctx.text_input(
-                    id=name, x=PAD, y=y, w=btn_w,
-                    placeholder=field.get("placeholder", field.get("default_str", "")),
-                )
-                if submitted is not None:
-                    self._field_values[name] = submitted
-                    if name == self._fields[-1]["name"]:
+            for ff in self._form_fields:
+                sub = ff.submitted
+                if sub is not None:
+                    self._field_values[ff.id] = sub
+                    if ff.id == self._form_fields[-1].id:
                         self._run()
-                self._hits.append((y, y + FIELD_H, name))
-                y += FIELD_H + FIELD_GAP
+                fh = ff.measure(ctx.w - 2 * SPACE_LG)
+                ff.render(ctx, SPACE_LG, y, ctx.w - 2 * SPACE_LG, fh)
+                y += fh
 
-            ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
-            ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Run",
-                     size=BODY, color=BG, bold=True, align="center")
-            self._hits.append((y, y + BTN_H, "run"))
-            y += BTN_H + BTN_GAP
+            run = ListItem(title="▶  Run", background=ACCENT, selected=False)
+            run_h = run.measure(ctx.w)
+            run.render(ctx, 0, y, ctx.w, run_h)
+            self._hits.append((y, y + run_h, "run"))
+            y += run_h + SPACE_SM
 
         if self._last_run:
-            ctx.rect(PAD, y, btn_w, 34, HIGHLIGHT, radius=4.0)
-            ctx.text(x=PAD + 10, y=y + 17, text=f"$ {self._last_run}",
-                     size=HINT, color=MUTED, monospace=True,
-                     align="left_center", max_width=btn_w - 20, elide=True)
+            last_run_h = TEXT_HINT + SPACE_XS * 2 + 4.0
+            ctx.rect(SPACE_LG, y, ctx.w - 2 * SPACE_LG, last_run_h, HIGHLIGHT, radius=RADIUS_SM)
+            ctx.text(x=SPACE_LG + SPACE_SM, y=y + last_run_h / 2,
+                     text=f"$ {self._last_run}",
+                     size=TEXT_HINT, color=MUTED, monospace=True,
+                     align="left_center", max_width=ctx.w - 2 * SPACE_LG - SPACE_MD, elide=True)
 
     # ── Interaction ───────────────────────────────────────────────────────────
 
-    def on_click(self, ctx: RenderContext, _x: float, y: float, button: str) -> None:
+    def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
         if button != "primary":
             return
-        for (y_top, y_bot, tag) in self._hits:
-            if y_top <= y < y_bot:
-                # Sync selection cursor to clicked row so it stays coherent
+        if self._view == "list":
+            # Check back button first (tracked in _hits)
+            for (yt, yb, tag) in self._hits:
+                if yt <= y < yb:
+                    self._handle(tag)
+                    self.emit.schedule_render(after_ms=16)
+                    return
+            # Then list items via SelectList
+            idx = self._select_list.hit_index(y)
+            if idx is not None:
+                self._selected_idx = idx
+                self._handle(idx)
+                self.emit.schedule_render(after_ms=16)
+            return
+        # Form view: use _hits
+        for (yt, yb, tag) in self._hits:
+            if yt <= y < yb:
                 if isinstance(tag, int) and self._view == "list":
                     self._selected_idx = tag
                 self._handle(tag)
@@ -329,7 +305,7 @@ class DescriptorRendererApp(App):
             elif self._cmd_path:
                 self._cmd_path.pop()
             self._selected_idx = 0
-            self._scroll_offset = 0
+            self._select_list.selected_idx = 0
             return
 
         if tag == "run":
@@ -343,7 +319,7 @@ class DescriptorRendererApp(App):
                 cmd = commands[tag]
                 self._cmd_path.append(cmd["name"])
                 self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
                 if not cmd.get("commands"):
                     self._enter_form(cmd)
 
@@ -351,6 +327,7 @@ class DescriptorRendererApp(App):
         self._view = "form"
         self._field_values = {}
         self._fields = []
+        self._form_fields = []
         for arg in cmd.get("args", []):
             default = arg.get("default")
             self._fields.append({
@@ -360,6 +337,12 @@ class DescriptorRendererApp(App):
                 "placeholder": arg.get("placeholder") or arg.get("description", ""),
                 "default_str": "" if default is None else str(default),
             })
+            self._form_fields.append(FormField(
+                id=arg["name"],
+                label=arg["name"],
+                placeholder=arg.get("placeholder") or arg.get("description", ""),
+                required=arg.get("required", False),
+            ))
             if default is not None:
                 self._field_values[arg["name"]] = str(default)
         for flag in cmd.get("flags", []):
@@ -371,6 +354,12 @@ class DescriptorRendererApp(App):
                 "placeholder": flag.get("description", ""),
                 "default_str": "" if default is None else str(default),
             })
+            self._form_fields.append(FormField(
+                id=flag["name"],
+                label=flag["name"],
+                placeholder=flag.get("description", ""),
+                required=False,
+            ))
             if default is not None:
                 self._field_values[flag["name"]] = str(default)
 
@@ -385,28 +374,18 @@ class DescriptorRendererApp(App):
         self.emit.run_in_linked_terminal(self._terminal_pane_id, cmd_str, echo=True)
         self.emit.info(f"descriptor-renderer: ran {cmd_str!r}")
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
-            assert self._descriptor is not None
-            commands = _commands_at(self._descriptor, self._cmd_path)
-            total = len(commands)
-            visible_rows = max(1, int((ctx.h - self._list_y0) / ROW_H))
-
-            if key in ("down", "j"):
-                self._selected_idx = min(self._selected_idx + 1, total - 1)
-                self._clamp_scroll(visible_rows)
-                self.emit.schedule_render(after_ms=16)
-            elif key in ("up", "k"):
-                self._selected_idx = max(self._selected_idx - 1, 0)
-                self._clamp_scroll(visible_rows)
+            if self._select_list.handle_key(key):
+                self._selected_idx = self._select_list.selected_idx
                 self.emit.schedule_render(after_ms=16)
             elif key in ("Return", "Enter"):
-                self._handle(self._selected_idx)
+                self._handle(self._select_list.selected_idx)
                 self.emit.schedule_render(after_ms=16)
             elif key == "Escape" and self._cmd_path:
                 self._cmd_path.pop()
                 self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
@@ -414,15 +393,8 @@ class DescriptorRendererApp(App):
                 self._view = "list"
                 self._cmd_path.pop()
                 self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
                 self.emit.schedule_render(after_ms=16)
-
-    def _clamp_scroll(self, visible_rows: int) -> None:
-        """Keep _scroll_offset so _selected_idx is always in the visible window."""
-        if self._selected_idx < self._scroll_offset:
-            self._scroll_offset = self._selected_idx
-        elif self._selected_idx >= self._scroll_offset + visible_rows:
-            self._scroll_offset = self._selected_idx - visible_rows + 1
 
 
 if __name__ == "__main__":

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -22,11 +22,10 @@ from typing import IO
 
 from plexi_sdk import App, RenderContext
 from plexi_sdk.ui import (
-    Column, AppBar, SelectList, FormField, ScrollLog, FooterKeys,
+    Column, AppBar, SelectList, FormField, Scrollable, FooterKeys,
     ListItem, Label, Spacer, Card,
-    ACCENT, RED,
-    TEXT_CAPTION,
-    SPACE_SM, SPACE_LG,
+    BG, ACCENT, RED,
+    SPACE_XS, SPACE_SM, SPACE_LG,
 )
 
 
@@ -147,7 +146,7 @@ class McpRendererApp(App):
         self._hits: list[tuple[float, float, object]] = []
         # UI components
         self._select_list = SelectList([])
-        self._result_log = ScrollLog([], line_size=TEXT_CAPTION)
+        self._result_scrollable = Scrollable(Label("", tone="hint"))
         # MCP client
         self._client: McpClient | None = None
         self._tools_ready = threading.Event()
@@ -206,6 +205,7 @@ class McpRendererApp(App):
         finally:
             self._calling = False
             self._view = "result"
+            self._result_scrollable.scroll_offset = 0.0
         self.emit.schedule_render(after_ms=16)
 
     # ── Render ────────────────────────────────────────────────────────────────
@@ -221,7 +221,7 @@ class McpRendererApp(App):
                 Spacer(grow=True),
                 Label("Connecting to MCP server…", tone="hint"),
                 Spacer(grow=True),
-            ], padding=0, gap=0))
+            ], padding=0, padding_top=0, gap=0))
             return
 
         if self._view == "error":
@@ -244,21 +244,29 @@ class McpRendererApp(App):
             ctx.render(Column([
                 AppBar(f"MCP · {cmd_name}", subtitle=subtitle),
                 self._select_list,
-            ], padding=0, gap=0))
+            ], padding=0, padding_top=0, gap=0))
             return
 
         if self._view == "form":
+            ctx.clear(BG)
             self._render_form(ctx)
             return
 
         if self._view == "result":
-            self._result_log.lines = self._result_lines
             tool_name = self._active_tool.get("name", "result")
+            if self._result_lines:
+                result_content = Column(
+                    [Label(line, tone="caption") for line in self._result_lines],
+                    padding=SPACE_LG, padding_top=SPACE_SM, gap=SPACE_XS,
+                )
+            else:
+                result_content = Column([Label("No output", tone="hint")], padding=SPACE_LG)
+            self._result_scrollable.child = result_content
             ctx.render(Column([
                 AppBar(f"Result: {tool_name}"),
-                self._result_log,
-                FooterKeys([("↑/↓", "scroll"), ("esc", "back")]),
-            ], padding=0, gap=0))
+                self._result_scrollable,
+                FooterKeys([("j/k", "scroll"), ("esc", "back")]),
+            ], padding=0, padding_top=0, gap=0))
 
     def _render_form(self, ctx: RenderContext) -> None:
         self._hits = []
@@ -413,7 +421,9 @@ class McpRendererApp(App):
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "result":
-            if key == "Escape":
+            if self._result_scrollable.handle_key(key):
+                self.emit.schedule_render(after_ms=16)
+            elif key == "Escape":
                 self._view = "list"
                 self._select_list.selected_idx = 0
                 self.emit.schedule_render(after_ms=16)

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -20,21 +20,14 @@ import sys
 import threading
 from typing import IO
 
-from plexi_sdk import (
-    App, RenderContext,
-    BG, FG, SURFACE, HIGHLIGHT, ACCENT, MUTED, RED,
-    HEADING, BODY, CAPTION, HINT,
-    PAD, HEADER_H,
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    Column, AppBar, SelectList, FormField, ScrollLog, FooterKeys,
+    ListItem, Label, Spacer, Card,
+    ACCENT, RED,
+    TEXT_CAPTION,
+    SPACE_SM, SPACE_LG,
 )
-
-# ── Layout constants ───────────────────────────────────────────────────────────
-
-BTN_H: float = 44.0
-BTN_GAP: float = 8.0
-FIELD_H: float = 36.0
-FIELD_GAP: float = 24.0  # label (16px) + gap below field
-ROW_H: float = BTN_H + BTN_GAP
-RESULT_LINE_H: float = 20.0
 
 
 # ── MCP stdio protocol ────────────────────────────────────────────────────────
@@ -142,18 +135,19 @@ class McpRendererApp(App):
         self._error: str = ""
         self._tools: list[dict] = []
         self._selected_idx: int = 0
-        self._scroll_offset: int = 0
-        self._list_y0: float = 0.0
         # Form state
         self._active_tool: dict = {}
         self._fields: list[dict] = []
         self._field_values: dict[str, str] = {}
+        self._form_fields: list[FormField] = []
         # Result state
         self._result_lines: list[str] = []
-        self._result_scroll: int = 0
         self._calling: bool = False
         # Hit regions: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
+        # UI components
+        self._select_list = SelectList([])
+        self._result_log = ScrollLog([], line_size=TEXT_CAPTION)
         # MCP client
         self._client: McpClient | None = None
         self._tools_ready = threading.Event()
@@ -212,195 +206,121 @@ class McpRendererApp(App):
         finally:
             self._calling = False
             self._view = "result"
-            self._result_scroll = 0
         self.emit.schedule_render(after_ms=16)
 
     # ── Render ────────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, BG)
+        cmd_name = sys.argv[1] if len(sys.argv) > 1 else "mcp"
+        tool_count = len(self._tools)
+        subtitle = f"{tool_count} tool{'s' if tool_count != 1 else ''}" if tool_count else None
 
         if self._view == "loading":
-            ctx.text(x=ctx.w / 2, y=ctx.h / 2, text="Connecting to MCP server…",
-                     size=BODY, color=MUTED, align="center")
+            ctx.render(Column([
+                AppBar(f"MCP · {cmd_name}"),
+                Spacer(grow=True),
+                Label("Connecting to MCP server…", tone="hint"),
+                Spacer(grow=True),
+            ], padding=0, gap=0))
             return
 
         if self._view == "error":
-            self._render_error(ctx)
+            ctx.render(Column([
+                AppBar(f"MCP · {cmd_name}"),
+                Spacer(SPACE_LG),
+                Card([
+                    Label("Error", color=RED, bold=True),
+                    Spacer(SPACE_SM),
+                    Label(self._error, tone="caption"),
+                ]),
+            ], padding=SPACE_LG, gap=0))
             return
-
-        y = self._render_header(ctx)
 
         if self._view == "list":
-            self._list_y0 = y
-            self._render_list(ctx, y)
-        elif self._view == "form":
-            self._render_form(ctx, y)
-        elif self._view == "result":
-            self._render_result(ctx, y)
-
-    def _render_header(self, ctx: RenderContext) -> float:
-        h = HEADER_H
-        ctx.rect(0, 0, ctx.w, h, SURFACE)
-        cmd_name = sys.argv[1] if len(sys.argv) > 1 else "mcp"
-        ctx.text(x=PAD, y=h / 2, text=f"MCP · {cmd_name}",
-                 size=HEADING, color=FG, bold=True, align="left_center")
-        tool_count = len(self._tools)
-        if tool_count:
-            ctx.text(x=ctx.w - PAD, y=h / 2,
-                     text=f"{tool_count} tool{'s' if tool_count != 1 else ''}",
-                     size=HINT, color=MUTED, align="right_center")
-        return h + PAD
-
-    def _render_error(self, ctx: RenderContext) -> None:
-        box_h = 100.0
-        ctx.rect(PAD, PAD, ctx.w - PAD * 2, box_h, SURFACE, radius=6.0)
-        ctx.text(x=PAD + 14, y=PAD + 22, text="Error", size=HEADING, color=RED, bold=True)
-        for i, line in enumerate(self._error.splitlines()):
-            ctx.text(x=PAD + 14, y=PAD + 48 + i * 20, text=line,
-                     size=CAPTION, color=FG, max_width=ctx.w - PAD * 2 - 28, elide=True)
-
-    def _render_list(self, ctx: RenderContext, y0: float) -> None:
-        btn_w = ctx.w - PAD * 2
-        self._hits = []
-        y = y0
-
-        if not self._tools:
-            ctx.text(x=ctx.w / 2, y=ctx.h / 2, text="No tools found",
-                     size=BODY, color=MUTED, align="center")
+            self._select_list.items = [
+                {"name": t["name"], "description": t.get("description") or None}
+                for t in self._tools
+            ]
+            ctx.render(Column([
+                AppBar(f"MCP · {cmd_name}", subtitle=subtitle),
+                self._select_list,
+            ], padding=0, gap=0))
             return
 
-        for i, tool in enumerate(self._tools):
-            by = y + (i - self._scroll_offset) * ROW_H
-            self._hits.append((by, by + BTN_H, i))
-            if by + BTN_H <= y0 or by >= ctx.h:
-                continue
+        if self._view == "form":
+            self._render_form(ctx)
+            return
 
-            selected = (i == self._selected_idx)
-            bg = HIGHLIGHT if selected else SURFACE
-            name_color = ACCENT if selected else FG
-            name = tool.get("name", "?")
-            desc = tool.get("description", "")
+        if self._view == "result":
+            self._result_log.lines = self._result_lines
+            tool_name = self._active_tool.get("name", "result")
+            ctx.render(Column([
+                AppBar(f"Result: {tool_name}"),
+                self._result_log,
+                FooterKeys([("↑/↓", "scroll"), ("esc", "back")]),
+            ], padding=0, gap=0))
 
-            ctx.rect(PAD, by, btn_w, BTN_H, bg, radius=6.0)
-            label_y = by + (BTN_H * 0.38 if desc else BTN_H / 2)
-            ctx.text(x=PAD + 14, y=label_y, text=name,
-                     size=BODY, color=name_color, bold=True, align="left_center")
-            if desc:
-                ctx.text(x=PAD + 14, y=by + BTN_H * 0.72, text=desc,
-                         size=HINT, color=MUTED, align="left_center",
-                         max_width=btn_w - 28, elide=True)
-
-        visible_rows = max(1, int((ctx.h - y0) / ROW_H))
-        if len(self._tools) > visible_rows:
-            ctx.text(x=ctx.w / 2, y=ctx.h - 16,
-                     text=f"j/k  ·  {self._selected_idx + 1} / {len(self._tools)}",
-                     size=HINT, color=MUTED, align="center")
-
-    def _render_form(self, ctx: RenderContext, y0: float) -> None:
-        btn_w = ctx.w - PAD * 2
+    def _render_form(self, ctx: RenderContext) -> None:
         self._hits = []
-        y = y0
+
+        # AppBar at top
+        app_bar = AppBar(self._active_tool.get("name", ""),
+                         subtitle=self._active_tool.get("description") or None)
+        app_bar_h = app_bar.measure(ctx.w)
+        app_bar.render(ctx, 0, 0, ctx.w, app_bar_h)
+        y = app_bar_h
 
         # Back button
-        ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-        ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back",
-                 size=BODY, color=ACCENT, bold=True, align="left_center")
-        self._hits.append((y, y + BTN_H, "back"))
-        y += BTN_H + BTN_GAP
+        back = ListItem(title="← Back", selected=False)
+        back_h = back.measure(ctx.w)
+        back.render(ctx, 0, y, ctx.w, back_h)
+        self._hits.append((y, y + back_h, "back"))
+        y += back_h + SPACE_SM
 
-        # Tool name
-        tool_name = self._active_tool.get("name", "")
-        ctx.text(x=PAD, y=y, text=tool_name, size=HEADING, color=FG, bold=True)
-        y += 28
-
-        tool_desc = self._active_tool.get("description", "")
-        if tool_desc:
-            ctx.text(x=PAD, y=y, text=tool_desc, size=CAPTION, color=MUTED,
-                     max_width=btn_w, elide=False)
-            y += 22
-
-        y += 8
-
-        if not self._fields:
-            # No args needed — just a Run button
-            ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
-            ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Call Tool",
-                     size=BODY, color=BG, bold=True, align="center")
-            self._hits.append((y, y + BTN_H, "run"))
+        if not self._form_fields:
+            # No-arg tool — just show run button
+            run = ListItem(title="▶  Call Tool", background=ACCENT, selected=False)
+            run_h = run.measure(ctx.w)
+            run.render(ctx, 0, y, ctx.w, run_h)
+            self._hits.append((y, y + run_h, "run"))
         else:
-            for field in self._fields:
-                name = field["name"]
-                req = " *" if field.get("required") else ""
-                ctx.text(x=PAD, y=y, text=f"{name}{req}", size=HINT, color=MUTED)
-                y += 18
-                submitted = ctx.text_input(
-                    id=name, x=PAD, y=y, w=btn_w,
-                    placeholder=field.get("placeholder", ""),
-                )
-                if submitted is not None:
-                    self._field_values[name] = submitted
-                    if name == self._fields[-1]["name"]:
+            # Process submitted values from form fields
+            for ff in self._form_fields:
+                sub = ff.submitted
+                if sub is not None:
+                    self._field_values[ff.id] = sub
+                    if ff.id == self._form_fields[-1].id:
                         self._run_tool()
-                self._hits.append((y, y + FIELD_H, name))
-                y += FIELD_H + FIELD_GAP
+                fh = ff.measure(ctx.w - 2 * SPACE_LG)
+                ff.render(ctx, SPACE_LG, y, ctx.w - 2 * SPACE_LG, fh)
+                y += fh
 
             if self._calling:
-                ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-                ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="Calling…",
-                         size=BODY, color=MUTED, align="center")
+                calling = Label("Calling…", tone="hint")
+                calling_h = calling.measure(ctx.w - 2 * SPACE_LG)
+                calling.render(ctx, SPACE_LG, y, ctx.w - 2 * SPACE_LG, calling_h)
             else:
-                ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
-                ctx.text(x=PAD + btn_w / 2, y=y + BTN_H / 2, text="▶  Call Tool",
-                         size=BODY, color=BG, bold=True, align="center")
-                self._hits.append((y, y + BTN_H, "run"))
-
-    def _render_result(self, ctx: RenderContext, y0: float) -> None:
-        btn_w = ctx.w - PAD * 2
-        self._hits = []
-        y = y0
-
-        # Back button
-        ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-        ctx.text(x=PAD + 14, y=y + BTN_H / 2, text="← Back to Tools",
-                 size=BODY, color=ACCENT, bold=True, align="left_center")
-        self._hits.append((y, y + BTN_H, "back"))
-        y += BTN_H + BTN_GAP
-
-        # Result label
-        tool_name = self._active_tool.get("name", "result")
-        ctx.text(x=PAD, y=y, text=f"Result: {tool_name}", size=HEADING, color=FG, bold=True)
-        y += 28
-
-        # Scrollable result lines
-        result_area_h = ctx.h - y - PAD
-        visible_lines = max(1, int(result_area_h / RESULT_LINE_H))
-        lines = self._result_lines
-        total = len(lines)
-
-        for i in range(visible_lines):
-            line_idx = i + self._result_scroll
-            if line_idx >= total:
-                break
-            line = lines[line_idx]
-            ctx.text(x=PAD, y=y + i * RESULT_LINE_H, text=line,
-                     size=CAPTION, color=FG, monospace=True,
-                     max_width=btn_w, elide=True)
-
-        if total > visible_lines:
-            ctx.text(x=ctx.w / 2, y=ctx.h - 16,
-                     text=f"↑/↓  ·  line {self._result_scroll + 1} / {total}",
-                     size=HINT, color=MUTED, align="center")
+                run = ListItem(title="▶  Call Tool", background=ACCENT, selected=False)
+                run_h = run.measure(ctx.w)
+                run.render(ctx, 0, y, ctx.w, run_h)
+                self._hits.append((y, y + run_h, "run"))
 
     # ── Interaction ───────────────────────────────────────────────────────────
 
     def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
         if button != "primary":
             return
+        # List view: use SelectList hit detection
+        if self._view == "list":
+            idx = self._select_list.hit_index(y)
+            if idx is not None:
+                self._selected_idx = idx
+                self._handle(idx)
+                self.emit.schedule_render(after_ms=16)
+            return
+        # Form/result views: use _hits
         for (y_top, y_bot, tag) in self._hits:
             if y_top <= y < y_bot:
-                if isinstance(tag, int) and self._view == "list":
-                    self._selected_idx = tag
                 self._handle(tag)
                 self.emit.schedule_render(after_ms=16)
                 return
@@ -410,7 +330,7 @@ class McpRendererApp(App):
             if self._view in ("form", "result"):
                 self._view = "list"
                 self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
             return
 
         if tag == "run":
@@ -425,6 +345,7 @@ class McpRendererApp(App):
         self._active_tool = tool
         self._field_values = {}
         self._fields = []
+        self._form_fields = []
         schema = tool.get("inputSchema", {})
         props = schema.get("properties", {})
         required_set = set(schema.get("required", []))
@@ -435,6 +356,12 @@ class McpRendererApp(App):
                 "required": prop_name in required_set,
                 "placeholder": prop_schema.get("description", prop_schema.get("title", "")),
             })
+            self._form_fields.append(FormField(
+                id=prop_name,
+                label=prop_name,
+                placeholder=prop_schema.get("description", prop_schema.get("title", "")),
+                required=prop_name in required_set,
+            ))
         self._view = "form"
 
     def _run_tool(self) -> None:
@@ -469,49 +396,27 @@ class McpRendererApp(App):
             daemon=True,
         ).start()
 
-    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
-            total = len(self._tools)
-            visible_rows = max(1, int((ctx.h - self._list_y0) / ROW_H))
-
-            if key in ("down", "j"):
-                self._selected_idx = min(self._selected_idx + 1, total - 1)
-                self._clamp_scroll(visible_rows)
-                self.emit.schedule_render(after_ms=16)
-            elif key in ("up", "k"):
-                self._selected_idx = max(self._selected_idx - 1, 0)
-                self._clamp_scroll(visible_rows)
+            if self._select_list.handle_key(key):
+                self._selected_idx = self._select_list.selected_idx
                 self.emit.schedule_render(after_ms=16)
             elif key in ("Return", "Enter"):
-                self._handle(self._selected_idx)
+                self._handle(self._select_list.selected_idx)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
             if key == "Escape":
                 self._view = "list"
                 self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "result":
-            total = len(self._result_lines)
-            if key in ("down", "j"):
-                self._result_scroll = min(self._result_scroll + 1, max(0, total - 1))
-                self.emit.schedule_render(after_ms=16)
-            elif key in ("up", "k"):
-                self._result_scroll = max(self._result_scroll - 1, 0)
-                self.emit.schedule_render(after_ms=16)
-            elif key == "Escape":
+            if key == "Escape":
                 self._view = "list"
-                self._selected_idx = 0
-                self._scroll_offset = 0
+                self._select_list.selected_idx = 0
                 self.emit.schedule_render(after_ms=16)
-
-    def _clamp_scroll(self, visible_rows: int) -> None:
-        if self._selected_idx < self._scroll_offset:
-            self._scroll_offset = self._selected_idx
-        elif self._selected_idx >= self._scroll_offset + visible_rows:
-            self._scroll_offset = self._selected_idx - visible_rows + 1
 
 
 if __name__ == "__main__":

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1066,6 +1066,155 @@ class ChatBubble(Component):
         ctx.markdown(text_x, text_y, text_w, self.text, base_size=fs, color=fg)
 
 
+class SelectList(Component):
+    """Keyboard-navigable scrollable list. Stateful — create in on_init, not on_render.
+
+    items: list of dicts with keys: name (str), description (str, optional),
+           leading (str, optional), trailing (str, optional)
+    selected_idx: currently highlighted row index
+
+    Call handle_key(key) from on_key. Call hit_index(click_y) from on_click.
+    """
+
+    def __init__(self, items: List[dict], selected_idx: int = 0) -> None:
+        self.items = items
+        self.selected_idx = selected_idx
+        self._scroll_px: float = 0.0
+        self._viewport_h: float = 0.0
+        self._rendered_rects: List[tuple] = []  # (y_top, y_bot, idx) populated each render
+
+    def is_grow(self) -> bool:
+        return True
+
+    def measure(self, avail_w: float) -> float:
+        return 0.0  # is_grow — allocated by parent
+
+    def _item_h(self, i: int) -> float:
+        item = self.items[i]
+        return ListItem.HEIGHT_DOUBLE if item.get("description") else ListItem.HEIGHT_SINGLE
+
+    def _item_top(self, idx: int) -> float:
+        """Item's y position in content-local space (before scroll)."""
+        y = 0.0
+        for i in range(idx):
+            y += self._item_h(i) + SPACE_XS
+        return y
+
+    def _total_content_h(self) -> float:
+        total = 0.0
+        for i in range(len(self.items)):
+            total += self._item_h(i) + SPACE_XS
+        return total
+
+    def _clamp_scroll(self) -> None:
+        max_scroll = max(0.0, self._total_content_h() - self._viewport_h)
+        self._scroll_px = max(0.0, min(self._scroll_px, max_scroll))
+
+    def handle_key(self, key: str) -> bool:
+        """Update selection and scroll for j/k/arrows. Returns True if consumed."""
+        total = len(self.items)
+        if total == 0:
+            return False
+        if key in ("j", "ArrowDown", "down"):
+            self.selected_idx = min(self.selected_idx + 1, total - 1)
+        elif key in ("k", "ArrowUp", "up"):
+            self.selected_idx = max(self.selected_idx - 1, 0)
+        else:
+            return False
+        # Scroll to keep selected item visible
+        item_top = self._item_top(self.selected_idx)
+        item_bot = item_top + self._item_h(self.selected_idx)
+        self._scroll_px = ensure_visible(self._scroll_px, self._viewport_h, item_top, item_bot)
+        self._clamp_scroll()
+        return True
+
+    def hit_index(self, click_y: float) -> Optional[int]:
+        """Return item index at click_y (screen coords from last render), or None."""
+        for (yt, yb, idx) in self._rendered_rects:
+            if yt <= click_y < yb:
+                return idx
+        return None
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        self._viewport_h = h
+        self._rendered_rects = []
+        self._clamp_scroll()
+
+        if not self.items:
+            ctx.text(x + w / 2, y + h / 2, "No items",
+                     size=TEXT_HINT, color=MUTED, align="center")
+            return
+
+        ctx.push_clip(x, y, w, h)
+        try:
+            cursor_y = y - self._scroll_px
+            for i, item in enumerate(self.items):
+                ih = self._item_h(i)
+                yt = cursor_y
+                yb = cursor_y + ih
+                if yb > y and yt < y + h:
+                    self._rendered_rects.append((yt, yb, i))
+                    li = ListItem(
+                        title=item["name"],
+                        subtitle=item.get("description") or None,
+                        leading=item.get("leading"),
+                        trailing=item.get("trailing"),
+                        selected=(i == self.selected_idx),
+                    )
+                    li.render(ctx, x, cursor_y, w, ih)
+                cursor_y += ih + SPACE_XS
+        finally:
+            ctx.pop_clip()
+
+        # Scrollbar indicator when content overflows
+        total_h = self._total_content_h()
+        if total_h > h and h > 0:
+            sb_w = 3.0
+            thumb_ratio = h / total_h
+            thumb_h = max(16.0, h * thumb_ratio)
+            thumb_y = y + (self._scroll_px / total_h) * h
+            thumb_y = min(thumb_y, y + h - thumb_h)
+            bar_x = x + w - sb_w
+            ctx.rect(bar_x, y, sb_w, h, HIGHLIGHT)
+            ctx.rect(bar_x, thumb_y, sb_w, thumb_h, MUTED)
+
+
+@dataclass
+class FormField(Component):
+    """Label + TextInput row. Create in on_init (stable across renders).
+
+    Read .submitted after ctx.render() — it contains the text entered
+    by the user when they pressed Enter, or None if no submission this frame.
+    """
+    id: str
+    label: str
+    placeholder: str = ""
+    required: bool = False
+    height: float = 48.0
+
+    LABEL_H: float = TEXT_HINT + SPACE_XS  # 11 + 4 = 15px
+    LABEL_GAP: float = SPACE_SM            # 8px gap between label and input
+    BOTTOM_PAD: float = SPACE_LG          # 16px below input before next item
+
+    def __post_init__(self) -> None:
+        self._input: TextInput = TextInput(self.id, placeholder=self.placeholder, height=self.height)
+
+    @property
+    def submitted(self) -> Optional[str]:
+        """Text submitted this frame (Enter pressed), or None."""
+        return self._input.submitted
+
+    def measure(self, avail_w: float) -> float:
+        return self.LABEL_H + self.LABEL_GAP + self.height + self.BOTTOM_PAD
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        req_suffix = " *" if self.required else ""
+        ctx.text(x, y, f"{self.label}{req_suffix}",
+                 size=TEXT_HINT, color=MUTED)
+        input_y = y + self.LABEL_H + self.LABEL_GAP
+        self._input.render(ctx, x, input_y, w, self.height)
+
+
 @dataclass
 class Column(Component):
     """The root container. Stacks children vertically. Handles grow spacers:
@@ -1155,6 +1304,7 @@ __all__ = [
     "AppBar", "Section", "KeyRow", "Heading", "Label",
     "Spacer", "Divider", "ScrollLog", "Scrollable", "Footer", "FooterKeys",
     "ListItem", "Row", "TextInput", "ChatBubble",
+    "SelectList", "FormField",
     # badge primitive
     "badge",
     # scroll helpers

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1101,10 +1101,9 @@ class SelectList(Component):
         return y
 
     def _total_content_h(self) -> float:
-        total = 0.0
-        for i in range(len(self.items)):
-            total += self._item_h(i) + SPACE_XS
-        return total
+        if not self.items:
+            return 0.0
+        return sum(self._item_h(i) for i in range(len(self.items))) + SPACE_XS * (len(self.items) - 1)
 
     def _clamp_scroll(self) -> None:
         max_scroll = max(0.0, self._total_content_h() - self._viewport_h)


### PR DESCRIPTION
## Summary
- Adds `SelectList` and `FormField` components to `plexi_sdk.ui`
- Migrates `mcp-renderer` and `descriptor-renderer` to use the declarative component system (`Column`, `AppBar`, `SelectList`, `FormField`, `ScrollLog`, `FooterKeys`, `ListItem`)
- Removes all manual layout constants (`BTN_H`, `ROW_H`, `FIELD_H`, `FIELD_GAP`) and raw `_constants.py` imports from both renderers

## Test plan
- [ ] `plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp` — tool list renders with consistent padding, typography, and selection highlight
- [ ] j/k navigation scrolls the list, Enter opens the form, Escape returns to list
- [ ] Form fields render with labels and accept input; Enter on last field calls the tool
- [ ] `plexi open --cli git` — command browser renders and navigates correctly
- [ ] Neither renderer imports `BTN_H`, `ROW_H`, `FIELD_H` or raw constants from `_constants.py`

Closes #1057