### PR TITLE
fix(examples/timer): add 15s duration + global notification scope

### DIFF
--- a/examples/apps/timer/main.py
+++ b/examples/apps/timer/main.py
@@ -11,6 +11,7 @@ from plexi_sdk import (
 from plexi_sdk.ui import Column, AppBar, FooterKeys, Component, Label
 
 DURATIONS = [
+    (15, "15 sec"),
     (30, "30 sec"),
     (60, "1 min"),
     (2 * 60, "2 min"),

--- a/examples/apps/timer/main.py
+++ b/examples/apps/timer/main.py
@@ -25,7 +25,7 @@ DURATIONS = [
     (60 * 60, "60 min"),
 ]
 
-DEFAULT_IDX = 4  # 5 min
+DEFAULT_IDX = 5  # 5 min
 DEFAULT_MSG = "Timer done!"
 TICK_ID = "tick"
 TWO_PI = 2 * math.pi

--- a/examples/apps/timer/manifest.toml
+++ b/examples/apps/timer/manifest.toml
@@ -14,3 +14,4 @@ capabilities = ["fs.read"]
 
 [launch]
 layout_hint = { side = "right", split = 0.5 }
+notification_scope = "global"


### PR DESCRIPTION
Fixes #1062

## Changes

- `examples/apps/timer/main.py` — adds `(15, "15 sec")` as first DURATIONS entry
- `examples/apps/timer/manifest.toml` — adds `notification_scope = "global"`

## Why

Timer had no 15-second option (minimum was 30s). Notifications used the default `Window` scope, so the completion alert was invisible when the user had switched to another pane. Global scope matches the stand-up-reminder pattern.

**Breaks if:** timer completion notification doesn't appear when the timer pane is not the active context.