### PR TITLE
fix(cli): app init splits origin pane, not focused pane

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1037,9 +1037,23 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} response_file={response_file:?}");
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} from_pane_id={from_pane_id:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
+
+                    // Override focused_pane for the split if from_pane_id is specified,
+                    // so the new pane splits the origin pane regardless of which pane has focus.
+                    let active = self.active_window;
+                    let original_focused = self.windows[active].focused_pane;
+                    if let Some(from_id) = from_pane_id {
+                        if let Some(tile) = self.windows[active].tree.tiles.find_pane(from_id) {
+                            log::info!("pane_ipc: spawn_pane: splitting relative to from_pane_id={from_id}");
+                            self.windows[active].focused_pane = Some(tile);
+                        } else {
+                            log::warn!("pane_ipc: spawn_pane: from_pane_id={from_id} not found, using focused pane");
+                        }
+                    }
+
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
                         let vertical = matches!(layout_str, "split_h" | "split_above");
@@ -1049,6 +1063,8 @@ impl PlexiApp {
                     } else {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
                     }
+
+                    self.windows[active].focused_pane = original_focused;
                     if let Some(rf) = response_file {
                         let json = format!("{{\"pane_id\":{new_pane_id}}}");
                         if let Err(e) = std::fs::write(rf, &json) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1064,7 +1064,10 @@ impl PlexiApp {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
                     }
 
-                    self.windows[active].focused_pane = original_focused;
+                    // Only restore if we overrode focus; otherwise the new pane keeps focus.
+                    if from_pane_id.is_some() {
+                        self.windows[active].focused_pane = original_focused;
+                    }
                     if let Some(rf) = response_file {
                         let json = format!("{{\"pane_id\":{new_pane_id}}}");
                         if let Err(e) = std::fs::write(rf, &json) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -522,8 +522,11 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 // The host rescans the registry on cache miss, so newly scaffolded
                 // apps are immediately openable without restarting Plexi.
                 if std::env::var("PLEXI_SOCKET").is_ok() {
-                    log::info!("app_init: auto-opening '{name}' via socket");
-                    let exit_code = crate::cli::open_cli(name, &[], None, None);
+                    let from_pane_id = std::env::var("PLEXI_PANE_ID")
+                        .ok()
+                        .and_then(|s| s.parse::<u64>().ok());
+                    log::info!("app_init: auto-opening '{name}' via socket from_pane_id={from_pane_id:?}");
+                    let exit_code = crate::cli::open_cli(name, &[], None, from_pane_id);
                     if exit_code != 0 {
                         eprintln!("warning: app created but could not auto-open '{name}' (exit {exit_code}) — run: plexi open {name}");
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -522,9 +522,16 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 // The host rescans the registry on cache miss, so newly scaffolded
                 // apps are immediately openable without restarting Plexi.
                 if std::env::var("PLEXI_SOCKET").is_ok() {
-                    let from_pane_id = std::env::var("PLEXI_PANE_ID")
-                        .ok()
-                        .and_then(|s| s.parse::<u64>().ok());
+                    let from_pane_id = match std::env::var("PLEXI_PANE_ID") {
+                        Ok(s) => match s.parse::<u64>() {
+                            Ok(id) => Some(id),
+                            Err(_) => {
+                                log::warn!("app_init: PLEXI_PANE_ID is set but not a valid number: {s}");
+                                None
+                            }
+                        },
+                        Err(_) => None,
+                    };
                     log::info!("app_init: auto-opening '{name}' via socket from_pane_id={from_pane_id:?}");
                     let exit_code = crate::cli::open_cli(name, &[], None, from_pane_id);
                     if exit_code != 0 {


### PR DESCRIPTION
Fixes #1065

## What

Two-site fix for `plexi app init` always spawning the new app pane near the focused pane instead of the pane that ran the command.

### `src/cli.rs` — `app_init`
Reads `PLEXI_PANE_ID` from the environment and passes it as `from_pane_id` to `open_cli`. Previously passed `None`, falling back to focused-pane placement.

### `src/app/mod.rs` — socket IPC `SpawnPane` handler
Previously used `..` to ignore `from_pane_id`. Now destructures it and, if set, temporarily overrides `focused_pane` to the origin pane before calling `split_focused` / `launch_app_by_id_with_layout`, then restores focus. Mirrors the existing `AppCommand::SpawnPane` logic at lines 1673–1682.

## Test

Run `plexi app init my-app` from a terminal pane that is **not** focused (click a different pane first). The new app should split the origin terminal pane, not the focused one.

**Breaks if:** new app opens next to the focused pane instead of the terminal where `app init` was run.