### PR TITLE
feat(sdk): add ListView widget to plexi_sdk.widgets

### DIFF
--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -19,13 +19,14 @@ from pathlib import Path
 
 from plexi_sdk import App, RenderContext, CapabilityDeniedError
 from plexi_sdk.ui import (
-    Column, AppBar, SelectList, FormField,
+    Column, AppBar, FormField,
     ListItem, Label, Spacer, Card,
     BG, HIGHLIGHT, ACCENT, MUTED, RED,
     TEXT_HINT,
     SPACE_XS, SPACE_SM, SPACE_MD, SPACE_LG,
     RADIUS_SM,
 )
+from plexi_sdk.widgets import ListView
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -106,7 +107,7 @@ class DescriptorRendererApp(App):
         # Hit regions: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
         # UI components
-        self._select_list = SelectList([])
+        self._list = ListView(item_height=ListItem.HEIGHT_DOUBLE)
 
         path = _parse_descriptor_path(sys.argv[1:])
         if not path:
@@ -190,14 +191,6 @@ class DescriptorRendererApp(App):
             crumb = None
             if self._cmd_path:
                 crumb = " › ".join([name] + list(self._cmd_path))
-            self._select_list.items = [
-                {
-                    "name": cmd["name"] + (" ›" if cmd.get("commands") else ""),
-                    "description": cmd.get("description") or None,
-                    "leading": cmd.get("icon") or None,
-                }
-                for cmd in commands
-            ]
             app_bar = AppBar(title, subtitle=crumb or desc or None)
             app_bar_h = app_bar.measure(ctx.w)
             header_items: list = [app_bar]
@@ -208,7 +201,15 @@ class DescriptorRendererApp(App):
                 self._hits = [(app_bar_h, app_bar_h + back_h, "back")]
             else:
                 self._hits = []
-            header_items.append(self._select_list)
+            header_items.append(self._list.render([
+                ListItem(
+                    title=cmd["name"] + (" ›" if cmd.get("commands") else ""),
+                    subtitle=cmd.get("description") or None,
+                    leading=cmd.get("icon") or None,
+                    selected=i == self._list.selected_index,
+                )
+                for i, cmd in enumerate(commands)
+            ]))
             ctx.render(Column(header_items, padding=0, padding_top=0, gap=0))
             return
 
@@ -282,9 +283,10 @@ class DescriptorRendererApp(App):
                     self._handle(tag)
                     self.emit.schedule_render(after_ms=16)
                     return
-            # Then list items via SelectList
-            idx = self._select_list.hit_index(y)
+            # Then list items via ListView
+            idx = self._list.hit_test(y)
             if idx is not None:
+                self._list.set_selected(idx)
                 self._selected_idx = idx
                 self._handle(idx)
                 self.emit.schedule_render(after_ms=16)
@@ -306,7 +308,7 @@ class DescriptorRendererApp(App):
             elif self._cmd_path:
                 self._cmd_path.pop()
             self._selected_idx = 0
-            self._select_list.selected_idx = 0
+            self._list.set_selected(0)
             return
 
         if tag == "run":
@@ -320,7 +322,7 @@ class DescriptorRendererApp(App):
                 cmd = commands[tag]
                 self._cmd_path.append(cmd["name"])
                 self._selected_idx = 0
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
                 if not cmd.get("commands"):
                     self._enter_form(cmd)
 
@@ -377,16 +379,16 @@ class DescriptorRendererApp(App):
 
     def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
-            if self._select_list.handle_key(key):
-                self._selected_idx = self._select_list.selected_idx
+            if self._list.handle_key(key):
+                self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
             elif key in ("Return", "Enter"):
-                self._handle(self._select_list.selected_idx)
+                self._handle(self._list.selected_index)
                 self.emit.schedule_render(after_ms=16)
             elif key == "Escape" and self._cmd_path:
                 self._cmd_path.pop()
                 self._selected_idx = 0
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
@@ -394,7 +396,7 @@ class DescriptorRendererApp(App):
                 self._view = "list"
                 self._cmd_path.pop()
                 self._selected_idx = 0
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
 
 

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -22,11 +22,12 @@ from typing import IO
 
 from plexi_sdk import App, RenderContext
 from plexi_sdk.ui import (
-    Column, AppBar, SelectList, FormField, Scrollable, FooterKeys,
+    Column, AppBar, FormField, Scrollable, FooterKeys,
     ListItem, Label, Spacer, Card,
     BG, ACCENT, RED,
     SPACE_XS, SPACE_SM, SPACE_LG,
 )
+from plexi_sdk.widgets import ListView
 
 
 # ── MCP stdio protocol ────────────────────────────────────────────────────────
@@ -142,10 +143,10 @@ class McpRendererApp(App):
         # Result state
         self._result_lines: list[str] = []
         self._calling: bool = False
-        # Hit regions: (y_top, y_bot, tag)
+        # Hit regions for form/result views: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
         # UI components
-        self._select_list = SelectList([])
+        self._list = ListView(item_height=ListItem.HEIGHT_DOUBLE)
         self._result_scrollable = Scrollable(Label("", tone="hint"))
         # MCP client
         self._client: McpClient | None = None
@@ -237,13 +238,16 @@ class McpRendererApp(App):
             return
 
         if self._view == "list":
-            self._select_list.items = [
-                {"name": t["name"], "description": t.get("description") or None}
-                for t in self._tools
-            ]
             ctx.render(Column([
                 AppBar(f"MCP · {cmd_name}", subtitle=subtitle),
-                self._select_list,
+                self._list.render([
+                    ListItem(
+                        title=t["name"],
+                        subtitle=t.get("description") or None,
+                        selected=i == self._list.selected_index,
+                    )
+                    for i, t in enumerate(self._tools)
+                ]),
             ], padding=0, padding_top=0, gap=0))
             return
 
@@ -318,10 +322,11 @@ class McpRendererApp(App):
     def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
         if button != "primary":
             return
-        # List view: use SelectList hit detection
+        # List view: use ListView hit detection
         if self._view == "list":
-            idx = self._select_list.hit_index(y)
+            idx = self._list.hit_test(y)
             if idx is not None:
+                self._list.set_selected(idx)
                 self._selected_idx = idx
                 self._handle(idx)
                 self.emit.schedule_render(after_ms=16)
@@ -338,7 +343,7 @@ class McpRendererApp(App):
             if self._view in ("form", "result"):
                 self._view = "list"
                 self._selected_idx = 0
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
             return
 
         if tag == "run":
@@ -406,18 +411,18 @@ class McpRendererApp(App):
 
     def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
-            if self._select_list.handle_key(key):
-                self._selected_idx = self._select_list.selected_idx
+            if self._list.handle_key(key):
+                self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
             elif key in ("Return", "Enter"):
-                self._handle(self._select_list.selected_idx)
+                self._handle(self._list.selected_index)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
             if key == "Escape":
                 self._view = "list"
                 self._selected_idx = 0
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "result":
@@ -425,7 +430,7 @@ class McpRendererApp(App):
                 self.emit.schedule_render(after_ms=16)
             elif key == "Escape":
                 self._view = "list"
-                self._select_list.selected_idx = 0
+                self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
 
 

--- a/sdk/python/plexi_sdk/widgets/__init__.py
+++ b/sdk/python/plexi_sdk/widgets/__init__.py
@@ -14,6 +14,7 @@ from plexi_sdk.widgets.text_area import TextArea, TextAreaTheme
 from plexi_sdk.widgets.text_input import emit_text_input
 from plexi_sdk.widgets.button import Button, ButtonStyle
 from plexi_sdk.widgets.keymap import KeyMap
+from plexi_sdk.widgets.list_view import ListView
 
 __all__ = [
     "ScrollState",
@@ -22,4 +23,5 @@ __all__ = [
     "emit_text_input",
     "Button", "ButtonStyle",
     "KeyMap",
+    "ListView",
 ]

--- a/sdk/python/plexi_sdk/widgets/list_view.py
+++ b/sdk/python/plexi_sdk/widgets/list_view.py
@@ -63,6 +63,8 @@ class ListView:
     """
 
     def __init__(self, item_height: float = 48.0) -> None:
+        if item_height <= 0:
+            raise ValueError(f"ListView: item_height must be > 0, got {item_height!r}")
         self._item_height = item_height
         self._selected: int = 0
         self._scroll_offset: float = 0.0

--- a/sdk/python/plexi_sdk/widgets/list_view.py
+++ b/sdk/python/plexi_sdk/widgets/list_view.py
@@ -1,0 +1,169 @@
+"""ListView — stateful scrollable list widget.
+
+Create once in on_init, call render(items) each frame inside Column([...]).
+handle_key / hit_test / set_selected give full keyboard and pointer control.
+"""
+
+from __future__ import annotations
+
+
+class _ListViewRenderer:
+    """Internal — returned by ListView.render(); bridges Component protocol."""
+
+    def __init__(self, owner: "ListView", items: list) -> None:
+        self._owner = owner
+        self._items = items
+
+    # -- Component protocol ---------------------------------------------------
+
+    def measure(self, _avail_w: float) -> float:
+        return 0.0  # grow
+
+    def is_grow(self) -> bool:
+        return True
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        self._owner._render_items(ctx, x, y, w, h, self._items)
+
+    # Let _render_clipped work (used by Column layout engine)
+    def _render_clipped(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        ctx.push_clip(x, y, w, h)
+        try:
+            self.render(ctx, x, y, w, h)
+        finally:
+            ctx.pop_clip()
+
+
+class ListView:
+    """Stateful scrollable list widget with fixed item height.
+
+    Usage::
+
+        class MyApp(App):
+            def on_init(self, ctx):
+                self._list = ListView(item_height=48.0)
+
+            def on_render(self, ctx):
+                ctx.render(Column([
+                    AppBar("Title"),
+                    self._list.render([
+                        ListItem(title=items[i], selected=i == self._list.selected_index)
+                        for i in range(len(items))
+                    ]),
+                ]))
+
+            def on_key(self, ctx, key, mods):
+                if self._list.handle_key(key):
+                    self.emit.schedule_render(after_ms=16)
+
+            def on_click(self, ctx, x, y, button):
+                idx = self._list.hit_test(y)
+                if idx is not None:
+                    self._list.set_selected(idx)
+    """
+
+    def __init__(self, item_height: float = 48.0) -> None:
+        self._item_height = item_height
+        self._selected: int = 0
+        self._scroll_offset: float = 0.0
+        self._viewport_y: float = 0.0
+        self._viewport_h: float = 0.0
+        self._item_count: int = 0
+
+    # -- Public API -----------------------------------------------------------
+
+    @property
+    def selected_index(self) -> int:
+        return self._selected
+
+    def set_selected(self, idx: int) -> None:
+        if self._item_count > 0:
+            self._selected = max(0, min(idx, self._item_count - 1))
+        else:
+            self._selected = 0
+        self._scroll_to_selected()
+
+    def handle_key(self, key: str) -> bool:
+        """Move selection for j/k/arrows. Returns True if the key was consumed."""
+        if self._item_count == 0:
+            return False
+        if key in ("j", "ArrowDown", "down"):
+            self._selected = min(self._selected + 1, self._item_count - 1)
+        elif key in ("k", "ArrowUp", "up"):
+            self._selected = max(self._selected - 1, 0)
+        else:
+            return False
+        self._scroll_to_selected()
+        return True
+
+    def hit_test(self, y: float) -> int | None:
+        """Return item index at screen-coord y (from last render), or None."""
+        if self._viewport_h == 0.0 or self._item_count == 0:
+            return None
+        local_y = y - self._viewport_y + self._scroll_offset
+        if local_y < 0.0:
+            return None
+        idx = int(local_y / self._item_height)
+        if 0 <= idx < self._item_count:
+            return idx
+        return None
+
+    def render(self, items: list) -> "_ListViewRenderer":
+        """Return a renderable Component containing the given items.
+
+        Call inside Column([...]) on every frame — the returned object is
+        lightweight and safe to recreate each render.
+        """
+        return _ListViewRenderer(self, items)
+
+    # -- Internal -------------------------------------------------------------
+
+    def _total_h(self) -> float:
+        return self._item_count * self._item_height
+
+    def _clamp_scroll(self) -> None:
+        max_scroll = max(0.0, self._total_h() - self._viewport_h)
+        self._scroll_offset = max(0.0, min(self._scroll_offset, max_scroll))
+
+    def _scroll_to_selected(self) -> None:
+        item_top = self._selected * self._item_height
+        item_bot = item_top + self._item_height
+        if item_top < self._scroll_offset:
+            self._scroll_offset = item_top
+        elif item_bot > self._scroll_offset + self._viewport_h:
+            self._scroll_offset = item_bot - self._viewport_h
+        self._clamp_scroll()
+
+    def _render_items(
+        self, ctx, x: float, y: float, w: float, h: float, items: list
+    ) -> None:
+        self._viewport_y = y
+        self._viewport_h = h
+        self._item_count = len(items)
+        self._clamp_scroll()
+
+        ctx.push_clip(x, y, w, h)
+        try:
+            cursor_y = y - self._scroll_offset
+            for item in items:
+                ib = cursor_y + self._item_height
+                if ib > y and cursor_y < y + h:
+                    item.render(ctx, x, cursor_y, w, self._item_height)
+                cursor_y += self._item_height
+        finally:
+            ctx.pop_clip()
+
+        # Scrollbar indicator when content overflows
+        total_h = self._total_h()
+        if total_h > h and h > 0:
+            try:
+                from plexi_sdk.ui import HIGHLIGHT, MUTED
+            except ImportError:
+                return
+            sb_w = 3.0
+            thumb_h = max(16.0, h * (h / total_h))
+            thumb_y = y + (self._scroll_offset / total_h) * h
+            thumb_y = min(thumb_y, y + h - thumb_h)
+            bar_x = x + w - sb_w
+            ctx.rect(bar_x, y, sb_w, h, HIGHLIGHT)
+            ctx.rect(bar_x, thumb_y, sb_w, thumb_h, MUTED)

--- a/sdk/python/plexi_sdk/widgets/list_view.py
+++ b/sdk/python/plexi_sdk/widgets/list_view.py
@@ -6,17 +6,17 @@ handle_key / hit_test / set_selected give full keyboard and pointer control.
 
 from __future__ import annotations
 
+from plexi_sdk.ui import Component, HIGHLIGHT, MUTED
 
-class _ListViewRenderer:
+
+class _ListViewRenderer(Component):
     """Internal — returned by ListView.render(); bridges Component protocol."""
 
     def __init__(self, owner: "ListView", items: list) -> None:
         self._owner = owner
         self._items = items
 
-    # -- Component protocol ---------------------------------------------------
-
-    def measure(self, _avail_w: float) -> float:
+    def measure(self, avail_w: float) -> float:  # noqa: ARG002
         return 0.0  # grow
 
     def is_grow(self) -> bool:
@@ -24,14 +24,6 @@ class _ListViewRenderer:
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         self._owner._render_items(ctx, x, y, w, h, self._items)
-
-    # Let _render_clipped work (used by Column layout engine)
-    def _render_clipped(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.push_clip(x, y, w, h)
-        try:
-            self.render(ctx, x, y, w, h)
-        finally:
-            ctx.pop_clip()
 
 
 class ListView:
@@ -146,22 +138,18 @@ class ListView:
 
         ctx.push_clip(x, y, w, h)
         try:
-            cursor_y = y - self._scroll_offset
-            for item in items:
-                ib = cursor_y + self._item_height
-                if ib > y and cursor_y < y + h:
-                    item.render(ctx, x, cursor_y, w, self._item_height)
-                cursor_y += self._item_height
+            # Only iterate the visible slice — O(visible) not O(N)
+            start_idx = max(0, int(self._scroll_offset / self._item_height))
+            end_idx = min(len(items), int((self._scroll_offset + h) / self._item_height) + 1)
+            for i in range(start_idx, end_idx):
+                item_y = y + (i * self._item_height) - self._scroll_offset
+                items[i].render(ctx, x, item_y, w, self._item_height)
         finally:
             ctx.pop_clip()
 
         # Scrollbar indicator when content overflows
         total_h = self._total_h()
         if total_h > h and h > 0:
-            try:
-                from plexi_sdk.ui import HIGHLIGHT, MUTED
-            except ImportError:
-                return
             sb_w = 3.0
             thumb_h = max(16.0, h * (h / total_h))
             thumb_y = y + (self._scroll_offset / total_h) * h

--- a/sdk/python/tests/test_list_view.py
+++ b/sdk/python/tests/test_list_view.py
@@ -1,0 +1,219 @@
+"""Tests for ListView stateful widget."""
+
+from unittest.mock import MagicMock
+
+from plexi_sdk.widgets.list_view import ListView
+
+
+class _FakeItem:
+    """Minimal Component-like object for testing."""
+
+    def measure(self, _avail_w: float) -> float:
+        return 0.0
+
+    def is_grow(self) -> bool:
+        return False
+
+    def render(self, ctx, x, y, w, h) -> None:
+        ctx.rect(x, y, w, h, "bg")
+
+
+def _make_items(n: int) -> list:
+    return [_FakeItem() for _ in range(n)]
+
+
+def _do_render(lv: ListView, items: list, x=0.0, y=10.0, w=200.0, h=300.0) -> None:
+    """Run a render pass so viewport state is recorded in lv."""
+    ctx = MagicMock()
+    component = lv.render(items)
+    component.render(ctx, x, y, w, h)
+
+
+# -- Key navigation -----------------------------------------------------------
+
+def test_j_moves_selection_down() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(5)
+    _do_render(lv, items)
+    consumed = lv.handle_key("j")
+    assert consumed is True
+    assert lv.selected_index == 1
+
+
+def test_k_moves_selection_up() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(5)
+    _do_render(lv, items)
+    lv.set_selected(3)
+    lv.handle_key("k")
+    assert lv.selected_index == 2
+
+
+def test_arrow_keys_consumed() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, _make_items(5))
+    assert lv.handle_key("ArrowDown") is True
+    assert lv.handle_key("ArrowUp") is True
+    assert lv.selected_index == 0  # down then up = back to 0
+
+
+def test_unrecognised_key_not_consumed() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, _make_items(3))
+    assert lv.handle_key("Return") is False
+
+
+def test_clamps_at_top_boundary() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, _make_items(3))
+    lv.handle_key("k")  # already at 0
+    assert lv.selected_index == 0
+
+
+def test_clamps_at_bottom_boundary() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, _make_items(3))
+    lv.set_selected(2)
+    lv.handle_key("j")  # already at last
+    assert lv.selected_index == 2
+
+
+def test_empty_list_keys_not_consumed() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, [])
+    assert lv.handle_key("j") is False
+    assert lv.handle_key("k") is False
+
+
+# -- Scroll clamping ----------------------------------------------------------
+
+def test_scroll_advances_when_selection_passes_viewport_bottom() -> None:
+    # viewport h=100, item_height=48 → 2 items visible
+    lv = ListView(item_height=48.0)
+    items = _make_items(10)
+    _do_render(lv, items, h=100.0)
+    # Press j twice — item 2 bottom is at 144 > 100
+    lv.handle_key("j")
+    lv.handle_key("j")
+    assert lv._scroll_offset > 0.0
+
+
+def test_scroll_retreats_when_selection_passes_viewport_top() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(10)
+    _do_render(lv, items, h=100.0)
+    lv.set_selected(5)
+    prev_scroll = lv._scroll_offset
+    lv.set_selected(0)
+    assert lv._scroll_offset < prev_scroll
+
+
+def test_scroll_clamps_to_zero() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(3)
+    _do_render(lv, items, h=300.0)  # viewport larger than content
+    assert lv._scroll_offset == 0.0
+
+
+def test_scroll_clamps_on_viewport_resize() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(10)
+    # Small viewport — scroll to bottom
+    _do_render(lv, items, h=100.0)
+    lv.set_selected(9)
+    assert lv._scroll_offset > 0.0
+    # Render with a larger viewport — scroll should be clamped down
+    _do_render(lv, items, h=600.0)  # bigger than total content 480px
+    assert lv._scroll_offset == 0.0
+
+
+# -- Hit testing --------------------------------------------------------------
+
+def test_hit_test_first_item() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(5)
+    # viewport starts at y=10
+    _do_render(lv, items, y=10.0, h=500.0)
+    # click at y=15 → inside first item (y=10 to y=58)
+    assert lv.hit_test(15.0) == 0
+
+
+def test_hit_test_second_item() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(5)
+    _do_render(lv, items, y=0.0, h=500.0)
+    # click at y=60 → second item (48..96)
+    assert lv.hit_test(60.0) == 1
+
+
+def test_hit_test_above_viewport_returns_none() -> None:
+    lv = ListView(item_height=48.0)
+    _do_render(lv, _make_items(3), y=50.0, h=300.0)
+    assert lv.hit_test(10.0) is None  # above y=50
+
+
+def test_hit_test_below_items_returns_none() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(3)  # total 144px
+    _do_render(lv, items, y=0.0, h=500.0)
+    assert lv.hit_test(200.0) is None  # beyond item 3 bottom
+
+
+def test_hit_test_with_scroll_offset() -> None:
+    lv = ListView(item_height=48.0)
+    items = _make_items(10)
+    _do_render(lv, items, y=0.0, h=100.0)
+    # Scroll down by one item
+    lv._scroll_offset = 48.0
+    # click at y=10 now maps to content_y=58 → index 1
+    assert lv.hit_test(10.0) == 1
+
+
+def test_hit_test_before_render_returns_none() -> None:
+    lv = ListView(item_height=48.0)
+    assert lv.hit_test(50.0) is None
+
+
+# -- set_selected -------------------------------------------------------------
+
+def test_set_selected_clamps_negative() -> None:
+    lv = ListView()
+    _do_render(lv, _make_items(5))
+    lv.set_selected(-1)
+    assert lv.selected_index == 0
+
+
+def test_set_selected_clamps_past_end() -> None:
+    lv = ListView()
+    _do_render(lv, _make_items(5))
+    lv.set_selected(100)
+    assert lv.selected_index == 4
+
+
+def test_set_selected_noop_on_empty() -> None:
+    lv = ListView()
+    _do_render(lv, [])
+    lv.set_selected(3)
+    assert lv.selected_index == 0
+
+
+# -- render returns a Component-protocol object --------------------------------
+
+def test_render_returns_grow_component() -> None:
+    lv = ListView()
+    comp = lv.render(_make_items(3))
+    assert comp.is_grow() is True
+    assert comp.measure(200.0) == 0.0
+
+
+def test_render_calls_item_render_for_visible_items() -> None:
+    lv = ListView(item_height=48.0)
+    items = [MagicMock() for _ in range(5)]
+    ctx = MagicMock()
+    ctx.push_clip = MagicMock()
+    ctx.pop_clip = MagicMock()
+    comp = lv.render(items)
+    comp.render(ctx, 0.0, 0.0, 200.0, 200.0)  # viewport shows ~4 items
+    # All 5 items fit in 240px content vs 200px viewport — 4 items visible
+    visible_calls = sum(1 for item in items if item.render.called)
+    assert visible_calls >= 4


### PR DESCRIPTION
## Summary
- Adds `ListView` class to `plexi_sdk.widgets` — stateful scrollable list widget with fixed item height
- `render(items) -> Component` for declarative use in `Column([...])`; `handle_key`, `hit_test`, `set_selected` API
- Migrates `mcp-renderer` and `descriptor-renderer` from `SelectList` (dict-driven) to `ListView` (Component-driven) as reference implementations
- 22 unit tests: j/k nav, arrow keys, boundary clamping, scroll auto-track, viewport resize clamp, hit-test with scroll, Component protocol

## Test plan
- [ ] Diff-only review — no binary install needed (pure Python, no Rust changes)
- [ ] `ListView` exported from `plexi_sdk.widgets`
- [ ] Both renderers import `ListView` and no longer reference `SelectList`
- [ ] 36 tests pass (`uv run pytest sdk/python/tests/`)

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)