### PR TITLE
polish(examples): migrate mcp-demo, backlog, csv_viewer to SelectList/FormField

### DIFF
--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
 from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN
+from plexi_sdk.ui import SelectList
 
-ROW_H     = 22.0
 LIST_FRAC = 0.38   # fraction of width for the item list
 # Chrome — where the list/preview body starts and ends vertically. These
 # replace the fixed header/footer bars from v1 chrome. They're tuned so the
@@ -39,6 +39,7 @@ class BacklogApp(App):
         self.confirm_delete = False
         self.in_add = False        # showcase: host-owned TextInput entry mode
         self.status = ""
+        self._item_list = SelectList([])
         self._load()
 
     # ── Data ────────────────────────────────────────────────────────────────────
@@ -63,6 +64,8 @@ class BacklogApp(App):
             if not q or q in f.stem.lower() or q in f.name.lower()
         ]
         self.selected = min(self.selected, max(0, len(self.filtered) - 1))
+        self._item_list.items = [{"name": p.stem} for p in self.filtered]
+        self._item_list.selected_idx = self.selected
         self._cache_preview()
 
     def _cache_preview(self) -> None:
@@ -176,24 +179,11 @@ class BacklogApp(App):
         ctx.line(list_w, TOP - 4, list_w, h - BOTTOM_BAR_H, color=HIGHLIGHT, width=1.0)
 
         # ── Item list ────────────────────────────────────────────────────────────
-        visible_start = max(0, self.selected - int(list_h / ROW_H) + 4)
-        for i, path in enumerate(self.filtered):
-            if i < visible_start:
-                continue
-            row_y = TOP + (i - visible_start) * ROW_H
-            if row_y + ROW_H > h - BOTTOM_BAR_H:
-                break
-            is_sel = i == self.selected
-            if is_sel:
-                ctx.rect(1, row_y, list_w - 2, ROW_H, HIGHLIGHT, radius=3.0)
-            name = path.stem
-            color = FG if is_sel else MUTED
-            ctx.text(12, row_y + 4, name, size=12, color=color,
-                     max_width=list_w - 24)
-
         if not self.filtered:
             msg = "No results" if self.search_query else "Backlog is empty"
             ctx.text(12, TOP + 12, msg, size=12, color=MUTED)
+        else:
+            self._item_list.render(ctx, 0, TOP, list_w, list_h)
 
         # ── Preview ──────────────────────────────────────────────────────────────
         px = list_w + 14
@@ -295,13 +285,9 @@ class BacklogApp(App):
             return
 
         # ── Normal mode ──────────────────────────────────────────────────────────
-        n = len(self.filtered)
-
-        if key in ("j", "down"):
-            self.selected = min(self.selected + 1, max(0, n - 1))
-            self._cache_preview()
-        elif key in ("k", "up"):
-            self.selected = max(0, self.selected - 1)
+        if key in ("j", "down", "k", "up"):
+            self._item_list.handle_key(key)
+            self.selected = self._item_list.selected_idx
             self._cache_preview()
         elif key in ("e", "Enter"):
             self._open()

--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -248,7 +248,7 @@ class BacklogApp(App):
 
     # ── Keys ─────────────────────────────────────────────────────────────────────
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         self.status = ""   # clear on any key
 
         # ── Add-item mode (host owns the buffer) ─────────────────────────────────
@@ -256,28 +256,28 @@ class BacklogApp(App):
         # exit shortcut. Submission is delivered via PlexiEvent::TextSubmitted
         # and consumed in `on_render`'s `ctx.text_input(...)` call.
         if self.in_add:
-            if key == "Escape":
+            if key == "escape":
                 self.in_add = False
             return
 
         # ── Confirm-delete mode ──────────────────────────────────────────────────
         if self.confirm_delete:
-            if key == "Enter":
+            if key == "return":
                 self._delete()
-            elif key in ("Escape", "d"):
+            elif key in ("escape", "d"):
                 self.confirm_delete = False
             return
 
         # ── Search mode ──────────────────────────────────────────────────────────
         if self.in_search:
-            if key == "Escape":
+            if key == "escape":
                 self.in_search = False
                 self.search_query = ""
                 self._refilter()
-            elif key == "Backspace":
+            elif key == "backspace":
                 self.search_query = self.search_query[:-1]
                 self._refilter()
-            elif key == "Enter":
+            elif key == "return":
                 self.in_search = False
             elif len(key) == 1:   # single char from Text event; ignores "Slash" etc.
                 self.search_query += key
@@ -285,11 +285,11 @@ class BacklogApp(App):
             return
 
         # ── Normal mode ──────────────────────────────────────────────────────────
-        if key in ("j", "down", "ArrowDown", "k", "up", "ArrowUp"):
+        if key in ("j", "down", "k", "up"):
             self._item_list.handle_key(key)
             self.selected = self._item_list.selected_idx
             self._cache_preview()
-        elif key in ("e", "Enter"):
+        elif key in ("e", "return"):
             self._open()
         elif key == "a":
             self._archive()

--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -285,7 +285,7 @@ class BacklogApp(App):
             return
 
         # ── Normal mode ──────────────────────────────────────────────────────────
-        if key in ("j", "down", "k", "up"):
+        if key in ("j", "down", "ArrowDown", "k", "up", "ArrowUp"):
             self._item_list.handle_key(key)
             self.selected = self._item_list.selected_idx
             self._cache_preview()

--- a/examples/csv_viewer/csv_viewer.py
+++ b/examples/csv_viewer/csv_viewer.py
@@ -54,7 +54,7 @@ class CsvViewer(App):
         if "rows" in payload:
             self._rows = [list(r) for r in payload["rows"]]
         if "selected" in payload:
-            self._selected = int(payload["selected"])
+            self._selected = max(0, min(len(self._files) - 1, int(payload["selected"]))) if self._files else 0
             self._file_list.selected_idx = self._selected
 
     def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:

--- a/examples/csv_viewer/csv_viewer.py
+++ b/examples/csv_viewer/csv_viewer.py
@@ -10,10 +10,10 @@ from plexi_sdk import (  # type: ignore[attr-defined]
     FG, MUTED, ACCENT, BG,
     BODY, CAPTION,
 )
+from plexi_sdk.ui import SelectList  # type: ignore[attr-defined]
 
 PAD = 16.0
 ROW_H = 24.0
-LIST_ITEM_H = 36.0
 COL_W = 130.0
 CELL_PAD = 8.0
 STRIPE = "#0d0d0d"
@@ -41,6 +41,9 @@ class CsvViewer(App):
                 self._file_hints[p] = f"{kb:.1f} KB" if kb < 1024 else f"{kb / 1024:.1f} MB"
             except OSError:
                 self._file_hints[p] = ""
+        self._file_list = SelectList(
+            [{"name": p.name, "description": self._file_hints.get(p) or None} for p in self._files]
+        )
         ctx.info(f"csv_viewer: {len(self._files)} CSV files in {launch_dir}")
 
     def on_inject(self, _ctx: RenderContext, payload: dict) -> None:
@@ -52,14 +55,13 @@ class CsvViewer(App):
             self._rows = [list(r) for r in payload["rows"]]
         if "selected" in payload:
             self._selected = int(payload["selected"])
+            self._file_list.selected_idx = self._selected
 
     def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._mode == "list":
-            if key in ("up", "k"):
-                self._selected = max(0, self._selected - 1)
-            elif key in ("down", "j"):
-                if self._files:
-                    self._selected = min(len(self._files) - 1, self._selected + 1)
+            if key in ("up", "k", "down", "j"):
+                self._file_list.handle_key(key)
+                self._selected = self._file_list.selected_idx
             elif key == "Enter":
                 if self._files:
                     self._load_csv(self._files[self._selected])
@@ -118,14 +120,10 @@ class CsvViewer(App):
 
         label = f"{len(self._files)} CSV file{'s' if len(self._files) != 1 else ''}"
         ctx.text(PAD, y, label, size=BODY, color=FG)
-        y += ROW_H + 4
+        y += 28.0
 
-        items = [
-            {"label": p.name, "secondary": self._file_hints.get(p, "") or None}
-            for p in self._files
-        ]
-        ctx.list_view(items, selected=self._selected, item_height=LIST_ITEM_H,
-                      x=0, y=y, w=w, h=h - y - 30)
+        self._file_list.selected_idx = self._selected
+        self._file_list.render(ctx, 0, y, w, h - y - 30)
 
         ctx.text(PAD, h - 20, "↑↓ / jk  navigate   ↵  open   esc  exit", size=CAPTION, color=MUTED)
 

--- a/examples/csv_viewer/csv_viewer.py
+++ b/examples/csv_viewer/csv_viewer.py
@@ -59,15 +59,15 @@ class CsvViewer(App):
 
     def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._mode == "list":
-            if key in ("up", "k", "ArrowUp", "down", "j", "ArrowDown"):
+            if key in ("up", "k", "down", "j"):
                 self._file_list.handle_key(key)
                 self._selected = self._file_list.selected_idx
-            elif key == "Enter":
+            elif key == "return":
                 if self._files:
                     self._load_csv(self._files[self._selected])
                     self._mode = "detail"
                     ctx.info(f"csv_viewer: opened {self._files[self._selected].name}")
-            elif key == "Escape":
+            elif key == "escape":
                 ctx.info("csv_viewer: exit via Escape")
                 sys.exit(0)
         else:
@@ -80,7 +80,7 @@ class CsvViewer(App):
             elif key in ("right", "l"):
                 max_h = max(0, len(self._headers) - 1)
                 self._h_scroll = min(max_h, self._h_scroll + 1)
-            elif key == "Escape":
+            elif key == "escape":
                 self._mode = "list"
                 ctx.info("csv_viewer: back to list")
 

--- a/examples/csv_viewer/csv_viewer.py
+++ b/examples/csv_viewer/csv_viewer.py
@@ -10,7 +10,7 @@ from plexi_sdk import (  # type: ignore[attr-defined]
     FG, MUTED, ACCENT, BG,
     BODY, CAPTION,
 )
-from plexi_sdk.ui import SelectList  # type: ignore[attr-defined]
+from plexi_sdk.ui import SelectList
 
 PAD = 16.0
 ROW_H = 24.0
@@ -59,7 +59,7 @@ class CsvViewer(App):
 
     def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._mode == "list":
-            if key in ("up", "k", "down", "j"):
+            if key in ("up", "k", "ArrowUp", "down", "j", "ArrowDown"):
                 self._file_list.handle_key(key)
                 self._selected = self._file_list.selected_idx
             elif key == "Enter":

--- a/examples/mcp-demo/mcp_demo.py
+++ b/examples/mcp-demo/mcp_demo.py
@@ -11,17 +11,16 @@ Connect Claude Desktop by adding to claude_desktop_config.json:
 """
 
 import os
-from plexi_sdk import App, RenderContext, BG, FG, SURFACE, ACCENT, MUTED, HEADING, BODY, CAPTION, HINT, PAD, HEADER_H
-
-BTN_H = 44.0
-FIELD_H = 36.0
-ROW_H = BTN_H + 8.0
+from plexi_sdk import App, RenderContext, BG, FG, SURFACE, ACCENT, MUTED, HEADING, CAPTION, HINT, PAD, HEADER_H
+from plexi_sdk.ui import SelectList, FormField
 
 
 class McpDemoApp(App):
     def on_init(self, ctx: RenderContext) -> None:
         self._notes: list[str] = []
         self._mcp_port: str = os.environ.get("PLEXI_MCP_PORT", "not set")
+        self._note_list = SelectList([])
+        self._note_form = FormField(id="draft", label="New note", placeholder="Type a note…  (Enter to add)", required=True)
         self.emit.info(f"mcp-demo: started, PLEXI_MCP_PORT={self._mcp_port}")
         ctx.status_summary(f"MCP Demo  ·  port {self._mcp_port}")
 
@@ -46,30 +45,18 @@ class McpDemoApp(App):
         return y + 56 + 12
 
     def _render_input(self, ctx: RenderContext, y: float) -> float:
-        btn_w = ctx.w - PAD*2
-        ctx.text(x=PAD, y=y, text="New note *", size=HINT, color=MUTED)
-        y += 18
-        submitted = ctx.text_input(id="draft", x=PAD, y=y, w=btn_w, placeholder="Type a note…")
-        if submitted is not None:
-            self._add_note(submitted)
-        y += FIELD_H + 8
-        ctx.rect(PAD, y, btn_w, BTN_H, ACCENT, radius=6.0)
-        ctx.text(x=PAD + btn_w/2, y=y+BTN_H/2, text="Add Note", size=BODY, color=BG, bold=True, align="center")
-        return y + BTN_H + 16
+        field_h = self._note_form.measure(ctx.w - PAD * 2)
+        self._note_form.render(ctx, PAD, y, ctx.w - PAD * 2, field_h)
+        if self._note_form.submitted is not None:
+            self._add_note(self._note_form.submitted)
+        return y + field_h
 
     def _render_notes(self, ctx: RenderContext, y0: float) -> None:
-        btn_w = ctx.w - PAD*2
+        self._note_list.items = [{"name": note} for note in reversed(self._notes)]
         if not self._notes:
             ctx.text(x=ctx.w/2, y=y0+40, text="No notes yet", size=CAPTION, color=MUTED, align="center")
             return
-        y = y0
-        for note in reversed(self._notes):
-            ctx.rect(PAD, y, btn_w, BTN_H, SURFACE, radius=6.0)
-            ctx.text(x=PAD+12, y=y+BTN_H/2, text=note, size=BODY, color=FG, align="left_center",
-                     max_width=btn_w-24, elide=True)
-            y += ROW_H
-            if y > ctx.h:
-                break
+        self._note_list.render(ctx, PAD, y0, ctx.w - PAD * 2, ctx.h - y0)
 
     def _add_note(self, text: str) -> None:
         text = text.strip()

--- a/examples/mcp-demo/mcp_demo.py
+++ b/examples/mcp-demo/mcp_demo.py
@@ -51,6 +51,9 @@ class McpDemoApp(App):
             self._add_note(self._note_form.submitted)
         return y + field_h
 
+    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+        self._note_list.handle_key(key)
+
     def _render_notes(self, ctx: RenderContext, y0: float) -> None:
         self._note_list.items = [{"name": note} for note in reversed(self._notes)]
         if not self._notes:


### PR DESCRIPTION
Closes #1070

Migrates three example apps from manual `ROW_H`/`BTN_H`/`FIELD_H` layout constants to `plexi_sdk.ui` components.

## Changes

**mcp-demo** — `FormField` for note input, `SelectList` for notes list.
- Removes `BTN_H = 44.0`, `FIELD_H = 36.0`, `ROW_H = BTN_H + 8.0`
- Removes the non-functional "Add Note" button (Enter already submitted via `ctx.text_input`; `FormField` makes this explicit)
- Notes list rendered via `SelectList` with scroll + selection

**backlog** — `SelectList` for the item list pane.
- Removes `ROW_H = 22.0` and the 14-line manual draw loop (visible_start calculation, per-row rect + text)
- Navigation delegates to `SelectList.handle_key()` instead of manual `min/max` bounds

**csv_viewer** — `SelectList` replaces `ctx.list_view()` for the file list.
- Removes `LIST_ITEM_H = 36.0`
- `ROW_H = 24.0` remains — it's used only in the table detail view (custom drawing, out of scope per issue notes)

## Out of scope

The remaining apps from the issue checklist are skipped:
- **storyboard** — horizontal card strip with no vertical list/form pattern
- **screen-time** — already imports from `plexi_sdk.ui` (Column, AppBar, etc.)
- **github-tree** — ROW_H is for git graph lane rendering (custom visualization)
- **calc** — BTN_H/BTN_W for calculator button grid (no text form input)
- **input-inspector** — display-only event log with per-row category color styling
- **logs** — already uses plexi_sdk.ui design tokens; complex multi-column log rows

## Breaks if

mcp-demo: notes list no longer scrolls or renders items after adding notes.
backlog: j/k navigation stops working or selection indicator disappears from list pane.
csv_viewer: file list no longer renders or Enter no longer opens selected file.