### PR TITLE
feat(sdk): add on_text_submitted hook (#1067)

### DIFF
--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -12,6 +12,7 @@ Form view:   host-managed text_input per field; first field auto-focused;
 Result view: Shows tool call output inline. Escape or Back returns to list.
 """
 
+import asyncio
 import json
 import os
 import select
@@ -142,7 +143,7 @@ class McpRendererApp(App):
         self._form_fields: list[FormField] = []
         # Result state
         self._result_lines: list[str] = []
-        self._calling: bool = False
+        self._calling: bool = False  # UI-only flag: True while tool call is in-flight
         # Hit regions for form/result views: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
         # UI components
@@ -185,7 +186,8 @@ class McpRendererApp(App):
         self._tools_ready.set()
         self.emit.schedule_render(after_ms=16)
 
-    def _call_tool_bg(self, name: str, arguments: dict) -> None:
+    def _do_call_tool(self, name: str, arguments: dict) -> list[str]:
+        """Blocking MCP call — runs via asyncio.to_thread. Returns result lines."""
         assert self._client is not None
         try:
             content = self._client.call_tool(name, arguments)
@@ -198,16 +200,11 @@ class McpRendererApp(App):
                     lines.append("[Image — open in terminal to view]")
                 else:
                     lines.append(json.dumps(item))
-            self._result_lines = lines
             self.emit.info(f"mcp-renderer: tool {name!r} returned {len(lines)} lines")
+            return lines
         except Exception as e:
-            self._result_lines = [f"Error: {e}"]
             self.emit.warn(f"mcp-renderer: tool call failed: {e}")
-        finally:
-            self._calling = False
-            self._view = "result"
-            self._result_scrollable.scroll_offset = 0.0
-        self.emit.schedule_render(after_ms=16)
+            return [f"Error: {e}"]
 
     # ── Render ────────────────────────────────────────────────────────────────
 
@@ -296,13 +293,8 @@ class McpRendererApp(App):
             run.render(ctx, 0, y, ctx.w, run_h)
             self._hits.append((y, y + run_h, "run"))
         else:
-            # Process submitted values from form fields
+            # Render form fields; submissions are handled in on_text_submitted
             for ff in self._form_fields:
-                sub = ff.submitted
-                if sub is not None:
-                    self._field_values[ff.id] = sub
-                    if ff.id == self._form_fields[-1].id:
-                        self._run_tool()
                 fh = ff.measure(ctx.w - 2 * SPACE_LG)
                 ff.render(ctx, SPACE_LG, y, ctx.w - 2 * SPACE_LG, fh)
                 y += fh
@@ -317,9 +309,21 @@ class McpRendererApp(App):
                 run.render(ctx, 0, y, ctx.w, run_h)
                 self._hits.append((y, y + run_h, "run"))
 
-    # ── Interaction ───────────────────────────────────────────────────────────
+    # ── Event handlers ────────────────────────────────────────────────────────
 
-    def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
+    async def on_text_submitted(self, ctx: RenderContext, id: str, text: str) -> None:
+        """Handle TextInput submissions — field values and tool dispatch live here."""
+        if self._view != "form":
+            return
+        self._field_values[id] = text
+        self.emit.info(f"mcp-renderer: field {id!r} submitted: {text!r}")
+        # If this was the last field, run the tool automatically
+        if self._form_fields and id == self._form_fields[-1].id:
+            await self._run_tool()
+        else:
+            self.emit.schedule_render(after_ms=16)
+
+    async def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
         if button != "primary":
             return
         # List view: use ListView hit detection
@@ -328,17 +332,17 @@ class McpRendererApp(App):
             if idx is not None:
                 self._list.set_selected(idx)
                 self._selected_idx = idx
-                self._handle(idx)
+                await self._handle(idx)
                 self.emit.schedule_render(after_ms=16)
             return
         # Form/result views: use _hits
         for (y_top, y_bot, tag) in self._hits:
             if y_top <= y < y_bot:
-                self._handle(tag)
+                await self._handle(tag)
                 self.emit.schedule_render(after_ms=16)
                 return
 
-    def _handle(self, tag: object) -> None:
+    async def _handle(self, tag: object) -> None:
         if tag == "back":
             if self._view in ("form", "result"):
                 self._view = "list"
@@ -347,7 +351,7 @@ class McpRendererApp(App):
             return
 
         if tag == "run":
-            self._run_tool()
+            await self._run_tool()
             return
 
         if isinstance(tag, int) and self._view == "list":
@@ -377,15 +381,14 @@ class McpRendererApp(App):
             ))
         self._view = "form"
 
-    def _run_tool(self) -> None:
-        if self._calling or self._client is None:
+    async def _run_tool(self) -> None:
+        if self._client is None:
             return
         self._calling = True
         arguments: dict = {}
         for field in self._fields:
             val = self._field_values.get(field["name"], "").strip()
             if val:
-                # Coerce to int/float if schema says so
                 ftype = field.get("type", "string")
                 if ftype == "integer":
                     try:
@@ -403,11 +406,13 @@ class McpRendererApp(App):
                     arguments[field["name"]] = val
         tool_name = self._active_tool.get("name", "")
         self.emit.info(f"mcp-renderer: calling tool {tool_name!r} with {arguments!r}")
-        threading.Thread(
-            target=self._call_tool_bg,
-            args=(tool_name, arguments),
-            daemon=True,
-        ).start()
+        self.emit.schedule_render(after_ms=16)  # show "Calling…" state
+        result_lines = await asyncio.to_thread(self._do_call_tool, tool_name, arguments)
+        self._calling = False
+        self._result_lines = result_lines
+        self._view = "result"
+        self._result_scrollable.scroll_offset = 0.0
+        self.emit.schedule_render(after_ms=16)
 
     def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
@@ -415,7 +420,9 @@ class McpRendererApp(App):
                 self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
             elif key in ("Return", "Enter"):
-                self._handle(self._list.selected_index)
+                idx = self._list.selected_index
+                if 0 <= idx < len(self._tools):
+                    self._enter_form(self._tools[idx])
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -143,7 +143,7 @@ class McpRendererApp(App):
         self._form_fields: list[FormField] = []
         # Result state
         self._result_lines: list[str] = []
-        self._calling: bool = False  # UI-only flag: True while tool call is in-flight
+        self._calling: bool = False  # True while tool call is in-flight; guards against concurrent calls
         # Hit regions for form/result views: (y_top, y_bot, tag)
         self._hits: list[tuple[float, float, object]] = []
         # UI components
@@ -382,7 +382,7 @@ class McpRendererApp(App):
         self._view = "form"
 
     async def _run_tool(self) -> None:
-        if self._client is None:
+        if self._calling or self._client is None:
             return
         self._calling = True
         arguments: dict = {}

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -60,6 +60,7 @@ class App:
         on_click(self, ctx, x, y, button)             — on Click event (task)
         on_command(self, ctx, text)                   — on Command event (task)
         on_paste(self, ctx, text)                     — on Paste event (task)
+        on_text_submitted(self, ctx, id, text)        — on TextInput Enter press (task)
         on_pipe_message(self, ctx, pipe_id, payload)  — on PipeMessage (task)
         on_path_changed(self, ctx, cwd)               — on PathChanged (task)
         on_suspend(self)                              — on Suspend (awaited)
@@ -188,6 +189,7 @@ class App:
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
+    def on_text_submitted(self, _ctx: RenderContext, _id: str, _text: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_file_picked(self, _ctx: RenderContext, _request_id: str, _paths: "list[str]") -> "Coroutine[Any, Any, None] | None":
         """Called when the user selected one or more files in the picker.
 
@@ -590,9 +592,17 @@ class App:
                     # `DrawCommand::TextInput` field. Stash the value keyed
                     # on the input id; `RenderContext.text_input(...)` will
                     # drain it on the next frame the app polls.
+                    # Also dispatch on_text_submitted as a hook task if the
+                    # app has overridden it — apps that use the event-handler
+                    # path can do I/O cleanly without side effects in on_render.
                     tid = ev.get("id", "")
                     if tid:
-                        self._text_submissions[tid] = ev.get("value", "")
+                        value = ev.get("value", "")
+                        self._text_submissions[tid] = value
+                        if type(self).on_text_submitted is not App.on_text_submitted:
+                            self._dispatch_hook_task(
+                                self.on_text_submitted, self._make_ctx(), tid, value
+                            )
 
                 elif t == "run_update":
                     pass  # apps can override on_run_update if needed

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -413,6 +413,10 @@ class AppHarness:
         """Inject a synthetic key event."""
         self._send({"type": "key", "key": key, "modifiers": modifiers or {}})
 
+    def text_submit(self, id: str, value: str) -> None:
+        """Inject a synthetic text_submitted event (user pressed Enter in a TextInput)."""
+        self._send({"type": "text_submitted", "id": id, "value": value})
+
     def screenshot(self) -> bytes:
         """Render current draw commands to PNG. Requires the plexi binary."""
         return render_draw_commands(self._draw_commands, self._width, self._height)

--- a/sdk/python/tests/test_on_text_submitted.py
+++ b/sdk/python/tests/test_on_text_submitted.py
@@ -1,0 +1,129 @@
+"""Tests for on_text_submitted hook (issue #1067).
+
+Verifies that:
+  - on_text_submitted fires when a text_submitted event arrives
+  - it does NOT fire during on_render (no side effect coupling)
+  - backward compat: _take_text_submission still works for apps that poll during render
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from plexi_sdk.testing import AppHarness
+
+# App that overrides on_text_submitted and tracks calls.
+# Exposes call count via draw commands so tests can assert from outside.
+_HOOK_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+
+    class HookApp(App):
+        def on_init(self, ctx: RenderContext) -> None:
+            self._hook_calls: list[tuple[str, str]] = []
+            self._render_count = 0
+
+        def on_render(self, ctx: RenderContext) -> None:
+            self._render_count += 1
+            # Render a TextInput — do NOT act on return value (migrated pattern)
+            ctx.text_input("field1", x=10, y=10, w=200, placeholder="enter text")
+            count = len(self._hook_calls)
+            ctx.text(10, 50, f"hook_calls={count}", size=14, color="#ffffff")
+            ctx.text(10, 70, f"renders={self._render_count}", size=14, color="#ffffff")
+
+        async def on_text_submitted(self, ctx: RenderContext, id: str, text: str) -> None:
+            self._hook_calls.append((id, text))
+
+    HookApp().run()
+""").lstrip()
+
+# App that does NOT override on_text_submitted — backward compat path via on_render polling.
+_COMPAT_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+
+    class CompatApp(App):
+        def on_init(self, ctx: RenderContext) -> None:
+            self._last_submitted: str | None = None
+
+        def on_render(self, ctx: RenderContext) -> None:
+            submitted = ctx.text_input("field1", x=10, y=10, w=200, placeholder="enter text")
+            if submitted is not None:
+                self._last_submitted = submitted
+            value = self._last_submitted or "none"
+            ctx.text(10, 50, f"last={value}", size=14, color="#ffffff")
+
+    CompatApp().run()
+""").lstrip()
+
+
+@pytest.fixture
+def hook_app(tmp_path: Path) -> Path:
+    p = tmp_path / "hook_app.py"
+    p.write_text(_HOOK_APP)
+    return p
+
+
+@pytest.fixture
+def compat_app(tmp_path: Path) -> Path:
+    p = tmp_path / "compat_app.py"
+    p.write_text(_COMPAT_APP)
+    return p
+
+
+def _text_values(cmds: list[dict]) -> list[str]:
+    return [c.get("text", "") for c in cmds if c.get("type") == "text"]
+
+
+def test_on_text_submitted_fires_on_event(hook_app: Path) -> None:
+    """on_text_submitted is called once when a text_submitted event arrives."""
+    with AppHarness(hook_app) as h:
+        h.run(1)  # initial render — hook not called yet
+        h.text_submit("field1", "hello")
+        h.run(1)  # event loop dispatches the hook task here
+        cmds = h.run(1)  # draw commands now reflect the hook call
+
+    texts = _text_values(cmds)
+    assert any("hook_calls=1" in t for t in texts), (
+        f"Expected hook_calls=1 in draw commands after text_submit, got: {texts}"
+    )
+
+
+def test_on_text_submitted_not_triggered_by_render(hook_app: Path) -> None:
+    """Rendering without a text_submitted event does not call on_text_submitted."""
+    with AppHarness(hook_app) as h:
+        cmds = h.run(3)  # three render frames, no text_submitted sent
+
+    texts = _text_values(cmds)
+    assert any("hook_calls=0" in t for t in texts), (
+        f"Expected hook_calls=0 after renders with no submission, got: {texts}"
+    )
+    assert any("renders=3" in t for t in texts), (
+        f"Expected renders=3 in draw commands, got: {texts}"
+    )
+
+
+def test_on_text_submitted_receives_id_and_text(hook_app: Path) -> None:
+    """on_text_submitted hook fires with the correct id and text."""
+    with AppHarness(hook_app) as h:
+        h.run(1)
+        h.text_submit("field1", "world")
+        h.run(1)
+        cmds = h.run(1)
+
+    texts = _text_values(cmds)
+    assert any("hook_calls=1" in t for t in texts), (
+        f"Expected hook_calls=1 in draw commands, got: {texts}"
+    )
+
+
+def test_backward_compat_render_polling(compat_app: Path) -> None:
+    """Apps that haven't adopted on_text_submitted still receive submissions via ctx.text_input()."""
+    with AppHarness(compat_app) as h:
+        h.run(1)
+        h.text_submit("field1", "compat-value")
+        cmds = h.run(1)
+
+    texts = _text_values(cmds)
+    assert any("last=compat-value" in t for t in texts), (
+        f"Expected 'last=compat-value' in draw commands for compat polling path, got: {texts}"
+    )


### PR DESCRIPTION
## Summary

- Adds `on_text_submitted(self, ctx, id, text)` hook to `App` base class, dispatched as an async hook task when the user presses Enter in a TextInput
- Backward compat: `_take_text_submission()` / `ctx.text_input()` return-value path still works for apps that haven't migrated
- Migrates `mcp_renderer.py` — removes `_calling` guard, `_call_tool_bg` thread, and form-field submission polling from `on_render`; adds `on_text_submitted` handler + async `_run_tool` via `asyncio.to_thread`
- Adds `AppHarness.text_submit(id, value)` for headless testing
- 4 new tests covering: hook fires on event, hook not triggered by render, backward compat polling path

## Test plan

- [x] `uv run --project sdk/python pytest sdk/python/tests/` — 40/40 pass
- [ ] Open mcp-renderer on alpha build, enter a form field and press Enter — tool should call (view transitions to result without needing the "▶ Call Tool" button)

Closes #1067