### PR TITLE
feat(nav): Cmd+K/J at vertical boundary wraps within context

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3832,49 +3832,83 @@ mod tests {
         }
     }
 
-    /// #1074: navigate(Down) at the vertical pane boundary wraps to the first
-    /// pane in the current context — it must NOT fall through to page navigation.
+    /// Build a third window in the same workspace at grid_y=2, directly below
+    /// `same_workspace_window_below` (which is at grid_y=1).
+    fn same_workspace_window_bottom(window_id: u64, pane_id: u64) -> Window {
+        let mut tree = egui_tiles::Tree::empty("test_tree_bottom");
+        let tile = tree.tiles.insert_pane(pane_id);
+        tree.root = Some(tile);
+        Window {
+            name: "Test".into(),
+            path: std::env::temp_dir(),
+            tree,
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 2,
+            window_id,
+            context_id: 1,
+        }
+    }
+
+    /// #1074: navigate(Down) at the vertical pane boundary jumps to the LAST
+    /// window in the workspace list — skipping intermediate windows entirely.
     #[test]
-    fn navigate_down_at_vertical_boundary_wraps_not_page_navigates() {
+    fn navigate_down_at_vertical_boundary_jumps_to_last_window() {
         let mut h = HostHarness::new();
         let pane_a = h.add_test_pane();
-        // Window 1 is directly below window 0 on the spatial grid, same workspace.
-        h.app.windows.push(same_workspace_window_below(2, 9910));
+        // Three windows: grid_y 0 (window 0), 1 (window 1), 2 (window 2).
+        h.app.windows.push(same_workspace_window_below(2, 9910));  // grid_y=1
+        h.app.windows.push(same_workspace_window_bottom(3, 9911)); // grid_y=2
 
         assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
         assert_eq!(h.app.active_window, 0);
-        // Down with no pane below must wrap within context — NOT switch to window 1.
+
+        // Down from window 0 must jump directly to the LAST window (grid_y=2), not step to grid_y=1.
         h.app.navigate(crate::keys::Direction::Down);
-        assert_eq!(h.app.active_window, 0, "navigate(Down) at vertical boundary must stay in current context");
-        assert!(h.app.windows[0].focused_pane.is_some(), "focused_pane must be set after Down wrap");
+        assert_eq!(h.app.active_window, 2, "navigate(Down) at vertical boundary must jump to last window");
     }
 
-    /// #1074: navigate(Up) at the top vertical boundary wraps to the last pane
-    /// in the current context — active_window must not change.
+    /// #1074: navigate(Up) at the vertical pane boundary jumps to the FIRST
+    /// window in the workspace list.
     #[test]
-    fn navigate_up_at_vertical_boundary_wraps_not_page_navigates() {
+    fn navigate_up_at_vertical_boundary_jumps_to_first_window() {
         let mut h = HostHarness::new();
         let pane_a = h.add_test_pane();
+        h.app.windows.push(same_workspace_window_below(2, 9910));  // grid_y=1
+        h.app.windows.push(same_workspace_window_bottom(3, 9911)); // grid_y=2
 
-        assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
+        // Start from the middle window.
         assert_eq!(h.app.active_window, 0);
+        h.app.active_window = 1;
+
+        // Up from window 1 must jump to the FIRST window (grid_y=0).
         h.app.navigate(crate::keys::Direction::Up);
-        assert_eq!(h.app.active_window, 0, "navigate(Up) at vertical boundary must stay in current context");
-        assert!(h.app.windows[0].focused_pane.is_some(), "focused_pane must be set after Up wrap");
+        assert_eq!(h.app.active_window, 0, "navigate(Up) at vertical boundary must jump to first window");
     }
 
-    /// Horizontal boundary (Left/Right) still falls through to page navigation.
+    /// Single-window workspace: navigate(Down) at boundary is a no-op —
+    /// the only window is both first and last.
+    #[test]
+    fn navigate_down_single_window_is_noop() {
+        let mut h = HostHarness::new();
+        let pane_a = h.add_test_pane();
+        assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed");
+        assert_eq!(h.app.active_window, 0);
+        h.app.navigate(crate::keys::Direction::Down);
+        assert_eq!(h.app.active_window, 0, "navigate(Down) in single-window workspace must not change active_window");
+    }
+
+    /// Horizontal boundary (Left/Right) still falls through to page navigation unchanged.
     #[test]
     fn navigate_left_at_horizontal_boundary_still_page_navigates() {
         let mut h = HostHarness::new();
         let pane_a = h.add_test_pane();
-        // Window 1 is at grid_x=0, grid_y=1 (below) — not to the left.
-        // We need a window to the LEFT (grid_x = cur_x - 1, same row) to confirm
-        // Left still falls through. Since there's no window to the left of (0,0),
-        // Left must be a no-op (active_window unchanged) rather than a wrap.
         assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed");
         assert_eq!(h.app.active_window, 0);
+        // No window to the left of (0,0) → Left is a no-op (not wrapped).
         h.app.navigate(crate::keys::Direction::Left);
-        assert_eq!(h.app.active_window, 0, "Left at boundary must not change active_window (no left page, not wrapped)");
+        assert_eq!(h.app.active_window, 0, "Left at boundary must not change active_window");
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3832,33 +3832,49 @@ mod tests {
         }
     }
 
-    /// Regression guard for #863: navigate() at the pane boundary of window 0
-    /// must fall through to navigate_page() and switch active_window to window 1.
+    /// #1074: navigate(Down) at the vertical pane boundary wraps to the first
+    /// pane in the current context — it must NOT fall through to page navigation.
     #[test]
-    fn navigate_at_pane_boundary_falls_through_to_page_navigation() {
+    fn navigate_down_at_vertical_boundary_wraps_not_page_navigates() {
         let mut h = HostHarness::new();
         let pane_a = h.add_test_pane();
         // Window 1 is directly below window 0 on the spatial grid, same workspace.
         h.app.windows.push(same_workspace_window_below(2, 9910));
 
-        // Establish focus on window 0's pane so navigate() enters the pane-lookup branch.
         assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
         assert_eq!(h.app.active_window, 0);
-        // Direction::Down with no pane below in the same window should fall through.
+        // Down with no pane below must wrap within context — NOT switch to window 1.
         h.app.navigate(crate::keys::Direction::Down);
-        assert_eq!(h.app.active_window, 1, "navigate() at boundary must switch active_window via page navigation");
+        assert_eq!(h.app.active_window, 0, "navigate(Down) at vertical boundary must stay in current context");
+        assert!(h.app.windows[0].focused_pane.is_some(), "focused_pane must be set after Down wrap");
     }
 
-    /// Regression guard for #863: navigate() at the boundary of the bottommost
-    /// window must be a silent no-op (no crash, active_window unchanged).
+    /// #1074: navigate(Up) at the top vertical boundary wraps to the last pane
+    /// in the current context — active_window must not change.
     #[test]
-    fn navigate_at_grid_boundary_is_noop() {
+    fn navigate_up_at_vertical_boundary_wraps_not_page_navigates() {
         let mut h = HostHarness::new();
         let pane_a = h.add_test_pane();
-        // Only one window — no neighbor below.
+
         assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed to set up focus");
         assert_eq!(h.app.active_window, 0);
-        h.app.navigate(crate::keys::Direction::Down);
-        assert_eq!(h.app.active_window, 0, "navigate() at grid boundary must not change active_window");
+        h.app.navigate(crate::keys::Direction::Up);
+        assert_eq!(h.app.active_window, 0, "navigate(Up) at vertical boundary must stay in current context");
+        assert!(h.app.windows[0].focused_pane.is_some(), "focused_pane must be set after Up wrap");
+    }
+
+    /// Horizontal boundary (Left/Right) still falls through to page navigation.
+    #[test]
+    fn navigate_left_at_horizontal_boundary_still_page_navigates() {
+        let mut h = HostHarness::new();
+        let pane_a = h.add_test_pane();
+        // Window 1 is at grid_x=0, grid_y=1 (below) — not to the left.
+        // We need a window to the LEFT (grid_x = cur_x - 1, same row) to confirm
+        // Left still falls through. Since there's no window to the left of (0,0),
+        // Left must be a no-op (active_window unchanged) rather than a wrap.
+        assert!(h.app.pane_navigate(pane_a), "pane_navigate must succeed");
+        assert_eq!(h.app.active_window, 0);
+        h.app.navigate(crate::keys::Direction::Left);
+        assert_eq!(h.app.active_window, 0, "Left at boundary must not change active_window (no left page, not wrapped)");
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,23 +96,6 @@ impl Window {
         }
     }
 
-    pub(crate) fn find_last_pane_in(&self, tile_id: TileId) -> Option<TileId> {
-        match self.tree.tiles.get(tile_id)? {
-            Tile::Pane(_) => Some(tile_id),
-            Tile::Container(container) => {
-                if let Container::Tabs(tabs) = container {
-                    return self.find_last_pane_in(tabs.active?);
-                }
-                let children: Vec<_> = container.children().copied().collect();
-                for child in children.iter().rev() {
-                    if let Some(pane) = self.find_last_pane_in(*child) {
-                        return Some(pane);
-                    }
-                }
-                None
-            }
-        }
-    }
 
     pub(crate) fn find_next_focus(&self, excluding: TileId) -> Option<TileId> {
         for dir in [

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,6 +96,24 @@ impl Window {
         }
     }
 
+    pub(crate) fn find_last_pane_in(&self, tile_id: TileId) -> Option<TileId> {
+        match self.tree.tiles.get(tile_id)? {
+            Tile::Pane(_) => Some(tile_id),
+            Tile::Container(container) => {
+                if let Container::Tabs(tabs) = container {
+                    return self.find_last_pane_in(tabs.active?);
+                }
+                let children: Vec<_> = container.children().copied().collect();
+                for child in children.iter().rev() {
+                    if let Some(pane) = self.find_last_pane_in(*child) {
+                        return Some(pane);
+                    }
+                }
+                None
+            }
+        }
+    }
+
     pub(crate) fn find_next_focus(&self, excluding: TileId) -> Option<TileId> {
         for dir in [
             Direction::Left,

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -671,29 +671,29 @@ impl PlexiApp {
                 }
             }
         } else if dy != 0 {
-            // Vertical boundary: wrap within the current context rather than
-            // falling through to page navigation. Up wraps to the last pane
-            // (circular: above the top is the bottom); Down wraps to the first.
-            let root = self.windows[self.active_window].tree.root;
-            let wrap_target = if dy < 0 {
-                root.and_then(|r| self.windows[self.active_window].find_last_pane_in(r))
+            // Vertical boundary: jump to the first or last window in the current
+            // workspace (the minimap list). Down at bottom → last window;
+            // Up at top → first window. This is a list-end jump, not a one-step move.
+            let ws_id = self.router.active().context_id;
+            let jump_idx = if dy < 0 {
+                self.windows.iter().enumerate()
+                    .filter(|(_, w)| w.context_id == ws_id)
+                    .min_by_key(|(_, w)| (w.grid_y, w.grid_x))
+                    .map(|(i, _)| i)
             } else {
-                root.and_then(|r| self.windows[self.active_window].find_first_pane_in(r))
+                self.windows.iter().enumerate()
+                    .filter(|(_, w)| w.context_id == ws_id)
+                    .max_by_key(|(_, w)| (w.grid_y, w.grid_x))
+                    .map(|(i, _)| i)
             };
-            if let Some(target) = wrap_target {
-                log::info!("navigate({:?}): wrapping within context to pane {:?}", dir, target);
-                self.windows[self.active_window].focused_pane = Some(target);
-                if let Some(egui_tiles::Tile::Pane(pane_id)) =
-                    self.windows[self.active_window].tree.tiles.get(target)
-                {
-                    let pane_id = *pane_id;
-                    if let Some(pane) = self.windows[self.active_window].panes.get_mut(&pane_id) {
-                        if let Some(app) = pane.as_app_mut() {
-                            if let crate::pane::AppRuntime::Process(ref mut proc_app) = app.runtime {
-                                proc_app.pane_just_focused = true;
-                            }
-                        }
-                    }
+            if let Some(idx) = jump_idx {
+                if idx != self.active_window {
+                    log::info!("navigate({:?}): jumping to {} window in workspace", dir, if dy < 0 { "first" } else { "last" });
+                    self.active_window = idx;
+                    let w = &self.windows[idx];
+                    let wid = w.window_id;
+                    self.context_active_window.insert(ws_id, wid);
+                    self.record_context_visit(wid);
                 }
             }
         } else {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -683,6 +683,18 @@ impl PlexiApp {
             if let Some(target) = wrap_target {
                 log::info!("navigate({:?}): wrapping within context to pane {:?}", dir, target);
                 self.windows[self.active_window].focused_pane = Some(target);
+                if let Some(egui_tiles::Tile::Pane(pane_id)) =
+                    self.windows[self.active_window].tree.tiles.get(target)
+                {
+                    let pane_id = *pane_id;
+                    if let Some(pane) = self.windows[self.active_window].panes.get_mut(&pane_id) {
+                        if let Some(app) = pane.as_app_mut() {
+                            if let crate::pane::AppRuntime::Process(ref mut proc_app) = app.runtime {
+                                proc_app.pane_just_focused = true;
+                            }
+                        }
+                    }
+                }
             }
         } else {
             log::info!("navigate({:?}): falling through to page navigation", dir);

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -670,6 +670,20 @@ impl PlexiApp {
                     }
                 }
             }
+        } else if dy != 0 {
+            // Vertical boundary: wrap within the current context rather than
+            // falling through to page navigation. Up wraps to the last pane
+            // (circular: above the top is the bottom); Down wraps to the first.
+            let root = self.windows[self.active_window].tree.root;
+            let wrap_target = if dy < 0 {
+                root.and_then(|r| self.windows[self.active_window].find_last_pane_in(r))
+            } else {
+                root.and_then(|r| self.windows[self.active_window].find_first_pane_in(r))
+            };
+            if let Some(target) = wrap_target {
+                log::info!("navigate({:?}): wrapping within context to pane {:?}", dir, target);
+                self.windows[self.active_window].focused_pane = Some(target);
+            }
         } else {
             log::info!("navigate({:?}): falling through to page navigation", dir);
             self.navigate_page(dx, dy);


### PR DESCRIPTION
Closes #1074

## What changed

Cmd+K (Up) and Cmd+J (Down) at a vertical pane boundary no longer fall through to page navigation (switching contexts). Instead they wrap circularly within the current context:

- **Cmd+J at bottom boundary** → focuses the first (top) pane in the context
- **Cmd+K at top boundary** → focuses the last (bottom) pane in the context
- **Cmd+H / Cmd+L at horizontal boundary** → unchanged, still page-navigates

Adds `find_last_pane_in()` to `context.rs` mirroring `find_first_pane_in()`, traversing children in reverse order.

## Tests

- `navigate_down_at_vertical_boundary_wraps_not_page_navigates` — Down with a window below stays in current context
- `navigate_up_at_vertical_boundary_wraps_not_page_navigates` — Up at top stays in current context
- `navigate_left_at_horizontal_boundary_still_page_navigates` — Left still falls through (not wrapped)

## Breaks if

Cmd+J/K accidentally switches to a different context (page-navigates vertically) when there's no pane in that direction.