### PR TITLE
fix(app-renderer): add padding/inset to MCP and CLI app panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 # Changelog
 
 Newest releases appear first.
+## [3.5.132] — 2026-05-11
+
+### Changes
+- polish(examples): migrate mcp-demo, backlog, csv_viewer to SelectList/FormField (#1071)
+- feat(pane-ops): Cmd+Ctrl+H/L moves pane into adjacent window at boundary (#1078)
+- feat(nav): Cmd+K/J at vertical boundary wraps within context (#1077)
+- feat(sdk): restyle default app init screen (#1073)
+- feat(sdk): add on_text_submitted hook (#1067) (#1072)
+- fix(cli): app init splits origin pane, not focused pane (#1068)
+- feat(sdk): add ListView widget to plexi_sdk.widgets (#1069)
+- feat(apps): add keyboard-driven Kanban app
+- chore: update dev log
+- fix(examples/timer): add 15s duration + global notification scope (#1063)
+- polish(renderers): migrate mcp-renderer + descriptor-renderer to plexi_sdk.ui (#1061)
+- chore: restore session edits carried through merge
+- fix(sdk+timer): key aliases + timer ring rendering (#1060)
+- chore: commit alpha changes before branching
+- feat(examples): timer app with J/K duration and custom notifications (#1056)
+- fix(sdk): always re-seed SDK on launch; add AppBar subtitle support (#1054)
+- fix(mcp-renderer): augment PATH when spawning MCP server subprocess (#1053)
+- feat(examples): migrate csv_viewer file list to ctx.list_view() (#1052)
+- feat(cli): improve app init Python template with SDK primitives (#1049)
+- feat(examples): csv_viewer — browse and inspect CSVs in launch directory (#1046)
+- feat(cli): --mcp and --cli flags on plexi open (#1033, #1034) (#1048)
+- fix(deps): disable eframe accesskit feature to eliminate accesskit_consumer panic (#1039)
+- feat(cli): cli_help_parser — parse_help_to_descriptor (#1042)
+- example(mcp-renderer): add demo_server.py — local MCP server for renderer testing (#1044)
+- fix(mcp-renderer): use plexi open syntax in no-command error message (#1041)
+- chore: commit alpha changes before branching
+- feat(quick-note): destination picker UI stub (#1030)
+- fix(file-browser): verify Enter/l/→ open files via system opener (#138) (#1029)
+- feat(navigation): Cmd+HJKL falls through to window nav at pane boundary (#1017)
+- fix(keybindings): Cmd+R rename-pane and font-size bindings broken by exact-modifier guard (#1027)
+- feat(logging): date-based log rotation with configurable retention (#1028)
+- chore: update ship-issue skill
+- feat: app_states rename, pane key injection, file-browser no-repeat nav (#1026)
+- feat(notify): snooze choice — defer notification by N seconds (#1024)
+- feat(cli): inject PLEXI_CONTEXT_ID/NAME env vars + context current command (#1025)
+- fix(bundle): keyboard_capture for input-inspector + rename app_state dir (#907, #851) (#1023)
+- chore: auto-install after promoting to main
 ## [3.5.131] — 2026-05-11
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.5.131"
+version = "3.5.132"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.5.131"
+version = "3.5.132"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -349,21 +349,23 @@ class AppBar(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         ctx.rect(x, y, w, h, BG)
         band = self._band()
+        text_x = x + SPACE_MD
+        text_w = w - SPACE_MD
         if self.subtitle:
             block_h = self.TITLE_SIZE + SPACE_XS + self.SUBTITLE_SIZE
             title_y = y + (band - block_h) / 2.0
             sub_y = title_y + self.TITLE_SIZE + SPACE_XS
-            ctx.text(x, title_y, self.title,
+            ctx.text(text_x, title_y, self.title,
                      size=self.TITLE_SIZE, color=self.accent, bold=True,
-                     max_width=w, elide=True)
-            ctx.text(x, sub_y, self.subtitle,
+                     max_width=text_w, elide=True)
+            ctx.text(text_x, sub_y, self.subtitle,
                      size=self.SUBTITLE_SIZE, color=MUTED,
-                     max_width=w, elide=True)
+                     max_width=text_w, elide=True)
         else:
             text_y = y + (band - self.TITLE_SIZE) / 2.0
-            ctx.text(x, text_y, self.title,
+            ctx.text(text_x, text_y, self.title,
                      size=self.TITLE_SIZE, color=self.accent, bold=True,
-                     max_width=w, elide=True)
+                     max_width=text_w, elide=True)
         ctx.rect(x, y + band, w, self.DIVIDER_H, HIGHLIGHT)
 
 

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -1,5 +1,6 @@
 use crate::pane::{Pane, TerminalPane};
 use crate::render;
+use crate::style;
 use crate::theme::Colors;
 use egui::Color32;
 use egui_term::{BackendCommand, TerminalTheme};
@@ -92,15 +93,23 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         let Some(pane) = self.panes.get_mut(pane_id) else {
             return UiResponse::None;
         };
-        ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
-        let mut inner_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
-        let ui = &mut inner_ui;
 
         if let Some(app_pane) = pane.as_app_mut() {
-            render::app_pane::render(ui, app_pane, &self.colors, is_focused);
+            // App panes: fill with bg_darkest so the inset band doesn't show
+            // terminal_bg through the gap — bg_darkest is dark enough to be
+            // nearly invisible against the SDK's default BG token. Use SPACE_MD
+            // inset so content has consistent breathing room from the pane edge.
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
+            let mut app_ui = ui.new_child(
+                egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_MD)),
+            );
+            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused);
         } else if let Some(terminal) = pane.as_terminal_mut() {
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
+            let mut terminal_ui =
+                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
             let close_exited = render::terminal_pane::render(
-                ui,
+                &mut terminal_ui,
                 terminal,
                 tile_id,
                 pane_id,

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -107,7 +107,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui =
-                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
+                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_SM)));
             let close_exited = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,


### PR DESCRIPTION
Closes #1076

## What changed

**`src/tiling.rs`** — split app/terminal render paths:
- App panes: fill with `colors.bg_darkest` (not `terminal_bg`) + shrink by `SPACE_MD` (12px). The `terminal_bg` fill was creating a visible colour-mismatched border around process-app content since the SDK's default `BG` token is a different shade.
- Terminal panes: unchanged (8px shrink, `terminal_bg` fill).

**`sdk/python/plexi_sdk/ui.py`** — `AppBar.render()`:
- Title/subtitle text now indented by `SPACE_MD` from the left edge, aligning with `ListItem`'s internal `_PAD_H` padding. Previously text sat flush at `x=0` while list items indented by 12px, causing a noticeable misalignment.

## Test plan
- [ ] Open `plexi-pr-<N> open mcp-renderer` and verify the list view has visible inset/padding on all sides with no colour-band artifact
- [ ] Verify AppBar title text aligns with list item text indentation
- [ ] Open a terminal pane and confirm terminal rendering is unchanged
- [ ] Open any SDK app (`plexi-pr-<N> open timer`) and verify consistent inset