### PR TITLE
fix(sdk): hold button active_fill for 150ms after click (#1083)

### DIFF
--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -142,6 +142,9 @@ class App:
         self._mx: float = 0.0
         self._my: float = 0.0
         self._click_buf: list[tuple[float, float]] = []
+        # Hold timer for ctx.button() active_fill (#1083): maps button id →
+        # monotonic timestamp at which the active state expires.
+        self._btn_active_until: dict[str, float] = {}
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -43,8 +43,13 @@ class RenderContext:
         self._my: float = app._my
         self._clicks: list[tuple[float, float]] = clicks or []
         # Shared reference to App's hold-timer map — mutations here persist
-        # across frames (#1083).
+        # across frames (#1083). Prune expired entries each frame so the dict
+        # stays bounded for apps that generate transient button IDs.
         self._btn_active_until: dict[str, float] = app._btn_active_until
+        _now = time.monotonic()
+        expired = [bid for bid, exp in self._btn_active_until.items() if exp <= _now]
+        for bid in expired:
+            del self._btn_active_until[bid]
 
     def _queue(self, obj: dict) -> None:
         """Buffer a render command for batch flush at frame_done()."""

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import time
 from typing import TYPE_CHECKING, Any
 
 from ._constants import FG, BG, ACCENT, BODY
@@ -41,6 +42,9 @@ class RenderContext:
         self._mx: float = app._mx
         self._my: float = app._my
         self._clicks: list[tuple[float, float]] = clicks or []
+        # Shared reference to App's hold-timer map — mutations here persist
+        # across frames (#1083).
+        self._btn_active_until: dict[str, float] = app._btn_active_until
 
     def _queue(self, obj: dict) -> None:
         """Buffer a render command for batch flush at frame_done()."""
@@ -179,12 +183,16 @@ class RenderContext:
             (x <= cx <= x + w) and (y <= cy <= y + h)
             for cx, cy in self._clicks
         )
-        bg = active_fill if clicked else (hover_fill if hovered else fill)
+        now = time.monotonic()
+        if clicked:
+            self._btn_active_until[id] = now + 0.15
+            self.schedule_render(after_ms=150)
+            self.info(f"button clicked: id={id!r}")
+        active = now < self._btn_active_until.get(id, 0.0)
+        bg = active_fill if (clicked or active) else (hover_fill if hovered else fill)
         self.rect(x, y, w, h, fill=bg, radius=radius)
         self.text(x + w / 2, y + h / 2, label, size=font_size,
                   color=text_color, align="center")
-        if clicked:
-            self.info(f"button clicked: id={id!r}")
         return clicked
 
     def key_chip_row(self, x: float, y: float, keys: "list[str]",


### PR DESCRIPTION
## What

`ctx.button()` and `Button.render()` now hold the `active_fill` colour for 150ms after a click, giving users visible feedback that their click registered.

## Root Cause

`clicked` was derived from `_clicks` (click events buffered since the previous frame). Once a frame consumed the click, `_clicks` was empty on the next frame and `clicked = False`, reverting to `hover_fill` or `fill` after ~16ms.

## Fix

- `App._btn_active_until: dict[str, float]` — cross-frame map of button id → expiry timestamp (monotonic)
- `RenderContext._btn_active_until` — shared reference to the same dict; mutations in one frame persist to the next
- On click: record `time.monotonic() + 0.15` and call `schedule_render(after_ms=150)` to trigger a re-render at expiry even without mouse movement
- Fill logic: `active_fill` when `clicked or (now < _btn_active_until[id])`

## Breaks if

Clicking a button produces no colour change at all (regression: shared dict not wired) or the colour change reverts in under 100ms (regression: timer not set or schedule_render not called).