### PR TITLE
fix(notify): anchor normal notifications to top-right toast position

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -155,6 +155,18 @@ Before writing any code, read the issue and the relevant codebase to produce a t
 
 **When prior commits exist on the branch:** Before reading worktree files, grep the issue's key identifiers (field names, function names listed in "Files to change" or "Done when") directly on alpha (`src/` in the repo root). If a grep hit confirms an identifier already exists on alpha, that criterion is already implemented — skip reading its worktree file and focus Phase 3 only on what's genuinely missing. This avoids reading files that are identical to alpha and misreading branch-vs-alpha diffs.
 
+**Grep GOTCHAS.md and DEV_LOG.md for related pitfalls (required):**
+
+Extract 3–5 key terms from the issue title and Done-When criteria (e.g. the noun being changed, the subsystem, the SDK method). Run:
+```bash
+grep -in "<term1>\|<term2>\|<term3>" GOTCHAS.md DEV_LOG.md
+```
+Surface every match under a **Gotchas found:** heading in your context. Each match requires an explicit disposition before writing any code:
+- **NOTED** — constraint will be respected; call out how in the spec
+- **N/A** — explain in one clause why it doesn't apply
+
+If nothing matches, write "Gotchas found: none." and proceed. Do not skip this step.
+
 **Assess scope:** count the files that will likely change.
 
 **If the issue involves a third-party library or framework** (egui, egui_tiles, tokio, etc.) and the expected behavior isn't immediately obvious from the code: invoke the `coding-conventions` skill and read the relevant section before speculating on the approach. Unexpected API behavior not yet documented there is a signal to add it via `/improve` after the session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 # Changelog
 
 Newest releases appear first.
+## [3.5.132] — 2026-05-11
+
+### Changes
+- polish(examples): migrate mcp-demo, backlog, csv_viewer to SelectList/FormField (#1071)
+- feat(pane-ops): Cmd+Ctrl+H/L moves pane into adjacent window at boundary (#1078)
+- feat(nav): Cmd+K/J at vertical boundary wraps within context (#1077)
+- feat(sdk): restyle default app init screen (#1073)
+- feat(sdk): add on_text_submitted hook (#1067) (#1072)
+- fix(cli): app init splits origin pane, not focused pane (#1068)
+- feat(sdk): add ListView widget to plexi_sdk.widgets (#1069)
+- feat(apps): add keyboard-driven Kanban app
+- chore: update dev log
+- fix(examples/timer): add 15s duration + global notification scope (#1063)
+- polish(renderers): migrate mcp-renderer + descriptor-renderer to plexi_sdk.ui (#1061)
+- chore: restore session edits carried through merge
+- fix(sdk+timer): key aliases + timer ring rendering (#1060)
+- chore: commit alpha changes before branching
+- feat(examples): timer app with J/K duration and custom notifications (#1056)
+- fix(sdk): always re-seed SDK on launch; add AppBar subtitle support (#1054)
+- fix(mcp-renderer): augment PATH when spawning MCP server subprocess (#1053)
+- feat(examples): migrate csv_viewer file list to ctx.list_view() (#1052)
+- feat(cli): improve app init Python template with SDK primitives (#1049)
+- feat(examples): csv_viewer — browse and inspect CSVs in launch directory (#1046)
+- feat(cli): --mcp and --cli flags on plexi open (#1033, #1034) (#1048)
+- fix(deps): disable eframe accesskit feature to eliminate accesskit_consumer panic (#1039)
+- feat(cli): cli_help_parser — parse_help_to_descriptor (#1042)
+- example(mcp-renderer): add demo_server.py — local MCP server for renderer testing (#1044)
+- fix(mcp-renderer): use plexi open syntax in no-command error message (#1041)
+- chore: commit alpha changes before branching
+- feat(quick-note): destination picker UI stub (#1030)
+- fix(file-browser): verify Enter/l/→ open files via system opener (#138) (#1029)
+- feat(navigation): Cmd+HJKL falls through to window nav at pane boundary (#1017)
+- fix(keybindings): Cmd+R rename-pane and font-size bindings broken by exact-modifier guard (#1027)
+- feat(logging): date-based log rotation with configurable retention (#1028)
+- chore: update ship-issue skill
+- feat: app_states rename, pane key injection, file-browser no-repeat nav (#1026)
+- feat(notify): snooze choice — defer notification by N seconds (#1024)
+- feat(cli): inject PLEXI_CONTEXT_ID/NAME env vars + context current command (#1025)
+- fix(bundle): keyboard_capture for input-inspector + rename app_state dir (#907, #851) (#1023)
+- chore: auto-install after promoting to main
 ## [3.5.131] — 2026-05-11
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "3.5.131"
+version = "3.5.132"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "3.5.131"
+version = "3.5.132"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -2,6 +2,14 @@
 
 Development log for PLEXI. Tracks root causes, non-obvious decisions, abandoned approaches, and environment quirks that git history won't capture. Entries are newest-first — most recent at the top.
 
+## 2026-05-11 — [GOTCHA] SDK key normalization (#1060) silently broke example apps using capitalized key names (PR #1071 → alpha)
+
+PR #1060 added `_KEY_ALIASES` normalization in `_app.py`: `"Enter"→"return"`, `"Escape"→"escape"`, `"Backspace"→"backspace"`. Any app checking `key == "Enter"` (capitalized) silently stops responding to that key — no error, no warning. The stale alpha binary (pre-#1060) masked this during initial testing because the test was done at 02:24 and #1060 merged at 02:33 the same day.
+
+**What NOT to do next time:** Don't validate key-event behavior against an alpha binary that was installed before a key normalization PR landed. Always check `_app.py:_KEY_ALIASES` for the canonical key name before writing any `key ==` check in an app.
+
+**Breaks if:** Enter/Escape/Backspace stop responding in csv_viewer or backlog (navigation j/k still works; only the affected keys are silent).
+
 ## 2026-05-11 — [CHANGED] Migrate mcp-renderer + descriptor-renderer to plexi_sdk.ui components (PR #1061 → alpha)
 Added `SelectList` (stateful scrollable list with j/k, hit detection, scrollbar) and `FormField` (label + TextInput wrapper with `.submitted` property) to `sdk/python/plexi_sdk/ui.py`. Migrated both example renderers to use the declarative component system — no more manual `ctx.rect`/`ctx.text` layout math in the renderers.
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -923,23 +923,34 @@ impl PlexiApp {
 
         let screen_rect = ctx.screen_rect();
 
-        // Dim the whole work area. The scrim swallows clicks so UI behind can't
-        // accidentally eat them.
-        egui::Area::new(egui::Id::new("notification_modal_scrim"))
-            .order(egui::Order::Foreground)
-            .fixed_pos(screen_rect.min)
-            .interactable(true)
-            .show(ctx, |ui| {
-                let (rect, _) = ui.allocate_exact_size(
-                    screen_rect.size(),
-                    egui::Sense::click(),
-                );
-                ui.painter().rect_filled(
-                    rect,
-                    CornerRadius::ZERO,
-                    Color32::from_black_alpha(style::SCRIM_ALPHA),
-                );
-            });
+        // PRIORITY_CRITICAL (≥200) demands full attention: keep the scrim and
+        // center the modal. Lower priorities show as a top-right toast so the
+        // app behind remains readable.
+        let is_critical = notif.priority >= 200;
+        log::info!(
+            "notification_modal: priority={} is_critical={} kind={:?}",
+            notif.priority, is_critical, notif.kind
+        );
+
+        if is_critical {
+            // Dim the whole work area. The scrim swallows clicks so UI behind can't
+            // accidentally eat them.
+            egui::Area::new(egui::Id::new("notification_modal_scrim"))
+                .order(egui::Order::Foreground)
+                .fixed_pos(screen_rect.min)
+                .interactable(true)
+                .show(ctx, |ui| {
+                    let (rect, _) = ui.allocate_exact_size(
+                        screen_rect.size(),
+                        egui::Sense::click(),
+                    );
+                    ui.painter().rect_filled(
+                        rect,
+                        CornerRadius::ZERO,
+                        Color32::from_black_alpha(style::SCRIM_ALPHA),
+                    );
+                });
+        }
 
         let level_color = match notif.level.as_str() {
             "error" => Color32::from_rgb(0xff, 0x55, 0x55),
@@ -1033,9 +1044,14 @@ impl PlexiApp {
             _ => {}
         }
 
+        let (modal_anchor, modal_offset) = if is_critical {
+            (Align2::CENTER_CENTER, Vec2::ZERO)
+        } else {
+            (Align2::RIGHT_TOP, Vec2::new(-16.0, 80.0))
+        };
         egui::Area::new(egui::Id::new("notification_modal"))
             .order(egui::Order::Tooltip)
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .anchor(modal_anchor, modal_offset)
             .show(ctx, |ui| {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)


### PR DESCRIPTION
## What

Notification modal was anchored at `CENTER_CENTER` of the full window, overlapping app pane content.

## Changes

- `PRIORITY_CRITICAL` (≥200): unchanged — CENTER_CENTER + full-window scrim forces user attention
- All other priorities (HIGH, NORMAL, LOW): anchored to `RIGHT_TOP` with `-16px` right margin and `80px` top offset to clear the header bar; no scrim so app remains interactive

## Testing

Trigger a `PRIORITY_NORMAL` notification from any app. The modal should appear in the top-right corner, not covering the app content.

Closes #1084