### PR TITLE
feat(dev): auto-restart watched apps after crash (#1055)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -248,6 +248,9 @@ pub struct PlexiApp {
     /// existing `AppPane` envelope.
     pub(crate) hot_reload: crate::hot_reload::HotReloadWatcher,
     pub(crate) hot_reload_rx: std::sync::mpsc::Receiver<crate::hot_reload::ReloadRequest>,
+    /// Watched panes scheduled for crash-restart. Value is the earliest `Instant` at
+    /// which the restart fires — giving the developer ~2s to read the crash overlay.
+    pub(crate) pending_crash_restarts: HashMap<PaneId, std::time::Instant>,
     /// Spatial-grid minimap overlay state. Controls visibility, fade timer,
     /// and the `Cmd+Shift+M` override-visible flag.
     pub(crate) minimap: crate::minimap::MinimapState,
@@ -634,6 +637,7 @@ impl PlexiApp {
                     directed_pipes: HashMap::new(),
                     hot_reload: hr_watcher,
                     hot_reload_rx: hr_rx,
+                    pending_crash_restarts: HashMap::new(),
                     minimap: crate::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
                     context_active_window: ws.context_active_window,
@@ -726,6 +730,7 @@ impl PlexiApp {
             directed_pipes: HashMap::new(),
             hot_reload: hr_watcher2,
             hot_reload_rx: hr_rx2,
+            pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
             context_active_window: HashMap::new(),
@@ -830,6 +835,7 @@ impl PlexiApp {
             directed_pipes: HashMap::new(),
             hot_reload: hr_watcher,
             hot_reload_rx: hr_rx,
+            pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
             context_active_window: HashMap::new(),
@@ -2433,6 +2439,10 @@ impl eframe::App for PlexiApp {
         // dropped (sending Shutdown + reaping the child) and replaced with
         // a fresh subprocess. Idempotent if the pane was closed since.
         self.drain_hot_reload_requests();
+
+        // Crash-resilient dev reload (#1055): auto-restart watched panes that
+        // have crashed, after a 2s delay so the developer can read the traceback.
+        self.drain_crash_restarts();
 
         // Reload configuration from disk when the user clicks
         // "Reload Configuration" in the app menu.

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -170,6 +170,11 @@ impl HotReloadWatcher {
         }
     }
 
+    /// Returns the pane IDs of all actively-watched panes.
+    pub fn watched_pane_ids(&self) -> Vec<PaneId> {
+        self.watchers.keys().copied().collect()
+    }
+
     /// Test-only — number of active watchers.
     #[cfg(test)]
     pub fn len(&self) -> usize {
@@ -332,5 +337,22 @@ mod tests {
         let (mut watcher, _rx) = HotReloadWatcher::new();
         watcher.unwatch(999); // never watched
         assert_eq!(watcher.len(), 0);
+    }
+
+    #[test]
+    fn watched_pane_ids_returns_all_watched() {
+        let dir = tempdir().unwrap();
+        let (mut watcher, _rx) = HotReloadWatcher::new();
+        watcher.watch(10, dir.path());
+        watcher.watch(20, dir.path());
+
+        let mut ids = watcher.watched_pane_ids();
+        ids.sort();
+        assert_eq!(ids, vec![10, 20]);
+
+        watcher.unwatch(10);
+        let mut ids = watcher.watched_pane_ids();
+        ids.sort();
+        assert_eq!(ids, vec![20]);
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -267,6 +267,54 @@ impl PlexiApp {
         }
     }
 
+    /// Detect crashes on watched panes and restart them after a brief delay
+    /// so the developer can read the crash overlay. Only applies to panes
+    /// that opted in via `[app] watch = true` — production installs are
+    /// unaffected. Called once per frame alongside `drain_hot_reload_requests`.
+    pub(crate) fn drain_crash_restarts(&mut self) {
+        use crate::process_app::LifecycleState;
+        use std::time::{Duration, Instant};
+
+        const CRASH_RESTART_DELAY: Duration = Duration::from_secs(2);
+
+        let active = self.active_window;
+
+        // Schedule restarts for newly-crashed watched panes.
+        for pane_id in self.hot_reload.watched_pane_ids() {
+            if self.pending_crash_restarts.contains_key(&pane_id) {
+                continue;
+            }
+            if let Some(pane) = self.windows[active].panes.get(&pane_id) {
+                if let Some(app_pane) = pane.as_app() {
+                    if let crate::pane::AppRuntime::Process(ref proc) = app_pane.runtime {
+                        if proc.lifecycle.state() == LifecycleState::Crashed {
+                            log::info!(
+                                "app::{}: crash detected on watched pane {pane_id} — scheduling restart in {}ms",
+                                app_pane.manifest_id,
+                                CRASH_RESTART_DELAY.as_millis()
+                            );
+                            self.pending_crash_restarts
+                                .insert(pane_id, Instant::now() + CRASH_RESTART_DELAY);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fire elapsed restarts.
+        let now = Instant::now();
+        let ready: Vec<_> = self
+            .pending_crash_restarts
+            .iter()
+            .filter(|(_, t)| **t <= now)
+            .map(|(id, _)| *id)
+            .collect();
+        for pane_id in ready {
+            self.pending_crash_restarts.remove(&pane_id);
+            self.reload_app_pane(pane_id, "crash-restart");
+        }
+    }
+
     /// Force-reload the focused app pane (manual trigger via Cmd+Option+R).
     /// No-op when the focused pane isn't a process-backed AppPane.
     pub(crate) fn force_reload_focused_app(&mut self) {


### PR DESCRIPTION
## Summary

- Watched dev apps (`[app] watch = true`) now auto-restart after a crash without manual intervention
- 2-second delay before restart gives the developer time to read the crash overlay and traceback
- File-save hot-reload continues to work after crash recovery
- Non-watched apps (production installs) are unaffected

## Implementation

- `HotReloadWatcher::watched_pane_ids()` — new public method returning actively-watched pane IDs
- `App::pending_crash_restarts: HashMap<PaneId, Instant>` — new field tracking scheduled restarts
- `drain_crash_restarts()` — new per-frame method: detects crashed watched panes, schedules restarts, fires elapsed ones via `reload_app_pane(..., "crash-restart")`
- Called alongside `drain_hot_reload_requests()` in the main update loop

## Test plan
- [ ] New unit test `watched_pane_ids_returns_all_watched` passes (verified: all 5 hot_reload tests green)
- [ ] `cargo build` clean
- [ ] In a watched dev app: trigger a Python exception → crash overlay appears for ~2s → app auto-restarts
- [ ] Hot-reload on file-save still works after crash recovery
- [ ] Non-watched apps stay in Crashed state (no auto-restart)

**Breaks if:** a watched dev app that crashes is not automatically restarted within ~3s, or the crash overlay is skipped (never shown before restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)