### PR TITLE
fix(app-init): remove ctx.notify() from default app scaffold

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -676,6 +676,7 @@ class __CLASS_NAME__(App):
         if self._btn.render(ctx):
             self.click_count += 1
             ctx.status_summary(f"Clicked {self.click_count} time(s)")
+            # ctx.notify("__DISPLAY_NAME__", f"Click #{self.click_count}", priority=PRIORITY_NORMAL)
 
         # ── 5. State label ───────────────────────────────────────────────────────
         # Mutations to self.* are visible on the next frame.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -676,7 +676,6 @@ class __CLASS_NAME__(App):
         if self._btn.render(ctx):
             self.click_count += 1
             ctx.status_summary(f"Clicked {self.click_count} time(s)")
-            ctx.notify("__DISPLAY_NAME__", f"Click #{self.click_count}", priority=PRIORITY_NORMAL)
 
         # ── 5. State label ───────────────────────────────────────────────────────
         # Mutations to self.* are visible on the next frame.


### PR DESCRIPTION
Closes #1084

Removes the live `ctx.notify()` call from the default button handler in `plexi app init`. Clicking the scaffolded button no longer fires a notification badge in the toolbar.

The `ctx.notify` API remains documented in a comment block inside `on_click` so new users can still discover it.