### PR TITLE
polish(sdk): reduce badge() default radius from RADIUS_MD to 6.0

### DIFF
--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -150,7 +150,7 @@ class RenderContext:
 
     def badge(self, x: float, y_center: float, label: str,
               fill: str = ACCENT, fg: str = BG,
-              font_size: float = 11.0, radius: float = 8.0) -> None:
+              font_size: float = 11.0, radius: float = 6.0) -> None:
         """Render a host-measured pill badge.
 
         The host measures the label with real egui font metrics, sizes the pill

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -62,6 +62,11 @@ TEXT_TITLE_XL = 28.0
 RADIUS_SM = 4.0
 RADIUS_MD = 8.0
 RADIUS_LG = 12.0
+# Badge-specific radius — between tag-chip (4) and full-stadium (8). At
+# TEXT_HINT size the pill height is ~17 px; RADIUS_MD makes it 94% of
+# max-oval (cliché). 6.0 gives visible corners while staying clearly rounded.
+# Keep in sync with src/style.rs RADIUS_BADGE and _render_context.py badge().
+RADIUS_BADGE = 6.0
 
 # Palette — matches the Python-side constants from plexi_sdk/__init__.py.
 # Re-exported here so UI code doesn't have to import both.
@@ -835,7 +840,7 @@ def badge(
     fill: str = ACCENT,
     fg: str = BG,
     font_size: float = TEXT_HINT,
-    radius: float = 6.0,
+    radius: float = RADIUS_BADGE,
 ) -> None:
     """Render a host-measured pill badge centred on ``y_center``.
 
@@ -851,8 +856,8 @@ def badge(
         fg:        Text colour (default ``BG`` — dark text on light pill).
         font_size: Label pt size (default ``TEXT_HINT``).
         radius:    Corner radius. Use ``RADIUS_SM`` (4 px) for tag chips,
-                   6.0 (default) for rounded badges without the perfect-stadium
-                   look of ``RADIUS_MD`` (8 px).
+                   ``RADIUS_BADGE`` (6 px, default) for rounded badges without
+                   the perfect-stadium look of ``RADIUS_MD`` (8 px).
     """
     ctx.badge(x=x, y_center=y_center, label=label,
               fill=fill, fg=fg, font_size=font_size, radius=radius)
@@ -1296,7 +1301,7 @@ __all__ = [
     "SPACE_XS", "SPACE_SM", "SPACE_MD", "SPACE_LG", "SPACE_XL",
     "TEXT_HINT", "TEXT_CAPTION", "TEXT_BODY", "TEXT_HEADING",
     "TEXT_TITLE", "TEXT_TITLE_XL",
-    "RADIUS_SM", "RADIUS_MD", "RADIUS_LG",
+    "RADIUS_SM", "RADIUS_MD", "RADIUS_LG", "RADIUS_BADGE",
     "BG", "SURFACE", "HIGHLIGHT", "ACCENT", "MUTED", "FG",
     "RED", "GREEN", "YELLOW",
     # components

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -835,7 +835,7 @@ def badge(
     fill: str = ACCENT,
     fg: str = BG,
     font_size: float = TEXT_HINT,
-    radius: float = RADIUS_MD,
+    radius: float = 6.0,
 ) -> None:
     """Render a host-measured pill badge centred on ``y_center``.
 
@@ -851,7 +851,8 @@ def badge(
         fg:        Text colour (default ``BG`` — dark text on light pill).
         font_size: Label pt size (default ``TEXT_HINT``).
         radius:    Corner radius. Use ``RADIUS_SM`` (4 px) for tag chips,
-                   ``RADIUS_MD`` (8 px, default) for branch badges.
+                   6.0 (default) for rounded badges without the perfect-stadium
+                   look of ``RADIUS_MD`` (8 px).
     """
     ctx.badge(x=x, y_center=y_center, label=label,
               fill=fill, fg=fg, font_size=font_size, radius=radius)

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -940,7 +940,7 @@ impl ProcessApp {
         // position the pill's *left edge* such that its right edge lands
         // at `pane_rect.max.x - inset`.
         let font_size = 11.0;
-        let radius = 6.0;
+        let radius = crate::style::RADIUS_BADGE;
         let inset = 8.0;
         let font_id = egui::FontId::proportional(font_size);
         let galley = ui.fonts(|f| f.layout_no_wrap(label.to_string(), font_id, egui::Color32::BLACK));
@@ -995,7 +995,7 @@ impl ProcessApp {
     ) {
         let label = if count > 9 { "9+".to_string() } else { count.to_string() };
         let font_size = 11.0;
-        let radius = 6.0;
+        let radius = crate::style::RADIUS_BADGE;
         let inset = 8.0;
         let font_id = egui::FontId::proportional(font_size);
         let fg_color = egui::Color32::from_rgb(0x1e, 0x1e, 0x2e);

--- a/src/style.rs
+++ b/src/style.rs
@@ -42,6 +42,11 @@ pub const TEXT_TITLE_XL: f32 = 28.0;   // Primary modal title — the thing the
 // ── Corner radii ───────────────────────────────────────────────────────────
 pub const RADIUS_MD: CornerRadius = CornerRadius::same(8);
 pub const RADIUS_LG: CornerRadius = CornerRadius::same(12);
+// Badge-specific radius. At TEXT_HINT size the pill height is ~17 px;
+// RADIUS_MD (8) is 94% of max-oval — a cliché perfect stadium. 6 gives
+// visible corners while staying clearly rounded. Keep in sync with
+// RADIUS_BADGE in plexi_sdk/ui.py.
+pub const RADIUS_BADGE: f32 = 6.0;
 
 // ── Modal widths ───────────────────────────────────────────────────────────
 // Pick the smallest width that fits the content without crowding. Bigger is


### PR DESCRIPTION
Closes #1095

## Summary

- `badge()` default `radius` changes from `RADIUS_MD` (8 px) to `6.0`
- At `TEXT_HINT` size, pill height ≈ 17 px; `RADIUS_MD` is 94% of half-height → perfect stadium shape. `6.0` is 71% — clearly rounded but with visible corners at the ends
- `ListItem` and `Card` keep `RADIUS_MD` (they're rectangular containers, not pill badges)
- Matches the `6.0` the Rust lifecycle pill already hardcodes

## Test plan

- [ ] Open any example app that renders `badge()` (e.g. `gh-issues`) and confirm pills look less perfectly ovular
- [ ] Diff-review only — no install needed