### PR TITLE
fix(app-renderer): add padding/inset to MCP and CLI app panes

### DIFF
--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -354,21 +354,23 @@ class AppBar(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         ctx.rect(x, y, w, h, BG)
         band = self._band()
+        text_x = x + SPACE_MD
+        text_w = w - SPACE_MD
         if self.subtitle:
             block_h = self.TITLE_SIZE + SPACE_XS + self.SUBTITLE_SIZE
             title_y = y + (band - block_h) / 2.0
             sub_y = title_y + self.TITLE_SIZE + SPACE_XS
-            ctx.text(x, title_y, self.title,
+            ctx.text(text_x, title_y, self.title,
                      size=self.TITLE_SIZE, color=self.accent, bold=True,
-                     max_width=w, elide=True)
-            ctx.text(x, sub_y, self.subtitle,
+                     max_width=text_w, elide=True)
+            ctx.text(text_x, sub_y, self.subtitle,
                      size=self.SUBTITLE_SIZE, color=MUTED,
-                     max_width=w, elide=True)
+                     max_width=text_w, elide=True)
         else:
             text_y = y + (band - self.TITLE_SIZE) / 2.0
-            ctx.text(x, text_y, self.title,
+            ctx.text(text_x, text_y, self.title,
                      size=self.TITLE_SIZE, color=self.accent, bold=True,
-                     max_width=w, elide=True)
+                     max_width=text_w, elide=True)
         ctx.rect(x, y + band, w, self.DIVIDER_H, HIGHLIGHT)
 
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -355,7 +355,7 @@ class AppBar(Component):
         ctx.rect(x, y, w, h, BG)
         band = self._band()
         text_x = x + SPACE_MD
-        text_w = w - SPACE_MD
+        text_w = w - 2 * SPACE_MD
         if self.subtitle:
             block_h = self.TITLE_SIZE + SPACE_XS + self.SUBTITLE_SIZE
             title_y = y + (band - block_h) / 2.0

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -1,5 +1,6 @@
 use crate::pane::{Pane, TerminalPane};
 use crate::render;
+use crate::style;
 use crate::theme::Colors;
 use egui::Color32;
 use egui_term::{BackendCommand, TerminalTheme};
@@ -92,15 +93,23 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         let Some(pane) = self.panes.get_mut(pane_id) else {
             return UiResponse::None;
         };
-        ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
-        let mut inner_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
-        let ui = &mut inner_ui;
 
         if let Some(app_pane) = pane.as_app_mut() {
-            render::app_pane::render(ui, app_pane, &self.colors, is_focused);
+            // App panes: fill with bg_darkest so the inset band doesn't show
+            // terminal_bg through the gap — bg_darkest is dark enough to be
+            // nearly invisible against the SDK's default BG token. Use SPACE_MD
+            // inset so content has consistent breathing room from the pane edge.
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
+            let mut app_ui = ui.new_child(
+                egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_MD)),
+            );
+            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused);
         } else if let Some(terminal) = pane.as_terminal_mut() {
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
+            let mut terminal_ui =
+                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
             let close_exited = render::terminal_pane::render(
-                ui,
+                &mut terminal_ui,
                 terminal,
                 tile_id,
                 pane_id,

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -107,7 +107,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui =
-                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(8.0)));
+                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_SM)));
             let close_exited = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,


### PR DESCRIPTION
Closes #1076

## What

MCP renderer and CLI app panes previously rendered flush against the pane edge. This PR adds consistent inset at the host render layer.

## Changes

**`src/tiling.rs`** — splits app/terminal render paths:
- App panes: fill with `bg_darkest`, shrink by `style::SPACE_MD` (12px)
- Terminal panes: fill with `terminal_bg`, shrink by `style::SPACE_SM` (8px, now uses named constant)

**`sdk/python/plexi_sdk/ui.py`** — `AppBar.render()` indents title/subtitle text by `SPACE_MD` from the left edge, aligning it with `ListItem`'s internal `_PAD_H` padding.

## Done When
- [x] MCP renderer panes have consistent inset matching design token scale (`SPACE_MD`)
- [x] CLI app panes have the same inset applied
- [x] Inset applied at host render layer, not in individual apps
- [x] Uses named constants from `src/style.rs`

**Breaks if:** app pane content appears flush against the pane edge (zero inset visible), or AppBar title text is unindented relative to list item text.