### PR TITLE
fix(examples): normalize Enter/Escape key strings in mcp-renderer and descriptor-renderer

### DIFF
--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -394,20 +394,15 @@ class DescriptorRendererApp(App):
                 self._handle(self._list.selected_index)
                 self.emit.schedule_render(after_ms=16)
             elif key == "escape" and self._cmd_path:
-                self._cmd_path.pop()
-                self._selected_idx = 0
-                self._list.set_selected(0)
+                self._handle("back")
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
             if key == "escape":
-                self._view = "list"
-                self._cmd_path.pop()
-                self._selected_idx = 0
-                self._list.set_selected(0)
+                self._handle("back")
                 self.emit.schedule_render(after_ms=16)
             elif key == "return":
-                self._run()
+                self._handle("run")
                 self.emit.schedule_render(after_ms=16)
 
 

--- a/examples/descriptor-renderer/descriptor_renderer.py
+++ b/examples/descriptor-renderer/descriptor_renderer.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from plexi_sdk import App, RenderContext, CapabilityDeniedError
 from plexi_sdk.ui import (
-    Column, AppBar, FormField,
+    Column, AppBar, FormField, FooterKeys,
     ListItem, Label, Spacer, Card,
     BG, HIGHLIGHT, ACCENT, MUTED, RED,
     TEXT_HINT,
@@ -210,6 +210,10 @@ class DescriptorRendererApp(App):
                 )
                 for i, cmd in enumerate(commands)
             ]))
+            footer_hints = [("j/k", "navigate"), ("enter", "open")]
+            if self._cmd_path:
+                footer_hints.append(("esc", "back"))
+            header_items.append(FooterKeys(footer_hints))
             ctx.render(Column(header_items, padding=0, padding_top=0, gap=0))
             return
 
@@ -270,6 +274,10 @@ class DescriptorRendererApp(App):
                      text=f"$ {self._last_run}",
                      size=TEXT_HINT, color=MUTED, monospace=True,
                      align="left_center", max_width=ctx.w - 2 * SPACE_LG - SPACE_MD, elide=True)
+
+        footer = FooterKeys([("enter", "run"), ("esc", "back")])
+        footer_h = footer.measure(ctx.w)
+        footer.render(ctx, 0, ctx.h - footer_h, ctx.w, footer_h)
 
     # ── Interaction ───────────────────────────────────────────────────────────
 
@@ -382,21 +390,24 @@ class DescriptorRendererApp(App):
             if self._list.handle_key(key):
                 self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
-            elif key in ("Return", "Enter"):
+            elif key == "return":
                 self._handle(self._list.selected_index)
                 self.emit.schedule_render(after_ms=16)
-            elif key == "Escape" and self._cmd_path:
+            elif key == "escape" and self._cmd_path:
                 self._cmd_path.pop()
                 self._selected_idx = 0
                 self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
-            if key == "Escape":
+            if key == "escape":
                 self._view = "list"
                 self._cmd_path.pop()
                 self._selected_idx = 0
                 self._list.set_selected(0)
+                self.emit.schedule_render(after_ms=16)
+            elif key == "return":
+                self._run()
                 self.emit.schedule_render(after_ms=16)
 
 

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -420,26 +420,21 @@ class McpRendererApp(App):
                 self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
             elif key == "return":
-                idx = self._list.selected_index
-                if 0 <= idx < len(self._tools):
-                    self._enter_form(self._tools[idx])
+                await self._handle(self._list.selected_index)
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
             if key == "escape":
-                self._view = "list"
-                self._selected_idx = 0
-                self._list.set_selected(0)
+                await self._handle("back")
                 self.emit.schedule_render(after_ms=16)
             elif key == "return":
-                await self._run_tool()
+                await self._handle("run")
 
         elif self._view == "result":
             if self._result_scrollable.handle_key(key):
                 self.emit.schedule_render(after_ms=16)
             elif key == "escape":
-                self._view = "list"
-                self._list.set_selected(0)
+                await self._handle("back")
                 self.emit.schedule_render(after_ms=16)
 
 

--- a/examples/mcp-renderer/mcp_renderer.py
+++ b/examples/mcp-renderer/mcp_renderer.py
@@ -414,28 +414,30 @@ class McpRendererApp(App):
         self._result_scrollable.scroll_offset = 0.0
         self.emit.schedule_render(after_ms=16)
 
-    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+    async def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         if self._view == "list":
             if self._list.handle_key(key):
                 self._selected_idx = self._list.selected_index
                 self.emit.schedule_render(after_ms=16)
-            elif key in ("Return", "Enter"):
+            elif key == "return":
                 idx = self._list.selected_index
                 if 0 <= idx < len(self._tools):
                     self._enter_form(self._tools[idx])
                 self.emit.schedule_render(after_ms=16)
 
         elif self._view == "form":
-            if key == "Escape":
+            if key == "escape":
                 self._view = "list"
                 self._selected_idx = 0
                 self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)
+            elif key == "return":
+                await self._run_tool()
 
         elif self._view == "result":
             if self._result_scrollable.handle_key(key):
                 self.emit.schedule_render(after_ms=16)
-            elif key == "Escape":
+            elif key == "escape":
                 self._view = "list"
                 self._list.set_selected(0)
                 self.emit.schedule_render(after_ms=16)


### PR DESCRIPTION
Fixes #1100, #1101

## What

PR #1060 added `_KEY_ALIASES` in `_app.py` that normalizes key names before dispatch (`"Enter"→"return"`, `"Escape"→"escape"`). Both `mcp-renderer` and `descriptor-renderer` still checked against the pre-normalization strings, silently killing all Enter and Escape handlers.

## Changes

**mcp-renderer:**
- Fix key comparisons: `"Return"/"Enter"` → `"return"`, `"Escape"` → `"escape"`
- Make `on_key` `async def` to support `await self._run_tool()`
- Add `elif key == "return": await self._run_tool()` in form branch

**descriptor-renderer:**
- Fix key comparisons: `"Return"/"Enter"` → `"return"`, `"Escape"` → `"escape"`
- Add `elif key == "return": self._run()` in form branch
- Add `FooterKeys` hints to list view (`j/k navigate`, `enter open`, `esc back`)
- Add `FooterKeys` hints to form view (`enter run`, `esc back`) via bottom-pinned manual render

## Testing

1. `plexi-alpha open mcp-renderer <any-mcp-server>` — j/k navigates, Enter opens form, Escape returns to list, Enter in form runs tool
2. `plexi-alpha open descriptor-renderer --descriptor <path.json>` — same keyboard flow, footer hints visible in both views