### PR TITLE
fix(rename-pane): modal TextEdit loses focus on open (#1110)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -199,6 +199,10 @@ pub struct PlexiApp {
     pub(crate) palette_selected: usize,
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
+    /// One-shot guard: true after `request_focus()` fires on the rename modal's
+    /// first render. Prevents the focus from being re-requested every frame,
+    /// which lets a later widget steal it on the same frame indefinitely.
+    pub(crate) rename_pane_focus_requested: bool,
     pub(crate) features: crate::features::FeatureFlags,
     /// Notifications queued from apps via ShowNotification.
     pub(crate) pending_notifications: Vec<PendingNotification>,
@@ -618,6 +622,7 @@ impl PlexiApp {
                     palette_selected: 0,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
+                    rename_pane_focus_requested: false,
                     registry,
                     features: features.clone(),
                     pending_notifications: Vec::new(),
@@ -714,6 +719,7 @@ impl PlexiApp {
             palette_selected: 0,
             context_visit_history: Vec::new(),
             renaming_pane: None,
+            rename_pane_focus_requested: false,
             registry: AppRegistry::load(&std::env::current_dir().unwrap_or_default()),
             features,
             pending_notifications: Vec::new(),
@@ -820,6 +826,7 @@ impl PlexiApp {
             palette_selected: 0,
             context_visit_history: Vec::new(),
             renaming_pane: None,
+            rename_pane_focus_requested: false,
             registry: AppRegistry::load_with_global(
                 &path,
                 &path.join("nonexistent-apps-dir"),
@@ -2196,7 +2203,7 @@ impl eframe::App for PlexiApp {
         };
 
         // Handle keyboard shortcuts
-        let modal_open = self.show_notification_modal;
+        let modal_open = self.input_captured_by_overlay();
         for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
             match action {
                 Action::SplitHorizontal => {
@@ -2352,6 +2359,13 @@ impl eframe::App for PlexiApp {
                                 .and_then(|t| t.name.clone())
                                 .unwrap_or_default();
                             self.renaming_pane = Some(pane_id);
+                            self.rename_pane_focus_requested = false;
+                            // Sync the focus layer immediately so `input_captured_by_overlay()`
+                            // is accurate for the rest of this frame — without this, there is a
+                            // one-frame window where `renaming_pane` is Some but the focus layer
+                            // has not been pushed yet.
+                            self.sync_rename_pane_focus();
+                            log::info!("rename_pane: opened for pane {pane_id:?}");
                         }
                     }
                 }
@@ -3960,5 +3974,32 @@ mod tests {
         // No window to the left of (0,0) → Left is a no-op (not wrapped).
         h.app.navigate(crate::keys::Direction::Left);
         assert_eq!(h.app.active_window, 0, "Left at boundary must not change active_window");
+    }
+
+    /// Regression guard for #1110: setting renaming_pane + sync_rename_pane_focus()
+    /// must push FocusLayer::RenamePane in the same call so input_captured_by_overlay()
+    /// is accurate immediately — not deferred to the next frame.
+    #[test]
+    fn rename_pane_focus_layer_syncs_immediately() {
+        let mut h = HostHarness::new();
+        let pane_a = h.add_test_pane();
+
+        assert!(h.app.focus_stack.is_empty(), "focus stack must start empty");
+        assert!(!h.app.input_captured_by_overlay(), "no overlay on start");
+
+        // Simulate what the fixed Action::RenamePane handler now does.
+        h.app.renaming_pane = Some(pane_a);
+        h.app.rename_pane_focus_requested = false;
+        h.app.sync_rename_pane_focus();
+
+        assert_eq!(
+            h.app.focus_stack.last(),
+            Some(&FocusLayer::RenamePane),
+            "FocusLayer::RenamePane must be on the stack after sync"
+        );
+        assert!(
+            h.app.input_captured_by_overlay(),
+            "input_captured_by_overlay must be true while rename modal is open"
+        );
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -431,7 +431,7 @@ pub fn poll_actions(
     bindings: &KeyBindings,
     app_active: bool,
     keyboard_capture_active: bool,
-    notification_modal_open: bool,
+    overlay_open: bool,
     shortcuts_overlay_open: bool,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
@@ -481,14 +481,14 @@ pub fn poll_actions(
         }
         // When the notification modal is open, next/prev tab cycle the queue instead.
         if input.consume_key(bindings.next_tab.0, bindings.next_tab.1) {
-            actions.push(if notification_modal_open {
+            actions.push(if overlay_open {
                 Action::NotificationCycleNext
             } else {
                 Action::NextTab
             });
         }
         if input.consume_key(bindings.prev_tab.0, bindings.prev_tab.1) {
-            actions.push(if notification_modal_open {
+            actions.push(if overlay_open {
                 Action::NotificationCyclePrev
             } else {
                 Action::PrevTab
@@ -516,7 +516,7 @@ pub fn poll_actions(
         }
 
         if input.consume_key(bindings.nav_back.0, bindings.nav_back.1) {
-            actions.push(if notification_modal_open {
+            actions.push(if overlay_open {
                 Action::NotificationCyclePrev
             } else {
                 Action::NavBackApp

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -566,8 +566,12 @@ impl PlexiApp {
                                 .font(egui::TextStyle::Body),
                         );
 
-                        // Auto-focus and select all
-                        if !te.has_focus() {
+                        // One-shot focus: only request on the first render frame.
+                        // Re-requesting every frame (guarded by `!te.has_focus()`) lets
+                        // any widget rendered later in the same frame steal focus
+                        // permanently — egui resolves `request_focus()` conflicts
+                        // last-caller-wins within a frame.
+                        if !self.rename_pane_focus_requested {
                             te.request_focus();
                             if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), te_id) {
                                 state
@@ -578,12 +582,15 @@ impl PlexiApp {
                                     )));
                                 state.store(ui.ctx(), te_id);
                             }
+                            self.rename_pane_focus_requested = true;
+                            log::info!("rename_pane: focus requested for TextEdit");
                         }
                     });
             });
 
         if cancel {
             self.renaming_pane = None;
+            self.rename_pane_focus_requested = false;
         } else if commit {
             let new_name = self.rename_buffer.trim().to_string();
             if let Some(pane) =
@@ -598,6 +605,7 @@ impl PlexiApp {
                 }
             }
             self.renaming_pane = None;
+            self.rename_pane_focus_requested = false;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that caused the rename-pane modal TextEdit to lose focus immediately on open:

- **`overlays.rs`**: `request_focus()` fired every frame the TextEdit lacked focus. egui resolves `request_focus()` conflicts last-caller-wins within a frame, so any widget rendered later permanently stole focus. Changed to a one-shot guard (`rename_pane_focus_requested: bool`) that fires only on the first render.

- **`app/mod.rs`**: `modal_open` passed to `poll_actions` was bound to `show_notification_modal` only. When the rename modal was open without a pending notification, the frame's keyboard drain could still produce tab/nav actions as if no modal existed. Changed to `input_captured_by_overlay()`.

- **`app/mod.rs`**: `sync_rename_pane_focus()` ran at frame-top (line 1553), before `Action::RenamePane` set `renaming_pane` mid-frame. For one frame, the focus layer wasn't pushed. Fixed by calling `sync_rename_pane_focus()` immediately in the action handler.

## Done When

- Press Cmd+R → rename modal appears → cursor is blinking in the TextEdit immediately
- Typing updates the input field on the first keypress with no need to click
- Pressing Cmd+R again while modal is open does not re-open or reset it
- Pressing Tab/Cmd+] while rename modal is open does not cycle contexts

## Test plan

- [ ] Open Plexi Alpha with at least one terminal pane focused
- [ ] Press Cmd+R — confirm cursor immediately blinks in the rename input
- [ ] Type a name — confirm it appears without needing to click
- [ ] Press Escape to cancel; press Cmd+R again — confirm it reopens cleanly
- [ ] While modal is open, press Tab — confirm it does NOT cycle pane contexts
- [ ] `cargo test rename_pane_focus_layer_syncs_immediately` passes