### PR TITLE
feat(quick-note): visual polish & keyboard navigation (#1122)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,10 @@ pub struct PlexiApp {
     pub(crate) quick_note_ctx: QuickNoteCtx,
     /// If in QuickNoteSubDestination phase, the key of the parent destination entry.
     pub(crate) quick_note_pending_parent: Option<u8>,
+    /// Cursor row in the destination picker (0 = global backlog, 1+ = config destinations).
+    pub(crate) quick_note_dest_cursor: usize,
+    /// Cursor row in the sub-destination picker.
+    pub(crate) quick_note_sub_cursor: usize,
     /// notify_id of the notification the modal currently has state for. Used to
     /// detect a front-of-queue change and reset focus/input buffer.
     pub(crate) modal_state_notify_id: String,
@@ -642,6 +646,8 @@ impl PlexiApp {
                     quick_note_text: String::new(),
                     quick_note_ctx: QuickNoteCtx::default(),
                     quick_note_pending_parent: None,
+                    quick_note_dest_cursor: 0,
+                    quick_note_sub_cursor: 0,
                     modal_state_notify_id: String::new(),
                     notification_images: HashMap::new(),
                     notifications_enabled,
@@ -742,6 +748,8 @@ impl PlexiApp {
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
             quick_note_pending_parent: None,
+            quick_note_dest_cursor: 0,
+            quick_note_sub_cursor: 0,
             modal_state_notify_id: String::new(),
             notification_images: HashMap::new(),
             notifications_enabled,
@@ -855,6 +863,8 @@ impl PlexiApp {
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
             quick_note_pending_parent: None,
+            quick_note_dest_cursor: 0,
+            quick_note_sub_cursor: 0,
             modal_state_notify_id: String::new(),
             notification_images: HashMap::new(),
             notifications_enabled: false,

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -763,7 +763,7 @@ impl PlexiApp {
                         egui::ScrollArea::vertical()
                             .max_height(max_text_h)
                             .show(ui, |ui| {
-                                let r = ui.add(
+                                ui.add(
                                     egui::TextEdit::multiline(&mut self.quick_note_text)
                                         .id(egui::Id::new("quick_note_text"))
                                         .font(egui::FontId::monospace(style::TEXT_BODY))
@@ -777,7 +777,6 @@ impl PlexiApp {
                                                 .size(style::TEXT_BODY),
                                         ),
                                 );
-                                r.request_focus();
                             });
                     });
             });
@@ -937,9 +936,9 @@ impl PlexiApp {
 
         let modal_w = (screen_rect.width() * 0.5).min(560.0).max(340.0);
         let cursor = self.quick_note_dest_cursor;
-        let destinations: Vec<_> = self.config.quick_note.as_ref()
-            .map(|qn| qn.destinations.clone())
-            .unwrap_or_default();
+        let destinations = self.config.quick_note.as_ref()
+            .map(|qn| qn.destinations.as_slice())
+            .unwrap_or(&[]);
         egui::Area::new(egui::Id::new("quick_note_dest_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)
@@ -956,13 +955,9 @@ impl PlexiApp {
                         let preview = {
                             let t = self.quick_note_text.trim();
                             let first_line = t.lines().next().unwrap_or("");
-                            let has_more = first_line.len() < t.len();
-                            if first_line.chars().count() > 80 {
-                                let idx = first_line.char_indices().nth(80)
-                                    .map(|(i, _)| i)
-                                    .unwrap_or(first_line.len());
+                            if let Some((idx, _)) = first_line.char_indices().nth(80) {
                                 format!("{}…", &first_line[..idx])
-                            } else if has_more {
+                            } else if first_line.len() < t.len() {
                                 format!("{}…", first_line)
                             } else {
                                 first_line.to_string()

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -713,8 +713,11 @@ impl PlexiApp {
             }
         });
         if advance && !self.quick_note_text.trim().is_empty() {
+            self.quick_note_dest_cursor = 0;
             self.push_focus_layer(crate::app::FocusLayer::QuickNoteDestination);
             log::info!("QuickNote: advancing to destination picker");
+            // Draw destination in the same frame to avoid a one-frame scrim flash.
+            self.draw_quick_note_destination(ctx);
             return;
         }
 
@@ -732,8 +735,9 @@ impl PlexiApp {
                 );
             });
 
-        // Modal
+        // Modal — grows with content up to (screen_height - 96px insets) then scrolls.
         let modal_w = (screen_rect.width() * 0.6).min(720.0).max(400.0);
+        let max_text_h = (screen_rect.height() - 160.0).max(80.0);
         egui::Area::new(egui::Id::new("quick_note_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)
@@ -755,40 +759,133 @@ impl PlexiApp {
                         );
                         ui.add_space(style::SPACE_SM);
 
-                        // Text input
-                        let text_response = ui.add_sized(
-                            [modal_w, 120.0],
-                            egui::TextEdit::multiline(&mut self.quick_note_text)
-                                .id(egui::Id::new("quick_note_text"))
-                                .font(egui::FontId::monospace(style::TEXT_BODY))
-                                .text_color(self.colors.text_primary)
-                                .desired_width(f32::INFINITY)
-                                .frame(false)
-                                .hint_text(
-                                    RichText::new("What's on your mind?")
-                                        .color(self.colors.text_dim.linear_multiply(0.3))
-                                        .size(style::TEXT_BODY),
-                                ),
-                        );
-                        text_response.request_focus();
+                        // Text input — expands line-by-line; scrolls once full.
+                        egui::ScrollArea::vertical()
+                            .max_height(max_text_h)
+                            .show(ui, |ui| {
+                                let r = ui.add(
+                                    egui::TextEdit::multiline(&mut self.quick_note_text)
+                                        .id(egui::Id::new("quick_note_text"))
+                                        .font(egui::FontId::monospace(style::TEXT_BODY))
+                                        .text_color(self.colors.text_primary)
+                                        .desired_width(f32::INFINITY)
+                                        .desired_rows(1)
+                                        .frame(false)
+                                        .hint_text(
+                                            RichText::new("What's on your mind?")
+                                                .color(self.colors.text_dim.linear_multiply(0.3))
+                                                .size(style::TEXT_BODY),
+                                        ),
+                                );
+                                r.request_focus();
+                            });
                     });
             });
     }
 
-    /// Quick note destination picker: digit keys route instantly.
+    /// Quick note destination picker: digit keys route instantly; arrows/jk navigate.
     pub(crate) fn draw_quick_note_destination(&mut self, ctx: &egui::Context) {
         use crate::style;
         use crate::widgets;
         use egui::{Align2, RichText, Vec2};
 
-        // Esc → back to compose.
-        let esc = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
-        if esc {
+        let dest_count = self.config.quick_note.as_ref()
+            .map(|qn| qn.destinations.len())
+            .unwrap_or(0);
+        let total = 1 + dest_count;
+
+        // H or Esc → back to compose.
+        let back = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::H)
+        });
+        if back {
             self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
             log::info!("QuickNote: destination picker dismissed, back to composing");
             return;
         }
 
+        // Arrow / vim navigation.
+        let up = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+        });
+        let down = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+        });
+        if up {
+            self.quick_note_dest_cursor = if self.quick_note_dest_cursor == 0 {
+                total.saturating_sub(1)
+            } else {
+                self.quick_note_dest_cursor - 1
+            };
+            log::info!("QuickNote: dest cursor → {}", self.quick_note_dest_cursor);
+        }
+        if down {
+            self.quick_note_dest_cursor = (self.quick_note_dest_cursor + 1) % total.max(1);
+            log::info!("QuickNote: dest cursor → {}", self.quick_note_dest_cursor);
+        }
+
+        // Enter → dispatch selected item.
+        let enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
+        if enter {
+            let cursor = self.quick_note_dest_cursor;
+            if cursor == 0 {
+                let text = self.quick_note_text.clone();
+                log::info!("QuickNote: destination selected via Enter: cursor=0 (global backlog)");
+                if self.commit_quick_note_global_backlog(&text) {
+                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                    self.quick_note_text.clear();
+                }
+                return;
+            }
+            let dest = self.config.quick_note.as_ref()
+                .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
+            if let Some(dest) = dest {
+                log::info!("QuickNote: destination selected via Enter: cursor={cursor} key={}", dest.key);
+                if dest.options.is_some() {
+                    let key = dest.key;
+                    self.quick_note_pending_parent = Some(key);
+                    self.quick_note_sub_cursor = 0;
+                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
+                    log::info!("QuickNote: submenu opened: parent={key}");
+                    self.draw_quick_note_subdestination(ctx);
+                } else {
+                    let text = self.quick_note_text.clone();
+                    if self.commit_quick_note(&text, &dest) {
+                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                        self.quick_note_text.clear();
+                    }
+                }
+            }
+            return;
+        }
+
+        // L → enter submenu for selected item (zero-flash).
+        let enter_sub = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::L));
+        if enter_sub {
+            let cursor = self.quick_note_dest_cursor;
+            if cursor > 0 {
+                let dest = self.config.quick_note.as_ref()
+                    .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
+                if let Some(dest) = dest {
+                    if dest.options.is_some() {
+                        let key = dest.key;
+                        self.quick_note_pending_parent = Some(key);
+                        self.quick_note_sub_cursor = 0;
+                        self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
+                        log::info!("QuickNote: submenu opened via L: parent={key}");
+                        self.draw_quick_note_subdestination(ctx);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Digit keys → fast-dispatch by number.
         let pressed = consume_digit_key(ctx);
 
         if let Some(key) = pressed {
@@ -808,8 +905,10 @@ impl PlexiApp {
                 log::info!("QuickNote: destination selected: key={key}");
                 if dest.options.is_some() {
                     self.quick_note_pending_parent = Some(key);
+                    self.quick_note_sub_cursor = 0;
                     self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
                     log::info!("QuickNote: submenu opened: parent={key}");
+                    self.draw_quick_note_subdestination(ctx);
                 } else {
                     let text = self.quick_note_text.clone();
                     if self.commit_quick_note(&text, &dest) {
@@ -837,6 +936,10 @@ impl PlexiApp {
             });
 
         let modal_w = (screen_rect.width() * 0.5).min(560.0).max(340.0);
+        let cursor = self.quick_note_dest_cursor;
+        let destinations: Vec<_> = self.config.quick_note.as_ref()
+            .map(|qn| qn.destinations.clone())
+            .unwrap_or_default();
         egui::Area::new(egui::Id::new("quick_note_dest_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)
@@ -849,13 +952,20 @@ impl PlexiApp {
                     .show(ui, |ui| {
                         ui.set_width(modal_w);
 
-                        // Note preview
+                        // Note preview — first line only, clean truncation.
                         let preview = {
                             let t = self.quick_note_text.trim();
-                            if let Some((idx, _)) = t.char_indices().nth(80) {
-                                format!("{}…", &t[..idx])
+                            let first_line = t.lines().next().unwrap_or("");
+                            let has_more = first_line.len() < t.len();
+                            if first_line.chars().count() > 80 {
+                                let idx = first_line.char_indices().nth(80)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(first_line.len());
+                                format!("{}…", &first_line[..idx])
+                            } else if has_more {
+                                format!("{}…", first_line)
                             } else {
-                                t.to_string()
+                                first_line.to_string()
                             }
                         };
                         ui.label(
@@ -873,26 +983,47 @@ impl PlexiApp {
                         );
                         ui.add_space(style::SPACE_MD);
 
-                        // Hard-coded destination 0
-                        ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing.x = style::SPACE_SM;
-                            widgets::key_chip(ui, "0", &self.colors);
-                            ui.label(
-                                RichText::new("Backlog (global)")
-                                    .color(self.colors.text_dim)
-                                    .size(style::TEXT_BODY),
-                            );
+                        // Row 0: global backlog
+                        let row0_frame = if cursor == 0 {
+                            egui::Frame::new()
+                                .fill(self.colors.bg_active)
+                                .corner_radius(egui::CornerRadius::same(4))
+                                .inner_margin(egui::Margin::symmetric(4, 2))
+                        } else {
+                            egui::Frame::new()
+                                .inner_margin(egui::Margin::symmetric(4, 2))
+                        };
+                        row0_frame.show(ui, |ui| {
+                            ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                                widgets::key_chip(ui, "0", &self.colors);
+                                ui.label(
+                                    RichText::new("Backlog (global)")
+                                        .color(self.colors.text_dim)
+                                        .size(style::TEXT_BODY),
+                                );
+                            });
                         });
                         ui.add_space(style::SPACE_SM);
 
                         // Config destinations
-                        if let Some(qn) = &self.config.quick_note {
-                            for dest in &qn.destinations {
-                                let label = if dest.options.is_some() {
-                                    format!("{} ›", dest.label)
-                                } else {
-                                    dest.label.clone()
-                                };
+                        for (idx, dest) in destinations.iter().enumerate() {
+                            let row_idx = idx + 1;
+                            let label = if dest.options.is_some() {
+                                format!("{} ›", dest.label)
+                            } else {
+                                dest.label.clone()
+                            };
+                            let row_frame = if cursor == row_idx {
+                                egui::Frame::new()
+                                    .fill(self.colors.bg_active)
+                                    .corner_radius(egui::CornerRadius::same(4))
+                                    .inner_margin(egui::Margin::symmetric(4, 2))
+                            } else {
+                                egui::Frame::new()
+                                    .inner_margin(egui::Margin::symmetric(4, 2))
+                            };
+                            row_frame.show(ui, |ui| {
                                 ui.horizontal(|ui| {
                                     ui.spacing_mut().item_spacing.x = style::SPACE_SM;
                                     widgets::key_chip(ui, &dest.key.to_string(), &self.colors);
@@ -902,13 +1033,13 @@ impl PlexiApp {
                                             .size(style::TEXT_BODY),
                                     );
                                 });
-                                ui.add_space(style::SPACE_SM);
-                            }
+                            });
+                            ui.add_space(style::SPACE_SM);
                         }
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
-                            RichText::new("Esc to go back")
+                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  H/Esc back")
                                 .color(self.colors.text_dim.linear_multiply(0.4))
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),
@@ -932,9 +1063,12 @@ impl PlexiApp {
             }
         };
 
-        // Esc → back to destination picker.
-        let esc = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
-        if esc {
+        // H or Esc → back to destination picker.
+        let back = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::H)
+        });
+        if back {
             self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
             self.quick_note_pending_parent = None;
             log::info!("QuickNote: submenu dismissed, back to destination picker");
@@ -947,10 +1081,60 @@ impl PlexiApp {
             .and_then(|d| d.options.clone())
             .unwrap_or_default();
 
+        let total = options.len();
+
+        // Arrow / vim navigation.
+        let up = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+        });
+        let down = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+        });
+        if up {
+            self.quick_note_sub_cursor = if self.quick_note_sub_cursor == 0 {
+                total.saturating_sub(1)
+            } else {
+                self.quick_note_sub_cursor - 1
+            };
+            log::info!("QuickNote: sub cursor → {}", self.quick_note_sub_cursor);
+        }
+        if down {
+            self.quick_note_sub_cursor = (self.quick_note_sub_cursor + 1) % total.max(1);
+            log::info!("QuickNote: sub cursor → {}", self.quick_note_sub_cursor);
+        }
+
+        // Enter → dispatch selected option.
+        let enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
+        if enter {
+            if let Some(opt) = options.get(self.quick_note_sub_cursor).cloned() {
+                let text = self.quick_note_text.clone();
+                let cmd_template = opt.command.clone();
+                let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
+                let ctx_data = self.quick_note_ctx.clone();
+                let cmd = Self::substitute_note_tokens_static(&cmd_template, &text, &ctx_data);
+                log::info!("QuickNote: submenu selected via Enter: parent={parent_key} cursor={}", self.quick_note_sub_cursor);
+                log::info!("QuickNote: committed via '{}' position={position:?}", opt.label);
+                match position.as_str() {
+                    "context-end" => self.open_at_context_end(&cmd),
+                    "context-start" => self.open_at_context_start(&cmd),
+                    _ => self.split_focused(false, Some(&cmd), true),
+                }
+                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
+                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                self.quick_note_text.clear();
+                self.quick_note_pending_parent = None;
+            }
+            return;
+        }
+
+        // Digit keys → fast-dispatch by number.
         let pressed = consume_digit_key(ctx);
 
         if let Some(key) = pressed {
-            if let Some(opt) = options.iter().find(|o| o.key == key) {
+            if let Some(opt) = options.iter().find(|o| o.key == key).cloned() {
                 let text = self.quick_note_text.clone();
                 let cmd_template = opt.command.clone();
                 let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
@@ -977,6 +1161,7 @@ impl PlexiApp {
 
         // Render
         let screen_rect = ctx.screen_rect();
+        let sub_cursor = self.quick_note_sub_cursor;
         egui::Area::new(egui::Id::new("quick_note_sub_scrim"))
             .fixed_pos(screen_rect.min)
             .order(egui::Order::Middle)
@@ -1010,22 +1195,33 @@ impl PlexiApp {
                         );
                         ui.add_space(style::SPACE_MD);
 
-                        for opt in &options {
-                            ui.horizontal(|ui| {
-                                ui.spacing_mut().item_spacing.x = style::SPACE_SM;
-                                widgets::key_chip(ui, &opt.key.to_string(), &self.colors);
-                                ui.label(
-                                    RichText::new(&opt.label)
-                                        .color(self.colors.text_dim)
-                                        .size(style::TEXT_BODY),
-                                );
+                        for (idx, opt) in options.iter().enumerate() {
+                            let row_frame = if sub_cursor == idx {
+                                egui::Frame::new()
+                                    .fill(self.colors.bg_active)
+                                    .corner_radius(egui::CornerRadius::same(4))
+                                    .inner_margin(egui::Margin::symmetric(4, 2))
+                            } else {
+                                egui::Frame::new()
+                                    .inner_margin(egui::Margin::symmetric(4, 2))
+                            };
+                            row_frame.show(ui, |ui| {
+                                ui.horizontal(|ui| {
+                                    ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                                    widgets::key_chip(ui, &opt.key.to_string(), &self.colors);
+                                    ui.label(
+                                        RichText::new(&opt.label)
+                                            .color(self.colors.text_dim)
+                                            .size(style::TEXT_BODY),
+                                    );
+                                });
                             });
                             ui.add_space(style::SPACE_SM);
                         }
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
-                            RichText::new("Esc to go back")
+                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  H/Esc back")
                                 .color(self.colors.text_dim.linear_multiply(0.4))
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -736,8 +736,8 @@ impl PlexiApp {
             });
 
         // Modal — grows with content up to (screen_height - 96px insets) then scrolls.
-        let modal_w = (screen_rect.width() * 0.6).min(720.0).max(400.0);
-        let max_text_h = (screen_rect.height() - 160.0).max(80.0);
+        let modal_w = (screen_rect.width() * 0.72).min(864.0).max(480.0);
+        let max_text_h = (screen_rect.height() * 0.8).max(80.0);
         egui::Area::new(egui::Id::new("quick_note_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)
@@ -923,7 +923,7 @@ impl PlexiApp {
         // Render
         let screen_rect = ctx.screen_rect();
 
-        egui::Area::new(egui::Id::new("quick_note_dest_scrim"))
+        egui::Area::new(egui::Id::new("quick_note_scrim"))
             .fixed_pos(screen_rect.min)
             .order(egui::Order::Middle)
             .show(ctx, |ui| {
@@ -934,7 +934,7 @@ impl PlexiApp {
                 );
             });
 
-        let modal_w = (screen_rect.width() * 0.5).min(560.0).max(340.0);
+        let modal_w = (screen_rect.width() * 0.6).min(672.0).max(408.0);
         let cursor = self.quick_note_dest_cursor;
         let destinations = self.config.quick_note.as_ref()
             .map(|qn| qn.destinations.as_slice())
@@ -951,17 +951,23 @@ impl PlexiApp {
                     .show(ui, |ui| {
                         ui.set_width(modal_w);
 
-                        // Note preview — first line only, clean truncation.
+                        // Note preview — up to 4 lines, each truncated at 80 chars.
                         let preview = {
                             let t = self.quick_note_text.trim();
-                            let first_line = t.lines().next().unwrap_or("");
-                            if let Some((idx, _)) = first_line.char_indices().nth(80) {
-                                format!("{}…", &first_line[..idx])
-                            } else if first_line.len() < t.len() {
-                                format!("{}…", first_line)
-                            } else {
-                                first_line.to_string()
+                            let mut lines: Vec<String> = t.lines()
+                                .take(4)
+                                .map(|line| {
+                                    if let Some((idx, _)) = line.char_indices().nth(80) {
+                                        format!("{}…", &line[..idx])
+                                    } else {
+                                        line.to_string()
+                                    }
+                                })
+                                .collect();
+                            if t.lines().count() > 4 {
+                                lines.push("…".to_string());
                             }
+                            lines.join("\n")
                         };
                         ui.label(
                             RichText::new(&preview)
@@ -1157,14 +1163,14 @@ impl PlexiApp {
         // Render
         let screen_rect = ctx.screen_rect();
         let sub_cursor = self.quick_note_sub_cursor;
-        egui::Area::new(egui::Id::new("quick_note_sub_scrim"))
+        egui::Area::new(egui::Id::new("quick_note_scrim"))
             .fixed_pos(screen_rect.min)
             .order(egui::Order::Middle)
             .show(ctx, |ui| {
                 ui.painter().rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(230));
             });
 
-        let modal_w = (screen_rect.width() * 0.5).min(560.0).max(340.0);
+        let modal_w = (screen_rect.width() * 0.6).min(672.0).max(408.0);
         egui::Area::new(egui::Id::new("quick_note_sub_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)


### PR DESCRIPTION
Closes #1122

## Changes

**1. TextEdit grow-to-fill + scroll**
`desired_rows(1)` inside a `ScrollArea` with `max_height = screen_height - 160px`. The modal auto-sizes with content; once full it scrolls.

**2. Zero-flash compose → destination / destination → submenu**
Both transitions now call the next phase's draw function in the same frame so the scrim is never absent between phases.

**3. Clean note preview**
Takes the first line only (up to 80 chars), appends `…` if the note has more lines or was truncated at 80 chars.

**4. Keyboard navigation — destination picker**
| Key | Action |
|-----|--------|
| `↑` / `k` | Move cursor up (wrap) |
| `↓` / `j` | Move cursor down (wrap) |
| `Enter` | Dispatch selected option |
| `L` | Enter submenu if selected has options |
| `H` / `Esc` | Go back to compose |
| `0`–`9` | Existing digit-dispatch unchanged |

Selected row gets a `bg_active` fill highlight.

**5. Keyboard navigation — sub-destination picker**
Same `↑↓/jk/Enter/H/Esc` model. Cursor resets to 0 on open.

## State added
- `quick_note_dest_cursor: usize` — initialized to 0 in all 3 constructors, reset to 0 when picker opens
- `quick_note_sub_cursor: usize` — same

## Breaks if
Quick-note modal opens with a fixed-height TextEdit that doesn't grow, or pressing Enter from compose causes a visible flash before the destination picker appears.