### PR TITLE
fix(process-app): immediate repaint after Click eliminates ~100ms button lag (#1134)

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1750,6 +1750,7 @@ impl App for ProcessApp {
                         y: pos.y - origin.y,
                         button: crate::app_protocol::MouseButton::Primary,
                     });
+                    needs_click_repaint = true;
                 }
                 if is_secondary_down {
                     self.send_event(&PlexiEvent::MouseDown {
@@ -1757,6 +1758,7 @@ impl App for ProcessApp {
                         y: pos.y - origin.y,
                         button: crate::app_protocol::MouseButton::Secondary,
                     });
+                    needs_click_repaint = true;
                 }
             }
 

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1730,6 +1730,7 @@ impl App for ProcessApp {
         // fires on button-release and does not track press or motion.
         let mouse_response = ui.interact(pane_rect, ui.id(), egui::Sense::click_and_drag());
         let mut needs_tracking_repaint = false;
+        let mut needs_click_repaint = false;
         if !pill_consumed_click {
             let origin = pane_rect.min;
 
@@ -1781,6 +1782,7 @@ impl App for ProcessApp {
                         y,
                         button: crate::app_protocol::MouseButton::Primary,
                     });
+                    needs_click_repaint = true;
                 }
                 if secondary_up {
                     self.send_event(&PlexiEvent::MouseUp {
@@ -1793,6 +1795,7 @@ impl App for ProcessApp {
                         y,
                         button: crate::app_protocol::MouseButton::Secondary,
                     });
+                    needs_click_repaint = true;
                 }
             }
 
@@ -1837,7 +1840,9 @@ impl App for ProcessApp {
         // Pointer-tracking apps are a special case: while the pointer is actively
         // moving we keep the repaint cadence near 60 FPS so host->app hover state
         // does not feel sticky.
-        if needs_tracking_repaint {
+        if needs_click_repaint {
+            ui.ctx().request_repaint();
+        } else if needs_tracking_repaint {
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(16));
         } else {


### PR DESCRIPTION
## What

Clicking canvas buttons (e.g. `[ Click me ]` in a freshly-scaffolded app) caused ~100ms delay before the counter incremented and the button flashed its active state.

## Root Cause

Two issues compounded in `src/process_app/mod.rs`:

1. `PlexiEvent::Render` is sent before click detection in `show()`, so the Python app always processes Render (with empty `_click_buf`) before Click in a given frame — meaning click responses only land in frame N+1.
2. Frame N+1 was scheduled via `request_repaint_after(100ms)` because `needs_tracking_repaint` was false for a plain click (no mouse movement).

## Fix

Introduce `needs_click_repaint` (bool, false by default). Set it true at both click `send_event` sites (primary and secondary). In the repaint scheduling block, prioritise `request_repaint()` (0ms) when a click fired — ahead of the 16ms tracking path and 100ms idle path.

Frame N+1 now fires as soon as the Python app's round-trip completes (~1–2ms), making button feedback feel instant.

**Breaks if:** clicking `[ Click me ]` in a freshly scaffolded app still shows a ~100ms delay before the counter increments.