### PR TITLE
ux(modals): polish text inputs — cursor width, accent color, border feedback, margin (#1108)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -571,13 +571,21 @@ impl PlexiApp {
                         ui.add_space(6.0);
 
                         let te_id = egui::Id::new("rename_pane_input");
-                        let te = ui.add(
-                            egui::TextEdit::singleline(&mut self.rename_buffer)
-                                .id(te_id)
-                                .desired_width(MODAL_WIDTH)
-                                .hint_text("Pane name...")
-                                .font(egui::TextStyle::Body),
-                        );
+                        let te = ui.scope(|ui| {
+                            ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                            ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
+                            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
+                            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.rename_buffer)
+                                    .id(te_id)
+                                    .desired_width(MODAL_WIDTH)
+                                    .hint_text("Pane name...")
+                                    .font(egui::TextStyle::Body)
+                                    .margin(egui::Margin::symmetric(8, 5)),
+                            )
+                        }).inner;
 
                         // One-shot focus: only request on the first render frame.
                         // Re-requesting every frame (guarded by `!te.has_focus()`) lets
@@ -596,6 +604,7 @@ impl PlexiApp {
                                 state.store(ui.ctx(), te_id);
                             }
                             self.rename_pane_focus_requested = true;
+                            log::info!("modal_text_polish: styled TextEdit rendered (rename_pane)");
                             log::info!("rename_pane: focus requested for TextEdit");
                         }
                     });
@@ -658,13 +667,21 @@ impl PlexiApp {
                         ui.add_space(6.0);
 
                         let te_id = egui::Id::new("rename_context_input");
-                        let te = ui.add(
-                            egui::TextEdit::singleline(&mut self.rename_buffer)
-                                .id(te_id)
-                                .desired_width(MODAL_WIDTH)
-                                .hint_text("Context name...")
-                                .font(egui::TextStyle::Body),
-                        );
+                        let te = ui.scope(|ui| {
+                            ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                            ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
+                            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
+                            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.rename_buffer)
+                                    .id(te_id)
+                                    .desired_width(MODAL_WIDTH)
+                                    .hint_text("Context name...")
+                                    .font(egui::TextStyle::Body)
+                                    .margin(egui::Margin::symmetric(8, 5)),
+                            )
+                        }).inner;
 
                         if !te.has_focus() {
                             te.request_focus();
@@ -763,20 +780,24 @@ impl PlexiApp {
                         egui::ScrollArea::vertical()
                             .max_height(max_text_h)
                             .show(ui, |ui| {
-                                ui.add(
-                                    egui::TextEdit::multiline(&mut self.quick_note_text)
-                                        .id(egui::Id::new("quick_note_text"))
-                                        .font(egui::FontId::monospace(style::TEXT_BODY))
-                                        .text_color(self.colors.text_primary)
-                                        .desired_width(f32::INFINITY)
-                                        .desired_rows(1)
-                                        .frame(false)
-                                        .hint_text(
-                                            RichText::new("What's on your mind?")
-                                                .color(self.colors.text_dim.linear_multiply(0.3))
-                                                .size(style::TEXT_BODY),
-                                        ),
-                                );
+                                ui.scope(|ui| {
+                                    ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                                    ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                                    ui.add(
+                                        egui::TextEdit::multiline(&mut self.quick_note_text)
+                                            .id(egui::Id::new("quick_note_text"))
+                                            .font(egui::FontId::monospace(style::TEXT_BODY))
+                                            .text_color(self.colors.text_primary)
+                                            .desired_width(f32::INFINITY)
+                                            .desired_rows(1)
+                                            .frame(false)
+                                            .hint_text(
+                                                RichText::new("What's on your mind?")
+                                                    .color(self.colors.text_dim.linear_multiply(0.3))
+                                                    .size(style::TEXT_BODY),
+                                            ),
+                                    );
+                                });
                             });
                     });
             });
@@ -1838,15 +1859,19 @@ impl PlexiApp {
                                 // Cmd+Enter submits (handled in the keyboard
                                 // pre-pass below). Scrolls vertically once it
                                 // exceeds the visible row count.
-                                let te = egui::TextEdit::multiline(
-                                    &mut self.modal_input_buffer,
-                                )
-                                .desired_width(f32::INFINITY)
-                                .desired_rows(6)
-                                .font(egui::FontId::proportional(16.0))
-                                .margin(egui::Margin::symmetric(12, 10))
-                                .hint_text("Type. Enter for newline, \u{2318}\u{21B5} to submit.");
-                                let resp = ui.add(te);
+                                let resp = ui.scope(|ui| {
+                                    ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                                    ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                                    ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
+                                    ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
+                                    ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
+                                    ui.add(egui::TextEdit::multiline(&mut self.modal_input_buffer)
+                                        .desired_width(f32::INFINITY)
+                                        .desired_rows(6)
+                                        .font(egui::FontId::proportional(16.0))
+                                        .margin(egui::Margin::symmetric(12, 10))
+                                        .hint_text("Type. Enter for newline, \u{2318}\u{21B5} to submit."))
+                                }).inner;
                                 resp.request_focus();
                             }
                         }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -604,7 +604,6 @@ impl PlexiApp {
                                 state.store(ui.ctx(), te_id);
                             }
                             self.rename_pane_focus_requested = true;
-                            log::info!("modal_text_polish: styled TextEdit rendered (rename_pane)");
                             log::info!("rename_pane: focus requested for TextEdit");
                         }
                     });

--- a/src/secrets_app.rs
+++ b/src/secrets_app.rs
@@ -307,13 +307,20 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let key_te = egui::TextEdit::singleline(&mut self.new_key)
-                        .desired_width(f32::INFINITY)
-                        .font(egui::FontId::monospace(12.0))
-                        .text_color(colors.text_primary)
-                        .frame(true)
-                        .hint_text("e.g. OPENAI_API_KEY");
-                    let key_resp = ui.add(key_te);
+                    let key_resp = ui.scope(|ui| {
+                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
+                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+                        ui.add(egui::TextEdit::singleline(&mut self.new_key)
+                            .desired_width(f32::INFINITY)
+                            .font(egui::FontId::monospace(12.0))
+                            .text_color(colors.text_primary)
+                            .frame(true)
+                            .margin(egui::Margin::symmetric(8, 5))
+                            .hint_text("e.g. OPENAI_API_KEY"))
+                    }).inner;
                     // Request focus on the key field when form opens
                     if !self.focus_requested {
                         key_resp.request_focus();
@@ -338,14 +345,21 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let val_te = egui::TextEdit::singleline(&mut self.new_value)
-                        .desired_width(f32::INFINITY)
-                        .font(egui::FontId::monospace(12.0))
-                        .text_color(colors.text_primary)
-                        .password(true)
-                        .frame(true)
-                        .hint_text("secret value");
-                    let val_resp = ui.add(val_te);
+                    let val_resp = ui.scope(|ui| {
+                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
+                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+                        ui.add(egui::TextEdit::singleline(&mut self.new_value)
+                            .desired_width(f32::INFINITY)
+                            .font(egui::FontId::monospace(12.0))
+                            .text_color(colors.text_primary)
+                            .password(true)
+                            .frame(true)
+                            .margin(egui::Margin::symmetric(8, 5))
+                            .hint_text("secret value"))
+                    }).inner;
                     if self.form_focus == FormField::Value && !val_resp.has_focus() {
                         val_resp.request_focus();
                     }
@@ -367,13 +381,20 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let dir_te = egui::TextEdit::singleline(&mut self.new_dir)
-                        .desired_width(f32::INFINITY)
-                        .font(egui::FontId::monospace(12.0))
-                        .text_color(colors.text_primary)
-                        .frame(true)
-                        .hint_text("/path/to/project");
-                    let dir_resp = ui.add(dir_te);
+                    let dir_resp = ui.scope(|ui| {
+                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
+                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+                        ui.add(egui::TextEdit::singleline(&mut self.new_dir)
+                            .desired_width(f32::INFINITY)
+                            .font(egui::FontId::monospace(12.0))
+                            .text_color(colors.text_primary)
+                            .frame(true)
+                            .margin(egui::Margin::symmetric(8, 5))
+                            .hint_text("/path/to/project"))
+                    }).inner;
                     if self.form_focus == FormField::Dir && !dir_resp.has_focus() {
                         dir_resp.request_focus();
                     }

--- a/src/secrets_app.rs
+++ b/src/secrets_app.rs
@@ -299,6 +299,17 @@ impl App for SecretsApp {
                 );
                 ui.add_space(10.0);
 
+                let styled_input = |ui: &mut egui::Ui, edit: egui::TextEdit| -> egui::Response {
+                    ui.scope(|ui| {
+                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
+                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+                        ui.add(edit)
+                    }).inner
+                };
+
                 // Key field
                 ui.horizontal(|ui| {
                     ui.label(
@@ -307,20 +318,13 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let key_resp = ui.scope(|ui| {
-                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
-                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
-                        ui.add(egui::TextEdit::singleline(&mut self.new_key)
-                            .desired_width(f32::INFINITY)
-                            .font(egui::FontId::monospace(12.0))
-                            .text_color(colors.text_primary)
-                            .frame(true)
-                            .margin(egui::Margin::symmetric(8, 5))
-                            .hint_text("e.g. OPENAI_API_KEY"))
-                    }).inner;
+                    let key_resp = styled_input(ui, egui::TextEdit::singleline(&mut self.new_key)
+                        .desired_width(f32::INFINITY)
+                        .font(egui::FontId::monospace(12.0))
+                        .text_color(colors.text_primary)
+                        .frame(true)
+                        .margin(egui::Margin::symmetric(8, 5))
+                        .hint_text("e.g. OPENAI_API_KEY"));
                     // Request focus on the key field when form opens
                     if !self.focus_requested {
                         key_resp.request_focus();
@@ -345,21 +349,14 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let val_resp = ui.scope(|ui| {
-                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
-                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
-                        ui.add(egui::TextEdit::singleline(&mut self.new_value)
-                            .desired_width(f32::INFINITY)
-                            .font(egui::FontId::monospace(12.0))
-                            .text_color(colors.text_primary)
-                            .password(true)
-                            .frame(true)
-                            .margin(egui::Margin::symmetric(8, 5))
-                            .hint_text("secret value"))
-                    }).inner;
+                    let val_resp = styled_input(ui, egui::TextEdit::singleline(&mut self.new_value)
+                        .desired_width(f32::INFINITY)
+                        .font(egui::FontId::monospace(12.0))
+                        .text_color(colors.text_primary)
+                        .password(true)
+                        .frame(true)
+                        .margin(egui::Margin::symmetric(8, 5))
+                        .hint_text("secret value"));
                     if self.form_focus == FormField::Value && !val_resp.has_focus() {
                         val_resp.request_focus();
                     }
@@ -381,20 +378,13 @@ impl App for SecretsApp {
                             .size(11.0)
                             .family(egui::FontFamily::Monospace),
                     );
-                    let dir_resp = ui.scope(|ui| {
-                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
-                        ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
-                        ui.add(egui::TextEdit::singleline(&mut self.new_dir)
-                            .desired_width(f32::INFINITY)
-                            .font(egui::FontId::monospace(12.0))
-                            .text_color(colors.text_primary)
-                            .frame(true)
-                            .margin(egui::Margin::symmetric(8, 5))
-                            .hint_text("/path/to/project"))
-                    }).inner;
+                    let dir_resp = styled_input(ui, egui::TextEdit::singleline(&mut self.new_dir)
+                        .desired_width(f32::INFINITY)
+                        .font(egui::FontId::monospace(12.0))
+                        .text_color(colors.text_primary)
+                        .frame(true)
+                        .margin(egui::Margin::symmetric(8, 5))
+                        .hint_text("/path/to/project"));
                     if self.form_focus == FormField::Dir && !dir_resp.has_focus() {
                         dir_resp.request_focus();
                     }


### PR DESCRIPTION
## What

Applies a consistent visual polish pass to all host-side `TextEdit` widgets across modals and the secrets app form.

## Changes

All sites wrapped in `ui.scope()` to prevent `visuals_mut()` leaking to adjacent widgets:

| Field | Files changed |
|---|---|
| Cursor width → 1.5px (was 2.0px egui default) | overlays.rs, secrets_app.rs |
| Cursor color → `colors.accent` | overlays.rs, secrets_app.rs |
| Input background → `colors.bg_active` | singleline + IQ prompt |
| Focus border → `colors.accent` stroke | singleline + IQ prompt |
| Unfocused border → `colors.border` stroke | singleline + IQ prompt |
| Padding → `margin(8, 5)` | all singleline inputs |

Covered sites: rename pane, rename context, quick note (cursor-only, frame=false), IQ prompt, secrets key/value/dir fields.

## Done When

- [x] Rename Pane modal shows ~1.5px cursor matching accent color
- [x] TextEdit fields have focus ring using accent, dim border when unfocused
- [x] Input background is visually distinct from modal background
- [x] `cargo build` passes with no warnings

Closes #1108