### PR TITLE
sec(quick-note): audit shell injection for pane destination token substitution (#1113)

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -1,8 +1,13 @@
 <!-- GOTCHAS.md — Non-obvious discoveries, failed approaches, and environment quirks specific to PLEXI. Only write an entry when something genuinely surprised you. For universal behavioral rules see ~/.claude/CLAUDE.md; for language/framework API gotchas see the coding-conventions skill. Review weekly: if the same area tag appears 3+ times, fix the root cause rather than adding another entry. -->
 
-## Area tags: git · ship · macos · rust · egui · sdk · cargo · python · cli
+## Area tags: git · ship · macos · rust · egui · sdk · cargo · python · cli · quick-note
 
 ---
+
+## [quick-note] shell injection surface for pane destination token substitution
+`substitute_note_tokens_static` applies `shell_quote` to both `{note}` and `{cwd}` before substituting into the command template. `shell_quote` uses POSIX single-quote wrapping (`'...'`) with `'` escaped as `'\''` — this blocks all expansion inside the quoted region including `$(...)`, backticks, `\`, newlines, and semicolons. Audit (issue #1113) confirmed no gaps: all three call sites (pane_ops/create.rs and two in overlays.rs) route through the same function.
+
+Key constraint: the command *template* comes from `config.toml` (user-controlled, not free-form input). Only the values substituted at `{note}` and `{cwd}` are escaped — the template structure itself is trusted. Do not add new substitution tokens that expand arbitrary strings without routing them through `shell_quote`.
 
 ## shell_join over-quotes single-arg terminal commands
 `shell_join(["echo hello"])` produces `'echo hello'` — zsh then tries to execute a command

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,6 +589,8 @@ confirm_close = false
 # available regardless of config.
 #
 # {note} = your note text (shell-escaped)   {cwd} = focused pane dir
+# Security: only {note} and {cwd} are shell-escaped. Do not add other user-supplied
+# values to the template — they will not be escaped and are a shell injection risk.
 
 [[quick_note.destinations]]
 key   = 1

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1122,22 +1122,96 @@ mod quick_note_tests {
     use super::*;
     use crate::app::QuickNoteCtx;
 
-    #[test]
-    fn substitute_tokens_escapes_shell_special_chars() {
-        let ctx = QuickNoteCtx {
-            cwd: std::path::PathBuf::from("/tmp/test dir"),
+    fn ctx(cwd: &str) -> QuickNoteCtx {
+        QuickNoteCtx {
+            cwd: std::path::PathBuf::from(cwd),
             workspace_root: None,
             context: "test".to_string(),
-        };
-        let cmd = "gh issue create --title {note} --body ''";
+        }
+    }
+
+    /// Run `sh -c <cmd>` and return trimmed stdout.
+    fn sh(cmd: &str) -> String {
+        let out = std::process::Command::new("sh")
+            .args(["-c", cmd])
+            .output()
+            .expect("sh -c failed");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn substitute_tokens_escapes_shell_special_chars() {
         let result = PlexiApp::substitute_note_tokens_static(
-            cmd,
+            "gh issue create --title {note} --body ''",
             "it's a note \"with quotes\"",
-            &ctx,
+            &ctx("/tmp/test dir"),
         );
-        // Verify it's valid shell (no unquoted single quote)
         assert!(!result.contains("it's"), "unescaped single quote found: {result}");
-        // The note should appear in escaped form
         assert!(result.contains("it"), "note text missing from: {result}");
+    }
+
+    /// `$(...)` in a note must not be evaluated by the shell.
+    #[test]
+    fn no_command_substitution_dollar_paren() {
+        let note = "$(printf INJECTED)";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        assert_eq!(out, note, "dollar-paren injection executed: got {out:?}");
+    }
+
+    /// Backtick command substitution in a note must not execute.
+    #[test]
+    fn no_command_substitution_backtick() {
+        let note = "`printf INJECTED`";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        assert_eq!(out, note, "backtick injection executed: got {out:?}");
+    }
+
+    /// A note containing `'; <command>; echo '` must not break out of the substitution context.
+    #[test]
+    fn no_injection_via_single_quote_break() {
+        let note = "'; printf INJECTED; printf '";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        assert_eq!(out, note, "single-quote break injection executed: got {out:?}");
+    }
+
+    /// Backslash in a note is passed through as a literal character.
+    #[test]
+    fn backslash_in_note_is_literal() {
+        let note = r"a\b";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        assert_eq!(out, note, "backslash mangled: got {out:?}");
+    }
+
+    /// Newlines in a note are preserved literally (not treated as command separators).
+    #[test]
+    fn newline_in_note_is_literal() {
+        let note = "first\nsecond";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        // printf '%s' strips the trailing newline; we check both lines appear in order.
+        assert!(out.contains("first") && out.contains("second"), "newline dropped: got {out:?}");
+        assert!(!out.contains("INJECTED"), "unexpected injection: got {out:?}");
+    }
+
+    /// `{cwd}` with a directory name containing a single quote expands safely.
+    #[test]
+    fn cwd_with_apostrophe_expands_safely() {
+        let path = "/tmp/it's a dir";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {cwd}", "note", &ctx(path));
+        let out = sh(&cmd);
+        assert_eq!(out, path, "cwd apostrophe mangled: got {out:?}");
+    }
+
+    /// A note consisting entirely of apostrophes must survive the round-trip.
+    #[test]
+    fn note_all_apostrophes_round_trips() {
+        let note = "'''";
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
+        let out = sh(&cmd);
+        assert_eq!(out, note, "all-apostrophe note mangled: got {out:?}");
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1130,13 +1130,20 @@ mod quick_note_tests {
         }
     }
 
-    /// Run `sh -c <cmd>` and return trimmed stdout.
+    /// Run `sh -c <cmd>` and return stdout. Panics if the command exits non-zero.
     fn sh(cmd: &str) -> String {
         let out = std::process::Command::new("sh")
             .args(["-c", cmd])
             .output()
             .expect("sh -c failed");
-        String::from_utf8_lossy(&out.stdout).trim().to_string()
+        if !out.status.success() {
+            panic!(
+                "sh command failed (exit {}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        String::from_utf8_lossy(&out.stdout).to_string()
     }
 
     #[test]
@@ -1192,9 +1199,7 @@ mod quick_note_tests {
         let note = "first\nsecond";
         let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
         let out = sh(&cmd);
-        // printf '%s' strips the trailing newline; we check both lines appear in order.
-        assert!(out.contains("first") && out.contains("second"), "newline dropped: got {out:?}");
-        assert!(!out.contains("INJECTED"), "unexpected injection: got {out:?}");
+        assert_eq!(out, note, "newline not preserved literally: got {out:?}");
     }
 
     /// `{cwd}` with a directory name containing a single quote expands safely.


### PR DESCRIPTION
## Summary

- Audited substitute_note_tokens_static and shell_quote for shell injection risks — no gaps found
- Added 8 regression tests in quick_note_tests covering every injection vector from the issue via actual sh -c execution: dollar-paren, backticks, quote-break, backslash, newlines, cwd with apostrophe, all-apostrophe note
- Documented findings in GOTCHAS.md under [quick-note] tag
- Added security comment to config.rs template

## Done When verified

- Note containing injection attempts does NOT execute injected code — verified by shell-execution tests
- cwd with apostrophe expands safely — verified by cwd_with_apostrophe_expands_safely test
- Findings documented in GOTCHAS.md under [quick-note] tag
- Regression tests in pane_ops::create::quick_note_tests (8 tests, all passing)

## Test plan

- cargo test --bin plexi quick_note_tests — 8 tests, all pass

Closes #1113