### PR TITLE
fix(workspace): new page follows active pane CWD, not context root

### DIFF
--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -76,11 +76,11 @@ impl PlexiApp {
     /// and make it the active context.
     pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let pane_cwd = self.windows[self.active_window]
+        let cwd = self.windows[self.active_window]
             .focused_pane
             .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
-            .unwrap_or_else(|| home.clone());
-        let cwd = self.router.active().root.clone().unwrap_or(pane_cwd);
+            .or_else(|| self.router.active().root.clone())
+            .unwrap_or(home);
         log::info!("create_page_at({grid_x},{grid_y}): cwd={}", cwd.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
         else {


### PR DESCRIPTION
## Summary

- `create_page_at` (Cmd+N) was using `router.active().root` as the CWD for new pages, ignoring where the user had actually navigated to in their active pane
- Root cause: `root.unwrap_or(pane_cwd)` — root always won when set, overriding pane CWD
- Fix: flip priority to `pane_cwd.or(root).unwrap_or(home)` — pane CWD wins, context root is fallback only

Also cleared the stale `~/temp` entry from `~/.plexi-alpha/workspaces/default.json` (direct fix, not in the PR).

## Breaks if

New pages (Cmd+N) spawn in context root instead of the active pane's current directory.