### PR TITLE
fix(overlays): cli setup modal captures keyboard input via FocusLayer (#1142)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3430,7 +3430,9 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::CliSetupPrompt);
         } else if !should_own && has_layer {
             log::info!("cli_setup: CliSetupPrompt focus layer released");
-            self.pop_focus_layer(&FocusLayer::CliSetupPrompt);
+            // Use retain rather than pop_focus_layer so stale entries are removed
+            // even if another layer was pushed on top (e.g. via rapid state change).
+            self.focus_stack.retain(|l| *l != FocusLayer::CliSetupPrompt);
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,6 +74,9 @@ pub(crate) enum FocusLayer {
     QuickNoteDestination,
     /// Quick note sub-destination picker. Inner u8 = parent key.
     QuickNoteSubDestination(u8),
+    /// First-launch CLI setup prompt. No text input — intercepts keys so they
+    /// don't fall through to the active terminal while the modal is visible.
+    CliSetupPrompt,
 }
 
 #[derive(Clone)]
@@ -1621,6 +1624,7 @@ impl eframe::App for PlexiApp {
         self.sync_command_palette_focus();
         self.sync_rename_pane_focus();
         self.sync_context_rename_focus();
+        self.sync_cli_setup_prompt_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
         // notification modal's TextEdit for the `input` kind, the palette's
@@ -1656,6 +1660,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::QuickNoteSubDestination(_)) => {
                     self.draw_quick_note_subdestination(ctx);
                 }
+                Some(FocusLayer::CliSetupPrompt) => {
+                    self.draw_cli_setup_modal(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -1668,6 +1675,7 @@ impl eframe::App for PlexiApp {
             self.sync_command_palette_focus();
             self.sync_rename_pane_focus();
             self.sync_context_rename_focus();
+            self.sync_cli_setup_prompt_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -3092,11 +3100,6 @@ impl eframe::App for PlexiApp {
         // Changelog overlay
         self.draw_changelog_overlay(ctx);
 
-        // First-launch CLI setup prompt
-        if self.show_cli_setup_prompt {
-            self.draw_cli_setup_modal(ctx);
-        }
-
         // Minimap overlay — auto-hidden when current workspace has <2 windows.
         let ws_id = self.router.active().context_id;
         let window_count = self.windows.iter().filter(|c| c.context_id == ws_id).count();
@@ -3167,6 +3170,7 @@ impl PlexiApp {
                 | Some(FocusLayer::QuickNote)
                 | Some(FocusLayer::QuickNoteDestination)
                 | Some(FocusLayer::QuickNoteSubDestination(_))
+                | Some(FocusLayer::CliSetupPrompt)
         )
     }
 
@@ -3412,6 +3416,21 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::NotificationModal);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::NotificationModal);
+        }
+    }
+
+    pub(crate) fn sync_cli_setup_prompt_focus(&mut self) {
+        let should_own = self.show_cli_setup_prompt;
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::CliSetupPrompt);
+        if should_own && !has_layer {
+            log::info!("cli_setup: focus captured by CliSetupPrompt layer");
+            self.push_focus_layer(FocusLayer::CliSetupPrompt);
+        } else if !should_own && has_layer {
+            log::info!("cli_setup: CliSetupPrompt focus layer released");
+            self.pop_focus_layer(&FocusLayer::CliSetupPrompt);
         }
     }
 


### PR DESCRIPTION
## Problem

Keystrokes typed while the CLI setup prompt modal was visible fell through to the active terminal pane.

## Root Cause

`draw_cli_setup_modal` rendered in the late draw path (after the early input-capture block) and never pushed a `FocusLayer`. `input_captured_by_overlay()` uses `focus_stack.last()` — since `show_cli_setup_prompt` never touched the stack, it always returned `false`, so keystrokes were dispatched to the focused pane.

## Fix

- Adds `FocusLayer::CliSetupPrompt` to the enum
- Adds it to `input_captured_by_overlay()`
- Adds `sync_cli_setup_prompt_focus()` (same pattern as all other modals)
- Wires the sync into the pre-capture and post-modal sync blocks in `update()`
- Adds a match arm in the early-capture dispatch block
- Removes the late `draw_cli_setup_modal` call that bypassed capture

Escape still dismisses the modal; all other keystrokes are now consumed.

## Done When

- [x] `cargo build` passes
- [x] 391 tests pass (2 pre-existing failures unrelated to this change)

Closes #1142