### PR TITLE
fix(close): advance focus to next sibling on pane/page close (#1152)

### DIFF
--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dispatch-next
-description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace from NEXT.md — creates up to 4 parallel Claude lanes for independent issues and queues sequential issues vertically below each lane.
+description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace — auto-computes parallel lanes from live issue state (grouped by area:* label), writes NEXT.md, then opens up to 4 Claude panes with queued sequential issues below each.
 ---
 
 # Dispatch Next
 
-Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude workspace.
+Auto-computes lane assignments from live GitHub issue state, writes `NEXT.md`, then initializes a Plexi multi-pane Claude workspace.
 
 ## Layout model
 
@@ -20,45 +20,158 @@ Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude w
 ## Invocation
 
 ```
-/dispatch-next              # reads NEXT.md in repo root
-/dispatch-next path/to/next.md
+/dispatch-next              # auto-computes lanes, writes NEXT.md, opens panes
+/dispatch-next path/to/next.md   # skip Step 0, read that file directly
 ```
+
+---
+
+## Step 0 — Compute lanes from issue state
+
+Skip this step only if a specific file path was passed as an argument.
+
+### 0a — Fetch ready issues
+
+```bash
+gh issue list --label "ready" --state open \
+  --json number,title,labels,body --limit 100
+```
+
+### 0b — Classify each issue
+
+For each issue build a record:
+
+```
+{
+  number: N,
+  title: "...",
+  priority: 0-4,       # extracted from P0..P4 label; 99 if none
+  area: "area:X/Y",    # first area:* label found; null if none
+  is_bundle: bool,     # has "bundle" label
+  in_progress: bool,   # has "in progress" label
+  blocked: bool,       # has "blocked" label
+}
+```
+
+**Exclude** from lane assignment:
+- `in_progress` — already running
+- `blocked` — dependency unresolved
+
+**Surface separately** (do not exclude — just flag):
+- Issues with no `area:*` label
+
+### 0c — Check for unlabeled P0/P1 issues
+
+If any excluded-from-lanes issue has priority P0 or P1:
+
+```
+STOP. The following high-priority issues have no area label and cannot be auto-dispatched:
+  #N — <title> [P0]
+  #M — <title> [P1]
+
+Triage these first: gh issue edit <N> --add-label "area:<namespace>/<module>"
+```
+
+Do not open any panes. Do not proceed to Step 1.
+
+### 0d — Build lane map
+
+Group remaining (area-labeled, non-excluded) issues by their `area` value.
+
+```python
+lanes = {}
+for issue in eligible:
+    area = issue.area
+    lanes.setdefault(area, []).append(issue)
+
+# Sort each lane: priority ASC, then number ASC
+for area in lanes:
+    lanes[area].sort(key=lambda i: (i.priority, i.number))
+```
+
+### 0e — Coalesce bundle issues
+
+Within each lane, if the lane's leading issues are ALL labeled `bundle`, merge them into a single ship call:
+
+```
+# Before: lane = [#1149(bundle), #1150(bundle), #1160]
+# After:  lane = [bundle(#1149+#1150), #1160]
+```
+
+A bundle lead is represented as a `+`-joined string: `"1149+1150"`.  
+Non-bundle issues that follow are individual queue entries.
+
+If a lane has a mix of bundle and non-bundle issues at the front, only coalesce the consecutive leading bundle issues.
+
+### 0f — Select active lanes
+
+Sort areas by their lane's lead issue priority (ASC), then lead issue number (ASC).  
+Take the first **4** as active lanes. Remaining areas are deferred.
+
+### 0g — Write NEXT.md
+
+Write to the repo root:
+
+```markdown
+# NEXT.md
+<!-- computed: <ISO timestamp> -->
+
+## Lanes
+
+| Lane | Area | Lead | Queue |
+|------|------|------|-------|
+| A | area:host/navigation | #934 | #316 |
+| B | area:ui/overlays | #321+#322 (bundle) | #354 |
+| C | area:host/pane-ops | #918 | |
+
+## Deferred (beyond 4-lane cap)
+
+- **area:sdk/pgap**: #1149, #1144
+
+## Needs area label
+
+- #1153 — quick-note: ArrowRight/ArrowLeft not bound in destination picker [P3]
+- #1152 — ux(close): closing a pane should advance focus to next sibling [P0 ⚠]
+```
+
+If there are no deferred areas or no unlabeled issues, omit those sections.
+
+Print the NEXT.md content to stdout so the user sees the computed plan.
 
 ---
 
 ## Step 1 — Parse NEXT.md
 
-Read the file. Extract:
-- The dependency graph (ASCII)
-- The "What runs in parallel" lanes table
-- The ordered next steps list
+Read the file (written by Step 0, or the path argument). Extract the lanes table.
 
 Build a lanes array (cap at 4):
 
 ```
 lanes = [
-  { lead: 934, queue: [316] },
-  { lead: 321, queue: [354, 316] },
-  { lead: 918, queue: [] },
+  { lead: "934",       queue: ["316"] },
+  { lead: "321+322",   queue: ["354"] },
+  { lead: "918",       queue: [] },
 ]
 ```
 
-`lead` = first unshipped issue in the lane.  
-`queue` = ordered list of issues that follow sequentially.
+`lead` = first unshipped entry in the lane. May be a `+`-joined bundle string.  
+`queue` = ordered list of issue numbers (or bundle strings) that follow.
 
-If NEXT.md has no explicit lanes table, derive lanes yourself from the dependency graph — independent branches are separate lanes.
+If NEXT.md has no explicit lanes table, derive lanes from any dependency graph present — independent branches are separate lanes.
 
 ---
 
 ## Step 2 — Skip already-closed leads
 
-For each lead issue, check state:
+For each lead issue (or each issue in a bundle lead), check state:
 
 ```bash
 gh issue view <N> --json state --jq '.state'
 ```
 
-If `CLOSED`, advance to the next issue in that lane's queue as the new lead. If the whole lane is closed, drop it.
+If a single-issue lead is `CLOSED`, advance to the next queue entry as the new lead.  
+If all issues in a bundle lead are `CLOSED`, advance to the next queue entry.  
+If the whole lane is closed, drop it.
 
 ---
 
@@ -91,7 +204,12 @@ print(new[-1] if new else '')
 ")
 ```
 
-Label it and start Claude inside it (no newline = not submitted yet for first lane; use `\n` to immediately start):
+Build the ship command from the lead:
+
+- Single issue `"934"` → `c "ship issue 934"`
+- Bundle `"321+322"` → `c "ship issue 321 322"`
+
+Label and start:
 
 ```bash
 plexi pane name $NEW_ID "Lane <X>: #<lead>"
@@ -123,7 +241,7 @@ plexi pane name $QUEUE_ID "queued: #<next>"
 plexi pane send $QUEUE_ID 'c "ship issue <next>"'
 ```
 
-If the lane has more than one queued issue (e.g. lane B has both #354 and #316 downstream), only queue the immediate next — not the full chain. The user will handle deeper queuing after #354 ships.
+If the lane has more than one queued issue, only queue the immediate next — the user handles deeper queuing after that issue ships.
 
 ---
 
@@ -144,4 +262,5 @@ Leave the user's cursor in the first active lane.
 - For queue panes, omit `\n` from `plexi pane send` so the command is staged but not executed.
 - `c` is a personal zsh alias (login shell) — available in all interactive panes opened by Plexi.
 - If a lane's lead issue has a feature branch already in progress (`wtp list` or `git worktree list`), note it in the pane title: `"Lane A: #934 (branch exists)"`.
-- If NEXT.md is absent or has no parseable lanes, surface the issue list from `gh issue list --label "ready" --json number,title` and ask the user to confirm the lane assignment before opening any panes.
+- NEXT.md is a cache. It goes stale as issues close. Re-run `/dispatch-next` to recompute.
+- The "Needs area label" section in NEXT.md is the triage backlog for the area labeling pass. P0/P1 items there block dispatch entirely.

--- a/src/context.rs
+++ b/src/context.rs
@@ -99,10 +99,10 @@ impl Window {
 
     pub(crate) fn find_next_focus(&self, excluding: TileId) -> Option<TileId> {
         for dir in [
-            Direction::Left,
-            Direction::Up,
             Direction::Right,
             Direction::Down,
+            Direction::Left,
+            Direction::Up,
         ] {
             if let Some(target) = self.find_pane_in_direction_from(excluding, dir) {
                 return Some(target);

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -110,27 +110,62 @@ impl PlexiApp {
         }
     }
 
-    /// After a context is deleted, find the nearest remaining context by grid
-    /// proximity (smallest Manhattan distance to the removed page's
-    /// coordinates). Returns the `active_context` index to switch to.
+    /// After a context is deleted, find the best remaining context to focus.
+    /// Returns the `active_context` index to switch to.
     pub(crate) fn nearest_context_after_delete(
         &self,
         removed_x: u32,
         removed_y: u32,
     ) -> usize {
         let ws_id = self.router.active().context_id;
-        self.windows
+        let pages: Vec<(u32, u32, usize)> = self
+            .windows
             .iter()
             .enumerate()
             .filter(|(_, c)| c.context_id == ws_id)
-            .min_by_key(|(_, c)| {
-                let dx = (c.grid_x as i64 - removed_x as i64).unsigned_abs();
-                let dy = (c.grid_y as i64 - removed_y as i64).unsigned_abs();
-                dx + dy
-            })
-            .map(|(i, _)| i)
-            .unwrap_or(0)
+            .map(|(i, c)| (c.grid_x, c.grid_y, i))
+            .collect();
+        next_context_after_delete(&pages, removed_x, removed_y)
     }
+}
+
+/// Select the best replacement context index after a page at `(removed_x, removed_y)` is deleted.
+///
+/// Priority:
+/// 1. Same row, next column — `(removed_x + 1, removed_y)`
+/// 2. Same column, next row — `(removed_x, removed_y + 1)`
+/// 3. Nearest by Manhattan distance; tie-break: forward direction (non-negative dx and dy) wins
+fn next_context_after_delete(
+    pages: &[(u32, u32, usize)],
+    removed_x: u32,
+    removed_y: u32,
+) -> usize {
+    // 1. Same row, next column
+    if let Some(&(_, _, i)) = pages
+        .iter()
+        .find(|&&(x, y, _)| y == removed_y && Some(x) == removed_x.checked_add(1))
+    {
+        return i;
+    }
+    // 2. Same column, next row
+    if let Some(&(_, _, i)) = pages
+        .iter()
+        .find(|&&(x, y, _)| x == removed_x && Some(y) == removed_y.checked_add(1))
+    {
+        return i;
+    }
+    // 3. Nearest by Manhattan distance; prefer forward (non-negative delta) on tie
+    pages
+        .iter()
+        .min_by_key(|&&(x, y, _)| {
+            let dx = x as i64 - removed_x as i64;
+            let dy = y as i64 - removed_y as i64;
+            let dist = dx.unsigned_abs() + dy.unsigned_abs();
+            let backward = if dx >= 0 && dy >= 0 { 0u64 } else { 1u64 };
+            (dist, backward)
+        })
+        .map(|&(_, _, i)| i)
+        .unwrap_or(0)
 }
 
 // ── Unit tests ───────────────────────────────────────────────────────────────
@@ -265,6 +300,36 @@ mod tests {
             find_navigation_target(&ps, 1, 0, 0, 1, 0, &HashMap::new()),
             None
         );
+    }
+
+    // ── next_context_after_delete ─────────────────────────────────────────
+
+    #[test]
+    fn delete_prefers_next_column_same_row() {
+        // Removed at (0,0). Candidates: (1,0) and (0,1). Same-row next col wins.
+        let candidates = vec![(1u32, 0u32, 0usize), (0u32, 1u32, 1usize)];
+        assert_eq!(next_context_after_delete(&candidates, 0, 0), 0); // (1,0)
+    }
+
+    #[test]
+    fn delete_falls_back_to_next_row_when_no_next_col() {
+        // Removed at (1,0). No candidate at (2,0). Candidate at (1,1) wins via priority 2.
+        let candidates = vec![(0u32, 0u32, 0usize), (1u32, 1u32, 1usize)];
+        assert_eq!(next_context_after_delete(&candidates, 1, 0), 1); // (1,1)
+    }
+
+    #[test]
+    fn delete_tie_prefers_forward_over_backward() {
+        // Removed at (1,0). (0,0) and (2,0) are equidistant. (2,0) is forward — it wins.
+        let candidates = vec![(0u32, 0u32, 0usize), (2u32, 0u32, 1usize)];
+        assert_eq!(next_context_after_delete(&candidates, 1, 0), 1); // (2,0)
+    }
+
+    #[test]
+    fn delete_falls_back_to_prev_when_last_in_row() {
+        // Removed at (2,0). No candidate to the right. Falls back to (1,0) as nearest.
+        let candidates = vec![(0u32, 0u32, 0usize), (1u32, 0u32, 1usize)];
+        assert_eq!(next_context_after_delete(&candidates, 2, 0), 1); // (1,0) is nearest
     }
 
     // ── Workspace isolation ───────────────────────────────────────────────

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -320,9 +320,11 @@ mod tests {
 
     #[test]
     fn delete_tie_prefers_forward_over_backward() {
-        // Removed at (1,0). (0,0) and (2,0) are equidistant. (2,0) is forward — it wins.
-        let candidates = vec![(0u32, 0u32, 0usize), (2u32, 0u32, 1usize)];
-        assert_eq!(next_context_after_delete(&candidates, 1, 0), 1); // (2,0)
+        // Removed at (1,1). Candidates: (0,0) and (2,2) — equidistant (Manhattan 2).
+        // Neither matches priority 1 (would need (2,1)) nor priority 2 (would need (1,2)).
+        // (2,2) has dx=1,dy=1 (forward) vs (0,0) dx=-1,dy=-1 (backward) — (2,2) wins.
+        let candidates = vec![(0u32, 0u32, 0usize), (2u32, 2u32, 1usize)];
+        assert_eq!(next_context_after_delete(&candidates, 1, 1), 1); // (2,2)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `find_next_focus` in `src/context.rs` scanned directions `[Left, Up, Right, Down]` — predecessor always won on close. Reordered to `[Right, Down, Left, Up]`.
- `nearest_context_after_delete` in `src/spatial.rs` used `min_by_key` on Manhattan distance with no tie-break — iteration order returned the left/previous page on ties. Replaced with explicit priority: (1) same-row next column, (2) same-column next row, (3) nearest with forward tie-break.
- `close_tile`'s tab/linear sibling selection already used `pos + 1` correctly — no change needed there.
- Extracted `next_context_after_delete` as a testable free function; 4 new unit tests added.

**Breaks if:** closing a pane with a right/lower neighbor focuses the left/upper neighbor instead.

Closes #1152