### PR TITLE
docs(readme): overhaul — Quick Note, Notifications, Apps, PGAP, Secrets, CLI reference (#1154)

### DIFF
--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dispatch-next
-description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace from NEXT.md — creates up to 4 parallel Claude lanes for independent issues and queues sequential issues vertically below each lane.
+description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace — auto-computes parallel lanes from live issue state (grouped by area:* label), writes NEXT.md, then opens up to 4 Claude panes with queued sequential issues below each.
 ---
 
 # Dispatch Next
 
-Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude workspace.
+Auto-computes lane assignments from live GitHub issue state, writes `NEXT.md`, then initializes a Plexi multi-pane Claude workspace.
 
 ## Layout model
 
@@ -20,45 +20,158 @@ Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude w
 ## Invocation
 
 ```
-/dispatch-next              # reads NEXT.md in repo root
-/dispatch-next path/to/next.md
+/dispatch-next              # auto-computes lanes, writes NEXT.md, opens panes
+/dispatch-next path/to/next.md   # skip Step 0, read that file directly
 ```
+
+---
+
+## Step 0 — Compute lanes from issue state
+
+Skip this step only if a specific file path was passed as an argument.
+
+### 0a — Fetch ready issues
+
+```bash
+gh issue list --label "ready" --state open \
+  --json number,title,labels,body --limit 100
+```
+
+### 0b — Classify each issue
+
+For each issue build a record:
+
+```
+{
+  number: N,
+  title: "...",
+  priority: 0-4,       # extracted from P0..P4 label; 99 if none
+  area: "area:X/Y",    # first area:* label found; null if none
+  is_bundle: bool,     # has "bundle" label
+  in_progress: bool,   # has "in progress" label
+  blocked: bool,       # has "blocked" label
+}
+```
+
+**Exclude** from lane assignment:
+- `in_progress` — already running
+- `blocked` — dependency unresolved
+
+**Surface separately** (do not exclude — just flag):
+- Issues with no `area:*` label
+
+### 0c — Check for unlabeled P0/P1 issues
+
+If any excluded-from-lanes issue has priority P0 or P1:
+
+```
+STOP. The following high-priority issues have no area label and cannot be auto-dispatched:
+  #N — <title> [P0]
+  #M — <title> [P1]
+
+Triage these first: gh issue edit <N> --add-label "area:<namespace>/<module>"
+```
+
+Do not open any panes. Do not proceed to Step 1.
+
+### 0d — Build lane map
+
+Group remaining (area-labeled, non-excluded) issues by their `area` value.
+
+```python
+lanes = {}
+for issue in eligible:
+    area = issue.area
+    lanes.setdefault(area, []).append(issue)
+
+# Sort each lane: priority ASC, then number ASC
+for area in lanes:
+    lanes[area].sort(key=lambda i: (i.priority, i.number))
+```
+
+### 0e — Coalesce bundle issues
+
+Within each lane, if the lane's leading issues are ALL labeled `bundle`, merge them into a single ship call:
+
+```
+# Before: lane = [#1149(bundle), #1150(bundle), #1160]
+# After:  lane = [bundle(#1149+#1150), #1160]
+```
+
+A bundle lead is represented as a `+`-joined string: `"1149+1150"`.  
+Non-bundle issues that follow are individual queue entries.
+
+If a lane has a mix of bundle and non-bundle issues at the front, only coalesce the consecutive leading bundle issues.
+
+### 0f — Select active lanes
+
+Sort areas by their lane's lead issue priority (ASC), then lead issue number (ASC).  
+Take the first **4** as active lanes. Remaining areas are deferred.
+
+### 0g — Write NEXT.md
+
+Write to the repo root:
+
+```markdown
+# NEXT.md
+<!-- computed: <ISO timestamp> -->
+
+## Lanes
+
+| Lane | Area | Lead | Queue |
+|------|------|------|-------|
+| A | area:host/navigation | #934 | #316 |
+| B | area:ui/overlays | #321+#322 (bundle) | #354 |
+| C | area:host/pane-ops | #918 | |
+
+## Deferred (beyond 4-lane cap)
+
+- **area:sdk/pgap**: #1149, #1144
+
+## Needs area label
+
+- #1153 — quick-note: ArrowRight/ArrowLeft not bound in destination picker [P3]
+- #1152 — ux(close): closing a pane should advance focus to next sibling [P0 ⚠]
+```
+
+If there are no deferred areas or no unlabeled issues, omit those sections.
+
+Print the NEXT.md content to stdout so the user sees the computed plan.
 
 ---
 
 ## Step 1 — Parse NEXT.md
 
-Read the file. Extract:
-- The dependency graph (ASCII)
-- The "What runs in parallel" lanes table
-- The ordered next steps list
+Read the file (written by Step 0, or the path argument). Extract the lanes table.
 
 Build a lanes array (cap at 4):
 
 ```
 lanes = [
-  { lead: 934, queue: [316] },
-  { lead: 321, queue: [354, 316] },
-  { lead: 918, queue: [] },
+  { lead: "934",       queue: ["316"] },
+  { lead: "321+322",   queue: ["354"] },
+  { lead: "918",       queue: [] },
 ]
 ```
 
-`lead` = first unshipped issue in the lane.  
-`queue` = ordered list of issues that follow sequentially.
+`lead` = first unshipped entry in the lane. May be a `+`-joined bundle string.  
+`queue` = ordered list of issue numbers (or bundle strings) that follow.
 
-If NEXT.md has no explicit lanes table, derive lanes yourself from the dependency graph — independent branches are separate lanes.
+If NEXT.md has no explicit lanes table, derive lanes from any dependency graph present — independent branches are separate lanes.
 
 ---
 
 ## Step 2 — Skip already-closed leads
 
-For each lead issue, check state:
+For each lead issue (or each issue in a bundle lead), check state:
 
 ```bash
 gh issue view <N> --json state --jq '.state'
 ```
 
-If `CLOSED`, advance to the next issue in that lane's queue as the new lead. If the whole lane is closed, drop it.
+If a single-issue lead is `CLOSED`, advance to the next queue entry as the new lead.  
+If all issues in a bundle lead are `CLOSED`, advance to the next queue entry.  
+If the whole lane is closed, drop it.
 
 ---
 
@@ -91,7 +204,12 @@ print(new[-1] if new else '')
 ")
 ```
 
-Label it and start Claude inside it (no newline = not submitted yet for first lane; use `\n` to immediately start):
+Build the ship command from the lead:
+
+- Single issue `"934"` → `c "ship issue 934"`
+- Bundle `"321+322"` → `c "ship issue 321 322"`
+
+Label and start:
 
 ```bash
 plexi pane name $NEW_ID "Lane <X>: #<lead>"
@@ -123,7 +241,7 @@ plexi pane name $QUEUE_ID "queued: #<next>"
 plexi pane send $QUEUE_ID 'c "ship issue <next>"'
 ```
 
-If the lane has more than one queued issue (e.g. lane B has both #354 and #316 downstream), only queue the immediate next — not the full chain. The user will handle deeper queuing after #354 ships.
+If the lane has more than one queued issue, only queue the immediate next — the user handles deeper queuing after that issue ships.
 
 ---
 
@@ -144,4 +262,5 @@ Leave the user's cursor in the first active lane.
 - For queue panes, omit `\n` from `plexi pane send` so the command is staged but not executed.
 - `c` is a personal zsh alias (login shell) — available in all interactive panes opened by Plexi.
 - If a lane's lead issue has a feature branch already in progress (`wtp list` or `git worktree list`), note it in the pane title: `"Lane A: #934 (branch exists)"`.
-- If NEXT.md is absent or has no parseable lanes, surface the issue list from `gh issue list --label "ready" --json number,title` and ask the user to confirm the lane assignment before opening any panes.
+- NEXT.md is a cache. It goes stale as issues close. Re-run `/dispatch-next` to recompute.
+- The "Needs area label" section in NEXT.md is the triage backlog for the area labeling pass. P0/P1 items there block dispatch entirely.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<h1 align="center"> under construction </h1>
-
-
-
 <p align="center">
   <img src="assets/icon.svg" width="80" alt="Plexi" />
 </p>
@@ -15,8 +11,6 @@
 </p>
 
 One binary. A tiling shell that brings Unix composability to the desktop — terminals, apps, and AI agents all speak the same protocol. Pipe output between processes, route notifications across panes, query any model from any context.
-
-
 
 ---
 
@@ -53,37 +47,117 @@ just install
 
 ---
 
-## Features
+## Quick Note (`Cmd+0`)
 
-**PGAP** — every pane communicates over a single protocol (newline-delimited JSON on stdin/stdout). No shared memory, no inherited file descriptors. Binary payloads travel on typed pipes alongside the command channel. The protocol is the isolation boundary. Full reference: [PGAP.md](PGAP.md).
+Quick Note is a global capture modal for routing text to any destination without breaking your flow.
 
-**Notification bus** — any terminal process can emit a notification; any app or pane can receive it. Route events across the workspace to tie independent processes together.
+**Opening it:** `Cmd+0` from anywhere in Plexi opens the compose modal. Type your note, press `Enter` to advance to the destination picker, then press a digit key to route instantly — no second `Enter` needed.
 
-**AI backend** — OpenRouter with configurable model tiers and real cost tracking. `ai.query()` is available in any app; agent panes run a full LLM turn loop backed by Claude or the Anthropic API.
+**Destination 0** (global backlog) is always available regardless of config. It saves notes to `~/.plexi/backlog/` as timestamped Markdown files.
 
-**App runtime** — write apps in Python (bundled 3.12, zero setup) that render native UI, play audio, capture MIDI, and communicate over typed pipes. Apps declare capabilities in a manifest; the host enforces them.
+**Custom destinations** are configured in `[[quick_note.destinations]]` in your `config.toml`. Each destination gets a digit key (`1`–`9`) and a label shown in the picker.
 
-**Workspace-scoped secrets** — credentials stored in macOS Keychain, keyed to a workspace root. An app at `/foo` cannot read a secret granted at `/bar` without a new prompt.
+### Destination types
 
-**App package manager** — install, update, uninstall, and list apps from the command palette or CLI.
+**`backlog`** — writes the note as a Markdown file into a directory.
 
-**Tiling layout** — split panes horizontally or vertically, navigate with `Cmd+H/J/K/L`, zoom any pane full-screen with `Cmd+Enter`. Press `Cmd+/` for the full shortcut list.
+```toml
+[[quick_note.destinations]]
+key   = 1
+label = "Backlog"
+type  = "backlog"
+path  = "~/.plexi/backlog"
+```
 
-**Command palette** (`Cmd+P`) — jump to any context or named pane, launch apps, run commands.
+**`pane`** — runs a shell command template in a new pane. Use `{note}` and `{cwd}` as tokens; both are shell-escaped before substitution.
+
+```toml
+[[quick_note.destinations]]
+key      = 2
+label    = "Ask Claude"
+type     = "pane"
+command  = "claude -p {note}"
+position = "context-end"
+```
+
+The `position` field controls where the new pane opens:
+- `context-end` — appended at the end of the current context
+- `context-start` — inserted at the start of the current context
+- *(omitted)* — splits the focused pane
+
+**Submenus** — omit `type` and set `options = [...]` to expand into a sub-picker on keypress:
+
+```toml
+[[quick_note.destinations]]
+key   = 3
+label = "GitHub issue"
+options = [
+  { key = 1, label = "Bug",         command = "cd {cwd} && gh issue create --label bug --title {note} --body {note}" },
+  { key = 2, label = "Enhancement", command = "cd {cwd} && gh issue create --label enhancement --title {note} --body {note}" },
+  { key = 3, label = "No label",    command = "cd {cwd} && gh issue create --title {note} --body {note}" },
+]
+```
+
+**Security:** Only `{note}` and `{cwd}` are shell-escaped. Do not interpolate other user-supplied values into command templates — they will not be escaped and are a shell injection risk.
+
+---
+
+## Notifications
+
+Any process running inside Plexi — a terminal command, an app, or the CLI — can emit a notification. The notification bus routes events across panes so independent processes can communicate.
+
+### Emitting a notification
+
+**From the CLI:**
+
+```bash
+plexi notify --title "Job done" --body "Output is ready in ~/out.txt"
+```
+
+**With action choices:**
+
+```bash
+plexi notify --title "Deploy ready" --body "Review before promoting." \
+  --choice "a:Open PR" \
+  --choice "b:Skip"
+```
+
+**From an app (Python SDK):**
+
+```python
+ctx.notify("Job done", body="Output is ready in ~/out.txt", priority=ctx.PRIORITY_HIGH)
+```
+
+### Priority tiers
+
+| Priority | Value | Behavior |
+|----------|-------|----------|
+| `PRIORITY_LOW` | 0 | Queues silently; badge ticks on toolbar |
+| `PRIORITY_NORMAL` | 50 | Queues silently by default |
+| `PRIORITY_HIGH` | 100 | Auto-opens the modal (default threshold) |
+| `PRIORITY_CRITICAL` | 200 | Always interrupts |
+
+The `interrupt_threshold` in `config.toml` sets the minimum priority that auto-opens the modal. Notifications below it queue silently — open `Cmd+Shift+A` to review.
+
+### The notification modal (`Cmd+Shift+A`)
+
+Keyboard-first navigation: `Enter` confirms / acknowledges, `j`/`k` or `↑`/`↓` cycles choices, `1`–`9` for direct selection, `Esc` defers (modal closes, notification stays in queue). Notifications with `required = true` cannot be deferred with `Esc`.
+
+A toolbar badge shows the count of pending notifications. `Cmd+Shift+A` always gives feedback — if the queue is empty, a brief empty-state card appears.
 
 ---
 
 ## Apps
 
-A fresh install seeds a core set of apps automatically. Browse them with `Cmd+P` or manage them from the terminal.
+Apps are Python processes that render native UI and communicate with the host over PGAP. They declare capabilities in a manifest; the host enforces them at runtime.
 
 ### Install an app
 
 ```bash
-plexi install <id>                        # from the registry
-plexi install github:owner/repo           # any public git repo
-plexi install git+https://example.com/repo.git   # explicit git URL
-plexi install --pack path/to/pack.toml    # apply a whole pack at once
+plexi install <id>                         # from the registry
+plexi install github:owner/repo            # any public git repo
+plexi install git+https://example.com/repo.git    # explicit git URL
+plexi install --pack path/to/pack.toml     # apply a whole pack at once
 ```
 
 Registry IDs resolve against the [Plexi app registry](https://github.com/ianjamesburke/plexi-registry). Git URLs clone the repo directly — no registry needed.
@@ -98,17 +172,15 @@ plexi update apps <id>        # update a specific app
 plexi validate <path>         # validate a manifest before publishing
 ```
 
-### Build an app
-
-Every Plexi app is a git repo with a `manifest.toml` at the root and a Python entry point. Scaffold one with:
+### Scaffold an app
 
 ```bash
 plexi app init my-app
 ```
 
-This creates `.plexi/apps/my-app/` in the current directory with `manifest.toml`, `main.py`, and a bundled `plexi_sdk.py`. Edit `main.py`, launch Plexi, and the app appears in the command palette immediately — no restart needed.
+Creates `.plexi/apps/my-app/` in the current directory with `manifest.toml`, `main.py`, and a bundled `plexi_sdk.py`. Edit `main.py`, open Plexi, and the app appears in the command palette immediately — no restart needed.
 
-The minimal `manifest.toml`:
+**Minimal `manifest.toml`:**
 
 ```toml
 schema_version = 1
@@ -122,23 +194,122 @@ version = "0.1.0"
 description = "What this app does"
 
 [app.capabilities]
-capabilities = []   # e.g. ["fs.read", "ai.query"]
+capabilities = []   # e.g. ["fs.read", "ai.query", "secrets.get"]
 
 [launch]
 layout_hint = { side = "right", split = 0.5 }
 ```
 
+### App interaction model
+
+Apps launch side-by-side with an agent pane (or alone, depending on `layout_hint`). The host spawns the app process and communicates over stdin/stdout using PGAP.
+
+**Inside a frame** (`on_render`): call `ctx.rect(...)`, `ctx.text(...)`, or pass a UI tree to `ctx.render(...)`. The SDK handles layout, padding, and truncation.
+
+**Outside frames**: use `emit.*` for out-of-frame actions — `emit.notify(...)`, `emit.info(...)`, `emit.error(...)`.
+
+**Logging from an app:**
+
+```python
+ctx.info("State initialized")   # inside on_render
+ctx.warn("Retrying connection")
+ctx.error("Auth failed", detail=str(e))
+emit.info("App starting up")    # outside frames / at module level
+```
+
+App logs forward into the host log tagged `app::<app_id>`. Check `~/.plexi/plexi.log` (or `~/.plexi-alpha/plexi.log` on alpha) when debugging.
+
 To share your app: push the repo to GitHub, then anyone can install it with `plexi install github:you/your-app`. To add it to the public registry, open a PR against [plexi-registry](https://github.com/ianjamesburke/plexi-registry).
 
 ---
 
-## Roadmap
+## PGAP — Plexi General App Protocol
 
-- Background apps — persist across pane close, restart on demand
-- Apps can open terminal and app panes programmatically
-- Brokered HTTP for apps via the `net` capability
-- Secret injection into shell environment
-- Auto-updater with toolbar badge
+PGAP is the wire protocol that every Plexi app speaks — built-in or third-party. It is the isolation boundary: no shared memory, no inherited file descriptors.
+
+**Transport:** newline-delimited JSON on **stdin** (host → app) and **stdout** (app → host). One JSON object per line; no framing, no length prefix.
+
+**Binary data** (audio PCM, video frames, raw bytes) travels on **typed pipes** — Unix sockets opened by the host on demand. The JSON wire carries only control and draw messages.
+
+**Handshake:**
+1. Host spawns the app process.
+2. Host sends one `init` event (fields: `protocol`, `app_id`, `workspace_root`, `capabilities`, `feature_flags`).
+3. App replies with `{"type": "ready", "sdk": "...", "features_used": [...]}`.
+4. Each frame: host sends `render`; app replies with draw commands terminated by `frame_done`.
+5. Input events (`key`, `click`, `command`, mouse) arrive between frames as they occur.
+6. Out-of-frame commands (`notify`, `secret_get`, `capability_request`, etc.) arrive at any time; host processes them immediately.
+7. On close: host sends `shutdown`; app must exit cleanly within a short timeout.
+
+Current protocol version: **pgap/3**. Full reference: [PGAP.md](PGAP.md).
+
+---
+
+## Secrets management *(in development)*
+
+Workspace-scoped secrets store credentials in the macOS Keychain without exposing them to the shell environment or other apps.
+
+Secrets are keyed by a `(app_id, workspace_root, capability)` triple. An app initialized at `/foo` cannot read a secret granted at `/bar` — a new prompt appears for each workspace root. Secret injection into the shell environment is on the roadmap.
+
+**CLI:**
+
+```bash
+plexi secret set <key>          # prompt for value, store in Keychain
+plexi secret get <key>          # retrieve (requires workspace context)
+plexi secret list               # list keys scoped to current workspace
+plexi secret delete <key>       # remove from Keychain
+```
+
+**From an app**, request the `secrets.get` capability in the manifest and call:
+
+```python
+value = await ctx.secret_get("MY_API_KEY")
+```
+
+The host presents a permission prompt on first access; subsequent calls within the same session use the cached grant.
+
+---
+
+## CLI reference
+
+All `plexi` subcommands work identically on alpha, beta, stable, and PR builds. `PLEXI_SOCKET` (set inside a Plexi pane) routes host commands to the correct running instance automatically.
+
+| Command | Description |
+|---------|-------------|
+| `plexi install <id>` | Install an app from the registry or a git URL |
+| `plexi uninstall <id>` | Remove an installed app |
+| `plexi update apps [id]` | Update all apps, or a specific one |
+| `plexi list` | List all installed apps and their versions |
+| `plexi validate <path>` | Validate an app directory's manifest |
+| `plexi pack` | Pack management (apply, list packs) |
+| `plexi app init <name>` | Scaffold a new app in the current directory |
+| `plexi open <app-id>` | Open an app pane |
+| `plexi terminal [cmd]` | Open a terminal pane, optionally running a command |
+| `plexi pane <subcommand>` | Pane management (name, close, list, focus) |
+| `plexi notify` | Emit a notification (see Notifications section) |
+| `plexi context` | Query or set the active workspace context |
+| `plexi workspace` | Workspace management (init, status) |
+| `plexi secret` | Secret management (set, get, list, delete) |
+| `plexi run <name>` | Run a named command from the registry |
+| `plexi completions <shell>` | Output shell completions (zsh, bash, fish) |
+
+---
+
+## Tiling layout
+
+Split panes, navigate, and zoom with keyboard shortcuts. Press `Cmd+/` for the full shortcut list at any time.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+D` | Split horizontally |
+| `Cmd+Shift+D` | Split vertically |
+| `Cmd+H/J/K/L` | Navigate between panes |
+| `Cmd+Enter` | Zoom focused pane full-screen |
+| `Cmd+W` | Close focused pane |
+| `Cmd+P` | Command palette |
+| `Cmd+T` | New tab |
+| `Cmd+N` | New page (right) |
+| `Cmd+R` | Rename pane |
+| `Cmd+[` / `Cmd+]` | Focus history — back / forward |
 
 ---
 


### PR DESCRIPTION
Closes #1154.

## What changed

Full README overhaul. Drops the stale Roadmap section. Adds:

- **Quick Note** (`Cmd+0`) — full flow, destination types (`backlog`, `pane`, submenus), `{note}`/`{cwd}` tokens, `position` options, security note on shell injection
- **Notifications** — CLI and SDK emit paths, all four priority tiers with values, modal behavior (`Cmd+Shift+A`), badge, Esc-defer vs Enter-acknowledge
- **Apps** — install/manage commands, scaffold flow, interaction model (frames, `ctx.*`, `emit.*`), logging
- **PGAP** — inline protocol summary (transport, handshake, binary pipes, pgap/3 version) with link to PGAP.md for full reference
- **Secrets management** — marked in-development, Keychain scoping, CLI commands, SDK `secret_get` flow
- **CLI reference** — full subcommand table with one-line descriptions
- **Tiling layout** — shortcut table for common pane operations

All content sourced from `PGAP.md`, `src/config.rs` (`CONFIG_TEMPLATE`), and `src/pane_ops/create.rs` (`commit_quick_note`). No behavior invented.

## Breaks if

N/A — docs only, no code changes.