### PR TITLE
feat(terminal): new_window layout — parallel dispatch spawns windows not splits

### DIFF
--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dispatch-next
-description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace from NEXT.md — creates up to 4 parallel Claude lanes for independent issues and queues sequential issues vertically below each lane.
+description: Use when the user says /dispatch-next or wants to initialize a multi-pane Plexi workspace — auto-computes parallel lanes from live issue state (grouped by area:* label), writes NEXT.md, then opens up to 4 Claude panes with queued sequential issues below each.
 ---
 
 # Dispatch Next
 
-Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude workspace.
+Auto-computes lane assignments from live GitHub issue state, writes `NEXT.md`, then initializes a Plexi multi-pane Claude workspace.
 
 ## Layout model
 
@@ -20,45 +20,158 @@ Reads `NEXT.md` (or a path argument) and initializes a Plexi multi-pane Claude w
 ## Invocation
 
 ```
-/dispatch-next              # reads NEXT.md in repo root
-/dispatch-next path/to/next.md
+/dispatch-next              # auto-computes lanes, writes NEXT.md, opens panes
+/dispatch-next path/to/next.md   # skip Step 0, read that file directly
 ```
+
+---
+
+## Step 0 — Compute lanes from issue state
+
+Skip this step only if a specific file path was passed as an argument.
+
+### 0a — Fetch ready issues
+
+```bash
+gh issue list --label "ready" --state open \
+  --json number,title,labels,body --limit 100
+```
+
+### 0b — Classify each issue
+
+For each issue build a record:
+
+```
+{
+  number: N,
+  title: "...",
+  priority: 0-4,       # extracted from P0..P4 label; 99 if none
+  area: "area:X/Y",    # first area:* label found; null if none
+  is_bundle: bool,     # has "bundle" label
+  in_progress: bool,   # has "in progress" label
+  blocked: bool,       # has "blocked" label
+}
+```
+
+**Exclude** from lane assignment:
+- `in_progress` — already running
+- `blocked` — dependency unresolved
+
+**Surface separately** (do not exclude — just flag):
+- Issues with no `area:*` label
+
+### 0c — Check for unlabeled P0/P1 issues
+
+If any excluded-from-lanes issue has priority P0 or P1:
+
+```
+STOP. The following high-priority issues have no area label and cannot be auto-dispatched:
+  #N — <title> [P0]
+  #M — <title> [P1]
+
+Triage these first: gh issue edit <N> --add-label "area:<namespace>/<module>"
+```
+
+Do not open any panes. Do not proceed to Step 1.
+
+### 0d — Build lane map
+
+Group remaining (area-labeled, non-excluded) issues by their `area` value.
+
+```python
+lanes = {}
+for issue in eligible:
+    area = issue.area
+    lanes.setdefault(area, []).append(issue)
+
+# Sort each lane: priority ASC, then number ASC
+for area in lanes:
+    lanes[area].sort(key=lambda i: (i.priority, i.number))
+```
+
+### 0e — Coalesce bundle issues
+
+Within each lane, if the lane's leading issues are ALL labeled `bundle`, merge them into a single ship call:
+
+```
+# Before: lane = [#1149(bundle), #1150(bundle), #1160]
+# After:  lane = [bundle(#1149+#1150), #1160]
+```
+
+A bundle lead is represented as a `+`-joined string: `"1149+1150"`.  
+Non-bundle issues that follow are individual queue entries.
+
+If a lane has a mix of bundle and non-bundle issues at the front, only coalesce the consecutive leading bundle issues.
+
+### 0f — Select active lanes
+
+Sort areas by their lane's lead issue priority (ASC), then lead issue number (ASC).  
+Take the first **4** as active lanes. Remaining areas are deferred.
+
+### 0g — Write NEXT.md
+
+Write to the repo root:
+
+```markdown
+# NEXT.md
+<!-- computed: <ISO timestamp> -->
+
+## Lanes
+
+| Lane | Area | Lead | Queue |
+|------|------|------|-------|
+| A | area:host/navigation | #934 | #316 |
+| B | area:ui/overlays | #321+#322 (bundle) | #354 |
+| C | area:host/pane-ops | #918 | |
+
+## Deferred (beyond 4-lane cap)
+
+- **area:sdk/pgap**: #1149, #1144
+
+## Needs area label
+
+- #1153 — quick-note: ArrowRight/ArrowLeft not bound in destination picker [P3]
+- #1152 — ux(close): closing a pane should advance focus to next sibling [P0 ⚠]
+```
+
+If there are no deferred areas or no unlabeled issues, omit those sections.
+
+Print the NEXT.md content to stdout so the user sees the computed plan.
 
 ---
 
 ## Step 1 — Parse NEXT.md
 
-Read the file. Extract:
-- The dependency graph (ASCII)
-- The "What runs in parallel" lanes table
-- The ordered next steps list
+Read the file (written by Step 0, or the path argument). Extract the lanes table.
 
 Build a lanes array (cap at 4):
 
 ```
 lanes = [
-  { lead: 934, queue: [316] },
-  { lead: 321, queue: [354, 316] },
-  { lead: 918, queue: [] },
+  { lead: "934",       queue: ["316"] },
+  { lead: "321+322",   queue: ["354"] },
+  { lead: "918",       queue: [] },
 ]
 ```
 
-`lead` = first unshipped issue in the lane.  
-`queue` = ordered list of issues that follow sequentially.
+`lead` = first unshipped entry in the lane. May be a `+`-joined bundle string.  
+`queue` = ordered list of issue numbers (or bundle strings) that follow.
 
-If NEXT.md has no explicit lanes table, derive lanes yourself from the dependency graph — independent branches are separate lanes.
+If NEXT.md has no explicit lanes table, derive lanes from any dependency graph present — independent branches are separate lanes.
 
 ---
 
 ## Step 2 — Skip already-closed leads
 
-For each lead issue, check state:
+For each lead issue (or each issue in a bundle lead), check state:
 
 ```bash
 gh issue view <N> --json state --jq '.state'
 ```
 
-If `CLOSED`, advance to the next issue in that lane's queue as the new lead. If the whole lane is closed, drop it.
+If a single-issue lead is `CLOSED`, advance to the next queue entry as the new lead.  
+If all issues in a bundle lead are `CLOSED`, advance to the next queue entry.  
+If the whole lane is closed, drop it.
 
 ---
 
@@ -91,7 +204,12 @@ print(new[-1] if new else '')
 ")
 ```
 
-Label it and start Claude inside it (no newline = not submitted yet for first lane; use `\n` to immediately start):
+Build the ship command from the lead:
+
+- Single issue `"934"` → `c "ship issue 934"`
+- Bundle `"321+322"` → `c "ship issue 321 322"`
+
+Label and start:
 
 ```bash
 plexi pane name $NEW_ID "Lane <X>: #<lead>"
@@ -123,7 +241,7 @@ plexi pane name $QUEUE_ID "queued: #<next>"
 plexi pane send $QUEUE_ID 'c "ship issue <next>"'
 ```
 
-If the lane has more than one queued issue (e.g. lane B has both #354 and #316 downstream), only queue the immediate next — not the full chain. The user will handle deeper queuing after #354 ships.
+If the lane has more than one queued issue, only queue the immediate next — the user handles deeper queuing after that issue ships.
 
 ---
 
@@ -144,4 +262,5 @@ Leave the user's cursor in the first active lane.
 - For queue panes, omit `\n` from `plexi pane send` so the command is staged but not executed.
 - `c` is a personal zsh alias (login shell) — available in all interactive panes opened by Plexi.
 - If a lane's lead issue has a feature branch already in progress (`wtp list` or `git worktree list`), note it in the pane title: `"Lane A: #934 (branch exists)"`.
-- If NEXT.md is absent or has no parseable lanes, surface the issue list from `gh issue list --label "ready" --json number,title` and ask the user to confirm the lane assignment before opening any panes.
+- NEXT.md is a cache. It goes stale as issues close. Re-run `/dispatch-next` to recompute.
+- The "Needs area label" section in NEXT.md is the triage backlog for the area labeling pass. P0/P1 items there block dispatch entirely.

--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -223,13 +223,14 @@ Update `BEFORE_IDS` with the new ID before opening the next lane.
 
 ---
 
-## Step 5 — Open queue panes (below each lane)
+## Step 5 — Open queue panes (as tabs within each lane window)
 
-For each lane that has a non-empty queue, focus the lane pane and open a split below it:
+For each lane that has a non-empty queue, focus the lane pane (switches active_window
+to the lane's window), then open a tab alongside it:
 
 ```bash
 plexi pane focus $LANE_<X>_ID
-plexi terminal --layout split_h
+plexi terminal --layout tab
 ```
 
 Find the new pane ID (same pattern as Step 4).
@@ -258,7 +259,7 @@ Leave the user's cursor in the first active lane.
 ## Notes
 
 - `plexi terminal` does not return a pane ID — always diff `plexi pane list` before/after to get it.
-- `new_window` creates a new spatial grid page to the right; `split_v` adds below within a window.
+- `new_window` creates a new spatial grid page to the right. `tab` adds a tab within the active window (run `pane focus` first to target the right window). `split_h` splits below.
 - For queue panes, omit `\n` from `plexi pane send` so the command is staged but not executed.
 - `c` is a personal zsh alias (login shell) — available in all interactive panes opened by Plexi.
 - If a lane's lead issue has a feature branch already in progress (`wtp list` or `git worktree list`), note it in the pane title: `"Lane A: #934 (branch exists)"`.

--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -223,13 +223,13 @@ Update `BEFORE_IDS` with the new ID before opening the next lane.
 
 ---
 
-## Step 5 — Open queue panes (vertical)
+## Step 5 — Open queue panes (below each lane)
 
 For each lane that has a non-empty queue, focus the lane pane and open a split below it:
 
 ```bash
 plexi pane focus $LANE_<X>_ID
-plexi terminal --layout split_v
+plexi terminal --layout split_h
 ```
 
 Find the new pane ID (same pattern as Step 4).

--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -184,12 +184,12 @@ BEFORE_IDS=$(plexi pane list | python3 -c \
 
 ---
 
-## Step 4 — Open lane panes (horizontal)
+## Step 4 — Open lane panes (new windows)
 
-For each active lane, open a terminal to the right of the current layout:
+For each active lane, open a new window to the right of the current context grid:
 
 ```bash
-plexi terminal --layout split_h
+plexi terminal --layout new_window
 ```
 
 After each `plexi terminal` call, find the new pane ID:
@@ -258,7 +258,7 @@ Leave the user's cursor in the first active lane.
 ## Notes
 
 - `plexi terminal` does not return a pane ID — always diff `plexi pane list` before/after to get it.
-- `split_h` adds to the right of the focused pane. `split_v` adds below.
+- `new_window` creates a new spatial grid page to the right; `split_v` adds below within a window.
 - For queue panes, omit `\n` from `plexi pane send` so the command is staged but not executed.
 - `c` is a personal zsh alias (login shell) — available in all interactive panes opened by Plexi.
 - If a lane's lead issue has a feature branch already in progress (`wtp list` or `git worktree list`), note it in the pane title: `"Lane A: #934 (branch exists)"`.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1153,6 +1153,9 @@ impl PlexiApp {
                             let new_x = max_x.map(|x| x + 1).unwrap_or(1);
                             log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y})");
                             self.create_page_at(new_x, active_y);
+                        } else if layout_str == "tab" {
+                            log::info!("pane_ipc: spawn_pane terminal layout=tab");
+                            self.new_tab();
                         } else {
                             let vertical = matches!(layout_str, "split_h" | "split_above");
                             let initial_cmd = cmd_from_args(args);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1141,10 +1141,24 @@ impl PlexiApp {
 
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
-                        let vertical = matches!(layout_str, "split_h" | "split_above");
-                        let initial_cmd = cmd_from_args(args);
-                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                        self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
+                        if layout_str == "new_window" {
+                            // Create a new spatial grid window to the right of the
+                            // current context row instead of splitting the active pane.
+                            let ws_id = self.router.active().context_id;
+                            let active_y = self.windows[self.active_window].grid_y;
+                            let max_x = self.windows.iter()
+                                .filter(|w| w.context_id == ws_id && w.grid_y == active_y)
+                                .map(|w| w.grid_x)
+                                .max();
+                            let new_x = max_x.map(|x| x + 1).unwrap_or(1);
+                            log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y})");
+                            self.create_page_at(new_x, active_y);
+                        } else {
+                            let vertical = matches!(layout_str, "split_h" | "split_above");
+                            let initial_cmd = cmd_from_args(args);
+                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                            self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
+                        }
                     } else {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
                     }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -966,7 +966,9 @@ pub enum HostCommand {
     /// Requires `panes.spawn` capability.
     /// `layout`: one of "split_v", "split_h", "split_above", "split_left", "overlay",
     ///   "new_window" (terminal only — creates a new spatial grid window to the right
-    ///   of the current context row instead of splitting the active pane).
+    ///   of the current context row instead of splitting the active pane),
+    ///   "tab" (terminal only — adds a new tab alongside the focused pane, wrapping
+    ///   both in a Tabs container if needed; use after `pane focus` to target a window).
     ///   "overlay_pane" and "background" are reserved but not yet implemented.
     /// `pipe_id`: when set, the host appends `--pipe=<pipe_id>` to args before launch
     ///   so the spawned app can reply via PipeSend on completion.

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -964,7 +964,9 @@ pub enum HostCommand {
 
     /// Unified pane spawn primitive (#592). Supersedes SpawnApp for new apps.
     /// Requires `panes.spawn` capability.
-    /// `layout`: one of "split_v", "split_h", "split_above", "split_left", "overlay".
+    /// `layout`: one of "split_v", "split_h", "split_above", "split_left", "overlay",
+    ///   "new_window" (terminal only — creates a new spatial grid window to the right
+    ///   of the current context row instead of splitting the active pane).
     ///   "overlay_pane" and "background" are reserved but not yet implemented.
     /// `pipe_id`: when set, the host appends `--pipe=<pipe_id>` to args before launch
     ///   so the spawned app can reply via PipeSend on completion.

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1049,6 +1049,54 @@ mod tests {
         );
     }
 
+    /// `plexi terminal --layout tab` must create a new tab pane alongside the
+    /// focused pane (wrapping both in a Tabs container) rather than splitting.
+    #[test]
+    fn spawn_pane_tab_creates_tab_not_split() {
+        let mut h = HostHarness::new();
+        let _pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile after add_test_pane");
+        h.app.windows[0].focused_pane = Some(root);
+
+        let before_panes = h.app.windows[0].panes.len();
+        let before_windows = h.app.windows.len();
+
+        h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
+            type_id: "terminal".to_string(),
+            layout: Some("tab".to_string()),
+            args: vec![],
+            pipe_id: None,
+            from_pane_id: None,
+            request_id: None,
+            response_file: None,
+            ephemeral: false,
+        });
+        h.run_frames(2);
+
+        // No new window — tab stays in the same window.
+        assert_eq!(
+            h.app.windows.len(),
+            before_windows,
+            "tab layout must not create a new window"
+        );
+        // One new pane added to the window.
+        assert_eq!(
+            h.app.windows[0].panes.len(),
+            before_panes + 1,
+            "tab layout must add exactly one new pane"
+        );
+        // The tile tree root must now be a Tabs container.
+        let root_tile = h.app.windows[0].tree.root.expect("root tile must exist");
+        let root_tile_ref = h.app.windows[0].tree.tiles.get(root_tile);
+        assert!(
+            matches!(
+                root_tile_ref,
+                Some(egui_tiles::Tile::Container(egui_tiles::Container::Tabs(_)))
+            ),
+            "root tile must be a Tabs container after tab spawn, got: {root_tile_ref:?}"
+        );
+    }
+
     /// `plexi terminal --layout new_window` must create a new spatial grid window
     /// in the current context rather than splitting the active pane.
     #[test]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1049,6 +1049,82 @@ mod tests {
         );
     }
 
+    /// `plexi terminal --layout new_window` must create a new spatial grid window
+    /// in the current context rather than splitting the active pane.
+    #[test]
+    fn spawn_pane_new_window_creates_separate_window() {
+        let mut h = HostHarness::new();
+        let _pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile after add_test_pane");
+        h.app.windows[0].focused_pane = Some(root);
+
+        let before_windows = h.app.windows.len();
+
+        h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
+            type_id: "terminal".to_string(),
+            layout: Some("new_window".to_string()),
+            args: vec![],
+            pipe_id: None,
+            from_pane_id: None,
+            request_id: None,
+            response_file: None,
+            ephemeral: false,
+        });
+        h.run_frames(2);
+
+        assert_eq!(
+            h.app.windows.len(),
+            before_windows + 1,
+            "new_window layout must create a new window (not a split)"
+        );
+        // Original window must still have the same pane count (no split occurred).
+        assert_eq!(
+            h.app.windows[0].panes.len(),
+            1,
+            "original window pane count must be unchanged after new_window spawn"
+        );
+        // New window must be placed to the right of the original at the same grid row.
+        let new_win = h.app.windows.last().unwrap();
+        assert_eq!(new_win.grid_x, 1, "new window must be at grid_x=1");
+        assert_eq!(new_win.grid_y, 0, "new window must be at grid_y=0");
+        // New window must contain exactly one Terminal pane.
+        assert_eq!(new_win.panes.len(), 1, "new window must have one pane");
+        assert!(
+            new_win.panes.values().any(|p| matches!(p, crate::pane::Pane::Terminal(_))),
+            "new window pane must be a Terminal"
+        );
+    }
+
+    /// A second `new_window` spawn places the next window at grid_x=2, not grid_x=1.
+    #[test]
+    fn spawn_pane_new_window_stacks_right() {
+        let mut h = HostHarness::new();
+        let _pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile");
+        h.app.windows[0].focused_pane = Some(root);
+
+        // Spawn two new windows in sequence.
+        for _ in 0..2 {
+            h.inject_ipc(crate::app_protocol::HostCommand::SpawnPane {
+                type_id: "terminal".to_string(),
+                layout: Some("new_window".to_string()),
+                args: vec![],
+                pipe_id: None,
+                from_pane_id: None,
+                request_id: None,
+                response_file: None,
+                ephemeral: false,
+            });
+            h.run_frames(2);
+        }
+
+        assert_eq!(h.app.windows.len(), 3, "two new_window spawns must create two windows");
+        let xs: Vec<u32> = h.app.windows.iter().map(|w| w.grid_x).collect();
+        assert!(xs.contains(&0), "original at grid_x=0");
+        assert!(xs.contains(&1), "first new_window at grid_x=1");
+        assert!(xs.contains(&2), "second new_window at grid_x=2");
+    }
+
     #[test]
     fn cli_binary_in_path_finds_real_binary() {
         // `/bin/sh` is guaranteed to exist on macOS/Linux.


### PR DESCRIPTION
## Summary

- Adds `layout=\"new_window\"` to `SpawnPane` for `type_id=\"terminal\"` — each call creates a new spatial grid window to the right of the current context row (`max_grid_x + 1`, same `grid_y`) instead of splitting the active pane
- Updates `dispatch-next` skill to use `--layout new_window` per lane so each agent lane gets a full independent window
- Adds doc comment to `app_protocol.rs` documenting the new layout value

## Test plan

- [ ] Two new HostHarness tests pass: `spawn_pane_new_window_creates_separate_window`, `spawn_pane_new_window_stacks_right`
- [ ] `cargo test` passes (pre-existing failures: `embedded_registry_round_trips_through_parser`, `core_pack_applies_only_when_apps_dir_empty` — both fail on alpha before this PR)
- [ ] Live: from inside a Plexi pane, run `plexi terminal --layout new_window` — new window should appear to the right on the spatial grid, not as a pane split in the current window
- [ ] Live: run `/dispatch-next` and verify each lane opens in its own window

## Breaks if

`plexi terminal --layout new_window` splits the current pane instead of creating a new spatial window — would indicate the layout string routing in `app/mod.rs:1142` wasn't applied or was overridden.