### PR TITLE
feat(cli): add -e short flag for --ephemeral on terminal command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3602,7 +3602,7 @@ _plexi() {
           ;;
         terminal)
           _arguments \
-            '--ephemeral[Close the pane when the process exits]' \
+            '(-e --ephemeral)'{-e,--ephemeral}'[Close the pane when the process exits]' \
             '--layout[Layout hint]:layout:(split_v split_h split_above)' \
             '--from-pane-id[Split relative to this pane ID]:pane_id:'
           ;;
@@ -3691,7 +3691,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       if [[ $prev == "--layout" ]]; then
         COMPREPLY=($(compgen -W "split_v split_h split_above" -- "$cur"))
       else
-        COMPREPLY=($(compgen -W "--ephemeral --layout --from-pane-id" -- "$cur"))
+        COMPREPLY=($(compgen -W "-e --ephemeral --layout --from-pane-id" -- "$cur"))
       fi
       ;;
     open)
@@ -3810,7 +3810,7 @@ complete -c plexi -n "__fish_seen_subcommand_from uninstall" -l yes -d "Skip con
 complete -c plexi -f -n "__fish_seen_subcommand_from completions" -a "zsh bash fish"
 
 # terminal flags
-complete -c plexi -n "__fish_seen_subcommand_from terminal" -l ephemeral -d "Close the pane when the process exits"
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -s e -l ephemeral -d "Close the pane when the process exits"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_v split_h split_above"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l from-pane-id -d "Split relative to this pane ID"
 # open flags

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -107,7 +107,7 @@ pub enum Commands {
         /// Optional command to run in the terminal
         cmd: Option<String>,
         /// Close the pane when the process exits
-        #[arg(long)]
+        #[arg(long, short = 'e')]
         ephemeral: bool,
         /// Layout hint (split_v, split_h, split_above)
         #[arg(long)]


### PR DESCRIPTION
## Summary

- Adds `-e` as a short alias for `--ephemeral` on `plexi terminal`
- Updates zsh, bash, and fish completions to include the short flag

## Test plan

- [ ] `plexi terminal -e <cmd>` closes pane on exit (same as `--ephemeral`)
- [ ] zsh/bash/fish completions suggest `-e` alongside `--ephemeral`

**Breaks if:** `plexi terminal -e <cmd>` is not recognised as a flag (argument parse error at startup).