### PR TITLE
feat(skills): add /daily-check skill and docs-freshness tracker

### DIFF
--- a/.claude/docs-freshness.toml
+++ b/.claude/docs-freshness.toml
@@ -1,0 +1,18 @@
+# Tracks the last CHANGELOG version at which each user-facing surface was reviewed
+# and verified to be current. Updated manually after a /daily-check review pass.
+#
+# To mark a surface as reviewed: update the version string to the current version
+# (from Cargo.toml) and commit this file.
+
+[docs]
+# PLEXI/README.md
+readme = "3.6.19"
+# ~/.agents/skills/plexi-cli/SKILL.md
+plexi_cli_skill = "3.6.19"
+# plexi-webapp/src/pages/docs.astro (holding page — no real docs yet)
+webapp = "3.6.19"
+
+[meta]
+# ISO date of the last improve triage scan.
+# Logs newer than this date will be included in the next /daily-check improve report.
+improve_last_scanned = "2026-05-12"

--- a/.claude/skills/daily-check/SKILL.md
+++ b/.claude/skills/daily-check/SKILL.md
@@ -1,0 +1,224 @@
+# Daily Check
+
+Triage report for three recurring maintenance concerns: docs freshness, improve
+patterns, and untriaged GitHub issues. Everything is read-only — nothing auto-applies.
+
+## Invocation
+
+  /daily-check
+
+No arguments. Always runs all three agents.
+
+---
+
+## Step 1 — Read freshness state
+
+Read `.claude/docs-freshness.toml` in the PLEXI repo root. Extract:
+- `docs.readme` — last version README was reviewed
+- `docs.plexi_cli_skill` — last version plexi-cli skill was reviewed
+- `docs.webapp` — last version webapp docs were reviewed
+- `meta.improve_last_scanned` — ISO date of last improve triage
+
+Get current version:
+  grep -m1 '^version' Cargo.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+
+If `docs-freshness.toml` does not exist, treat all last-reviewed values as `0.0.0`
+and `improve_last_scanned` as 30 days ago.
+
+---
+
+## Step 2 — Spawn three parallel sub-agents
+
+Run all three simultaneously. Each returns a formatted section. Combine in Step 3.
+
+--------
+
+### Agent A — Docs Freshness
+
+**Inputs:** `docs-freshness.toml`, `CHANGELOG.md`, current version from `Cargo.toml`
+
+**Steps:**
+
+1. For each tracked surface, extract the CHANGELOG block between `last_reviewed`
+   version and `current` version (inclusive of current, exclusive of last_reviewed).
+   CHANGELOG format: `## [X.Y.Z] — YYYY-MM-DD` headers, bullet entries below.
+
+2. Filter entries by surface relevance:
+
+   **README** — flag entries matching:
+     feat(, ux(, fix(, docs(readme), sec(, chore(config)
+   
+   **plexi-cli skill** — flag entries matching:
+     feat(terminal), feat(pane), feat(notify), feat(context), feat(workspace),
+     feat(app), feat(quick-note), fix( on any CLI-exposed command
+   
+   **webapp** — flag all `feat(` and `docs(` entries until real docs land
+     (current docs page is a holding stub — any user-visible change is relevant)
+
+3. For each surface, output one verdict:
+   - `CURRENT` — no relevant entries since last_reviewed
+   - `NEEDS REVIEW (N changes)` — list the relevant entries
+   - `STALE` — version gap > 10 releases with no review
+
+**Output format:**
+
+  ## Docs Freshness
+
+  README (last reviewed: 3.6.11 → current: 3.6.19): NEEDS REVIEW (6 changes)
+    - feat(quick-note): visual polish & keyboard navigation (#1124)
+    - feat(navigation): pane focus history — Cmd+[ / Cmd+] (#1119)
+    - feat(config): all 6 theme presets + docs link (#1117)
+    - feat(navigation): remap tab cycle to Cmd+Shift+H/L (#1107)
+    - fix(mcp-renderer): reduce handshake timeout, surface server stderr (#1106)
+    - feat(quick-note): backend — FocusLayer modal, config routing (#1105)
+
+  plexi-cli skill (last reviewed: 3.6.14 → current: 3.6.19): NEEDS REVIEW (1 change)
+    - feat(terminal): new_window layout — parallel dispatch spawns windows (#1158)
+
+  webapp (last reviewed: 3.6.19 → current: 3.6.19): CURRENT
+    (holding page — no action needed until real docs land)
+
+--------
+
+### Agent B — Improve Triage
+
+**Inputs:** `meta.improve_last_scanned` from `docs-freshness.toml`, daily log files
+
+**Steps:**
+
+1. Find all `~/Documents/github/daily_log/YYYY-MM-DD_*.md` files with a date
+   component newer than `improve_last_scanned`. Skip `.jsonl` files.
+
+2. Scan each file for friction signals:
+   - Explicit corrections: "that's wrong", "don't do that", "stop", "no not that"
+   - Retries: same tool called 3+ times in a row, or direction reversal on a task
+   - Unresolved `/improve` invocations (skill invoked but no CLAUDE.md commit followed)
+   - Multi-turn clarification on something that should have been clear
+
+3. Group signals by pattern across all sessions (not by session). A pattern seen in
+   3 sessions outranks one seen in 1.
+
+4. Output top 5 patterns max. For each: description, session count, last seen date,
+   and a one-line suggested fix (rule for CLAUDE.md or workflow fix for a skill).
+
+If no logs newer than `improve_last_scanned`: output `No new logs since last scan.`
+
+**Output format:**
+
+  ## Improve Triage (logs since 2026-05-01)
+
+  1. [3 sessions] Agent used relative path with git -C, failed when CWD ≠ repo root
+     Last seen: 2026-05-11
+     Suggested: add lesson to CLAUDE.md — always use absolute paths with git -C
+
+  2. [2 sessions] Brainstorming skill skipped on "just a small change" rationalization
+     Last seen: 2026-05-10
+     Suggested: tighten using-superpowers rule — "small change" is not an exemption
+
+--------
+
+### Agent C — Issue Triage
+
+**Steps:**
+
+1. Fetch open issues:
+     gh issue list --state open --json number,title,labels --limit 200
+
+2. Filter for issues with NO priority label (P0, P1, P2, P3, P4 absent).
+
+3. Group by type label (bug / enhancement / idea). Issues with no type label go
+   in a fourth group: unlabeled.
+
+4. Sort each group by issue number ascending (oldest untriad first).
+
+**Output format:**
+
+  ## Untriaged Issues (no priority label)
+
+  bugs (2):
+    #1045 — fix(pane): focus not restored after modal close
+    #1061 — fix(terminal): cursor blink rate ignores system preference
+
+  enhancements (3):
+    #1033 — feat(context): auto-name from git remote
+    #1044 — feat(workspace): remember last open page per context
+    #1052 — feat(pane): drag-to-reorder panes within a window
+
+  ideas (1):
+    #998 — idea: inline diff view for file changes
+
+  unlabeled (0):
+
+---
+
+## Step 3 — Assemble and present report
+
+Print:
+
+  # Daily Check — YYYY-MM-DD (vX.Y.Z)
+
+  [Agent A output]
+
+  [Agent B output]
+
+  [Agent C output]
+
+  ---
+  ## What to do next
+
+  Mark a doc as reviewed — edit .claude/docs-freshness.toml and commit:
+    readme = "X.Y.Z"
+    plexi_cli_skill = "X.Y.Z"
+
+  Apply an improve pattern:
+    /improve (describe the pattern)
+
+  Triage an issue:
+    gh issue edit <N> --add-label "P2"
+
+---
+
+## Step 4 — Offer to update improve_last_scanned
+
+After presenting the report, ask once:
+
+  "Update `improve_last_scanned` to today in .claude/docs-freshness.toml
+  and commit? (marks these logs as scanned)"
+
+If yes: edit the file, set `improve_last_scanned = "YYYY-MM-DD"` (today's date),
+commit with message:
+  chore: daily-check scan YYYY-MM-DD
+
+---
+
+## Tracked surfaces
+
+| Surface | File | Relevant CHANGELOG prefixes |
+|---------|------|---------------------------|
+| README | PLEXI/README.md | feat(, ux(, fix(, docs(readme), sec( |
+| plexi-cli skill | ~/.agents/skills/plexi-cli/SKILL.md | feat(terminal), feat(pane), feat(notify), feat(context), feat(workspace), feat(app), fix( |
+| webapp | plexi-webapp/src/pages/docs.astro | feat(, docs( (placeholder) |
+
+To add a surface: add an entry to `[docs]` in `.claude/docs-freshness.toml`
+and a row to this table.
+
+---
+
+## Launchd drift watcher
+
+A background script runs every 6 hours via launchd and spawns a `/daily-check`
+pane when docs version drift is detected.
+
+**Status: not yet active — depends on `plexi terminal --cwd` (#1168).**
+
+Once #1168 ships, set up:
+  Script:  ~/dotfiles/scripts/plexi-drift-check.sh
+  Plist:   ~/dotfiles/launchd/com.plexi.drift-check.plist
+  Install: ln -sf ~/dotfiles/launchd/com.plexi.drift-check.plist \
+             ~/Library/LaunchAgents/ && launchctl load ~/Library/LaunchAgents/com.plexi.drift-check.plist
+
+Script logic (see docs/superpowers/specs/2026-05-12-daily-check-design.md):
+- Read docs-freshness.toml versions vs Cargo.toml current version
+- If drift found and no daily-check pane already open:
+    plexi-alpha terminal --cwd "$PLEXI_REPO" --layout new_window "c '/daily-check'"
+- If no drift: exit silently

--- a/docs/superpowers/specs/2026-05-12-daily-check-design.md
+++ b/docs/superpowers/specs/2026-05-12-daily-check-design.md
@@ -1,0 +1,257 @@
+# Daily Check — Design Spec
+
+**Date:** 2026-05-12  
+**Status:** Approved, pending implementation plan
+
+---
+
+## Problem
+
+Several maintenance tasks need to happen regularly but have no reliable trigger:
+
+1. Docs drift — README, plexi-cli skill, and webapp docs fall behind as PRs ship
+2. Improve backlog — friction patterns surface in conversation logs but never get acted on
+3. Issue triage — new issues accumulate without priority labels, blocking the ship skill
+
+Without a system, these accumulate silently until something breaks or the debt is too large to address quickly.
+
+---
+
+## Solution Overview
+
+A `/daily-check` skill that orchestrates three parallel read-only sub-agents and assembles their output into a single triage report. Nothing auto-applies. The user reviews and decides what to act on.
+
+A companion launchd background job checks for docs version drift every 6 hours and spawns a `plexi terminal` pane with `/daily-check` pre-typed when drift is detected — non-intrusive, no interruption.
+
+---
+
+## Component 1: Freshness Tracking File
+
+**Location:** `.claude/docs-freshness.toml` (committed to the PLEXI repo)
+
+```toml
+# Last version at which each surface was reviewed and verified current.
+# Updated manually after a review pass (prompted by /daily-check report).
+
+[docs]
+readme = "3.6.19"           # PLEXI/README.md
+plexi_cli_skill = "3.6.19"  # ~/.agents/skills/plexi-cli/SKILL.md
+webapp = "3.6.19"           # plexi-webapp/src/pages/docs.astro (placeholder — no real docs yet)
+
+[meta]
+improve_last_scanned = "2026-05-12"  # ISO date; logs newer than this are scanned by improve agent
+```
+
+Rules:
+- `readme`, `plexi_cli_skill`, `webapp` — semver strings matching CHANGELOG section headers
+- `improve_last_scanned` — ISO date; the improve agent only reads logs newer than this
+- Updated by committing a change to this file after a review pass
+- The `/daily-check` skill reads this file at the start of every run; it never writes to it automatically
+
+---
+
+## Component 2: `/daily-check` Skill
+
+**Location:** `.claude/skills/daily-check/SKILL.md`
+
+### Invocation
+
+```
+/daily-check
+```
+
+No arguments. Always runs all three agents.
+
+### Step 1 — Read freshness state
+
+Read `.claude/docs-freshness.toml`. Get current version from `Cargo.toml` (`grep -m1 "^version"`). If the file doesn't exist yet, treat all `last_verified` values as `"0.0.0"` and `improve_last_scanned` as 30 days ago.
+
+### Step 2 — Spawn three parallel sub-agents
+
+#### Agent A: Docs Freshness
+
+Inputs: `docs-freshness.toml`, `CHANGELOG.md`, current version
+
+Steps:
+1. For each tracked doc, extract CHANGELOG entries between `last_verified` and `current`
+2. Filter for entries relevant to that surface:
+   - README: `feat(`, `ux(`, `fix(`, `docs(readme)`, any user-facing behavior change
+   - plexi-cli skill: `feat(terminal)`, `feat(pane)`, `feat(notify)`, `feat(context)`, `feat(workspace)`, `feat(app)`, `fix(` on any CLI-exposed command, any new CLI flag
+   - webapp: `docs(`, `feat(` (for now, flag anything — docs page is a stub)
+3. For each doc, output one of:
+   - `CURRENT` — no relevant changes since last_verified
+   - `NEEDS REVIEW` — N relevant changelog entries listed
+   - `STALE` — version gap > 10 releases with no review
+
+Output format:
+```
+## Docs Freshness
+
+README (last reviewed: 3.6.11 → current: 3.6.19): NEEDS REVIEW
+  - feat(quick-note): visual polish & keyboard navigation (#1124)
+  - feat(navigation): pane focus history (#1119)
+  - feat(config): all 6 theme presets + docs link (#1117)
+  [... N more]
+
+plexi-cli skill (last reviewed: 3.6.14 → current: 3.6.19): NEEDS REVIEW
+  - feat(terminal): new_window layout (#1158)
+  [... N more]
+
+webapp (last reviewed: 3.6.19): CURRENT (holding page — no action needed)
+```
+
+#### Agent B: Improve Triage
+
+Inputs: `improve_last_scanned` date from `docs-freshness.toml`, `~/Documents/github/daily_log/`
+
+Steps:
+1. Find all `YYYY-MM-DD_*.md` log files newer than `improve_last_scanned`
+2. Scan for friction signals:
+   - Multiple retries or direction changes on the same task
+   - Explicit "that's wrong", "don't do that", "stop" corrections
+   - Tasks that took >3 back-and-forth turns to resolve
+   - Any `/improve` invocations that didn't result in a committed rule change
+3. Group by pattern (not by session). A pattern that appeared in 3 sessions is one entry, ranked higher.
+4. Output top 5 patterns max, each with: pattern description, frequency, example session date, suggested rule/fix
+
+Output format:
+```
+## Improve Triage (logs since 2026-05-01)
+
+1. [3 sessions] Agent reads worktree path as relative, fails when CWD ≠ repo root
+   Last seen: 2026-05-11. Suggested fix: add lesson to CLAUDE.md — always use absolute paths with git -C.
+
+2. [2 sessions] Skill invoked but not followed — brainstorming skipped on "just a small change"
+   Last seen: 2026-05-10. Suggested fix: tighten using-superpowers rule for small-change rationalization.
+
+[... up to 5]
+```
+
+If no logs newer than `improve_last_scanned`: output `No new logs since last scan.`
+
+#### Agent C: Issue Triage
+
+Steps:
+1. `gh issue list --state open --json number,title,labels --limit 200`
+2. Filter for issues with no P0/P1/P2/P3/P4 label
+3. Group by type label (bug / enhancement / idea / unlabeled)
+4. Sort by issue number ascending (oldest first)
+
+Output format:
+```
+## Untriaged Issues (no priority label)
+
+bugs (N):
+  #1045 — fix(pane): focus not restored after modal close
+  #1061 — fix(terminal): cursor blink rate ignores system preference
+
+enhancements (N):
+  #1033 — feat(context): auto-name from git remote
+  ...
+
+ideas (N):
+  ...
+
+unlabeled (N):
+  ...
+```
+
+### Step 3 — Assemble report
+
+Concatenate the three agent outputs under a single header:
+
+```
+# Daily Check — 2026-05-12 (v3.6.19)
+
+[Agent A output]
+[Agent B output]
+[Agent C output]
+
+---
+## Actions
+
+To mark a doc as reviewed, update .claude/docs-freshness.toml and commit:
+  readme = "3.6.19"
+  plexi_cli_skill = "3.6.19"
+
+To apply an improve pattern: /improve (describe the pattern)
+To triage an issue: gh issue edit <N> --add-label "P2"
+```
+
+### Step 4 — Update improve_last_scanned
+
+After the report is assembled, prompt the user:
+
+> "Update `improve_last_scanned` to today's date in `docs-freshness.toml`? (Marks these logs as reviewed)"
+
+If yes: edit the file and commit with message `chore: daily-check scan 2026-05-12`.
+
+---
+
+## Component 3: Launchd Drift Watcher
+
+**Purpose:** Detect version drift every 6 hours, spawn a `/daily-check` pane when found.
+
+**Prerequisite:** Depends on `plexi terminal --cwd` flag (issue #1168). The drift watcher should not be activated until #1168 is shipped.
+
+**Files:**
+- Script: `~/dotfiles/scripts/plexi-drift-check.sh`
+- Plist: `~/dotfiles/launchd/com.plexi.drift-check.plist` (symlinked to `~/Library/LaunchAgents/`)
+
+**Script logic:**
+
+```bash
+#!/bin/bash
+# Reads docs-freshness.toml, compares to current Cargo.toml version.
+# If any doc is behind, spawns a /daily-check pane in Plexi.
+
+PLEXI_REPO="$HOME/Documents/GitHub/PLEXI"
+FRESHNESS="$PLEXI_REPO/.claude/docs-freshness.toml"
+
+current=$(grep -m1 '^version' "$PLEXI_REPO/Cargo.toml" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+readme=$(grep 'readme' "$FRESHNESS" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+skill=$(grep 'plexi_cli_skill' "$FRESHNESS" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+if [ "$current" != "$readme" ] || [ "$current" != "$skill" ]; then
+  plexi-alpha terminal --cwd "$PLEXI_REPO" --layout new_window "c '/daily-check'"
+fi
+```
+
+**Plist:** `StartInterval` = 21600 (6 hours), `RunAtLoad` = false, `WorkingDirectory` = `$HOME`.
+
+**Behavior:**
+- Runs silently if docs are current
+- Spawns exactly one pane titled `"Daily Check — v{old} → v{current}"` if drift found
+- Does not spawn a second pane if one is already open (script checks `plexi pane list` first)
+
+---
+
+## Surfaces Tracked
+
+| Surface | File | Relevant CHANGELOG prefixes |
+|---------|------|---------------------------|
+| README | `PLEXI/README.md` | `feat(`, `ux(`, `fix(`, `docs(readme)` |
+| plexi-cli skill | `~/.agents/skills/plexi-cli/SKILL.md` | `feat(terminal)`, `feat(pane)`, `feat(notify)`, `feat(context)`, `feat(workspace)`, `feat(app)`, `fix(` on CLI commands |
+| webapp | `plexi-webapp/src/pages/docs.astro` | Placeholder — flag any `feat(` or `docs(` until real docs land |
+
+Adding a new surface: add an entry to `docs-freshness.toml` and a row to this table.
+
+---
+
+## What This Does Not Do
+
+- Does not auto-apply improve rules to CLAUDE.md or skill files
+- Does not auto-label GitHub issues
+- Does not update docs itself
+- Does not run on a schedule within Claude Code (the launchd watcher is external)
+- Does not block or interrupt an in-progress session
+
+---
+
+## Dependencies
+
+| Dependency | Status | Blocks |
+|-----------|--------|--------|
+| `plexi terminal --cwd` (#1168) | Open | Launchd drift watcher |
+| `docs-freshness.toml` initial file | New — created in implementation | Everything |
+| `/daily-check` skill | New — created in implementation | Everything |


### PR DESCRIPTION
## Summary

- Adds `/daily-check` skill at `.claude/skills/daily-check/SKILL.md` — three parallel sub-agents producing a triage report: docs freshness, improve patterns, untriaged issues
- Adds `.claude/docs-freshness.toml` — tracks last-reviewed CHANGELOG version per surface (README, plexi-cli skill, webapp); initialized to v3.6.19
- Adds design spec at `docs/superpowers/specs/2026-05-12-daily-check-design.md`

## What it does

Run `/daily-check` to get:
1. **Docs Freshness** — which surfaces have relevant CHANGELOG entries since they were last reviewed
2. **Improve Triage** — friction patterns from recent daily logs (read-only report, not auto-applied)
3. **Issue Triage** — open GitHub issues with no priority label

Nothing auto-applies. All three agents are read-only. User reviews the report and decides what to act on.

## Not included (deferred)

Launchd drift watcher (runs every 6h, spawns a `/daily-check` pane on version drift) is scaffolded in the skill doc but gated on `plexi terminal --cwd` (#1168). Activate after that ships.

## Test plan

- [ ] Run `/daily-check` from inside the PLEXI repo — confirm three-section report appears
- [ ] Manually set `readme = "3.6.0"` in `docs-freshness.toml`, re-run — confirm README shows NEEDS REVIEW with relevant changelog entries
- [ ] Confirm improve agent skips gracefully if no logs newer than `improve_last_scanned`
- [ ] Confirm issue triage lists only issues with no P0–P4 label