### PR TITLE
security(shell): inventory all sh -c paths, add StreamProcess denial test (#1177)

### DIFF
--- a/docs/security/shell-execution-inventory.md
+++ b/docs/security/shell-execution-inventory.md
@@ -23,7 +23,7 @@ between an app's runtime and the host OS.
 
 | Field | Value |
 |---|---|
-| File | `src/process_app/routing.rs:553` |
+| File | `src/process_app/routing.rs` — `ProcessApp::route_command`, `HostCommand::StreamProcess` arm |
 | Class | **app-requested** |
 | Capability gate | `Capability::TerminalBindings` (`terminal.bindings`) |
 | Denial path | Returns `PlexiEvent::StreamEnd { exit_code: 1 }` immediately; subprocess never spawned |
@@ -46,7 +46,7 @@ gate is warranted — trust is identical to a shell alias or cron job.
 
 | Field | Value |
 |---|---|
-| File | `src/cli.rs:109` |
+| File | `src/cli.rs` — `run_command` function, `sh -c` spawn |
 | Class | **user-authored-config** |
 | Input source | `.plexi/commands.toml` `run` field — written by the workspace owner |
 | Secret injection | Secrets are resolved by name from the workspace secrets store and injected as env vars. Secret values never appear in the command string itself. |
@@ -61,13 +61,13 @@ substituting empty strings.
 
 | Field | Value |
 |---|---|
-| File | `src/pane_ops/create.rs:791` (`substitute_note_tokens_static`) |
+| File | `src/pane_ops/create.rs` — `substitute_note_tokens_static` |
 | Class | **user-authored-config** |
 | Input source | `[[quick_note.destinations]]` in `config.toml` — written by the user |
 | User-supplied tokens | `{note}` and `{cwd}` — both routed through `shell_quote` before substitution |
 | Shell-quote impl | POSIX single-quote wrapping (`'...'`) with `'` escaped as `'\''`; blocks `$(...)`, backticks, `\`, newlines, semicolons |
 | App-reachable | No — apps cannot submit notes or select destinations |
-| Tests | `src/pane_ops/create.rs:1274–1342` — 8 injection / escaping tests added by issue #1113 |
+| Tests | `src/pane_ops/create.rs` — 8 injection / escaping tests in the `#[cfg(test)]` block, added by issue #1113 |
 
 The command _template_ is trusted (user-authored config). Only the substituted
 values are escaped. Do not add new substitution tokens that expand
@@ -81,24 +81,23 @@ These paths execute hardcoded binaries with caller-controlled (not user/app-cont
 arguments. Shell injection is not possible because no free-form string reaches
 these exec calls.
 
-| File | Binary | Purpose |
+| File / Symbol | Binary | Purpose |
 |---|---|---|
-| `src/shell.rs:107,135` | User's configured login shell | Resolve env vars at startup |
-| `src/shell.rs:289` | `/usr/sbin/lsof` | Check port occupancy |
-| `src/install.rs:77,93,97,112,123,562,610,626` | `git` | App install / update lifecycle |
-| `src/cli.rs:1598,1627` | `unzip`, `cp` | App bundle extraction |
-| `src/cli.rs:1685,1701` | `nohup`, `osascript` | Self-relaunch after update |
-| `src/app_render.rs:35` | Resolved Python binary | Spawn the app subprocess |
-| `src/process_app/mod.rs:355,359` | Python binary or explicit bin_path | Spawn the app subprocess |
-| `src/cli_help_parser.rs:52` | CLI binary being probed | Harvest `--help` output for completions |
-| `src/cli_crawl.rs:45,60` | CLI binary | Crawl subcommands for completion generation |
-| `src/pane_ops/create.rs:588` | `plexi` / channel binary | Probe CLI for workspace path resolution |
-| `src/app/canvas_bindings.rs:333,355` | `open` / `xdg-open` | Open URLs from canvas taps |
-| `src/cli.rs:2061,2070` | `jq` | Pretty-print JSON output |
-| `src/cli.rs:2571,2576` | `stty` | Terminal echo control during secret input |
-| `src/cli.rs:2623,2631,2638` | Probed tool binary | Check tool availability for doctor command |
-| `src/cli.rs:2984` | Configured CLI tool | Run a user-configured doctor check (internal constant list) |
-| `src/cli.rs:3342` | `python3` | Check Python version during app scaffolding |
+| `src/shell.rs` — `resolve_env_vars`, `detect_shell` | User's configured login shell | Resolve env vars at startup |
+| `src/shell.rs` — `check_port_in_use` | `/usr/sbin/lsof` | Check port occupancy |
+| `src/install.rs` — app install helpers | `git` | App install / update lifecycle |
+| `src/cli.rs` — app bundle extraction | `unzip`, `cp` | App bundle extraction |
+| `src/cli.rs` — self-relaunch after update | `nohup`, `osascript` | Self-relaunch after update |
+| `src/app_render.rs` — `AppRenderer::spawn` | Resolved Python binary | Spawn the app subprocess |
+| `src/process_app/mod.rs` — `ProcessApp::launch` | Python binary or explicit bin_path | Spawn the app subprocess |
+| `src/cli_help_parser.rs` — `parse_help` | CLI binary being probed | Harvest `--help` output for completions |
+| `src/cli_crawl.rs` — `crawl_cli` | CLI binary | Crawl subcommands for completion generation |
+| `src/pane_ops/create.rs` — workspace path probe | `plexi` / channel binary | Probe CLI for workspace path resolution |
+| `src/app/canvas_bindings.rs` — `open_url` | `open` / `xdg-open` | Open URLs from canvas taps |
+| `src/cli.rs` — `jq` pretty-printer | `jq` | Pretty-print JSON output |
+| `src/cli.rs` — secret input echo suppression | `stty` | Terminal echo control during secret input |
+| `src/cli.rs` — `plexi doctor` tool checks | Probed tool binary | Check tool availability for doctor command |
+| `src/cli.rs` — `plexi app init` | `python3` | Check Python version during app scaffolding |
 
 None of these accept app-supplied strings at the exec boundary. The set of binaries
 is fixed at compile time or resolved from user config (shell path, Python path);

--- a/docs/security/shell-execution-inventory.md
+++ b/docs/security/shell-execution-inventory.md
@@ -1,0 +1,126 @@
+# Shell Execution Inventory
+
+Every `sh -c`, `Command::new`, and shell-string execution path in Plexi, classified
+by trust source. Maintained as an authoritative audit document (issue #1177).
+
+## Classification legend
+
+| Class | Meaning |
+|---|---|
+| **internal-constant** | Hardcoded binary + args; no user or app input reaches the exec path |
+| **user-authored-config** | String originates from user-owned config (`config.toml`, `.plexi/commands.toml`); the user is also the operator, so trust is equivalent to a shell alias |
+| **app-requested** | String supplied by an app subprocess; requires a declared capability gate before execution |
+
+---
+
+## App-reachable paths
+
+These paths are reachable by installed Plexi apps via the draw-command protocol.
+Every entry **must** have a capability gate. The gate is the only trust boundary
+between an app's runtime and the host OS.
+
+### `DrawCommand::StreamProcess` → `sh -c`
+
+| Field | Value |
+|---|---|
+| File | `src/process_app/routing.rs:553` |
+| Class | **app-requested** |
+| Capability gate | `Capability::TerminalBindings` (`terminal.bindings`) |
+| Denial path | Returns `PlexiEvent::StreamEnd { exit_code: 1 }` immediately; subprocess never spawned |
+| Logging | `log::warn!` on denial; `log::info!` with app id + command + channel on allow |
+| Test | `stream_process_denied_without_terminal_bindings` in `src/testing.rs` |
+
+An app that declares `terminal.bindings` in its manifest is explicitly trusted
+to execute shell commands on the user's behalf. The capability prompt is shown
+at first use and remembered per workspace. An undeclared app hits the denial
+path — no subprocess is ever spawned.
+
+---
+
+## User-authored paths
+
+These paths run commands that the user wrote themselves. No additional capability
+gate is warranted — trust is identical to a shell alias or cron job.
+
+### `plexi run` → `sh -c`
+
+| Field | Value |
+|---|---|
+| File | `src/cli.rs:109` |
+| Class | **user-authored-config** |
+| Input source | `.plexi/commands.toml` `run` field — written by the workspace owner |
+| Secret injection | Secrets are resolved by name from the workspace secrets store and injected as env vars. Secret values never appear in the command string itself. |
+| App-reachable | No — this is a CLI subcommand invoked by the user directly, not by app protocol |
+| Test | None required (user-authored); see secret resolution tests in `src/workspace_secrets.rs` |
+
+`.plexi/commands.toml` is executable code. Any secret referenced must exist in
+the workspace secrets store; missing secrets abort with a clear error rather than
+substituting empty strings.
+
+### Quick-note destination command templates → `zsh -c` / `sh -c`
+
+| Field | Value |
+|---|---|
+| File | `src/pane_ops/create.rs:791` (`substitute_note_tokens_static`) |
+| Class | **user-authored-config** |
+| Input source | `[[quick_note.destinations]]` in `config.toml` — written by the user |
+| User-supplied tokens | `{note}` and `{cwd}` — both routed through `shell_quote` before substitution |
+| Shell-quote impl | POSIX single-quote wrapping (`'...'`) with `'` escaped as `'\''`; blocks `$(...)`, backticks, `\`, newlines, semicolons |
+| App-reachable | No — apps cannot submit notes or select destinations |
+| Tests | `src/pane_ops/create.rs:1274–1342` — 8 injection / escaping tests added by issue #1113 |
+
+The command _template_ is trusted (user-authored config). Only the substituted
+values are escaped. Do not add new substitution tokens that expand
+arbitrary strings without routing them through `shell_quote`.
+
+---
+
+## Internal paths
+
+These paths execute hardcoded binaries with caller-controlled (not user/app-controlled)
+arguments. Shell injection is not possible because no free-form string reaches
+these exec calls.
+
+| File | Binary | Purpose |
+|---|---|---|
+| `src/shell.rs:107,135` | User's configured login shell | Resolve env vars at startup |
+| `src/shell.rs:289` | `/usr/sbin/lsof` | Check port occupancy |
+| `src/install.rs:77,93,97,112,123,562,610,626` | `git` | App install / update lifecycle |
+| `src/cli.rs:1598,1627` | `unzip`, `cp` | App bundle extraction |
+| `src/cli.rs:1685,1701` | `nohup`, `osascript` | Self-relaunch after update |
+| `src/app_render.rs:35` | Resolved Python binary | Spawn the app subprocess |
+| `src/process_app/mod.rs:355,359` | Python binary or explicit bin_path | Spawn the app subprocess |
+| `src/cli_help_parser.rs:52` | CLI binary being probed | Harvest `--help` output for completions |
+| `src/cli_crawl.rs:45,60` | CLI binary | Crawl subcommands for completion generation |
+| `src/pane_ops/create.rs:588` | `plexi` / channel binary | Probe CLI for workspace path resolution |
+| `src/app/canvas_bindings.rs:333,355` | `open` / `xdg-open` | Open URLs from canvas taps |
+| `src/cli.rs:2061,2070` | `jq` | Pretty-print JSON output |
+| `src/cli.rs:2571,2576` | `stty` | Terminal echo control during secret input |
+| `src/cli.rs:2623,2631,2638` | Probed tool binary | Check tool availability for doctor command |
+| `src/cli.rs:2984` | Configured CLI tool | Run a user-configured doctor check (internal constant list) |
+| `src/cli.rs:3342` | `python3` | Check Python version during app scaffolding |
+
+None of these accept app-supplied strings at the exec boundary. The set of binaries
+is fixed at compile time or resolved from user config (shell path, Python path);
+arguments are constructed by the host, not received over protocol.
+
+---
+
+## Invariants
+
+1. **No new app-reachable `sh -c` path may be added without a capability gate** and
+   a denial test in `src/testing.rs` following the pattern of
+   `stream_process_denied_without_terminal_bindings`.
+
+2. **No new `{token}` substitution** in a quick-note or similar user-config command
+   template may be introduced without routing the substituted value through
+   `shell_quote`. The template itself is trusted; the substituted values are not.
+
+3. **`.plexi/commands.toml` is workspace-scoped executable code.** It is read from
+   the user's project directory, not from a shared or system path. An app cannot
+   read, modify, or invoke entries in this file; it is not part of the protocol.
+
+4. **Secret values are never interpolated into command strings.** The `plexi run`
+   path injects secrets exclusively as environment variables. If a command needs a
+   secret value in a flag (e.g. `--token $MY_SECRET`), the command string
+   references `$MY_SECRET` (a known env var name), not the secret value itself.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -456,4 +456,58 @@ mod tests {
         h.run_frames(1);
     }
 
+    // -- Shell execution security (issue #1177) ───────────────────────────────
+
+    /// Regression guard: an app without `terminal.bindings` must never reach
+    /// the `sh -c` spawn in `StreamProcess`. The host must return
+    /// `StreamEnd { exit_code: 1 }` immediately and never spawn a subprocess.
+    ///
+    /// This is the only app-reachable `sh -c` path in the codebase. Any future
+    /// app-reachable shell execution path must add a matching denial test here.
+    /// See `docs/security/shell-execution-inventory.md` for the full audit.
+    #[test]
+    fn stream_process_denied_without_terminal_bindings() {
+        use crate::app_protocol::{DrawCommand, HostCommand, PlexiEvent, StreamChannel};
+
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
+
+        h.inject(
+            pane,
+            DrawCommand::Host(HostCommand::StreamProcess {
+                correlation_id: "sec-test-1".to_string(),
+                terminal_pane_id: 0,
+                command: "echo SHOULD_NOT_RUN".to_string(),
+                channel: StreamChannel::Stdout,
+            }),
+        );
+
+        {
+            let win = &mut h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(proc) = &mut app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            proc.background_tick();
+        }
+
+        let effects = h.effects_drain(pane);
+        assert!(
+            !effects.is_empty(),
+            "StreamProcess must produce an outbound event — got none. \
+             This means the denial path was not reached."
+        );
+        let stream_end = effects.iter().find(|e| {
+            matches!(e, PlexiEvent::StreamEnd { correlation_id, exit_code: 1 }
+                if correlation_id == "sec-test-1")
+        });
+        assert!(
+            stream_end.is_some(),
+            "expected StreamEnd {{ exit_code: 1 }} for denied StreamProcess, got: {:?}",
+            effects
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary
- Adds `docs/security/shell-execution-inventory.md` — a checked-in audit doc classifying every `sh -c` / `Command::new` execution path as `internal-constant`, `user-authored-config`, or `app-requested`
- Confirms `DrawCommand::StreamProcess` is the only app-reachable shell execution path and it is correctly gated on `Capability::TerminalBindings`
- Adds `stream_process_denied_without_terminal_bindings` HostHarness test proving an unprivileged app receives `StreamEnd { exit_code: 1 }` and no subprocess is ever spawned

## Done when criteria met
- ✅ Checked-in audit doc enumerating every shell execution path (`docs/security/shell-execution-inventory.md`)
- ✅ Every app-reachable path has a capability gate (`StreamProcess` → `terminal.bindings`)
- ✅ Test proving unprivileged apps cannot reach it (`stream_process_denied_without_terminal_bindings`)

## Test plan
- `cargo test stream_process_denied_without_terminal_bindings` → passes
- `cargo build` → clean, no warnings introduced

Closes #1177