### PR TITLE
fix(terminal): pass initial_cmd to new_window and tab layouts (#1184)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1144,6 +1144,7 @@ impl PlexiApp {
 
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
+                        let initial_cmd = cmd_from_args(args);
                         if layout_str == "new_window" {
                             // Create a new spatial grid window to the right of the
                             // current context row instead of splitting the active pane.
@@ -1154,14 +1155,13 @@ impl PlexiApp {
                                 .map(|w| w.grid_x)
                                 .max();
                             let new_x = max_x.map(|x| x + 1).unwrap_or(1);
-                            log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y})");
-                            self.create_page_at(new_x, active_y);
+                            log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                            self.create_page_at(new_x, active_y, initial_cmd.as_deref(), *ephemeral);
                         } else if layout_str == "tab" {
-                            log::info!("pane_ipc: spawn_pane terminal layout=tab");
-                            self.new_tab();
+                            log::info!("pane_ipc: spawn_pane terminal layout=tab initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                            self.new_tab(initial_cmd.as_deref(), *ephemeral);
                         } else {
                             let vertical = matches!(layout_str, "split_h" | "split_above");
-                            let initial_cmd = cmd_from_args(args);
                             log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
                         }
@@ -2412,7 +2412,7 @@ impl eframe::App for PlexiApp {
                     self.step_focus_history_forward();
                 }
                 Action::NewTab => {
-                    self.new_tab();
+                    self.new_tab(None, false);
                     self.save_workspace();
                 }
                 Action::ToggleZoom => {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -418,19 +418,45 @@ impl PlexiApp {
     pub(super) fn create_single_pane_tree(
         &mut self,
         cwd: Option<PathBuf>,
+        initial_cmd: Option<&str>,
+        close_on_exit: bool,
     ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.host.alloc_pane_id();
 
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
-        let pane = TerminalPane::new(
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        if let Some(cmd) = initial_cmd {
+            log::info!("create_single_pane_tree: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
+            let shell_name = std::path::Path::new(&settings.shell)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            let effective_cmd: String = if !close_on_exit {
+                let shell_path = &settings.shell;
+                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
+                let sep = if trimmed.is_empty() { "" } else { "; " };
+                match shell_name {
+                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
+                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
+                }
+            } else {
+                cmd.to_string()
+            };
+            settings.args = match shell_name {
+                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
+                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
+                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
+            };
+        }
+        let mut pane = TerminalPane::new(
             new_id,
             self.ctx.clone(),
             self.pty_event_tx.clone(),
             settings,
             self.default_font_size,
         )?;
+        pane.ephemeral = close_on_exit;
 
         let mut panes = HashMap::new();
         panes.insert(new_id, Pane::Terminal(Box::new(pane)));

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -428,26 +428,7 @@ impl PlexiApp {
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         if let Some(cmd) = initial_cmd {
             log::info!("create_single_pane_tree: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
-            let shell_name = std::path::Path::new(&settings.shell)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("");
-            let effective_cmd: String = if !close_on_exit {
-                let shell_path = &settings.shell;
-                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
-                let sep = if trimmed.is_empty() { "" } else { "; " };
-                match shell_name {
-                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
-                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
-                }
-            } else {
-                cmd.to_string()
-            };
-            settings.args = match shell_name {
-                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
-                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
-                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
-            };
+            super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
         }
         let mut pane = TerminalPane::new(
             new_id,

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -345,6 +345,7 @@ impl PlexiApp {
             let ctx_name = self.context_name_for(ctx_id);
             let mut settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
             if let Some(cmd) = initial_cmd {
+                log::info!("new_tab (empty context): initial_cmd={cmd:?} close_on_exit={close_on_exit}");
                 let shell_name = std::path::Path::new(&settings.shell)
                     .file_name()
                     .and_then(|n| n.to_str())

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -231,33 +231,7 @@ impl PlexiApp {
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         if let Some(cmd) = initial_cmd {
             log::info!("split_focused: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
-            let shell_name = std::path::Path::new(&settings.shell)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("");
-            // When staying alive (not ephemeral), append `; exec <shell> -i -l` so the pane
-            // drops into an interactive shell after the command completes instead of dying.
-            // Use the absolute shell path from settings (already resolved) rather than $SHELL
-            // to guarantee the right shell. Trim trailing semicolons to avoid `;;` syntax errors.
-            // `-i` sources ~/.zshrc so PATH additions (Homebrew, nvm, etc.) are
-            // visible. Fish uses different flags; for other POSIX shells we use
-            // the safe no-interactive fallback.
-            let effective_cmd: String = if !close_on_exit {
-                let shell_path = &settings.shell;
-                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
-                let sep = if trimmed.is_empty() { "" } else { "; " };
-                match shell_name {
-                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
-                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
-                }
-            } else {
-                cmd.to_string()
-            };
-            settings.args = match shell_name {
-                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
-                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
-                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
-            };
+            super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
         }
         let Some(mut pane) = TerminalPane::new(
             new_id,
@@ -346,26 +320,7 @@ impl PlexiApp {
             let mut settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
             if let Some(cmd) = initial_cmd {
                 log::info!("new_tab (empty context): initial_cmd={cmd:?} close_on_exit={close_on_exit}");
-                let shell_name = std::path::Path::new(&settings.shell)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("");
-                let effective_cmd: String = if !close_on_exit {
-                    let shell_path = &settings.shell;
-                    let trimmed = cmd.trim().trim_end_matches([';', ' ']);
-                    let sep = if trimmed.is_empty() { "" } else { "; " };
-                    match shell_name {
-                        "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
-                        _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
-                    }
-                } else {
-                    cmd.to_string()
-                };
-                settings.args = match shell_name {
-                    "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
-                    "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
-                    _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
-                };
+                super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
             }
             let Some(mut pane) = TerminalPane::new(
                 new_id,
@@ -398,27 +353,8 @@ impl PlexiApp {
         let ctx_name = self.context_name_for(ctx_id);
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
         if let Some(cmd) = initial_cmd {
-            let shell_name = std::path::Path::new(&settings.shell)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("");
             log::info!("new_tab: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
-            let effective_cmd: String = if !close_on_exit {
-                let shell_path = &settings.shell;
-                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
-                let sep = if trimmed.is_empty() { "" } else { "; " };
-                match shell_name {
-                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
-                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
-                }
-            } else {
-                cmd.to_string()
-            };
-            settings.args = match shell_name {
-                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
-                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
-                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
-            };
+            super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
         }
         let Some(mut pane) = TerminalPane::new(
             new_id,

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -149,7 +149,7 @@ impl PlexiApp {
             // the tree. If it has panes but none focused (rare), drop into the
             // standard terminal split path which will no-op for now.
             if self.windows[active].panes.is_empty() {
-                if let Some((tree, panes, root_tile)) = self.create_single_pane_tree(None) {
+                if let Some((tree, panes, root_tile)) = self.create_single_pane_tree(None, None, false) {
                     self.windows[active].tree = tree;
                     self.windows[active].panes = panes;
                     self.windows[active].focused_pane = Some(root_tile);
@@ -337,14 +337,36 @@ impl PlexiApp {
         ctx.focused_pane = Some(new_tile);
     }
 
-    pub(crate) fn new_tab(&mut self) {
+    pub(crate) fn new_tab(&mut self, initial_cmd: Option<&str>, close_on_exit: bool) {
         // Empty context (welcome screen): create the first pane as tree root.
         if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
             let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
             let ctx_name = self.context_name_for(ctx_id);
-            let settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
-            let Some(pane) = TerminalPane::new(
+            let mut settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
+            if let Some(cmd) = initial_cmd {
+                let shell_name = std::path::Path::new(&settings.shell)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                let effective_cmd: String = if !close_on_exit {
+                    let shell_path = &settings.shell;
+                    let trimmed = cmd.trim().trim_end_matches([';', ' ']);
+                    let sep = if trimmed.is_empty() { "" } else { "; " };
+                    match shell_name {
+                        "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
+                        _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
+                    }
+                } else {
+                    cmd.to_string()
+                };
+                settings.args = match shell_name {
+                    "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
+                    "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
+                    _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
+                };
+            }
+            let Some(mut pane) = TerminalPane::new(
                 new_id,
                 self.ctx.clone(),
                 self.pty_event_tx.clone(),
@@ -354,6 +376,7 @@ impl PlexiApp {
                 log::error!("Failed to create first terminal pane in empty context");
                 return;
             };
+            pane.ephemeral = close_on_exit;
             let ctx = &mut self.windows[self.active_window];
             ctx.panes.insert(new_id, Pane::Terminal(Box::new(pane)));
             let pane_tile = ctx.tree.tiles.insert_pane(new_id);
@@ -372,8 +395,31 @@ impl PlexiApp {
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
-        let Some(pane) = TerminalPane::new(
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        if let Some(cmd) = initial_cmd {
+            let shell_name = std::path::Path::new(&settings.shell)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            log::info!("new_tab: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
+            let effective_cmd: String = if !close_on_exit {
+                let shell_path = &settings.shell;
+                let trimmed = cmd.trim().trim_end_matches([';', ' ']);
+                let sep = if trimmed.is_empty() { "" } else { "; " };
+                match shell_name {
+                    "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
+                    _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
+                }
+            } else {
+                cmd.to_string()
+            };
+            settings.args = match shell_name {
+                "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
+                "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
+                _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
+            };
+        }
+        let Some(mut pane) = TerminalPane::new(
             new_id,
             self.ctx.clone(),
             self.pty_event_tx.clone(),
@@ -383,6 +429,7 @@ impl PlexiApp {
             log::error!("Failed to create new terminal pane");
             return;
         };
+        pane.ephemeral = close_on_exit;
         self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));

--- a/src/pane_ops/mod.rs
+++ b/src/pane_ops/mod.rs
@@ -16,3 +16,32 @@ mod layout;
 mod workspace;
 
 pub(crate) use layout::SwapResult;
+
+/// Apply `initial_cmd` to `settings`, using the same shell-suffix injection
+/// logic as `split_focused`. Call before `TerminalPane::new`.
+pub(super) fn apply_initial_cmd(
+    settings: &mut egui_term::BackendSettings,
+    cmd: &str,
+    close_on_exit: bool,
+) {
+    let shell_name = std::path::Path::new(&settings.shell)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    let effective_cmd: String = if !close_on_exit {
+        let shell_path = &settings.shell;
+        let trimmed = cmd.trim().trim_end_matches([';', ' ']);
+        let sep = if trimmed.is_empty() { "" } else { "; " };
+        match shell_name {
+            "fish" => format!("{trimmed}{sep}exec \"{shell_path}\" --login -i"),
+            _ => format!("{trimmed}{sep}exec \"{shell_path}\" -i -l"),
+        }
+    } else {
+        cmd.to_string()
+    };
+    settings.args = match shell_name {
+        "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), effective_cmd],
+        "fish" => vec!["--login".to_string(), "-c".to_string(), effective_cmd],
+        _ => vec!["-l".to_string(), "-c".to_string(), effective_cmd],
+    };
+}

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -15,7 +15,7 @@ impl PlexiApp {
             .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
             .unwrap_or_else(|| home.clone());
         log::info!("new_context: cwd={}", cwd.display());
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), None, false)
         else {
             log::error!("Failed to create terminal for new context");
             return;
@@ -69,20 +69,20 @@ impl PlexiApp {
             Some(x) => x + 1,
             None => 1,
         };
-        self.create_page_at(new_x, active_y);
+        self.create_page_at(new_x, active_y, None, false);
     }
 
     /// Shared creation helper: create a single-pane context at `(grid_x, grid_y)`
     /// and make it the active context.
-    pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32) {
+    pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32, initial_cmd: Option<&str>, close_on_exit: bool) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = self.windows[self.active_window]
             .focused_pane
             .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
             .or_else(|| self.router.active().root.clone())
             .unwrap_or(home);
-        log::info!("create_page_at({grid_x},{grid_y}): cwd={}", cwd.display());
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()))
+        log::info!("create_page_at({grid_x},{grid_y}): cwd={} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}", cwd.display());
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), initial_cmd, close_on_exit)
         else {
             log::error!("Failed to create terminal for new page at ({grid_x}, {grid_y})");
             return;
@@ -110,7 +110,7 @@ impl PlexiApp {
 
     pub(crate) fn reset_active_context(&mut self) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()))
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()), None, false)
         else {
             log::error!("Failed to create terminal for reset context");
             return;


### PR DESCRIPTION
## Summary

- `new_window` and `tab` layout branches in `SpawnPane` were silently dropping the `args` vector — only `split_v`/`split_h` called `cmd_from_args`
- `create_page_at` and `new_tab` now accept `initial_cmd: Option<&str>` and `close_on_exit: bool`, applying the same shell-suffix injection logic that `split_focused` already uses
- All non-command callers updated with `None, false`

## Done When

- `plexi terminal "echo test" --layout new_window` prints "test" and drops to an interactive shell
- `plexi terminal "echo test" --layout tab` same behaviour
- `plexi terminal "echo test" --layout split_v` still works (no regression)
- Keyboard shortcut new-tab (no command) still works

Closes #1184