### PR TITLE
feat(terminal): add --cwd flag for explicit working directory (#1168)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1125,8 +1125,8 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} from_pane_id={from_pane_id:?} response_file={response_file:?}");
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
                     // Override focused_pane for the split if from_pane_id is specified,
@@ -1145,6 +1145,7 @@ impl PlexiApp {
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
                         let initial_cmd = cmd_from_args(args);
+                        let cwd_override: Option<std::path::PathBuf> = cwd.as_deref().map(std::path::PathBuf::from);
                         if layout_str == "new_window" {
                             // Create a new spatial grid window to the right of the
                             // current context row instead of splitting the active pane.
@@ -1163,7 +1164,7 @@ impl PlexiApp {
                         } else {
                             let vertical = matches!(layout_str, "split_h" | "split_above");
                             log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                            self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral);
+                            self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, cwd_override);
                         }
                     } else {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
@@ -1358,12 +1359,13 @@ impl PlexiApp {
                         .collect()
                 })
                 .unwrap_or_default();
-            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral}");
+            let cwd_override: Option<std::path::PathBuf> = val["cwd"].as_str().map(std::path::PathBuf::from);
+            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral} cwd={cwd_override:?}");
             if type_id == "terminal" {
                 let layout_str = layout.as_deref().unwrap_or("split_v");
                 let vertical = matches!(layout_str, "split_h" | "split_above");
                 let initial_cmd = cmd_from_args(&args);
-                self.split_focused(vertical, initial_cmd.as_deref(), ephemeral);
+                self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, cwd_override);
             } else {
                 self.launch_app_by_id_with_layout(&type_id, layout, &args);
             }
@@ -1834,7 +1836,7 @@ impl eframe::App for PlexiApp {
                         );
                         // SDK-spawned terminal with a cmd closes on exit (matches historical behavior).
                         // CLI terminal uses the ephemeral flag exclusively — cmd alone does not close.
-                        self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some());
+                        self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some(), None);
                     } else {
                         self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
@@ -2303,13 +2305,13 @@ impl eframe::App for PlexiApp {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
-                    self.split_focused(false, None, false);
+                    self.split_focused(false, None, false, None);
                     self.save_workspace();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
-                    self.split_focused(true, None, false);
+                    self.split_focused(true, None, false, None);
                     self.save_workspace();
                 }
                 Action::SplitRight => {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -990,6 +990,8 @@ pub enum HostCommand {
         response_file: Option<String>,
         #[serde(default, skip_serializing_if = "is_false")]
         ephemeral: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2473,7 +2473,7 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
 ///
 /// Opens a terminal pane. Supports the --ephemeral flag which closes the pane when the
 /// process exits.
-pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
+pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     let layout_str = layout.unwrap_or("split_v");
     let args: Vec<String> = cmd.map(|c| vec![c.to_string()]).unwrap_or_default();
 
@@ -2496,7 +2496,10 @@ pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, fr
         if let Some(pid) = from_pane_id {
             payload["from_pane_id"] = serde_json::Value::Number(pid.into());
         }
-        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} from_pane_id={from_pane_id:?} response_file={response_file:?}");
+        if let Some(cwd) = cwd {
+            payload["cwd"] = serde_json::Value::String(cwd.to_string());
+        }
+        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
@@ -2554,12 +2557,15 @@ pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, fr
     if ephemeral {
         queue_payload["ephemeral"] = serde_json::Value::Bool(true);
     }
+    if let Some(cwd) = cwd {
+        queue_payload["cwd"] = serde_json::Value::String(cwd.to_string());
+    }
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
-    log::info!("terminal:cli: queued ephemeral={ephemeral}");
+    log::info!("terminal:cli: queued ephemeral={ephemeral} cwd={cwd:?}");
     println!("queued: open terminal");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0
@@ -3604,7 +3610,8 @@ _plexi() {
           _arguments \
             '(-e --ephemeral)'{-e,--ephemeral}'[Close the pane when the process exits]' \
             '--layout[Layout hint]:layout:(split_v split_h split_above)' \
-            '--from-pane-id[Split relative to this pane ID]:pane_id:'
+            '--from-pane-id[Split relative to this pane ID]:pane_id:' \
+            '--cwd[Working directory for the new terminal pane]:directory:_directories'
           ;;
         descriptor)
           local subcmds
@@ -3690,8 +3697,10 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
     terminal)
       if [[ $prev == "--layout" ]]; then
         COMPREPLY=($(compgen -W "split_v split_h split_above" -- "$cur"))
+      elif [[ $prev == "--cwd" ]]; then
+        COMPREPLY=($(compgen -d -- "$cur"))
       else
-        COMPREPLY=($(compgen -W "-e --ephemeral --layout --from-pane-id" -- "$cur"))
+        COMPREPLY=($(compgen -W "-e --ephemeral --layout --from-pane-id --cwd" -- "$cur"))
       fi
       ;;
     open)
@@ -3813,6 +3822,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from completions" -a "zsh bash f
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -s e -l ephemeral -d "Close the pane when the process exits"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_v split_h split_above"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l from-pane-id -d "Split relative to this pane ID"
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -l cwd -d "Working directory for the new terminal pane" -a "(__fish_complete_directories)"
 # open flags
 complete -c plexi -n "__fish_seen_subcommand_from open" -l layout -d "Layout hint" -a "split_v split_h split_above overlay"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l from-pane-id -d "Split relative to this pane ID"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -115,6 +115,9 @@ pub enum Commands {
         /// Split relative to this pane ID instead of the focused pane
         #[arg(long)]
         from_pane_id: Option<u64>,
+        /// Working directory for the new terminal pane
+        #[arg(long)]
+        cwd: Option<String>,
     },
     /// Open an app pane
     Open {

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,8 +374,8 @@ fn main() -> eframe::Result {
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },
-                    Commands::Terminal { cmd, ephemeral, layout, from_pane_id } => {
-                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id));
+                    Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd } => {
+                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref()));
                     }
                     Commands::Open { type_id, mcp, cli: cli_flag, layout, from_pane_id, extra_args } => {
                         let mode_count = type_id.is_some() as u8

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1143,7 +1143,7 @@ impl PlexiApp {
                 match position.as_str() {
                     "context-end" => self.open_at_context_end(&cmd),
                     "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true),
+                    _ => self.split_focused(false, Some(&cmd), true, None),
                 }
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
@@ -1171,7 +1171,7 @@ impl PlexiApp {
                 match position.as_str() {
                     "context-end" => self.open_at_context_end(&cmd),
                     "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true),
+                    _ => self.split_focused(false, Some(&cmd), true, None),
                 }
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -521,7 +521,7 @@ impl PlexiApp {
             log::info!(
                 "SpawnPane: terminal layout='{layout_str}' vertical={vertical} initial_cmd={initial_cmd:?}"
             );
-            self.split_focused(vertical, initial_cmd.as_deref(), false);
+            self.split_focused(vertical, initial_cmd.as_deref(), false, None);
             return;
         }
 
@@ -739,7 +739,7 @@ impl PlexiApp {
                 match position {
                     "context-end" => self.open_at_context_end(&cmd),
                     "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true),
+                    _ => self.split_focused(false, Some(&cmd), true, None),
                 }
                 true
             }
@@ -810,7 +810,7 @@ impl PlexiApp {
     pub(crate) fn open_at_context_end(&mut self, cmd: &str) {
         let did_insert = self.try_insert_at_root(cmd, false);
         if !did_insert {
-            self.split_focused(false, Some(cmd), true);
+            self.split_focused(false, Some(cmd), true, None);
         }
     }
 
@@ -818,7 +818,7 @@ impl PlexiApp {
     pub(crate) fn open_at_context_start(&mut self, cmd: &str) {
         let did_insert = self.try_insert_at_root(cmd, true);
         if !did_insert {
-            self.split_focused(false, Some(cmd), true);
+            self.split_focused(false, Some(cmd), true, None);
         }
     }
 
@@ -967,6 +967,7 @@ mod tests {
             request_id: None,
             response_file: None,
             ephemeral: false,
+            cwd: None,
         });
         h.run_frames(2);
 
@@ -1002,6 +1003,7 @@ mod tests {
             request_id: None,
             response_file: None,
             ephemeral: false,
+            cwd: None,
         });
         h.run_frames(2);
 
@@ -1040,6 +1042,7 @@ mod tests {
             request_id: None,
             response_file: None,
             ephemeral: false,
+            cwd: None,
         });
         h.run_frames(2);
 
@@ -1077,6 +1080,7 @@ mod tests {
             request_id: None,
             response_file: None,
             ephemeral: false,
+            cwd: None,
         });
         h.run_frames(2);
 
@@ -1124,6 +1128,7 @@ mod tests {
             request_id: None,
             response_file: None,
             ephemeral: false,
+            cwd: None,
         });
         h.run_frames(2);
 
@@ -1169,6 +1174,7 @@ mod tests {
                 request_id: None,
                 response_file: None,
                 ephemeral: false,
+                cwd: None,
             });
             h.run_frames(2);
         }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -186,7 +186,7 @@ impl PlexiApp {
         match kind {
             Kind::Terminal => {
                 // Reuse the existing terminal split path.
-                self.split_focused(vertical, None, false);
+                self.split_focused(vertical, None, false, None);
             }
             Kind::App(manifest_id) => {
                 // Fresh instance of the same app at the requested placement.
@@ -203,7 +203,7 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool) {
+    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool, cwd_override: Option<std::path::PathBuf>) {
         let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
@@ -225,7 +225,7 @@ impl PlexiApp {
             })
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
-        let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
+        let cwd = cwd_override.or_else(|| self.windows[self.active_window].get_focused_pane_cwd(focused));
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -770,6 +770,7 @@ impl ProcessApp {
                 request_id,
                 response_file: _,
                 ephemeral: _,
+                cwd: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)


### PR DESCRIPTION
## Summary

- Adds `--cwd <path>` flag to `plexi terminal` so external callers can spawn terminal panes in a specific working directory
- Threads cwd through both the socket path (inside Plexi pane) and spawn-queue path (outside Plexi, e.g. from launchd)
- `split_focused` now accepts a `cwd_override` that takes precedence over the focused pane's cwd when set
- Completions updated for zsh (`_directories`), bash (`compgen -d`), and fish (`__fish_complete_directories`)

## Done When

`plexi terminal --cwd /Users/ianburke/Documents/GitHub/PLEXI "c '/daily-check'"` spawns a pane whose shell starts in the PLEXI repo, confirmed by `pwd` in the new pane. Log line `cwd=Some(...)` appears in `plexi.log`.

Closes #1168