### PR TITLE
feat(pgap): FileRead/FileWrite protocol messages and SDK helpers (#1196)

### DIFF
--- a/examples/minimal-editor/app.py
+++ b/examples/minimal-editor/app.py
@@ -12,7 +12,7 @@ NOTES_FILE = "notes.txt"
 
 
 class MinimalEditorApp(App):
-    def on_init(self, ctx: RenderContext) -> None:
+    async def on_init(self, ctx: RenderContext) -> None:
         self._lines: list[str] = [""]
         self._cursor_line = 0
         self._status = ""
@@ -20,7 +20,7 @@ class MinimalEditorApp(App):
         self._loading = True
         # Attempt to load existing file.
         try:
-            content = self.emit.run_sync(self.emit.read_file(NOTES_FILE))  # type: ignore[attr-defined]
+            content = await self.emit.read_file(NOTES_FILE)  # type: ignore[attr-defined]
             self._lines = content.split("\n") if content else [""]
             self._cursor_line = max(0, len(self._lines) - 1)
             self._status = f"Loaded {len(content)} chars from {NOTES_FILE}"
@@ -28,7 +28,6 @@ class MinimalEditorApp(App):
         except RuntimeError as e:
             err = str(e)
             if "file not found" in err or "inaccessible" in err:
-                # New file — start blank.
                 self._lines = [""]
                 self._status = f"New file: {NOTES_FILE}"
                 self._status_color = MUTED
@@ -41,20 +40,20 @@ class MinimalEditorApp(App):
     def _char_count(self) -> int:
         return sum(len(ln) for ln in self._lines) + max(0, len(self._lines) - 1)
 
-    def _save(self, ctx: RenderContext) -> None:
+    async def _save(self, ctx: RenderContext) -> None:
         content = "\n".join(self._lines)
         try:
-            n = self.emit.run_sync(self.emit.write_file(NOTES_FILE, content))  # type: ignore[attr-defined]
+            n = await self.emit.write_file(NOTES_FILE, content)  # type: ignore[attr-defined]
             self._status = f"Saved {n} bytes to {NOTES_FILE}"
             self._status_color = GREEN
         except RuntimeError as e:
             self._status = f"Save error: {e}"
             self._status_color = ACCENT
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    async def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
         cmd = mods.get("cmd", False)
         if cmd and key == "s":
-            self._save(ctx)
+            await self._save(ctx)
             return
         if key == "Enter":
             self._lines.insert(self._cursor_line + 1, "")

--- a/examples/minimal-editor/app.py
+++ b/examples/minimal-editor/app.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Minimal Editor — POC for fs.read / fs.write capability (#1196).
+
+Loads notes.txt from the workspace root on init (creates empty if absent).
+Cmd+S saves the current content back via ctx.emit.write_file().
+Shows a status line: bytes written on save, char count while editing.
+"""
+
+from plexi_sdk import App, RenderContext, FG, MUTED, SURFACE, GREEN, ACCENT, BG, BODY, CAPTION, HINT  # type: ignore[attr-defined]
+
+NOTES_FILE = "notes.txt"
+
+
+class MinimalEditorApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._lines: list[str] = [""]
+        self._cursor_line = 0
+        self._status = ""
+        self._status_color = MUTED
+        self._loading = True
+        # Attempt to load existing file.
+        try:
+            content = self.emit.run_sync(self.emit.read_file(NOTES_FILE))  # type: ignore[attr-defined]
+            self._lines = content.split("\n") if content else [""]
+            self._cursor_line = max(0, len(self._lines) - 1)
+            self._status = f"Loaded {len(content)} chars from {NOTES_FILE}"
+            self._status_color = MUTED
+        except RuntimeError as e:
+            err = str(e)
+            if "file not found" in err or "inaccessible" in err:
+                # New file — start blank.
+                self._lines = [""]
+                self._status = f"New file: {NOTES_FILE}"
+                self._status_color = MUTED
+            else:
+                self._status = f"Load error: {err}"
+                self._status_color = ACCENT
+        finally:
+            self._loading = False
+
+    def _char_count(self) -> int:
+        return sum(len(ln) for ln in self._lines) + max(0, len(self._lines) - 1)
+
+    def _save(self, ctx: RenderContext) -> None:
+        content = "\n".join(self._lines)
+        try:
+            n = self.emit.run_sync(self.emit.write_file(NOTES_FILE, content))  # type: ignore[attr-defined]
+            self._status = f"Saved {n} bytes to {NOTES_FILE}"
+            self._status_color = GREEN
+        except RuntimeError as e:
+            self._status = f"Save error: {e}"
+            self._status_color = ACCENT
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        cmd = mods.get("cmd", False)
+        if cmd and key == "s":
+            self._save(ctx)
+            return
+        if key == "Enter":
+            self._lines.insert(self._cursor_line + 1, "")
+            self._cursor_line += 1
+        elif key == "Backspace":
+            if self._lines[self._cursor_line]:
+                self._lines[self._cursor_line] = self._lines[self._cursor_line][:-1]
+            elif self._cursor_line > 0:
+                self._lines.pop(self._cursor_line)
+                self._cursor_line -= 1
+        elif key == "up":
+            self._cursor_line = max(0, self._cursor_line - 1)
+        elif key == "down":
+            self._cursor_line = min(len(self._lines) - 1, self._cursor_line + 1)
+        elif len(key) == 1 and not cmd:
+            self._lines[self._cursor_line] += key
+            self._status = f"{self._char_count()} chars"
+            self._status_color = MUTED
+
+    def on_render(self, ctx: RenderContext) -> None:
+        from plexi_sdk.ui import Column, AppBar, FooterKeys, Footer, Spacer
+
+        ctx.clear(BG)
+
+        _app = self
+
+        class _Body:
+            def measure(self, avail_w: float) -> float:
+                return 0.0
+
+            def is_grow(self) -> bool:
+                return True
+
+            def render(self, ctx2, x: float, y: float, w: float, h: float) -> None:
+                if _app._loading:
+                    ctx2.text(x, y + 16, "Loading…", size=BODY, color=MUTED)
+                    return
+                cy = y
+                for i, line in enumerate(_app._lines):
+                    is_cursor = i == _app._cursor_line
+                    cursor = "▌" if is_cursor else ""
+                    color = FG if is_cursor else MUTED
+                    ctx2.text(x, cy, line + cursor, size=BODY, color=color)
+                    cy += BODY + 6
+                    if cy > y + h - 4:
+                        break
+
+        children = [
+            AppBar(title="Minimal Editor", subtitle=NOTES_FILE),
+            _Body(),
+            Spacer(size=HINT),
+        ]
+        if self._status:
+            children.append(Footer(self._status, color=self._status_color))
+        children.append(FooterKeys([(["⌘", "s"], "save")]))
+        ctx.render(Column(children))
+
+
+if __name__ == "__main__":
+    MinimalEditorApp().run()

--- a/examples/minimal-editor/app.py
+++ b/examples/minimal-editor/app.py
@@ -6,7 +6,7 @@ Cmd+S saves the current content back via ctx.emit.write_file().
 Shows a status line: bytes written on save, char count while editing.
 """
 
-from plexi_sdk import App, RenderContext, FG, MUTED, SURFACE, GREEN, ACCENT, BG, BODY, CAPTION, HINT  # type: ignore[attr-defined]
+from plexi_sdk import App, RenderContext, FG, MUTED, GREEN, ACCENT, BG, BODY  # type: ignore[attr-defined]
 
 NOTES_FILE = "notes.txt"
 
@@ -74,42 +74,34 @@ class MinimalEditorApp(App):
             self._status_color = MUTED
 
     def on_render(self, ctx: RenderContext) -> None:
-        from plexi_sdk.ui import Column, AppBar, FooterKeys, Footer, Spacer
-
         ctx.clear(BG)
+        pad = 16.0
+        y = pad
 
-        _app = self
+        ctx.text(pad, y, "Minimal Editor", size=16.0, color=FG, bold=True)
+        y += 28.0
+        ctx.text(pad, y, NOTES_FILE, size=BODY, color=MUTED)
+        y += 24.0
+        ctx.rect(pad, y, ctx.w - pad * 2, 1.0, fill=MUTED, radius=0.0)
+        y += 12.0
 
-        class _Body:
-            def measure(self, avail_w: float) -> float:
-                return 0.0
+        if self._loading:
+            ctx.text(pad, y, "Loading…", size=BODY, color=MUTED)
+        else:
+            for i, line in enumerate(self._lines):
+                is_cursor = i == self._cursor_line
+                text = line + ("▌" if is_cursor else "")
+                ctx.text(pad, y, text if text else ("▌" if is_cursor else " "), size=BODY, color=FG if is_cursor else MUTED)
+                y += BODY + 4.0
+                if y > ctx.h - 60:
+                    remaining = len(self._lines) - i - 1
+                    if remaining > 0:
+                        ctx.text(pad, y, f"… {remaining} more line(s)", size=BODY, color=MUTED)
+                    break
 
-            def is_grow(self) -> bool:
-                return True
-
-            def render(self, ctx2, x: float, y: float, w: float, h: float) -> None:
-                if _app._loading:
-                    ctx2.text(x, y + 16, "Loading…", size=BODY, color=MUTED)
-                    return
-                cy = y
-                for i, line in enumerate(_app._lines):
-                    is_cursor = i == _app._cursor_line
-                    cursor = "▌" if is_cursor else ""
-                    color = FG if is_cursor else MUTED
-                    ctx2.text(x, cy, line + cursor, size=BODY, color=color)
-                    cy += BODY + 6
-                    if cy > y + h - 4:
-                        break
-
-        children = [
-            AppBar(title="Minimal Editor", subtitle=NOTES_FILE),
-            _Body(),
-            Spacer(size=HINT),
-        ]
         if self._status:
-            children.append(Footer(self._status, color=self._status_color))
-        children.append(FooterKeys([(["⌘", "s"], "save")]))
-        ctx.render(Column(children))
+            ctx.text(pad, ctx.h - 36.0, self._status, size=BODY, color=self._status_color)
+        ctx.text(pad, ctx.h - 18.0, "⌘S  save", size=BODY, color=MUTED)
 
 
 if __name__ == "__main__":

--- a/examples/minimal-editor/manifest.toml
+++ b/examples/minimal-editor/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "minimal-editor"
+type = "app"
+name = "Minimal Editor"
+version = "0.1.0"
+description = "POC for fs.read/fs.write capability — load and save a text file (#1196)."
+entry = "app.py"
+
+[app.capabilities]
+capabilities = ["fs.read", "fs.write"]
+
+[launch]
+layout_hint = { side = "right", split = 0.5 }

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -94,6 +94,8 @@ class App:
         self._pending_secret: "dict[str, asyncio.Queue]" = {}
         self._app_state: dict = {}
         self._pending_http: "dict[str, asyncio.Queue]" = {}
+        self._pending_file_read: "dict[str, asyncio.Queue]" = {}
+        self._pending_file_write: "dict[str, asyncio.Queue]" = {}
         # v3.3 ai.query broker (#284): awaits PlexiEvent::AiResponse keyed
         # on request_id. Each entry is consumed by a single ai_query() call.
         self._pending_ai: "dict[str, asyncio.Queue]" = {}
@@ -464,6 +466,24 @@ class App:
                             q.put_nowait(("error", ev["error"]))
                         else:
                             q.put_nowait(("ok", ev.get("body", "")))
+
+                elif t == "file_read_result":
+                    req_id = ev.get("request_id", "")
+                    q = self._pending_file_read.pop(req_id, None)
+                    if q:
+                        if ev.get("error"):
+                            q.put_nowait(("error", ev["error"]))
+                        else:
+                            q.put_nowait(("ok", ev.get("content", "")))
+
+                elif t == "file_write_result":
+                    req_id = ev.get("request_id", "")
+                    q = self._pending_file_write.pop(req_id, None)
+                    if q:
+                        if ev.get("error"):
+                            q.put_nowait(("error", ev["error"], 0))
+                        else:
+                            q.put_nowait(("ok", "", ev.get("bytes_written", 0)))
 
                 elif t == "ai_response":
                     # v3.3 ai.query broker (#284). Hand the whole event dict to

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -651,6 +651,45 @@ class Emitter:
         return await self.secret_get(key)
 
     @_blocking_emit_method
+    async def read_file(self, path: str) -> str:
+        """Read a file within workspace_root. Requires fs.read capability.
+
+        Returns the file content as a UTF-8 string.
+        Raises RuntimeError if denied or the file cannot be read.
+
+        From background threads:
+        ``self.emit.run_sync(self.emit.read_file(path))``.
+        """
+        req_id = str(uuid.uuid4())
+        q: asyncio.Queue[tuple[str, str]] = _make_async_queue()
+        self._app._pending_file_read[req_id] = q
+        _emit({"type": "file_read", "request_id": req_id, "path": path})
+        status, value = await q.get()
+        if status == "error":
+            raise RuntimeError(f"read_file {path!r}: {value}")
+        return value
+
+    @_blocking_emit_method
+    async def write_file(self, path: str, content: str, append: bool = False) -> int:
+        """Write content to a file within workspace_root. Requires fs.write capability.
+
+        Returns the number of bytes written.
+        Raises RuntimeError if denied or the file cannot be written.
+
+        From background threads:
+        ``self.emit.run_sync(self.emit.write_file(path, content))``.
+        """
+        req_id = str(uuid.uuid4())
+        q: asyncio.Queue[tuple[str, str, int]] = _make_async_queue()
+        self._app._pending_file_write[req_id] = q
+        _emit({"type": "file_write", "request_id": req_id, "path": path,
+               "content": content, "append": append})
+        status, err, bytes_written = await q.get()
+        if status == "error":
+            raise RuntimeError(f"write_file {path!r}: {err}")
+        return bytes_written
+
+    @_blocking_emit_method
     async def http_get(self, url: str) -> str:
         """HTTP GET brokered through the host. Requires net.http capability.
         Raises RuntimeError on failure.

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -335,6 +335,25 @@ pub enum PlexiEvent {
     /// dialog without selecting a file, or the app lacks `fs.pick` capability.
     FilePickCancelled { request_id: String },
 
+    /// Response to `HostCommand::FileRead`. `content` is present on success;
+    /// `error` is present on failure (permission denied, file not found, I/O error).
+    FileReadResult {
+        request_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        content: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// Response to `HostCommand::FileWrite`. `bytes_written` is present on success;
+    /// `error` is present on failure.
+    FileWriteResult {
+        request_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bytes_written: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+
     /// Chunk of stdout/stderr bytes from an active `DrawCommand::StreamProcess`
     /// child. `bytes` is a raw byte array (values 0–255); decode with
     /// `bytes(event['bytes'])` in Python. Delivered at up to ~30 Hz.
@@ -1375,6 +1394,30 @@ pub enum HostCommand {
         request_id: String,
         filter: Vec<String>,
         multiple: bool,
+    },
+
+    // ── File I/O (#1196) ──────────────────────────────────────────────────────
+    /// Read a file within workspace_root. Requires `fs.read` capability.
+    ///
+    /// `path` must be relative to workspace_root or an absolute path within it.
+    /// Host resolves and validates the path, then replies with
+    /// `PlexiEvent::FileReadResult { request_id, content, error }`.
+    FileRead {
+        request_id: String,
+        /// Path relative to workspace_root, or absolute path within it.
+        path: String,
+    },
+    /// Write content to a file within workspace_root. Requires `fs.write` capability.
+    ///
+    /// If `append` is true, content is appended; otherwise the file is overwritten.
+    /// Host validates the path, writes atomically (write to temp then rename for overwrite),
+    /// and replies with `PlexiEvent::FileWriteResult { request_id, bytes_written, error }`.
+    FileWrite {
+        request_id: String,
+        path: String,
+        content: String,
+        #[serde(default)]
+        append: bool,
     },
 }
 

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -116,6 +116,28 @@ pub enum HostEvent {
         channel: String,
         timestamp: String,
     },
+    /// A file read was denied (capability check) or failed.
+    FileReadDenied {
+        app_id: String,
+        path: String,
+        reason: String,
+        timestamp: String,
+    },
+    /// A file write was denied (capability check) or failed.
+    FileWriteDenied {
+        app_id: String,
+        path: String,
+        reason: String,
+        timestamp: String,
+    },
+    /// A file operation completed successfully.
+    FileOpCompleted {
+        app_id: String,
+        path: String,
+        op: String, // "read" or "write"
+        bytes: u64,
+        timestamp: String,
+    },
 }
 
 // ── Wire envelope ─────────────────────────────────────────────────────────────

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -20,6 +20,16 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, OnceLock};
 
+// ── Supporting types ──────────────────────────────────────────────────────────
+
+/// File operation kind — compile-time safe alternative to a freeform String.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileOperation {
+    Read,
+    Write,
+}
+
 // ── HostEvent enum ────────────────────────────────────────────────────────────
 
 /// All events the host can emit to the event log.
@@ -134,7 +144,7 @@ pub enum HostEvent {
     FileOpCompleted {
         app_id: String,
         path: String,
-        op: String, // "read" or "write"
+        op: FileOperation,
         bytes: u64,
         timestamp: String,
     },

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -727,6 +727,232 @@ impl ProcessApp {
                 }).expect("failed to spawn file-picker thread");
             }
 
+            // ── File read (#1196) ──────────────────────────────────────────
+            HostCommand::FileRead { request_id, path } => {
+                log::info!(
+                    "ProcessApp[{}]: FileRead request_id={request_id} path={path:?}",
+                    self.type_id
+                );
+                if let PermissionCheck::Denied(reason) =
+                    check(&self.permissions, Capability::FsRead)
+                {
+                    log::warn!("ProcessApp[{}]: FileRead denied — {reason}", self.type_id);
+                    event_log::emit(HostEvent::FileReadDenied {
+                        app_id: self.type_id.clone(),
+                        path: path.clone(),
+                        reason: format!("capability_denied: {reason}"),
+                        timestamp: event_log::now_timestamp(),
+                    });
+                    self.outbound_events.push_back(PlexiEvent::FileReadResult {
+                        request_id,
+                        content: None,
+                        error: Some(format!("permission denied: {reason}")),
+                    });
+                    return;
+                }
+
+                // Resolve and validate path stays within workspace_root.
+                let target = if std::path::Path::new(&path).is_absolute() {
+                    std::path::PathBuf::from(&path)
+                } else {
+                    self.workspace_root.join(&path)
+                };
+                let canonical = match std::fs::canonicalize(&target) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        log::warn!(
+                            "ProcessApp[{}]: FileRead path={path:?} canonicalize failed: {e}",
+                            self.type_id
+                        );
+                        event_log::emit(HostEvent::FileReadDenied {
+                            app_id: self.type_id.clone(),
+                            path: path.clone(),
+                            reason: format!("path_error: {e}"),
+                            timestamp: event_log::now_timestamp(),
+                        });
+                        self.outbound_events.push_back(PlexiEvent::FileReadResult {
+                            request_id,
+                            content: None,
+                            error: Some(format!("file not found or inaccessible: {e}")),
+                        });
+                        return;
+                    }
+                };
+                let ws_canonical = self.workspace_root.canonicalize().unwrap_or_else(|_| self.workspace_root.clone());
+                if !canonical.starts_with(&ws_canonical) {
+                    log::warn!(
+                        "ProcessApp[{}]: FileRead path={path:?} escapes workspace_root",
+                        self.type_id
+                    );
+                    event_log::emit(HostEvent::FileReadDenied {
+                        app_id: self.type_id.clone(),
+                        path: path.clone(),
+                        reason: "path_escape: outside workspace_root".to_string(),
+                        timestamp: event_log::now_timestamp(),
+                    });
+                    self.outbound_events.push_back(PlexiEvent::FileReadResult {
+                        request_id,
+                        content: None,
+                        error: Some("access denied: path outside workspace root".to_string()),
+                    });
+                    return;
+                }
+
+                match std::fs::read_to_string(&canonical) {
+                    Ok(content) => {
+                        let bytes = content.len() as u64;
+                        log::info!(
+                            "ProcessApp[{}]: FileRead ok path={} bytes={bytes}",
+                            self.type_id,
+                            canonical.display()
+                        );
+                        event_log::emit(HostEvent::FileOpCompleted {
+                            app_id: self.type_id.clone(),
+                            path: canonical.display().to_string(),
+                            op: "read".to_string(),
+                            bytes,
+                            timestamp: event_log::now_timestamp(),
+                        });
+                        self.outbound_events.push_back(PlexiEvent::FileReadResult {
+                            request_id,
+                            content: Some(content),
+                            error: None,
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "ProcessApp[{}]: FileRead read_to_string failed: {e}",
+                            self.type_id
+                        );
+                        event_log::emit(HostEvent::FileReadDenied {
+                            app_id: self.type_id.clone(),
+                            path: path.clone(),
+                            reason: format!("io_error: {e}"),
+                            timestamp: event_log::now_timestamp(),
+                        });
+                        self.outbound_events.push_back(PlexiEvent::FileReadResult {
+                            request_id,
+                            content: None,
+                            error: Some(format!("read failed: {e}")),
+                        });
+                    }
+                }
+            }
+
+            // ── File write (#1196) ────────────────────────────────────────
+            HostCommand::FileWrite { request_id, path, content, append } => {
+                log::info!(
+                    "ProcessApp[{}]: FileWrite request_id={request_id} path={path:?} append={append}",
+                    self.type_id
+                );
+                if let PermissionCheck::Denied(reason) =
+                    check(&self.permissions, Capability::FsWrite)
+                {
+                    log::warn!("ProcessApp[{}]: FileWrite denied — {reason}", self.type_id);
+                    event_log::emit(HostEvent::FileWriteDenied {
+                        app_id: self.type_id.clone(),
+                        path: path.clone(),
+                        reason: format!("capability_denied: {reason}"),
+                        timestamp: event_log::now_timestamp(),
+                    });
+                    self.outbound_events.push_back(PlexiEvent::FileWriteResult {
+                        request_id,
+                        bytes_written: None,
+                        error: Some(format!("permission denied: {reason}")),
+                    });
+                    return;
+                }
+
+                // Resolve target path.
+                let target = if std::path::Path::new(&path).is_absolute() {
+                    std::path::PathBuf::from(&path)
+                } else {
+                    self.workspace_root.join(&path)
+                };
+
+                // Validate parent dir stays within workspace_root.
+                let parent = target.parent().unwrap_or(&target);
+                let parent_canonical = std::fs::canonicalize(parent)
+                    .or_else(|_| {
+                        // Parent dir may not exist yet — canonicalize what we can.
+                        std::fs::canonicalize(self.workspace_root.as_path())
+                    })
+                    .unwrap_or_else(|_| self.workspace_root.clone());
+                let ws_canonical = self.workspace_root.canonicalize().unwrap_or_else(|_| self.workspace_root.clone());
+                if !parent_canonical.starts_with(&ws_canonical) {
+                    log::warn!(
+                        "ProcessApp[{}]: FileWrite path={path:?} escapes workspace_root",
+                        self.type_id
+                    );
+                    event_log::emit(HostEvent::FileWriteDenied {
+                        app_id: self.type_id.clone(),
+                        path: path.clone(),
+                        reason: "path_escape: outside workspace_root".to_string(),
+                        timestamp: event_log::now_timestamp(),
+                    });
+                    self.outbound_events.push_back(PlexiEvent::FileWriteResult {
+                        request_id,
+                        bytes_written: None,
+                        error: Some("access denied: path outside workspace root".to_string()),
+                    });
+                    return;
+                }
+
+                let write_result: std::io::Result<u64> = if append {
+                    use std::io::Write;
+                    std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&target)
+                        .and_then(|mut f| f.write_all(content.as_bytes()).map(|_| content.len() as u64))
+                } else {
+                    // Atomic overwrite: write to temp file in same dir, then rename.
+                    let tmp_path = target.with_extension("plexi_tmp");
+                    std::fs::write(&tmp_path, content.as_bytes())
+                        .and_then(|_| std::fs::rename(&tmp_path, &target))
+                        .map(|_| content.len() as u64)
+                };
+
+                match write_result {
+                    Ok(bytes_written) => {
+                        log::info!(
+                            "ProcessApp[{}]: FileWrite ok path={} bytes={bytes_written}",
+                            self.type_id,
+                            target.display()
+                        );
+                        event_log::emit(HostEvent::FileOpCompleted {
+                            app_id: self.type_id.clone(),
+                            path: target.display().to_string(),
+                            op: "write".to_string(),
+                            bytes: bytes_written,
+                            timestamp: event_log::now_timestamp(),
+                        });
+                        self.outbound_events.push_back(PlexiEvent::FileWriteResult {
+                            request_id,
+                            bytes_written: Some(bytes_written),
+                            error: None,
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "ProcessApp[{}]: FileWrite failed: {e}",
+                            self.type_id
+                        );
+                        event_log::emit(HostEvent::FileWriteDenied {
+                            app_id: self.type_id.clone(),
+                            path: path.clone(),
+                            reason: format!("io_error: {e}"),
+                            timestamp: event_log::now_timestamp(),
+                        });
+                        self.outbound_events.push_back(PlexiEvent::FileWriteResult {
+                            request_id,
+                            bytes_written: None,
+                            error: Some(format!("write failed: {e}")),
+                        });
+                    }
+                }
+            }
+
             // ── Mouse tracking toggle ──────────────────────────────────────
             HostCommand::SetMouseTracking { enabled } => {
                 self.mouse_tracking_enabled = enabled;
@@ -2189,6 +2415,90 @@ fn pick_files(filter: &[String], multiple: bool) -> Option<Vec<String>> {
     } else {
         let handle = block_on(dialog.pick_file())?;
         Some(vec![handle.path().to_string_lossy().into_owned()])
+    }
+}
+
+#[cfg(test)]
+mod file_io_tests {
+    use super::*;
+    use crate::app_permissions::AppPermissions;
+    use crate::app_protocol::HostCommand;
+
+    fn make_app(caps: &[&str]) -> crate::process_app::ProcessApp {
+        let strings: Vec<String> = caps.iter().map(|s| s.to_string()).collect();
+        let perms = AppPermissions::from_capability_strings(&strings);
+        let (mut app, _draw_tx) = crate::process_app::ProcessApp::new_for_test(1, perms);
+        // Use a real temp dir as workspace_root so canonicalize works.
+        app.workspace_root = std::env::temp_dir().canonicalize().unwrap();
+        app
+    }
+
+    #[test]
+    fn file_read_denied_without_capability() {
+        let mut app = make_app(&[]);
+        app.route_command(HostCommand::FileRead {
+            request_id: "r1".to_string(),
+            path: "foo.txt".to_string(),
+        });
+        let ev = app.outbound_events.pop_front().expect("expected FileReadResult event");
+        match ev {
+            PlexiEvent::FileReadResult { request_id, content, error } => {
+                assert_eq!(request_id, "r1");
+                assert!(content.is_none(), "content should be None on denial");
+                assert!(error.is_some(), "error should be set on denial");
+                let err = error.unwrap();
+                assert!(err.contains("permission denied"), "unexpected error: {err}");
+            }
+            other => panic!("expected FileReadResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_write_denied_without_capability() {
+        let mut app = make_app(&[]);
+        app.route_command(HostCommand::FileWrite {
+            request_id: "w1".to_string(),
+            path: "out.txt".to_string(),
+            content: "hello".to_string(),
+            append: false,
+        });
+        let ev = app.outbound_events.pop_front().expect("expected FileWriteResult event");
+        match ev {
+            PlexiEvent::FileWriteResult { request_id, bytes_written, error } => {
+                assert_eq!(request_id, "w1");
+                assert!(bytes_written.is_none(), "bytes_written should be None on denial");
+                assert!(error.is_some(), "error should be set on denial");
+                let err = error.unwrap();
+                assert!(err.contains("permission denied"), "unexpected error: {err}");
+            }
+            other => panic!("expected FileWriteResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_read_outside_workspace_root_blocked() {
+        let mut app = make_app(&["fs.read"]);
+        // Path traversal using absolute path outside workspace_root.
+        // /etc/passwd is guaranteed to be outside temp_dir().
+        app.route_command(HostCommand::FileRead {
+            request_id: "r2".to_string(),
+            path: "/etc/passwd".to_string(),
+        });
+        let ev = app.outbound_events.pop_front().expect("expected FileReadResult event");
+        match ev {
+            PlexiEvent::FileReadResult { request_id, content, error } => {
+                assert_eq!(request_id, "r2");
+                assert!(content.is_none(), "content should be None for path escape");
+                let err = error.unwrap_or_default();
+                // Should be either "access denied" (path escape) or "file not found"
+                // depending on whether /etc/passwd exists; both are correct rejections.
+                assert!(
+                    err.contains("access denied") || err.contains("file not found") || err.contains("not found"),
+                    "unexpected error: {err}"
+                );
+            }
+            other => panic!("expected FileReadResult, got {other:?}"),
+        }
     }
 }
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -994,9 +994,9 @@ impl ProcessApp {
                 pipe_id,
                 from_pane_id,
                 request_id,
+                cwd: _,
                 response_file: _,
                 ephemeral: _,
-                cwd: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -809,7 +809,7 @@ impl ProcessApp {
                         event_log::emit(HostEvent::FileOpCompleted {
                             app_id: self.type_id.clone(),
                             path: canonical.display().to_string(),
-                            op: "read".to_string(),
+                            op: event_log::FileOperation::Read,
                             bytes,
                             timestamp: event_log::now_timestamp(),
                         });
@@ -923,7 +923,7 @@ impl ProcessApp {
                         event_log::emit(HostEvent::FileOpCompleted {
                             app_id: self.type_id.clone(),
                             path: target.display().to_string(),
-                            op: "write".to_string(),
+                            op: event_log::FileOperation::Write,
                             bytes: bytes_written,
                             timestamp: event_log::now_timestamp(),
                         });


### PR DESCRIPTION
## What

Adds host-brokered file I/O to PGAP using the pre-existing `fs.read`/`fs.write` capabilities that were defined but never wired up.

## Changes

- **`src/app_protocol.rs`** — `HostCommand::FileRead { request_id, path }`, `HostCommand::FileWrite { request_id, path, content, append }`, `PlexiEvent::FileReadResult`, `PlexiEvent::FileWriteResult`
- **`src/event_log.rs`** — `FileReadDenied`, `FileWriteDenied`, `FileOpCompleted` host events for audit trail
- **`src/process_app/routing.rs`** — handlers with capability check → path validation → workspace_root escape guard → I/O with atomic overwrite for non-append writes. 3 unit tests.
- **`sdk/python/plexi_sdk/_emitter.py`** — `async read_file(path)` and `write_file(path, content, append=False)` helpers
- **`sdk/python/plexi_sdk/_app.py`** — `file_read_result`/`file_write_result` response dispatch
- **`examples/minimal-editor/`** — POC app: loads `notes.txt` on init, edits with keyboard, saves on Cmd+S

## Done When

- [x] `cargo test` passes with 3 new `file_io_tests` (capability denial, path escape guard)
- [x] Example app `minimal-editor` opens a file, edits it, saves successfully
- [x] File operations appear in event log with correct capability + path
- [x] SDK methods `read_file()` and `write_file()` wired end-to-end

## Breaks if

App with `fs.read` or `fs.write` capability sends `file_read`/`file_write` messages and gets no `file_read_result`/`file_write_result` response back.