### PR TITLE
fix(quick-note): same-frame draw on H/Esc exit to eliminate scrim flicker (#1128)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -826,6 +826,7 @@ impl PlexiApp {
         if back {
             self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
             log::info!("QuickNote: destination picker dismissed, back to composing");
+            self.draw_quick_note_modal(ctx); // same-frame draw to avoid flash
             return;
         }
 
@@ -1098,6 +1099,7 @@ impl PlexiApp {
             self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
             self.quick_note_pending_parent = None;
             log::info!("QuickNote: submenu dismissed, back to destination picker");
+            self.draw_quick_note_destination(ctx); // same-frame draw to avoid flash
             return;
         }
 


### PR DESCRIPTION
## Summary

- Mirrors the entry-path fix from PR #1124 for the exit path
- On H/Esc in `draw_quick_note_subdestination`: after `pop_focus_layer`, falls through to `draw_quick_note_destination` in the same frame
- On H/Esc in `draw_quick_note_destination`: after `pop_focus_layer`, falls through to `draw_quick_note_modal` in the same frame
- Eliminates the one-frame gap that caused the scrim to briefly disappear when navigating back

## Done When
H and Esc from any quick-note picker navigate back with no visible scrim flicker.

Closes #1128