### PR TITLE
fix(render): downgrade render_layout_node per-frame log::info! to debug (#1149)

### DIFF
--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -1116,7 +1116,7 @@ pub(crate) fn render_layout_node(
                 log::warn!("render_layout_node: nested nodes inside root Stack not yet supported");
             }
         }
-        log::info!("render_layout_node: painted stack at pane ({pane_x}, {pane_y})");
+        log::debug!("render_layout_node: painted stack at pane ({pane_x}, {pane_y})");
         return;
     }
 
@@ -1158,7 +1158,7 @@ pub(crate) fn render_layout_node(
     let screen_origin = pane_rect.min;
     paint_node(&taffy, root, 0.0, 0.0, ui, screen_origin, pane_x, pane_y, clip, colors);
 
-    log::info!("render_layout_node: painted layout tree at pane ({pane_x}, {pane_y})");
+    log::debug!("render_layout_node: painted layout tree at pane ({pane_x}, {pane_y})");
 }
 
 /// Parse a hex color string like `"#1e1e2e"` into Color32.


### PR DESCRIPTION
## Summary

Downgrades two `log::info!` calls in `render_layout_node` to `log::debug!`. These fire on every paint frame (~60fps), flooding `plexi.log` with ~120 lines/second of noise when any app uses `RenderCommand::Layout`.

## Done When
- `grep -n 'log::info.*render_layout_node' src/process_app/render.rs` returns no results ✅
- `cargo build` passes ✅

Closes #1149