### PR TITLE
feat(quick-note): stay_alive option for pane destinations (#1112)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -996,6 +996,9 @@ pub struct QuickNoteDestinationConfig {
     /// For `type = "pane"`: where to open the new pane.
     /// "split" (default) | "context-end" | "context-start"
     pub position: Option<String>,
+    /// For `type = "pane"`: keep the pane open after the command exits.
+    /// Defaults to `false` (pane closes when command exits).
+    pub stay_alive: Option<bool>,
     /// When set, this entry is a submenu. No `dest_type` needed at top level.
     pub options: Option<Vec<QuickNoteSubOptionConfig>>,
 }
@@ -1007,6 +1010,8 @@ pub struct QuickNoteSubOptionConfig {
     pub label: String,
     pub command: String,
     pub position: Option<String>,
+    /// Keep the pane open after the command exits. Defaults to `false`.
+    pub stay_alive: Option<bool>,
 }
 
 // ── Adopted workspace root (set once by main when an explicit path arg is

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1140,14 +1140,15 @@ impl PlexiApp {
                 let text = self.quick_note_text.clone();
                 let cmd_template = opt.command.clone();
                 let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
+                let stay_alive = opt.stay_alive.unwrap_or(false);
                 let ctx_data = self.quick_note_ctx.clone();
                 let cmd = Self::substitute_note_tokens_static(&cmd_template, &text, &ctx_data);
                 log::info!("QuickNote: submenu selected via Enter: parent={parent_key} cursor={}", self.quick_note_sub_cursor);
-                log::info!("QuickNote: committed via '{}' position={position:?}", opt.label);
+                log::info!("QuickNote: committed via '{}' position={position:?} stay_alive={stay_alive}", opt.label);
                 match position.as_str() {
-                    "context-end" => self.open_at_context_end(&cmd),
-                    "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true, None),
+                    "context-end" => self.open_at_context_end(&cmd, stay_alive),
+                    "context-start" => self.open_at_context_start(&cmd, stay_alive),
+                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
                 }
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
@@ -1166,16 +1167,17 @@ impl PlexiApp {
                 let text = self.quick_note_text.clone();
                 let cmd_template = opt.command.clone();
                 let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
+                let stay_alive = opt.stay_alive.unwrap_or(false);
                 let ctx_data = self.quick_note_ctx.clone();
                 let cmd = Self::substitute_note_tokens_static(
                     &cmd_template, &text, &ctx_data,
                 );
                 log::info!("QuickNote: submenu selected: parent={parent_key} key={key}");
-                log::info!("QuickNote: committed via '{}' position={position:?}", opt.label);
+                log::info!("QuickNote: committed via '{}' position={position:?} stay_alive={stay_alive}", opt.label);
                 match position.as_str() {
-                    "context-end" => self.open_at_context_end(&cmd),
-                    "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true, None),
+                    "context-end" => self.open_at_context_end(&cmd, stay_alive),
+                    "context-start" => self.open_at_context_start(&cmd, stay_alive),
+                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
                 }
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
                 self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -731,15 +731,16 @@ impl PlexiApp {
                 };
                 let cmd = Self::substitute_note_tokens_static(&cmd_template, text, &ctx);
                 let position = dest.position.as_deref().unwrap_or("split");
+                let stay_alive = dest.stay_alive.unwrap_or(false);
                 log::info!(
-                    "QuickNote: committed via '{}' position={:?}",
+                    "QuickNote: committed via '{}' position={:?} stay_alive={stay_alive}",
                     dest.label,
                     position
                 );
                 match position {
-                    "context-end" => self.open_at_context_end(&cmd),
-                    "context-start" => self.open_at_context_start(&cmd),
-                    _ => self.split_focused(false, Some(&cmd), true, None),
+                    "context-end" => self.open_at_context_end(&cmd, stay_alive),
+                    "context-start" => self.open_at_context_start(&cmd, stay_alive),
+                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
                 }
                 true
             }
@@ -807,22 +808,22 @@ impl PlexiApp {
     }
 
     /// Spawn a terminal pane as the last child of the root container.
-    pub(crate) fn open_at_context_end(&mut self, cmd: &str) {
-        let did_insert = self.try_insert_at_root(cmd, false);
+    pub(crate) fn open_at_context_end(&mut self, cmd: &str, stay_alive: bool) {
+        let did_insert = self.try_insert_at_root(cmd, false, stay_alive);
         if !did_insert {
-            self.split_focused(false, Some(cmd), true, None);
+            self.split_focused(false, Some(cmd), !stay_alive, None);
         }
     }
 
     /// Spawn a terminal pane as the first child of the root container.
-    pub(crate) fn open_at_context_start(&mut self, cmd: &str) {
-        let did_insert = self.try_insert_at_root(cmd, true);
+    pub(crate) fn open_at_context_start(&mut self, cmd: &str, stay_alive: bool) {
+        let did_insert = self.try_insert_at_root(cmd, true, stay_alive);
         if !did_insert {
-            self.split_focused(false, Some(cmd), true, None);
+            self.split_focused(false, Some(cmd), !stay_alive, None);
         }
     }
 
-    fn try_insert_at_root(&mut self, cmd: &str, prepend: bool) -> bool {
+    fn try_insert_at_root(&mut self, cmd: &str, prepend: bool, stay_alive: bool) -> bool {
         use egui_tiles::{Container, Tile};
         let new_id = self.host.alloc_pane_id();
         let active = self.active_window;
@@ -833,16 +834,7 @@ impl PlexiApp {
         let ctx_name = self.context_name_for(ctx_id);
         let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
 
-        let shell_name = std::path::Path::new(&settings.shell)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-        let trimmed = cmd.trim().trim_end_matches([';', ' ']);
-        settings.args = match shell_name {
-            "zsh" | "bash" => vec!["-i".to_string(), "-l".to_string(), "-c".to_string(), trimmed.to_string()],
-            "fish" => vec!["--login".to_string(), "-c".to_string(), trimmed.to_string()],
-            _ => vec!["-l".to_string(), "-c".to_string(), trimmed.to_string()],
-        };
+        super::apply_initial_cmd(&mut settings, cmd, !stay_alive);
 
         let Some(mut pane) = crate::pane::TerminalPane::new(
             new_id,
@@ -853,7 +845,7 @@ impl PlexiApp {
         ) else {
             return false;
         };
-        pane.ephemeral = true;
+        pane.ephemeral = !stay_alive;
         self.windows[active].panes.insert(new_id, crate::pane::Pane::Terminal(Box::new(pane)));
 
         let ctx = &mut self.windows[active];


### PR DESCRIPTION
## Summary

Adds `stay_alive: Option<bool>` to `QuickNoteDestinationConfig` and `QuickNoteSubOptionConfig`. When `true`, the spawned pane keeps the shell alive after the command exits (using the existing `apply_initial_cmd` exec-suffix pattern) and is not marked ephemeral.

## Done When

- A destination with `stay_alive = true` keeps the pane open after exit ✓
- Default behaviour (no flag / `false`) unchanged — pane closes when command exits ✓

## Config example

```toml
[[quick_note.destinations]]
key       = 2
label     = "Echo to pane"
type      = "pane"
command   = "echo {note}"
position  = "context-end"
stay_alive = true
```

## Files changed

- `src/config.rs` — `stay_alive: Option<bool>` on both destination structs
- `src/pane_ops/create.rs` — `commit_quick_note` passes flag; `open_at_context_end/start` and `try_insert_at_root` accept `stay_alive` param; `try_insert_at_root` now uses `apply_initial_cmd` instead of manual shell args
- `src/overlays.rs` — submenu Enter and digit-key dispatch paths read `opt.stay_alive`

Closes #1112