### PR TITLE
fix(ship-issue): verify stash-pop files are PR-related before auto-committing (#1006)

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -651,13 +651,13 @@ if [ "${STASHED:-0}" = 1 ]; then
   # Cross-reference restored files against the PR's files (top commit on origin/alpha after squash-merge).
   # Discard any restored file that wasn't in the PR — it's unrelated WIP and must not corrupt alpha.
   PR_FILES=$(git show origin/alpha --name-only --format="" | grep .)
-  for f in $(git status --porcelain | grep "^ M\|^M " | awk '{print $2}'); do
+  while IFS= read -r f; do
     if ! echo "$PR_FILES" | grep -qF "$f"; then
       echo "WARNING: $f from stash is unrelated to this PR — discarding to keep alpha clean"
       git restore "$f"
     fi
-  done
-  REMAINING=$(git status --porcelain | grep "^ M\|^M ")
+  done < <(git diff --name-only)
+  REMAINING=$(git diff --name-only)
   if [ -n "$REMAINING" ]; then
     git add -u && git commit -m "chore: restore session edits carried through merge"
   fi

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -652,8 +652,8 @@ if [ "${STASHED:-0}" = 1 ]; then
   # Discard any restored file that wasn't in the PR — it's unrelated WIP and must not corrupt alpha.
   PR_FILES=$(git show origin/alpha --name-only --format="" | grep .)
   while IFS= read -r f; do
-    if ! echo "$PR_FILES" | grep -qF "$f"; then
-      echo "WARNING: $f from stash is unrelated to this PR — discarding to keep alpha clean"
+    if ! printf '%s\n' "$PR_FILES" | grep -qxF "$f"; then
+      printf 'WARNING: %s from stash is unrelated to this PR — discarding to keep alpha clean\n' "$f"
       git restore "$f"
     fi
   done < <(git diff --name-only)

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -648,8 +648,17 @@ Then restore the stash if one was created:
 ```bash
 if [ "${STASHED:-0}" = 1 ]; then
   git stash pop
-  RESTORED=$(git status --porcelain | grep "^ M\|^M ")
-  if [ -n "$RESTORED" ]; then
+  # Cross-reference restored files against the PR's files (top commit on origin/alpha after squash-merge).
+  # Discard any restored file that wasn't in the PR — it's unrelated WIP and must not corrupt alpha.
+  PR_FILES=$(git show origin/alpha --name-only --format="" | grep .)
+  for f in $(git status --porcelain | grep "^ M\|^M " | awk '{print $2}'); do
+    if ! echo "$PR_FILES" | grep -qF "$f"; then
+      echo "WARNING: $f from stash is unrelated to this PR — discarding to keep alpha clean"
+      git restore "$f"
+    fi
+  done
+  REMAINING=$(git status --porcelain | grep "^ M\|^M ")
+  if [ -n "$REMAINING" ]; then
     git add -u && git commit -m "chore: restore session edits carried through merge"
   fi
 fi


### PR DESCRIPTION
## Summary

- Phase 5 stash-pop previously staged and committed all restored files blindly, including unrelated WIP from other in-flight issues on alpha
- Now cross-references each restored file against the squash commit's file list (`git show origin/alpha --name-only`) — files not in the PR are discarded with a warning, not committed
- Files that were part of the PR are still committed as before

## Done when
- [x] Phase 5 stash-pop block in SKILL.md includes the cross-reference check
- [x] Files unrelated to the current PR are discarded (not committed) with a logged warning
- [x] Files that are PR-related are still committed as before

## Breaks if:
After a ship cycle where alpha has stashed WIP for another issue, stash-pop commits that unrelated file onto alpha.

Closes #1006