### PR TITLE
feat(docs): generate CLI reference from clap via gen_cli_docs (#711)

### DIFF
--- a/.github/workflows/check-cli-docs.yml
+++ b/.github/workflows/check-cli-docs.yml
@@ -1,0 +1,36 @@
+name: check CLI docs
+
+on:
+  push:
+    branches: [alpha]
+    paths:
+      - 'src/cli_args.rs'
+      - 'tools/gen_cli_docs/**'
+      - 'website/src/content/docs/cli.md'
+  pull_request:
+    branches: [alpha]
+    paths:
+      - 'src/cli_args.rs'
+      - 'tools/gen_cli_docs/**'
+      - 'website/src/content/docs/cli.md'
+
+jobs:
+  check-cli-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check CLI docs are up to date
+        run: |
+          cargo run -p gen_cli_docs > /tmp/fresh_cli.md
+          if ! diff -q website/src/content/docs/cli.md /tmp/fresh_cli.md; then
+            echo "website/src/content/docs/cli.md is stale. Run 'just gen-cli-docs' and commit the result."
+            diff website/src/content/docs/cli.md /tmp/fresh_cli.md
+            exit 1
+          fi
+          echo "CLI docs are up to date."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen_cli_docs"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "plexi",
+]
+
+[[package]]
 name = "gen_schema"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tools/gen_schema", "sdk/rust"]
+members = ["tools/gen_schema", "tools/gen_cli_docs", "sdk/rust"]
 resolver = "2"
 
 [package]

--- a/justfile
+++ b/justfile
@@ -32,6 +32,25 @@ gen-schema:
     python3 tools/gen_protocol_py.py
     @echo "Schema and Python protocol models regenerated."
 
+# Regenerate the CLI reference docs from the clap Command tree.
+# Run after any change to src/cli_args.rs.
+gen-cli-docs:
+    cargo run -p gen_cli_docs > website/src/content/docs/cli.md
+    @echo "CLI reference regenerated."
+
+# Verify the committed CLI docs are up to date with the current Rust source.
+# Fails if website/src/content/docs/cli.md is stale.
+check-cli-docs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo run -p gen_cli_docs > /tmp/plexi_check_cli.md
+    if ! diff -q website/src/content/docs/cli.md /tmp/plexi_check_cli.md > /dev/null; then
+        echo "ERROR: website/src/content/docs/cli.md is stale. Run 'just gen-cli-docs'."
+        diff website/src/content/docs/cli.md /tmp/plexi_check_cli.md || true
+        exit 1
+    fi
+    echo "CLI docs are up to date."
+
 # Verify the committed schema is up to date with the current Rust source.
 # Fails if sdk/protocol/pgap.schema.json is stale.
 check-schema:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
-//! Plexi library target — exposes `app_protocol` for the `gen_schema` binary.
+//! Plexi library target — exposes `app_protocol` for the `gen_schema` binary
+//! and `cli_args` for the `gen_cli_docs` binary.
 //! This lib.rs is intentionally minimal: it only declares the modules that
-//! `app_protocol` references via `crate::`, using stub types that satisfy
-//! the type system without pulling in the full GUI/audio dependency tree.
+//! these tools reference, using stub types that satisfy the type system
+//! without pulling in the full GUI/audio dependency tree.
 
 pub mod app_protocol;
+pub mod cli_args;
 
 // Stub modules: only the types used by app_protocol via crate:: references.
 // The real implementations live in the binary target (src/main.rs).

--- a/tools/gen_cli_docs/Cargo.toml
+++ b/tools/gen_cli_docs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gen_cli_docs"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+plexi = { path = "../.." }
+clap = { version = "4", features = ["derive"] }

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -1,0 +1,145 @@
+//! Generates website/src/content/docs/cli.md from the clap Command tree.
+//! Usage: cargo run -p gen_cli_docs > website/src/content/docs/cli.md
+
+use clap::{Arg, ArgAction, Command, CommandFactory};
+use plexi::cli_args::Cli;
+
+fn main() {
+    let cmd = Cli::command();
+    // Use the version from the plexi package, not gen_cli_docs
+    let version = cmd
+        .get_version()
+        .unwrap_or(env!("CARGO_PKG_VERSION"));
+
+    print!(
+        r#"---
+title: CLI Reference
+description: Complete reference for all plexi subcommands and flags.
+verified_version: "{version}"
+order: 7
+---
+
+The `plexi` CLI is the primary way to interact with a running Plexi instance from the terminal, and to manage workspaces and apps from outside the UI.
+
+All commands work identically across build channels (`plexi`, `plexi-alpha`, `plexi-beta`). When run inside a Plexi pane, `PLEXI_SOCKET` routes host commands to the correct running instance automatically.
+
+"#
+    );
+
+    for sub in cmd.get_subcommands() {
+        if sub.is_hide_set() {
+            continue;
+        }
+        emit_subcommand(sub, "plexi", 2);
+    }
+}
+
+fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
+    let name = cmd.get_name();
+    let full_path = format!("{parent_path} {name}");
+    let heading = "#".repeat(depth);
+    let about = cmd
+        .get_long_about()
+        .or_else(|| cmd.get_about())
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+
+    println!("{heading} `{full_path}`");
+    println!();
+    if !about.is_empty() {
+        // Normalize multi-line about strings: blank lines become paragraph breaks
+        let normalized = about
+            .lines()
+            .map(|l| l.trim())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        println!("{normalized}");
+        println!();
+    }
+
+    let subs: Vec<&Command> = cmd
+        .get_subcommands()
+        .filter(|s| !s.is_hide_set())
+        .collect();
+
+    let args: Vec<&Arg> = cmd
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .collect();
+
+    if !subs.is_empty() {
+        println!("| Subcommand | Description |");
+        println!("|---|---|");
+        for sub in &subs {
+            let desc = sub
+                .get_about()
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            println!("| `{}` | {} |", sub.get_name(), desc);
+        }
+        println!();
+
+        for sub in subs {
+            emit_subcommand(sub, &full_path, depth + 1);
+        }
+    } else if !args.is_empty() {
+        println!("| Flag / Arg | Type | Required | Description |");
+        println!("|---|---|---|---|");
+        for arg in args {
+            emit_arg_row(arg);
+        }
+        println!();
+    }
+}
+
+fn emit_arg_row(arg: &Arg) {
+    let id = arg.get_id().as_str();
+    let is_positional = arg.get_long().is_none() && arg.get_short().is_none();
+
+    let flag = if is_positional {
+        format!("`<{id}>`")
+    } else {
+        let long = arg.get_long().map(|l| format!("--{l}")).unwrap_or_default();
+        let short = arg
+            .get_short()
+            .map(|s| format!(" / `-{s}`"))
+            .unwrap_or_default();
+        format!("`{long}`{short}")
+    };
+
+    let ty = match arg.get_action() {
+        ArgAction::SetTrue | ArgAction::SetFalse | ArgAction::Count => "flag".to_string(),
+        ArgAction::Append => "string (repeatable)".to_string(),
+        _ => "string".to_string(),
+    };
+
+    let required = if arg.is_required_set() { "yes" } else { "no" };
+
+    let help = arg
+        .get_long_help()
+        .or_else(|| arg.get_help())
+        .map(|s| {
+            s.to_string()
+                .lines()
+                .map(|l| l.trim())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+
+    let default = arg
+        .get_default_values()
+        .first()
+        .and_then(|v| {
+            let s = v.to_string_lossy();
+            // Skip empty string defaults — they're noise
+            if s.is_empty() { None } else { Some(format!(" Default: `{s}`.")) }
+        })
+        .unwrap_or_default();
+
+    let desc = format!("{help}{default}").trim().to_string();
+
+    println!("| {flag} | {ty} | {required} | {desc} |");
+}

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,7 @@
 ---
-title: CLI Overview
-description: The plexi command-line interface — all subcommands at a glance.
-verified_version: "3.6.19"
+title: CLI Reference
+description: Complete reference for all plexi subcommands and flags.
+verified_version: "3.6.38"
 order: 7
 ---
 
@@ -9,77 +9,391 @@ The `plexi` CLI is the primary way to interact with a running Plexi instance fro
 
 All commands work identically across build channels (`plexi`, `plexi-alpha`, `plexi-beta`). When run inside a Plexi pane, `PLEXI_SOCKET` routes host commands to the correct running instance automatically.
 
-## Pane Commands
+## `plexi run`
 
-```sh
-plexi pane name "my pane"    # rename the focused pane
-plexi pane close             # close the focused pane
-```
+Run a named command from .plexi/commands.toml
 
-## Terminal
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<command>` | string | yes |  |
 
-Open a new terminal pane and optionally run a command:
+## `plexi workspace`
 
-```sh
-plexi terminal                       # open a blank terminal
-plexi terminal -- npm run dev        # open terminal, run command, keep shell alive
-```
+Workspace management
 
-## Quick Note
+| Subcommand | Description |
+|---|---|
+| `init` | Initialise a .plexi/ workspace in the current directory |
 
-```sh
-plexi note                   # open Quick Note
-```
+### `plexi workspace init`
 
-## Notifications
+Initialise a .plexi/ workspace in the current directory
 
-Send a push notification to the user:
+## `plexi secret`
 
-```sh
-plexi notify "Build complete" --body "npm run build finished in 4.2s"
-```
+Secret management
 
-## Context
+| Subcommand | Description |
+|---|---|
+| `set` | Store a secret |
+| `get` | Read a secret value to stdout |
+| `list` | List stored secrets |
+| `delete` | Delete a secret |
 
-Read or update workspace context values:
+### `plexi secret set`
 
-```sh
-plexi context get git_branch
-plexi context set my_key my_value
-```
+Store a secret
 
-## Workspace
+Prompts for value with hidden input; walks up to nearest .plexi/ workspace. Use --from-env to read from an env var instead of prompting, or --global to store cross-workspace.
 
-Initialize or inspect a workspace in the current directory:
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<friendly_name>` | string | yes | Name of the secret (also the env var name when using --from-env) |
+| `--from-env` | flag | no | Read value from the environment variable named FRIENDLY_NAME instead of prompting |
+| `--global` | flag | no | Store globally (cross-workspace) rather than scoped to the nearest .plexi/ workspace |
 
-```sh
-plexi workspace init         # create .plexi/workspace.toml
-plexi workspace status       # show workspace info
-```
+### `plexi secret get`
 
-## Apps
+Read a secret value to stdout
 
-```sh
-plexi app init my-app        # scaffold a new app
-plexi app run my-app         # run app in focused pane
-plexi app list               # list apps in the current workspace
-```
+Walks up to nearest .plexi/ workspace, resolves from there first, then falls back to global. Use --global to read from the global store only.
 
-## Secrets
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<friendly_name>` | string | yes | Name of the secret |
+| `--global` | flag | no | Read from global store only (skip workspace lookup) |
 
-```sh
-plexi secrets set KEY value
-plexi secrets get KEY
-plexi secrets list
-plexi secrets delete KEY
-```
+### `plexi secret list`
 
-## Shell Completions
+List stored secrets
 
-Generate completions for your shell:
+### `plexi secret delete`
 
-```sh
-plexi completions zsh        # output zsh completions
-plexi completions bash
-plexi completions fish
-```
+Delete a secret
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<friendly_name>` | string | yes |  |
+
+## `plexi app`
+
+App management
+
+| Subcommand | Description |
+|---|---|
+| `init` | Scaffold a new app |
+| `uninstall` | Uninstall an app |
+| `list` | List installed apps |
+| `render` | Render an app to PNG headlessly |
+| `info` | Show app info (id, name, version, MCP tools if any) |
+| `install` | Install a local app directory into the channel's app store |
+| `link` | Register a local app directory with the workspace (does not move files) |
+| `unlink` | Remove a linked app directory from the workspace registry |
+
+### `plexi app init`
+
+Scaffold a new app
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes |  |
+| `--lang` | string | no | Default: `python`. |
+
+### `plexi app uninstall`
+
+Uninstall an app
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<id>` | string | yes |  |
+
+### `plexi app list`
+
+List installed apps
+
+### `plexi app render`
+
+Render an app to PNG headlessly
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<id>` | string | yes | App id to render (e.g. "snake") |
+| `--size` | string | no | Dimensions as WxH (e.g. 500x500) Default: `800x600`. |
+| `--state` | string | no | Pre-seed app state from a JSON file before render |
+| `--output` | string | no | Output PNG path (default: stdout) |
+
+### `plexi app info`
+
+Show app info (id, name, version, MCP tools if any)
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<id>` | string | yes |  |
+
+### `plexi app install`
+
+Install a local app directory into the channel's app store
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes | Path to the app directory containing manifest.toml |
+
+### `plexi app link`
+
+Register a local app directory with the workspace (does not move files)
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes | Path to the app directory containing manifest.toml |
+
+### `plexi app unlink`
+
+Remove a linked app directory from the workspace registry
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes | Path to the app directory (same path used with `link`) |
+
+## `plexi install`
+
+Install an app
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<spec>` | string | no | Source spec (e.g. github:user/repo or bare app id) |
+| `--pack` | string | no | Install from a pack file or 'core' |
+
+## `plexi uninstall`
+
+Uninstall an app
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<id>` | string | yes | App id to remove |
+| `--yes` / `-y` | flag | no | Skip confirmation prompt |
+
+## `plexi update`
+
+Update apps or self
+
+| Subcommand | Description |
+|---|---|
+| `apps` | Update installed apps |
+
+### `plexi update apps`
+
+Update installed apps
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<id>` | string | no | Specific app id to update (omit to update all) |
+
+## `plexi list`
+
+List installed apps
+
+## `plexi validate`
+
+Validate a Plexi app directory
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no | Path to validate (default: current directory) Default: `.`. |
+
+## `plexi pack`
+
+Pack management
+
+| Subcommand | Description |
+|---|---|
+| `export` | Export current apps as a pack file |
+
+### `plexi pack export`
+
+Export current apps as a pack file
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes |  |
+
+## `plexi notify`
+
+Send a notification [requires PLEXI_SOCKET — run inside a Plexi pane]
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `--title` | string | yes | Notification title (required) |
+| `--body` | string | no | Notification body |
+| `--level` | string | no | Level: info, warn, or error Default: `info`. |
+| `--choice` | string (repeatable) | no | Choice option. Format: `key:Label` (returns key when selected) or `Label:pane_focus:<pane_id>` (navigates to pane and returns label). Repeatable |
+| `--host-action` | string (repeatable) | no | Host-side action for a choice key. Format: `key:action_type:action_arg`. Repeatable. The host performs this action when the user clicks the matching choice, even if the spawner has already exited |
+| `--timeout` | string | no | Timeout in seconds (0 = no timeout) Default: `0`. |
+| `--scope` | string | no | Notification visibility scope: window, context, or global. Default: global |
+
+## `plexi pane`
+
+Pane management [requires PLEXI_SOCKET — run inside a Plexi pane]
+
+| Subcommand | Description |
+|---|---|
+| `name` | Set the name of a pane |
+| `list` | List all open panes as a JSON array |
+| `focus` | Move UI focus to a pane by ID |
+| `close` | Close a pane. Omit <pane_id> to close the current pane via PLEXI_PANE_ID |
+| `send` | Send text to a running pane's PTY stdin [requires PLEXI_SOCKET — run inside a Plexi pane] |
+| `info` | Print JSON info for the current pane [requires PLEXI_PANE_ID] |
+| `key` | Deliver a synthetic key event to a pane [requires PLEXI_SOCKET — run inside a Plexi pane] |
+
+### `plexi pane name`
+
+Set the name of a pane
+
+Usage: plexi pane name <title>           — renames the current (focused) pane plexi pane name <pane-id> <title> — renames an arbitrary pane by ID
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<first>` | string | yes | Pane ID (from `plexi pane list`) or title when used alone |
+| `<second>` | string | no | Title when pane-id is given as the first argument |
+
+### `plexi pane list`
+
+List all open panes as a JSON array
+
+### `plexi pane focus`
+
+Move UI focus to a pane by ID
+
+NOTE: This moves the *user's visual focus* to the target pane — it does NOT relocate the agent's execution context. An agent calling this from pane A remains in pane A after the call; only the user sees focus shift to pane B.
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<pane_id>` | string | yes | Pane ID (from `plexi pane list`) |
+
+### `plexi pane close`
+
+Close a pane. Omit <pane_id> to close the current pane via PLEXI_PANE_ID
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<pane_id>` | string | no | Pane ID (from `plexi pane list`). Defaults to PLEXI_PANE_ID if not given |
+
+### `plexi pane send`
+
+Send text to a running pane's PTY stdin [requires PLEXI_SOCKET — run inside a Plexi pane]
+
+Use `\n` in the text to send Enter (submits the command).
+
+Example: plexi pane send 42 "git status\n"
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<pane_id>` | string | yes | Pane ID (from `plexi pane list`) |
+| `<text>` | string | yes | Text to inject (use \n for Enter) |
+
+### `plexi pane info`
+
+Print JSON info for the current pane [requires PLEXI_PANE_ID]
+
+### `plexi pane key`
+
+Deliver a synthetic key event to a pane [requires PLEXI_SOCKET — run inside a Plexi pane]
+
+For terminal panes, injects as PTY keystroke. For app panes, delivers a structured key event.
+
+Key format: single char ("h"), named key ("enter", "escape", "space", "up", "down", "left", "right", "backspace"), or chord ("ctrl+c").
+
+Example: plexi pane key 42 enter
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<pane_id>` | string | yes | Pane ID (from `plexi pane list`) |
+| `<key>` | string | yes | Key to inject |
+
+## `plexi terminal`
+
+Open a terminal pane
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<cmd>` | string | no | Optional command to run in the terminal |
+| `--ephemeral` / `-e` | flag | no | Close the pane when the process exits |
+| `--layout` | string | no | Layout hint (split_v, split_h, split_above) |
+| `--from-pane-id` | string | no | Split relative to this pane ID instead of the focused pane |
+| `--cwd` | string | no | Working directory for the new terminal pane |
+
+## `plexi open`
+
+Open an app pane
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<type_id>` | string | no | App or pane type id (mutually exclusive with --mcp and --cli) |
+| `--mcp` | string (repeatable) | no | Wrap the given stdio MCP server command in the bundled mcp-renderer  Example: plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp |
+| `--cli` | string | no | Wrap the given CLI binary in the bundled descriptor-renderer  Example: plexi open --cli git |
+| `--layout` | string | no | Layout hint |
+| `--from-pane-id` | string | no | Split relative to this pane ID instead of the focused pane |
+| `<extra_args>` | string (repeatable) | no | Extra args passed to the app (only valid with type_id) |
+
+## `plexi registry`
+
+CLI registry
+
+| Subcommand | Description |
+|---|---|
+| `watch` | Watch installed CLIs for descriptor drift |
+
+### `plexi registry watch`
+
+Watch installed CLIs for descriptor drift
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<cli>` | string | no | Only check this CLI |
+
+## `plexi context`
+
+Context management [requires PLEXI_SOCKET — run inside a Plexi pane]
+
+| Subcommand | Description |
+|---|---|
+| `new` | Create a new context, optionally opening a path |
+| `open` | Open a context at a path |
+| `set-root` | Set the root directory for the active context |
+| `current` | Print the context ID and name for the current pane as JSON |
+
+### `plexi context new`
+
+Create a new context, optionally opening a path
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no |  |
+
+### `plexi context open`
+
+Open a context at a path
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no |  |
+
+### `plexi context set-root`
+
+Set the root directory for the active context
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no |  |
+
+### `plexi context current`
+
+Print the context ID and name for the current pane as JSON
+
+## `plexi completions`
+
+Print shell completion script
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<shell>` | string | no | Shell name (zsh, bash, fish) |
+


### PR DESCRIPTION
## Summary

- Adds `tools/gen_cli_docs` — a build tool that walks the clap `Command` tree and emits `website/src/content/docs/cli.md`
- Replaces the hand-written CLI docs stub (v3.6.19, 8 sections) with a comprehensive auto-generated reference (v3.6.38, all subcommands + flags)
- Exposes `plexi::cli_args` via `src/lib.rs` (pure clap types, no binary deps) so the tool can import it
- Adds `just gen-cli-docs` and `just check-cli-docs` recipes (mirrors the `gen-schema` pattern)
- Adds `.github/workflows/check-cli-docs.yml` — CI fails if `cli_args.rs` changes without regenerating `cli.md`

## Done when

- `cargo run -p gen_cli_docs > website/src/content/docs/cli.md` produces up-to-date markdown
- `just check-cli-docs` passes on a clean tree
- The website `/docs/cli` page shows all subcommands with flag tables

## Test plan

- [ ] `just check-cli-docs` exits 0 on the PR branch
- [ ] Diff of `website/src/content/docs/cli.md` shows all major subcommands: `notify`, `pane`, `terminal`, `open`, `secret`, `app`, `context`, `completions`
- [ ] `cargo build` passes

Closes #711