### PR TITLE
feat(quick-note): recursive menus, bare-command leaves, and dynamic children (#1212)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -44,6 +44,7 @@ pub(crate) struct QuickNoteCtx {
     pub cwd: std::path::PathBuf,
     pub workspace_root: Option<std::path::PathBuf>,
     pub context: String,
+    pub context_root: Option<std::path::PathBuf>,
 }
 
 /// Which layer currently owns keyboard input.
@@ -72,8 +73,9 @@ pub(crate) enum FocusLayer {
     QuickNote,
     /// Quick note destination picker.
     QuickNoteDestination,
-    /// Quick note sub-destination picker. Inner u8 = parent key.
-    QuickNoteSubDestination(u8),
+    /// Quick note sub-destination picker. Inner Vec<u8> = key path from root to current node.
+    /// E.g. vec![3] = inside destination 3's children; vec![3,2] = destination 3 → child 2.
+    QuickNoteSubDestination(Vec<u8>),
     /// First-launch CLI setup prompt. No text input — intercepts keys so they
     /// don't fall through to the active terminal while the modal is visible.
     CliSetupPrompt,
@@ -232,12 +234,14 @@ pub struct PlexiApp {
     pub(crate) quick_note_text: String,
     /// Context captured at the time the quick note modal was opened.
     pub(crate) quick_note_ctx: QuickNoteCtx,
-    /// If in QuickNoteSubDestination phase, the key of the parent destination entry.
-    pub(crate) quick_note_pending_parent: Option<u8>,
     /// Cursor row in the destination picker (0 = global backlog, 1+ = config destinations).
     pub(crate) quick_note_dest_cursor: usize,
     /// Cursor row in the sub-destination picker.
     pub(crate) quick_note_sub_cursor: usize,
+    /// Cache of dynamically loaded children, keyed by node key. Cleared on modal open.
+    pub(crate) quick_note_children_cache: HashMap<u8, Vec<crate::config::QuickNoteNode>>,
+    /// Pending children_cmd receiver: (node_key, receiver).
+    pub(crate) quick_note_children_rx: Option<(u8, std::sync::mpsc::Receiver<Result<Vec<crate::config::QuickNoteNode>, String>>)>,
     /// notify_id of the notification the modal currently has state for. Used to
     /// detect a front-of-queue change and reset focus/input buffer.
     pub(crate) modal_state_notify_id: String,
@@ -654,9 +658,10 @@ impl PlexiApp {
                     modal_input_buffer: String::new(),
                     quick_note_text: String::new(),
                     quick_note_ctx: QuickNoteCtx::default(),
-                    quick_note_pending_parent: None,
                     quick_note_dest_cursor: 0,
                     quick_note_sub_cursor: 0,
+                    quick_note_children_cache: HashMap::new(),
+                    quick_note_children_rx: None,
                     modal_state_notify_id: String::new(),
                     notification_images: HashMap::new(),
                     notifications_enabled,
@@ -758,9 +763,10 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
-            quick_note_pending_parent: None,
             quick_note_dest_cursor: 0,
             quick_note_sub_cursor: 0,
+            quick_note_children_cache: HashMap::new(),
+            quick_note_children_rx: None,
             modal_state_notify_id: String::new(),
             notification_images: HashMap::new(),
             notifications_enabled,
@@ -875,9 +881,10 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
-            quick_note_pending_parent: None,
             quick_note_dest_cursor: 0,
             quick_note_sub_cursor: 0,
+            quick_note_children_cache: HashMap::new(),
+            quick_note_children_rx: None,
             modal_state_notify_id: String::new(),
             notification_images: HashMap::new(),
             notifications_enabled: false,
@@ -1719,8 +1726,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::QuickNoteDestination) => {
                     self.draw_quick_note_destination(ctx);
                 }
-                Some(FocusLayer::QuickNoteSubDestination(_)) => {
-                    self.draw_quick_note_subdestination(ctx);
+                Some(FocusLayer::QuickNoteSubDestination(path)) => {
+                    let path = path.clone();
+                    self.draw_quick_note_menu(ctx, &path);
                 }
                 Some(FocusLayer::CliSetupPrompt) => {
                     self.draw_cli_setup_modal(ctx);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -238,10 +238,10 @@ pub struct PlexiApp {
     pub(crate) quick_note_dest_cursor: usize,
     /// Cursor row in the sub-destination picker.
     pub(crate) quick_note_sub_cursor: usize,
-    /// Cache of dynamically loaded children, keyed by node key. Cleared on modal open.
-    pub(crate) quick_note_children_cache: HashMap<u8, Vec<crate::config::QuickNoteNode>>,
-    /// Pending children_cmd receiver: (node_key, receiver).
-    pub(crate) quick_note_children_rx: Option<(u8, std::sync::mpsc::Receiver<Result<Vec<crate::config::QuickNoteNode>, String>>)>,
+    /// Cache of dynamically loaded children, keyed by full key path. Cleared on modal open.
+    pub(crate) quick_note_children_cache: HashMap<Vec<u8>, Vec<crate::config::QuickNoteNode>>,
+    /// Pending children_cmd receiver: (key_path, receiver).
+    pub(crate) quick_note_children_rx: Option<(Vec<u8>, std::sync::mpsc::Receiver<Result<Vec<crate::config::QuickNoteNode>, String>>)>,
     /// notify_id of the notification the modal currently has state for. Used to
     /// detect a front-of-queue change and reset focus/input buffer.
     pub(crate) modal_state_notify_id: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -590,9 +590,11 @@ confirm_close = false
 # Destination 0 (global backlog → ~/.plexi/backlog) is always
 # available regardless of config.
 #
-# {note} = your note text (shell-escaped)   {cwd} = focused pane dir
-# Security: only {note} and {cwd} are shell-escaped. Do not add other user-supplied
-# values to the template — they will not be escaped and are a shell injection risk.
+# Tokens: {note} = your note text (shell-escaped)
+#         {cwd}  = focused pane directory (shell-escaped)
+#         {context_root} = active context's project root (shell-escaped, empty if unset)
+# Security: only token values are shell-escaped. The command template itself is trusted
+# (comes from config.toml). Do not substitute arbitrary user input outside of these tokens.
 
 [[quick_note.destinations]]
 key   = 1
@@ -601,11 +603,33 @@ type  = "backlog"
 path  = "~/.plexi/backlog"
 
 [[quick_note.destinations]]
-key      = 2
-label    = "Ask Claude"
-type     = "pane"
-command  = "claude -p {note}"
-position = "context-end"
+key     = 2
+label   = "Ask Claude"
+command = "plexi terminal --layout context-end -- claude -p {note}"
+
+[[quick_note.destinations]]
+key   = 3
+label = "GitHub issue"
+# Submenu — each option runs a gh command in the background (hidden = true means no pane).
+options = [
+  { key = 1, label = "Bug",         command = "cd {cwd} && gh issue create --label bug --title {note} --body {note}",         hidden = true },
+  { key = 2, label = "Enhancement", command = "cd {cwd} && gh issue create --label enhancement --title {note} --body {note}", hidden = true },
+  { key = 3, label = "No label",    command = "cd {cwd} && gh issue create --title {note} --body {note}",                     hidden = true },
+]
+
+[[quick_note.destinations]]
+key     = 4
+label   = "Copy to clipboard"
+command = "printf '%s' {note} | pbcopy"
+hidden  = true
+
+# Dynamic branch example — uncomment and customize:
+# [[quick_note.destinations]]
+# key          = 5
+# label        = "Recent projects"
+# children_cmd = "~/.plexi/scripts/top-projects.sh"
+# # Script stdout format: one entry per line as  key|label|command
+# # Example line: 1|PLEXI|cd ~/Documents/GitHub/PLEXI && plexi terminal --layout context-end -- claude -p {note}
 
 [[quick_note.destinations]]
 key   = 3
@@ -970,48 +994,58 @@ impl VoiceAgentConfig {
 #[derive(Deserialize, Default, Clone)]
 pub struct QuickNoteConfig {
     #[serde(default)]
-    pub destinations: Vec<QuickNoteDestinationConfig>,
+    pub destinations: Vec<QuickNoteNode>,
 }
 
 impl QuickNoteConfig {
     fn overlay(&mut self, other: Self) {
         if !other.destinations.is_empty() {
             self.destinations = other.destinations;
+            warn_deprecated_quick_note_fields(&self.destinations);
         }
     }
 }
 
-/// A destination entry in `[[quick_note.destinations]]`.
-#[derive(Deserialize, Clone)]
-pub struct QuickNoteDestinationConfig {
-    pub key: u8,
-    pub label: String,
-    /// Destination type: "backlog" or "pane". Absent when `options` is set (submenu).
-    #[serde(rename = "type")]
-    pub dest_type: Option<String>,
-    /// For `type = "backlog"`: directory path (tilde-expanded) to write notes into.
-    pub path: Option<String>,
-    /// For `type = "pane"`: shell command template. Tokens: `{note}`, `{cwd}`.
-    pub command: Option<String>,
-    /// For `type = "pane"`: where to open the new pane.
-    /// "split" (default) | "context-end" | "context-start"
-    pub position: Option<String>,
-    /// For `type = "pane"`: keep the pane open after the command exits.
-    /// Defaults to `false` (pane closes when command exits).
-    pub stay_alive: Option<bool>,
-    /// When set, this entry is a submenu. No `dest_type` needed at top level.
-    pub options: Option<Vec<QuickNoteSubOptionConfig>>,
+fn warn_deprecated_quick_note_fields(nodes: &[QuickNoteNode]) {
+    for node in nodes {
+        if node.dest_type.as_deref() == Some("pane") || node.position.is_some() {
+            log::warn!(
+                "QuickNote: destination '{}' uses deprecated 'type = \"pane\"' or 'position'. \
+                 Migrate to a bare 'command' string. See config docs for the new schema.",
+                node.label
+            );
+        }
+        if let Some(opts) = &node.options {
+            warn_deprecated_quick_note_fields(opts);
+        }
+    }
 }
 
-/// A sub-option inside a submenu destination.
+/// A node in the quick-note destination tree. Used at every level — root destinations,
+/// static submenu children (`options`), and dynamic children (`children_cmd` output).
 #[derive(Deserialize, Clone)]
-pub struct QuickNoteSubOptionConfig {
+pub struct QuickNoteNode {
     pub key: u8,
     pub label: String,
-    pub command: String,
-    pub position: Option<String>,
-    /// Keep the pane open after the command exits. Defaults to `false`.
+    /// Shell command template. Tokens: {note}, {cwd}, {context_root}. Required on leaves.
+    pub command: Option<String>,
+    /// If true, run command without a visible terminal pane (fire-and-forget background spawn).
+    #[serde(default)]
+    pub hidden: bool,
+    /// Keep spawned pane alive after command exits. Defaults to false.
     pub stay_alive: Option<bool>,
+    /// Static child nodes (submenu). Mutually exclusive with `command` at this node.
+    pub options: Option<Vec<QuickNoteNode>>,
+    /// Shell command whose stdout populates children dynamically. Format: one entry per
+    /// line as `key|label|command`. {note} and {cwd} in output are substituted before execution.
+    pub children_cmd: Option<String>,
+    // ── Deprecated ────────────────────────────────────────────────────────────────────────
+    // These fields are parsed for backward compatibility and to emit a migration warning,
+    // but are no longer used for dispatch.
+    #[serde(rename = "type")]
+    pub dest_type: Option<String>,
+    pub position: Option<String>,
+    pub path: Option<String>,
 }
 
 // ── Adopted workspace root (set once by main when an explicit path arg is

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1114,36 +1114,38 @@ impl PlexiApp {
         let current_layer = crate::app::FocusLayer::QuickNoteSubDestination(key_path.to_vec());
 
         // ── Drain children_cmd receiver if pending ────────────────────────────────
-        let node_key = key_path.last().copied().unwrap_or(0);
+        // Cache key is the full key_path to avoid collisions when different submenus
+        // share child keys (e.g. both have a child with key=1).
+        let node_path = key_path.to_vec();
         {
             let mut received = None;
-            if let Some((pending_key, rx)) = &self.quick_note_children_rx {
-                if *pending_key == node_key {
+            if let Some((pending_path, rx)) = &self.quick_note_children_rx {
+                if pending_path == &node_path {
                     match rx.try_recv() {
                         Ok(Ok(children)) => {
                             log::info!(
-                                "QuickNote: children_cmd result received for key={} count={}",
-                                node_key, children.len()
+                                "QuickNote: children_cmd result received for path={:?} count={}",
+                                node_path, children.len()
                             );
-                            received = Some((node_key, Ok(children)));
+                            received = Some((node_path.clone(), Ok(children)));
                         }
                         Ok(Err(e)) => {
-                            log::error!("QuickNote: children_cmd failed for key={}: {e}", node_key);
-                            received = Some((node_key, Err(e)));
+                            log::error!("QuickNote: children_cmd failed for path={:?}: {e}", node_path);
+                            received = Some((node_path.clone(), Err(e)));
                         }
                         Err(std::sync::mpsc::TryRecvError::Empty) => {}
                         Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                            log::error!("QuickNote: children_cmd sender dropped for key={}", node_key);
-                            received = Some((node_key, Err("sender dropped".to_string())));
+                            log::error!("QuickNote: children_cmd sender dropped for path={:?}", node_path);
+                            received = Some((node_path.clone(), Err("sender dropped".to_string())));
                         }
                     }
                 }
             }
-            if let Some((k, result)) = received {
+            if let Some((path, result)) = received {
                 self.quick_note_children_rx = None;
                 match result {
-                    Ok(children) => { self.quick_note_children_cache.insert(k, children); }
-                    Err(_) => { self.quick_note_children_cache.insert(k, vec![]); }
+                    Ok(children) => { self.quick_note_children_cache.insert(path, children); }
+                    Err(_) => { self.quick_note_children_cache.insert(path, vec![]); }
                 }
                 self.quick_note_sub_cursor = 0;
             }
@@ -1153,13 +1155,13 @@ impl PlexiApp {
         // Priority: static options > dynamic children_cmd results.
         let static_options = node.as_ref().and_then(|n| n.options.as_ref());
         let dynamic_children = if static_options.is_none() {
-            self.quick_note_children_cache.get(&node_key).cloned()
+            self.quick_note_children_cache.get(&node_path).cloned()
         } else {
             None
         };
         let loading = static_options.is_none()
             && dynamic_children.is_none()
-            && self.quick_note_children_rx.as_ref().map(|(k, _)| *k == node_key).unwrap_or(false);
+            && self.quick_note_children_rx.as_ref().map(|(p, _)| p == &node_path).unwrap_or(false);
 
         // Kick off children_cmd loading if needed and not already in flight.
         if static_options.is_none() && dynamic_children.is_none() && !loading {
@@ -1171,7 +1173,7 @@ impl PlexiApp {
                         &self.quick_note_ctx,
                     );
                     let (tx, rx) = std::sync::mpsc::channel();
-                    let key = node_key;
+                    let path_for_log = node_path.clone();
                     std::thread::spawn(move || {
                         let result = std::process::Command::new("sh")
                             .args(["-c", &cmd])
@@ -1188,8 +1190,8 @@ impl PlexiApp {
                             });
                         let _ = tx.send(result);
                     });
-                    log::info!("QuickNote: children_cmd spawned for key={}", key);
-                    self.quick_note_children_rx = Some((key, rx));
+                    log::info!("QuickNote: children_cmd spawned for path={:?}", path_for_log);
+                    self.quick_note_children_rx = Some((node_path, rx));
                     ctx.request_repaint_after(std::time::Duration::from_millis(100));
                 }
             }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1190,6 +1190,7 @@ impl PlexiApp {
                     });
                     log::info!("QuickNote: children_cmd spawned for key={}", key);
                     self.quick_note_children_rx = Some((key, rx));
+                    ctx.request_repaint_after(std::time::Duration::from_millis(100));
                 }
             }
         }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -870,19 +870,22 @@ impl PlexiApp {
                 .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
             if let Some(dest) = dest {
                 log::info!("QuickNote: destination selected via Enter: cursor={cursor} key={}", dest.key);
-                if dest.options.is_some() {
+                if dest.options.is_some() || dest.children_cmd.is_some() {
                     let key = dest.key;
-                    self.quick_note_pending_parent = Some(key);
                     self.quick_note_sub_cursor = 0;
-                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
-                    log::info!("QuickNote: submenu opened: parent={key}");
-                    self.draw_quick_note_subdestination(ctx);
+                    self.quick_note_children_cache.clear();
+                    self.quick_note_children_rx = None;
+                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
+                    log::info!("QuickNote: submenu opened: path=[{key}]");
+                    self.draw_quick_note_menu(ctx, &[key]);
                 } else {
                     let text = self.quick_note_text.clone();
                     if self.commit_quick_note(&text, &dest) {
                         self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
                         self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
                         self.quick_note_text.clear();
+                        self.quick_note_children_cache.clear();
+                        self.quick_note_children_rx = None;
                     }
                 }
             }
@@ -897,13 +900,14 @@ impl PlexiApp {
                 let dest = self.config.quick_note.as_ref()
                     .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
                 if let Some(dest) = dest {
-                    if dest.options.is_some() {
+                    if dest.options.is_some() || dest.children_cmd.is_some() {
                         let key = dest.key;
-                        self.quick_note_pending_parent = Some(key);
                         self.quick_note_sub_cursor = 0;
-                        self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
-                        log::info!("QuickNote: submenu opened via L: parent={key}");
-                        self.draw_quick_note_subdestination(ctx);
+                        self.quick_note_children_cache.clear();
+                        self.quick_note_children_rx = None;
+                        self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
+                        log::info!("QuickNote: submenu opened via L: path=[{key}]");
+                        self.draw_quick_note_menu(ctx, &[key]);
                         return;
                     }
                 }
@@ -928,18 +932,21 @@ impl PlexiApp {
                 .and_then(|qn| qn.destinations.iter().find(|d| d.key == key).cloned());
             if let Some(dest) = dest {
                 log::info!("QuickNote: destination selected: key={key}");
-                if dest.options.is_some() {
-                    self.quick_note_pending_parent = Some(key);
+                if dest.options.is_some() || dest.children_cmd.is_some() {
                     self.quick_note_sub_cursor = 0;
-                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(key));
-                    log::info!("QuickNote: submenu opened: parent={key}");
-                    self.draw_quick_note_subdestination(ctx);
+                    self.quick_note_children_cache.clear();
+                    self.quick_note_children_rx = None;
+                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
+                    log::info!("QuickNote: submenu opened: path=[{key}]");
+                    self.draw_quick_note_menu(ctx, &[key]);
                 } else {
                     let text = self.quick_note_text.clone();
                     if self.commit_quick_note(&text, &dest) {
                         self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
                         self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
                         self.quick_note_text.clear();
+                        self.quick_note_children_cache.clear();
+                        self.quick_note_children_rx = None;
                     }
                 }
             }
@@ -1036,7 +1043,7 @@ impl PlexiApp {
                         // Config destinations
                         for (idx, dest) in destinations.iter().enumerate() {
                             let row_idx = idx + 1;
-                            let label = if dest.options.is_some() {
+                            let label = if dest.options.is_some() || dest.children_cmd.is_some() {
                                 format!("{} ›", dest.label)
                             } else {
                                 dest.label.clone()
@@ -1075,123 +1082,210 @@ impl PlexiApp {
             });
     }
 
-    /// Quick note sub-destination picker.
-    pub(crate) fn draw_quick_note_subdestination(&mut self, ctx: &egui::Context) {
+    /// Recursive quick-note menu renderer. `key_path` is the sequence of keys from the
+    /// root destinations list to the current node. E.g. `&[3]` = children of destination 3.
+    pub(crate) fn draw_quick_note_menu(&mut self, ctx: &egui::Context, key_path: &[u8]) {
         use crate::style;
         use crate::widgets;
         use egui::{Align2, RichText, Vec2};
 
-        let parent_key = match self.focus_stack.last() {
-            Some(crate::app::FocusLayer::QuickNoteSubDestination(k)) => *k,
-            _ => {
-                // Shouldn't happen — defensive pop of whatever is on top.
-                self.focus_stack.pop();
-                return;
+        // Resolve the current node by walking key_path through the config tree.
+        let node: Option<crate::config::QuickNoteNode> = {
+            let mut current: Option<&Vec<crate::config::QuickNoteNode>> =
+                self.config.quick_note.as_ref().map(|qn| &qn.destinations);
+            let mut found = None;
+            for &key in key_path {
+                if let Some(nodes) = current {
+                    if let Some(n) = nodes.iter().find(|n| n.key == key) {
+                        found = Some(n.clone());
+                        current = n.options.as_ref();
+                    } else {
+                        found = None;
+                        break;
+                    }
+                } else {
+                    found = None;
+                    break;
+                }
             }
+            found
         };
 
-        // H or Esc → back to destination picker.
+        let current_layer = crate::app::FocusLayer::QuickNoteSubDestination(key_path.to_vec());
+
+        // ── Drain children_cmd receiver if pending ────────────────────────────────
+        let node_key = key_path.last().copied().unwrap_or(0);
+        {
+            let mut received = None;
+            if let Some((pending_key, rx)) = &self.quick_note_children_rx {
+                if *pending_key == node_key {
+                    match rx.try_recv() {
+                        Ok(Ok(children)) => {
+                            log::info!(
+                                "QuickNote: children_cmd result received for key={} count={}",
+                                node_key, children.len()
+                            );
+                            received = Some((node_key, Ok(children)));
+                        }
+                        Ok(Err(e)) => {
+                            log::error!("QuickNote: children_cmd failed for key={}: {e}", node_key);
+                            received = Some((node_key, Err(e)));
+                        }
+                        Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                            log::error!("QuickNote: children_cmd sender dropped for key={}", node_key);
+                            received = Some((node_key, Err("sender dropped".to_string())));
+                        }
+                    }
+                }
+            }
+            if let Some((k, result)) = received {
+                self.quick_note_children_rx = None;
+                match result {
+                    Ok(children) => { self.quick_note_children_cache.insert(k, children); }
+                    Err(_) => { self.quick_note_children_cache.insert(k, vec![]); }
+                }
+                self.quick_note_sub_cursor = 0;
+            }
+        }
+
+        // Determine the list of children to display.
+        // Priority: static options > dynamic children_cmd results.
+        let static_options = node.as_ref().and_then(|n| n.options.as_ref());
+        let dynamic_children = if static_options.is_none() {
+            self.quick_note_children_cache.get(&node_key).cloned()
+        } else {
+            None
+        };
+        let loading = static_options.is_none()
+            && dynamic_children.is_none()
+            && self.quick_note_children_rx.as_ref().map(|(k, _)| *k == node_key).unwrap_or(false);
+
+        // Kick off children_cmd loading if needed and not already in flight.
+        if static_options.is_none() && dynamic_children.is_none() && !loading {
+            if let Some(n) = &node {
+                if let Some(cmd_template) = &n.children_cmd {
+                    let cmd = Self::substitute_note_tokens_static(
+                        cmd_template,
+                        &self.quick_note_text,
+                        &self.quick_note_ctx,
+                    );
+                    let (tx, rx) = std::sync::mpsc::channel();
+                    let key = node_key;
+                    std::thread::spawn(move || {
+                        let result = std::process::Command::new("sh")
+                            .args(["-c", &cmd])
+                            .output()
+                            .map_err(|e| e.to_string())
+                            .and_then(|out| {
+                                if out.status.success() {
+                                    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+                                    let children = parse_children_cmd_output(&stdout);
+                                    Ok(children)
+                                } else {
+                                    Err(String::from_utf8_lossy(&out.stderr).to_string())
+                                }
+                            });
+                        let _ = tx.send(result);
+                    });
+                    log::info!("QuickNote: children_cmd spawned for key={}", key);
+                    self.quick_note_children_rx = Some((key, rx));
+                }
+            }
+        }
+
+        // Resolve effective children list (empty if loading or no children).
+        let children: Vec<crate::config::QuickNoteNode> = if let Some(opts) = static_options {
+            opts.clone()
+        } else if let Some(dyn_children) = dynamic_children {
+            dyn_children
+        } else {
+            vec![]
+        };
+
+        let total = children.len();
+
+        // ── Input handling ────────────────────────────────────────────────────────
+
+        // H or Esc → navigate up.
         let back = ctx.input_mut(|i| {
             i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
                 || i.consume_key(egui::Modifiers::NONE, egui::Key::H)
         });
         if back {
-            self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
-            self.quick_note_pending_parent = None;
-            log::info!("QuickNote: submenu dismissed, back to destination picker");
-            self.draw_quick_note_destination(ctx); // same-frame draw to avoid flash
-            return;
-        }
-
-        // Find parent destination options.
-        let options: Vec<crate::config::QuickNoteSubOptionConfig> = self.config.quick_note.as_ref()
-            .and_then(|qn| qn.destinations.iter().find(|d| d.key == parent_key))
-            .and_then(|d| d.options.clone())
-            .unwrap_or_default();
-
-        let total = options.len();
-
-        // Arrow / vim navigation.
-        let up = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::K)
-        });
-        let down = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::J)
-        });
-        if up {
-            self.quick_note_sub_cursor = if self.quick_note_sub_cursor == 0 {
-                total.saturating_sub(1)
+            self.pop_focus_layer(&current_layer);
+            log::info!("QuickNote: menu back: path={key_path:?}");
+            if key_path.len() > 1 {
+                let parent_path = key_path[..key_path.len() - 1].to_vec();
+                self.draw_quick_note_menu(ctx, &parent_path);
             } else {
-                self.quick_note_sub_cursor - 1
-            };
-            log::info!("QuickNote: sub cursor → {}", self.quick_note_sub_cursor);
-        }
-        if down {
-            self.quick_note_sub_cursor = (self.quick_note_sub_cursor + 1) % total.max(1);
-            log::info!("QuickNote: sub cursor → {}", self.quick_note_sub_cursor);
-        }
-
-        // Enter → dispatch selected option.
-        let enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
-        if enter {
-            if let Some(opt) = options.get(self.quick_note_sub_cursor).cloned() {
-                let text = self.quick_note_text.clone();
-                let cmd_template = opt.command.clone();
-                let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
-                let stay_alive = opt.stay_alive.unwrap_or(false);
-                let ctx_data = self.quick_note_ctx.clone();
-                let cmd = Self::substitute_note_tokens_static(&cmd_template, &text, &ctx_data);
-                log::info!("QuickNote: submenu selected via Enter: parent={parent_key} cursor={}", self.quick_note_sub_cursor);
-                log::info!("QuickNote: committed via '{}' position={position:?} stay_alive={stay_alive}", opt.label);
-                match position.as_str() {
-                    "context-end" => self.open_at_context_end(&cmd, stay_alive),
-                    "context-start" => self.open_at_context_start(&cmd, stay_alive),
-                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
-                }
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
-                self.quick_note_text.clear();
-                self.quick_note_pending_parent = None;
+                self.draw_quick_note_destination(ctx);
             }
             return;
+        }
+
+        // Arrow / vim navigation (only when children are available).
+        if !children.is_empty() {
+            let up = ctx.input_mut(|i| {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                    || i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+            });
+            let down = ctx.input_mut(|i| {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                    || i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+            });
+            if up {
+                self.quick_note_sub_cursor = if self.quick_note_sub_cursor == 0 {
+                    total.saturating_sub(1)
+                } else {
+                    self.quick_note_sub_cursor - 1
+                };
+                log::info!("QuickNote: menu cursor → {}", self.quick_note_sub_cursor);
+            }
+            if down {
+                self.quick_note_sub_cursor = (self.quick_note_sub_cursor + 1) % total.max(1);
+                log::info!("QuickNote: menu cursor → {}", self.quick_note_sub_cursor);
+            }
+        }
+
+        // Enter → dispatch selected child.
+        let enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
+        if enter && !children.is_empty() {
+            if let Some(child) = children.get(self.quick_note_sub_cursor).cloned() {
+                let key_path_owned = key_path.to_vec();
+                self.dispatch_menu_child(ctx, &key_path_owned, &child);
+            }
+            return;
+        }
+
+        // L → enter submenu for selected child.
+        let enter_sub = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::L));
+        if enter_sub && !children.is_empty() {
+            if let Some(child) = children.get(self.quick_note_sub_cursor).cloned() {
+                if child.options.is_some() || child.children_cmd.is_some() {
+                    let mut new_path = key_path.to_vec();
+                    new_path.push(child.key);
+                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(new_path.clone()));
+                    self.quick_note_sub_cursor = 0;
+                    log::info!("QuickNote: menu enter via L: path={new_path:?}");
+                    self.draw_quick_note_menu(ctx, &new_path);
+                    return;
+                }
+            }
         }
 
         // Digit keys → fast-dispatch by number.
         let pressed = consume_digit_key(ctx);
-
         if let Some(key) = pressed {
-            if let Some(opt) = options.iter().find(|o| o.key == key).cloned() {
-                let text = self.quick_note_text.clone();
-                let cmd_template = opt.command.clone();
-                let position = opt.position.clone().unwrap_or_else(|| "split".to_string());
-                let stay_alive = opt.stay_alive.unwrap_or(false);
-                let ctx_data = self.quick_note_ctx.clone();
-                let cmd = Self::substitute_note_tokens_static(
-                    &cmd_template, &text, &ctx_data,
-                );
-                log::info!("QuickNote: submenu selected: parent={parent_key} key={key}");
-                log::info!("QuickNote: committed via '{}' position={position:?} stay_alive={stay_alive}", opt.label);
-                match position.as_str() {
-                    "context-end" => self.open_at_context_end(&cmd, stay_alive),
-                    "context-start" => self.open_at_context_start(&cmd, stay_alive),
-                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
-                }
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteSubDestination(parent_key));
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
-                self.quick_note_text.clear();
-                self.quick_note_pending_parent = None;
+            if let Some(child) = children.iter().find(|c| c.key == key).cloned() {
+                let key_path_owned = key_path.to_vec();
+                self.dispatch_menu_child(ctx, &key_path_owned, &child);
             }
-            // Unrecognised key — digit was consumed but no matching option; redraw.
             return;
         }
 
-        // Render
+        // ── Render ────────────────────────────────────────────────────────────────
         let screen_rect = ctx.screen_rect();
-        let sub_cursor = self.quick_note_sub_cursor;
         egui::Area::new(egui::Id::new("quick_note_scrim"))
             .fixed_pos(screen_rect.min)
             .order(egui::Order::Middle)
@@ -1200,6 +1294,9 @@ impl PlexiApp {
             });
 
         let modal_w = (screen_rect.width() * 0.6).min(672.0).max(408.0);
+        let sub_cursor = self.quick_note_sub_cursor;
+        let node_label = node.as_ref().map(|n| n.label.as_str()).unwrap_or("Menu");
+
         egui::Area::new(egui::Id::new("quick_note_sub_modal"))
             .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
             .order(egui::Order::Foreground)
@@ -1212,52 +1309,106 @@ impl PlexiApp {
                     .show(ui, |ui| {
                         ui.set_width(modal_w);
 
-                        let parent_label = self.config.quick_note.as_ref()
-                            .and_then(|qn| qn.destinations.iter().find(|d| d.key == parent_key))
-                            .map(|d| d.label.as_str())
-                            .unwrap_or("Submenu");
-
                         ui.label(
-                            RichText::new(parent_label)
+                            RichText::new(node_label)
                                 .color(self.colors.text_primary)
                                 .size(style::TEXT_BODY)
                                 .strong(),
                         );
                         ui.add_space(style::SPACE_MD);
 
-                        for (idx, opt) in options.iter().enumerate() {
-                            let row_frame = if sub_cursor == idx {
-                                egui::Frame::new()
-                                    .fill(self.colors.bg_active)
-                                    .corner_radius(egui::CornerRadius::same(4))
-                                    .inner_margin(egui::Margin::symmetric(4, 2))
-                            } else {
-                                egui::Frame::new()
-                                    .inner_margin(egui::Margin::symmetric(4, 2))
-                            };
-                            row_frame.show(ui, |ui| {
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = style::SPACE_SM;
-                                    widgets::key_chip(ui, &opt.key.to_string(), &self.colors);
-                                    ui.label(
-                                        RichText::new(&opt.label)
-                                            .color(self.colors.text_dim)
-                                            .size(style::TEXT_BODY),
-                                    );
+                        if loading {
+                            ui.label(
+                                RichText::new("Loading…")
+                                    .color(self.colors.text_dim)
+                                    .size(style::TEXT_BODY),
+                            );
+                        } else if children.is_empty() {
+                            ui.label(
+                                RichText::new("No items")
+                                    .color(self.colors.text_dim.linear_multiply(0.5))
+                                    .size(style::TEXT_BODY),
+                            );
+                        } else {
+                            for (idx, child) in children.iter().enumerate() {
+                                let child_label = if child.options.is_some() || child.children_cmd.is_some() {
+                                    format!("{} ›", child.label)
+                                } else {
+                                    child.label.clone()
+                                };
+                                let row_frame = if sub_cursor == idx {
+                                    egui::Frame::new()
+                                        .fill(self.colors.bg_active)
+                                        .corner_radius(egui::CornerRadius::same(4))
+                                        .inner_margin(egui::Margin::symmetric(4, 2))
+                                } else {
+                                    egui::Frame::new()
+                                        .inner_margin(egui::Margin::symmetric(4, 2))
+                                };
+                                row_frame.show(ui, |ui| {
+                                    ui.horizontal(|ui| {
+                                        ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                                        widgets::key_chip(ui, &child.key.to_string(), &self.colors);
+                                        ui.label(
+                                            RichText::new(&child_label)
+                                                .color(self.colors.text_dim)
+                                                .size(style::TEXT_BODY),
+                                        );
+                                    });
                                 });
-                            });
-                            ui.add_space(style::SPACE_SM);
+                                ui.add_space(style::SPACE_SM);
+                            }
                         }
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
-                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  H/Esc back")
+                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  L enter  ·  H/Esc back")
                                 .color(self.colors.text_dim.linear_multiply(0.4))
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),
                         );
                     });
             });
+    }
+
+    /// Dispatch a child node selected from within a menu at `parent_path`.
+    /// Handles: entering deeper submenus, committing leaf commands.
+    fn dispatch_menu_child(
+        &mut self,
+        ctx: &egui::Context,
+        parent_path: &[u8],
+        child: &crate::config::QuickNoteNode,
+    ) {
+        if child.options.is_some() || child.children_cmd.is_some() {
+            // Submenu — navigate deeper.
+            let mut new_path = parent_path.to_vec();
+            new_path.push(child.key);
+            self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(new_path.clone()));
+            self.quick_note_sub_cursor = 0;
+            log::info!("QuickNote: menu enter: path={new_path:?}");
+            self.draw_quick_note_menu(ctx, &new_path);
+        } else {
+            // Leaf — commit.
+            let text = self.quick_note_text.clone();
+            log::info!(
+                "QuickNote: menu commit: path={:?} key={} label='{}'",
+                parent_path, child.key, child.label
+            );
+            if self.commit_quick_note(&text, child) {
+                // Pop all submenu layers + destination + compose layers.
+                while matches!(
+                    self.focus_stack.last(),
+                    Some(crate::app::FocusLayer::QuickNoteSubDestination(_))
+                ) {
+                    self.focus_stack.pop();
+                }
+                self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                self.quick_note_text.clear();
+                self.quick_note_children_cache.clear();
+                self.quick_note_children_rx = None;
+            }
+        }
     }
 
     pub(crate) fn draw_quit_confirm_overlay(&self, ctx: &egui::Context) {
@@ -2742,4 +2893,28 @@ impl PlexiApp {
             self.show_cli_setup_prompt = false;
         }
     }
+}
+
+fn parse_children_cmd_output(stdout: &str) -> Vec<crate::config::QuickNoteNode> {
+    stdout.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() { return None; }
+            let (key_str, rest) = line.split_once('|')?;
+            let (label, command) = rest.split_once('|')?;
+            let key: u8 = key_str.trim().parse().ok()?;
+            Some(crate::config::QuickNoteNode {
+                key,
+                label: label.trim().to_string(),
+                command: Some(command.trim().to_string()),
+                hidden: false,
+                stay_alive: None,
+                options: None,
+                children_cmd: None,
+                dest_type: None,
+                position: None,
+                path: None,
+            })
+        })
+        .collect()
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -722,9 +722,12 @@ impl PlexiApp {
             if node.hidden {
                 log::info!("QuickNote: committed via '{}' (hidden background spawn)", node.label);
                 std::thread::spawn(move || {
-                    let _ = std::process::Command::new("sh")
+                    if let Err(e) = std::process::Command::new("sh")
                         .args(["-c", &cmd])
-                        .spawn();
+                        .spawn()
+                    {
+                        log::warn!("QuickNote: hidden spawn failed for '{}': {e}", cmd);
+                    }
                 });
             } else {
                 // Legacy position support during migration period

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -685,9 +685,11 @@ impl PlexiApp {
         let workspace_root = crate::config::active_workspace_root();
         let context_id = self.windows.get(active).map(|w| w.context_id).unwrap_or(0);
         let context = self.context_name_for(context_id);
+        let context_root = self.router.active().root.clone();
         self.quick_note_text = String::new();
-        self.quick_note_ctx = crate::app::QuickNoteCtx { cwd, workspace_root, context };
-        self.quick_note_pending_parent = None;
+        self.quick_note_ctx = crate::app::QuickNoteCtx { cwd, workspace_root, context, context_root };
+        self.quick_note_children_cache.clear();
+        self.quick_note_children_rx = None;
         self.push_focus_layer(crate::app::FocusLayer::QuickNote);
         log::info!(
             "QuickNote: modal opened — cwd={}, workspace={:?}",
@@ -701,53 +703,61 @@ impl PlexiApp {
     pub(crate) fn commit_quick_note(
         &mut self,
         text: &str,
-        dest: &crate::config::QuickNoteDestinationConfig,
+        node: &crate::config::QuickNoteNode,
     ) -> bool {
         let ctx = self.quick_note_ctx.clone();
-        match dest.dest_type.as_deref() {
-            Some("backlog") | None if dest.options.is_none() => {
-                let path = dest.path.as_deref().unwrap_or("");
-                let dir = if path.is_empty() {
-                    crate::config::config_dir().join("backlog")
-                } else {
-                    let expanded = if path.starts_with("~/") {
-                        dirs::home_dir()
-                            .unwrap_or_else(|| PathBuf::from("/"))
-                            .join(&path[2..])
-                    } else {
-                        PathBuf::from(path)
-                    };
-                    expanded
-                };
-                Self::write_backlog_note(text, &dir, &ctx)
-            }
-            Some("pane") => {
-                let cmd_template = match &dest.command {
-                    Some(c) => c.clone(),
-                    None => {
-                        log::warn!("QuickNote: pane destination '{}' has no command", dest.label);
-                        return false;
-                    }
-                };
-                let cmd = Self::substitute_note_tokens_static(&cmd_template, text, &ctx);
-                let position = dest.position.as_deref().unwrap_or("split");
-                let stay_alive = dest.stay_alive.unwrap_or(false);
+
+        // Deprecation warning for old-style fields
+        if node.dest_type.as_deref() == Some("pane") || node.position.is_some() {
+            log::warn!(
+                "QuickNote: '{}' uses deprecated 'type = \"pane\"' or 'position' — migrate to bare command",
+                node.label
+            );
+        }
+
+        if let Some(cmd_template) = &node.command {
+            let cmd = Self::substitute_note_tokens_static(cmd_template, text, &ctx);
+            let stay_alive = node.stay_alive.unwrap_or(false);
+
+            if node.hidden {
+                log::info!("QuickNote: committed via '{}' (hidden background spawn)", node.label);
+                std::thread::spawn(move || {
+                    let _ = std::process::Command::new("sh")
+                        .args(["-c", &cmd])
+                        .spawn();
+                });
+            } else {
+                // Legacy position support during migration period
+                let position = node.position.as_deref().unwrap_or("split");
                 log::info!(
                     "QuickNote: committed via '{}' position={:?} stay_alive={stay_alive}",
-                    dest.label,
-                    position
+                    node.label, position
                 );
                 match position {
                     "context-end" => self.open_at_context_end(&cmd, stay_alive),
                     "context-start" => self.open_at_context_start(&cmd, stay_alive),
                     _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
                 }
-                true
             }
-            _ => {
-                log::warn!("QuickNote: unknown dest_type for '{}'", dest.label);
-                false
-            }
+            true
+        } else if node.dest_type.as_deref() == Some("backlog") ||
+                  (node.dest_type.is_none() && node.command.is_none() &&
+                   node.options.is_none() && node.children_cmd.is_none()) {
+            // Backlog destination (type = "backlog" or bare with just path)
+            let path = node.path.as_deref().unwrap_or("");
+            let dir = if path.is_empty() {
+                crate::config::config_dir().join("backlog")
+            } else if path.starts_with("~/") {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("/"))
+                    .join(&path[2..])
+            } else {
+                PathBuf::from(path)
+            };
+            Self::write_backlog_note(text, &dir, &ctx)
+        } else {
+            log::warn!("QuickNote: leaf '{}' has no command or recognized dest_type", node.label);
+            false
         }
     }
 
@@ -803,8 +813,13 @@ impl PlexiApp {
     ) -> String {
         let esc = |s: &str| -> String { crate::shell::shell_quote(s) };
         let cwd_str = ctx.cwd.to_string_lossy().to_string();
+        let context_root_str = ctx.context_root
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
         cmd.replace("{note}", &esc(note))
            .replace("{cwd}", &esc(&cwd_str))
+           .replace("{context_root}", &esc(&context_root_str))
     }
 
     /// Spawn a terminal pane as the last child of the root container.
@@ -1256,6 +1271,7 @@ mod quick_note_tests {
             cwd: std::path::PathBuf::from(cwd),
             workspace_root: None,
             context: "test".to_string(),
+            context_root: None,
         }
     }
 
@@ -1347,5 +1363,22 @@ mod quick_note_tests {
         let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {note}", note, &ctx("/tmp"));
         let out = sh(&cmd);
         assert_eq!(out, note, "all-apostrophe note mangled: got {out:?}");
+    }
+
+    #[test]
+    fn context_root_token_is_shell_escaped() {
+        let mut c = ctx("/tmp");
+        c.context_root = Some(std::path::PathBuf::from("/projects/it's a dir"));
+        let cmd = PlexiApp::substitute_note_tokens_static("printf '%s' {context_root}", "note", &c);
+        let out = sh(&cmd);
+        assert_eq!(out, "/projects/it's a dir", "context_root apostrophe mangled: got {out:?}");
+    }
+
+    #[test]
+    fn context_root_empty_when_unset() {
+        let c = ctx("/tmp");
+        let result = PlexiApp::substitute_note_tokens_static("echo {context_root}", "note", &c);
+        // When context_root is None, {context_root} substitutes to shell_quote("") = ''
+        assert!(result.contains("''") || result.ends_with("echo "), "unexpected result: {result}");
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -721,14 +721,12 @@ impl PlexiApp {
 
             if node.hidden {
                 log::info!("QuickNote: committed via '{}' (hidden background spawn)", node.label);
-                std::thread::spawn(move || {
-                    if let Err(e) = std::process::Command::new("sh")
-                        .args(["-c", &cmd])
-                        .spawn()
-                    {
-                        log::warn!("QuickNote: hidden spawn failed for '{}': {e}", cmd);
-                    }
-                });
+                if let Err(e) = std::process::Command::new("sh")
+                    .args(["-c", &cmd])
+                    .spawn()
+                {
+                    log::warn!("QuickNote: hidden spawn failed for '{}': {e}", cmd);
+                }
             } else {
                 // Legacy position support during migration period
                 let position = node.position.as_deref().unwrap_or("split");


### PR DESCRIPTION
## Summary

- **Recursive `options`**: Collapses `QuickNoteDestinationConfig` + `QuickNoteSubOptionConfig` into a single recursive `QuickNoteNode`. Any node at any depth can have `options` (static submenu) or `children_cmd` (dynamic children from script stdout).
- **`children_cmd`**: Shell command whose stdout (`key|label|command` per line) populates a menu level at navigate time. Runs off the UI thread (std::thread + channel), shows "Loading…" spinner, caches result per-session.
- **`hidden = true`**: Runs command without spawning a visible pane (fire-and-forget background spawn). GitHub issue and clipboard destinations now use this.
- **`{context_root}` token**: Active context root path, shell-escaped, available in all `command` and `children_cmd` fields.
- **Deprecated `type = "pane"` / `position`**: Still parsed for backward compatibility, emit `log::warn!` migration message. `type = "backlog"` is unchanged.
- **Updated `CONFIG_TEMPLATE`**: Bare commands, `hidden = true`, commented `children_cmd` example. Closes #1111 (hidden absorption).

## Done when

- [x] Bare `command` destination with no `type` routes correctly
- [x] `options` submenu at depth 3+ navigates (H/Esc back, digit select)
- [x] `children_cmd` shows spinner on first navigate, populates from script stdout
- [x] `{context_root}` substitutes active context's root path in leaf commands
- [x] Config with old `type = "pane"` / `position` logs deprecation warning
- [x] `CONFIG_TEMPLATE` ships with new schema + commented `children_cmd` example

## Test plan

- [ ] Install PR build and verify destination picker renders
- [ ] Configure a bare `command` destination — confirm it opens a terminal pane
- [ ] Configure `hidden = true` destination — confirm no pane spawned, command runs
- [ ] Configure a 3-level deep `options` submenu — navigate in and out
- [ ] Configure a `children_cmd` destination — confirm spinner then populated list
- [ ] Verify `{context_root}` substitutes correctly (set context root via `plexi context root <path>`)
- [ ] Old `type = "pane"` config — confirm deprecation warning in log, command still runs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)