### PR TITLE
feat(terminal): add --no-focus flag to prevent new pane from stealing focus (#1192)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1194,6 +1194,10 @@ impl PlexiApp {
                     if *no_focus || from_pane_id.is_some() {
                         let reason = if *no_focus { "no_focus=true" } else { "from_pane_id override" };
                         log::info!("pane_ipc: spawn_pane: {reason}, retaining focus on pane_id={original_focused:?}");
+                        // Also restore active_window — new_window layout switches it to the new window.
+                        if *no_focus {
+                            self.active_window = active;
+                        }
                         self.windows[active].focused_pane = original_focused;
                     }
                     if let Some(rf) = response_file {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1192,9 +1192,8 @@ impl PlexiApp {
 
                     // Restore original focus when no_focus is requested or from_pane_id overrode it.
                     if *no_focus || from_pane_id.is_some() {
-                        if *no_focus {
-                            log::info!("pane_ipc: spawn_pane: no_focus=true, retaining focus on pane_id={original_focused:?}");
-                        }
+                        let reason = if *no_focus { "no_focus=true" } else { "from_pane_id override" };
+                        log::info!("pane_ipc: spawn_pane: {reason}, retaining focus on pane_id={original_focused:?}");
                         self.windows[active].focused_pane = original_focused;
                     }
                     if let Some(rf) = response_file {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1386,7 +1386,10 @@ impl PlexiApp {
                 })
                 .unwrap_or_default();
             let cwd_override: Option<std::path::PathBuf> = val["cwd"].as_str().map(std::path::PathBuf::from);
-            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral} cwd={cwd_override:?}");
+            let no_focus = val["no_focus"].as_bool().unwrap_or(false);
+            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd_override:?}");
+            let active = self.active_window;
+            let original_focused = self.windows[active].focused_pane;
             if type_id == "terminal" {
                 let layout_str = layout.as_deref().unwrap_or("split_v");
                 let vertical = matches!(layout_str, "split_h" | "split_above");
@@ -1394,6 +1397,11 @@ impl PlexiApp {
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, cwd_override);
             } else {
                 self.launch_app_by_id_with_layout(&type_id, layout, &args);
+            }
+            if no_focus {
+                log::info!("spawn-queue: no_focus=true, retaining focus on pane_id={original_focused:?}");
+                self.active_window = active;
+                self.windows[active].focused_pane = original_focused;
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1145,8 +1145,8 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+                crate::app_protocol::HostCommand::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
                     // Override focused_pane for the split if from_pane_id is specified,
@@ -1190,8 +1190,11 @@ impl PlexiApp {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
                     }
 
-                    // Only restore if we overrode focus; otherwise the new pane keeps focus.
-                    if from_pane_id.is_some() {
+                    // Restore original focus when no_focus is requested or from_pane_id overrode it.
+                    if *no_focus || from_pane_id.is_some() {
+                        if *no_focus {
+                            log::info!("pane_ipc: spawn_pane: no_focus=true, retaining focus on pane_id={original_focused:?}");
+                        }
                         self.windows[active].focused_pane = original_focused;
                     }
                     if let Some(rf) = response_file {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -992,6 +992,8 @@ pub enum HostCommand {
         ephemeral: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cwd: Option<String>,
+        #[serde(default, skip_serializing_if = "is_false")]
+        no_focus: bool,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
@@ -2629,6 +2631,32 @@ mod tests {
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(serialised.contains(r#""from_pane_id":42"#), "from_pane_id missing: {serialised}");
         assert!(serialised.contains(r#""request_id":"req-1""#), "request_id missing: {serialised}");
+    }
+
+    #[test]
+    fn spawn_pane_no_focus_round_trips_serde() {
+        let json = r#"{"type":"spawn_pane","type_id":"terminal","no_focus":true}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::SpawnPane { no_focus, .. }) => {
+                assert!(*no_focus, "no_focus should be true");
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""no_focus":true"#), "no_focus missing: {serialised}");
+
+        // default (false) should be omitted from serialised output
+        let json_default = r#"{"type":"spawn_pane","type_id":"terminal"}"#;
+        let cmd_default: DrawCommand = serde_json::from_str(json_default).expect("deserialise default");
+        match &cmd_default {
+            DrawCommand::Host(HostCommand::SpawnPane { no_focus, .. }) => {
+                assert!(!*no_focus, "no_focus should default to false");
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised_default = serde_json::to_string(&cmd_default).expect("serialise default");
+        assert!(!serialised_default.contains("no_focus"), "no_focus should be omitted when false: {serialised_default}");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2435,11 +2435,11 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
     0
 }
 
-/// `plexi terminal [cmd] [--ephemeral] [--layout=X]`
+/// `plexi terminal [cmd] [--ephemeral] [--layout=X] [--no-focus]`
 ///
 /// Opens a terminal pane. Supports the --ephemeral flag which closes the pane when the
-/// process exits.
-pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
+/// process exits, and --no-focus to keep focus on the originating pane.
+pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>, no_focus: bool) -> i32 {
     let layout_str = layout.unwrap_or("split_v");
     let args: Vec<String> = cmd.map(|c| vec![c.to_string()]).unwrap_or_default();
 
@@ -2465,7 +2465,10 @@ pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, fr
         if let Some(cwd) = cwd {
             payload["cwd"] = serde_json::Value::String(cwd.to_string());
         }
-        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+        if no_focus {
+            payload["no_focus"] = serde_json::Value::Bool(true);
+        }
+        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
@@ -2526,12 +2529,15 @@ pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, fr
     if let Some(cwd) = cwd {
         queue_payload["cwd"] = serde_json::Value::String(cwd.to_string());
     }
+    if no_focus {
+        queue_payload["no_focus"] = serde_json::Value::Bool(true);
+    }
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
-    log::info!("terminal:cli: queued ephemeral={ephemeral} cwd={cwd:?}");
+    log::info!("terminal:cli: queued ephemeral={ephemeral} no_focus={no_focus} cwd={cwd:?}");
     println!("queued: open terminal");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0
@@ -3789,6 +3795,7 @@ complete -c plexi -n "__fish_seen_subcommand_from terminal" -s e -l ephemeral -d
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_v split_h split_above"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l from-pane-id -d "Split relative to this pane ID"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l cwd -d "Working directory for the new terminal pane" -a "(__fish_complete_directories)"
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -l no-focus -d "Keep focus on the originating pane"
 # open flags
 complete -c plexi -n "__fish_seen_subcommand_from open" -l layout -d "Layout hint" -a "split_v split_h split_above overlay"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l from-pane-id -d "Split relative to this pane ID"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -118,6 +118,9 @@ pub enum Commands {
         /// Working directory for the new terminal pane
         #[arg(long)]
         cwd: Option<String>,
+        /// Keep focus on the originating pane; do not move focus to the new pane
+        #[arg(long)]
+        no_focus: bool,
     },
     /// Open an app pane
     Open {

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,8 +374,8 @@ fn main() -> eframe::Result {
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                     },
-                    Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd } => {
-                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref()));
+                    Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
+                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));
                     }
                     Commands::Open { type_id, mcp, cli: cli_flag, layout, from_pane_id, extra_args } => {
                         let mode_count = type_id.is_some() as u8

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -976,6 +976,7 @@ mod tests {
             response_file: None,
             ephemeral: false,
             cwd: None,
+            no_focus: false,
         });
         h.run_frames(2);
 
@@ -1012,6 +1013,7 @@ mod tests {
             response_file: None,
             ephemeral: false,
             cwd: None,
+            no_focus: false,
         });
         h.run_frames(2);
 
@@ -1051,6 +1053,7 @@ mod tests {
             response_file: None,
             ephemeral: false,
             cwd: None,
+            no_focus: false,
         });
         h.run_frames(2);
 
@@ -1089,6 +1092,7 @@ mod tests {
             response_file: None,
             ephemeral: false,
             cwd: None,
+            no_focus: false,
         });
         h.run_frames(2);
 
@@ -1137,6 +1141,7 @@ mod tests {
             response_file: None,
             ephemeral: false,
             cwd: None,
+            no_focus: false,
         });
         h.run_frames(2);
 
@@ -1183,6 +1188,7 @@ mod tests {
                 response_file: None,
                 ephemeral: false,
                 cwd: None,
+                no_focus: false,
             });
             h.run_frames(2);
         }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -771,6 +771,7 @@ impl ProcessApp {
                 response_file: _,
                 ephemeral: _,
                 cwd: _,
+                no_focus: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)


### PR DESCRIPTION
## What

Adds `--no-focus` to `plexi terminal`. When set, the originating pane retains focus after the new terminal pane is created. Default behavior (without the flag) is unchanged — new pane takes focus.

## How

- `--no-focus: bool` added to the `Terminal` struct in `cli_args.rs`
- Threaded through `main.rs` → `terminal_cli()` → socket payload and spawn-queue fallback
- `HostCommand::SpawnPane` gains a `no_focus: bool` field (serde default false, omitted when false)
- `pane_ipc` handler restores `original_focused` when `no_focus=true`, with an `info`-level log trace
- Fish completions updated
- Serde round-trip test added

## Done When

- `plexi terminal "echo hi" --layout new_window --no-focus` creates the window but focus stays on the originating pane
- `plexi terminal "echo hi" --layout tab --no-focus` same for tabs
- Default behavior (without flag) unchanged

Closes #1192