### PR TITLE
feat(host): double-spacebar scratchpad — instant capture-to-file text editor (#1213)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -334,6 +334,9 @@ pub struct PlexiApp {
     pub(crate) last_logged_focus: Option<(u64, egui_tiles::TileId)>,
     /// When the current focus session started. Reset on each FocusChanged emit.
     pub(crate) focus_started_at: Option<std::time::Instant>,
+    /// Timestamp of the last Space keydown — used to detect double-spacebar
+    /// for scratchpad activation. Reset on trigger or when the interval expires.
+    pub(crate) last_space_press: Option<std::time::Instant>,
 }
 
 #[cfg(test)]
@@ -692,6 +695,7 @@ impl PlexiApp {
                     pane_ipc_rx,
                     last_logged_focus: None,
                     focus_started_at: None,
+                    last_space_press: None,
                 };
             }
         }
@@ -797,6 +801,7 @@ impl PlexiApp {
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
+            last_space_press: None,
         }
     }
 
@@ -916,6 +921,7 @@ impl PlexiApp {
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
+            last_space_press: None,
         }, pane_ipc_tx)
     }
 
@@ -2362,6 +2368,35 @@ impl eframe::App for PlexiApp {
             };
             (active, capture)
         };
+
+        // Double-spacebar scratchpad trigger — peek at events without consuming Space.
+        if !app_active && !keyboard_capture_active {
+            let space_pressed = ctx.input(|i| {
+                i.events.iter().any(|e| matches!(
+                    e,
+                    egui::Event::Key {
+                        key: egui::Key::Space,
+                        pressed: true,
+                        repeat: false,
+                        ..
+                    }
+                ))
+            });
+            if space_pressed {
+                let now = std::time::Instant::now();
+                if let Some(last) = self.last_space_press {
+                    if now.duration_since(last) < std::time::Duration::from_millis(250) {
+                        log::info!("scratchpad: double-spacebar detected — opening");
+                        self.last_space_press = None;
+                        self.open_scratchpad();
+                    } else {
+                        self.last_space_press = Some(now);
+                    }
+                } else {
+                    self.last_space_press = Some(now);
+                }
+            }
+        }
 
         // Handle keyboard shortcuts
         let modal_open = self.input_captured_by_overlay();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2369,7 +2369,8 @@ impl eframe::App for PlexiApp {
             (active, capture)
         };
 
-        // Double-spacebar scratchpad trigger — peek at events without consuming Space.
+        // Double-spacebar scratchpad trigger — first Space passes through to the terminal;
+        // the second Space within 250ms is consumed and opens the scratchpad.
         if !app_active && !keyboard_capture_active {
             let space_pressed = ctx.input(|i| {
                 i.events.iter().any(|e| matches!(
@@ -2388,6 +2389,20 @@ impl eframe::App for PlexiApp {
                     if now.duration_since(last) < std::time::Duration::from_millis(250) {
                         log::info!("scratchpad: double-spacebar detected — opening");
                         self.last_space_press = None;
+                        // Consume the triggering Space so it doesn't reach the terminal.
+                        ctx.input_mut(|i| {
+                            if let Some(pos) = i.events.iter().position(|e| matches!(
+                                e,
+                                egui::Event::Key {
+                                    key: egui::Key::Space,
+                                    pressed: true,
+                                    repeat: false,
+                                    ..
+                                }
+                            )) {
+                                i.events.remove(pos);
+                            }
+                        });
                         self.open_scratchpad();
                     } else {
                         self.last_space_press = Some(now);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod install;
 mod protocol;
 mod runs;
 mod secrets;
+mod scratchpad;
 mod secrets_app;
 mod workspace_router;
 mod workspace_secrets;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -675,6 +675,45 @@ impl PlexiApp {
         self.open_builtin_app_pane(app, perms, cwd, None, Some("overlay"), None);
     }
 
+    /// Open the scratchpad as a full-pane overlay on the focused terminal.
+    pub(crate) fn open_scratchpad(&mut self) {
+        // Toggle: if already open, close it.
+        let ctx = &self.windows[self.active_window];
+        if let Some(focused) = ctx.focused_pane {
+            if let Some(egui_tiles::Tile::Pane(pane_id)) = ctx.tree.tiles.get(focused) {
+                if let Some(pane) = ctx.panes.get(pane_id) {
+                    if let Some(a) = pane.as_app() {
+                        if a.runtime.type_id() == "scratchpad" {
+                            log::info!("scratchpad: already open — closing");
+                            self.close_focused_app();
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        let cwd = {
+            let ctx = &self.windows[self.active_window];
+            ctx.focused_pane
+                .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
+                .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+        };
+
+        let workspace_root = crate::config::active_workspace_root()
+            .unwrap_or_else(|| cwd.clone());
+
+        log::info!(
+            "scratchpad: opening — cwd={} workspace_root={}",
+            cwd.display(),
+            workspace_root.display()
+        );
+
+        let app = Box::new(crate::scratchpad::ScratchpadApp::new(workspace_root.clone()));
+        let perms = crate::app_permissions::AppPermissions::builtin();
+        self.open_builtin_app_pane(app, perms, workspace_root, None, Some("overlay"), None);
+    }
+
     /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
     pub(crate) fn open_quick_note_modal(&mut self) {
         let active = self.active_window;

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -1,0 +1,255 @@
+use chrono::Local;
+use std::path::PathBuf;
+use crate::app_trait::{App, AppCommand, AppRenderContext};
+use crate::style;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Mode {
+    Editing,
+    SaveModal,
+}
+
+pub struct ScratchpadApp {
+    workspace_root: PathBuf,
+    text: String,
+    mode: Mode,
+    filename: String,
+    focus_requested: bool,
+    save_focus_requested: bool,
+    wants_close: bool,
+    pending_cmds: Vec<AppCommand>,
+}
+
+fn default_filename() -> String {
+    Local::now().format("%Y-%m-%d_%H%M%S.md").to_string()
+}
+
+impl ScratchpadApp {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self {
+            workspace_root,
+            text: String::new(),
+            mode: Mode::Editing,
+            filename: default_filename(),
+            focus_requested: false,
+            save_focus_requested: false,
+            wants_close: false,
+            pending_cmds: Vec::new(),
+        }
+    }
+
+    fn save_file(&mut self) {
+        let notes_dir = self.workspace_root.join(".plexi").join("notes");
+        if let Err(e) = std::fs::create_dir_all(&notes_dir) {
+            log::error!("scratchpad: failed to create notes dir {:?}: {e}", notes_dir);
+            self.wants_close = true;
+            return;
+        }
+        let path = notes_dir.join(&self.filename);
+        if let Err(e) = std::fs::write(&path, &self.text) {
+            log::error!("scratchpad: failed to write {:?}: {e}", path);
+        } else {
+            log::info!("scratchpad: saved to {:?}", path);
+        }
+        self.wants_close = true;
+    }
+}
+
+impl App for ScratchpadApp {
+    fn type_id(&self) -> &'static str {
+        "scratchpad"
+    }
+
+    fn display_name(&self) -> String {
+        "Scratchpad".to_string()
+    }
+
+    fn keyboard_capture(&self) -> bool {
+        true
+    }
+
+    fn wants_close(&self) -> bool {
+        self.wants_close
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<AppCommand> {
+        std::mem::take(&mut self.pending_cmds)
+    }
+
+    fn handle_key(&mut self, _input: &egui::InputState) -> bool {
+        false
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+
+        if self.mode == Mode::Editing {
+            let save_pressed = ui.input_mut(|i| {
+                i.consume_key(egui::Modifiers::COMMAND, egui::Key::S)
+            });
+            let discard_pressed = ui.input_mut(|i| {
+                i.consume_key(egui::Modifiers::COMMAND, egui::Key::X)
+            });
+            let esc_pressed = ui.input_mut(|i| {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
+            });
+
+            if save_pressed && !self.text.trim().is_empty() {
+                self.mode = Mode::SaveModal;
+                self.save_focus_requested = false;
+                log::info!("scratchpad: Cmd+S — opening save modal");
+                return;
+            }
+            if discard_pressed || esc_pressed {
+                log::info!("scratchpad: discarding");
+                self.wants_close = true;
+                return;
+            }
+
+            let status_height = style::TEXT_HINT + style::SPACE_SM * 2.0;
+            let available = ui.available_rect_before_wrap();
+            let text_rect = egui::Rect::from_min_max(
+                available.min,
+                egui::pos2(available.max.x, available.max.y - status_height),
+            );
+            let status_rect = egui::Rect::from_min_max(
+                egui::pos2(available.min.x, available.max.y - status_height),
+                available.max,
+            );
+
+            let te_id = egui::Id::new("scratchpad_text");
+            if !self.focus_requested {
+                ui.ctx().memory_mut(|m| m.request_focus(te_id));
+                self.focus_requested = true;
+            }
+
+            ui.allocate_new_ui(egui::UiBuilder::new().max_rect(text_rect), |ui| {
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    ui.scope(|ui| {
+                        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                        ui.add(
+                            egui::TextEdit::multiline(&mut self.text)
+                                .id(te_id)
+                                .font(egui::FontId::monospace(style::TEXT_BODY))
+                                .text_color(colors.text_primary)
+                                .desired_width(f32::INFINITY)
+                                .frame(false),
+                        );
+                    });
+                });
+            });
+
+            // Status bar
+            ui.painter().rect_filled(status_rect, 0.0, colors.bg_sidebar);
+            ui.allocate_new_ui(egui::UiBuilder::new().max_rect(status_rect), |ui| {
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    ui.add_space(style::SPACE_SM);
+                    crate::widgets::key_combo_list(
+                        ui,
+                        &[&["⌘", "S"], &["⌘", "X"], &["Esc"]],
+                        Some("save · discard · discard"),
+                        colors,
+                    );
+                });
+            });
+        } else {
+            // Save modal
+            let available = ui.available_rect_before_wrap();
+
+            // Dim background
+            ui.painter().rect_filled(available, 0.0, egui::Color32::from_black_alpha(200));
+
+            let modal_w = (available.width() * 0.6).min(480.0).max(300.0);
+            let esc_pressed = ui.input_mut(|i| {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
+            });
+            if esc_pressed {
+                self.mode = Mode::Editing;
+                return;
+            }
+
+            let te_id = egui::Id::new("scratchpad_filename");
+            if !self.save_focus_requested {
+                ui.ctx().memory_mut(|m| m.request_focus(te_id));
+                self.save_focus_requested = true;
+            }
+
+            egui::Area::new(egui::Id::new("scratchpad_save_modal"))
+                .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+                .order(egui::Order::Foreground)
+                .show(ui.ctx(), |ui| {
+                    egui::Frame::new()
+                        .fill(colors.bg_sidebar)
+                        .stroke(egui::Stroke::new(1.0, colors.border))
+                        .corner_radius(style::RADIUS_MD)
+                        .inner_margin(egui::Margin::symmetric(24, 20))
+                        .show(ui, |ui| {
+                            ui.set_width(modal_w);
+
+                            ui.label(
+                                egui::RichText::new("Save as")
+                                    .color(colors.text_dim)
+                                    .size(style::TEXT_HINT)
+                                    .family(egui::FontFamily::Monospace),
+                            );
+                            ui.add_space(style::SPACE_SM);
+
+                            let enter_pressed = ui.input_mut(|i| {
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+                            });
+
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.filename)
+                                    .id(te_id)
+                                    .font(egui::FontId::monospace(style::TEXT_BODY))
+                                    .text_color(colors.text_primary)
+                                    .desired_width(f32::INFINITY),
+                            );
+
+                            if enter_pressed && !self.filename.trim().is_empty() {
+                                log::info!("scratchpad: saving as '{}'", self.filename);
+                                self.save_file();
+                                return;
+                            }
+
+                            ui.add_space(style::SPACE_SM);
+                            crate::widgets::key_combo_list(
+                                ui,
+                                &[&["Enter"], &["Esc"]],
+                                Some("save · go back"),
+                                colors,
+                            );
+                        });
+                });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scratchpad_initial_state() {
+        let app = ScratchpadApp::new(std::path::PathBuf::from("/tmp/test_workspace"));
+        assert!(!app.wants_close(), "new scratchpad should not want close");
+        assert_eq!(app.type_id(), "scratchpad");
+        assert!(app.keyboard_capture(), "scratchpad must capture keyboard");
+        assert!(app.text.is_empty(), "text starts empty");
+        assert_eq!(app.mode, Mode::Editing);
+    }
+
+    #[test]
+    fn scratchpad_display_name() {
+        let app = ScratchpadApp::new(std::path::PathBuf::from("/tmp"));
+        assert_eq!(app.display_name(), "Scratchpad");
+    }
+
+    #[test]
+    fn scratchpad_pending_commands_empty_initially() {
+        let mut app = ScratchpadApp::new(std::path::PathBuf::from("/tmp"));
+        let cmds = app.take_pending_commands();
+        assert!(cmds.is_empty());
+    }
+}

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -38,20 +38,24 @@ impl ScratchpadApp {
         }
     }
 
-    fn save_file(&mut self) {
+    fn save_file(&mut self) -> bool {
         let notes_dir = self.workspace_root.join(".plexi").join("notes");
         if let Err(e) = std::fs::create_dir_all(&notes_dir) {
             log::error!("scratchpad: failed to create notes dir {:?}: {e}", notes_dir);
-            self.wants_close = true;
-            return;
+            return false;
         }
-        let path = notes_dir.join(&self.filename);
+        let safe_name = std::path::Path::new(&self.filename)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "note.md".to_string());
+        let path = notes_dir.join(&safe_name);
         if let Err(e) = std::fs::write(&path, &self.text) {
             log::error!("scratchpad: failed to write {:?}: {e}", path);
+            false
         } else {
             log::info!("scratchpad: saved to {:?}", path);
+            true
         }
-        self.wants_close = true;
     }
 }
 
@@ -209,7 +213,9 @@ impl App for ScratchpadApp {
 
                             if enter_pressed && !self.filename.trim().is_empty() {
                                 log::info!("scratchpad: saving as '{}'", self.filename);
-                                self.save_file();
+                                if self.save_file() {
+                                    self.wants_close = true;
+                                }
                                 return;
                             }
 


### PR DESCRIPTION
## What

Double-spacebar (two Space keydowns within 250ms) in a terminal pane opens a built-in full-pane overlay scratchpad. No command, no menu — just a blank page instantly.

## Done When

- [x] Double-spacebar in a terminal pane opens the scratchpad instantly
- [x] Typing works with full multiline editing (arrow keys, selection, copy/paste)
- [x] Cmd+S opens save modal with timestamped default filename (`YYYY-MM-DD_HHmmss.md`)
- [x] Renaming the file in the save modal works
- [x] File is written to `.plexi/notes/` on save
- [x] Cmd+X / Esc discards and returns to terminal
- [x] Normal terminal usage (single spaces, pasted text) is unaffected
- [x] `cargo test` passes

## Changes

- `src/scratchpad.rs` (new) — `ScratchpadApp` implementing `App` trait; Editing and SaveModal modes; `keyboard_capture() = true`
- `src/app/mod.rs` — `last_space_press: Option<Instant>` field + double-spacebar detection in `update()` (peeks without consuming Space)
- `src/pane_ops/create.rs` — `open_scratchpad()` with overlay launch + toggle-close
- `src/main.rs` — `mod scratchpad;`

Closes #1213