### PR TITLE
feat(cli): plexi pane capture — read PTY scrollback from any pane (#978)

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -386,6 +386,44 @@ impl TerminalBackend {
         self.child_pid
     }
 
+    /// Read the last `n` lines from the PTY scrollback buffer.
+    ///
+    /// Returns a `Vec<String>` of at most `n` entries, ordered oldest → newest.
+    /// Each string has trailing whitespace stripped. Read-only — does not affect
+    /// PTY state or scrollback position.
+    pub fn capture_lines(&self, n: usize) -> Vec<String> {
+        use alacritty_terminal::index::{Column, Line};
+
+        if n == 0 {
+            return Vec::new();
+        }
+
+        let term = self.term.lock();
+        let grid = term.grid();
+        let screen_lines = grid.screen_lines();
+        let history_size = grid.history_size();
+        let total = screen_lines + history_size;
+        let take = n.min(total);
+        let columns = grid.columns();
+
+        // Line(0)..Line(screen_lines-1) are the visible rows (bottommost = screen_lines-1).
+        // Line(-1)..Line(-(history_size)) are scrollback (most recent = -1).
+        // We want the last `take` lines in order, ending at Line(screen_lines-1).
+        let first = screen_lines as i32 - take as i32;
+        let last = screen_lines as i32 - 1;
+
+        let mut result = Vec::with_capacity(take);
+        for line_idx in first..=last {
+            let row = &grid[Line(line_idx)];
+            let mut s = String::with_capacity(columns);
+            for col_idx in 0..columns {
+                s.push(row[Column(col_idx)].c);
+            }
+            result.push(s.trim_end().to_string());
+        }
+        result
+    }
+
     fn process_link_action(
         &mut self,
         terminal: &Term<EventProxy>,

--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -415,11 +415,12 @@ impl TerminalBackend {
         let mut result = Vec::with_capacity(take);
         for line_idx in first..=last {
             let row = &grid[Line(line_idx)];
-            let mut s = String::with_capacity(columns);
-            for col_idx in 0..columns {
-                s.push(row[Column(col_idx)].c);
-            }
-            result.push(s.trim_end().to_string());
+            let mut s: String = (0..columns)
+                .map(|col_idx| row[Column(col_idx)].c)
+                .collect();
+            let trimmed_len = s.trim_end().len();
+            s.truncate(trimmed_len);
+            result.push(s);
         }
         result
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1277,6 +1277,29 @@ impl PlexiApp {
                         }
                     }
                 }
+                crate::app_protocol::HostCommand::CapturePane { pane_id, lines, response_file } => {
+                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} response_file={:?}", response_file);
+                    let result = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
+                        None => {
+                            log::warn!("pane_ipc: capture_pane: pane_id={pane_id} not found");
+                            Err(format!("pane {pane_id} not found"))
+                        }
+                        Some(pane) => match pane.as_terminal() {
+                            None => {
+                                log::warn!("pane_ipc: capture_pane: pane_id={pane_id} is not a terminal pane");
+                                Err(format!("pane {pane_id} is not a terminal pane"))
+                            }
+                            Some(term) => Ok(term.backend.capture_lines(*lines)),
+                        },
+                    };
+                    let json_str = match result {
+                        Ok(captured) => serde_json::to_string(&captured).unwrap_or_else(|_| "[]".to_string()),
+                        Err(msg) => format!("{{\"error\":{}}}", serde_json::to_string(&msg).unwrap_or_else(|_| format!("\"{msg}\""))),
+                    };
+                    if let Err(e) = std::fs::write(response_file, &json_str) {
+                        log::error!("pane_ipc: capture_pane: could not write response file {response_file:?}: {e}");
+                    }
+                }
                 crate::app_protocol::HostCommand::Notify {
                     level, title, body, kind, options, input_prompt,
                     required, priority, image_inline, image_pipe_id,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1294,7 +1294,7 @@ impl PlexiApp {
                     };
                     let json_str = match result {
                         Ok(captured) => serde_json::to_string(&captured).unwrap_or_else(|_| "[]".to_string()),
-                        Err(msg) => format!("{{\"error\":{}}}", serde_json::to_string(&msg).unwrap_or_else(|_| format!("\"{msg}\""))),
+                        Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
                     if let Err(e) = std::fs::write(response_file, &json_str) {
                         log::error!("pane_ipc: capture_pane: could not write response file {response_file:?}: {e}");

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1048,6 +1048,15 @@ pub enum HostCommand {
         response_file: Option<String>,
     },
 
+    /// Read the last N lines from a terminal pane's PTY scrollback buffer.
+    /// Sent by `plexi pane capture`. Host writes a JSON array of strings to `response_file`.
+    CapturePane {
+        pane_id: u64,
+        /// Number of lines to capture from the end of the scrollback.
+        lines: usize,
+        response_file: String,
+    },
+
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
     CreateContext {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2748,6 +2757,29 @@ mod tests {
         assert!(
             serde_json::from_str::<DrawCommand>(bad).is_err(),
             "must fail without required key field"
+        );
+    }
+
+    #[test]
+    fn capture_pane_command_round_trips_serde() {
+        let json = r#"{"type":"capture_pane","pane_id":7,"lines":20,"response_file":"capture.json"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::CapturePane { pane_id, lines, response_file }) => {
+                assert_eq!(*pane_id, 7);
+                assert_eq!(*lines, 20);
+                assert_eq!(response_file, "capture.json");
+            }
+            other => panic!("expected CapturePane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"capture_pane""#), "wire tag missing: {serialised}");
+
+        // Missing required fields must fail
+        let bad = r#"{"type":"capture_pane","pane_id":1}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without lines and response_file"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2333,6 +2333,77 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
     }
 }
 
+/// `plexi pane capture [--lines N] [pane_id]`
+///
+/// Reads the last N lines from a pane's PTY scrollback buffer and prints a JSON array
+/// of strings to stdout. If `pane_id` is omitted, defaults to PLEXI_PANE_ID.
+/// Returns 0 on success, 1 on error.
+pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize) -> i32 {
+    let resolved_pane_id = match pane_id {
+        Some(id) => id,
+        None => match std::env::var("PLEXI_PANE_ID") {
+            Ok(v) => match v.parse::<u64>() {
+                Ok(id) => id,
+                Err(_) => {
+                    eprintln!("error: PLEXI_PANE_ID is not a valid number: {v}");
+                    return 1;
+                }
+            },
+            Err(_) => {
+                eprintln!("error: pane_id not provided and PLEXI_PANE_ID is not set — run inside a Plexi pane or pass a pane ID");
+                return 1;
+            }
+        },
+    };
+
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-capture-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} response_file={response_file:?}");
+
+    let code = send_to_socket(serde_json::json!({
+        "type": "capture_pane",
+        "pane_id": resolved_pane_id,
+        "lines": lines,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                            eprintln!("error: {err}");
+                            return 1;
+                        }
+                    }
+                    return print_json_output(&content);
+                }
+                Err(e) => {
+                    log::warn!("pane_capture:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane capture response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a
@@ -3575,7 +3646,7 @@ _plexi() {
           ;;
         pane)
           local subcmds
-          subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)' 'key:Inject a synthetic key event into a pane')
+          subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)' 'list:List all open panes as JSON' 'focus:Move focus to a pane' 'close:Close a pane' 'send:Send text to a pane PTY' 'info:Print current pane info as JSON' 'capture:Read PTY scrollback and print as JSON array' 'key:Inject a synthetic key event into a pane')
           _describe 'subcommand' subcmds
           ;;
         terminal)
@@ -3664,7 +3735,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "export" -- "$cur"))
       ;;
     pane)
-      COMPREPLY=($(compgen -W "name set-title key" -- "$cur"))
+      COMPREPLY=($(compgen -W "name set-title list focus close send info capture key" -- "$cur"))
       ;;
     terminal)
       if [[ $prev == "--layout" ]]; then
@@ -3759,6 +3830,12 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pack" -a export -d "Export 
 # pane subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a name -d "Set the name of a pane (current or by ID)"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a set-title -d "Set the name of a pane (deprecated: use name)"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a list -d "List all open panes as JSON"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a focus -d "Move focus to a pane by ID"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a close -d "Close a pane"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a send -d "Send text to a pane PTY"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a info -d "Print current pane info as JSON"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a capture -d "Read PTY scrollback and print as JSON array"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a synthetic key event into a pane"
 
 # descriptor subcommands

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -327,6 +327,18 @@ pub enum PaneCmd {
     },
     /// Print JSON info for the current pane [requires PLEXI_PANE_ID]
     Info,
+    /// Read the last N lines from a pane's PTY scrollback and print as a JSON array [requires PLEXI_SOCKET]
+    ///
+    /// Defaults to the current pane (PLEXI_PANE_ID) when <pane_id> is omitted.
+    ///
+    /// Example: plexi pane capture --lines 50 42
+    Capture {
+        /// Pane ID to capture. Defaults to PLEXI_PANE_ID.
+        pane_id: Option<u64>,
+        /// Number of lines to read from the end of the scrollback
+        #[arg(long, default_value = "50")]
+        lines: usize,
+    },
     /// Deliver a synthetic key event to a pane [requires PLEXI_SOCKET — run inside a Plexi pane]
     ///
     /// For terminal panes, injects as PTY keystroke.

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,6 +374,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
+                        PaneCmd::Capture { pane_id, lines } => std::process::exit(cli::pane_capture_cli(pane_id, lines)),
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1677,6 +1677,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            HostCommand::CapturePane { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: CapturePane pane_id={pane_id} received in app routing — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `plexi pane capture [--lines N] [pane_id]` — reads last N lines from a terminal pane's PTY scrollback, prints as JSON array of strings
- Defaults to `PLEXI_PANE_ID` when `pane_id` is omitted, enabling self-capture from a running pane
- Read-only: does not affect PTY state, scroll position, or alter the buffer

## Implementation

- `TerminalBackend::capture_lines(n)` in `deps/egui_term/src/backend/mod.rs` — locks the alacritty `Grid`, walks the last `n` rows across history + visible, trims trailing whitespace
- `HostCommand::CapturePane { pane_id, lines, response_file }` in `src/app_protocol.rs` (serde tag: `capture_pane`)
- IPC handler in `src/app/mod.rs` — finds pane by ID, reads scrollback, writes JSON array to response file
- `pane_capture_cli` in `src/cli.rs` — follows same response-file polling pattern as `pane_send`/`pane_list`
- `ProcessApp::routing.rs` — PGAP path warns and ignores (socket-only command)
- Completions updated for zsh, bash, fish (`capture` added + other missing pane subcommands)

## Test plan

- [ ] `cargo test --bin plexi capture_pane_command_round_trips_serde` — PASS
- [ ] `plexi pane capture` with no args from a terminal pane returns JSON array of last 50 lines
- [ ] `plexi pane capture --lines 20 <pane_id>` from another pane returns exactly 20 strings
- [ ] `plexi pane capture --lines 0 <id>` returns `[]`
- [ ] Non-terminal pane ID returns `{"error":"pane X is not a terminal pane"}`
- [ ] Missing pane ID (outside Plexi, no PLEXI_PANE_ID) prints error and exits 1