### PR TITLE
fix(scratchpad): leading space on open, Cmd+X broken, save path fallback (#1231)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2412,9 +2412,10 @@ impl eframe::App for PlexiApp {
                     if now.duration_since(last) < std::time::Duration::from_millis(250) {
                         log::info!("scratchpad: double-spacebar detected — opening");
                         self.last_space_press = None;
-                        // Consume the triggering Space so it doesn't reach the terminal.
+                        // Consume ALL pending Space keydown events so none leak into
+                        // the TextEdit on its first frame.
                         ctx.input_mut(|i| {
-                            if let Some(pos) = i.events.iter().position(|e| matches!(
+                            i.events.retain(|e| !matches!(
                                 e,
                                 egui::Event::Key {
                                     key: egui::Key::Space,
@@ -2422,9 +2423,7 @@ impl eframe::App for PlexiApp {
                                     repeat: false,
                                     ..
                                 }
-                            )) {
-                                i.events.remove(pos);
-                            }
+                            ));
                         });
                         self.open_scratchpad();
                     } else {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -701,7 +701,7 @@ impl PlexiApp {
         };
 
         let workspace_root = crate::config::active_workspace_root()
-            .unwrap_or_else(|| cwd.clone());
+            .unwrap_or_else(|| crate::config::config_dir());
 
         log::info!(
             "scratchpad: opening — cwd={} workspace_root={}",

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -84,15 +84,7 @@ impl App for ScratchpadApp {
         std::mem::take(&mut self.pending_cmds)
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> bool {
-        if self.mode == Mode::Editing
-            && input.modifiers.command
-            && input.key_pressed(egui::Key::X)
-        {
-            log::info!("scratchpad: Cmd+X — discarding (handle_key)");
-            self.wants_close = true;
-            return true;
-        }
+    fn handle_key(&mut self, _input: &egui::InputState) -> bool {
         false
     }
 
@@ -160,8 +152,8 @@ impl App for ScratchpadApp {
                     ui.add_space(style::SPACE_SM);
                     crate::widgets::key_combo_list(
                         ui,
-                        &[&["⌘", "S"], &["⌘", "X"], &["Esc"]],
-                        Some("save · discard · discard"),
+                        &[&["⌘", "S"], &["Esc"]],
+                        Some("save · discard"),
                         colors,
                     );
                 });

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -38,8 +38,12 @@ impl ScratchpadApp {
         }
     }
 
+    fn notes_dir(&self) -> PathBuf {
+        self.workspace_root.join(".plexi").join("notes")
+    }
+
     fn save_file(&mut self) -> bool {
-        let notes_dir = self.workspace_root.join(".plexi").join("notes");
+        let notes_dir = self.notes_dir();
         if let Err(e) = std::fs::create_dir_all(&notes_dir) {
             log::error!("scratchpad: failed to create notes dir {:?}: {e}", notes_dir);
             return false;
@@ -80,7 +84,15 @@ impl App for ScratchpadApp {
         std::mem::take(&mut self.pending_cmds)
     }
 
-    fn handle_key(&mut self, _input: &egui::InputState) -> bool {
+    fn handle_key(&mut self, input: &egui::InputState) -> bool {
+        if self.mode == Mode::Editing
+            && input.modifiers.command
+            && input.key_pressed(egui::Key::X)
+        {
+            log::info!("scratchpad: Cmd+X — discarding (handle_key)");
+            self.wants_close = true;
+            return true;
+        }
         false
     }
 
@@ -90,9 +102,6 @@ impl App for ScratchpadApp {
         if self.mode == Mode::Editing {
             let save_pressed = ui.input_mut(|i| {
                 i.consume_key(egui::Modifiers::COMMAND, egui::Key::S)
-            });
-            let discard_pressed = ui.input_mut(|i| {
-                i.consume_key(egui::Modifiers::COMMAND, egui::Key::X)
             });
             let esc_pressed = ui.input_mut(|i| {
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
@@ -104,8 +113,8 @@ impl App for ScratchpadApp {
                 log::info!("scratchpad: Cmd+S — opening save modal");
                 return;
             }
-            if discard_pressed || esc_pressed {
-                log::info!("scratchpad: discarding");
+            if esc_pressed {
+                log::info!("scratchpad: Esc — discarding");
                 self.wants_close = true;
                 return;
             }
@@ -209,6 +218,14 @@ impl App for ScratchpadApp {
                                     .font(egui::FontId::monospace(style::TEXT_BODY))
                                     .text_color(colors.text_primary)
                                     .desired_width(f32::INFINITY),
+                            );
+
+                            let dir_display = self.notes_dir().display().to_string();
+                            ui.label(
+                                egui::RichText::new(dir_display)
+                                    .color(colors.text_dim)
+                                    .size(style::TEXT_HINT)
+                                    .family(egui::FontFamily::Monospace),
                             );
 
                             if enter_pressed && !self.filename.trim().is_empty() {


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during PR #1230 testing (double-spacebar scratchpad):

- **Leading space on open:** retain-filter ALL Space keydown events from the event queue on double-spacebar trigger, not just the second one — prevents the first Space from leaking into the TextEdit on its first frame
- **Cmd+X does nothing:** moved discard handling from `ui()` to `handle_key()` so it fires before egui's TextEdit intercepts `Cmd+X` as macOS "cut"
- **Save path falls back to wrong dir:** fall back to `config_dir()` (channel-isolated profile dir) instead of CWD when no workspace is active; also shows the resolved save directory as a hint in the save modal

## Test plan

- [ ] Double-spacebar opens scratchpad with empty text (no leading space)
- [ ] Cmd+X closes scratchpad without saving
- [ ] With no workspace, notes save to `<config_dir>/notes/` (channel-isolated)
- [ ] With workspace, notes save to `<workspace_root>/.plexi/notes/`
- [ ] Save modal shows resolved directory path hint below filename field

Closes #1231