### PR TITLE
feat(config): hot-reload config.toml on save without restart (#1115)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -292,6 +292,10 @@ pub struct PlexiApp {
     /// existing `AppPane` envelope.
     pub(crate) hot_reload: crate::hot_reload::HotReloadWatcher,
     pub(crate) hot_reload_rx: std::sync::mpsc::Receiver<crate::hot_reload::ReloadRequest>,
+    /// Config file watcher (#1115). Watches `config.toml` for saves and fires
+    /// a signal so `reload_config()` runs automatically.
+    pub(crate) _config_watcher: Option<crate::config_watcher::ConfigWatcher>,
+    pub(crate) config_reload_rx: Option<std::sync::mpsc::Receiver<()>>,
     /// Watched panes scheduled for crash-restart. Value is the earliest `Instant` at
     /// which the restart fires — giving the developer ~2s to read the crash overlay.
     pub(crate) pending_crash_restarts: HashMap<PaneId, std::time::Instant>,
@@ -405,6 +409,14 @@ impl PlexiApp {
         // names — kept on stack until consumed by `Self {..}`.
         let (hr_watcher, hr_rx) = crate::hot_reload::HotReloadWatcher::new();
         let (hr_watcher2, hr_rx2) = crate::hot_reload::HotReloadWatcher::new();
+
+        // Config file watcher (#1115). Watches config.toml for saves so the
+        // host can hot-reload theme/font/notification settings automatically.
+        let (mut cfg_watcher, mut cfg_reload_rx) =
+            match crate::config_watcher::start(crate::config::config_path()) {
+                Some((w, rx)) => (Some(w), Some(rx)),
+                None => (None, None),
+            };
 
         // Resolve the active workspace (explicit `plexi <path>` arg, then
         // CWD-walk fallback) and overlay its `.plexi/config.toml` on top of
@@ -681,6 +693,8 @@ impl PlexiApp {
                     directed_pipes: HashMap::new(),
                     hot_reload: hr_watcher,
                     hot_reload_rx: hr_rx,
+                    _config_watcher: cfg_watcher.take(),
+                    config_reload_rx: cfg_reload_rx.take(),
                     pending_crash_restarts: HashMap::new(),
                     minimap: crate::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
@@ -787,6 +801,8 @@ impl PlexiApp {
             directed_pipes: HashMap::new(),
             hot_reload: hr_watcher2,
             hot_reload_rx: hr_rx2,
+            _config_watcher: cfg_watcher.take(),
+            config_reload_rx: cfg_reload_rx.take(),
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -905,6 +921,8 @@ impl PlexiApp {
             directed_pipes: HashMap::new(),
             hot_reload: hr_watcher,
             hot_reload_rx: hr_rx,
+            _config_watcher: None,
+            config_reload_rx: None,
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -2745,6 +2763,21 @@ impl eframe::App for PlexiApp {
         // "Reload Configuration" in the app menu.
         crate::macos_menu::apply_version_title_once();
         if crate::macos_menu::take_reload_config_flag() {
+            self.reload_config();
+        }
+
+        // Config hot-reload (#1115): drain filesystem watcher signals.
+        let config_changed = self
+            .config_reload_rx
+            .as_ref()
+            .map_or(false, |rx| {
+                let hit = rx.try_recv().is_ok();
+                if hit {
+                    while rx.try_recv().is_ok() {}
+                }
+                hit
+            });
+        if config_changed {
             self.reload_config();
         }
 

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -1,0 +1,209 @@
+//! Watches `config.toml` for filesystem changes and emits debounced reload
+//! signals so the host can call `reload_config()` without a manual shortcut.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const DEBOUNCE_MS: u64 = 200;
+
+pub struct ConfigWatcher {
+    _watcher: RecommendedWatcher,
+    cancel: Arc<Mutex<bool>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for ConfigWatcher {
+    fn drop(&mut self) {
+        if let Ok(mut c) = self.cancel.lock() {
+            *c = true;
+        }
+        if let Some(h) = self.thread.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Start watching `config_path` for changes. Returns a receiver that yields
+/// `()` on each debounced config change, plus the watcher handle (must be kept
+/// alive). Returns `None` if the watcher could not be created.
+pub fn start(config_path: PathBuf) -> Option<(ConfigWatcher, Receiver<()>)> {
+    let watch_dir = config_path.parent()?.to_path_buf();
+    let target_name = config_path.file_name()?.to_os_string();
+
+    let (reload_tx, reload_rx) = mpsc::channel::<()>();
+    let (raw_tx, raw_rx) = mpsc::channel::<()>();
+
+    let filter_name = target_name.clone();
+    let mut watcher = match notify::recommended_watcher(move |res: notify::Result<Event>| {
+        match res {
+            Ok(ev) => {
+                if matches!(
+                    ev.kind,
+                    EventKind::Modify(_) | EventKind::Create(_)
+                ) {
+                    let dominated = ev
+                        .paths
+                        .iter()
+                        .any(|p| p.file_name() == Some(&filter_name));
+                    if dominated {
+                        let _ = raw_tx.send(());
+                    }
+                }
+            }
+            Err(e) => log::warn!("config_watcher: watcher error: {e}"),
+        }
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            log::warn!("config_watcher: failed to create watcher: {e}");
+            return None;
+        }
+    };
+
+    if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        log::warn!("config_watcher: failed to watch {watch_dir:?}: {e}");
+        return None;
+    }
+
+    log::info!("config_watcher: watching {config_path:?}");
+
+    let cancel = Arc::new(Mutex::new(false));
+    let cancel_thread = Arc::clone(&cancel);
+
+    let thread = thread::spawn(move || {
+        debounce_loop(raw_rx, reload_tx, cancel_thread);
+    });
+
+    Some((
+        ConfigWatcher {
+            _watcher: watcher,
+            cancel,
+            thread: Some(thread),
+        },
+        reload_rx,
+    ))
+}
+
+fn debounce_loop(
+    rx: Receiver<()>,
+    sender: Sender<()>,
+    cancel: Arc<Mutex<bool>>,
+) {
+    let mut last_event: Option<Instant> = None;
+    let debounce = Duration::from_millis(DEBOUNCE_MS);
+    let poll = Duration::from_millis(50);
+
+    loop {
+        if cancel.lock().map(|g| *g).unwrap_or(true) {
+            return;
+        }
+
+        match rx.try_recv() {
+            Ok(()) => {
+                last_event = Some(Instant::now());
+            }
+            Err(TryRecvError::Disconnected) => return,
+            Err(TryRecvError::Empty) => {
+                if let Some(t) = last_event {
+                    if t.elapsed() >= debounce {
+                        log::info!("config_watcher: config.toml changed, reloading");
+                        if sender.send(()).is_err() {
+                            return;
+                        }
+                        last_event = None;
+                    }
+                }
+                thread::sleep(poll);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn poll_for_signal(rx: &Receiver<()>, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if rx.try_recv().is_ok() {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        false
+    }
+
+    #[test]
+    fn fires_on_config_change() {
+        let dir = tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        fs::write(&config, "# v1\n").unwrap();
+
+        let (watcher, rx) = start(config.clone()).expect("watcher should start");
+        thread::sleep(Duration::from_millis(150));
+
+        fs::write(&config, "# v2\n").unwrap();
+        assert!(
+            poll_for_signal(&rx, Duration::from_secs(3)),
+            "should fire after config change"
+        );
+        drop(watcher);
+    }
+
+    #[test]
+    fn ignores_unrelated_files() {
+        let dir = tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        fs::write(&config, "# v1\n").unwrap();
+
+        let (watcher, rx) = start(config).expect("watcher should start");
+        // Drain any initial FSEvents from the config.toml creation above.
+        thread::sleep(Duration::from_millis(500));
+        while rx.try_recv().is_ok() {}
+
+        fs::write(dir.path().join("other.txt"), "noise\n").unwrap();
+        assert!(
+            !poll_for_signal(&rx, Duration::from_millis(800)),
+            "should not fire for unrelated file"
+        );
+        drop(watcher);
+    }
+
+    #[test]
+    fn debounces_burst() {
+        let dir = tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        fs::write(&config, "# v0\n").unwrap();
+
+        let (_watcher, rx) = start(config.clone()).expect("watcher should start");
+        thread::sleep(Duration::from_millis(150));
+
+        for i in 0..5 {
+            fs::write(&config, format!("# v{i}\n")).unwrap();
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(poll_for_signal(&rx, Duration::from_secs(3)));
+
+        let mut extras = 0;
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            if rx.try_recv().is_ok() {
+                extras += 1;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            extras <= 1,
+            "burst of 5 writes should debounce to 1-2 signals, got {} extras",
+            extras
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod cli_registry;
 mod cli_setup;
 mod command_palette;
 mod config;
+mod config_watcher;
 mod context;
 mod event_log;
 mod features;


### PR DESCRIPTION
## Summary

- Adds filesystem watcher on `~/.plexi-<channel>/config.toml` using the `notify` crate (already a dependency)
- 200ms debounce window prevents double-fires on save
- On change: calls existing `reload_config()` — theme, font size, notifications, feature flags, and keybindings apply immediately
- Parse errors are handled by `reload_config()` (logs warning, keeps current config)
- `log::info!` confirms each reload: `config_watcher: config.toml changed, reloading`

## Implementation

New `config_watcher` module — standalone watcher with debounce thread, matching the pattern in `hot_reload.rs`. Watches the config directory non-recursively and filters events by filename to avoid false triggers from other files in the profile dir.

Wired into `PlexiApp` via two fields: `_config_watcher` (owns the watcher handle lifetime) and `config_reload_rx` (drained each frame in the update loop). Test constructor uses `None` — no filesystem watcher in headless tests.

## Test plan

- [ ] Launch PR build, open `config.toml`, change the theme, save → theme applies immediately without restart
- [ ] Change font size in config, save → font size updates live
- [ ] Introduce a TOML syntax error, save → host continues running with previous config, warning in log
- [ ] Verify `config_watcher: watching` and `config_watcher: config.toml changed, reloading` appear in log

Closes #1115