### PR TITLE
feat(sdk): self-documenting SDK — typed surface + auto-generated docs website (#1248)

### DIFF
--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -237,24 +237,32 @@ class App:
              timeout_ms: "int | None" = None) -> Any:
         """Decorator — register a method as an AI-callable tool and expose it.
 
-        Usage::
+        Tools are functions that AI agents can invoke by name. Each tool has a description
+        and a JSON schema defining its parameters.
+
+        Args:
+            name: Tool identifier; used by agents to invoke this tool
+            description: Human-readable description of what the tool does
+            schema: JSON schema object for tool parameters (type: "object" with properties)
+            timeout_ms: Optional timeout in milliseconds; None = no timeout
+
+        Returns:
+            A decorator function that registers the method as a tool.
+
+        Example::
 
             @app.tool("increment", description="Increment counter", schema={
                 "type": "object",
-                "properties": {"n": {"type": "integer"}},
+                "properties": {"n": {"type": "integer", "description": "Amount to increment"}},
+                "required": ["n"],
             })
-            def handle_increment(self_or_args, args=None):
-                ...
+            async def handle_increment(self, args):
+                n = args.get("n", 0)
+                self.counter += n
+                return {"new_value": self.counter}
 
-        The decorated method is called with ``(args_dict)`` where
-        ``args_dict`` is the parsed JSON arguments from the LLM. The method
-        may be a plain function or a bound method; the decorator normalises
-        the call convention.
-
-        Returns are JSON-serialised and sent as ``DrawCommand::ToolResult``.
-        Exceptions are caught and sent as the ``error`` field.
-
-        ``expose_tools`` is called automatically when the decorator runs.
+        The decorated method receives a dict of parsed arguments and can return any JSON-serializable
+        value or raise an exception (which becomes the tool's error response).
         """
         def decorator(fn: Any) -> Any:
             self._tool_handlers[name] = fn
@@ -389,7 +397,14 @@ class App:
         )
 
     def run(self) -> None:
-        """Start the PGAP v3 asyncio event loop. Blocks until Shutdown."""
+        """Start the PGAP v3 asyncio event loop. Blocks until Shutdown.
+
+        This is the entry point for all Plexi apps. Call it from your main block:
+
+            if __name__ == '__main__':
+                app = MyApp()
+                app.run()
+        """
         sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
         asyncio.run(self._async_main())
 

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -478,10 +478,8 @@ class Emitter:
         return its `terminal_pane_id` (an integer). Awaits until the host
         emits `LinkedTerminalReady`.
 
-        Returns 0 if the host denied the request — this happens when the
-        manifest doesn't declare `terminal.bindings`. Apps should treat 0
-        as a hard error (no terminal to drive). Raises `CapabilityDeniedError`
-        in that case so the failure is loud.
+        Raises `CapabilityDeniedError` if the manifest doesn't declare
+        `terminal.bindings`.
 
         Await this from async hooks. From background threads use
         ``self.emit.run_sync(self.emit.request_linked_terminal(...))``.
@@ -1096,8 +1094,8 @@ class Emitter:
         source: absolute path to audio file (mp3, wav, ogg, etc.)
         volume: playback volume 0.0–1.0 (default 1.0)
 
-        Fire-and-forget — no response event. Stop playback by calling
-        audio_play(source, state="stopped") or closing the pane.
+        Fire-and-forget — no response event. Playback stops when the pane
+        closes; there is no explicit stop API yet.
         """
         _emit({
             "type": "audio_play",

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -71,11 +71,28 @@ class RenderContext:
 
     def rect(self, x: float, y: float, w: float, h: float, fill: str,
              radius: float = 0.0) -> None:
+        """Draw a filled rectangle.
+
+        Args:
+            x: Left edge in logical pixels
+            y: Top edge in logical pixels
+            w: Width in logical pixels
+            h: Height in logical pixels
+            fill: Fill color as hex string (e.g., "#ff0000" or "#ff0000aa" with alpha)
+            radius: Corner radius in pixels (0.0 = sharp corners, default)
+        """
         self._queue({"type": "rect", "x": x, "y": y, "w": w, "h": h,
                      "fill": fill, "radius": radius})
 
     def circle(self, cx: float, cy: float, r: float, fill: str) -> None:
-        """Draw a filled circle. Alpha supported via 8-digit hex (#rrggbbaa) or dim()."""
+        """Draw a filled circle.
+
+        Args:
+            cx: Center X in logical pixels
+            cy: Center Y in logical pixels
+            r: Radius in logical pixels
+            fill: Fill color as hex string; supports 8-digit hex (#rrggbbaa) for alpha
+        """
         self._queue({"type": "circle", "cx": cx, "cy": cy, "r": r, "fill": fill})
 
     def arc(self, cx: float, cy: float, r: float,
@@ -343,6 +360,16 @@ class RenderContext:
 
     def line(self, x1: float, y1: float, x2: float, y2: float,
              color: str, width: float = 1.0) -> None:
+        """Draw a line segment.
+
+        Args:
+            x1: Start X in logical pixels
+            y1: Start Y in logical pixels
+            x2: End X in logical pixels
+            y2: End Y in logical pixels
+            color: Line color as hex string
+            width: Line width in logical pixels (default: 1.0)
+        """
         self._queue({"type": "line", "x1": x1, "y1": y1, "x2": x2, "y2": y2,
                      "color": color, "width": width})
 
@@ -367,6 +394,17 @@ class RenderContext:
     def list_view(self, items: "list[dict]", selected: int = 0,
              item_height: float = 40.0, x: float = 0.0, y: float = 0.0,
              w: "float | None" = None, h: "float | None" = None) -> None:
+        """Draw a scrollable list of items with optional selection highlight.
+
+        Args:
+            items: List of item dicts, each with keys "text" (required) and optional "disabled"
+            selected: Index of the highlighted item (0-indexed)
+            item_height: Height of each item in logical pixels
+            x: Left edge of the list
+            y: Top edge of the list
+            w: Width of the list (defaults to full pane width)
+            h: Height of the list (defaults to remaining pane height below y)
+        """
         self._queue({"type": "list", "x": x, "y": y,
                      "w": self.w if w is None else w,
                      "h": self.h - y if h is None else h,
@@ -682,6 +720,11 @@ class RenderContext:
         })
 
     def frame_done(self) -> None:
+        """Flush all buffered draw commands for this frame.
+
+        Called automatically after on_render returns. Only call this manually
+        if you're rendering in multiple phases and need intermediate updates.
+        """
         self._buf.append(json.dumps({"type": "frame_done", "frame_id": self.frame_id}) + "\n")
         with _LOCK:
             sys.stdout.write("".join(self._buf))

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -8,10 +8,13 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY website/package.json website/package-lock.json ./
 RUN npm ci
 
-COPY . .
+COPY sdk/python/plexi_sdk /sdk/plexi_sdk
+COPY website/ .
+
+ENV SDK_SOURCE=/sdk/plexi_sdk
 RUN npm run build
 
 # Drop dev deps for a lean runtime copy. Native binaries are already compiled.

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "python3 scripts/generate-sdk-docs.py && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "og": "node scripts/generate-og.mjs"

--- a/website/railway.json
+++ b/website/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "dockerfilePath": "website/Dockerfile"
   },
   "deploy": {
     "startCommand": "node ./dist/server/entry.mjs",

--- a/website/scripts/generate-sdk-docs.py
+++ b/website/scripts/generate-sdk-docs.py
@@ -101,13 +101,24 @@ class DocExtractor:
         return f"{prefix} {node.name}({', '.join(parts)}){ret}"
 
 
+def _clean_docstring(doc: str) -> str:
+    """Convert rST artifacts to markdown-friendly equivalents."""
+    lines = doc.split("\n")
+    cleaned = []
+    for line in lines:
+        if line.rstrip().endswith("::"):
+            line = line.rstrip()[:-1]
+        cleaned.append(line)
+    return "\n".join(cleaned)
+
+
 def fmt_methods(methods: list[dict]) -> str:
     out = ""
     for m in methods:
         out += f"### `{m['name']}`\n\n"
         out += f"```python\n{m['signature']}\n```\n\n"
         if m["docstring"]:
-            out += f"{m['docstring']}\n\n"
+            out += f"{_clean_docstring(m['docstring'])}\n\n"
         out += "---\n\n"
     return out
 
@@ -239,7 +250,7 @@ def generate_widgets_docs(sdk_source: Path) -> str:
         for cls in classes:
             sections += f"## {cls['name']}\n\n"
             if cls["docstring"]:
-                sections += f"{cls['docstring']}\n\n"
+                sections += f"{_clean_docstring(cls['docstring'])}\n\n"
             if cls["methods"]:
                 sections += fmt_methods(cls["methods"])
 

--- a/website/scripts/generate-sdk-docs.py
+++ b/website/scripts/generate-sdk-docs.py
@@ -29,7 +29,7 @@ class DocExtractor:
 
     def __init__(self, file_path: Path):
         self.file_path = file_path
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             self.source = f.read()
         self.tree = ast.parse(self.source)
 
@@ -57,6 +57,13 @@ class DocExtractor:
         for node in class_node.body:
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 if node.name.startswith("_"):
+                    continue
+                is_prop = any(
+                    (isinstance(d, ast.Name) and d.id == "property")
+                    or (isinstance(d, ast.Attribute) and d.attr == "setter")
+                    for d in node.decorator_list
+                )
+                if is_prop:
                     continue
                 methods.append(self._extract_method(node))
         return methods
@@ -92,6 +99,17 @@ class DocExtractor:
                 s += f" = {default_str}"
 
             parts.append(s)
+
+        if node.args.vararg:
+            v = f"*{node.args.vararg.arg}"
+            if node.args.vararg.annotation:
+                v += f": {ast.unparse(node.args.vararg.annotation)}"
+            parts.append(v)
+        if node.args.kwarg:
+            kw = f"**{node.args.kwarg.arg}"
+            if node.args.kwarg.annotation:
+                kw += f": {ast.unparse(node.args.kwarg.annotation)}"
+            parts.append(kw)
 
         ret = ""
         if node.returns:

--- a/website/scripts/generate-sdk-docs.py
+++ b/website/scripts/generate-sdk-docs.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Generate Astro-compatible markdown docs from Python SDK source files.
+
+Uses the ast module to extract classes, methods, and docstrings. Generates
+markdown files in website/src/content/docs/ with Astro frontmatter.
+
+Set SDK_SOURCE env var to override SDK path. Defaults to ../../sdk/python/plexi_sdk
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+VERIFIED_VERSION = "3.6.54"
+
+
+def get_sdk_source() -> Path:
+    env_path = os.environ.get("SDK_SOURCE")
+    if env_path:
+        return Path(env_path)
+    script_dir = Path(__file__).parent
+    return script_dir.parent.parent / "sdk" / "python" / "plexi_sdk"
+
+
+class DocExtractor:
+    """Extract docstrings and signatures from Python source."""
+
+    def __init__(self, file_path: Path):
+        self.file_path = file_path
+        with open(file_path) as f:
+            self.source = f.read()
+        self.tree = ast.parse(self.source)
+
+    def get_module_docstring(self) -> Optional[str]:
+        return ast.get_docstring(self.tree)
+
+    def extract_classes(self, include_private: bool = False) -> list[dict]:
+        classes = []
+        for node in self.tree.body:
+            if isinstance(node, ast.ClassDef):
+                if not include_private and node.name.startswith("_"):
+                    continue
+                classes.append(self._extract_class(node))
+        return classes
+
+    def _extract_class(self, node: ast.ClassDef) -> dict:
+        return {
+            "name": node.name,
+            "docstring": ast.get_docstring(node),
+            "methods": self._extract_methods(node),
+        }
+
+    def _extract_methods(self, class_node: ast.ClassDef) -> list[dict]:
+        methods = []
+        for node in class_node.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name.startswith("_"):
+                    continue
+                methods.append(self._extract_method(node))
+        return methods
+
+    def _extract_method(self, node: "ast.FunctionDef | ast.AsyncFunctionDef") -> dict:
+        is_async = isinstance(node, ast.AsyncFunctionDef)
+        sig = self._signature(node)
+        return {
+            "name": node.name,
+            "async": is_async,
+            "signature": sig,
+            "docstring": ast.get_docstring(node),
+        }
+
+    def _signature(self, node: "ast.FunctionDef | ast.AsyncFunctionDef") -> str:
+        """Build method signature preserving type hints alongside defaults."""
+        all_args = node.args.args
+        n_defaults = len(node.args.defaults)
+        n_args = len(all_args)
+
+        parts: list[str] = []
+        for i, arg in enumerate(all_args):
+            if arg.arg == "self":
+                continue
+
+            s = arg.arg
+            if arg.annotation:
+                s += f": {ast.unparse(arg.annotation)}"
+
+            default_idx = i - (n_args - n_defaults)
+            if default_idx >= 0:
+                default_str = ast.unparse(node.args.defaults[default_idx])
+                s += f" = {default_str}"
+
+            parts.append(s)
+
+        ret = ""
+        if node.returns:
+            ret = f" -> {ast.unparse(node.returns)}"
+
+        prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+        return f"{prefix} {node.name}({', '.join(parts)}){ret}"
+
+
+def fmt_methods(methods: list[dict]) -> str:
+    out = ""
+    for m in methods:
+        out += f"### `{m['name']}`\n\n"
+        out += f"```python\n{m['signature']}\n```\n\n"
+        if m["docstring"]:
+            out += f"{m['docstring']}\n\n"
+        out += "---\n\n"
+    return out
+
+
+def generate_sdk_overview(sdk_source: Path) -> str:
+    init_file = sdk_source / "__init__.py"
+    extractor = DocExtractor(init_file)
+    module_doc = extractor.get_module_docstring() or ""
+
+    return f'''---
+title: "SDK Overview"
+description: "Python SDK for building Plexi pane apps"
+verified_version: "{VERIFIED_VERSION}"
+---
+
+{module_doc}
+'''
+
+
+def generate_app_docs(sdk_source: Path) -> str:
+    extractor = DocExtractor(sdk_source / "_app.py")
+    classes = extractor.extract_classes()
+    app_class = next((c for c in classes if c["name"] == "App"), None)
+    if not app_class:
+        return _empty_page("App", "No App class found.")
+
+    docstring = app_class["docstring"] or ""
+
+    return f'''---
+title: "App"
+description: "Base class for Plexi pane apps with lifecycle hooks"
+verified_version: "{VERIFIED_VERSION}"
+---
+
+# App
+
+{docstring}
+
+## Methods
+
+{fmt_methods(app_class["methods"])}'''
+
+
+def generate_render_context_docs(sdk_source: Path) -> str:
+    extractor = DocExtractor(sdk_source / "_render_context.py")
+    classes = extractor.extract_classes()
+    ctx_class = next((c for c in classes if c["name"] == "RenderContext"), None)
+    if not ctx_class:
+        return _empty_page("RenderContext", "No RenderContext class found.")
+
+    docstring = ctx_class["docstring"] or ""
+
+    return f'''---
+title: "RenderContext"
+description: "Drawing API for rendering pane content"
+verified_version: "{VERIFIED_VERSION}"
+---
+
+# RenderContext
+
+{docstring}
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `x` | `float` | Pane origin x (usually 0) |
+| `y` | `float` | Pane origin y (usually 0) |
+| `w` | `float` | Pane width in logical pixels |
+| `h` | `float` | Pane height in logical pixels |
+| `width` | `float` | Alias for `w` |
+| `height` | `float` | Alias for `h` |
+| `frame_id` | `int` | Monotonically increasing render counter |
+| `elapsed` | `float` | Seconds since previous on_render (0.0 on first frame) |
+| `workspace_root` | `str` | Absolute path to the workspace root |
+| `capabilities` | `list[str]` | Granted capability strings |
+| `feature_flags` | `list[str]` | Enabled feature flag strings |
+| `emit` | `Emitter` | Emitter instance for out-of-frame commands |
+
+## Methods
+
+{fmt_methods(ctx_class["methods"])}'''
+
+
+def generate_emitter_docs(sdk_source: Path) -> str:
+    extractor = DocExtractor(sdk_source / "_emitter.py")
+    classes = extractor.extract_classes()
+    emitter_class = next((c for c in classes if c["name"] == "Emitter"), None)
+    if not emitter_class:
+        return _empty_page("Emitter", "No Emitter class found.")
+
+    docstring = emitter_class["docstring"] or ""
+
+    return f'''---
+title: "Emitter"
+description: "Host commands, notifications, HTTP, secrets, and device APIs"
+verified_version: "{VERIFIED_VERSION}"
+---
+
+# Emitter
+
+{docstring}
+
+Available as `self.emit` on App or `ctx.emit` on RenderContext. All methods are thread-safe.
+
+## Methods
+
+{fmt_methods(emitter_class["methods"])}'''
+
+
+def generate_widgets_docs(sdk_source: Path) -> str:
+    widgets_dir = sdk_source / "widgets"
+    widget_files = [
+        ("Button & ButtonStyle", "button.py"),
+        ("KeyMap", "keymap.py"),
+        ("ListView", "list_view.py"),
+        ("ScrollState", "scroll.py"),
+        ("TextArea & TextAreaTheme", "text_area.py"),
+        ("TextBuffer, Cursor & Selection", "text_buffer.py"),
+    ]
+
+    sections = ""
+    for _, filename in widget_files:
+        filepath = widgets_dir / filename
+        if not filepath.exists():
+            continue
+        extractor = DocExtractor(filepath)
+        classes = extractor.extract_classes()
+        for cls in classes:
+            sections += f"## {cls['name']}\n\n"
+            if cls["docstring"]:
+                sections += f"{cls['docstring']}\n\n"
+            if cls["methods"]:
+                sections += fmt_methods(cls["methods"])
+
+    return f'''---
+title: "Widgets"
+description: "Reusable UI components for Plexi apps"
+verified_version: "{VERIFIED_VERSION}"
+---
+
+# Widgets
+
+Import widgets from `plexi_sdk.widgets`:
+
+```python
+from plexi_sdk.widgets import (
+    Button, ButtonStyle,
+    KeyMap,
+    ListView,
+    ScrollState,
+    TextArea, TextAreaTheme,
+    TextBuffer, Cursor, Selection,
+    emit_text_input,
+)
+```
+
+{sections}'''
+
+
+def _empty_page(title: str, msg: str) -> str:
+    return f'''---
+title: "{title}"
+description: ""
+verified_version: "{VERIFIED_VERSION}"
+---
+
+# {title}
+
+{msg}
+'''
+
+
+def main() -> None:
+    sdk_source = get_sdk_source()
+    if not sdk_source.exists():
+        print(f"Error: SDK source not found at {sdk_source}", file=sys.stderr)
+        sys.exit(1)
+
+    docs_dir = Path(__file__).parent.parent / "src" / "content" / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    pages = {
+        "sdk.md": generate_sdk_overview(sdk_source),
+        "sdk-app.md": generate_app_docs(sdk_source),
+        "sdk-render-context.md": generate_render_context_docs(sdk_source),
+        "sdk-emitter.md": generate_emitter_docs(sdk_source),
+        "sdk-widgets.md": generate_widgets_docs(sdk_source),
+    }
+
+    for filename, content in pages.items():
+        path = docs_dir / filename
+        path.write_text(content)
+        print(f"Generated {path}")
+
+    print(f"\nSDK docs generated in {docs_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/src/content/docs/sdk-app.md
+++ b/website/src/content/docs/sdk-app.md
@@ -267,7 +267,7 @@ Args:
 Returns:
     A decorator function that registers the method as a tool.
 
-Example::
+Example:
 
     @app.tool("increment", description="Increment counter", schema={
         "type": "object",

--- a/website/src/content/docs/sdk-app.md
+++ b/website/src/content/docs/sdk-app.md
@@ -1,0 +1,326 @@
+---
+title: "App"
+description: "Base class for Plexi pane apps with lifecycle hooks"
+verified_version: "3.6.54"
+---
+
+# App
+
+Base class for Plexi v3 apps. Subclass and override event handlers.
+
+Override any of:
+    on_init(self, ctx)                            — after Init handshake (awaited)
+    on_render(self, ctx)                          — on each Render event (awaited)
+    on_key(self, ctx, key, mods)                  — on Key event (task)
+    on_click(self, ctx, x, y, button)             — on Click event (task)
+    on_command(self, ctx, text)                   — on Command event (task)
+    on_paste(self, ctx, text)                     — on Paste event (task)
+    on_text_submitted(self, ctx, id, text)        — on TextInput Enter press (task)
+    on_pipe_message(self, ctx, pipe_id, payload)  — on PipeMessage (task)
+    on_path_changed(self, ctx, cwd)               — on PathChanged (task)
+    on_suspend(self)                              — on Suspend (awaited)
+    on_resume(self)                               — on Resume (awaited)
+    on_shutdown(self)                             — on Shutdown (awaited)
+
+Handlers marked (task) are dispatched as asyncio tasks — the event loop
+does not wait for them to complete before processing the next event. Declare
+them ``async def`` whenever they do any I/O. Never call blocking operations
+(time.sleep, requests.get, etc.) directly from these handlers; use
+``await asyncio.to_thread(fn)`` or ``threading.Thread`` + ``emit.run_sync()``.
+
+Handlers marked (awaited) block the event loop until they return. Use
+``await``-able Emitter helpers freely; they do not deadlock because the
+stdin reader runs as a concurrent task.
+
+## Methods
+
+### `on_init`
+
+```python
+def on_init(_ctx: RenderContext) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_render`
+
+```python
+def on_render(_ctx: RenderContext) -> None
+```
+
+---
+
+### `on_key`
+
+```python
+def on_key(_ctx: RenderContext, _key: str, _mods: dict) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_click`
+
+```python
+def on_click(_ctx: RenderContext, _x: float, _y: float, _button: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_mouse_down`
+
+```python
+def on_mouse_down(_ctx: RenderContext, _x: float, _y: float, _button: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_mouse_up`
+
+```python
+def on_mouse_up(_ctx: RenderContext, _x: float, _y: float, _button: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_mouse_move`
+
+```python
+def on_mouse_move(_ctx: RenderContext, _x: float, _y: float, _buttons: list) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_command`
+
+```python
+def on_command(_ctx: RenderContext, _text: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_paste`
+
+```python
+def on_paste(_ctx: RenderContext, _text: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_pipe_message`
+
+```python
+def on_pipe_message(_ctx: RenderContext, _pipe_id: str, _payload: Any) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_path_changed`
+
+```python
+def on_path_changed(_ctx: RenderContext, _cwd: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_inject`
+
+```python
+def on_inject(_ctx: RenderContext, _payload: Any) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_nav_back`
+
+```python
+def on_nav_back(_ctx: RenderContext, _view_id: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+Called when the host emits ``NavBack`` — user pressed Cmd+[ or the
+back arrow in the pane chrome. ``view_id`` is the view being navigated
+*back to* (the new top of stack, or empty string for root).
+
+The app should update its own view state to show ``view_id``, then call
+``ctx.emit.pop_nav()`` to remove the entry from the host stack.
+
+---
+
+### `on_app_spawned`
+
+```python
+def on_app_spawned(_pane_id: int, _type_id: str) -> None
+```
+
+---
+
+### `on_pane_spawned`
+
+```python
+def on_pane_spawned(pane_id: int, request_id: 'str | None' = None) -> None
+```
+
+Called when a SpawnPane request succeeded (#592). Override to track the spawned pane.
+
+---
+
+### `on_pane_spawn_error`
+
+```python
+def on_pane_spawn_error(reason: str, request_id: 'str | None' = None) -> None
+```
+
+Called when a SpawnPane request failed (#592). Override to handle the error.
+
+---
+
+### `on_timer`
+
+```python
+def on_timer(_ctx: RenderContext, _timer_id: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_scroll`
+
+```python
+def on_scroll(_ctx: RenderContext, _id: str, _offset_y: float) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_text_submitted`
+
+```python
+def on_text_submitted(_ctx: RenderContext, _id: str, _text: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+---
+
+### `on_file_picked`
+
+```python
+def on_file_picked(_ctx: RenderContext, _request_id: str, _paths: 'list[str]') -> 'Coroutine[Any, Any, None] | None'
+```
+
+Called when the user selected one or more files in the picker.
+
+``_request_id`` matches the id passed to ``ctx.emit.open_file_picker``.
+``_paths`` is a list of absolute file paths chosen by the user.
+
+---
+
+### `on_file_pick_cancelled`
+
+```python
+def on_file_pick_cancelled(_ctx: RenderContext, _request_id: str) -> 'Coroutine[Any, Any, None] | None'
+```
+
+Called when the user dismissed the file picker without selecting a file,
+or if the ``fs.pick`` capability was not declared.
+
+---
+
+### `on_mcp_call`
+
+```python
+def on_mcp_call(_ctx: RenderContext, _tool_name: str, _arguments: dict) -> 'dict | Coroutine[Any, Any, dict] | None'
+```
+
+Called when an external MCP client calls a tool declared in [app.mcp].
+
+Override to handle the call and return a result dict. The result should
+follow MCP CallToolResult schema: ``{"content": [{"type": "text", "text": "..."}]}``.
+Return ``None`` to respond with a generic 'not implemented' error.
+
+---
+
+### `on_midi_input_opened`
+
+```python
+def on_midi_input_opened(_pipe_id: str, _port_id: str, _port_name: str) -> None
+```
+
+Override to react to a successful OpenMidiInput. Apps that just
+want the byte stream typically read directly from the binary pipe
+opened alongside this event — Plexi sends `pipe_opened` first.
+
+---
+
+### `tool`
+
+```python
+def tool(name: str, description: str, schema: dict, timeout_ms: 'int | None' = None) -> Any
+```
+
+Decorator — register a method as an AI-callable tool and expose it.
+
+Tools are functions that AI agents can invoke by name. Each tool has a description
+and a JSON schema defining its parameters.
+
+Args:
+    name: Tool identifier; used by agents to invoke this tool
+    description: Human-readable description of what the tool does
+    schema: JSON schema object for tool parameters (type: "object" with properties)
+    timeout_ms: Optional timeout in milliseconds; None = no timeout
+
+Returns:
+    A decorator function that registers the method as a tool.
+
+Example::
+
+    @app.tool("increment", description="Increment counter", schema={
+        "type": "object",
+        "properties": {"n": {"type": "integer", "description": "Amount to increment"}},
+        "required": ["n"],
+    })
+    async def handle_increment(self, args):
+        n = args.get("n", 0)
+        self.counter += n
+        return {"new_value": self.counter}
+
+The decorated method receives a dict of parsed arguments and can return any JSON-serializable
+value or raise an exception (which becomes the tool's error response).
+
+---
+
+### `on_suspend`
+
+```python
+def on_suspend() -> None
+```
+
+---
+
+### `on_resume`
+
+```python
+def on_resume() -> None
+```
+
+---
+
+### `on_shutdown`
+
+```python
+def on_shutdown() -> None
+```
+
+---
+
+### `run`
+
+```python
+def run() -> None
+```
+
+Start the PGAP v3 asyncio event loop. Blocks until Shutdown.
+
+This is the entry point for all Plexi apps. Call it from your main block:
+
+    if __name__ == '__main__':
+        app = MyApp()
+        app.run()
+
+---
+

--- a/website/src/content/docs/sdk-emitter.md
+++ b/website/src/content/docs/sdk-emitter.md
@@ -1,0 +1,849 @@
+---
+title: "Emitter"
+description: "Host commands, notifications, HTTP, secrets, and device APIs"
+verified_version: "3.6.54"
+---
+
+# Emitter
+
+Emit out-of-frame commands to Plexi. Thread-safe.
+
+Available as `self.emit` on App or `ctx.emit` on RenderContext. All methods are thread-safe.
+
+## Methods
+
+### `log`
+
+```python
+def log(level: str, message: str) -> None
+```
+
+---
+
+### `info`
+
+```python
+def info(message: str) -> None
+```
+
+---
+
+### `warn`
+
+```python
+def warn(message: str) -> None
+```
+
+---
+
+### `error`
+
+```python
+def error(message: str) -> None
+```
+
+---
+
+### `debug`
+
+```python
+def debug(message: str) -> None
+```
+
+---
+
+### `notify`
+
+```python
+def notify(title: str, body: str = '', level: str = 'info', priority: 'int | None' = None, actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
+```
+
+Post a message notification. The modal shows title + body and a
+single Acknowledge button; Enter / Space acknowledge, Esc dismisses
+(unless required=True — use `notify_and_wait` for that flow).
+
+`priority` is required (int, higher = more urgent).
+`actions` is the legacy side-effect list (action_type =
+resume_run | open_intent | run_command). It does NOT render UI.
+`image_inline` (#74): {"mime": "image/png"|"image/jpeg",
+"base64": str}. Decoded host-side; >50KB triggers a placeholder.
+`image_pipe_id` (#74): pipe id of a binary ring carrying RGBA frames
+prefixed with width/height u32-LE. Mutually exclusive with
+`image_inline` — host warns + drops the pipe ref if both set.
+
+---
+
+### `run_sync`
+
+```python
+def run_sync(coro: 'Any') -> Any
+```
+
+Run a coroutine from a background thread and return its result.
+
+Use this when calling async Emitter methods from a non-async context
+(e.g. inside a ``threading.Thread`` callback)::
+
+    def _worker(self) -> None:
+        result = self.emit.run_sync(self.emit.http_get(url))
+
+Must NOT be called from within the event loop thread — it will deadlock.
+Raises ``RuntimeError`` if there is no running event loop to dispatch to
+(e.g. called before ``App.run()`` starts).
+
+---
+
+### `notify_choice`
+
+```python
+async def notify_choice(title: str, options: list, body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post a choice notification and await until the user picks one.
+
+`options` is a list of dicts: {"label": str, "value": str (optional),
+"shortcut": str (optional, single char)}. If `value` is omitted, the
+label is returned. Issue #74's structured-choice spec maps directly:
+`key` → `shortcut`, `payload` → `value`.
+
+`priority` is required (int, higher = more urgent).
+`image_inline` (#74): {"mime", "base64"} — same shape as `notify`.
+`image_pipe_id` (#74): pipe id of a binary ring carrying RGBA frames.
+Returns the chosen option's value (or the label if no value set). If
+`required=False` the user may cancel with Esc — this returns the string
+`"__cancel__"`.
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.notify_choice(...))``.
+
+---
+
+### `notify_with_image`
+
+```python
+async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, level: str = 'info', priority: 'int | None' = None, choices: 'list | None' = None) -> 'str | None'
+```
+
+Post a notification with an inline base64-encoded image attachment.
+
+`image_bytes` must be ≤ 50_000 bytes — anything larger raises
+`ValueError` here so the app sees a fast, local failure instead of
+having the host silently render a placeholder. Use the pipe-ref
+path (`emit.notify(..., image_pipe_id=...)`) for larger images.
+
+`mime` must be `"image/png"` or `"image/jpeg"`.
+
+`choices` is optional. When None this posts a fire-and-forget
+message-kind notification (returns None). When set, this routes to
+`notify_choice` and awaits until the user picks one (returns the
+chosen value, or `"__cancel__"`).
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.notify_with_image(...))``.
+
+---
+
+### `notify_input`
+
+```python
+async def notify_input(title: str, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post an input notification and await until the user submits or
+cancels. Returns the typed text (possibly empty), or "__cancel__" if
+the user dismissed with Esc (only possible when required=False).
+
+`priority` is required (int, higher = more urgent).
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.notify_input(...))``.
+
+---
+
+### `notify_and_wait`
+
+```python
+async def notify_and_wait(title: str, body: str = '', level: str = 'info', actions: 'list | None' = None, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post a message notification and await until the user acknowledges
+or cancels. Returns "acknowledge" on Enter/Space/button, "cancel" on Esc.
+
+For richer interaction, use `notify_choice` or `notify_input`.
+`priority` is required (int, higher = more urgent).
+`actions` is the legacy server-side side-effect list.
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.notify_and_wait(...))``.
+
+---
+
+### `run_in_terminal`
+
+```python
+def run_in_terminal(command: str) -> None
+```
+
+---
+
+### `cd`
+
+```python
+def cd(path: str) -> None
+```
+
+---
+
+### `status_summary`
+
+```python
+def status_summary(text: str) -> None
+```
+
+---
+
+### `push_nav`
+
+```python
+def push_nav(view_id: str, title: str) -> None
+```
+
+Push a new view onto the host navigation stack.
+
+The host appends an entry keyed on `view_id` with display `title`
+and shows a back arrow + `title` in the pane chrome while this view
+is active. Cmd+[ (or clicking the back arrow) sends
+``PlexiEvent::NavBack { view_id }`` back to the app, where
+``view_id`` is the view being navigated *back to* (the entry below
+the current top, or empty string for root).
+
+The app is responsible for tracking its own internal view state and
+calling ``pop_nav()`` after navigating back.
+
+---
+
+### `pop_nav`
+
+```python
+def pop_nav() -> None
+```
+
+Pop the current view off the host navigation stack.
+
+Call this after the app has already rendered the previous view (e.g.
+inside the ``on_nav_back`` handler). The host removes the top entry
+from the stack; if the stack becomes empty the back arrow disappears.
+
+---
+
+### `open_file_picker`
+
+```python
+def open_file_picker(request_id: str, filter: 'list[str] | None' = None, multiple: bool = False) -> None
+```
+
+Show a native macOS file picker dialog. Requires ``fs.pick`` capability.
+
+The host responds asynchronously with either:
+- ``on_file_picked(ctx, request_id, paths)`` — one or more files selected
+- ``on_file_pick_cancelled(ctx, request_id)`` — user dismissed the dialog
+
+Args:
+    request_id: Caller-supplied correlation ID echoed back in the response.
+    filter: File extension whitelist without leading dots
+            (e.g. ``["mp4", "mov"]``). ``None`` or empty = all files.
+    multiple: Allow picking more than one file.
+
+---
+
+### `spawn_pane`
+
+```python
+def spawn_pane(type_id: str, layout: str = 'split_v', args: 'list[str] | None' = None, pipe_id: 'str | None' = None, from_pane_id: 'int | None' = None, request_id: 'str | None' = None) -> None
+```
+
+Request the host to open a new pane with the given app (#592).
+
+Requires the ``panes.spawn`` capability. The host responds with
+``on_pane_spawned(pane_id, request_id)`` on success or
+``on_pane_spawn_error(reason, request_id)`` on failure.
+
+Args:
+    type_id: App manifest id or ``"terminal"``.
+    layout: One of ``"split_v"`` (default, below), ``"split_h"`` (right),
+            ``"split_above"``, ``"split_left"``, ``"overlay"``.
+    args: Extra argv passed to the spawned app.
+    pipe_id: Optional. If set, the host appends ``--pipe=<id>`` to the
+             spawned app's args so it can reply via ``emit.pipe_send()``.
+    from_pane_id: Optional pane_id to split relative to instead of the
+                  currently focused pane.
+    request_id: Optional correlation id echoed back in on_pane_spawned /
+                on_pane_spawn_error.
+
+---
+
+### `cd_to`
+
+```python
+def cd_to(cwd: str) -> None
+```
+
+Request the host to cd all terminals in the same pane group to `cwd`.
+
+---
+
+### `copy_to_clipboard`
+
+```python
+def copy_to_clipboard(text: str) -> None
+```
+
+Write `text` to the OS clipboard via the host (issue #146).
+
+Routed through `egui::Context::copy_text` so the platform backend
+(NSPasteboard / X11 / Wayland / Win32) handles the actual write.
+Synchronous from the app's perspective — no acknowledgement event.
+No capability flag is required; clipboard writes are low-risk and
+the app already chooses when to fire (key handler, button, etc.).
+
+---
+
+### `request_linked_terminal`
+
+```python
+async def request_linked_terminal(cwd: 'str | None' = None, label: 'str | None' = None) -> int
+```
+
+Ask the host to open a fresh terminal pane next to this app and
+return its `terminal_pane_id` (an integer). Awaits until the host
+emits `LinkedTerminalReady`.
+
+Returns 0 if the host denied the request — this happens when the
+manifest doesn't declare `terminal.bindings`. Apps should treat 0
+as a hard error (no terminal to drive). Raises `CapabilityDeniedError`
+in that case so the failure is loud.
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.request_linked_terminal(...))``.
+
+---
+
+### `run_in_linked_terminal`
+
+```python
+def run_in_linked_terminal(terminal_pane_id: int, command: str, echo: bool = True) -> None
+```
+
+Run `command` in the linked terminal. With `echo=True` the user
+sees the command typed into the terminal; with `echo=False` the
+signalled intent is silent execution (PTY-level echo is shell-
+controlled — the flag is best-effort observational).
+
+Fire-and-forget — capability denial drops silently with a host
+log line.
+
+---
+
+### `insert_path_token`
+
+```python
+def insert_path_token(terminal_pane_id: int, path: str, mode: str = 'replace') -> None
+```
+
+Inject `path` at the linked terminal's cursor.
+
+`mode = "replace"` — Ctrl-W (kill-word) before the path so the
+                    shell readline removes the partial token.
+`mode = "append"`  — write the path verbatim.
+
+The host POSIX-quotes the path when it contains shell metacharacters.
+Fire-and-forget — capability denial drops silently with a host log
+line.
+
+---
+
+### `request_command_preview`
+
+```python
+async def request_command_preview(terminal_pane_id: int, command: str) -> 'tuple[str, str]'
+```
+
+Return `(command, would_run_in_cwd)` for `command` in the linked
+terminal. Doesn't execute. Useful for confirmation modals before
+destructive operations.
+
+If the host denies the request, `would_run_in_cwd` is empty string;
+the SDK does NOT raise — apps that want to be loud should check for
+empty cwd themselves (the most common failure mode is a missing
+capability, which the host already logs).
+
+Await this from async hooks. From background threads use
+``self.emit.run_sync(self.emit.request_command_preview(...))``.
+
+---
+
+### `open_artifact`
+
+```python
+def open_artifact(path: str, mode: str = 'open_in_pane') -> None
+```
+
+Open a workspace artifact via the host.
+
+Modes:
+  - `"open_in_pane"`        — directories open the file browser
+                              next to the app; files open with
+                              the OS default app (v3.5).
+  - `"reveal_in_finder"`    — `open -R <path>` on macOS.
+  - `"open_with_default"`   — `open <path>` on macOS.
+
+Fire-and-forget. Capability denial drops silently with a host log
+line.
+
+---
+
+### `schedule_render`
+
+```python
+def schedule_render(after_ms: int = 16) -> None
+```
+
+Ask the host to send a new Render event after `after_ms` milliseconds.
+Call at the end of on_render to sustain a game/animation loop.
+16 ms ≈ 60 fps.  32 ms ≈ 30 fps.
+
+---
+
+### `run_get`
+
+```python
+def run_get(intent: str, payload: Any = None) -> str
+```
+
+---
+
+### `capability_request`
+
+```python
+async def capability_request(capability: str) -> bool
+```
+
+Await until host grants or denies the capability. Returns True if granted.
+
+Await from async hooks. From background threads:
+``self.emit.run_sync(self.emit.capability_request(capability))``.
+
+---
+
+### `secret_get`
+
+```python
+async def secret_get(key: str) -> 'str | None'
+```
+
+Await until host returns the secret value (or None if denied).
+
+From background threads:
+``self.emit.run_sync(self.emit.secret_get(key))``.
+
+---
+
+### `get_secret`
+
+```python
+async def get_secret(key: str) -> 'str | None'
+```
+
+Alias for secret_get(). Preferred name going forward.
+
+---
+
+### `http_get`
+
+```python
+async def http_get(url: str) -> str
+```
+
+HTTP GET brokered through the host. Requires net.http capability.
+Raises RuntimeError on failure.
+
+From background threads:
+``self.emit.run_sync(self.emit.http_get(url))``.
+
+---
+
+### `http_request`
+
+```python
+async def http_request(url: str, method: str = 'GET', headers: 'dict[str, str] | None' = None, body: 'str | None' = None) -> str
+```
+
+HTTP request brokered through the host. Requires net.http capability.
+Supports custom method, headers, and body. Raises RuntimeError on failure.
+
+From background threads:
+``self.emit.run_sync(self.emit.http_request(...))``.
+
+---
+
+### `ai_query`
+
+```python
+async def ai_query(model_tier: str, system: str, messages: 'list[dict]', tools: 'list[dict] | None' = None) -> AiResponse
+```
+
+Call into the host's Plexi AI broker (#284). Requires the
+`ai.query` capability declared in `manifest.toml`.
+
+Args:
+    model_tier: one of "low" | "medium" | "high" — the host maps these
+        to Haiku / Sonnet / Opus respectively.
+    system: system prompt (may be empty string).
+    messages: list of `{"role": "user"|"assistant", "content": str}`
+        dicts. At least one message is required.
+    tools: optional extra tool defs to include in this query. Tools
+        exposed by other panes in the same context via ``@self.tool()``
+        or ``expose_tools()`` are automatically injected by the host —
+        you do not need to pass them here.
+
+Returns:
+    AiResponse with `content`, `tokens_in`, `tokens_out`.
+
+Raises:
+    CapabilityDeniedError: app didn't declare `ai.query` in its manifest
+        (or the host returned any other "capability denied" error).
+    RuntimeError: backend failed (e.g. missing API key, network error).
+
+From background threads:
+``self.emit.run_sync(self.emit.ai_query(...))``.
+
+---
+
+### `mcp_tool_result`
+
+```python
+def mcp_tool_result(call_id: str, result: 'dict | None' = None, error: 'str | None' = None) -> None
+```
+
+Send a McpToolResult response for a pending McpToolCall.
+
+One of ``result`` or ``error`` must be provided (not both, not neither).
+``result`` should be a MCP CallToolResult dict, e.g.:
+``{"content": [{"type": "text", "text": "done"}]}``.
+
+---
+
+### `expose_tools`
+
+```python
+def expose_tools(tools: 'list[dict]') -> None
+```
+
+Declare callable tools to the host (#398, #399).
+
+Each entry in `tools` must have:
+  - ``name`` (str): unique tool identifier.
+  - ``description`` (str): human-readable description for the LLM.
+  - ``input_schema`` (dict): JSON Schema object (type=object).
+  - ``timeout_ms`` (int, optional): max ms to wait for result (default 30 000).
+
+The host registers these tools in the global registry. When an AI turn
+requests a tool call the host sends a ``PlexiEvent::ToolCall``; the SDK
+routes it to the handler registered via ``@app.tool(…)``.
+
+---
+
+### `list_midi_devices`
+
+```python
+async def list_midi_devices(timeout: float = 5.0) -> 'MidiDeviceList'
+```
+
+Enumerate CoreMIDI input + output ports (#320).
+No capability gate — port names are publicly visible in Audio MIDI
+Setup. Requires `midi.in` / `midi.out` only on subsequent open/send.
+
+Returns a MidiDeviceList with `inputs` and `outputs` lists of
+MidiPortInfo (id, name, default).
+
+Raises RuntimeError on host enumeration failure or timeout.
+
+From background threads:
+``self.emit.run_sync(self.emit.list_midi_devices())``.
+
+---
+
+### `list_audio_devices`
+
+```python
+async def list_audio_devices(timeout: float = 5.0) -> 'AudioDeviceList'
+```
+
+Enumerate CoreAudio input + output devices (#341).
+No capability gate — device names are publicly visible.
+Requires ``audio.record`` / ``audio.playback`` only on subsequent capture/play.
+
+Returns an AudioDeviceList with ``inputs`` and ``outputs`` lists of
+AudioDeviceInfo (id, name, default).
+
+Raises RuntimeError on host enumeration failure or timeout.
+
+From background threads:
+``self.emit.run_sync(self.emit.list_audio_devices())``.
+
+---
+
+### `open_midi_input`
+
+```python
+def open_midi_input(port_id: str, pipe_id: str) -> 'Pipe'
+```
+
+Open a CoreMIDI input port and pipe its MIDI byte streams into a
+binary pipe. Requires `midi.in` capability declared in manifest.toml.
+
+Returns the Pipe handle. The host emits `PipeOpened` then
+`MidiInputOpened`; the Pipe auto-connects to its socket on
+`PipeOpened`. Apps then call `pipe.read_frame()` in a loop to
+receive 1–3 byte MIDI messages (channel-voice / system real-time).
+
+Each pipe frame is one MIDI 1.0 message — apps don't need to parse
+message boundaries themselves.
+
+---
+
+### `close_midi_input`
+
+```python
+def close_midi_input(port_id: str) -> None
+```
+
+Close a previously-opened MIDI input port. The associated binary
+pipe drains and closes; the app should drop its Pipe handle.
+
+---
+
+### `send_midi`
+
+```python
+def send_midi(port_id: str, bytes_: 'bytes | bytearray | list[int]') -> None
+```
+
+Fire-and-forget send of one MIDI 1.0 byte stream to `port_id`.
+Requires `midi.out` capability. The host opens the output port lazily
+on the first send and reuses the handle afterwards.
+
+`bytes_` is a 1–3 byte sequence: NoteOn `[0x90+ch, note, vel]`,
+NoteOff `[0x80+ch, note, vel]`, CC `[0xB0+ch, num, val]`, clock
+pulse `[0xF8]`, etc. Use `plexi_sdk.midi` helpers to construct
+messages with named arguments.
+
+Successful sends produce no event; failures arrive as a logged
+`midi_send_error` warning. Apps that need explicit error handling
+should validate the destination via `list_midi_devices()` first.
+
+---
+
+### `open_video`
+
+```python
+async def open_video(source: str, pipe_id: str, timeout: float = 10.0) -> 'VideoHandle'
+```
+
+Open a video decoder against `source` and return a VideoHandle
+carrying the negotiated width/height/fps/duration_ms plus the
+attached Pipe (#345). Requires `video.playback` capability.
+
+**Pre-v1 note:** `video.playback` is not production-ready. The
+`file:///` decoder returns NotImplemented in all shipping builds
+until AVFoundation backing lands (#346). Only `mock://gradient`
+works today. Do not ship apps that depend on real video decoding.
+
+Decoded frames flow as raw RGBA8 packets on the Pipe — one packet
+per video frame, length `width * height * 4`. Apps spin a reader
+thread that calls `handle.pipe.read_frame()` and either renders
+the bytes (if a frame-render API is available) or surfaces a
+frame counter.
+
+Source schemes:
+  - `mock://gradient` — procedural mock decoder (always works).
+  - `file:///...` — production decoder; returns NotImplemented
+    until #346 lands AVFoundation backing.
+
+Raises CapabilityDeniedError if `video.playback` is not declared.
+Raises RuntimeError on any other failure (NotImplemented, bad
+source, decoder error, timeout).
+
+From background threads:
+``self.emit.run_sync(self.emit.open_video(source, pipe_id))``.
+
+---
+
+### `set_video_state`
+
+```python
+def set_video_state(handle_id: int, state: str, position_ms: int = 0) -> None
+```
+
+Drive playback for a video opened with `open_video` (#345).
+`state` is one of `"play"`, `"pause"`, `"seek"`. For `"seek"`,
+`position_ms` is the absolute target position in milliseconds.
+Fire-and-forget — no response event.
+
+---
+
+### `close_video`
+
+```python
+def close_video(handle_id: int) -> None
+```
+
+Close a previously-opened video handle (#345). The host tears down
+the decoder and drains the binary pipe. No response event.
+
+---
+
+### `audio_capture`
+
+```python
+def audio_capture(pipe_id: str, sample_rate: int = 48000, buffer_size: int = 512, device_id: 'str | None' = None) -> 'Pipe'
+```
+
+Start mic capture (#277). PCM frames stream as raw f32 PCM on
+a binary pipe — interleaved per-channel, ``sample_rate`` per
+channel per second.
+
+Returns the binary Pipe immediately (negotiated values arrive
+async via ``PlexiEvent::AudioCaptureStarted`` and the host log;
+the app reads ``handle.read_frame()`` once it connects). Failure
+arrives as ``PlexiEvent::AudioCaptureError``.
+
+If ``pipe_id`` is already registered (i.e. the app is restarting
+capture), the old Pipe is closed before the new one is created —
+prevents OSError on the reader thread's recv() from a stale socket.
+
+Requires ``audio.in`` capability. Raises ``CapabilityDeniedError``
+only when the gate fires synchronously at the wire layer; the
+usual TCC mic-permission denial surfaces async on the first frame
+attempt as an ``AudioCaptureError`` event.
+
+---
+
+### `stop_audio_capture`
+
+```python
+def stop_audio_capture(pipe_id: str) -> None
+```
+
+Stop an active audio capture and close its pipe (#862).
+
+Closes the Pipe registered under ``pipe_id`` and removes it from
+the internal registry. The host cleans up the stale session on the
+next ``AudioCapture`` for the same ``pipe_id``. No host command is
+needed — closing the socket is sufficient.
+
+Apps should join any reader thread after calling this to avoid
+reading from a closed socket::
+
+    self.emit.stop_audio_capture("mic")
+    self._reader_thread.join(timeout=2.0)
+
+No-op if ``pipe_id`` is not registered.
+
+---
+
+### `audio_play`
+
+```python
+def audio_play(source: str, volume: float = 1.0) -> None
+```
+
+Play an audio file via the host (rodio). Requires audio.playback capability.
+
+source: absolute path to audio file (mp3, wav, ogg, etc.)
+volume: playback volume 0.0–1.0 (default 1.0)
+
+Fire-and-forget — no response event. Stop playback by calling
+audio_play(source, state="stopped") or closing the pane.
+
+---
+
+### `set_timer`
+
+```python
+def set_timer(timer_id: str, after_ms: int) -> None
+```
+
+Fire PlexiEvent::Timer after after_ms milliseconds. Requires timer capability.
+
+---
+
+### `cancel_timer`
+
+```python
+def cancel_timer(timer_id: str) -> None
+```
+
+Cancel a pending timer set with set_timer().
+
+---
+
+### `set_mouse_tracking`
+
+```python
+def set_mouse_tracking(enabled: bool) -> None
+```
+
+Enable or disable PlexiEvent::MouseMove delivery for this pane.
+
+MouseMove is off by default to avoid flooding apps that don't need
+continuous pointer tracking. Call set_mouse_tracking(True) after
+on_init to start receiving on_mouse_move callbacks. Call with False
+to stop.
+
+---
+
+### `pipe_open`
+
+```python
+def pipe_open(pipe_id: str, mode: str = 'binary', direction: str = 'in') -> 'Pipe'
+```
+
+Open a typed pipe. Returns a Pipe handle. mode: json|binary. direction: in|out|duplex.
+
+---
+
+### `pipe_open_directed`
+
+```python
+def pipe_open_directed(pipe_id: str, target_pane_id: int) -> 'Pipe'
+```
+
+Open a *directed* JSON pipe to one specific target pane (#286).
+
+Mirrors `pipe_open` but the host scopes `PipeMessage` delivery so
+only the caller and `target_pane_id` see traffic on `pipe_id` —
+peers that coincidentally `pipe_open` the same id stay isolated.
+Always JSON-mode duplex; `pipe.send(payload)` is symmetric on
+either end.
+
+Capability: `pipe.open` (same as `pipe_open`).
+
+---
+
+### `pipe_send`
+
+```python
+def pipe_send(pipe_id: str, payload: Any) -> None
+```
+
+Send a JSON payload on an already-open pipe by id (#286).
+
+Use this when you don't own a `Pipe` handle locally — for example
+when replying on a directed pipe a *peer* opened (you're the target;
+the host subscribed you, but the SDK doesn't auto-build a handle).
+Sends a `pipe_send` DrawCommand; the host routes per the existing
+directed-pipe pair table.
+
+---
+

--- a/website/src/content/docs/sdk-emitter.md
+++ b/website/src/content/docs/sdk-emitter.md
@@ -82,7 +82,7 @@ def run_sync(coro: 'Any') -> Any
 Run a coroutine from a background thread and return its result.
 
 Use this when calling async Emitter methods from a non-async context
-(e.g. inside a ``threading.Thread`` callback)::
+(e.g. inside a ``threading.Thread`` callback):
 
     def _worker(self) -> None:
         result = self.emit.run_sync(self.emit.http_get(url))
@@ -318,10 +318,8 @@ Ask the host to open a fresh terminal pane next to this app and
 return its `terminal_pane_id` (an integer). Awaits until the host
 emits `LinkedTerminalReady`.
 
-Returns 0 if the host denied the request — this happens when the
-manifest doesn't declare `terminal.bindings`. Apps should treat 0
-as a hard error (no terminal to drive). Raises `CapabilityDeniedError`
-in that case so the failure is loud.
+Raises `CapabilityDeniedError` if the manifest doesn't declare
+`terminal.bindings`.
 
 Await this from async hooks. From background threads use
 ``self.emit.run_sync(self.emit.request_linked_terminal(...))``.
@@ -743,7 +741,7 @@ next ``AudioCapture`` for the same ``pipe_id``. No host command is
 needed — closing the socket is sufficient.
 
 Apps should join any reader thread after calling this to avoid
-reading from a closed socket::
+reading from a closed socket:
 
     self.emit.stop_audio_capture("mic")
     self._reader_thread.join(timeout=2.0)
@@ -763,8 +761,8 @@ Play an audio file via the host (rodio). Requires audio.playback capability.
 source: absolute path to audio file (mp3, wav, ogg, etc.)
 volume: playback volume 0.0–1.0 (default 1.0)
 
-Fire-and-forget — no response event. Stop playback by calling
-audio_play(source, state="stopped") or closing the pane.
+Fire-and-forget — no response event. Playback stops when the pane
+closes; there is no explicit stop API yet.
 
 ---
 

--- a/website/src/content/docs/sdk-render-context.md
+++ b/website/src/content/docs/sdk-render-context.md
@@ -27,22 +27,6 @@ Passed to on_render. Accumulate draw commands; FrameDone is auto-emitted.
 
 ## Methods
 
-### `width`
-
-```python
-def width() -> float
-```
-
----
-
-### `height`
-
-```python
-def height() -> float
-```
-
----
-
 ### `clear`
 
 ```python

--- a/website/src/content/docs/sdk-render-context.md
+++ b/website/src/content/docs/sdk-render-context.md
@@ -1,0 +1,799 @@
+---
+title: "RenderContext"
+description: "Drawing API for rendering pane content"
+verified_version: "3.6.54"
+---
+
+# RenderContext
+
+Passed to on_render. Accumulate draw commands; FrameDone is auto-emitted.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `x` | `float` | Pane origin x (usually 0) |
+| `y` | `float` | Pane origin y (usually 0) |
+| `w` | `float` | Pane width in logical pixels |
+| `h` | `float` | Pane height in logical pixels |
+| `width` | `float` | Alias for `w` |
+| `height` | `float` | Alias for `h` |
+| `frame_id` | `int` | Monotonically increasing render counter |
+| `elapsed` | `float` | Seconds since previous on_render (0.0 on first frame) |
+| `workspace_root` | `str` | Absolute path to the workspace root |
+| `capabilities` | `list[str]` | Granted capability strings |
+| `feature_flags` | `list[str]` | Enabled feature flag strings |
+| `emit` | `Emitter` | Emitter instance for out-of-frame commands |
+
+## Methods
+
+### `width`
+
+```python
+def width() -> float
+```
+
+---
+
+### `height`
+
+```python
+def height() -> float
+```
+
+---
+
+### `clear`
+
+```python
+def clear(fill: str = '#000000') -> None
+```
+
+Fill the entire pane with a single color. Shorthand for a full-size rect.
+
+---
+
+### `rect`
+
+```python
+def rect(x: float, y: float, w: float, h: float, fill: str, radius: float = 0.0) -> None
+```
+
+Draw a filled rectangle.
+
+Args:
+    x: Left edge in logical pixels
+    y: Top edge in logical pixels
+    w: Width in logical pixels
+    h: Height in logical pixels
+    fill: Fill color as hex string (e.g., "#ff0000" or "#ff0000aa" with alpha)
+    radius: Corner radius in pixels (0.0 = sharp corners, default)
+
+---
+
+### `circle`
+
+```python
+def circle(cx: float, cy: float, r: float, fill: str) -> None
+```
+
+Draw a filled circle.
+
+Args:
+    cx: Center X in logical pixels
+    cy: Center Y in logical pixels
+    r: Radius in logical pixels
+    fill: Fill color as hex string; supports 8-digit hex (#rrggbbaa) for alpha
+
+---
+
+### `arc`
+
+```python
+def arc(cx: float, cy: float, r: float, start_angle: float, end_angle: float, fill: str) -> None
+```
+
+Draw a filled pie slice. Angles in radians, clockwise from east (right).
+Full circle: start_angle=0, end_angle=6.2832 (2*pi).
+Example pie slice: arc(cx, cy, r, 0, math.pi * 0.5, fill="#ff0000")
+
+---
+
+### `text`
+
+```python
+def text(x: float, y: float, text: str, size: float, color: str, monospace: bool = False, bold: bool = False, align: str = 'top_left', max_width: 'float | None' = None, elide: bool = True, selectable: bool = False) -> None
+```
+
+Draw text. `align` controls how `(x, y)` maps to the text box:
+
+  - "top_left" (default) — (x, y) is the top-left corner.
+  - "center"              — (x, y) is the visual center.
+  - "top_center"          — (x, y) is the top-center.
+  - "right"               — (x, y) is the top-right corner.
+
+Use "center" when placing text inside a fixed-size container (a badge,
+a button, a pie-chart label) — the host uses real font metrics, which
+is noticeably more accurate than Python-side math with approximate
+character-width ratios.
+
+`max_width` — when set, the host clips the text at this pixel width.
+`elide`     — when True (default), a "…" is appended at the clip point;
+              when False, the text is hard-clipped with no marker.
+`selectable` — when True, the host renders the text as a real egui
+               label so the user can drag-select inside it and Cmd+C
+               copies the current selection. Default False (#200).
+
+`max_width`, `elide`, and `selectable` are sent explicitly on the wire
+so the host always has required fields (no serde defaults). The SDK
+fills in None / True / False when the caller omits them.
+
+---
+
+### `markdown`
+
+```python
+def markdown(x: float, y: float, w: float, text: str, base_size: float = 14.0, color: str = FG) -> None
+```
+
+Render markdown text via the host's egui_commonmark renderer.
+
+The host creates a child Ui at (x, y) with width w and renders the
+markdown with proper formatting (bold, italic, code blocks, lists, etc.).
+
+`base_size` — body font size in pt (headers scale relative to this).
+`color`     — default text colour (hex).
+
+---
+
+### `image`
+
+```python
+def image(src: str, x: float, y: float, w: float, h: float, fit: str = 'contain') -> None
+```
+
+Draw an image from a file path or URL.
+
+`fit` controls scaling: "contain" (default, letterbox), "cover"
+(crop to fill), or "fill" (stretch). Host must implement
+DrawCommand::Image for this to render.
+
+---
+
+### `copy_to_clipboard`
+
+```python
+def copy_to_clipboard(text: str) -> None
+```
+
+Convenience shortcut for `emit.copy_to_clipboard(text)` (#146).
+
+---
+
+### `badge`
+
+```python
+def badge(x: float, y_center: float, label: str, fill: str = ACCENT, fg: str = BG, font_size: float = 11.0, radius: float = 6.0) -> None
+```
+
+Render a host-measured pill badge.
+
+The host measures the label with real egui font metrics, sizes the pill
+(text_w + padding), and centres the text — no Python width math.
+
+`x`        — left edge of the badge.
+`y_center` — vertical centre of the badge.
+`label`    — text to display.
+`fill`     — pill background colour.
+`fg`       — text colour.
+`font_size`— label pt size.
+`radius`   — corner radius (8.0 = fully rounded pill; 4.0 = tag chip).
+
+---
+
+### `button`
+
+```python
+def button(id: str, x: float, y: float, w: float, h: float, label: str, fill: str = '#313244', hover_fill: str = '#45475a', active_fill: str = '#585b70', text_color: str = '#cdd6f4', font_size: float = 13.0, radius: float = 6.0) -> bool
+```
+
+Draw a button and return True if it was clicked this frame.
+
+Hover state is derived from the current mouse position (requires
+mouse_tracking = true in the manifest, or degrades gracefully without it).
+Click state is derived from buffered click events since the previous frame.
+
+`id` is currently unused but reserved for future focus tracking.
+
+---
+
+### `key_chip_row`
+
+```python
+def key_chip_row(x: float, y: float, keys: 'list[str]', description: 'str | None' = None, font_size: float = 11.0) -> None
+```
+
+Render a row of keycap chips followed by an optional description.
+
+The host measures each chip with real egui font metrics and flows them
+left-to-right — no Python width math.
+
+`x`, `y`     — origin of the chip row (left edge, top of chips).
+`keys`       — list of key labels, e.g. ["⌘", "K"] for a chord.
+`description`— optional trailing text label after the chips.
+`font_size`  — chip label pt size.
+
+For multi-pair shortcut rows with horizontal flow + multi-line
+wrapping, use `ctx.shortcuts(...)` instead — that's the right
+primitive for footer-style "[k] desc · [j] desc · …" layouts.
+
+---
+
+### `text_row`
+
+```python
+def text_row(x: float, y: float, items: 'list[dict]', gap: float = 8.0, align: str = 'left_center') -> None
+```
+
+Render multiple text segments horizontally with configurable spacing.
+
+The host measures each text segment with real font metrics and flows
+them left-to-right — no Python width math.
+
+`x`, `y`    — origin of the text row.
+`items`     — list of text segment dicts, each with keys:
+              - `text`      — string to display (required)
+              - `color`     — color string (default: FG)
+              - `size`      — font size in pt (default: BODY)
+              - `monospace` — bool (default: False)
+`gap`       — spacing between items in pixels (default: 8.0).
+`align`     — vertical alignment; use "left_center" to center items
+              on the y-axis at their midline (default: "left_center").
+
+Example::
+
+    ctx.text_row(
+        x=24.0, y=200.0,
+        items=[
+            {"text": "12:34:56", "color": "#6c7086", "size": CAPTION, "monospace": True},
+            {"text": "key pressed", "color": FG, "size": CAPTION},
+        ],
+        gap=12.0,
+    )
+
+---
+
+### `shortcuts`
+
+```python
+def shortcuts(x: float, y: float, max_width: float, pairs: 'list[tuple]', font_size: float = 11.0) -> None
+```
+
+Render a multi-group shortcut row with host-measured layout.
+
+The host owns ALL geometry: chip widths from real font metrics,
+horizontal flow with inter-group spacing, multi-line wrapping
+when the next group would exceed `max_width`. SDK callers send
+one DrawCommand and trust the result — no Python width math,
+no truncation, no overflow.
+
+`pairs` is a list of `(keys, description)` tuples where `keys`
+is either a single string or a list of strings (multi-key
+chord). Example::
+
+    ctx.shortcuts(
+        x=24.0, y=12.0, max_width=ctx.w - 48.0,
+        pairs=[
+            (["[", "]"], "week"),
+            ("t", "today"),
+            (["j", "k"], "commit"),
+            ("?", "help"),
+        ],
+    )
+
+---
+
+### `measure_text`
+
+```python
+async def measure_text(text: str, font_size: float, monospace: bool = False) -> 'tuple[float, float]'
+```
+
+Measure `text` at `font_size` using the host's real font metrics.
+
+Sends a `MeasureText` DrawCommand and awaits `TextMeasured` from the
+host. Returns `(width, height)` in logical pixels.
+
+Use this only when layout depends on measured text width (e.g. flowing
+multiple badges horizontally). Avoid on hot render paths — prefer
+passing `max_width` on `ctx.text()` for simple truncation.
+
+Must be called with ``await`` from an async hook.
+
+---
+
+### `push_clip`
+
+```python
+def push_clip(x: float, y: float, w: float, h: float) -> None
+```
+
+Push a clip rect onto the host's clip stack.
+
+All subsequent draws are clipped to the intersection of this rect with
+the current top of the stack (or the pane rect if the stack is empty).
+Must be balanced with a matching `pop_clip()`. Use `_render_clipped`
+on Component subclasses instead of calling this directly.
+
+---
+
+### `pop_clip`
+
+```python
+def pop_clip() -> None
+```
+
+Pop the most recently pushed clip rect. Must balance a `push_clip()`.
+
+---
+
+### `line`
+
+```python
+def line(x1: float, y1: float, x2: float, y2: float, color: str, width: float = 1.0) -> None
+```
+
+Draw a line segment.
+
+Args:
+    x1: Start X in logical pixels
+    y1: Start Y in logical pixels
+    x2: End X in logical pixels
+    y2: End Y in logical pixels
+    color: Line color as hex string
+    width: Line width in logical pixels (default: 1.0)
+
+---
+
+### `render`
+
+```python
+def render(tree: Any, fill: str = '#1e1e2e') -> None
+```
+
+Render a declarative UI tree (see `plexi_sdk.ui`). Clears the pane
+to `fill` first, then lays out `tree` into the full pane rect.
+
+Example:
+    from plexi_sdk.ui import Column, Header, Footer, Spacer
+    ctx.render(Column([
+        Header("My App"),
+        Spacer(grow=True),
+        Footer("status line"),
+    ]))
+
+---
+
+### `list_view`
+
+```python
+def list_view(items: 'list[dict]', selected: int = 0, item_height: float = 40.0, x: float = 0.0, y: float = 0.0, w: 'float | None' = None, h: 'float | None' = None) -> None
+```
+
+Draw a scrollable list of items with optional selection highlight.
+
+Args:
+    items: List of item dicts, each with keys "text" (required) and optional "disabled"
+    selected: Index of the highlighted item (0-indexed)
+    item_height: Height of each item in logical pixels
+    x: Left edge of the list
+    y: Top edge of the list
+    w: Width of the list (defaults to full pane width)
+    h: Height of the list (defaults to remaining pane height below y)
+
+---
+
+### `begin_scroll`
+
+```python
+def begin_scroll(id: str, x: float, y: float, w: float, h: float, content_height: float) -> None
+```
+
+Begin a host-managed vertical scroll region (#446).
+
+Declares a viewport at (x, y, w, h) within this pane. This rect does
+two things: it clips all draw commands until the matching `end_scroll()`
+call, AND it defines where the host detects scroll gestures. The host
+only fires `on_scroll` when the pointer is inside this rect.
+
+**Common mistake:** if your scrollable list occupies only part of the
+pane (e.g. the right half), set x/w to cover the full pane width anyway
+so the user can scroll from anywhere — not just when hovering over the
+list. Clipping is only applied to content drawn *inside* the block, so
+content drawn before `begin_scroll` is unaffected regardless of x/w.
+
+The host tracks the scroll position across frames and calls
+`on_scroll(ctx, id, offset_y)` whenever the user scrolls so the app
+can re-render content translated by `offset_y`.
+
+`content_height` is the total virtual height of the scrollable content
+in logical pixels — the host uses this to size the scrollbar thumb.
+Pass the full height of all items even if most are off-screen.
+
+`id` must be stable across frames — use a descriptive string rather
+than a counter. Typical pattern::
+
+    def on_scroll(self, ctx, id, offset_y):
+        if id == "main-list":
+            self.scroll_y = offset_y
+
+    def on_render(self, ctx):
+        ctx.begin_scroll("main-list", 0, 48, ctx.w, ctx.h - 48,
+                         content_height=100 * ROW_H)
+        for i, item in enumerate(self.items):
+            y = i * ROW_H - self.scroll_y
+            ctx.text(8, y, item, size=14, color=FG)
+        ctx.end_scroll()
+
+---
+
+### `end_scroll`
+
+```python
+def end_scroll() -> None
+```
+
+Close the most recently opened scroll region. Must balance begin_scroll.
+
+---
+
+### `text_input`
+
+```python
+def text_input(id: str, x: float, y: float, w: float, placeholder: str = '', multiline: bool = False, h: float = 24.0) -> 'str | None'
+```
+
+Text input — host-owned buffer, submit-only.
+
+Emits a `DrawCommand::TextInput` and returns the most recently
+submitted value for `id` if any landed since the previous frame,
+else `None`. The host owns the buffer entirely — typed
+characters never reach the app between keystrokes. On Enter the
+host emits `PlexiEvent::TextSubmitted { id, value }` and clears
+its buffer.
+
+The host auto-focuses the widget on its first visible frame so
+the user can type immediately without clicking.
+
+When `multiline=True`, Enter submits and Shift+Enter inserts a
+newline. When `multiline=False` (default), Enter submits
+immediately.
+
+Pattern (poll on every frame)::
+
+    submitted = ctx.text_input("note", x=12, y=12, w=300,
+                               placeholder="Type a note…")
+    if submitted is not None:
+        save_note(submitted)
+
+Real-time validation (per-keystroke access) is out of scope —
+see issue #283.
+
+---
+
+### `log`
+
+```python
+def log(level: str, message: str) -> None
+```
+
+---
+
+### `info`
+
+```python
+def info(message: str) -> None
+```
+
+---
+
+### `warn`
+
+```python
+def warn(message: str) -> None
+```
+
+---
+
+### `error`
+
+```python
+def error(message: str) -> None
+```
+
+---
+
+### `debug`
+
+```python
+def debug(message: str) -> None
+```
+
+---
+
+### `notify`
+
+```python
+def notify(title: str, body: str = '', level: str = 'info', priority: 'int | None' = None, actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
+```
+
+Post a message notification. See Emitter.notify.
+`priority` is required (int, higher = more urgent).
+`image_inline` / `image_pipe_id` (#74) optionally attach an image.
+Scope is resolved from the app's manifest — not an argument.
+
+---
+
+### `notify_choice`
+
+```python
+async def notify_choice(title: str, options: list, body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post a choice notification and await until the user picks.
+`priority` is required (int, higher = more urgent).
+`image_inline` / `image_pipe_id` (#74) optionally attach an image.
+Returns the chosen option's value (or label if no value set),
+or "__cancel__" if the user dismissed. Use with ``await``.
+
+---
+
+### `notify_with_image`
+
+```python
+async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, level: str = 'info', priority: 'int | None' = None, choices: 'list | None' = None) -> 'str | None'
+```
+
+Convenience: post a notification with an inline base64 image.
+See Emitter.notify_with_image — handles base64 + 50KB cap. Use with ``await``.
+
+---
+
+### `notify_input`
+
+```python
+async def notify_input(title: str, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post an input notification and await until the user submits.
+`priority` is required (int, higher = more urgent).
+Returns the typed text, or "__cancel__" if dismissed. Use with ``await``.
+
+---
+
+### `notify_and_wait`
+
+```python
+async def notify_and_wait(title: str, body: str = '', level: str = 'info', actions: 'list | None' = None, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+```
+
+Post a message notification and await for acknowledge/cancel.
+`priority` is required (int, higher = more urgent).
+See Emitter.notify_and_wait. Use with ``await``.
+
+---
+
+### `status_summary`
+
+```python
+def status_summary(text: str) -> None
+```
+
+---
+
+### `set_timer`
+
+```python
+def set_timer(timer_id: str, after_ms: int) -> None
+```
+
+---
+
+### `cancel_timer`
+
+```python
+def cancel_timer(timer_id: str) -> None
+```
+
+---
+
+### `set_mouse_tracking`
+
+```python
+def set_mouse_tracking(enabled: bool) -> None
+```
+
+Enable or disable on_mouse_move delivery for this pane.
+Call with True in on_init to start receiving mouse-move events.
+Delegates to emit.set_mouse_tracking().
+
+---
+
+### `schedule_render`
+
+```python
+def schedule_render(after_ms: int = 16) -> None
+```
+
+Ask the host to send a new Render event after `after_ms` milliseconds.
+Delegates to emit.schedule_render(). 16 ms ≈ 60 fps. 32 ms ≈ 30 fps.
+
+---
+
+### `get_secret`
+
+```python
+async def get_secret(key: str) -> 'str | None'
+```
+
+Request a secret by key. Alias for emit.get_secret(). Use with ``await``.
+
+---
+
+### `load_state`
+
+```python
+def load_state() -> dict
+```
+
+Return persisted app state loaded at startup. {} if nothing saved.
+
+---
+
+### `save_state`
+
+```python
+def save_state(state: dict) -> None
+```
+
+Persist state to workspace (if workspace active) or global storage.
+Fire-and-forget — no acknowledgement from host.
+
+---
+
+### `http_request`
+
+```python
+async def http_request(url: str, method: str = 'GET', headers: 'dict[str, str] | None' = None, body: 'str | None' = None) -> str
+```
+
+HTTP request brokered through the host. Requires net.http capability. Use with ``await``.
+
+---
+
+### `ai_query`
+
+```python
+async def ai_query(model_tier: str, system: str, messages: 'list[dict]', tools: 'list[dict] | None' = None) -> object
+```
+
+AI broker call through the host. Requires ai.query capability. Use with ``await``.
+
+---
+
+### `spawn_pane`
+
+```python
+def spawn_pane(type_id: str, layout: str = 'split_v', args: 'list[str] | None' = None, pipe_id: 'str | None' = None, from_pane_id: 'int | None' = None, request_id: 'str | None' = None) -> None
+```
+
+Request the host to open a new pane. Requires panes.spawn capability.
+
+---
+
+### `badge_child`
+
+```python
+def badge_child(label: str, fill: str = '#89b4fa', fg: str = '#1e1e2e', font_size: float = 11.0, radius: float = 8.0) -> dict
+```
+
+Return a layout child node for a Badge. Use inside ctx.row/column/stack.
+
+---
+
+### `text_child`
+
+```python
+def text_child(text: str, size: float = 12.0, color: str = '#cdd6f4', monospace: bool = False, bold: bool = False, max_width: 'float | None' = None, elide: bool = False, selectable: bool = False) -> dict
+```
+
+Return a layout child node for Text. Use inside ctx.row/column/stack.
+
+---
+
+### `key_chip_child`
+
+```python
+def key_chip_child(label: str, font_size: float = 11.0) -> dict
+```
+
+Return a layout child node for a KeyChip. Use inside ctx.row/column/stack.
+
+---
+
+### `layout_node`
+
+```python
+def layout_node(direction: str, children: 'list[dict]', gap: float = 0.0) -> dict
+```
+
+Return a nested layout node for use inside ctx.row/column/stack.
+
+---
+
+### `row`
+
+```python
+def row(x: float, y: float, children: 'list[dict]', gap: float = 6.0) -> None
+```
+
+Emit a declarative flex-row layout tree.
+
+The host resolves all child positions using taffy (flexbox) and real
+egui font metrics. Children are layout child dicts from badge_child(),
+text_child(), key_chip_child(), or layout_node().
+
+`x`, `y`    — pane-relative top-left anchor.
+`children`  — list of layout child dicts.
+`gap`       — space between children in pixels (default 6.0).
+
+Example::
+
+    ctx.row(
+        x=24.0, y=40.0,
+        children=[
+            ctx.badge_child("4 files"),
+            ctx.text_child(" modified"),
+        ],
+        gap=6.0,
+    )
+
+---
+
+### `column`
+
+```python
+def column(x: float, y: float, children: 'list[dict]', gap: float = 6.0) -> None
+```
+
+Emit a declarative flex-column layout tree.
+
+Same as row() but stacks children top-to-bottom.
+
+---
+
+### `stack`
+
+```python
+def stack(x: float, y: float, children: 'list[dict]') -> None
+```
+
+Emit a declarative stack layout — all children rendered at the same origin.
+
+Use for layering (background rect behind text, etc.).
+
+---
+
+### `frame_done`
+
+```python
+def frame_done() -> None
+```
+
+Flush all buffered draw commands for this frame.
+
+Called automatically after on_render returns. Only call this manually
+if you're rendering in multiple phases and need intermediate updates.
+
+---
+

--- a/website/src/content/docs/sdk-render-context.md
+++ b/website/src/content/docs/sdk-render-context.md
@@ -250,7 +250,7 @@ them left-to-right — no Python width math.
 `align`     — vertical alignment; use "left_center" to center items
               on the y-axis at their midline (default: "left_center").
 
-Example::
+Example:
 
     ctx.text_row(
         x=24.0, y=200.0,
@@ -279,7 +279,7 @@ no truncation, no overflow.
 
 `pairs` is a list of `(keys, description)` tuples where `keys`
 is either a single string or a list of strings (multi-key
-chord). Example::
+chord). Example:
 
     ctx.shortcuts(
         x=24.0, y=12.0, max_width=ctx.w - 48.0,
@@ -421,7 +421,7 @@ in logical pixels — the host uses this to size the scrollbar thumb.
 Pass the full height of all items even if most are off-screen.
 
 `id` must be stable across frames — use a descriptive string rather
-than a counter. Typical pattern::
+than a counter. Typical pattern:
 
     def on_scroll(self, ctx, id, offset_y):
         if id == "main-list":
@@ -469,7 +469,7 @@ When `multiline=True`, Enter submits and Shift+Enter inserts a
 newline. When `multiline=False` (default), Enter submits
 immediately.
 
-Pattern (poll on every frame)::
+Pattern (poll on every frame):
 
     submitted = ctx.text_input("note", x=12, y=12, w=300,
                                placeholder="Type a note…")
@@ -747,7 +747,7 @@ text_child(), key_chip_child(), or layout_node().
 `children`  — list of layout child dicts.
 `gap`       — space between children in pixels (default 6.0).
 
-Example::
+Example:
 
     ctx.row(
         x=24.0, y=40.0,

--- a/website/src/content/docs/sdk-widgets.md
+++ b/website/src/content/docs/sdk-widgets.md
@@ -116,14 +116,6 @@ Usage:
             if idx is not None:
                 self._list.set_selected(idx)
 
-### `selected_index`
-
-```python
-def selected_index() -> int
-```
-
----
-
 ### `set_selected`
 
 ```python
@@ -173,54 +165,6 @@ Offset is always clamped to [0, max_offset] after any mutation.
 Negative inputs for content_height and viewport_height are clamped to 0
 with a warning rather than raising, so callers with stale layout data
 degrade gracefully.
-
-### `content_height`
-
-```python
-def content_height() -> float
-```
-
----
-
-### `content_height`
-
-```python
-def content_height(value: float) -> None
-```
-
----
-
-### `viewport_height`
-
-```python
-def viewport_height() -> float
-```
-
----
-
-### `viewport_height`
-
-```python
-def viewport_height(value: float) -> None
-```
-
----
-
-### `offset`
-
-```python
-def offset() -> float
-```
-
----
-
-### `max_offset`
-
-```python
-def max_offset() -> float
-```
-
----
 
 ### `scroll_by`
 
@@ -332,32 +276,6 @@ Pure text model: lines, cursor, and optional selection.
 
 Internal representation: list of strings, no trailing newlines per line.
 An empty buffer contains exactly one empty string.
-
-### `lines`
-
-```python
-def lines() -> list[str]
-```
-
-Read-only view of the line list.
-
----
-
-### `cursor`
-
-```python
-def cursor() -> Cursor
-```
-
----
-
-### `selection`
-
-```python
-def selection() -> Selection | None
-```
-
----
 
 ### `text`
 

--- a/website/src/content/docs/sdk-widgets.md
+++ b/website/src/content/docs/sdk-widgets.md
@@ -1,0 +1,470 @@
+---
+title: "Widgets"
+description: "Reusable UI components for Plexi apps"
+verified_version: "3.6.54"
+---
+
+# Widgets
+
+Import widgets from `plexi_sdk.widgets`:
+
+```python
+from plexi_sdk.widgets import (
+    Button, ButtonStyle,
+    KeyMap,
+    ListView,
+    ScrollState,
+    TextArea, TextAreaTheme,
+    TextBuffer, Cursor, Selection,
+    emit_text_input,
+)
+```
+
+## ButtonStyle
+
+## Button
+
+Stateful button widget. Tracks its own hover/click state across frames.
+
+Usage::
+
+    btn = Button("ok", x=20, y=40, w=80, h=32, label="OK")
+
+    def on_render(self, ctx):
+        if btn.render(ctx):
+            handle_ok()
+
+### `render`
+
+```python
+def render(ctx: 'RenderContext') -> bool
+```
+
+Draw the button and return True if clicked this frame.
+
+---
+
+## KeyMap
+
+Declarative keyboard shortcut registry.
+
+Usage::
+
+    km = KeyMap()
+    km.bind("s", mod="cmd", action="save")
+    km.bind("q", action="quit")
+
+    def on_key(self, ctx, key, mods):
+        action = km.handle(key, mods)
+        if action == "save":
+            save()
+        elif action == "quit":
+            quit()
+
+### `bind`
+
+```python
+def bind(key: str, action: str, mod: str = '') -> None
+```
+
+Bind a key + optional modifier to an action name.
+
+`mod` is a pipe-separated string of modifier names:
+"cmd", "shift", "ctrl", "alt". Order does not matter.
+Example: ``km.bind("s", "save", mod="cmd")``
+
+---
+
+### `handle`
+
+```python
+def handle(key: str, mods: dict) -> 'str | None'
+```
+
+Return the action name for this key+mods, or None if unbound.
+
+`mods` is the dict from on_key: {"shift": bool, "ctrl": bool,
+"alt": bool, "meta": bool}. "meta" is treated as "cmd".
+
+---
+
+## ListView
+
+Stateful scrollable list widget with fixed item height.
+
+Usage::
+
+    class MyApp(App):
+        def on_init(self, ctx):
+            self._list = ListView(item_height=48.0)
+
+        def on_render(self, ctx):
+            ctx.render(Column([
+                AppBar("Title"),
+                self._list.render([
+                    ListItem(title=items[i], selected=i == self._list.selected_index)
+                    for i in range(len(items))
+                ]),
+            ]))
+
+        def on_key(self, ctx, key, mods):
+            if self._list.handle_key(key):
+                self.emit.schedule_render(after_ms=16)
+
+        def on_click(self, ctx, x, y, button):
+            idx = self._list.hit_test(y)
+            if idx is not None:
+                self._list.set_selected(idx)
+
+### `selected_index`
+
+```python
+def selected_index() -> int
+```
+
+---
+
+### `set_selected`
+
+```python
+def set_selected(idx: int) -> None
+```
+
+---
+
+### `handle_key`
+
+```python
+def handle_key(key: str) -> bool
+```
+
+Move selection for j/k/arrows. Returns True if the key was consumed.
+
+---
+
+### `hit_test`
+
+```python
+def hit_test(y: float) -> int | None
+```
+
+Return item index at screen-coord y (from last render), or None.
+
+---
+
+### `render`
+
+```python
+def render(items: list) -> '_ListViewRenderer'
+```
+
+Return a renderable Component containing the given items.
+
+Call inside Column([...]) on every frame — the returned object is
+lightweight and safe to recreate each render.
+
+---
+
+## ScrollState
+
+Pure data model for vertical scroll state.
+
+Offset is always clamped to [0, max_offset] after any mutation.
+Negative inputs for content_height and viewport_height are clamped to 0
+with a warning rather than raising, so callers with stale layout data
+degrade gracefully.
+
+### `content_height`
+
+```python
+def content_height() -> float
+```
+
+---
+
+### `content_height`
+
+```python
+def content_height(value: float) -> None
+```
+
+---
+
+### `viewport_height`
+
+```python
+def viewport_height() -> float
+```
+
+---
+
+### `viewport_height`
+
+```python
+def viewport_height(value: float) -> None
+```
+
+---
+
+### `offset`
+
+```python
+def offset() -> float
+```
+
+---
+
+### `max_offset`
+
+```python
+def max_offset() -> float
+```
+
+---
+
+### `scroll_by`
+
+```python
+def scroll_by(dy: float) -> None
+```
+
+Positive dy scrolls down (reveals content below).
+
+---
+
+### `scroll_to`
+
+```python
+def scroll_to(y: float) -> None
+```
+
+Set offset directly. Clamped to [0, max_offset].
+
+---
+
+### `ensure_visible`
+
+```python
+def ensure_visible(y: float, margin: float = 0.0) -> None
+```
+
+Adjust offset so content-coord y is inside the viewport.
+
+If y is above the viewport (y < offset + margin), scroll up so
+y lands at offset + margin.
+If y is below the viewport (y > offset + viewport_height - margin),
+scroll down so y lands at offset + viewport_height - margin.
+Otherwise no-op. Result is always clamped.
+
+---
+
+## TextAreaTheme
+
+## TextArea
+
+TextBuffer + ScrollState + theme → DrawCommands.
+
+The widget owns geometry (position + size) at render time; the buffer and
+scroll are passed in so callers control state.
+
+### `on_key`
+
+```python
+def on_key(key: str, shift: bool = False, ctrl: bool = False) -> None
+```
+
+Handle a key event. Mutates buffer + keeps cursor visible via scroll.
+
+---
+
+### `ensure_cursor_visible`
+
+```python
+def ensure_cursor_visible() -> None
+```
+
+---
+
+### `render`
+
+```python
+def render(x: float, y: float, w: float, h: float) -> list[dict]
+```
+
+Return DrawCommands for a TextArea at the given viewport rect.
+
+Updates scroll.viewport_height and scroll.content_height as a side
+effect (so it clamps correctly when the viewport changes size).
+All returned coordinates are absolute (include x, y offsets).
+
+---
+
+## Cursor
+
+## Selection
+
+Anchor is fixed; head follows the cursor.
+
+The selection is inclusive of anchor and exclusive of head, like most
+editors. Use normalized() to always get (start, end) in document order.
+
+### `is_empty`
+
+```python
+def is_empty() -> bool
+```
+
+---
+
+### `normalized`
+
+```python
+def normalized() -> tuple[Cursor, Cursor]
+```
+
+Return (start, end) where start <= end in document order.
+
+---
+
+## TextBuffer
+
+Pure text model: lines, cursor, and optional selection.
+
+Internal representation: list of strings, no trailing newlines per line.
+An empty buffer contains exactly one empty string.
+
+### `lines`
+
+```python
+def lines() -> list[str]
+```
+
+Read-only view of the line list.
+
+---
+
+### `cursor`
+
+```python
+def cursor() -> Cursor
+```
+
+---
+
+### `selection`
+
+```python
+def selection() -> Selection | None
+```
+
+---
+
+### `text`
+
+```python
+def text() -> str
+```
+
+---
+
+### `selected_text`
+
+```python
+def selected_text() -> str
+```
+
+---
+
+### `insert`
+
+```python
+def insert(ch: str) -> None
+```
+
+Insert text at cursor, replacing any existing selection first.
+
+---
+
+### `insert_newline`
+
+```python
+def insert_newline() -> None
+```
+
+Convenience wrapper; equivalent to insert('\n').
+
+---
+
+### `delete_back`
+
+```python
+def delete_back() -> None
+```
+
+Backspace. Deletes selection if one exists, else deletes char before cursor.
+
+---
+
+### `delete_forward`
+
+```python
+def delete_forward() -> None
+```
+
+Forward delete. Symmetric to delete_back.
+
+---
+
+### `move_cursor`
+
+```python
+def move_cursor(direction: str, select: bool = False) -> None
+```
+
+Move cursor in the given direction.
+
+Valid directions: 'left', 'right', 'up', 'down',
+                  'home', 'end', 'doc_start', 'doc_end'.
+
+If select=True the selection head is extended; otherwise any existing
+selection is cleared first (standard editor behaviour: pressing an
+arrow key without Shift collapses to the nearer edge).
+
+---
+
+### `set_cursor`
+
+```python
+def set_cursor(row: int, col: int, select: bool = False) -> None
+```
+
+Jump cursor to (row, col), clamped to valid positions.
+
+---
+
+### `select_to`
+
+```python
+def select_to(row: int, col: int) -> None
+```
+
+Extend selection head to (row, col); creates selection if none.
+
+---
+
+### `clear_selection`
+
+```python
+def clear_selection() -> None
+```
+
+---
+
+### `select_all`
+
+```python
+def select_all() -> None
+```
+
+---
+

--- a/website/src/content/docs/sdk-widgets.md
+++ b/website/src/content/docs/sdk-widgets.md
@@ -26,7 +26,7 @@ from plexi_sdk.widgets import (
 
 Stateful button widget. Tracks its own hover/click state across frames.
 
-Usage::
+Usage:
 
     btn = Button("ok", x=20, y=40, w=80, h=32, label="OK")
 
@@ -48,7 +48,7 @@ Draw the button and return True if clicked this frame.
 
 Declarative keyboard shortcut registry.
 
-Usage::
+Usage:
 
     km = KeyMap()
     km.bind("s", mod="cmd", action="save")
@@ -92,7 +92,7 @@ Return the action name for this key+mods, or None if unbound.
 
 Stateful scrollable list widget with fixed item height.
 
-Usage::
+Usage:
 
     class MyApp(App):
         def on_init(self, ctx):

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -1,0 +1,445 @@
+---
+title: "SDK Overview"
+description: "Python SDK for building Plexi pane apps"
+verified_version: "3.6.54"
+---
+
+plexi_sdk — Plexi external app SDK (Python), PGAP v3
+
+Spec: docs/specs/releases/plexi-v3.0.md §3 (PGAP v3), §7 (typed pipes).
+Zero dependencies, pure stdlib.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+QUICK START
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+    from plexi_sdk import App, BG, FG, BODY, ACCENT
+
+    class CounterApp(App):
+        async def on_init(self, ctx):
+            # Called once after the host completes the Init handshake.
+            # ctx.workspace_root, ctx.capabilities, ctx.feature_flags are set.
+            # Hooks may be async def (to use await) or plain def (fire-and-forget).
+            self.count = 0
+            self.emit.info("CounterApp ready")
+            # Blocking helpers are coroutines — await them directly:
+            # api_key = await self.emit.secret_get("MY_API_KEY")
+
+        def on_render(self, ctx):
+            # Pure-sync render hooks work unchanged — no await needed here.
+            # ctx.w / ctx.h are the current pane dimensions.
+            # ctx.elapsed is seconds since the previous render (0.0 on first frame).
+            ctx.clear(BG)
+            ctx.rect(20, 20, ctx.w - 40, 60, fill="#313244", radius=8.0)
+            ctx.text(36, 42, f"Count: {self.count}", size=BODY, color=FG)
+            ctx.text(36, 72, "Press +/- to change  •  q to quit", size=12.0, color="#6c7086")
+
+        def on_key(self, ctx, key, mods):
+            # key is a string: "a"-"z", "up", "down", "left", "right",
+            # "return", "escape", "backspace", "tab", "space", "f1"…"f12", etc.
+            # mods shape: {"shift": bool, "ctrl": bool, "alt": bool, "meta": bool}
+            if key == "+" or (key == "=" and mods.get("shift")):
+                self.count += 1
+            elif key == "-":
+                self.count -= 1
+            elif key == "q":
+                pass  # host handles quit; apps cannot self-exit
+
+        def on_click(self, ctx, x, y, button):
+            # button: "primary" | "secondary" | "middle"
+            # x, y are pixel coordinates within the pane
+            ctx.notify("Clicked", f"({x:.0f}, {y:.0f}) {button}")
+
+    CounterApp().run()
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PROTOCOL OVERVIEW (PGAP v3)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Newline-delimited JSON over stdin/stdout. Binary data travels on typed Unix
+socket pipes, not stdio.
+
+PlexiEvent  (host → app):
+  Init               — handshake; delivers app_id, workspace_root, capabilities,
+                        feature_flags, and protocol version string ("pgap/3.x")
+  Render             — draw a new frame; carries frame_id and rect {x,y,w,h}
+  Key                — keypress; carries key string and modifiers dict
+  Click              — pointer event; carries x, y, button string
+  Command            — command-palette entry submitted by the user; carries text
+  CapabilityDecision — response to a CapabilityRequest; carries request_id and granted bool
+  SecretValue        — response to SecretGet; carries key and value (str or null)
+  HttpResponse       — response to HttpRequest; carries request_id, body, and optional error
+  RunUpdate          — streaming update from a RunGet job; carries run_id and payload
+  PipeMessage        — JSON-mode pipe message; carries pipe_id and payload
+  PipeOpened         — binary pipe ready; carries pipe_id and socket_path (Unix socket)
+  PipeOverrun        — host dropped frames on a pipe; carries pipe_id and dropped_frames count
+  PathChanged        — terminal cwd broadcast; carries cwd string
+  AppSpawned         — confirmation that a SpawnApp request completed; carries pane_id and type_id
+  PaneSpawned        — confirmation that a SpawnPane request completed; carries pane_id
+  PaneSpawnError     — SpawnPane could not be fulfilled; carries reason
+  InjectState        — host-initiated state injection; carries payload dict
+  Suspend            — app is being hidden/backgrounded
+  Resume             — app is visible again
+  Shutdown           — app should clean up and exit
+
+DrawCommand (app → host):
+  Rect          — filled rectangle with optional corner radius
+  Circle        — filled circle
+  Text          — text label with font size, color, monospace/bold flags
+  Line          — straight line segment
+  List          — scrollable item list (see ListItem shape below)
+  Image         — display a raster image by path or data URI
+  VideoPlayer   — embed a video player widget
+  AudioMeter    — display a real-time audio level meter
+  AudioPlay     — play audio from a file or pipe
+  AudioCapture  — open an audio capture stream
+  FrameDone     — signals end of a render frame (auto-sent by SDK; do not call manually)
+  Log           — structured log line forwarded to the host log
+  Notify        — trigger a system notification
+  CapabilityRequest — request a runtime capability; host may prompt the user
+  SecretGet     — request a secret by key from the host secrets store
+  HttpRequest   — broker an HTTP request through the host (requires net.http capability)
+  RunGet        — dispatch an intent-based AI/agent job
+  RunComplete   — mark a RunGet job as finished
+  PipeOpen      — open a typed pipe (json or binary, in/out/duplex)
+  PipeSend      — send a JSON payload on a json-mode pipe
+  StatusSummary — set the status bar summary text for this pane
+  ScheduleRender — ask the host to send a Render event after N milliseconds
+  SpawnApp      — [DEPRECATED: use SpawnPane instead] request the host to open a new pane with a given app type
+  SpawnPane     — request the host to open a pane with given app, layout, args, and optional pipe_id
+  CdRequest     — request the host to cd all terminals in the pane group to a path
+  Ready         — sent automatically after Init; do not emit manually
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+THEME CONSTANTS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Font sizes (float, points):
+  TITLE      = 22.0   — primary heading
+  HEADING    = 18.0   — section heading
+  BODY       = 15.0   — default body text
+  CAPTION    = 13.0   — secondary label
+  HINT       = 12.0   — muted hint text
+  MONO_BODY  = 14.0   — monospace body (code)
+  MONO_SMALL = 12.0   — monospace small (log output)
+
+Layout (float, pixels):
+  PAD        = 16.0   — standard outer padding
+  PAD_TIGHT  =  8.0   — tight/inner padding
+  HEADER_H   = 48.0   — standard header bar height
+  STATUS_H   = 44.0   — status bar height
+
+Colors (hex strings, Catppuccin Mocha):
+  BG        = "#1e1e2e"   — main background
+  SURFACE   = "#313244"   — elevated surface / card
+  HIGHLIGHT = "#45475a"   — hover / selection highlight
+  ACCENT    = "#89b4fa"   — primary accent (blue)
+  MUTED     = "#6c7086"   — muted / disabled text
+  FG        = "#cdd6f4"   — primary foreground text
+  RED       = "#f38ba8"   — error / destructive
+  GREEN     = "#a6e3a1"   — success / positive
+  YELLOW    = "#f9e2af"   — warning / caution
+
+Color helpers:
+  rgba(r, g, b, a=255) -> str  — build an 8-digit hex string #rrggbbaa
+  dim(hex_color, alpha) -> str — apply alpha (0-255) to an existing hex color
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+NOTIFICATIONS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Four kinds. All are posted via ctx.notify* and render in the central
+notification modal (ctx.notify(...) returns immediately; the other three
+block the calling thread until the user responds — run them on a worker
+thread if the app needs to stay interactive).
+
+  ctx.notify(title, body="", level="info", priority=PRIORITY_NORMAL)
+      Fire-and-forget message. Enter / Space acknowledge, Esc dismisses.
+
+  ctx.notify_and_wait(title, body="", priority=...)  -> str
+      Same as notify() but blocks. Returns "acknowledge" or "cancel".
+
+  ctx.notify_choice(title, options, body="", required=False, priority=...) -> str
+      Blocking choice picker. options = [{"label":..., "value":...,
+      "shortcut":...}]. Returns chosen value (or label if no value),
+      or "__cancel__" if dismissed.
+
+  ctx.notify_input(title, prompt="", body="", required=False, priority=...) -> str
+      Blocking text input. Returns the typed string, or "__cancel__".
+
+  ctx.notify_with_image(title, body, image_bytes, mime, priority=...,
+                        choices=None) -> str | None
+      Convenience wrapper that handles base64 encoding + 50 KB cap.
+      `image_bytes` > 50 KB raises ValueError locally. With `choices=None`
+      this is fire-and-forget (returns None); with `choices` set it routes
+      to notify_choice and blocks for the user's pick. `mime` must be
+      "image/png" or "image/jpeg".
+
+Image attachments (#74) — pass `image_inline={"mime", "base64"}` to any of
+the notify* methods, or use `notify_with_image` for the convenience wrap.
+Inline images cap at 50 KB decoded; oversized images render a placeholder
+badge instead of the bitmap. The `image_pipe_id` field is reserved for a
+future host-side rendering primitive — apps cannot publish frames through
+it today. Use the inline path for now.
+
+Priority — required kwarg on every call. Use the named constants:
+
+  PRIORITY_LOW      = 0     Background info. Stacks at the bottom of the queue.
+  PRIORITY_NORMAL   = 50    Standard confirmations — "note saved", "done", etc.
+  PRIORITY_HIGH     = 100   Needs attention soon — not blocking but noticeable.
+  PRIORITY_CRITICAL = 200   Interrupt-level. Use sparingly; reserve for user
+                            decisions the app genuinely depends on. If every
+                            notification is CRITICAL, none is.
+
+(A future version may reserve a user-only priority band above CRITICAL so
+a misbehaving app can't yell itself to the top of someone's queue. Apps
+should stay under 200 regardless; 0..200 is the app band.)
+
+Queue model:
+
+- Notifications pile into a single priority-sorted queue (priority DESC,
+  arrival ASC). The front-most is pinned by id — new notifications
+  arriving NEVER change what's on screen, only the total count.
+- On dismiss, the next front-most is chosen dynamically from whatever's
+  in the queue right now — not from a pre-frozen snapshot.
+- Cmd+] / Cmd+[ preview other queued notifications without acknowledging.
+  Cmd+Shift+A toggles the modal on/off.
+
+Scope — window / context / global — is NOT a runtime choice. It's declared
+per-app in the app's manifest.toml under [launch]:
+
+  [launch]
+  notification_scope = "global"   # "window" | "context" | "global"
+
+  "window"   — default. Visible only when the app's window is active.
+               No behaviour change for apps that omit the field.
+  "context"  — visible whenever the user is in the same sidebar project,
+               regardless of which window page is showing.
+  "global"   — always visible across all contexts (use for stand-up
+               reminders, timers, monitoring dashboards).
+
+The user controls which scope a given app uses by editing its manifest.
+Apps do not see or set scope at the SDK level.
+
+Round-trip response — notify_choice / notify_input / notify_and_wait all
+block for the user's answer. For fire-and-forget notifications that still
+need a response, set notify_id explicitly and handle PlexiEvent::NotifyAction
+in your event loop. The blocking helpers handle this plumbing internally.
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MANIFEST REFERENCE (examples/<app>/manifest.toml)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Required:
+  [app]
+  id = "my-app"             # stable identifier — used for launch slot, log
+                            # target "app::<id>", install dir, pack refs
+  name = "My App"           # human-readable display name
+  version = "0.1.0"
+  description = "…"
+  entry = "my_app.py"       # executable entry point, relative to manifest
+
+Optional:
+  [launch]
+  notification_scope = "context"   # "window" (default) | "context" | "global"
+
+  [app.capabilities]
+  capabilities = []         # e.g. ["net.http", "audio.record"]
+                            # apps must declare what they use; host prompts
+                            # on install (future) and gates at runtime
+
+  [launch]
+  layout_hint = { side = "above", split = 0.5 }  # preferred split direction
+                                                  # + size when spawned
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+RenderContext  (ctx passed to on_init, on_render, on_key, on_click, …)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Attributes:
+  ctx.x, ctx.y          — pane origin in logical pixels (usually 0, 0)
+  ctx.w, ctx.h          — pane width and height in logical pixels
+  ctx.frame_id          — monotonically increasing render counter
+  ctx.elapsed           — seconds since previous on_render (0.0 on first frame)
+  ctx.workspace_root    — absolute path to the workspace root directory
+  ctx.capabilities      — list of granted capability strings
+  ctx.feature_flags     — list of enabled feature flag strings
+  ctx.emit              — Emitter instance (same as self.emit on App)
+
+Drawing methods:
+  ctx.clear(fill)
+      Fill the entire pane with a solid color. Equivalent to ctx.rect(0, 0, w, h, fill).
+
+  ctx.rect(x, y, w, h, fill, radius=0.0)
+      Draw a filled rectangle. radius > 0 rounds the corners.
+
+  ctx.circle(cx, cy, r, fill)
+      Draw a filled circle centered at (cx, cy) with radius r.
+
+  ctx.text(x, y, text, size, color, monospace=False, bold=False)
+      Draw a text label. x, y are the top-left origin of the text block.
+
+  ctx.line(x1, y1, x2, y2, color, width=1.0)
+      Draw a straight line segment.
+
+  ctx.list_view(items, selected=0, item_height=40.0, x=0, y=0, w=None, h=None)
+      Draw a scrollable list. w defaults to ctx.w; h defaults to ctx.h - y.
+      Each item is a dict — see ListItem shape below.
+
+Notification / logging (usable inside or outside a frame):
+  ctx.notify(title, body, level="info", actions=None)
+      Trigger a system notification. actions: list of NotifyAction dicts (see below).
+
+  ctx.status_summary(text)
+      Set the status bar summary text for this pane.
+
+  ctx.log(level, message)  /  ctx.info(msg)  /  ctx.warn(msg)
+  ctx.error(msg)           /  ctx.debug(msg)
+      Forward a log line to the host logger, tagged with this app's ID.
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Emitter  (self.emit — available at all times, including background threads)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+All methods are thread-safe (protected by a global write lock).
+
+  emit.notify(title, body, level="info", actions=None)
+      Trigger a system notification outside of a render frame.
+
+  emit.log(level, message)  /  emit.info(msg)  /  emit.warn(msg)
+  emit.error(msg)           /  emit.debug(msg)
+      Write a structured log line to the host log.
+
+  emit.status_summary(text)
+      Set the status bar summary text for this pane.
+
+  emit.schedule_render(after_ms=16)
+      Ask the host to send a Render event after after_ms milliseconds.
+      Use at the end of on_render to drive a continuous animation loop.
+      16 ms ≈ 60 fps  |  32 ms ≈ 30 fps.
+
+  emit.secret_get(key) -> str | None        [BLOCKING]
+      Request a secret by key from the host secrets store. Blocks until the
+      host responds. Returns the secret string, or None if denied/not found.
+
+  emit.http_get(url) -> str                 [BLOCKING]
+      Broker an HTTP GET through the host. Requires the net.http capability.
+      Blocks until the response arrives. Raises RuntimeError on failure.
+      Call from a background thread to avoid stalling the render loop.
+
+  emit.ai_query(model_tier, system, messages, tools=None) -> AiResponse  [BLOCKING]
+      Plexi AI broker call (#284). Requires the `ai.query` capability declared
+      in manifest.toml. `model_tier` is "low" | "medium" | "high"
+      (Haiku / Sonnet / Opus). Returns an AiResponse with content, tokens_in,
+      tokens_out. Raises CapabilityDeniedError if the manifest didn't grant
+      `ai.query`, or RuntimeError on any other backend failure. Call from a
+      background thread — the host may take seconds to reply.
+
+  emit.capability_request(capability) -> bool  [BLOCKING]
+      Request a runtime capability (e.g. "net.http", "fs.write"). The host
+      may show a permission prompt to the user. Blocks until granted or denied.
+      Returns True if granted. Call once at startup, not on every render.
+
+  emit.cd_to(cwd)
+      Request the host to cd all terminals in the same pane group to cwd.
+
+  emit.run_get(intent, payload=None) -> str
+      Dispatch an intent-based AI/agent job. Returns a run_id. Progress arrives
+      via RunUpdate PlexiEvents; handle them in on_run_update if needed.
+
+  emit.pipe_open(pipe_id, mode="binary", direction="in") -> Pipe
+      Open a typed pipe and return a Pipe handle.
+      mode: "json" | "binary"    direction: "in" | "out" | "duplex"
+      For binary mode, call pipe.connect() and wait for PipeOpened before I/O.
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+STRUCTURED ARGUMENT SHAPES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+mods  (passed to on_key):
+    {"shift": bool, "ctrl": bool, "alt": bool, "meta": bool}
+
+ListItem  (each element of the items list passed to ctx.list_view):
+    {
+        "title":    str,          # primary label (required)
+        "subtitle": str,          # secondary label (optional)
+        "icon":     str,          # SF Symbol name or emoji (optional)
+        "color":    str,          # override title color (optional hex)
+        "tag":      str,          # right-aligned badge text (optional)
+    }
+
+NotifyAction  (each element of the actions list passed to notify):
+    {
+        "label": str,             # button label shown in the notification
+        "key":   str,             # identifier sent back in a Command event
+    }
+
+Pipe  (returned by emit.pipe_open):
+    pipe.connect(timeout=5.0) -> bool    — wait for the socket to be ready
+    pipe.read_frame()         -> bytes | None  — read one length-prefixed frame
+    pipe.write_frame(data)               — write one length-prefixed frame
+    pipe.send(payload)                   — JSON-mode send (dict/list/scalar)
+    pipe.close()                         — release the socket
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+App EVENT HANDLERS (override in your subclass)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  on_init(self, ctx)                            — after Init handshake completes
+  on_render(self, ctx)                          — on each Render event; auto-sends FrameDone
+  on_key(self, ctx, key, mods)                  — on Key event
+  on_click(self, ctx, x, y, button)             — on Click event
+  on_command(self, ctx, text)                   — on Command event (command palette)
+  on_pipe_message(self, ctx, pipe_id, payload)  — on PipeMessage (json-mode pipe)
+  on_path_changed(self, ctx, cwd)               — on PathChanged broadcast
+  on_inject(self, ctx, payload)                 — on InjectState from the host
+  on_app_spawned(self, pane_id, type_id)        — on AppSpawned confirmation
+  on_suspend(self)                              — on Suspend (app hidden/backgrounded)
+  on_resume(self)                               — on Resume (app visible again)
+  on_shutdown(self)                             — on Shutdown (clean up before exit)
+
+All handlers except on_suspend, on_resume, and on_shutdown receive a
+RenderContext as their first argument. on_render is the only handler that
+auto-emits FrameDone; all others must NOT emit FrameDone.
+
+ASYNC HANDLERS AND BLOCKING I/O (#393)
+
+Input-driven hooks (on_key, on_click, on_command, on_paste, on_pipe_message,
+on_path_changed, on_inject, on_timer) are dispatched as asyncio tasks — the
+event loop does NOT wait for them to finish before processing the next event.
+This means a slow handler never stalls the stdin reader or delays a Render.
+
+Rules:
+
+  1. Declare handlers ``async def`` whenever they need to do any I/O or call
+     ``await``-able Emitter helpers:
+
+         async def on_key(self, ctx, key, mods):
+             result = await self.emit.http_get(url)   # non-blocking — fine
+
+  2. Never call blocking operations directly from a handler. These freeze the
+     event loop thread and starve all other tasks:
+
+         def on_key(self, ctx, key, mods):
+             time.sleep(1)          # BAD — blocks event loop thread
+             requests.get(url)      # BAD — blocks event loop thread
+
+     Instead, use ``asyncio.to_thread`` from an async handler, or kick off a
+     ``threading.Thread`` and bridge back with ``emit.run_sync()``.
+
+  3. ``on_render`` is awaited directly — all draw commands must complete before
+     FrameDone is sent. Keep on_render free of I/O; use on_render to read state
+     that background tasks have already fetched and stored.
+
+  4. ``on_init`` and ``on_shutdown`` are also awaited (startup / teardown
+     ordering). Blocking I/O in on_init should use ``await`` Emitter helpers.
+
+Call MyApp().run() to start the PGAP event loop. This blocks until Shutdown.

--- a/website/src/lib/docsNav.ts
+++ b/website/src/lib/docsNav.ts
@@ -26,6 +26,16 @@ export const docsNav: DocNavSection[] = [
     ],
   },
   {
+    section: 'SDK Reference',
+    items: [
+      { slug: 'sdk', title: 'Overview' },
+      { slug: 'sdk-app', title: 'App' },
+      { slug: 'sdk-render-context', title: 'RenderContext' },
+      { slug: 'sdk-emitter', title: 'Emitter' },
+      { slug: 'sdk-widgets', title: 'Widgets' },
+    ],
+  },
+  {
     section: 'CLI Reference',
     items: [
       { slug: 'cli', title: 'CLI Overview' },


### PR DESCRIPTION
## Summary

- Add `website/scripts/generate-sdk-docs.py` — AST-based doc generator that extracts classes, methods, docstrings, and type-annotated signatures from SDK Python source
- Generates 5 Astro-compatible markdown pages: SDK Overview, App, RenderContext, Emitter, Widgets
- Wire generator into `npm run build` so docs never drift from source
- Update Dockerfile/Railway config: build context → repo root so Docker can access both `website/` and `sdk/`
- Add docstrings to key public methods in `_app.py` and `_render_context.py`
- Add "SDK Reference" nav section in `docsNav.ts`

## Test plan

- [ ] `cd website && npm run build` succeeds (generator + Astro build)
- [ ] Generated markdown files have correct frontmatter (title, description, verified_version)
- [ ] All SDK public methods appear in generated docs with signatures and docstrings
- [ ] Widget docs use AST-extracted content (no fabricated examples)
- [ ] Railway deployment picks up new build context and serves /docs/sdk/* pages

Closes #1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)