### PR TITLE
feat(config): validate config.toml and surface errors (#1116)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3606,6 +3606,60 @@ impl PlexiApp {
     /// confirmation toggles). Logs the reload so the user knows it worked.
     pub(crate) fn reload_config(&mut self) {
         let active_workspace = crate::config::active_workspace_root();
+
+        let mut all_diags = crate::config::validate_from_path(&crate::config::config_path());
+        if let Some(root) = active_workspace.as_ref() {
+            let project_path = root.join(".plexi").join("config.toml");
+            all_diags.extend(crate::config::validate_from_path(&project_path));
+        }
+
+        let has_errors = all_diags.iter().any(|d| d.is_error());
+
+        let warnings: Vec<_> = all_diags.iter().filter(|d| !d.is_error()).collect();
+        if !warnings.is_empty() {
+            let body = warnings.iter().map(|d| d.to_string()).collect::<Vec<_>>().join("\n");
+            log::warn!("config: unknown keys found:\n{body}");
+        }
+
+        if has_errors {
+            let error_msg = all_diags
+                .iter()
+                .filter(|d| d.is_error())
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            log::warn!("config: parse error, keeping current config:\n{error_msg}");
+            self.pending_notifications.push(PendingNotification {
+                notify_id: format!(
+                    "config-error-{}",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis())
+                        .unwrap_or(0)
+                ),
+                sender_pane_id: 0,
+                source_context_id: 0,
+                level: "error".to_string(),
+                title: "Config Error".to_string(),
+                body: error_msg,
+                kind: crate::app_protocol::NotifyKind::Message,
+                options: vec![],
+                input_prompt: None,
+                required: false,
+                priority: 100,
+                scope: crate::app_protocol::NotifyScope::Global,
+                image_inline: None,
+                image_pipe_id: None,
+                response_file: None,
+                timeout_secs: None,
+                on_dismiss: None,
+                enqueued_at: std::time::Instant::now(),
+                tombstoned: false,
+                deliver_after: None,
+            });
+            return;
+        }
+
         let fresh = crate::config::PlexiConfig::load_with_workspace(active_workspace.as_deref());
 
         // Theme

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3629,14 +3629,15 @@ impl PlexiApp {
                 .collect::<Vec<_>>()
                 .join("\n");
             log::warn!("config: parse error, keeping current config:\n{error_msg}");
+            let notify_id = format!(
+                "config-error-{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0)
+            );
             self.pending_notifications.push(PendingNotification {
-                notify_id: format!(
-                    "config-error-{}",
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis())
-                        .unwrap_or(0)
-                ),
+                notify_id: notify_id.clone(),
                 sender_pane_id: 0,
                 source_context_id: 0,
                 level: "error".to_string(),
@@ -3657,6 +3658,12 @@ impl PlexiApp {
                 tombstoned: false,
                 deliver_after: None,
             });
+            if !self.notifications_focus_mode {
+                self.show_notification_modal = true;
+                if self.current_notify_id.is_none() {
+                    self.current_notify_id = Some(notify_id);
+                }
+            }
             return;
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3788,7 +3788,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
   local cur prev words cword
   _init_completion || return
 
-  local commands="run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config config"
+  local commands="run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config"
 
   if [[ $cword -eq 1 ]]; then
     COMPREPLY=($(compgen -W "$commands" -- "$cur"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3570,6 +3570,34 @@ pub fn context_current_cli() -> i32 {
 ///
 /// Prints a static shell completion script to stdout. Pipe to the appropriate
 /// location for your shell (see `plexi completions --help`).
+pub fn config_check() -> i32 {
+    log::info!("config_check: validating config files");
+    let diags = crate::config::validate_all();
+
+    if diags.is_empty() {
+        let path = crate::config::config_path();
+        eprintln!("✓ {} is valid", path.display());
+        if let Some(root) = crate::config::active_workspace_root() {
+            let project_path = root.join(".plexi").join("config.toml");
+            if project_path.exists() {
+                eprintln!("✓ {} is valid", project_path.display());
+            }
+        }
+        return 0;
+    }
+
+    let has_errors = diags.iter().any(|d| d.is_error());
+    for d in &diags {
+        if d.is_error() {
+            eprintln!("✗ {d}");
+        } else {
+            eprintln!("⚠ {d}");
+        }
+    }
+
+    if has_errors { 1 } else { 0 }
+}
+
 pub fn completions_cli(shell: &str) -> i32 {
     match shell {
         "zsh" => { print!("{}", ZSH_COMPLETION); 0 }
@@ -3614,6 +3642,7 @@ _plexi() {
         'registry:CLI registry'
         'context:Context management'
         'completions:Print shell completion script'
+        'config:Configuration management'
       )
       _describe 'command' commands
       ;;
@@ -3742,6 +3771,11 @@ _plexi() {
           shells=('zsh' 'bash' 'fish')
           _describe 'shell' shells
           ;;
+        config)
+          local subcmds
+          subcmds=('check:Validate config.toml and report errors')
+          _describe 'subcommand' subcmds
+          ;;
       esac
       ;;
   esac
@@ -3754,7 +3788,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
   local cur prev words cword
   _init_completion || return
 
-  local commands="run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions"
+  local commands="run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config config"
 
   if [[ $cword -eq 1 ]]; then
     COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -3862,6 +3896,9 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
     completions)
       COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur"))
       ;;
+    config)
+      COMPREPLY=($(compgen -W "check" -- "$cur"))
+      ;;
   esac
 }
 
@@ -3870,24 +3907,28 @@ complete -F _plexi_completions plexi
 
 const FISH_COMPLETION: &str = r#"# Plexi shell completions for fish
 
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a run -d "Run a named command"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a workspace -d "Workspace management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a secret -d "Secret management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a app -d "App management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a install -d "Install an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a uninstall -d "Uninstall an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a update -d "Update apps or self"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a list -d "List installed apps"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a validate -d "Validate a Plexi app directory"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a pack -d "Pack management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a notify -d "Send a notification"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a pane -d "Pane management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a terminal -d "Open a terminal pane"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a open -d "Open an app pane"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a descriptor -d "Descriptor probe"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a registry -d "CLI registry"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a context -d "Context management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions" -a completions -d "Print shell completion script"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a run -d "Run a named command"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a workspace -d "Workspace management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a secret -d "Secret management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a app -d "App management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a install -d "Install an app"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a uninstall -d "Uninstall an app"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a update -d "Update apps or self"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a list -d "List installed apps"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a validate -d "Validate a Plexi app directory"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a pack -d "Pack management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a notify -d "Send a notification"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a pane -d "Pane management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a terminal -d "Open a terminal pane"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a open -d "Open an app pane"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a descriptor -d "Descriptor probe"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a registry -d "CLI registry"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a context -d "Context management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a completions -d "Print shell completion script"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a config -d "Configuration management"
+
+# config subcommands
+complete -c plexi -f -n "__fish_seen_subcommand_from config" -a check -d "Validate config.toml and report errors"
 
 # secret subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from secret" -a set -d "Store a secret"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -168,6 +168,11 @@ pub enum Commands {
         /// Shell name (zsh, bash, fish)
         shell: Option<String>,
     },
+    /// Configuration management
+    Config {
+        #[command(subcommand)]
+        cmd: ConfigCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -399,4 +404,10 @@ pub enum ContextCmd {
     },
     /// Print the context ID and name for the current pane as JSON
     Current,
+}
+
+#[derive(Subcommand)]
+pub enum ConfigCmd {
+    /// Validate config.toml and report errors
+    Check,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,155 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+// ── Config validation (#1116) ───────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum ConfigDiagnostic {
+    ReadError { path: String, error: String },
+    ParseError { path: String, error: String },
+    UnknownKey { path: String, table: String, key: String },
+}
+
+impl ConfigDiagnostic {
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::ReadError { .. } | Self::ParseError { .. })
+    }
+}
+
+impl std::fmt::Display for ConfigDiagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadError { path, error } => write!(f, "{path}: read error: {error}"),
+            Self::ParseError { path, error } => write!(f, "{path}: {error}"),
+            Self::UnknownKey { path, table, key } => {
+                if table.is_empty() {
+                    write!(f, "{path}: unknown key `{key}`")
+                } else {
+                    write!(f, "{path}: unknown key `{key}` in [{table}]")
+                }
+            }
+        }
+    }
+}
+
+const KNOWN_TOP_LEVEL: &[&str] = &[
+    "font_size", "theme_preset", "theme", "beta", "log",
+    "notifications", "ai", "confirm_quit", "confirm_close",
+    "keybindings", "quick_note",
+];
+const KNOWN_THEME: &[&str] = &[
+    "bg_darkest", "bg_sidebar", "bg_toolbar", "terminal_bg", "bg_hover",
+    "bg_sidebar_hover", "bg_active", "text_primary", "text_dim",
+    "text_section", "accent", "border", "foreground", "background",
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+    "bright_black", "bright_red", "bright_green", "bright_yellow",
+    "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+    "bright_foreground",
+];
+const KNOWN_BETA: &[&str] = &["crt", "ghost", "osc_pane_title"];
+const KNOWN_LOG: &[&str] = &["level", "retention_days"];
+const KNOWN_NOTIFICATIONS: &[&str] = &["enabled", "focus_mode", "interrupt_threshold"];
+const KNOWN_AI: &[&str] = &["backend", "openrouter", "ollama"];
+const KNOWN_AI_OPENROUTER: &[&str] = &["api_key_env", "model_low", "model_medium", "model_high"];
+const KNOWN_AI_OLLAMA: &[&str] = &["host", "model_low", "model_medium", "model_high"];
+const KNOWN_KEYBINDINGS: &[&str] = &[
+    "quit", "close_pane", "toggle_command_palette", "split_horizontal",
+    "split_vertical", "split_right", "split_down", "swap_pane_left",
+    "swap_pane_down", "swap_pane_up", "swap_pane_right", "navigate_left",
+    "navigate_down", "navigate_up", "navigate_right", "new_tab", "next_tab",
+    "prev_tab", "first_tab", "last_tab", "nav_back", "focus_history_forward",
+    "toggle_sidebar", "toggle_zoom", "toggle_shortcuts", "rename_context",
+    "rename_pane", "new_context", "new_page_right", "toggle_minimap",
+    "scroll_up", "scroll_down", "increase_font_size", "decrease_font_size",
+    "open_file_browser", "open_quick_note", "open_config", "reload_config",
+    "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
+];
+
+pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
+    let mut diags = Vec::new();
+    let path_str = path.display().to_string();
+
+    let data = match std::fs::read_to_string(path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return diags,
+        Err(e) => {
+            diags.push(ConfigDiagnostic::ReadError {
+                path: path_str,
+                error: e.to_string(),
+            });
+            return diags;
+        }
+    };
+
+    if let Err(e) = toml::from_str::<PlexiConfig>(&data) {
+        diags.push(ConfigDiagnostic::ParseError {
+            path: path_str,
+            error: e.to_string(),
+        });
+        return diags;
+    }
+
+    if let Ok(value) = toml::from_str::<toml::Value>(&data) {
+        if let Some(table) = value.as_table() {
+            check_unknown_keys(table, "", KNOWN_TOP_LEVEL, &path_str, &mut diags);
+
+            if let Some(toml::Value::Table(t)) = table.get("theme") {
+                check_unknown_keys(t, "theme", KNOWN_THEME, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("beta") {
+                check_unknown_keys(t, "beta", KNOWN_BETA, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("log") {
+                check_unknown_keys(t, "log", KNOWN_LOG, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("notifications") {
+                check_unknown_keys(t, "notifications", KNOWN_NOTIFICATIONS, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("ai") {
+                check_unknown_keys(t, "ai", KNOWN_AI, &path_str, &mut diags);
+                if let Some(toml::Value::Table(or)) = t.get("openrouter") {
+                    check_unknown_keys(or, "ai.openrouter", KNOWN_AI_OPENROUTER, &path_str, &mut diags);
+                }
+                if let Some(toml::Value::Table(ol)) = t.get("ollama") {
+                    check_unknown_keys(ol, "ai.ollama", KNOWN_AI_OLLAMA, &path_str, &mut diags);
+                }
+            }
+            if let Some(toml::Value::Table(t)) = table.get("keybindings") {
+                check_unknown_keys(t, "keybindings", KNOWN_KEYBINDINGS, &path_str, &mut diags);
+            }
+        }
+    }
+
+    diags
+}
+
+fn check_unknown_keys(
+    table: &toml::map::Map<String, toml::Value>,
+    section: &str,
+    known: &[&str],
+    path: &str,
+    diags: &mut Vec<ConfigDiagnostic>,
+) {
+    for key in table.keys() {
+        if !known.contains(&key.as_str()) {
+            diags.push(ConfigDiagnostic::UnknownKey {
+                path: path.to_string(),
+                table: section.to_string(),
+                key: key.clone(),
+            });
+        }
+    }
+}
+
+pub fn validate_all() -> Vec<ConfigDiagnostic> {
+    let mut diags = validate_from_path(&config_path());
+    if let Some(root) = active_workspace_root() {
+        let project_path = root.join(".plexi").join("config.toml");
+        diags.extend(validate_from_path(&project_path));
+    }
+    diags
+}
+
 /// Per-action keybinding overrides. Each field is the name of an action;
 /// the value is a key combo string like `"cmd+d"` or `"cmd+shift+d"`.
 /// Omitting a field preserves the default binding for that action.
@@ -1090,6 +1239,56 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn validate_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "font_size = 14.0\ntheme_preset = \"dracula\"\n").unwrap();
+        let diags = validate_from_path(&path);
+        assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+    }
+
+    #[test]
+    fn validate_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "font_size = not_a_number\n").unwrap();
+        let diags = validate_from_path(&path);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].is_error());
+        assert!(diags[0].to_string().contains("config.toml"));
+    }
+
+    #[test]
+    fn validate_unknown_key_top_level() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "font_size = 14.0\nfoobar = true\n").unwrap();
+        let diags = validate_from_path(&path);
+        assert_eq!(diags.len(), 1);
+        assert!(!diags[0].is_error());
+        assert!(diags[0].to_string().contains("foobar"));
+    }
+
+    #[test]
+    fn validate_unknown_key_in_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[beta]\ncrt = true\nfake_flag = true\n").unwrap();
+        let diags = validate_from_path(&path);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].to_string().contains("fake_flag"));
+        assert!(diags[0].to_string().contains("[beta]"));
+    }
+
+    #[test]
+    fn validate_missing_file_no_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.toml");
+        let diags = validate_from_path(&path);
+        assert!(diags.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd};
+    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -450,6 +450,11 @@ fn main() -> eframe::Result {
                         let s = shell.as_deref().unwrap_or("zsh");
                         std::process::exit(cli::completions_cli(s));
                     }
+                    Commands::Config { cmd: config_cmd } => match config_cmd {
+                        ConfigCmd::Check => {
+                            std::process::exit(cli::config_check());
+                        }
+                    },
                 }
             }
             // No subcommand — fall through to workspace path check, then GUI
@@ -552,6 +557,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         // #680 — context root and shell integration.
         "context",
         "completions",
+        "config",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).


### PR DESCRIPTION
## Summary
- Adds `validate_from_path()` infrastructure: parse error detection + unknown key audit across all config sections
- New `plexi config check` CLI command — validates global + workspace config, exits non-zero on errors, prints warnings for unknown keys
- Hot-reload now validates before applying — parse errors surface as a notification modal and keep the current config
- Shell completions updated for zsh/bash/fish

## Done When (from issue)
- [x] Parse error → visible error notification naming file and TOML error line/column
- [x] Validation runs on hot-reload — same behavior
- [x] Unknown keys produce a warning (manual key audit against known field lists)
- [x] `plexi config check` CLI validates and exits non-zero on error

Closes #1116

## Test plan
- [ ] `plexi-pr-N config check` on a valid config → prints ✓, exits 0
- [ ] Break config.toml syntax → `config check` prints ✗ with line/col, exits 1
- [ ] Add unknown key → `config check` prints ⚠ warning, exits 0
- [ ] Break config.toml, save → notification modal appears, config unchanged
- [ ] Fix config.toml, save → config reloads normally