### PR TITLE
fix(terminal): remove 8px inner padding causing background color fringe (#632)

### DIFF
--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -107,7 +107,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui =
-                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_SM)));
+                ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
             let close_exited = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,


### PR DESCRIPTION
## Summary

- Removed the `pane_rect.shrink(style::SPACE_SM)` (8px inset) from terminal pane rendering in `tiling.rs`
- The shrink created a visible gap between the outer `rect_filled` (using `colors.terminal_bg`) and egui_term's own background (from `TerminalTheme`), showing as a "rocky fringe" at the pane border
- The focus outline uses `StrokeKind::Outside` at the tile level (app/mod.rs), so the inset was never needed for outline clearance

## Test plan

- [ ] Open any terminal pane — borders should show a clean, uniform background with no visible fringe or color mismatch
- [ ] Verify with a saturated terminal background color (where the mismatch was most visible)
- [ ] Confirm focus outline still renders correctly around the terminal pane

Closes #632