### PR TITLE
feat(cli): add `plexi pane self` and suppress CLI stderr log noise

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2114,6 +2114,31 @@ pub fn pane_list_cli() -> i32 {
     }
 }
 
+/// `plexi pane self`
+///
+/// Prints the current pane ID (just the number) to stdout. Reads PLEXI_PANE_ID.
+/// No JSON, no socket round-trip — pure env-var lookup for agent callers.
+pub fn pane_self_cli() -> i32 {
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    match pane_id_str.parse::<u64>() {
+        Ok(id) => {
+            log::info!("pane_self:cli: pane_id={id}");
+            println!("{id}");
+            0
+        }
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+            1
+        }
+    }
+}
+
 /// `plexi pane info`
 ///
 /// Sends a `get_pane_info` command to PLEXI_SOCKET for the current pane
@@ -3705,7 +3730,7 @@ _plexi() {
               ;;
             *)
               local subcmds
-              subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)' 'list:List all open panes as JSON' 'focus:Move focus to a pane' 'close:Close a pane' 'send:Send text to a pane PTY' 'info:Print current pane info as JSON' 'capture:Read PTY scrollback and print as JSON array' 'key:Inject a synthetic key event into a pane')
+              subcmds=('name:Set the name of a pane (current or by ID)' 'set-title:Set the name of a pane (deprecated: use name)' 'list:List all open panes as JSON' 'self:Print current pane ID' 'focus:Move focus to a pane' 'close:Close a pane' 'send:Send text to a pane PTY' 'info:Print current pane info as JSON' 'capture:Read PTY scrollback and print as JSON array' 'key:Inject a synthetic key event into a pane')
               _describe 'subcommand' subcmds
               ;;
           esac
@@ -3836,7 +3861,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       ;;
     pane)
       if [[ $cword -eq 2 ]]; then
-        COMPREPLY=($(compgen -W "name set-title list focus close send info capture key" -- "$cur"))
+        COMPREPLY=($(compgen -W "name set-title list self focus close send info capture key" -- "$cur"))
       else
         case "${words[2]}" in
           capture)
@@ -3977,6 +4002,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a list -d "List all 
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a focus -d "Move focus to a pane by ID"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a close -d "Close a pane"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a send -d "Send text to a pane PTY"
+complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a self -d "Print current pane ID"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a info -d "Print current pane info as JSON"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a capture -d "Read PTY scrollback and print as JSON array"
 complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a synthetic key event into a pane"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -330,6 +330,12 @@ pub enum PaneCmd {
         /// Text to inject (use \n for Enter)
         text: String,
     },
+    /// Print the current pane ID to stdout [requires PLEXI_PANE_ID]
+    ///
+    /// Reads PLEXI_PANE_ID and prints just the numeric ID — no JSON, no parsing.
+    /// Designed for agent callers who need `MY_PANE=$(plexi pane self)`.
+    #[command(name = "self")]
+    Self_,
     /// Print JSON info for the current pane [requires PLEXI_PANE_ID]
     Info,
     /// Read the last N lines from a pane's PTY scrollback and print as a JSON array [requires PLEXI_SOCKET]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -123,7 +123,9 @@ fn rotate_and_prune(
 
 /// Initialise the logger. Must be called before any `log::` macro is used.
 /// If the log file cannot be opened, falls back to stderr-only and logs a warning.
-pub fn init(level: log::LevelFilter, retention_days: u32) {
+/// When `cli_mode` is true, INFO/DEBUG logs are suppressed on stderr (file-only)
+/// so CLI callers (especially agents) don't see noisy socket-level trace lines.
+pub fn init(level: log::LevelFilter, retention_days: u32, cli_mode: bool) {
     let log_file_path = log_path();
     let config_dir = crate::config::config_dir();
 
@@ -166,7 +168,16 @@ pub fn init(level: log::LevelFilter, retention_days: u32) {
         .level_for("app", level);
 
     let dispatch = match file_result {
-        Ok(file) => dispatch.chain(std::io::stderr()).chain(file),
+        Ok(file) => {
+            if cli_mode {
+                let stderr_dispatch = fern::Dispatch::new()
+                    .level(log::LevelFilter::Warn)
+                    .chain(std::io::stderr());
+                dispatch.chain(stderr_dispatch).chain(file)
+            } else {
+                dispatch.chain(std::io::stderr()).chain(file)
+            }
+        }
         Err(e) => {
             eprintln!("[plexi::logging] could not open log file {log_file_path:?}: {e}; falling back to stderr only");
             dispatch.chain(std::io::stderr())

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,13 @@ fn main() -> eframe::Result {
         .unwrap_or_default();
     let log_level = log_config.level_filter().unwrap_or(log::LevelFilter::Info);
     let retention_days = log_config.retention_days.unwrap_or(30);
-    let cli_mode = raw_args.get(1).is_some_and(|a| {
+    let cli_mode = raw_args.iter().skip(1).any(|a| {
         const CLI_SUBCOMMANDS: &[&str] = &[
             "run", "secret", "app", "workspace", "notify", "pane", "terminal",
             "open", "install", "uninstall", "update", "list", "pack",
             "descriptor", "registry", "validate", "context", "completions", "config",
         ];
-        CLI_SUBCOMMANDS.contains(&a.as_str())
+        !a.starts_with('-') && CLI_SUBCOMMANDS.contains(&a.as_str())
     });
     crate::logging::init(log_level, retention_days, cli_mode);
     let frame_tick = crate::logging::new_frame_tick();

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,8 @@ fn main() -> eframe::Result {
         .unwrap_or_default();
     let log_level = log_config.level_filter().unwrap_or(log::LevelFilter::Info);
     let retention_days = log_config.retention_days.unwrap_or(30);
-    crate::logging::init(log_level, retention_days);
+    let cli_mode = raw_args.get(1).is_some_and(|a| !a.starts_with('-'));
+    crate::logging::init(log_level, retention_days, cli_mode);
     let frame_tick = crate::logging::new_frame_tick();
     // Note: spawn_heartbeat is deferred to just before eframe::run_native so
     // the shell probes below don't trigger false FREEZE alerts. The heartbeat
@@ -375,6 +376,7 @@ fn main() -> eframe::Result {
                         }
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
+                        PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                         PaneCmd::Capture { pane_id, lines } => std::process::exit(cli::pane_capture_cli(pane_id, lines)),
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,14 @@ fn main() -> eframe::Result {
         .unwrap_or_default();
     let log_level = log_config.level_filter().unwrap_or(log::LevelFilter::Info);
     let retention_days = log_config.retention_days.unwrap_or(30);
-    let cli_mode = raw_args.get(1).is_some_and(|a| !a.starts_with('-'));
+    let cli_mode = raw_args.get(1).is_some_and(|a| {
+        const CLI_SUBCOMMANDS: &[&str] = &[
+            "run", "secret", "app", "workspace", "notify", "pane", "terminal",
+            "open", "install", "uninstall", "update", "list", "pack",
+            "descriptor", "registry", "validate", "context", "completions", "config",
+        ];
+        CLI_SUBCOMMANDS.contains(&a.as_str())
+    });
     crate::logging::init(log_level, retention_days, cli_mode);
     let frame_tick = crate::logging::new_frame_tick();
     // Note: spawn_heartbeat is deferred to just before eframe::run_native so


### PR DESCRIPTION
## Summary

Closes #1245

- **`plexi pane self`** — prints the current pane ID (just the number) to stdout. Reads `PLEXI_PANE_ID` env var, no socket round-trip. Replaces the ~120-token JSON-parse boilerplate agents use on every session start.
- **CLI stderr log suppression** — when a CLI subcommand is detected (first arg doesn't start with `-`), INFO/DEBUG log lines are suppressed on stderr. They're still written to the log file. Agents no longer see noisy `[INFO] [plexi::cli] pane_list:cli: sending via socket response_file=...` lines mixed into command output.
- Updated zsh, bash, and fish shell completions with the new `self` subcommand.

## Done When

- [x] `plexi pane self` prints just the numeric pane ID
- [x] CLI commands no longer emit INFO log lines to stderr
- [x] Shell completions updated for zsh, bash, fish
- [x] `plexi pane --help` shows `self` subcommand

## Test plan

- [ ] Run `plexi pane self` inside a Plexi pane → prints just the numeric ID
- [ ] Run `plexi pane list` → no `[INFO]` lines on stderr
- [ ] Run `plexi pane self` outside a pane → error message on stderr, exit 1