### PR TITLE
feat(sdk): runtime isinstance check in Column/Card/Scrollable (#1202)

### DIFF
--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -940,6 +940,7 @@ class Card(Component):
     radius: float = RADIUS_MD
 
     def __post_init__(self):
+        self.children = list(self.children)
         for child in self.children:
             if not isinstance(child, Component):
                 raise TypeError(
@@ -1258,6 +1259,7 @@ class Column(Component):
     gap: float = SPACE_MD
 
     def __post_init__(self):
+        self.children = list(self.children)
         for child in self.children:
             if not isinstance(child, Component):
                 raise TypeError(

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -492,6 +492,13 @@ class Scrollable(Component):
     # How many pixels j/k advances per keypress.
     key_step: float = 20.0
 
+    def __post_init__(self):
+        if not isinstance(self.child, Component):
+            raise TypeError(
+                f"Scrollable child must subclass Component, got {type(self.child).__name__}. "
+                "Ad-hoc widget classes missing _render_clipped will crash at render time."
+            )
+
     # Width of the scrollbar indicator drawn when content overflows.
     _SCROLLBAR_W: float = field(default=3.0, init=False, repr=False)
     # Stored child height from last measure (used for scrollbar sizing).
@@ -932,6 +939,14 @@ class Card(Component):
     border: Optional[str] = HIGHLIGHT  # set to None for a borderless card
     radius: float = RADIUS_MD
 
+    def __post_init__(self):
+        for child in self.children:
+            if not isinstance(child, Component):
+                raise TypeError(
+                    f"Card children must subclass Component, got {type(child).__name__}. "
+                    "Ad-hoc widget classes missing _render_clipped will crash at render time."
+                )
+
     def _inner_w(self, outer_w: float) -> float:
         return outer_w - 2 * self.padding
 
@@ -1241,6 +1256,14 @@ class Column(Component):
     padding: float = SPACE_XL
     padding_top: Optional[float] = None
     gap: float = SPACE_MD
+
+    def __post_init__(self):
+        for child in self.children:
+            if not isinstance(child, Component):
+                raise TypeError(
+                    f"Column children must subclass Component, got {type(child).__name__}. "
+                    "Ad-hoc widget classes missing _render_clipped will crash at render time."
+                )
 
     @property
     def _pad_top(self) -> float:

--- a/sdk/python/tests/test_container_children.py
+++ b/sdk/python/tests/test_container_children.py
@@ -1,0 +1,48 @@
+"""Tests that Column, Card, and Scrollable reject non-Component children at construction."""
+
+import pytest
+from plexi_sdk.ui import Column, Card, Scrollable, Label, Component
+
+
+class _FakeWidget:
+    """Ad-hoc class with measure/render but NOT a Component subclass."""
+    def measure(self, avail_w: float) -> float:
+        return 10.0
+
+    def render(self, ctx, x, y, w, h):
+        pass
+
+
+def test_column_rejects_non_component_child():
+    with pytest.raises(TypeError, match="must subclass Component"):
+        Column(children=[Label(text="ok"), _FakeWidget()])
+
+
+def test_column_accepts_component_children():
+    col = Column(children=[Label(text="a"), Label(text="b")])
+    assert len(col.children) == 2
+
+
+def test_card_rejects_non_component_child():
+    with pytest.raises(TypeError, match="must subclass Component"):
+        Card(children=[_FakeWidget()])
+
+
+def test_card_accepts_component_children():
+    card = Card(children=[Label(text="a")])
+    assert len(card.children) == 1
+
+
+def test_scrollable_rejects_non_component_child():
+    with pytest.raises(TypeError, match="must subclass Component"):
+        Scrollable(child=_FakeWidget())
+
+
+def test_scrollable_accepts_component_child():
+    s = Scrollable(child=Label(text="ok"))
+    assert isinstance(s.child, Component)
+
+
+def test_error_message_names_bad_class():
+    with pytest.raises(TypeError, match="_FakeWidget"):
+        Column(children=[_FakeWidget()])


### PR DESCRIPTION
## Summary
- Column, Card, and Scrollable now validate children in `__post_init__`
- Non-Component children raise `TypeError` at construction with the offending class name
- Eliminates the cryptic `AttributeError: '_Body' object has no attribute '_render_clipped'` crash path

## Test plan
- [x] 7 new tests in `test_container_children.py` — all pass
- [x] Existing SDK tests unaffected (pre-existing appbar test failure is unrelated)

Closes #1202