### PR TITLE
fix(minimap): number cells by spatial position, not array index (#1274)

### DIFF
--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -196,6 +196,17 @@ pub fn render_minimap(
     // and act on any click that didn't land exactly on a cell.
     ui.allocate_rect(panel_rect, egui::Sense::hover());
 
+    // Spatial ordering: assign page numbers by (grid_y, grid_x) so they
+    // stay sequential after reorder operations.
+    let spatial_rank: std::collections::HashMap<usize, usize> = {
+        let mut sorted: Vec<(usize, u32, u32)> = visible
+            .iter()
+            .map(|(i, w)| (*i, w.grid_y, w.grid_x))
+            .collect();
+        sorted.sort_by_key(|&(_, gy, gx)| (gy, gx));
+        sorted.iter().enumerate().map(|(rank, &(i, _, _))| (i, rank)).collect()
+    };
+
     let mut clicked: Option<usize> = None;
 
     for (original_idx, ctx) in &visible {
@@ -228,8 +239,7 @@ pub fn render_minimap(
             egui::StrokeKind::Inside,
         );
 
-        // Small page number inside each cell (0-based, left-bottom)
-        let page_num = visible.iter().position(|(i, _)| *i == idx).unwrap_or(0);
+        let page_num = spatial_rank.get(&idx).copied().unwrap_or(0);
         ui.painter().text(
             egui::pos2(cell_rect.left() + 3.0, cell_rect.bottom() - 2.0),
             egui::Align2::LEFT_BOTTOM,


### PR DESCRIPTION
## Summary

- Minimap page numbers were derived from the window's position in the global array, not its spatial grid position
- After any reorder operation (move-to-front, swap, etc.) the labels showed stale indices like `5,0,1,2,3,4,6` instead of sequential `0,1,2,3,4,5,6`
- Build a `spatial_rank` map sorted by `(grid_y, grid_x)` and use that for the displayed number

Closes #1274

## Test plan

- [ ] Open 5+ windows in a single context
- [ ] Swap/move windows to different grid positions (Cmd+Ctrl+K/J/H/L at boundaries, or Move to Top/Bottom from context menu)
- [ ] Verify minimap numbers always read 0…N sequentially left-to-right, top-to-bottom
- [ ] Verify clicking a minimap cell still switches to the correct window