### PR TITLE
feat(context): add description field with sidebar modal + CLI

### DIFF
--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -66,7 +66,8 @@ impl PlexiApp {
         let new_id = self.host.alloc_pane_id();
         let ctx_id = self.windows[active].context_id;
         let ctx_name = self.context_name_for(ctx_id);
-        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors, ctx_id, &ctx_name);
+        let ctx_desc = self.context_description_for(ctx_id);
+        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
         let Some(term) = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -45,6 +45,7 @@ pub(crate) struct QuickNoteCtx {
     pub workspace_root: Option<std::path::PathBuf>,
     pub context: String,
     pub context_root: Option<std::path::PathBuf>,
+    pub context_description: Option<String>,
 }
 
 /// Which layer currently owns keyboard input.
@@ -69,6 +70,8 @@ pub(crate) enum FocusLayer {
     /// sidebar is hidden. Mirrors the inline sidebar rename but as a centred
     /// overlay so the terminal is immediately usable after dismissal.
     ContextRename,
+    /// Context description editor overlay.
+    ContextDescription,
     /// Quick note compose modal (text input phase).
     QuickNote,
     /// Quick note destination picker.
@@ -197,6 +200,8 @@ pub struct PlexiApp {
     pub(crate) voice_config: crate::config::VoiceConfig,
     pub(crate) renaming_window: Option<usize>,
     pub(crate) rename_buffer: String,
+    pub(crate) editing_description: Option<usize>,
+    pub(crate) description_buffer: String,
     pub(crate) drag_context: Option<usize>,
     pub(crate) registry: AppRegistry,
     pub(crate) show_command_palette: bool,
@@ -482,6 +487,9 @@ impl PlexiApp {
             let ctx_name_map: std::collections::HashMap<u64, String> = ws.contexts.iter()
                 .map(|c| (c.context_id, c.name.clone()))
                 .collect();
+            let ctx_desc_map: std::collections::HashMap<u64, String> = ws.contexts.iter()
+                .filter_map(|c| c.description.as_ref().map(|d| (c.context_id, d.clone())))
+                .collect();
             for saved_win in ws.windows {
                 let mut panes = HashMap::new();
                 for saved_pane in &saved_win.panes {
@@ -560,7 +568,8 @@ impl PlexiApp {
 
                     if pane_entry.is_none() {
                         let ctx_name = ctx_name_map.get(&saved_win.context_id).cloned().unwrap_or_default();
-                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name);
+                        let ctx_desc = ctx_desc_map.get(&saved_win.context_id).cloned().unwrap_or_default();
+                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name, &ctx_desc);
                         if let Some(mut pane) = TerminalPane::new(
                             saved_pane.id,
                             cc.egui_ctx.clone(),
@@ -621,6 +630,7 @@ impl PlexiApp {
                         name: saved_ctx.name,
                         path: saved_ctx.path,
                         root: saved_ctx.root,
+                        description: saved_ctx.description,
                         context_id: saved_ctx.context_id,
                     });
                 }
@@ -657,6 +667,8 @@ impl PlexiApp {
                     frame_tick: frame_tick.clone(),
                     renaming_window: None,
                     rename_buffer: String::new(),
+                    editing_description: None,
+                    description_buffer: String::new(),
                     drag_context: None,
                     show_command_palette: false,
                     palette_query: String::new(),
@@ -733,6 +745,7 @@ impl PlexiApp {
                     name: "Default".into(),
                     path: path.clone(),
                     root: None,
+                    description: None,
                     context_id: 1,
                 }],
                 0,
@@ -765,6 +778,8 @@ impl PlexiApp {
             frame_tick,
             renaming_window: None,
             rename_buffer: String::new(),
+            editing_description: None,
+            description_buffer: String::new(),
             drag_context: None,
             show_command_palette: false,
             palette_query: String::new(),
@@ -853,6 +868,7 @@ impl PlexiApp {
                     name: "Test".into(),
                     path: path.clone(),
                     root: None,
+                    description: None,
                     context_id: 1,
                 }],
                 0,
@@ -883,6 +899,8 @@ impl PlexiApp {
             frame_tick,
             renaming_window: None,
             rename_buffer: String::new(),
+            editing_description: None,
+            description_buffer: String::new(),
             drag_context: None,
             show_command_palette: false,
             palette_query: String::new(),
@@ -995,6 +1013,7 @@ impl PlexiApp {
         colors: &Colors,
         context_id: u64,
         context_name: &str,
+        context_description: &str,
     ) -> BackendSettings {
         log::info!("make_backend_settings: pane_id={pane_id} context_id={context_id} context_name={context_name:?}");
         let mut env = shell::build_env();
@@ -1006,6 +1025,7 @@ impl PlexiApp {
         env.insert("PLEXI_SOCKET".into(), socket);
         env.insert("PLEXI_CONTEXT_ID".into(), context_id.to_string());
         env.insert("PLEXI_CONTEXT_NAME".into(), context_name.to_string());
+        env.insert("PLEXI_CONTEXT_DESCRIPTION".into(), context_description.to_string());
         BackendSettings {
             shell: shell::detect_shell(),
             args: vec!["-l".to_string()],
@@ -1019,6 +1039,13 @@ impl PlexiApp {
         self.router.iter()
             .find(|c| c.context_id == context_id)
             .map(|c| c.name.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn context_description_for(&self, context_id: u64) -> String {
+        self.router.iter()
+            .find(|c| c.context_id == context_id)
+            .and_then(|c| c.description.clone())
             .unwrap_or_default()
     }
 
@@ -1391,6 +1418,12 @@ impl PlexiApp {
                 crate::app_protocol::HostCommand::SetContextRoot { root } => {
                     log::info!("pane_ipc: kind=set_context_root root={}", root.display());
                     self.set_active_context_root(root.clone());
+                    self.save_workspace();
+                }
+                crate::app_protocol::HostCommand::SetContextDescription { description } => {
+                    log::info!("pane_ipc: kind=set_context_description");
+                    let idx = self.router.active_idx();
+                    self.router.get_mut(idx).description = if description.is_empty() { None } else { Some(description.clone()) };
                     self.save_workspace();
                 }
                 _ => {
@@ -1780,6 +1813,9 @@ impl eframe::App for PlexiApp {
                 }
                 Some(FocusLayer::ContextRename) => {
                     self.draw_rename_context_overlay(ctx);
+                }
+                Some(FocusLayer::ContextDescription) => {
+                    self.draw_edit_description_overlay(ctx);
                 }
                 Some(FocusLayer::QuickNote) => {
                     self.draw_quick_note_modal(ctx);
@@ -3401,6 +3437,7 @@ impl PlexiApp {
         };
         let Some(pane) = win.panes.get(&pane_id) else { return };
         let context_name = self.context_name_for(win.context_id);
+        let context_description = self.context_description_for(win.context_id);
 
         let (cwd, pty_title, pane_name, app_type_id) = match pane {
             crate::pane::Pane::Terminal(t) => {
@@ -3421,6 +3458,7 @@ impl PlexiApp {
         crate::event_log::emit(crate::event_log::HostEvent::FocusChanged {
             pane_id,
             context_name,
+            context_description,
             cwd,
             pty_title,
             pane_name,
@@ -3441,6 +3479,7 @@ impl PlexiApp {
                 | Some(FocusLayer::CommandPalette)
                 | Some(FocusLayer::RenamePane)
                 | Some(FocusLayer::ContextRename)
+                | Some(FocusLayer::ContextDescription)
                 | Some(FocusLayer::QuickNote)
                 | Some(FocusLayer::QuickNoteDestination)
                 | Some(FocusLayer::QuickNoteSubDestination(_))
@@ -4146,6 +4185,7 @@ mod tests {
             name: "Context B".into(),
             path: std::env::temp_dir(),
             root: None,
+            description: None,
             context_id: 2,
         });
 
@@ -4166,6 +4206,7 @@ mod tests {
             name: "Context B".into(),
             path: std::env::temp_dir(),
             root: None,
+            description: None,
             context_id: 2,
         });
 
@@ -4186,6 +4227,7 @@ mod tests {
             name: "Context B".into(),
             path: std::env::temp_dir(),
             root: None,
+            description: None,
             context_id: 2,
         });
 
@@ -4241,6 +4283,7 @@ mod tests {
             name: "Context B".into(),
             path: std::env::temp_dir(),
             root: None,
+            description: None,
             context_id: 2,
         });
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -202,6 +202,7 @@ pub struct PlexiApp {
     pub(crate) rename_buffer: String,
     pub(crate) editing_description: Option<usize>,
     pub(crate) description_buffer: String,
+    pub(crate) description_focus_requested: bool,
     pub(crate) drag_context: Option<usize>,
     pub(crate) registry: AppRegistry,
     pub(crate) show_command_palette: bool,
@@ -669,6 +670,7 @@ impl PlexiApp {
                     rename_buffer: String::new(),
                     editing_description: None,
                     description_buffer: String::new(),
+                    description_focus_requested: false,
                     drag_context: None,
                     show_command_palette: false,
                     palette_query: String::new(),
@@ -780,6 +782,7 @@ impl PlexiApp {
             rename_buffer: String::new(),
             editing_description: None,
             description_buffer: String::new(),
+            description_focus_requested: false,
             drag_context: None,
             show_command_palette: false,
             palette_query: String::new(),
@@ -901,6 +904,7 @@ impl PlexiApp {
             rename_buffer: String::new(),
             editing_description: None,
             description_buffer: String::new(),
+            description_focus_requested: false,
             drag_context: None,
             show_command_palette: false,
             palette_query: String::new(),
@@ -1423,7 +1427,8 @@ impl PlexiApp {
                 crate::app_protocol::HostCommand::SetContextDescription { description } => {
                     log::info!("pane_ipc: kind=set_context_description");
                     let idx = self.router.active_idx();
-                    self.router.get_mut(idx).description = if description.is_empty() { None } else { Some(description.clone()) };
+                    let trimmed = description.trim().to_string();
+                    self.router.get_mut(idx).description = if trimmed.is_empty() { None } else { Some(trimmed) };
                     self.save_workspace();
                 }
                 _ => {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1072,6 +1072,10 @@ pub enum HostCommand {
     SetContextRoot {
         root: std::path::PathBuf,
     },
+    /// Set/update the description of the active context. Sent by `plexi context describe`.
+    SetContextDescription {
+        description: String,
+    },
 
     // ── Media + HTTP primitives ──────────────────────────────────────────
     /// Host-brokered HTTP request. Requires `net.http` capability.

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -2802,4 +2802,27 @@ mod tests {
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(serialised.contains(r#""type":"layout""#), "wire tag missing: {serialised}");
     }
+
+    #[test]
+    fn set_context_description_round_trips_serde() {
+        let json = r#"{"type":"set_context_description","description":"Main project workspace"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(HostCommand::SetContextDescription { description }) => {
+                assert_eq!(description, "Main project workspace");
+            }
+            other => panic!("expected SetContextDescription, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"set_context_description""#),
+            "wire tag missing: {serialised}"
+        );
+
+        let bad = r#"{"type":"set_context_description"}"#;
+        assert!(
+            serde_json::from_str::<DrawCommand>(bad).is_err(),
+            "must fail without required description field"
+        );
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3913,7 +3913,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "watch" -- "$cur"))
       ;;
     context)
-      COMPREPLY=($(compgen -W "new open set-root current" -- "$cur"))
+      COMPREPLY=($(compgen -W "new open set-root current describe" -- "$cur"))
       ;;
     notify)
       if [[ $prev == "--level" ]]; then

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3557,6 +3557,16 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
     }))
 }
 
+/// `plexi context describe "text"`
+///
+/// Sets the description of the active context.
+pub fn context_describe_cli(text: &str) -> i32 {
+    send_to_socket(serde_json::json!({
+        "type": "set_context_description",
+        "description": text,
+    }))
+}
+
 /// `plexi context current`
 ///
 /// Prints the context ID and name for the current pane as JSON.
@@ -3570,6 +3580,7 @@ pub fn context_current_cli() -> i32 {
         }
     };
     let context_name = std::env::var("PLEXI_CONTEXT_NAME").unwrap_or_default();
+    let context_description = std::env::var("PLEXI_CONTEXT_DESCRIPTION").unwrap_or_default();
     let id_num: u64 = match context_id.parse() {
         Ok(n) => n,
         Err(_) => {
@@ -3580,6 +3591,7 @@ pub fn context_current_cli() -> i32 {
     let json = serde_json::json!({
         "context_id": id_num,
         "context_name": context_name,
+        "context_description": context_description,
     });
     match serde_json::to_string_pretty(&json) {
         Ok(s) => println!("{s}"),
@@ -3765,7 +3777,7 @@ _plexi() {
           ;;
         context)
           local subcmds
-          subcmds=('new:Create a new context' 'open:Open a context at a path' 'set-root:Set the root directory' 'current:Print current context as JSON')
+          subcmds=('new:Create a new context' 'open:Open a context at a path' 'set-root:Set the root directory' 'current:Print current context as JSON' 'describe:Set context description')
           _describe 'subcommand' subcmds
           ;;
         notify)
@@ -4026,6 +4038,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from context" -a new -d "Create 
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a open -d "Open a context at a path"
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a set-root -d "Set the root directory"
 complete -c plexi -f -n "__fish_seen_subcommand_from context" -a current -d "Print current context as JSON"
+complete -c plexi -f -n "__fish_seen_subcommand_from context" -a describe -d "Set context description"
 
 # notify flags
 complete -c plexi -n "__fish_seen_subcommand_from notify" -l title -d "Notification title"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -410,6 +410,11 @@ pub enum ContextCmd {
     },
     /// Print the context ID and name for the current pane as JSON
     Current,
+    /// Set the description for the active context
+    Describe {
+        /// Description text
+        text: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 pub(crate) enum WindowMenuAction {
     Rename,
+    EditDescription,
     MoveToTop,
     MoveUp,
     MoveDown,
@@ -26,6 +27,8 @@ pub struct Context {
     /// Optional project root. When set, new panes in this context open at
     /// this directory rather than inheriting the focused pane's CWD.
     pub root: Option<PathBuf>,
+    /// Optional description — ambient intent for what you're doing in this context.
+    pub description: Option<String>,
     /// Stable unique ID, assigned at creation and never reused.
     pub context_id: u64,
 }

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -122,7 +122,7 @@ pub enum HostEvent {
         pane_id: u64,
         /// Name of the context (sidebar project) this pane belongs to.
         context_name: String,
-        /// Optional description of the context.
+        /// Description of the context.
         context_description: String,
         /// CWD of the departing pane (terminals via proc_info; apps via workspace_root).
         cwd: Option<String>,

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -122,6 +122,8 @@ pub enum HostEvent {
         pane_id: u64,
         /// Name of the context (sidebar project) this pane belongs to.
         context_name: String,
+        /// Optional description of the context.
+        context_description: String,
         /// CWD of the departing pane (terminals via proc_info; apps via workspace_root).
         cwd: Option<String>,
         /// Last OSC 2 title string the process wrote, if any.

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,7 @@ fn main() -> eframe::Result {
                         ContextCmd::Open { path } => std::process::exit(cli::context_open_cli(path.as_deref())),
                         ContextCmd::SetRoot { path } => std::process::exit(cli::context_set_root_cli(path.as_deref())),
                         ContextCmd::Current => std::process::exit(cli::context_current_cli()),
+                        ContextCmd::Describe { text } => std::process::exit(cli::context_describe_cli(&text)),
                     },
                     Commands::Completions { shell } => {
                         let s = shell.as_deref().unwrap_or("zsh");

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -712,8 +712,12 @@ impl PlexiApp {
     /// Cmd+Enter to save, Esc to cancel.
     pub(crate) fn draw_edit_description_overlay(&mut self, ctx: &egui::Context) {
         let ctx_idx = match self.editing_description {
-            Some(idx) => idx,
-            None => return,
+            Some(idx) if idx < self.router.len() => idx,
+            _ => {
+                self.editing_description = None;
+                self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+                return;
+            }
         };
 
         let (commit, cancel) = ctx.input_mut(|i| {
@@ -767,19 +771,29 @@ impl PlexiApp {
                                 .color(self.colors.text_dim),
                         );
 
-                        if !te.has_focus() {
+                        if !self.description_focus_requested {
                             te.request_focus();
+                            if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), te_id) {
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::two(
+                                    egui::text::CCursor::new(0),
+                                    egui::text::CCursor::new(self.description_buffer.len()),
+                                )));
+                                state.store(ui.ctx(), te_id);
+                            }
+                            self.description_focus_requested = true;
                         }
                     });
             });
 
         if cancel {
             self.editing_description = None;
+            self.description_focus_requested = false;
             self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
         } else if commit {
             let new_desc = self.description_buffer.trim().to_string();
             self.router.get_mut(ctx_idx).description = if new_desc.is_empty() { None } else { Some(new_desc) };
             self.editing_description = None;
+            self.description_focus_requested = false;
             self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
             self.save_workspace();
             log::info!("context_description: updated ctx_idx={ctx_idx}");

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -708,6 +708,84 @@ impl PlexiApp {
         }
     }
 
+    /// Modal for editing a context's description. Multiline text input with
+    /// Cmd+Enter to save, Esc to cancel.
+    pub(crate) fn draw_edit_description_overlay(&mut self, ctx: &egui::Context) {
+        let ctx_idx = match self.editing_description {
+            Some(idx) => idx,
+            None => return,
+        };
+
+        let (commit, cancel) = ctx.input_mut(|i| {
+            let cmd_enter = i.consume_key(egui::Modifiers::COMMAND, egui::Key::Enter);
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            (cmd_enter, esc)
+        });
+
+        egui::Area::new(egui::Id::new("edit_description_overlay"))
+            .anchor(Align2::CENTER_TOP, Vec2::new(0.0, 80.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(16, 12))
+                    .show(ui, |ui| {
+                        ui.set_width(MODAL_WIDTH);
+                        let ctx_name = self.router.get(ctx_idx).name.clone();
+                        ui.label(
+                            RichText::new(format!("Description for \"{}\"", ctx_name))
+                                .size(13.0)
+                                .color(self.colors.text_primary)
+                                .strong(),
+                        );
+                        ui.add_space(6.0);
+
+                        let te_id = egui::Id::new("edit_description_input");
+                        let te = ui.scope(|ui| {
+                            ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                            ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
+                            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
+                            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
+                            ui.add(
+                                egui::TextEdit::multiline(&mut self.description_buffer)
+                                    .id(te_id)
+                                    .desired_width(MODAL_WIDTH)
+                                    .desired_rows(3)
+                                    .hint_text("What are you working on in this context?")
+                                    .font(egui::TextStyle::Body)
+                                    .margin(egui::Margin::symmetric(8, 5)),
+                            )
+                        }).inner;
+
+                        ui.add_space(4.0);
+                        ui.label(
+                            RichText::new("Cmd+Enter to save  ·  Esc to cancel")
+                                .size(11.0)
+                                .color(self.colors.text_dim),
+                        );
+
+                        if !te.has_focus() {
+                            te.request_focus();
+                        }
+                    });
+            });
+
+        if cancel {
+            self.editing_description = None;
+            self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+        } else if commit {
+            let new_desc = self.description_buffer.trim().to_string();
+            self.router.get_mut(ctx_idx).description = if new_desc.is_empty() { None } else { Some(new_desc) };
+            self.editing_description = None;
+            self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+            self.save_workspace();
+            log::info!("context_description: updated ctx_idx={ctx_idx}");
+        }
+    }
+
     /// Quick note compose phase: full-screen scrim + centered text input.
     pub(crate) fn draw_quick_note_modal(&mut self, ctx: &egui::Context) {
         use crate::style;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -425,7 +425,8 @@ impl PlexiApp {
 
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        let ctx_desc = self.context_description_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
         if let Some(cmd) = initial_cmd {
             log::info!("create_single_pane_tree: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -725,8 +726,9 @@ impl PlexiApp {
         let context_id = self.windows.get(active).map(|w| w.context_id).unwrap_or(0);
         let context = self.context_name_for(context_id);
         let context_root = self.router.active().root.clone();
+        let context_description = self.router.active().description.clone();
         self.quick_note_text = String::new();
-        self.quick_note_ctx = crate::app::QuickNoteCtx { cwd, workspace_root, context, context_root };
+        self.quick_note_ctx = crate::app::QuickNoteCtx { cwd, workspace_root, context, context_root, context_description };
         self.quick_note_children_cache.clear();
         self.quick_note_children_rx = None;
         self.push_focus_layer(crate::app::FocusLayer::QuickNote);
@@ -824,9 +826,13 @@ impl PlexiApp {
                     p.strip_prefix(&home).ok().map(|rel| format!("~/{}", rel.display()))
                 })
                 .or_else(|| ctx.workspace_root.as_ref().map(|p| p.to_string_lossy().to_string()));
+            let name_and_desc = match &ctx.context_description {
+                Some(desc) if !desc.is_empty() => format!("{} — \"{}\"", ctx.context, desc),
+                _ => ctx.context.clone(),
+            };
             match ws {
-                Some(w) => format!("{} · {}", ctx.context, w),
-                None => ctx.context.clone(),
+                Some(w) => format!("{name_and_desc} · {w}"),
+                None => name_and_desc,
             }
         };
 
@@ -887,7 +893,8 @@ impl PlexiApp {
             .and_then(|t| self.windows[active].get_focused_pane_cwd(t));
         let ctx_id = self.windows.get(active).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        let ctx_desc = self.context_description_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
 
         super::apply_initial_cmd(&mut settings, cmd, !stay_alive);
 
@@ -1318,6 +1325,7 @@ mod quick_note_tests {
             workspace_root: None,
             context: "test".to_string(),
             context_root: None,
+            context_description: None,
         }
     }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -228,7 +228,8 @@ impl PlexiApp {
         let cwd = cwd_override.or_else(|| self.windows[self.active_window].get_focused_pane_cwd(focused));
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        let ctx_desc = self.context_description_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
         if let Some(cmd) = initial_cmd {
             log::info!("split_focused: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -317,7 +318,8 @@ impl PlexiApp {
             let new_id = self.host.alloc_pane_id();
             let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
             let ctx_name = self.context_name_for(ctx_id);
-            let mut settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name);
+            let ctx_desc = self.context_description_for(ctx_id);
+            let mut settings = Self::make_backend_settings(new_id, None, &self.colors, ctx_id, &ctx_name, &ctx_desc);
             if let Some(cmd) = initial_cmd {
                 log::info!("new_tab (empty context): initial_cmd={cmd:?} close_on_exit={close_on_exit}");
                 super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -351,7 +353,8 @@ impl PlexiApp {
         let cwd = self.windows[self.active_window].get_focused_pane_cwd(focused);
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name);
+        let ctx_desc = self.context_description_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
         if let Some(cmd) = initial_cmd {
             log::info!("new_tab: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -31,6 +31,7 @@ impl PlexiApp {
             name: ctx_name,
             path: cwd.clone(),
             root: Some(cwd.clone()),
+            description: None,
             context_id: ctx_id,
         });
         self.windows.push(Window {
@@ -346,6 +347,7 @@ impl PlexiApp {
                 name: ctx.name.clone(),
                 path: ctx.path.clone(),
                 root: ctx.root.clone(),
+                description: ctx.description.clone(),
                 context_id: ctx.context_id,
             });
         }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1608,6 +1608,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            HostCommand::SetContextDescription { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received SetContextDescription over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
             HostCommand::ListPanes { .. } => {
                 log::warn!(
                     "ProcessApp[{}]: received ListPanes over PGAP — ignored (use PLEXI_SOCKET instead)",

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -183,6 +183,10 @@ impl PlexiApp {
                         menu_action = Some((i, WindowMenuAction::Rename));
                         ui.close_menu();
                     }
+                    if ui.button("Edit Description").clicked() {
+                        menu_action = Some((i, WindowMenuAction::EditDescription));
+                        ui.close_menu();
+                    }
                     ui.separator();
                     if i > 0 {
                         if ui.button("Move to Top").clicked() { menu_action = Some((i, WindowMenuAction::MoveToTop)); ui.close_menu(); }
@@ -266,6 +270,11 @@ impl PlexiApp {
                 WindowMenuAction::Rename => {
                     self.renaming_window = Some(i);
                     self.rename_buffer = self.router.get(i).name.clone();
+                }
+                WindowMenuAction::EditDescription => {
+                    self.editing_description = Some(i);
+                    self.description_buffer = self.router.get(i).description.clone().unwrap_or_default();
+                    self.push_focus_layer(crate::app::FocusLayer::ContextDescription);
                 }
                 WindowMenuAction::MoveToTop => {
                     self.renaming_window = None;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -274,6 +274,7 @@ impl PlexiApp {
                 WindowMenuAction::EditDescription => {
                     self.editing_description = Some(i);
                     self.description_buffer = self.router.get(i).description.clone().unwrap_or_default();
+                    self.description_focus_requested = false;
                     self.push_focus_layer(crate::app::FocusLayer::ContextDescription);
                 }
                 WindowMenuAction::MoveToTop => {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -26,6 +26,9 @@ pub struct SavedContext {
     /// Optional project root — persisted so contexts restore their root on relaunch.
     #[serde(default)]
     pub root: Option<PathBuf>,
+    /// Optional description — ambient intent for what you're doing in this context.
+    #[serde(default)]
+    pub description: Option<String>,
     pub context_id: u64,
 }
 


### PR DESCRIPTION
## Summary

- Add `description: Option<String>` to `Context` and `SavedContext` — persists across restarts via workspace JSON
- Right-click context in sidebar → **Edit Description** opens a multiline modal (Cmd+Enter to save, Esc to cancel)
- New env var `PLEXI_CONTEXT_DESCRIPTION` set on every pane spawn
- `plexi context current` JSON output now includes `context_description`
- New CLI command: `plexi context describe "Backend refactor for v3"` — sets description programmatically
- Quick notes include description in metadata: `Context: API — "Refactoring auth" · ~/project`
- Event log `FocusChanged` event carries context description
- Zsh and Fish completions updated for `describe` subcommand

Closes #1120