### PR TITLE
feat(config): expose pane focus history depth as configurable setting

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -265,6 +265,7 @@ pub struct PlexiApp {
     pub(crate) focus_stack: Vec<FocusLayer>,
     /// Pane focus history for Cmd+[ time-travel. Each entry is (window_id, tile_id)
     /// captured just before a focus change. Capped at 100; oldest evicted from front.
+    pub(crate) focus_history_depth: usize,
     pub(crate) pane_focus_history: Vec<(u64, egui_tiles::TileId)>,
     /// Pane focus future — entries undone by back-navigation; cleared on any
     /// organic focus change.
@@ -446,6 +447,8 @@ impl PlexiApp {
             .as_ref()
             .and_then(|n| n.interrupt_threshold)
             .unwrap_or(100); // PRIORITY_HIGH — only HIGH/CRITICAL interrupt by default
+        let focus_history_depth = config.focus_history_depth.unwrap_or(100);
+        log::info!("config: focus_history_depth={focus_history_depth}");
         let default_font_size = config.font_size.unwrap_or(theme::FONT_SIZE);
         let theme_cfg = Self::resolve_theme_config(&config);
         let colors = Colors::from_config(&theme_cfg);
@@ -683,6 +686,7 @@ impl PlexiApp {
                     notifications_focus_mode,
                     notifications_interrupt_threshold,
                     focus_stack: Vec::new(),
+                    focus_history_depth,
                     pane_focus_history: Vec::new(),
                     pane_focus_future: Vec::new(),
                     navigating_history: false,
@@ -791,6 +795,7 @@ impl PlexiApp {
             notifications_focus_mode,
             notifications_interrupt_threshold,
             focus_stack: Vec::new(),
+            focus_history_depth,
             pane_focus_history: Vec::new(),
             pane_focus_future: Vec::new(),
             navigating_history: false,
@@ -912,6 +917,7 @@ impl PlexiApp {
             notifications_focus_mode: false,
             notifications_interrupt_threshold: 100,
             focus_stack: Vec::new(),
+            focus_history_depth: 100,
             pane_focus_history: Vec::new(),
             pane_focus_future: Vec::new(),
             navigating_history: false,
@@ -3519,15 +3525,13 @@ impl PlexiApp {
         }
     }
 
-    /// Push `old_focus` onto `pane_focus_history` for `window_id`, clear `pane_focus_future`,
-    /// and cap history at 100. No-op if `navigating_history` is true or `old_focus` is None.
     pub(crate) fn push_focus_history(&mut self, window_id: u64, old_focus: Option<egui_tiles::TileId>) {
         if self.navigating_history {
             return;
         }
         let Some(tile_id) = old_focus else { return };
         self.pane_focus_history.push((window_id, tile_id));
-        if self.pane_focus_history.len() > 100 {
+        if self.pane_focus_history.len() > self.focus_history_depth {
             self.pane_focus_history.remove(0);
         }
         self.pane_focus_future.clear();
@@ -3557,6 +3561,9 @@ impl PlexiApp {
             let current_window_id = self.windows[self.active_window].window_id;
             if let Some(current_tile) = self.windows[self.active_window].focused_pane {
                 self.pane_focus_future.push((current_window_id, current_tile));
+                if self.pane_focus_future.len() > self.focus_history_depth {
+                    self.pane_focus_future.remove(0);
+                }
             }
             self.windows[idx].focused_pane = Some(tile_id);
             self.active_window = idx;
@@ -3589,7 +3596,7 @@ impl PlexiApp {
             let current_window_id = self.windows[self.active_window].window_id;
             if let Some(current_tile) = self.windows[self.active_window].focused_pane {
                 self.pane_focus_history.push((current_window_id, current_tile));
-                if self.pane_focus_history.len() > 100 {
+                if self.pane_focus_history.len() > self.focus_history_depth {
                     self.pane_focus_history.remove(0);
                 }
             }
@@ -3703,6 +3710,8 @@ impl PlexiApp {
             .as_ref()
             .and_then(|n| n.interrupt_threshold)
             .unwrap_or(100);
+
+        self.focus_history_depth = fresh.focus_history_depth.unwrap_or(100);
 
         // Feature flags
         self.features = crate::features::FeatureFlags::from_config(&fresh);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -578,3 +578,54 @@ fn focus_changed_not_emitted_for_same_pane() {
         .and_then(|win| win.focused_pane.map(|tile| (win.window_id, tile)));
     assert_eq!(current_focus, app.last_logged_focus);
 }
+
+#[test]
+fn focus_history_depth_caps_at_configured_limit() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    app.focus_history_depth = 1;
+
+    let (tile_a, _) = app.add_test_pane();
+    let (tile_b, _) = app.add_test_pane();
+    let (tile_c, _) = app.add_test_pane();
+    let win_id = app.windows[0].window_id;
+
+    app.windows[0].focused_pane = Some(tile_a);
+    app.push_focus_history(win_id, Some(tile_a));
+    assert_eq!(app.pane_focus_history.len(), 1);
+
+    app.windows[0].focused_pane = Some(tile_b);
+    app.push_focus_history(win_id, Some(tile_b));
+    assert_eq!(app.pane_focus_history.len(), 1, "history should stay capped at depth 1");
+
+    app.windows[0].focused_pane = Some(tile_c);
+    app.push_focus_history(win_id, Some(tile_c));
+    assert_eq!(app.pane_focus_history.len(), 1);
+    assert_eq!(app.pane_focus_history[0], (win_id, tile_c));
+}
+
+#[test]
+fn focus_future_caps_at_configured_depth() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    app.focus_history_depth = 2;
+
+    let (tile_a, _) = app.add_test_pane();
+    let (tile_b, _) = app.add_test_pane();
+    let (tile_c, _) = app.add_test_pane();
+    let win_id = app.windows[0].window_id;
+
+    app.windows[0].focused_pane = Some(tile_a);
+    app.push_focus_history(win_id, Some(tile_a));
+    app.windows[0].focused_pane = Some(tile_b);
+    app.push_focus_history(win_id, Some(tile_b));
+    app.windows[0].focused_pane = Some(tile_c);
+    app.push_focus_history(win_id, Some(tile_c));
+
+    app.step_focus_history_back();
+    app.step_focus_history_back();
+    app.step_focus_history_back();
+    assert!(app.pane_focus_future.len() <= 2, "future stack should be capped at depth");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,7 @@ pub struct PlexiConfig {
     pub confirm_close: Option<bool>,
     pub keybindings: Option<KeybindingsConfig>,
     pub quick_note: Option<QuickNoteConfig>,
+    pub focus_history_depth: Option<usize>,
 }
 
 /// Plexi AI broker configuration (`ai.query` capability).
@@ -600,6 +601,10 @@ theme_preset = "catppuccin-mocha"
 # confirm_close shows a dialog before Cmd+W closes a pane.
 confirm_quit  = true
 confirm_close = false
+
+# ── Navigation ─────────────────────────────────────────────────
+# Maximum depth of pane focus history (Cmd+[ / Cmd+]).
+# focus_history_depth = 100
 
 # ── Notifications ──────────────────────────────────────────────
 # The work-area modal is the one and only notification surface.


### PR DESCRIPTION
## Summary
- Adds `focus_history_depth` config field to `PlexiConfig` (default: 100)
- Replaces three hardcoded `100` caps in `push_focus_history` and `step_focus_history_forward` with the configured value
- Caps `pane_focus_future` symmetrically in `step_focus_history_back` (was uncapped)
- Adds commented template entry under a new `# ── Navigation ──` section in generated `config.toml`
- Value reloads on `Cmd+Shift+Comma`
- Two new unit tests: depth-1 cap smoke test and future-stack cap

Closes #1164

## Test plan
- [ ] Set `focus_history_depth = 3` in config.toml, restart, open 5+ panes, Cmd+[ should exhaust after 3 steps
- [ ] Default (no config entry) behaves identically to before (100 steps)
- [ ] `cargo test --bin plexi -- focus_history` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)