### PR TITLE
fix(sdk): docstring and naming inconsistencies (#1260)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -43,7 +43,7 @@ QUICK START
         def on_click(self, ctx, x, y, button):
             # button: "primary" | "secondary" | "middle"
             # x, y are pixel coordinates within the pane
-            ctx.notify("Clicked", f"({x:.0f}, {y:.0f}) {button}")
+            ctx.notify("Clicked", priority=50, body=f"({x:.0f}, {y:.0f}) {button}")
 
     CounterApp().run()
 
@@ -151,22 +151,22 @@ notification modal (ctx.notify(...) returns immediately; the other three
 block the calling thread until the user responds — run them on a worker
 thread if the app needs to stay interactive).
 
-  ctx.notify(title, body="", level="info", priority=PRIORITY_NORMAL)
+  ctx.notify(title, priority, body="", level="info")
       Fire-and-forget message. Enter / Space acknowledge, Esc dismisses.
 
-  ctx.notify_and_wait(title, body="", priority=...)  -> str
+  ctx.notify_and_wait(title, priority, body="")  -> str
       Same as notify() but blocks. Returns "acknowledge" or "cancel".
 
-  ctx.notify_choice(title, options, body="", required=False, priority=...) -> str
+  ctx.notify_choice(title, options, priority, body="", required=False) -> str
       Blocking choice picker. options = [{"label":..., "value":...,
       "shortcut":...}]. Returns chosen value (or label if no value),
       or "__cancel__" if dismissed.
 
-  ctx.notify_input(title, prompt="", body="", required=False, priority=...) -> str
+  ctx.notify_input(title, priority, prompt="", body="", required=False) -> str
       Blocking text input. Returns the typed string, or "__cancel__".
 
-  ctx.notify_with_image(title, body, image_bytes, mime, priority=...,
-                        choices=None) -> str | None
+  ctx.notify_with_image(title, body, image_bytes, mime, priority,
+                        level="info", choices=None) -> str | None
       Convenience wrapper that handles base64 encoding + 50 KB cap.
       `image_bytes` > 50 KB raises ValueError locally. With `choices=None`
       this is fire-and-forget (returns None); with `choices` set it routes
@@ -287,7 +287,7 @@ Drawing methods:
       Each item is a dict — see ListItem shape below.
 
 Notification / logging (usable inside or outside a frame):
-  ctx.notify(title, body, level="info", actions=None)
+  ctx.notify(title, priority, body="", level="info", actions=None)
       Trigger a system notification. actions: list of NotifyAction dicts (see below).
 
   ctx.status_summary(text)
@@ -304,7 +304,7 @@ Emitter  (self.emit — available at all times, including background threads)
 
 All methods are thread-safe (protected by a global write lock).
 
-  emit.notify(title, body, level="info", actions=None)
+  emit.notify(title, priority, body="", level="info", actions=None)
       Trigger a system notification outside of a render frame.
 
   emit.log(level, message)  /  emit.info(msg)  /  emit.warn(msg)

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -56,35 +56,35 @@ class App:
     Override any of:
 
     Awaited (block the event loop until they return):
-        on_init(ctx)                                 — after Init handshake
-        on_render(ctx)                               — on each Render event
-        on_suspend()                                 — on Suspend
-        on_resume()                                  — on Resume
-        on_shutdown()                                — on Shutdown
+        on_init(ctx)                                — after Init handshake
+        on_render(ctx)                              — on each Render event
+        on_suspend()                                — on Suspend
+        on_resume()                                 — on Resume
+        on_shutdown()                               — on Shutdown
 
     Task (dispatched as asyncio tasks — event loop continues):
-        on_key(ctx, key, mods)                       — on Key event
-        on_click(ctx, x, y, button)                  — on Click event
-        on_mouse_down(ctx, x, y, button)             — on MouseDown event
-        on_mouse_up(ctx, x, y, button)               — on MouseUp event
-        on_mouse_move(ctx, x, y, buttons)            — on MouseMove event
-        on_command(ctx, text)                         — on Command event
-        on_paste(ctx, text)                           — on Paste event
-        on_text_submitted(ctx, id, text)              — on TextInput Enter press
-        on_pipe_message(ctx, pipe_id, payload)        — on PipeMessage
-        on_path_changed(ctx, cwd)                     — on PathChanged
-        on_inject(ctx, payload)                       — on Inject event
-        on_nav_back(ctx, view_id)                     — on NavBack event
-        on_timer(ctx, timer_id)                       — on Timer event
-        on_scroll(ctx, id, offset_y)                  — on Scroll event
-        on_file_picked(ctx, request_id, paths)        — on FilePicked event
-        on_file_pick_cancelled(ctx, request_id)       — on FilePickCancelled
-        on_mcp_call(ctx, tool_name, arguments)        — on MCP tool call
+        on_key(ctx, key, mods)                      — on Key event
+        on_click(ctx, x, y, button)                 — on Click event
+        on_mouse_down(ctx, x, y, button)            — on MouseDown event
+        on_mouse_up(ctx, x, y, button)              — on MouseUp event
+        on_mouse_move(ctx, x, y, buttons)           — on MouseMove event
+        on_command(ctx, text)                        — on Command event
+        on_paste(ctx, text)                          — on Paste event
+        on_text_submitted(ctx, id, text)             — on TextInput Enter press
+        on_pipe_message(ctx, pipe_id, payload)       — on PipeMessage
+        on_path_changed(ctx, cwd)                    — on PathChanged
+        on_inject(ctx, payload)                      — on Inject event
+        on_nav_back(ctx, view_id)                    — on NavBack event
+        on_timer(ctx, timer_id)                      — on Timer event
+        on_scroll(ctx, id, offset_y)                 — on Scroll event
+        on_file_picked(ctx, request_id, paths)       — on FilePicked event
+        on_file_pick_cancelled(ctx, request_id)      — on FilePickCancelled
+        on_mcp_call(ctx, tool_name, arguments)       — on MCP tool call
 
     Fire-and-forget (no RenderContext — called outside a render frame):
-        on_app_spawned(pane_id, type_id)              — app spawn succeeded
-        on_pane_spawned(pane_id, request_id)           — pane spawn succeeded
-        on_pane_spawn_error(reason, request_id)        — pane spawn failed
+        on_app_spawned(pane_id, type_id)             — app spawn succeeded
+        on_pane_spawned(pane_id, request_id)         — pane spawn succeeded
+        on_pane_spawn_error(reason, request_id)      — pane spawn failed
         on_midi_input_opened(pipe_id, port_id, port_name) — MIDI input opened
 
     Task handlers are dispatched as asyncio tasks — the event loop does not

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -54,28 +54,51 @@ class App:
     Base class for Plexi v3 apps. Subclass and override event handlers.
 
     Override any of:
-        on_init(self, ctx)                            — after Init handshake (awaited)
-        on_render(self, ctx)                          — on each Render event (awaited)
-        on_key(self, ctx, key, mods)                  — on Key event (task)
-        on_click(self, ctx, x, y, button)             — on Click event (task)
-        on_command(self, ctx, text)                   — on Command event (task)
-        on_paste(self, ctx, text)                     — on Paste event (task)
-        on_text_submitted(self, ctx, id, text)        — on TextInput Enter press (task)
-        on_pipe_message(self, ctx, pipe_id, payload)  — on PipeMessage (task)
-        on_path_changed(self, ctx, cwd)               — on PathChanged (task)
-        on_suspend(self)                              — on Suspend (awaited)
-        on_resume(self)                               — on Resume (awaited)
-        on_shutdown(self)                             — on Shutdown (awaited)
 
-    Handlers marked (task) are dispatched as asyncio tasks — the event loop
-    does not wait for them to complete before processing the next event. Declare
-    them ``async def`` whenever they do any I/O. Never call blocking operations
+    Awaited (block the event loop until they return):
+        on_init(ctx)                                 — after Init handshake
+        on_render(ctx)                               — on each Render event
+        on_suspend()                                 — on Suspend
+        on_resume()                                  — on Resume
+        on_shutdown()                                — on Shutdown
+
+    Task (dispatched as asyncio tasks — event loop continues):
+        on_key(ctx, key, mods)                       — on Key event
+        on_click(ctx, x, y, button)                  — on Click event
+        on_mouse_down(ctx, x, y, button)             — on MouseDown event
+        on_mouse_up(ctx, x, y, button)               — on MouseUp event
+        on_mouse_move(ctx, x, y, buttons)            — on MouseMove event
+        on_command(ctx, text)                         — on Command event
+        on_paste(ctx, text)                           — on Paste event
+        on_text_submitted(ctx, id, text)              — on TextInput Enter press
+        on_pipe_message(ctx, pipe_id, payload)        — on PipeMessage
+        on_path_changed(ctx, cwd)                     — on PathChanged
+        on_inject(ctx, payload)                       — on Inject event
+        on_nav_back(ctx, view_id)                     — on NavBack event
+        on_timer(ctx, timer_id)                       — on Timer event
+        on_scroll(ctx, id, offset_y)                  — on Scroll event
+        on_file_picked(ctx, request_id, paths)        — on FilePicked event
+        on_file_pick_cancelled(ctx, request_id)       — on FilePickCancelled
+        on_mcp_call(ctx, tool_name, arguments)        — on MCP tool call
+
+    Fire-and-forget (no RenderContext — called outside a render frame):
+        on_app_spawned(pane_id, type_id)              — app spawn succeeded
+        on_pane_spawned(pane_id, request_id)           — pane spawn succeeded
+        on_pane_spawn_error(reason, request_id)        — pane spawn failed
+        on_midi_input_opened(pipe_id, port_id, port_name) — MIDI input opened
+
+    Task handlers are dispatched as asyncio tasks — the event loop does not
+    wait for them to complete before processing the next event. Declare them
+    ``async def`` whenever they do any I/O. Never call blocking operations
     (time.sleep, requests.get, etc.) directly from these handlers; use
     ``await asyncio.to_thread(fn)`` or ``threading.Thread`` + ``emit.run_sync()``.
 
-    Handlers marked (awaited) block the event loop until they return. Use
-    ``await``-able Emitter helpers freely; they do not deadlock because the
-    stdin reader runs as a concurrent task.
+    Awaited handlers block the event loop until they return. Use ``await``-able
+    Emitter helpers freely; they do not deadlock because the stdin reader runs
+    as a concurrent task.
+
+    Fire-and-forget handlers do not receive a RenderContext because they are
+    dispatched outside a render frame.
     """
 
     def __init__(self) -> None:
@@ -184,10 +207,10 @@ class App:
         """
         return None
     def on_app_spawned(self, _pane_id: int, _type_id: str) -> None: pass
-    def on_pane_spawned(self, pane_id: int, request_id: "str | None" = None) -> None:
+    def on_pane_spawned(self, _pane_id: int, _request_id: "str | None" = None) -> None:
         """Called when a SpawnPane request succeeded (#592). Override to track the spawned pane."""
 
-    def on_pane_spawn_error(self, reason: str, request_id: "str | None" = None) -> None:
+    def on_pane_spawn_error(self, _reason: str, _request_id: "str | None" = None) -> None:
         """Called when a SpawnPane request failed (#592). Override to handle the error."""
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -108,8 +108,8 @@ class Emitter:
     # in manifest.toml under [launch] notification_scope and resolved by the
     # host at dispatch time. Apps just call notify(); the manifest controls
     # whether the notification crosses window or context boundaries.
-    def notify(self, title: str, body: str = "", level: str = "info",
-               priority: "int | None" = None,
+    def notify(self, title: str, priority: int, body: str = "",
+               level: str = "info",
                actions: "list | None" = None,
                image_inline: "dict | None" = None,
                image_pipe_id: "str | None" = None,
@@ -128,11 +128,9 @@ class Emitter:
         prefixed with width/height u32-LE. Mutually exclusive with
         `image_inline` — host warns + drops the pipe ref if both set.
         """
-        if priority is None:
-            raise TypeError("notify() requires 'priority' (int, higher = more urgent)")
         payload = {"type": "notify", "level": level, "title": title,
                    "body": body, "kind": "message",
-                   "priority": int(priority),
+                   "priority": priority,
                    "actions": actions or []}
         if image_inline is not None:
             payload["image_inline"] = image_inline
@@ -169,9 +167,9 @@ class Emitter:
 
     # kind = "choice"
     @_blocking_emit_method
-    async def notify_choice(self, title: str, options: list, body: str = "",
+    async def notify_choice(self, title: str, options: list, priority: int,
+                            body: str = "",
                             level: str = "info", required: bool = False,
-                            priority: "int | None" = None,
                             image_inline: "dict | None" = None,
                             image_pipe_id: "str | None" = None,
                             timeout_secs: "int | None" = None,
@@ -193,8 +191,6 @@ class Emitter:
         Await this from async hooks. From background threads use
         ``self.emit.run_sync(self.emit.notify_choice(...))``.
         """
-        if priority is None:
-            raise TypeError("notify_choice() requires 'priority' (int, higher = more urgent)")
         # Warn if any option uses a reserved shortcut key.
         import warnings
         for opt in options:
@@ -211,7 +207,7 @@ class Emitter:
         self._app._pending_notify[notify_id] = q
         payload = {"type": "notify", "level": level, "title": title, "body": body,
                    "kind": "choice", "options": options, "required": required,
-                   "priority": int(priority),
+                   "priority": priority,
                    "notify_id": notify_id}
         if image_inline is not None:
             payload["image_inline"] = image_inline
@@ -229,8 +225,8 @@ class Emitter:
     # bytes on payloads the host will only reject.
     @_blocking_emit_method
     async def notify_with_image(self, title: str, body: str, image_bytes: bytes,
-                                mime: str, level: str = "info",
-                                priority: "int | None" = None,
+                                mime: str, priority: int,
+                                level: str = "info",
                                 choices: "list | None" = None) -> "str | None":
         """Post a notification with an inline base64-encoded image attachment.
 
@@ -249,8 +245,6 @@ class Emitter:
         Await this from async hooks. From background threads use
         ``self.emit.run_sync(self.emit.notify_with_image(...))``.
         """
-        if priority is None:
-            raise TypeError("notify_with_image() requires 'priority' (int, higher = more urgent)")
         if mime not in ("image/png", "image/jpeg"):
             raise ValueError(f"notify_with_image() mime must be image/png or image/jpeg, got {mime!r}")
         # 50 KB cap: matches the host's `MAX_INLINE_IMAGE_BYTES`. Apps that
@@ -275,9 +269,9 @@ class Emitter:
 
     # kind = "input"
     @_blocking_emit_method
-    async def notify_input(self, title: str, prompt: str = "", body: str = "",
+    async def notify_input(self, title: str, priority: int,
+                           prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
-                           priority: "int | None" = None,
                            timeout_secs: "int | None" = None,
                            on_dismiss: "str | None" = None) -> str:
         """Post an input notification and await until the user submits or
@@ -289,14 +283,12 @@ class Emitter:
         Await this from async hooks. From background threads use
         ``self.emit.run_sync(self.emit.notify_input(...))``.
         """
-        if priority is None:
-            raise TypeError("notify_input() requires 'priority' (int, higher = more urgent)")
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
         payload = {"type": "notify", "level": level, "title": title, "body": body,
                    "kind": "input", "input_prompt": prompt, "required": required,
-                   "priority": int(priority),
+                   "priority": priority,
                    "notify_id": notify_id}
         if timeout_secs is not None:
             payload["timeout_secs"] = int(timeout_secs)
@@ -306,9 +298,9 @@ class Emitter:
         return await q.get()
 
     @_blocking_emit_method
-    async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
+    async def notify_and_wait(self, title: str, priority: int,
+                              body: str = "", level: str = "info",
                               actions: "list | None" = None,
-                              priority: "int | None" = None,
                               timeout_secs: "int | None" = None,
                               on_dismiss: "str | None" = None) -> str:
         """Post a message notification and await until the user acknowledges
@@ -321,14 +313,12 @@ class Emitter:
         Await this from async hooks. From background threads use
         ``self.emit.run_sync(self.emit.notify_and_wait(...))``.
         """
-        if priority is None:
-            raise TypeError("notify_and_wait() requires 'priority' (int, higher = more urgent)")
         notify_id = str(uuid.uuid4())
         q: asyncio.Queue[str] = _make_async_queue()
         self._app._pending_notify[notify_id] = q
         payload = {"type": "notify", "level": level, "title": title, "body": body,
                    "kind": "message", "actions": actions or [],
-                   "priority": int(priority),
+                   "priority": priority,
                    "notify_id": notify_id}
         if timeout_secs is not None:
             payload["timeout_secs"] = int(timeout_secs)

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -499,8 +499,8 @@ class RenderContext:
     def error(self, message: str) -> None: self.log("error", message)
     def debug(self, message: str) -> None: self.log("debug", message)
 
-    def notify(self, title: str, body: str = "", level: str = "info",
-               priority: "int | None" = None,
+    def notify(self, title: str, priority: int, body: str = "",
+               level: str = "info",
                actions: "list | None" = None,
                image_inline: "dict | None" = None,
                image_pipe_id: "str | None" = None,
@@ -510,14 +510,14 @@ class RenderContext:
         `priority` is required (int, higher = more urgent).
         `image_inline` / `image_pipe_id` (#74) optionally attach an image.
         Scope is resolved from the app's manifest — not an argument."""
-        self.emit.notify(title=title, body=body, level=level,
-                         priority=priority, actions=actions,
+        self.emit.notify(title=title, priority=priority, body=body, level=level,
+                         actions=actions,
                          image_inline=image_inline, image_pipe_id=image_pipe_id,
                          timeout_secs=timeout_secs, on_dismiss=on_dismiss)
 
-    async def notify_choice(self, title: str, options: list, body: str = "",
+    async def notify_choice(self, title: str, options: list, priority: int,
+                            body: str = "",
                             level: str = "info", required: bool = False,
-                            priority: "int | None" = None,
                             image_inline: "dict | None" = None,
                             image_pipe_id: "str | None" = None,
                             timeout_secs: "int | None" = None,
@@ -527,49 +527,50 @@ class RenderContext:
         `image_inline` / `image_pipe_id` (#74) optionally attach an image.
         Returns the chosen option's value (or label if no value set),
         or "__cancel__" if the user dismissed. Use with ``await``."""
-        return await self.emit.notify_choice(title=title, options=options, body=body,
+        return await self.emit.notify_choice(title=title, options=options,
+                                             priority=priority, body=body,
                                              level=level, required=required,
-                                             priority=priority,
                                              image_inline=image_inline,
                                              image_pipe_id=image_pipe_id,
                                              timeout_secs=timeout_secs,
                                              on_dismiss=on_dismiss)
 
     async def notify_with_image(self, title: str, body: str, image_bytes: bytes,
-                                mime: str, level: str = "info",
-                                priority: "int | None" = None,
+                                mime: str, priority: int,
+                                level: str = "info",
                                 choices: "list | None" = None) -> "str | None":
         """Convenience: post a notification with an inline base64 image.
         See Emitter.notify_with_image — handles base64 + 50KB cap. Use with ``await``."""
         return await self.emit.notify_with_image(title=title, body=body,
                                                  image_bytes=image_bytes, mime=mime,
-                                                 level=level, priority=priority,
+                                                 priority=priority, level=level,
                                                  choices=choices)
 
-    async def notify_input(self, title: str, prompt: str = "", body: str = "",
+    async def notify_input(self, title: str, priority: int,
+                           prompt: str = "", body: str = "",
                            level: str = "info", required: bool = False,
-                           priority: "int | None" = None,
                            timeout_secs: "int | None" = None,
                            on_dismiss: "str | None" = None) -> str:
         """Post an input notification and await until the user submits.
         `priority` is required (int, higher = more urgent).
         Returns the typed text, or "__cancel__" if dismissed. Use with ``await``."""
-        return await self.emit.notify_input(title=title, prompt=prompt, body=body,
+        return await self.emit.notify_input(title=title, priority=priority,
+                                            prompt=prompt, body=body,
                                             level=level, required=required,
-                                            priority=priority,
                                             timeout_secs=timeout_secs,
                                             on_dismiss=on_dismiss)
 
-    async def notify_and_wait(self, title: str, body: str = "", level: str = "info",
+    async def notify_and_wait(self, title: str, priority: int,
+                              body: str = "", level: str = "info",
                               actions: "list | None" = None,
-                              priority: "int | None" = None,
                               timeout_secs: "int | None" = None,
                               on_dismiss: "str | None" = None) -> str:
         """Post a message notification and await for acknowledge/cancel.
         `priority` is required (int, higher = more urgent).
         See Emitter.notify_and_wait. Use with ``await``."""
-        return await self.emit.notify_and_wait(title=title, body=body, level=level,
-                                               actions=actions, priority=priority,
+        return await self.emit.notify_and_wait(title=title, priority=priority,
+                                               body=body, level=level,
+                                               actions=actions,
                                                timeout_secs=timeout_secs,
                                                on_dismiss=on_dismiss)
 

--- a/sdk/python/plexi_sdk/widgets/button.py
+++ b/sdk/python/plexi_sdk/widgets/button.py
@@ -13,6 +13,7 @@ _ACTIVE = "#585b70"
 
 @dataclass
 class ButtonStyle:
+    """Visual style for Button widgets — fill, hover, active colors and font size."""
     fill: str = _BG
     hover_fill: str = _HOVER
     active_fill: str = _ACTIVE

--- a/sdk/python/plexi_sdk/widgets/text_area.py
+++ b/sdk/python/plexi_sdk/widgets/text_area.py
@@ -15,6 +15,7 @@ from plexi_sdk.widgets.text_buffer import TextBuffer
 
 @dataclass
 class TextAreaTheme:
+    """Color and spacing theme for TextArea widgets."""
     background: str = "#1e1e2e"
     foreground: str = "#cdd6f4"
     cursor: str = "#cdd6f4"

--- a/sdk/python/plexi_sdk/widgets/text_buffer.py
+++ b/sdk/python/plexi_sdk/widgets/text_buffer.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Cursor:
+    """Row/column position in a TextBuffer."""
     row: int = 0
     col: int = 0
 

--- a/website/src/content/docs/sdk-app.md
+++ b/website/src/content/docs/sdk-app.md
@@ -11,35 +11,35 @@ Base class for Plexi v3 apps. Subclass and override event handlers.
 Override any of:
 
 Awaited (block the event loop until they return):
-    on_init(ctx)                                 — after Init handshake
-    on_render(ctx)                               — on each Render event
-    on_suspend()                                 — on Suspend
-    on_resume()                                  — on Resume
-    on_shutdown()                                — on Shutdown
+    on_init(ctx)                                — after Init handshake
+    on_render(ctx)                              — on each Render event
+    on_suspend()                                — on Suspend
+    on_resume()                                 — on Resume
+    on_shutdown()                               — on Shutdown
 
 Task (dispatched as asyncio tasks — event loop continues):
-    on_key(ctx, key, mods)                       — on Key event
-    on_click(ctx, x, y, button)                  — on Click event
-    on_mouse_down(ctx, x, y, button)             — on MouseDown event
-    on_mouse_up(ctx, x, y, button)               — on MouseUp event
-    on_mouse_move(ctx, x, y, buttons)            — on MouseMove event
-    on_command(ctx, text)                         — on Command event
-    on_paste(ctx, text)                           — on Paste event
-    on_text_submitted(ctx, id, text)              — on TextInput Enter press
-    on_pipe_message(ctx, pipe_id, payload)        — on PipeMessage
-    on_path_changed(ctx, cwd)                     — on PathChanged
-    on_inject(ctx, payload)                       — on Inject event
-    on_nav_back(ctx, view_id)                     — on NavBack event
-    on_timer(ctx, timer_id)                       — on Timer event
-    on_scroll(ctx, id, offset_y)                  — on Scroll event
-    on_file_picked(ctx, request_id, paths)        — on FilePicked event
-    on_file_pick_cancelled(ctx, request_id)       — on FilePickCancelled
-    on_mcp_call(ctx, tool_name, arguments)        — on MCP tool call
+    on_key(ctx, key, mods)                      — on Key event
+    on_click(ctx, x, y, button)                 — on Click event
+    on_mouse_down(ctx, x, y, button)            — on MouseDown event
+    on_mouse_up(ctx, x, y, button)              — on MouseUp event
+    on_mouse_move(ctx, x, y, buttons)           — on MouseMove event
+    on_command(ctx, text)                        — on Command event
+    on_paste(ctx, text)                          — on Paste event
+    on_text_submitted(ctx, id, text)             — on TextInput Enter press
+    on_pipe_message(ctx, pipe_id, payload)       — on PipeMessage
+    on_path_changed(ctx, cwd)                    — on PathChanged
+    on_inject(ctx, payload)                      — on Inject event
+    on_nav_back(ctx, view_id)                    — on NavBack event
+    on_timer(ctx, timer_id)                      — on Timer event
+    on_scroll(ctx, id, offset_y)                 — on Scroll event
+    on_file_picked(ctx, request_id, paths)       — on FilePicked event
+    on_file_pick_cancelled(ctx, request_id)      — on FilePickCancelled
+    on_mcp_call(ctx, tool_name, arguments)       — on MCP tool call
 
 Fire-and-forget (no RenderContext — called outside a render frame):
-    on_app_spawned(pane_id, type_id)              — app spawn succeeded
-    on_pane_spawned(pane_id, request_id)           — pane spawn succeeded
-    on_pane_spawn_error(reason, request_id)        — pane spawn failed
+    on_app_spawned(pane_id, type_id)             — app spawn succeeded
+    on_pane_spawned(pane_id, request_id)         — pane spawn succeeded
+    on_pane_spawn_error(reason, request_id)      — pane spawn failed
     on_midi_input_opened(pipe_id, port_id, port_name) — MIDI input opened
 
 Task handlers are dispatched as asyncio tasks — the event loop does not

--- a/website/src/content/docs/sdk-app.md
+++ b/website/src/content/docs/sdk-app.md
@@ -9,28 +9,51 @@ verified_version: "3.6.54"
 Base class for Plexi v3 apps. Subclass and override event handlers.
 
 Override any of:
-    on_init(self, ctx)                            — after Init handshake (awaited)
-    on_render(self, ctx)                          — on each Render event (awaited)
-    on_key(self, ctx, key, mods)                  — on Key event (task)
-    on_click(self, ctx, x, y, button)             — on Click event (task)
-    on_command(self, ctx, text)                   — on Command event (task)
-    on_paste(self, ctx, text)                     — on Paste event (task)
-    on_text_submitted(self, ctx, id, text)        — on TextInput Enter press (task)
-    on_pipe_message(self, ctx, pipe_id, payload)  — on PipeMessage (task)
-    on_path_changed(self, ctx, cwd)               — on PathChanged (task)
-    on_suspend(self)                              — on Suspend (awaited)
-    on_resume(self)                               — on Resume (awaited)
-    on_shutdown(self)                             — on Shutdown (awaited)
 
-Handlers marked (task) are dispatched as asyncio tasks — the event loop
-does not wait for them to complete before processing the next event. Declare
-them ``async def`` whenever they do any I/O. Never call blocking operations
+Awaited (block the event loop until they return):
+    on_init(ctx)                                 — after Init handshake
+    on_render(ctx)                               — on each Render event
+    on_suspend()                                 — on Suspend
+    on_resume()                                  — on Resume
+    on_shutdown()                                — on Shutdown
+
+Task (dispatched as asyncio tasks — event loop continues):
+    on_key(ctx, key, mods)                       — on Key event
+    on_click(ctx, x, y, button)                  — on Click event
+    on_mouse_down(ctx, x, y, button)             — on MouseDown event
+    on_mouse_up(ctx, x, y, button)               — on MouseUp event
+    on_mouse_move(ctx, x, y, buttons)            — on MouseMove event
+    on_command(ctx, text)                         — on Command event
+    on_paste(ctx, text)                           — on Paste event
+    on_text_submitted(ctx, id, text)              — on TextInput Enter press
+    on_pipe_message(ctx, pipe_id, payload)        — on PipeMessage
+    on_path_changed(ctx, cwd)                     — on PathChanged
+    on_inject(ctx, payload)                       — on Inject event
+    on_nav_back(ctx, view_id)                     — on NavBack event
+    on_timer(ctx, timer_id)                       — on Timer event
+    on_scroll(ctx, id, offset_y)                  — on Scroll event
+    on_file_picked(ctx, request_id, paths)        — on FilePicked event
+    on_file_pick_cancelled(ctx, request_id)       — on FilePickCancelled
+    on_mcp_call(ctx, tool_name, arguments)        — on MCP tool call
+
+Fire-and-forget (no RenderContext — called outside a render frame):
+    on_app_spawned(pane_id, type_id)              — app spawn succeeded
+    on_pane_spawned(pane_id, request_id)           — pane spawn succeeded
+    on_pane_spawn_error(reason, request_id)        — pane spawn failed
+    on_midi_input_opened(pipe_id, port_id, port_name) — MIDI input opened
+
+Task handlers are dispatched as asyncio tasks — the event loop does not
+wait for them to complete before processing the next event. Declare them
+``async def`` whenever they do any I/O. Never call blocking operations
 (time.sleep, requests.get, etc.) directly from these handlers; use
 ``await asyncio.to_thread(fn)`` or ``threading.Thread`` + ``emit.run_sync()``.
 
-Handlers marked (awaited) block the event loop until they return. Use
-``await``-able Emitter helpers freely; they do not deadlock because the
-stdin reader runs as a concurrent task.
+Awaited handlers block the event loop until they return. Use ``await``-able
+Emitter helpers freely; they do not deadlock because the stdin reader runs
+as a concurrent task.
+
+Fire-and-forget handlers do not receive a RenderContext because they are
+dispatched outside a render frame.
 
 ## Methods
 
@@ -156,7 +179,7 @@ def on_app_spawned(_pane_id: int, _type_id: str) -> None
 ### `on_pane_spawned`
 
 ```python
-def on_pane_spawned(pane_id: int, request_id: 'str | None' = None) -> None
+def on_pane_spawned(_pane_id: int, _request_id: 'str | None' = None) -> None
 ```
 
 Called when a SpawnPane request succeeded (#592). Override to track the spawned pane.
@@ -166,7 +189,7 @@ Called when a SpawnPane request succeeded (#592). Override to track the spawned 
 ### `on_pane_spawn_error`
 
 ```python
-def on_pane_spawn_error(reason: str, request_id: 'str | None' = None) -> None
+def on_pane_spawn_error(_reason: str, _request_id: 'str | None' = None) -> None
 ```
 
 Called when a SpawnPane request failed (#592). Override to handle the error.

--- a/website/src/content/docs/sdk-emitter.md
+++ b/website/src/content/docs/sdk-emitter.md
@@ -55,7 +55,7 @@ def debug(message: str) -> None
 ### `notify`
 
 ```python
-def notify(title: str, body: str = '', level: str = 'info', priority: 'int | None' = None, actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
+def notify(title: str, priority: int, body: str = '', level: str = 'info', actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
 ```
 
 Post a message notification. The modal shows title + body and a
@@ -96,7 +96,7 @@ Raises ``RuntimeError`` if there is no running event loop to dispatch to
 ### `notify_choice`
 
 ```python
-async def notify_choice(title: str, options: list, body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_choice(title: str, options: list, priority: int, body: str = '', level: str = 'info', required: bool = False, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post a choice notification and await until the user picks one.
@@ -121,7 +121,7 @@ Await this from async hooks. From background threads use
 ### `notify_with_image`
 
 ```python
-async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, level: str = 'info', priority: 'int | None' = None, choices: 'list | None' = None) -> 'str | None'
+async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, priority: int, level: str = 'info', choices: 'list | None' = None) -> 'str | None'
 ```
 
 Post a notification with an inline base64-encoded image attachment.
@@ -146,7 +146,7 @@ Await this from async hooks. From background threads use
 ### `notify_input`
 
 ```python
-async def notify_input(title: str, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_input(title: str, priority: int, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post an input notification and await until the user submits or
@@ -163,7 +163,7 @@ Await this from async hooks. From background threads use
 ### `notify_and_wait`
 
 ```python
-async def notify_and_wait(title: str, body: str = '', level: str = 'info', actions: 'list | None' = None, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_and_wait(title: str, priority: int, body: str = '', level: str = 'info', actions: 'list | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post a message notification and await until the user acknowledges

--- a/website/src/content/docs/sdk-render-context.md
+++ b/website/src/content/docs/sdk-render-context.md
@@ -508,7 +508,7 @@ def debug(message: str) -> None
 ### `notify`
 
 ```python
-def notify(title: str, body: str = '', level: str = 'info', priority: 'int | None' = None, actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
+def notify(title: str, priority: int, body: str = '', level: str = 'info', actions: 'list | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> None
 ```
 
 Post a message notification. See Emitter.notify.
@@ -521,7 +521,7 @@ Scope is resolved from the app's manifest — not an argument.
 ### `notify_choice`
 
 ```python
-async def notify_choice(title: str, options: list, body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_choice(title: str, options: list, priority: int, body: str = '', level: str = 'info', required: bool = False, image_inline: 'dict | None' = None, image_pipe_id: 'str | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post a choice notification and await until the user picks.
@@ -535,7 +535,7 @@ or "__cancel__" if the user dismissed. Use with ``await``.
 ### `notify_with_image`
 
 ```python
-async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, level: str = 'info', priority: 'int | None' = None, choices: 'list | None' = None) -> 'str | None'
+async def notify_with_image(title: str, body: str, image_bytes: bytes, mime: str, priority: int, level: str = 'info', choices: 'list | None' = None) -> 'str | None'
 ```
 
 Convenience: post a notification with an inline base64 image.
@@ -546,7 +546,7 @@ See Emitter.notify_with_image — handles base64 + 50KB cap. Use with ``await``.
 ### `notify_input`
 
 ```python
-async def notify_input(title: str, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_input(title: str, priority: int, prompt: str = '', body: str = '', level: str = 'info', required: bool = False, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post an input notification and await until the user submits.
@@ -558,7 +558,7 @@ Returns the typed text, or "__cancel__" if dismissed. Use with ``await``.
 ### `notify_and_wait`
 
 ```python
-async def notify_and_wait(title: str, body: str = '', level: str = 'info', actions: 'list | None' = None, priority: 'int | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
+async def notify_and_wait(title: str, priority: int, body: str = '', level: str = 'info', actions: 'list | None' = None, timeout_secs: 'int | None' = None, on_dismiss: 'str | None' = None) -> str
 ```
 
 Post a message notification and await for acknowledge/cancel.

--- a/website/src/content/docs/sdk-widgets.md
+++ b/website/src/content/docs/sdk-widgets.md
@@ -22,6 +22,8 @@ from plexi_sdk.widgets import (
 
 ## ButtonStyle
 
+Visual style for Button widgets — fill, hover, active colors and font size.
+
 ## Button
 
 Stateful button widget. Tracks its own hover/click state across frames.
@@ -204,6 +206,8 @@ Otherwise no-op. Result is always clamped.
 
 ## TextAreaTheme
 
+Color and spacing theme for TextArea widgets.
+
 ## TextArea
 
 TextBuffer + ScrollState + theme → DrawCommands.
@@ -244,6 +248,8 @@ All returned coordinates are absolute (include x, y offsets).
 ---
 
 ## Cursor
+
+Row/column position in a TextBuffer.
 
 ## Selection
 

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -48,7 +48,7 @@ QUICK START
         def on_click(self, ctx, x, y, button):
             # button: "primary" | "secondary" | "middle"
             # x, y are pixel coordinates within the pane
-            ctx.notify("Clicked", f"({x:.0f}, {y:.0f}) {button}")
+            ctx.notify("Clicked", priority=50, body=f"({x:.0f}, {y:.0f}) {button}")
 
     CounterApp().run()
 
@@ -156,22 +156,22 @@ notification modal (ctx.notify(...) returns immediately; the other three
 block the calling thread until the user responds — run them on a worker
 thread if the app needs to stay interactive).
 
-  ctx.notify(title, body="", level="info", priority=PRIORITY_NORMAL)
+  ctx.notify(title, priority, body="", level="info")
       Fire-and-forget message. Enter / Space acknowledge, Esc dismisses.
 
-  ctx.notify_and_wait(title, body="", priority=...)  -> str
+  ctx.notify_and_wait(title, priority, body="")  -> str
       Same as notify() but blocks. Returns "acknowledge" or "cancel".
 
-  ctx.notify_choice(title, options, body="", required=False, priority=...) -> str
+  ctx.notify_choice(title, options, priority, body="", required=False) -> str
       Blocking choice picker. options = [{"label":..., "value":...,
       "shortcut":...}]. Returns chosen value (or label if no value),
       or "__cancel__" if dismissed.
 
-  ctx.notify_input(title, prompt="", body="", required=False, priority=...) -> str
+  ctx.notify_input(title, priority, prompt="", body="", required=False) -> str
       Blocking text input. Returns the typed string, or "__cancel__".
 
-  ctx.notify_with_image(title, body, image_bytes, mime, priority=...,
-                        choices=None) -> str | None
+  ctx.notify_with_image(title, body, image_bytes, mime, priority,
+                        level="info", choices=None) -> str | None
       Convenience wrapper that handles base64 encoding + 50 KB cap.
       `image_bytes` > 50 KB raises ValueError locally. With `choices=None`
       this is fire-and-forget (returns None); with `choices` set it routes
@@ -292,7 +292,7 @@ Drawing methods:
       Each item is a dict — see ListItem shape below.
 
 Notification / logging (usable inside or outside a frame):
-  ctx.notify(title, body, level="info", actions=None)
+  ctx.notify(title, priority, body="", level="info", actions=None)
       Trigger a system notification. actions: list of NotifyAction dicts (see below).
 
   ctx.status_summary(text)
@@ -309,7 +309,7 @@ Emitter  (self.emit — available at all times, including background threads)
 
 All methods are thread-safe (protected by a global write lock).
 
-  emit.notify(title, body, level="info", actions=None)
+  emit.notify(title, priority, body="", level="info", actions=None)
       Trigger a system notification outside of a render frame.
 
   emit.log(level, message)  /  emit.info(msg)  /  emit.warn(msg)


### PR DESCRIPTION
## Summary
- Completes the App class docstring handler overview — was listing 12 of 26+ handlers, now lists all grouped by dispatch type (awaited/task/fire-and-forget)
- Changes `priority` parameter on all 5 notify methods from `int | None = None` (runtime TypeError) to required `int` — static analysis now catches missing priority at call sites
- Adds underscore prefixes to `on_pane_spawned` and `on_pane_spawn_error` params to match SDK convention
- Adds one-line docstrings to `ButtonStyle`, `TextAreaTheme`, and `Cursor` dataclasses
- Regenerates SDK doc pages

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('sdk/python/plexi_sdk/_emitter.py').read())"` passes
- [ ] SDK doc generation produces no empty headings
- [ ] Existing apps using `priority=N` keyword args still work unchanged

Closes #1260