### PR TITLE
feat(context): keyboard-driven context close + context inspector modal (#1273)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -79,6 +79,8 @@ pub(crate) enum FocusLayer {
     /// First-launch CLI setup prompt. No text input — intercepts keys so they
     /// don't fall through to the active terminal while the modal is visible.
     CliSetupPrompt,
+    /// Context inspector modal — shows pane list, allows close/delete.
+    ContextInspector,
 }
 
 #[derive(Clone)]
@@ -189,6 +191,10 @@ pub struct PlexiApp {
     pub(crate) quit_press_count: u8,
     pub(crate) quit_last_press: Option<std::time::Instant>,
     pub(crate) pending_close: bool,
+    pub(crate) show_context_inspector: bool,
+    pub(crate) inspector_selected_pane: usize,
+    pub(crate) welcome_delete_press_count: u8,
+    pub(crate) welcome_delete_last_press: Option<std::time::Instant>,
     pub(crate) frame_tick: crate::logging::FrameTick,
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
@@ -653,6 +659,10 @@ impl PlexiApp {
                     quitting: false,
                     quit_press_count: 0,
                     quit_last_press: None,
+                    show_context_inspector: false,
+                    inspector_selected_pane: 0,
+                    welcome_delete_press_count: 0,
+                    welcome_delete_last_press: None,
                     config: config.clone(),
                     key_bindings: key_bindings.clone(),
                     voice_config: voice_config.clone(),
@@ -762,6 +772,10 @@ impl PlexiApp {
             quitting: false,
             quit_press_count: 0,
             quit_last_press: None,
+            show_context_inspector: false,
+            inspector_selected_pane: 0,
+            welcome_delete_press_count: 0,
+            welcome_delete_last_press: None,
             config,
             key_bindings,
             voice_config,
@@ -881,6 +895,10 @@ impl PlexiApp {
             quitting: false,
             quit_press_count: 0,
             quit_last_press: None,
+            show_context_inspector: false,
+            inspector_selected_pane: 0,
+            welcome_delete_press_count: 0,
+            welcome_delete_last_press: None,
             config,
             key_bindings,
             voice_config: config::VoiceConfig::default(),
@@ -1800,6 +1818,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::CliSetupPrompt) => {
                     self.draw_cli_setup_modal(ctx);
                 }
+                Some(FocusLayer::ContextInspector) => {
+                    self.draw_context_inspector(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -1813,6 +1834,7 @@ impl eframe::App for PlexiApp {
             self.sync_rename_pane_focus();
             self.sync_context_rename_focus();
             self.sync_cli_setup_prompt_focus();
+            self.sync_context_inspector_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -2749,6 +2771,11 @@ impl eframe::App for PlexiApp {
                     self.new_context();
                     self.save_workspace();
                 }
+                Action::ContextInspector => {
+                    self.show_context_inspector = !self.show_context_inspector;
+                    self.inspector_selected_pane = 0;
+                    log::info!("ContextInspector: toggled to {}", self.show_context_inspector);
+                }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();
                 }
@@ -2861,7 +2888,50 @@ impl eframe::App for PlexiApp {
             .show(ctx, |ui| {
                 let active = self.active_window;
                 if self.windows[active].panes.is_empty() || self.windows[active].tree.root.is_none() {
+                    if self.router.len() > 1 {
+                        let delete_pressed = ctx.input_mut(|input| {
+                            input.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
+                                || input.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
+                        });
+                        if delete_pressed {
+                            let now = std::time::Instant::now();
+                            let elapsed = self
+                                .welcome_delete_last_press
+                                .map(|t| now.duration_since(t))
+                                .unwrap_or(std::time::Duration::MAX);
+                            if elapsed > std::time::Duration::from_millis(1500) {
+                                self.welcome_delete_press_count = 0;
+                            }
+                            self.welcome_delete_press_count += 1;
+                            self.welcome_delete_last_press = Some(now);
+                            if self.welcome_delete_press_count >= 3 {
+                                let ctx_idx = self.router.active_idx();
+                                log::info!(
+                                    "welcome_delete: triple-tap delete context idx={ctx_idx} name={:?}",
+                                    self.router.active().name
+                                );
+                                self.welcome_delete_press_count = 0;
+                                self.welcome_delete_last_press = None;
+                                self.delete_context(ctx_idx);
+                                self.save_workspace();
+                                return;
+                            }
+                        }
+                    }
                     self.draw_welcome_screen(ui);
+                    if self.welcome_delete_press_count > 0 {
+                        let timed_out = self
+                            .welcome_delete_last_press
+                            .map(|t| t.elapsed() > std::time::Duration::from_millis(1500))
+                            .unwrap_or(false);
+                        if timed_out {
+                            self.welcome_delete_press_count = 0;
+                            self.welcome_delete_last_press = None;
+                        } else {
+                            self.draw_welcome_delete_overlay(ctx);
+                            ctx.request_repaint_after(std::time::Duration::from_millis(100));
+                        }
+                    }
                     return;
                 }
 
@@ -3451,6 +3521,7 @@ impl PlexiApp {
                 | Some(FocusLayer::QuickNoteDestination)
                 | Some(FocusLayer::QuickNoteSubDestination(_))
                 | Some(FocusLayer::CliSetupPrompt)
+                | Some(FocusLayer::ContextInspector)
         )
     }
 
@@ -3777,6 +3848,20 @@ impl PlexiApp {
             // Use retain rather than pop_focus_layer so stale entries are removed
             // even if another layer was pushed on top (e.g. via rapid state change).
             self.focus_stack.retain(|l| *l != FocusLayer::CliSetupPrompt);
+        }
+    }
+
+    pub(crate) fn sync_context_inspector_focus(&mut self) {
+        let should_own = self.show_context_inspector;
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::ContextInspector);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::ContextInspector);
+        } else if !should_own && has_layer {
+            self.focus_stack
+                .retain(|l| *l != FocusLayer::ContextInspector);
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1779,6 +1779,7 @@ impl eframe::App for PlexiApp {
         self.sync_rename_pane_focus();
         self.sync_context_rename_focus();
         self.sync_cli_setup_prompt_focus();
+        self.sync_context_inspector_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
         // notification modal's TextEdit for the `input` kind, the palette's

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "scroll_up", "scroll_down", "increase_font_size", "decrease_font_size",
     "open_file_browser", "open_quick_note", "open_config", "reload_config",
     "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
+    "context_inspector",
 ];
 
 pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,7 @@ pub struct KeybindingsConfig {
     pub open_secrets_manager: Option<String>,
     pub force_reload_app: Option<String>,
     pub toggle_notification_modal: Option<String>,
+    pub context_inspector: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -253,6 +254,7 @@ impl KeybindingsConfig {
         overlay_field!(open_secrets_manager);
         overlay_field!(force_reload_app);
         overlay_field!(toggle_notification_modal);
+        overlay_field!(context_inspector);
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -26,6 +26,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+Up / Cmd+Down           — scroll
 // Cmd+= / Cmd+-               — font size
 // Cmd+E                       — file browser
+// Cmd+I                       — context inspector
 // Cmd+0                       — quick note
 // Cmd+1–9                     — switch context (sidebar)
 // Escape (app active)         — close app
@@ -105,6 +106,8 @@ pub enum Action {
     /// Create a new context (sidebar item) and immediately open the rename modal.
     /// Bound to Cmd+Shift+N.
     NewContext,
+    /// Toggle the context inspector modal. Bound to Cmd+I.
+    ContextInspector,
     /// Toggle the minimap overlay. Bound to Cmd+Shift+M.
     ToggleMinimap,
     /// Reload configuration from disk. Bound to Cmd+Shift+,.
@@ -165,6 +168,7 @@ pub struct KeyBindings {
     pub open_secrets_manager: (egui::Modifiers, egui::Key),
     pub force_reload_app: (egui::Modifiers, egui::Key),
     pub toggle_notification_modal: (egui::Modifiers, egui::Key),
+    pub context_inspector: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -222,6 +226,7 @@ impl Default for KeyBindings {
             open_secrets_manager:      (cmd_shift(), egui::Key::S),
             force_reload_app:          (cmd_alt(),   egui::Key::R),
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
+            context_inspector:         (cmd(),       egui::Key::I),
         }
     }
 }
@@ -369,6 +374,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(open_secrets_manager, "open_secrets_manager");
     apply_override!(force_reload_app, "force_reload_app");
     apply_override!(toggle_notification_modal, "toggle_notification_modal");
+    apply_override!(context_inspector, "context_inspector");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -413,6 +419,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("open_secrets_manager",      bindings.open_secrets_manager),
         ("force_reload_app",          bindings.force_reload_app),
         ("toggle_notification_modal", bindings.toggle_notification_modal),
+        ("context_inspector",         bindings.context_inspector),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -623,6 +630,9 @@ pub fn poll_actions(
         }
         if input.consume_key(bindings.toggle_notification_modal.0, bindings.toggle_notification_modal.1) {
             actions.push(Action::ToggleNotificationModal);
+        }
+        if input.consume_key(bindings.context_inspector.0, bindings.context_inspector.1) {
+            actions.push(Action::ContextInspector);
         }
 
         // Switch context (Cmd+1 through Cmd+9) — these remain hardcoded for now.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1422,6 +1422,325 @@ impl PlexiApp {
         }
     }
 
+    pub(crate) fn draw_context_inspector(&mut self, ctx: &egui::Context) {
+        let mut dismissed = false;
+        let mut close_pane: Option<PaneId> = None;
+        let mut delete_context = false;
+
+        let (nav_down, nav_up, enter_pressed) = ctx.input_mut(|i| {
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            let down = i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown);
+            let up = i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
+            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            if esc {
+                dismissed = true;
+            }
+            (down, up, enter)
+        });
+
+        let active_ctx_id = self.router.active().context_id;
+        let ctx_name = self.router.active().name.clone();
+        let ctx_root = self.router.active().root.clone();
+        let num_contexts = self.router.len();
+
+        let mut pane_ids: Vec<PaneId> = Vec::new();
+        let mut pane_kinds: Vec<&'static str> = Vec::new();
+        let mut pane_names: Vec<String> = Vec::new();
+        let mut pane_statuses: Vec<&'static str> = Vec::new();
+
+        for win in self.windows.iter() {
+            if win.context_id != active_ctx_id {
+                continue;
+            }
+            for (_, pane) in &win.panes {
+                match pane {
+                    crate::pane::Pane::Terminal(t) => {
+                        pane_ids.push(t.id);
+                        pane_kinds.push("Terminal");
+                        pane_names.push(
+                            t.name
+                                .clone()
+                                .or_else(|| t.pty_title.clone())
+                                .unwrap_or_default(),
+                        );
+                        pane_statuses.push(if t.exited { "exited" } else { "running" });
+                    }
+                    crate::pane::Pane::App(a) => {
+                        pane_ids.push(a.id);
+                        pane_kinds.push("App");
+                        pane_names.push(a.name.clone());
+                        pane_statuses.push("running");
+                    }
+                }
+            }
+        }
+
+        let pane_count = pane_ids.len();
+        if nav_down && pane_count > 0 {
+            self.inspector_selected_pane = (self.inspector_selected_pane + 1) % pane_count;
+        }
+        if nav_up && pane_count > 0 {
+            self.inspector_selected_pane =
+                (self.inspector_selected_pane + pane_count - 1) % pane_count;
+        }
+        if self.inspector_selected_pane >= pane_count && pane_count > 0 {
+            self.inspector_selected_pane = pane_count - 1;
+        }
+        if enter_pressed && pane_count > 0 {
+            close_pane = Some(pane_ids[self.inspector_selected_pane]);
+        }
+
+        let colors = self.colors;
+        let selected = self.inspector_selected_pane;
+
+        let screen_rect = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("context_inspector_scrim"))
+            .fixed_pos(screen_rect.min)
+            .order(egui::Order::Middle)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(
+                    screen_rect,
+                    0.0,
+                    Color32::from_black_alpha(style::SCRIM_ALPHA),
+                );
+                if ui
+                    .allocate_rect(screen_rect, egui::Sense::click())
+                    .clicked()
+                {
+                    dismissed = true;
+                }
+            });
+
+        egui::Area::new(egui::Id::new("context_inspector_overlay"))
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, colors.border))
+                    .corner_radius(style::RADIUS_MD)
+                    .inner_margin(egui::Margin::symmetric(
+                        style::MODAL_PADDING_H,
+                        style::MODAL_PADDING_V,
+                    ))
+                    .show(ui, |ui| {
+                        ui.set_width(style::MODAL_WIDTH_MD);
+
+                        ui.label(
+                            RichText::new(&ctx_name)
+                                .size(style::TEXT_TITLE_XL)
+                                .color(colors.text_primary)
+                                .strong(),
+                        );
+
+                        if let Some(root) = &ctx_root {
+                            ui.add_space(style::SPACE_SM);
+                            ui.horizontal(|ui| {
+                                ui.label(
+                                    RichText::new(root.display().to_string())
+                                        .size(style::TEXT_CAPTION)
+                                        .color(colors.text_dim),
+                                );
+                                crate::widgets::copy_button(
+                                    ui,
+                                    egui::Id::new("inspector_copy_root"),
+                                    &root.display().to_string(),
+                                );
+                            });
+                        }
+
+                        ui.add_space(style::SPACE_XL);
+                        ui.label(
+                            RichText::new("Panes")
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_dim)
+                                .strong(),
+                        );
+                        ui.add_space(style::SPACE_SM);
+
+                        if pane_count == 0 {
+                            ui.label(
+                                RichText::new("No panes")
+                                    .size(style::TEXT_BODY)
+                                    .color(colors.text_dim),
+                            );
+                        } else {
+                            for i in 0..pane_count {
+                                let is_selected = i == selected;
+                                let (row_resp, _) = crate::widgets::selectable_row(
+                                    ui,
+                                    is_selected,
+                                    &colors,
+                                    |ui| {
+                                        ui.horizontal(|ui| {
+                                            ui.label(
+                                                RichText::new(pane_kinds[i])
+                                                    .size(style::TEXT_CAPTION)
+                                                    .color(colors.text_dim),
+                                            );
+                                            let display_name = if pane_names[i].is_empty() {
+                                                pane_kinds[i].to_string()
+                                            } else {
+                                                pane_names[i].clone()
+                                            };
+                                            ui.label(
+                                                RichText::new(&display_name)
+                                                    .size(style::TEXT_BODY)
+                                                    .color(colors.text_primary),
+                                            );
+                                            ui.with_layout(
+                                                Layout::right_to_left(Align::Center),
+                                                |ui| {
+                                                    if ui
+                                                        .add(
+                                                            egui::Button::new(
+                                                                RichText::new("✕")
+                                                                    .size(style::TEXT_CAPTION)
+                                                                    .color(colors.text_dim),
+                                                            )
+                                                            .frame(false),
+                                                        )
+                                                        .on_hover_cursor(
+                                                            egui::CursorIcon::PointingHand,
+                                                        )
+                                                        .clicked()
+                                                    {
+                                                        close_pane = Some(pane_ids[i]);
+                                                    }
+                                                    let status_color =
+                                                        if pane_statuses[i] == "running" {
+                                                            colors.accent
+                                                        } else {
+                                                            colors.text_dim
+                                                        };
+                                                    ui.label(
+                                                        RichText::new(pane_statuses[i])
+                                                            .size(style::TEXT_HINT)
+                                                            .color(status_color),
+                                                    );
+                                                },
+                                            );
+                                        });
+                                    },
+                                );
+                                if row_resp.clicked() {
+                                    close_pane = Some(pane_ids[i]);
+                                }
+                            }
+                        }
+
+                        ui.add_space(style::SPACE_XL);
+                        ui.separator();
+                        ui.add_space(style::SPACE_MD);
+
+                        ui.horizontal(|ui| {
+                            if num_contexts > 1 {
+                                if ui
+                                    .add(
+                                        egui::Button::new(
+                                            RichText::new("Delete context")
+                                                .size(style::TEXT_CAPTION)
+                                                .color(colors.text_primary),
+                                        )
+                                        .fill(colors.bg_active),
+                                    )
+                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                    .clicked()
+                                {
+                                    delete_context = true;
+                                }
+                                ui.add_space(style::SPACE_XL);
+                            }
+                            crate::widgets::key_combo_list(
+                                ui,
+                                &[&["Esc"]],
+                                Some("close"),
+                                &colors,
+                            );
+                            ui.add_space(style::SPACE_MD);
+                            crate::widgets::key_combo_list(
+                                ui,
+                                &[&["j"], &["k"]],
+                                Some("navigate"),
+                                &colors,
+                            );
+                            if pane_count > 0 {
+                                ui.add_space(style::SPACE_MD);
+                                crate::widgets::key_combo_list(
+                                    ui,
+                                    &[&["Enter"]],
+                                    Some("close pane"),
+                                    &colors,
+                                );
+                            }
+                        });
+                    });
+            });
+
+        if dismissed {
+            self.show_context_inspector = false;
+            log::info!("ContextInspector: closed");
+        }
+
+        if let Some(pid) = close_pane {
+            log::info!("ContextInspector: closing pane {pid}");
+            self.close_pane_by_id(pid);
+        }
+
+        if delete_context {
+            let ctx_idx = self.router.active_idx();
+            log::info!(
+                "ContextInspector: deleting context idx={ctx_idx} name={:?}",
+                self.router.active().name
+            );
+            self.show_context_inspector = false;
+            self.delete_context(ctx_idx);
+            self.save_workspace();
+        }
+    }
+
+    pub(crate) fn draw_welcome_delete_overlay(&self, ctx: &egui::Context) {
+        let count = self.welcome_delete_press_count;
+        egui::Area::new(egui::Id::new("welcome_delete_overlay"))
+            .anchor(Align2::CENTER_BOTTOM, Vec2::new(0.0, -40.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(16, 10))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                RichText::new(format!(
+                                    "⌫ pressed {} of 3 — press again to delete context",
+                                    count
+                                ))
+                                .size(12.0)
+                                .color(self.colors.text_dim),
+                            );
+                            ui.add_space(8.0);
+                            for i in 1u8..=3 {
+                                let color = if i <= count {
+                                    self.colors.accent
+                                } else {
+                                    self.colors.bg_active
+                                };
+                                let (rect, _) = ui.allocate_exact_size(
+                                    Vec2::new(8.0, 8.0),
+                                    egui::Sense::hover(),
+                                );
+                                ui.painter()
+                                    .circle_filled(rect.center(), 4.0, color);
+                            }
+                        });
+                    });
+            });
+    }
+
     pub(crate) fn draw_quit_confirm_overlay(&self, ctx: &egui::Context) {
         let count = self.quit_press_count;
         egui::Area::new(egui::Id::new("quit_confirm_overlay"))

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -533,6 +533,7 @@ mod tests {
             FocusLayer::QuickNoteDestination,
             FocusLayer::QuickNoteSubDestination(vec![0]),
             FocusLayer::CliSetupPrompt,
+            FocusLayer::ContextInspector,
         ];
 
         let input_events = vec![


### PR DESCRIPTION
## Summary

- Add **Cmd+I context inspector modal** showing context name, root path, and pane list with running/idle status
- Panes can be closed from the modal via click, Enter key, or ✕ button
- "Delete context" button available when multiple contexts exist
- Add **triple-tap Backspace/Delete on welcome screen** to delete empty contexts (same UX pattern as triple-tap Cmd+Q to quit)
- Full keyboard navigation: j/k to move selection, Enter to close selected pane, Esc to dismiss

## Test plan

- [ ] Cmd+I opens the context inspector modal
- [ ] Modal shows context name and root path (if set)
- [ ] Modal lists all panes with type (Terminal/App), name, and status (running/exited)
- [ ] j/k navigates the pane list; Enter closes the selected pane
- [ ] ✕ button on each row closes that pane
- [ ] "Delete context" button deletes the context (only when >1 context)
- [ ] Esc or clicking outside dismisses the modal
- [ ] On welcome screen (empty context), triple Backspace deletes the context
- [ ] Progress dots appear during triple-tap (like quit confirmation)
- [ ] Triple-tap only works when >1 context exists

Closes #1273
Supersedes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)