### PR TITLE
feat(finder): restore macOS Finder 'Open in Plexi' service (#690)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ security-framework = "3"
 # stays available under `cfg(test)`).
 coremidi = "0.9"
 objc2 = "0.5"
-objc2-app-kit = { version = "0.2.2", features = ["NSApplication", "NSMenu", "NSMenuItem", "NSRunningApplication", "NSWindow"] }
-objc2-foundation = { version = "0.2.2", features = ["NSThread", "NSString"] }
+objc2-app-kit = { version = "0.2.2", features = ["NSApplication", "NSMenu", "NSMenuItem", "NSPasteboard", "NSRunningApplication", "NSWindow"] }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSThread", "NSString"] }
 # AVFoundation video decoder (#346). The 0.3.x family is on objc2 0.6 (already
 # transitive via arboard / cpal / eframe), so this introduces no new obj-c
 # stack — just a direct dep on what's already in the tree. Path of least

--- a/assets/Info.plist.fragment
+++ b/assets/Info.plist.fragment
@@ -1,2 +1,23 @@
 <key>NSMicrophoneUsageDescription</key>
 <string>Plexi needs access to the microphone for audio-capture apps you choose to run.</string>
+<key>NSServices</key>
+<array>
+  <dict>
+    <key>NSMenuItem</key>
+    <dict>
+      <key>default</key>
+      <string>Open in Plexi</string>
+    </dict>
+    <key>NSMessage</key>
+    <string>openInPlexi</string>
+    <key>NSSendTypes</key>
+    <array>
+      <string>NSFilenamesPboardType</string>
+    </array>
+    <key>NSRequiredContext</key>
+    <dict>
+      <key>NSTextContent</key>
+      <string>FilePath</string>
+    </dict>
+  </dict>
+</array>

--- a/assets/Info.plist.fragment
+++ b/assets/Info.plist.fragment
@@ -10,6 +10,8 @@
     </dict>
     <key>NSMessage</key>
     <string>openInPlexi</string>
+    <key>NSPortName</key>
+    <string>Plexi</string>
     <key>NSSendTypes</key>
     <array>
       <string>NSFilenamesPboardType</string>

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1401,13 +1401,12 @@ impl PlexiApp {
                         self.new_context_at_path(r.clone());
                     } else {
                         self.new_context();
-                        self.save_workspace();
                     }
                     if let Some(n) = name {
                         let idx = self.router.len() - 1;
                         self.router.get_mut(idx).name = n.clone();
-                        self.save_workspace();
                     }
+                    self.save_workspace();
                 }
                 crate::app_protocol::HostCommand::FocusContext { root } => {
                     log::warn!(
@@ -1762,11 +1761,18 @@ impl eframe::App for PlexiApp {
             if let Some(ctx_path) = crate::config::take_adopted_context_path() {
                 log::info!("adopted context path: {}", ctx_path.display());
                 self.new_context_at_path(ctx_path);
+                self.save_workspace();
             }
             #[cfg(target_os = "macos")]
-            for path in crate::finder_service::drain() {
-                log::info!("finder_service: opening context for {}", path.display());
-                self.new_context_at_path(path);
+            {
+                let finder_paths = crate::finder_service::drain();
+                if !finder_paths.is_empty() {
+                    for path in finder_paths {
+                        log::info!("finder_service: opening context for {}", path.display());
+                        self.new_context_at_path(path);
+                    }
+                    self.save_workspace();
+                }
             }
             self.tick_notification_timeouts();
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -404,6 +404,8 @@ impl PlexiApp {
     pub fn new(cc: &eframe::CreationContext<'_>, frame_tick: crate::logging::FrameTick) -> Self {
         #[cfg(target_os = "macos")]
         crate::macos_menu::customize_app_menu();
+        #[cfg(target_os = "macos")]
+        crate::finder_service::register();
 
         theme::setup_fonts(&cc.egui_ctx);
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
@@ -1395,16 +1397,17 @@ impl PlexiApp {
                 }
                 crate::app_protocol::HostCommand::CreateContext { root, name } => {
                     log::info!("pane_ipc: kind=create_context root={:?} name={:?}", root, name);
-                    self.new_context();
                     if let Some(r) = root {
-                        let idx = self.router.len() - 1;
-                        self.router.get_mut(idx).root = Some(r.clone());
+                        self.new_context_at_path(r.clone());
+                    } else {
+                        self.new_context();
+                        self.save_workspace();
                     }
                     if let Some(n) = name {
                         let idx = self.router.len() - 1;
                         self.router.get_mut(idx).name = n.clone();
+                        self.save_workspace();
                     }
-                    self.save_workspace();
                 }
                 crate::app_protocol::HostCommand::FocusContext { root } => {
                     log::warn!(
@@ -1756,6 +1759,15 @@ impl eframe::App for PlexiApp {
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_spawn_queue();
+            if let Some(ctx_path) = crate::config::take_adopted_context_path() {
+                log::info!("adopted context path: {}", ctx_path.display());
+                self.new_context_at_path(ctx_path);
+            }
+            #[cfg(target_os = "macos")]
+            for path in crate::finder_service::drain() {
+                log::info!("finder_service: opening context for {}", path.display());
+                self.new_context_at_path(path);
+            }
             self.tick_notification_timeouts();
         }
         self.drain_pane_cmd_channel();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1755,25 +1755,25 @@ impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.frame_tick.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let _frame_start = std::time::Instant::now();
+        if let Some(ctx_path) = crate::config::take_adopted_context_path() {
+            log::info!("adopted context path: {}", ctx_path.display());
+            self.new_context_at_path(ctx_path);
+            self.save_workspace();
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let finder_paths = crate::finder_service::drain();
+            if !finder_paths.is_empty() {
+                for path in finder_paths {
+                    log::info!("finder_service: opening context for {}", path.display());
+                    self.new_context_at_path(path);
+                }
+                self.save_workspace();
+            }
+        }
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_spawn_queue();
-            if let Some(ctx_path) = crate::config::take_adopted_context_path() {
-                log::info!("adopted context path: {}", ctx_path.display());
-                self.new_context_at_path(ctx_path);
-                self.save_workspace();
-            }
-            #[cfg(target_os = "macos")]
-            {
-                let finder_paths = crate::finder_service::drain();
-                if !finder_paths.is_empty() {
-                    for path in finder_paths {
-                        log::info!("finder_service: opening context for {}", path.display());
-                        self.new_context_at_path(path);
-                    }
-                    self.save_workspace();
-                }
-            }
             self.tick_notification_timeouts();
         }
         self.drain_pane_cmd_channel();

--- a/src/config.rs
+++ b/src/config.rs
@@ -453,7 +453,7 @@ pub struct ThemeConfig {
     pub bright_foreground: Option<String>,
 }
 
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 static PROFILE_OVERRIDE: OnceLock<Option<String>> = OnceLock::new();
 
@@ -1224,6 +1224,24 @@ pub fn set_adopted_workspace_root(root: Option<PathBuf>) {
 /// [`crate::app_registry::resolve_workspace_root`].
 pub fn adopted_workspace_root() -> Option<PathBuf> {
     ADOPTED_WORKSPACE_ROOT.get().and_then(|opt| opt.clone())
+}
+
+// ── Adopted context path (set once by main when `plexi <path>` targets a
+// directory without a `.plexi/` workspace) ──────────────────────────────────
+
+static ADOPTED_CONTEXT_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Store a directory path for context-only opening (no workspace).
+/// Called from `parse_workspace_path_arg` when the target dir has no `.plexi/`.
+pub fn set_adopted_context_path(path: PathBuf) {
+    if let Ok(mut guard) = ADOPTED_CONTEXT_PATH.lock() {
+        *guard = Some(path);
+    }
+}
+
+/// Consume the adopted context path. Returns `Some` at most once.
+pub fn take_adopted_context_path() -> Option<PathBuf> {
+    ADOPTED_CONTEXT_PATH.lock().ok().and_then(|mut guard| guard.take())
 }
 
 /// Convenience: the active workspace root for this process. Returns the

--- a/src/finder_service.rs
+++ b/src/finder_service.rs
@@ -9,7 +9,7 @@ use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject, Sel};
 use objc2::{sel, ClassType};
 use objc2_app_kit::NSApplication;
-use objc2_foundation::MainThreadMarker;
+use objc2_foundation::{MainThreadMarker, NSString};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
@@ -33,11 +33,9 @@ fn register_provider_class() -> &'static objc2::runtime::AnyClass {
                 log::warn!("finder_service: pasteboard is null");
                 return;
             }
-            let type_str: *const AnyObject = objc2::msg_send![
-                objc2::runtime::AnyClass::get("NSString").unwrap(),
-                stringWithUTF8String: b"NSFilenamesPboardType\0".as_ptr()
-            ];
-            let plist: *const AnyObject = objc2::msg_send![&*pboard, propertyListForType: type_str];
+            let type_str = NSString::from_str("NSFilenamesPboardType");
+            let plist: *const AnyObject =
+                objc2::msg_send![&*pboard, propertyListForType: &*type_str];
             if plist.is_null() {
                 log::warn!("finder_service: no NSFilenamesPboardType on pasteboard");
                 return;

--- a/src/finder_service.rs
+++ b/src/finder_service.rs
@@ -1,0 +1,102 @@
+//! macOS Finder "Open in Plexi" service provider.
+//!
+//! Registers an NSServicesProvider so the right-click → Services menu in
+//! Finder shows "Open in Plexi". Paths received from the pasteboard are
+//! queued and drained each frame by `PlexiApp::update()`.
+
+use objc2::declare::ClassBuilder;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject, Sel};
+use objc2::{sel, ClassType};
+use objc2_app_kit::NSApplication;
+use objc2_foundation::MainThreadMarker;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+static PATH_QUEUE: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+fn register_provider_class() -> &'static objc2::runtime::AnyClass {
+    static CLASS: OnceLock<&'static objc2::runtime::AnyClass> = OnceLock::new();
+    CLASS.get_or_init(|| {
+        let superclass = NSObject::class();
+        let mut builder =
+            ClassBuilder::new("PlexiServicesProvider", superclass).expect("class already registered");
+
+        unsafe extern "C" fn open_in_plexi(
+            _this: &AnyObject,
+            _cmd: Sel,
+            pboard: *mut AnyObject,
+            _user_data: *mut AnyObject,
+            _error: *mut *mut AnyObject,
+        ) {
+            if pboard.is_null() {
+                log::warn!("finder_service: pasteboard is null");
+                return;
+            }
+            let type_str: *const AnyObject = objc2::msg_send![
+                objc2::runtime::AnyClass::get("NSString").unwrap(),
+                stringWithUTF8String: b"NSFilenamesPboardType\0".as_ptr()
+            ];
+            let plist: *const AnyObject = objc2::msg_send![&*pboard, propertyListForType: type_str];
+            if plist.is_null() {
+                log::warn!("finder_service: no NSFilenamesPboardType on pasteboard");
+                return;
+            }
+            let count: usize = objc2::msg_send![&*plist, count];
+            let mut paths = Vec::with_capacity(count);
+            for i in 0..count {
+                let item: *const AnyObject = objc2::msg_send![&*plist, objectAtIndex: i];
+                if item.is_null() {
+                    continue;
+                }
+                let utf8: *const std::ffi::c_char = objc2::msg_send![&*item, UTF8String];
+                if utf8.is_null() {
+                    continue;
+                }
+                let path_str = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+                let path = PathBuf::from(path_str.as_ref());
+                log::info!("finder_service: received path: {}", path.display());
+                paths.push(path);
+            }
+            if let Ok(mut queue) = PATH_QUEUE.lock() {
+                queue.extend(paths);
+            }
+        }
+
+        unsafe {
+            builder.add_method(
+                sel!(openInPlexi:userData:error:),
+                open_in_plexi as unsafe extern "C" fn(_, _, _, _, _),
+            );
+        }
+
+        builder.register()
+    })
+}
+
+/// Register the Finder services provider with NSApp. Call once from
+/// `PlexiApp::new()` on the main thread.
+pub fn register() {
+    let Some(mtm) = MainThreadMarker::new() else {
+        log::warn!("finder_service: not on main thread, cannot register");
+        return;
+    };
+    let cls = register_provider_class();
+    let obj: Retained<NSObject> = unsafe { objc2::msg_send_id![cls, new] };
+    let app = NSApplication::sharedApplication(mtm);
+    let ptr = Retained::as_ptr(&obj) as *const AnyObject;
+    unsafe {
+        let _: () = objc2::msg_send![&*app, setServicesProvider: ptr];
+    }
+    std::mem::forget(obj);
+    log::info!("finder_service: registered NSServicesProvider");
+}
+
+/// Drain all queued paths received from the Finder service. Returns an empty
+/// vec when nothing is pending.
+pub fn drain() -> Vec<PathBuf> {
+    match PATH_QUEUE.lock() {
+        Ok(mut queue) => std::mem::take(&mut *queue),
+        Err(_) => Vec::new(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,9 +102,9 @@ fn main() -> eframe::Result {
     }
 
     // Adopt an explicit workspace root from `plexi <path>` if one was given.
-    // Errors out if the path exists but has no `.plexi/` ancestor — the user
-    // can run `plexi workspace init` to create one. Bare `plexi` continues to
-    // resolve via CWD-walk later in `PlexiApp::new`.
+    // If the path has no `.plexi/` ancestor, an adopted context path is set
+    // instead — the directory opens as a new context on first frame.
+    // Bare `plexi` continues to resolve via CWD-walk later in `PlexiApp::new`.
     let adopted_root = match parse_workspace_path_arg(&raw_args) {
         Ok(root) => root,
         Err(e) => {
@@ -535,8 +535,9 @@ fn main() -> eframe::Result {
 /// Scan argv for the first positional that points at an existing directory
 /// — the `plexi <path>` "open folder" arg, modelled on VS Code. Returns
 /// `Ok(Some(workspace_root))` when an ancestor `.plexi/` is found,
-/// `Ok(None)` when no path arg was given, and `Err(_)` when the user passed
-/// a path that has no `.plexi/` workspace anywhere up the tree.
+/// `Ok(None)` when no path arg was given or the directory has no `.plexi/`
+/// ancestor (in which case an adopted context path is set via
+/// `config::set_adopted_context_path`), and `Err(_)` only for invalid paths.
 ///
 /// Anything starting with `--` is skipped (flags) and so are values that
 /// follow a known value-bearing flag (`--profile`). Recognized CLI

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ mod input_intent;
 mod keys;
 mod logging;
 #[cfg(target_os = "macos")]
+mod finder_service;
+#[cfg(target_os = "macos")]
 mod macos_menu;
 mod midi;
 mod overlays;
@@ -605,11 +607,8 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         match crate::app_registry::resolve_workspace_root(&canonical) {
             Some(root) => return Ok(Some(root)),
             None => {
-                return Err(format!(
-                    "no .plexi/ workspace found at or above {}.\n\
-                     Run `plexi workspace init` in that directory first.",
-                    canonical.display()
-                ));
+                crate::config::set_adopted_context_path(canonical);
+                return Ok(None);
             }
         }
     }
@@ -705,15 +704,20 @@ mod cli_tests {
     }
 
     #[test]
-    fn plexi_path_arg_with_no_dotplexi_errors() {
+    fn plexi_path_arg_with_no_dotplexi_sets_context_path() {
         let bare = tempfile::tempdir().unwrap();
         let path_str = bare.path().to_string_lossy().to_string();
 
-        let err = parse_workspace_path_arg(&argv(&[path_str.as_str()]))
-            .expect_err("missing .plexi/ should error");
+        let resolved = parse_workspace_path_arg(&argv(&[path_str.as_str()]))
+            .expect("non-workspace dir should not error");
         assert!(
-            err.contains("no .plexi/ workspace found"),
-            "expected workspace-not-found error, got: {err}"
+            resolved.is_none(),
+            "non-workspace dir should return None for workspace root"
+        );
+        let ctx_path = crate::config::take_adopted_context_path();
+        assert!(
+            ctx_path.is_some(),
+            "adopted context path should be set for non-workspace dir"
         );
     }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -56,6 +56,51 @@ impl PlexiApp {
         self.rename_buffer = self.router.get(new_ctx_idx).name.clone();
     }
 
+    /// Create a new context at a specific directory path. The terminal pane
+    /// opens at `path` and the context root is set to it. Named after the
+    /// directory basename.
+    pub(crate) fn new_context_at_path(&mut self, path: PathBuf) {
+        log::info!("new_context_at_path: path={}", path.display());
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(path.clone()), None, false)
+        else {
+            log::error!("new_context_at_path: failed to create terminal for {}", path.display());
+            return;
+        };
+
+        let ctx_id = self.next_window_id;
+        self.next_window_id += 1;
+        let win_id = self.next_window_id;
+        self.next_window_id += 1;
+
+        let ctx_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| format!("Context {}", self.router.len() + 1));
+        self.router.push(crate::context::Context {
+            name: ctx_name,
+            path: path.clone(),
+            root: Some(path.clone()),
+            context_id: ctx_id,
+        });
+        self.windows.push(Window {
+            name: String::new(),
+            path,
+            tree,
+            panes,
+            focused_pane: Some(root_tile),
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+        self.router.activate_last();
+        self.active_window = self.windows.len() - 1;
+        self.context_active_window.insert(ctx_id, win_id);
+        self.minimap.visible = false;
+        self.save_workspace();
+    }
+
     /// Create a new page immediately to the right of the active page on the
     /// same grid row, then switch to it.
     pub(crate) fn new_page_right(&mut self) {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -58,7 +58,7 @@ impl PlexiApp {
 
     /// Create a new context at a specific directory path. The terminal pane
     /// opens at `path` and the context root is set to it. Named after the
-    /// directory basename.
+    /// directory basename. Callers must call `save_workspace()` afterward.
     pub(crate) fn new_context_at_path(&mut self, path: PathBuf) {
         log::info!("new_context_at_path: path={}", path.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(path.clone()), None, false)
@@ -98,7 +98,6 @@ impl PlexiApp {
         self.active_window = self.windows.len() - 1;
         self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = false;
-        self.save_workspace();
     }
 
     /// Create a new page immediately to the right of the active page on the


### PR DESCRIPTION
## Summary

- Restores the macOS Finder right-click → Services → "Open in Plexi" entry that was dropped during the v3 rewrite
- New `src/finder_service.rs`: in-process NSServicesProvider via objc2 with thread-safe path queue drained each frame
- NSServices entry added to `Info.plist.fragment` with `NSFilenamesPboardType` send type
- New `new_context_at_path(path)` method creates a context at a specific directory with terminal CWD and context root set correctly
- `plexi <path>` now opens any directory as a context (previously required `.plexi/` workspace)
- Fixes `plexi context new <path>` to start the terminal at the specified path (was using focused pane CWD)

Closes #690

## Test plan

- [ ] `just pr-install` from the feature worktree
- [ ] Fully quit the PR build, then relaunch
- [ ] `pbs -dump_pboard | grep openInPlexi` shows the entry
- [ ] Right-click a folder in Finder → Services → "Open in Plexi" appears
- [ ] Selecting it creates a new context at that folder path
- [ ] With Plexi already running, repeat — appends a new context

🤖 Generated with [Claude Code](https://claude.com/claude-code)