### PR TITLE
fix(quick-note): log substituted command + warn on quoted tokens

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1174,6 +1174,33 @@ fn warn_deprecated_quick_note_fields(nodes: &[QuickNoteNode]) {
                 node.label
             );
         }
+        // Warn if command wraps tokens in quotes — tokens are already shell-escaped
+        if let Some(cmd) = &node.command {
+            for token in ["{note}", "{cwd}", "{context_root}"] {
+                let single = format!("'{token}'");
+                let double = format!("\"{token}\"");
+                if cmd.contains(&single) || cmd.contains(&double) {
+                    log::warn!(
+                        "QuickNote: destination '{}' wraps {token} in quotes — \
+                         tokens are already shell-escaped, extra quotes will break substitution",
+                        node.label
+                    );
+                }
+            }
+        }
+        if let Some(children) = &node.children_cmd {
+            for token in ["{note}", "{cwd}", "{context_root}"] {
+                let single = format!("'{token}'");
+                let double = format!("\"{token}\"");
+                if children.contains(&single) || children.contains(&double) {
+                    log::warn!(
+                        "QuickNote: destination '{}' children_cmd wraps {token} in quotes — \
+                         tokens are already shell-escaped, extra quotes will break substitution",
+                        node.label
+                    );
+                }
+            }
+        }
         if let Some(opts) = &node.options {
             warn_deprecated_quick_note_fields(opts);
         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -758,7 +758,7 @@ impl PlexiApp {
             let stay_alive = node.stay_alive.unwrap_or(false);
 
             if node.hidden {
-                log::info!("QuickNote: committed via '{}' (hidden background spawn)", node.label);
+                log::info!("QuickNote: committed via '{}' (hidden background spawn) cmd={cmd:?}", node.label);
                 if let Err(e) = std::process::Command::new("sh")
                     .args(["-c", &cmd])
                     .spawn()
@@ -769,7 +769,7 @@ impl PlexiApp {
                 // Legacy position support during migration period
                 let position = node.position.as_deref().unwrap_or("split");
                 log::info!(
-                    "QuickNote: committed via '{}' position={:?} stay_alive={stay_alive}",
+                    "QuickNote: committed via '{}' position={:?} stay_alive={stay_alive} cmd={cmd:?}",
                     node.label, position
                 );
                 match position {


### PR DESCRIPTION
## Summary

- **#1302**: Add `cmd={cmd:?}` to QuickNote commit trace log lines (both hidden background spawns and visible pane spawns) so the full substituted command is visible in `plexi.log`
- **#1303**: At config load time, warn when a destination's `command` or `children_cmd` wraps `{note}`, `{cwd}`, or `{context_root}` in quotes — tokens are already shell-escaped, so user-added quotes double-wrap and corrupt multi-word values

Closes #1302
Closes #1303

## Test plan

- [ ] Add a QuickNote destination with a `{note}` command, commit a note, verify `plexi.log` shows the full substituted command string
- [ ] Add a destination with `command = "echo '{note}'"`, reload config, verify `plexi.log` contains the quoted-token warning naming the destination and token
- [ ] Verify `cargo build` and `cargo test --bin plexi` pass