### PR TITLE
fix(inspector): pane row layout alignment

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1574,55 +1574,61 @@ impl PlexiApp {
                                     is_selected,
                                     &colors,
                                     |ui| {
-                                        ui.horizontal(|ui| {
-                                            ui.label(
-                                                RichText::new(pane_kinds[i])
-                                                    .size(style::TEXT_CAPTION)
-                                                    .color(colors.text_dim),
-                                            );
-                                            let display_name = if pane_names[i].is_empty() {
-                                                pane_kinds[i].to_string()
-                                            } else {
-                                                pane_names[i].clone()
-                                            };
-                                            ui.label(
-                                                RichText::new(&display_name)
-                                                    .size(style::TEXT_BODY)
-                                                    .color(colors.text_primary),
-                                            );
-                                            ui.with_layout(
-                                                Layout::right_to_left(Align::Center),
-                                                |ui| {
-                                                    if ui
-                                                        .add(
-                                                            egui::Button::new(
-                                                                RichText::new("✕")
-                                                                    .size(style::TEXT_CAPTION)
-                                                                    .color(colors.text_dim),
+                                        ui.with_layout(
+                                            Layout::left_to_right(Align::Center),
+                                            |ui| {
+                                                ui.label(
+                                                    RichText::new(pane_kinds[i])
+                                                        .size(style::TEXT_CAPTION)
+                                                        .color(colors.text_dim),
+                                                );
+                                                let display_name =
+                                                    if pane_names[i].is_empty() {
+                                                        pane_kinds[i].to_string()
+                                                    } else {
+                                                        pane_names[i].clone()
+                                                    };
+                                                ui.label(
+                                                    RichText::new(&display_name)
+                                                        .size(style::TEXT_BODY)
+                                                        .color(colors.text_primary),
+                                                );
+                                                ui.with_layout(
+                                                    Layout::right_to_left(Align::Center),
+                                                    |ui| {
+                                                        if ui
+                                                            .add(
+                                                                egui::Button::new(
+                                                                    RichText::new("✕")
+                                                                        .size(
+                                                                            style::TEXT_CAPTION,
+                                                                        )
+                                                                        .color(colors.text_dim),
+                                                                )
+                                                                .frame(false),
                                                             )
-                                                            .frame(false),
-                                                        )
-                                                        .on_hover_cursor(
-                                                            egui::CursorIcon::PointingHand,
-                                                        )
-                                                        .clicked()
-                                                    {
-                                                        close_pane = Some(pane_ids[i]);
-                                                    }
-                                                    let status_color =
-                                                        if pane_statuses[i] == "running" {
-                                                            colors.accent
-                                                        } else {
-                                                            colors.text_dim
-                                                        };
-                                                    ui.label(
-                                                        RichText::new(pane_statuses[i])
-                                                            .size(style::TEXT_HINT)
-                                                            .color(status_color),
-                                                    );
-                                                },
-                                            );
-                                        });
+                                                            .on_hover_cursor(
+                                                                egui::CursorIcon::PointingHand,
+                                                            )
+                                                            .clicked()
+                                                        {
+                                                            close_pane = Some(pane_ids[i]);
+                                                        }
+                                                        let status_color =
+                                                            if pane_statuses[i] == "running" {
+                                                                colors.accent
+                                                            } else {
+                                                                colors.text_dim
+                                                            };
+                                                        ui.label(
+                                                            RichText::new(pane_statuses[i])
+                                                                .size(style::TEXT_HINT)
+                                                                .color(status_color),
+                                                        );
+                                                    },
+                                                );
+                                            },
+                                        );
                                     },
                                 );
                                 if row_resp.clicked() {

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -47,10 +47,14 @@ pub(crate) fn selectable_row<R>(
     });
 
     let row_rect = scope.response.rect;
+    // Inset highlight rect symmetrically so it doesn't extend beyond
+    // visible content bounds (the content already has ROW_PAD_H left
+    // indent, mirror that on the right).
+    let highlight_rect = row_rect.shrink2(Vec2::new(ROW_PAD_H, 0.0));
 
     ui.painter().set(
         bg_idx,
-        egui::Shape::rect_filled(row_rect, CornerRadius::same(4), fill),
+        egui::Shape::rect_filled(highlight_rect, CornerRadius::same(4), fill),
     );
 
     let response = ui.interact(


### PR DESCRIPTION
## Summary
- Replace outer `ui.horizontal` (default `Align::TOP`) with `Layout::left_to_right(Align::Center)` in the context inspector pane rows so status badge, close button, and pane name vertically center-align
- Inset `selectable_row` highlight rect by `ROW_PAD_H` on each side so the background fill doesn't extend beyond visible content bounds

## Test plan
- [ ] Open context inspector with multiple panes — verify status badge and ✕ button are vertically centered with pane name text
- [ ] Verify selectable_row highlight background doesn't overshoot content area on either side
- [ ] Check command palette selectable rows still look correct (shared widget change)

Closes #1287