### PR TITLE
fix(navigation): push focus history before pane creation

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -629,3 +629,30 @@ fn focus_future_caps_at_configured_depth() {
     app.step_focus_history_back();
     assert!(app.pane_focus_future.len() <= 2, "future stack should be capped at depth");
 }
+
+#[test]
+fn split_with_new_pane_pushes_focus_history() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, _pane_a) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+
+    // Split — this should record tile_a in focus history before moving focus.
+    let new_pane_id = 50000;
+    let share = crate::host::command::ShareRatio { numerator: 1.0, denominator: 1.0 };
+    let new_tile = app.split_with_new_pane(new_pane_id, true, share, false);
+    assert!(new_tile.is_some(), "split_with_new_pane should succeed");
+
+    // Focus should now be on the new tile.
+    assert_eq!(app.windows[0].focused_pane, new_tile);
+
+    // History should contain tile_a so Cmd+[ works.
+    assert!(!app.pane_focus_history.is_empty(), "focus history should be non-empty after split");
+    assert_eq!(app.pane_focus_history.last().unwrap().1, tile_a);
+
+    // Step back should restore focus to tile_a.
+    app.step_focus_history_back();
+    assert_eq!(app.windows[0].focused_pane, Some(tile_a));
+}

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -63,11 +63,14 @@ impl PlexiApp {
         share: crate::host::command::ShareRatio,
         new_pane_first: bool,
     ) -> Option<egui_tiles::TileId> {
+        let old_window_id = self.windows[self.active_window].window_id;
+        let old_focus = self.windows[self.active_window].focused_pane;
         let focused = self.windows[self.active_window].focused_pane?;
         let split_target = match self.windows[self.active_window].find_ancestor_tabs(focused) {
             Some((tabs_id, _)) => tabs_id,
             None => focused,
         };
+        self.push_focus_history(old_window_id, old_focus);
 
         let ctx = &mut self.windows[self.active_window];
         let parent = ctx.tree.tiles.parent_of(split_target);
@@ -204,6 +207,8 @@ impl PlexiApp {
     }
 
     pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool, cwd_override: Option<std::path::PathBuf>) {
+        let old_window_id = self.windows[self.active_window].window_id;
+        let old_focus = self.windows[self.active_window].focused_pane;
         let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
@@ -253,6 +258,7 @@ impl PlexiApp {
             Some((tabs_id, _)) => tabs_id,
             None => focused,
         };
+        self.push_focus_history(old_window_id, old_focus);
 
         let ctx = &mut self.windows[self.active_window];
         let parent = ctx.tree.tiles.parent_of(split_target);
@@ -345,6 +351,8 @@ impl PlexiApp {
             return;
         }
 
+        let old_window_id = self.windows[self.active_window].window_id;
+        let old_focus = self.windows[self.active_window].focused_pane;
         let Some(focused) = self.windows[self.active_window].focused_pane else {
             return;
         };
@@ -374,6 +382,7 @@ impl PlexiApp {
         self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
+        self.push_focus_history(old_window_id, old_focus);
 
         let ctx = &mut self.windows[self.active_window];
         let new_tile = ctx.tree.tiles.insert_pane(new_id);

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -119,6 +119,8 @@ impl PlexiApp {
     /// Shared creation helper: create a single-pane context at `(grid_x, grid_y)`
     /// and make it the active context.
     pub(crate) fn create_page_at(&mut self, grid_x: u32, grid_y: u32, initial_cmd: Option<&str>, close_on_exit: bool) {
+        let old_window_id = self.windows[self.active_window].window_id;
+        let old_focus = self.windows[self.active_window].focused_pane;
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
             .unwrap_or(home);
@@ -132,6 +134,7 @@ impl PlexiApp {
         let ctx_id = self.router.active().context_id;
         let win_id = self.next_window_id;
         self.next_window_id += 1;
+        self.push_focus_history(old_window_id, old_focus);
         self.windows.push(Window {
             name,
             path: cwd,


### PR DESCRIPTION
## Summary

- Four pane-creation paths (`split_with_new_pane`, `split_focused`, `new_tab`, `create_page_at`) set `focused_pane` without calling `push_focus_history` first, making Cmd+[ a no-op after Cmd+D/T/N
- Captures `(window_id, focused_pane)` at function entry and pushes history before the mutable borrow that sets the new focus
- Adds `split_with_new_pane_pushes_focus_history` HostHarness test: split, assert history non-empty, step back, assert focus restored

## Test plan

- [ ] `cargo test --bin plexi -- focus_history` — all 7 tests pass (6 existing + 1 new)
- [ ] PR build: Cmd+D then Cmd+[ returns to pre-split pane
- [ ] PR build: Cmd+T then Cmd+[ returns to previous tab
- [ ] PR build: Cmd+N then Cmd+[ returns to previous page

Closes #1284