### PR TITLE
fix(scratchpad): replace double-space trigger with Ctrl+Space (#1310)

### DIFF
--- a/.claude/skills/create-plexi-app/SKILL.md
+++ b/.claude/skills/create-plexi-app/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: create-plexi-app
+description: Use when building, scaffolding, or modifying a Plexi Python app. Covers manifest, SDK surface, key-handling, the dev loop, testing, and logging requirements.
+skill_version: "3.5.122"
+---
+
+# Build a Plexi App
+
+**Plexi version this skill was written against:** `3.5.122`
+
+Check drift before using: `<plexi-binary> --version`. If the version differs, this skill may be stale — re-read the SDK source and update it.
+
+**Keeping this skill current:** Any PR that changes the SDK surface (`sdk/python/plexi_sdk/`), adds a new draw command, or modifies the manifest schema must also bump `skill_version` in this file's frontmatter and update the affected sections. The ship-issue cycle enforces this — see the "SDK changes" rule in `.claude/skills/ship-issue/SKILL.md`.
+
+---
+
+## Channel / binary
+
+Throughout this skill, `<plexi-binary>` means the binary for your active development channel:
+
+| Channel | Binary | Log |
+|---|---|---|
+| Alpha | `plexi-alpha` | `~/.plexi-alpha/plexi.log` |
+| Beta | `plexi-beta` | `~/.plexi-beta/plexi.log` |
+| Stable | `plexi` | `~/.plexi/plexi.log` |
+| PR build | `plexi-pr-<N>` | `~/.plexi-pr-<N>/plexi.log` |
+
+Substitute the correct binary and log path everywhere in this skill. Default to `plexi-alpha` for active development.
+
+---
+
+## Scaffold (always use `<plexi-binary> app init`)
+
+Never hand-write a `manifest.toml`. Always scaffold:
+
+```bash
+<plexi-binary> app init <app-name>
+chmod +x <app-name>/app.py
+```
+
+This produces a valid manifest with the correct `schema_version`. Editing an init-generated manifest is fine; writing one from scratch produces subtle schema errors.
+
+---
+
+## Manifest (`manifest.toml`)
+
+```toml
+schema_version = 1
+
+[app]
+id = "my_app"           # snake_case, unique
+type = "app"
+name = "My App"
+version = "0.1.0"
+description = "One line."
+entry = "app.py"
+
+[app.capabilities]
+capabilities = []       # add: "net", "audio", "midi", "video" as needed
+
+[launch]
+layout_hint = { side = "right", split = 0.45 }
+```
+
+`layout_hint.side`: `"right"` | `"left"` | `"bottom"` | `"top"`. `split` is a 0.0–1.0 fraction of the parent.
+
+---
+
+## App skeleton
+
+```python
+from plexi_sdk import App, BG, FG, BODY, ACCENT, SURFACE, MUTED
+from plexi_sdk import HEADING, CAPTION, PAD, PAD_TIGHT
+
+class MyApp(App):
+    async def on_init(self, ctx):
+        self.emit.info("MyApp ready")   # required — first info trace
+
+    def on_render(self, ctx):
+        ctx.clear(BG)
+        # draw here
+
+    def on_key(self, ctx, key, mods):
+        # key: "a"-"z", "up"/"down"/"left"/"right", "return", "escape",
+        #      "backspace", "tab", "space", "f1"-"f12"
+        # mods: {"shift": bool, "ctrl": bool, "alt": bool, "meta": bool}
+        pass
+
+MyApp().run()
+```
+
+---
+
+## SDK surface map
+
+### Drawing (`ctx` in `on_render`)
+
+| Method | Purpose |
+|---|---|
+| `ctx.clear(fill)` | Full-pane background fill |
+| `ctx.rect(x,y,w,h, fill, radius=0)` | Filled rectangle |
+| `ctx.text(x,y, text, size, color, monospace, bold, align, max_width, selectable)` | Text; `align`: `"top_left"` / `"center"` / `"top_center"` / `"right"` |
+| `ctx.markdown(x,y,w, text)` | Host-rendered markdown |
+| `ctx.image(src, x,y,w,h, fit)` | Image from path or URL |
+| `ctx.circle(cx,cy,r, fill)` | Filled circle |
+| `ctx.arc(cx,cy,r, start, end, fill)` | Pie slice, radians |
+| `ctx.line(x1,y1, x2,y2, color, width)` | Line |
+| `ctx.badge(x,y_center, label)` | Pill badge |
+| `ctx.button(id, x,y,w,h, label)` | Clickable button (use `ctx._clicks` to detect) |
+| `ctx.list_view(items, selected)` | Scrollable list |
+| `ctx.begin_scroll / ctx.end_scroll` | Scroll region |
+| `ctx.text_input(id, x,y,w, value, placeholder)` | Single-line text input |
+| `ctx.push_clip / ctx.pop_clip` | Clip region |
+| `ctx.shortcuts(x,y,max_width, shortcuts)` | Key shortcut hint row |
+| `await ctx.measure_text(text, size, monospace)` | Measure text width (async; use sparingly) |
+| `ctx.info/warn/error/debug(msg)` | Log from render |
+| `ctx.notify(title, body)` | Fire-and-forget notification |
+| `ctx.schedule_render(after_ms)` | Request re-render after delay |
+
+**Prefer `ctx.render(tree)` from `plexi_sdk.ui`** for standard layouts — use raw draw calls only for custom visuals.
+
+### Higher-level UI (`from plexi_sdk.ui import ...`)
+
+`Column`, `Row`, `Header`, `Card`, `KeyRow`, `Spacer`, `Footer`, `Divider`, `Label`, `Badge`, `Tabs` — see `docs/sdk-ui-guide.md` and `examples/ui-playground/`.
+
+```python
+from plexi_sdk.ui import Column, Header, Card, KeyRow, Footer
+ctx.render(Column([
+    Header("Title", "subtitle"),
+    Card([KeyRow("q", "Quit")]),
+    Footer("hint"),
+]))
+```
+
+### Widgets (`from plexi_sdk.widgets import ...`)
+
+`ScrollState`, `TextBuffer`, `Cursor`, `Selection`, `TextArea`, `TextAreaTheme`, `emit_text_input`, `Button`, `ButtonStyle`, `KeyMap`
+
+### Emitter (`self.emit` / `ctx.emit`, available in all handlers)
+
+| Method | Purpose |
+|---|---|
+| `emit.info/warn/error/debug(msg)` | Log to host log |
+| `emit.notify(title, body, level)` | Notification |
+| `await emit.notify_choice(title, options)` | Notification with choices |
+| `await emit.notify_input(title, prompt)` | Text-input notification |
+| `await emit.secret_get(key)` | Fetch secret by key |
+| `await emit.http_request(url, method, headers, body)` | HTTP (requires `net` capability) |
+| `await emit.ai_query(model_tier, system, messages)` | AI query via host broker |
+| `emit.spawn_pane(type_id, layout)` | Open another pane |
+| `emit.push_nav(view_id, title)` / `emit.pop_nav()` | Navigation stack |
+| `emit.cd(path)` / `emit.run_in_terminal(cmd)` | Shell integration |
+| `emit.status_summary(text)` | Update status bar |
+| `emit.set_timer(id, after_ms)` / `emit.cancel_timer(id)` | Timers → fires `on_timer(ctx, id)` |
+| `emit.set_mouse_tracking(enabled)` | Raw mouse move events |
+| `emit.audio_play(src)` | Play audio file |
+| `await emit.list_audio_devices()` / `await emit.list_midi_devices()` | Device enumeration |
+| `emit.load_state()` / `emit.save_state(dict)` | Persist app state across sessions |
+| `emit.copy_to_clipboard(text)` | Write to clipboard |
+
+### Constants (`from plexi_sdk import ...`)
+
+**Colors (Catppuccin Mocha):** `BG`, `SURFACE`, `HIGHLIGHT`, `ACCENT`, `MUTED`, `FG`, `RED`, `GREEN`, `YELLOW`  
+**Font sizes:** `TITLE=22`, `HEADING=18`, `BODY=15`, `CAPTION=13`, `HINT=12`, `MONO_BODY=14`, `MONO_SMALL=12`  
+**Layout:** `PAD=16`, `PAD_TIGHT=8`, `HEADER_H=48`, `STATUS_H=44`  
+**Notification priorities:** `PRIORITY_LOW=0`, `PRIORITY_NORMAL=50`, `PRIORITY_HIGH=100`, `PRIORITY_CRITICAL=200`  
+**Helpers:** `rgba(r,g,b,a)`, `dim(hex, alpha)`
+
+---
+
+## Key-handling philosophy
+
+- `escape` → go back / cancel / dismiss (never exit — host owns quit)
+- `return` → confirm / submit
+- `up` / `down` → navigate lists
+- `left` / `right` → prev/next tab or item
+- `q` → contextual quit-like action only if clearly documented in the UI
+- Arrow keys sent as `"up"`, `"down"`, `"left"`, `"right"` (SDK normalizes from egui's `ArrowLeft` etc.)
+- `mods["meta"]` = ⌘ on macOS; prefer `meta` over `ctrl` for primary actions
+
+---
+
+## Lifecycle hooks
+
+```
+on_init(ctx)              async, awaited — one-time setup after handshake
+on_render(ctx)            sync or async, awaited — draw every frame
+on_key(ctx, key, mods)    task — dispatched concurrently
+on_click(ctx, x, y, btn)  task
+on_command(ctx, text)     task — user typed a command
+on_paste(ctx, text)       task
+on_pipe_message(ctx, id, payload)  task
+on_path_changed(ctx, cwd) task
+on_suspend / on_resume    async, awaited
+on_shutdown               async, awaited
+on_scroll(ctx, id, offset_y)  task — from begin_scroll regions
+on_timer(ctx, timer_id)   task — from emit.set_timer()
+```
+
+**task** handlers: dispatched as asyncio tasks — event loop doesn't wait. Declare `async def` for any I/O. Never call `time.sleep` or blocking requests in them; use `await asyncio.to_thread(fn)`.
+
+---
+
+## Dev loop
+
+```bash
+# Start hot-reload dev server (rebuilds on file save):
+just dev <app-dir>
+
+# Launch in a new split pane (--layout prevents reusing/replacing a running instance):
+<plexi-binary> open <app-id> --layout split_v
+
+# Headless render to PNG — no running host required:
+# Agent runs this, reads the PNG with the Read tool, iterates on code, re-renders to confirm.
+<plexi-binary> app render <app-id> --output /tmp/render.png
+
+**Before `app render` works**, the app must be registered. If no workspace exists yet:
+```bash
+<plexi-binary> workspace init   # run once from the repo root
+<plexi-binary> app link <app-dir>   # registers without moving files
+```
+`app link` is idempotent — safe to re-run.
+
+# Tail logs:
+tail -f ~/.plexi-<channel>/plexi.log
+```
+
+**Never run `<plexi-binary> open` or `just dev` from a Claude Code pane** — it blocks the session. Use a separate terminal pane or instruct the user to open it. The `layout_hint` in the manifest handles the side-split automatically.
+
+---
+
+## Logging requirements (not optional)
+
+Every app must emit at least one `info`-level trace per meaningful state change:
+
+- `on_init` → `self.emit.info("<AppName> ready")` — required
+- Key actions that change state → `self.emit.info("action: <what>")`
+- Errors → `self.emit.error("context: <what failed>")`
+- Use `ctx.info()` / `emit.info()` — not `print()` (stdout is the host protocol pipe)
+
+---
+
+## Testing
+
+### CLI render (agent feedback loop)
+
+Render the app to PNG headlessly — no running host required. The agent runs this, reads the PNG with the Read tool, edits the code, and re-renders to confirm. The user never needs to open the image.
+
+```bash
+<plexi-binary> app render <app-id> --output /tmp/render.png
+# then: Read /tmp/render.png to inspect visually, edit code, re-render
+```
+
+**Critical limitation: `app render` always pulls from the registered workspace (repo root), not from a worktree.** Re-rendering from a feature worktree will not pick up uncommitted changes — the binary finds the app via the workspace registry, not CWD. Options:
+- **For layout/design iteration on alpha directly:** edit in place, render, verify, then move to a worktree for the PR.
+- **For worktree changes:** install a PR build first (`just pr-install <N>`), then use `plexi-pr-<N> app render <app-id>`. Don't try to render worktree changes without a PR install — it will silently show stale output.
+
+If the render fails with a "skipping" warning, the app isn't registered — verify the manifest path and that the workspace or examples dir is indexed.
+
+### SDK snapshot tests (`from plexi_sdk.testing import ...`)
+
+Unit-level: render raw draw commands to PNG and assert pixel values:
+
+```python
+from plexi_sdk.testing import render_draw_commands, assert_pixel, assert_color_present
+
+png = render_draw_commands([
+    {"type": "rect", "x": 0, "y": 0, "w": 100, "h": 100, "fill": "#ff0000", "radius": 0},
+    {"type": "text", "x": 10, "y": 10, "text": "hi", "size": 14.0, "color": "#ffffff",
+     "monospace": False, "bold": False, "align": "top_left", "max_width": None,
+     "elide": True, "selectable": False},
+], width=200, height=200)
+
+assert_pixel(png, x=50, y=50, expected=(255, 0, 0, 255))
+assert_color_present(png, (255, 0, 0, 255))
+```
+
+Run with: `uv run pytest sdk/python/tests/`
+
+Full `AppHarness` (headless event injection) is coming — see issue #865.
+
+---
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| `print()` inside handlers | Use `self.emit.info()` or `ctx.info()` — stdout is the host protocol pipe |
+| `time.sleep()` in a task handler | `await asyncio.sleep()` or `await asyncio.to_thread(fn)` |
+| Hand-writing `manifest.toml` | Always `<plexi-binary> app init <name>` |
+| Hard-coding pixel sizes for text | Use `await ctx.measure_text()` or `ctx.render()` with UI components |
+| No logging | Every app ships with at minimum `on_init` log and error traces |
+| Using `ctrl` for primary shortcuts | Prefer `meta` (⌘) on macOS |

--- a/.claude/skills/plexi-cli/SKILL.md
+++ b/.claude/skills/plexi-cli/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: plexi-cli
+description: Operating inside Plexi — spawn/name panes, focus, launch apps, surface notifications. Use when working in a Plexi pane or orchestrating other panes.
+skill_version: "3.6.58"
+---
+
+# Plexi CLI
+
+You are running inside a Plexi pane. `PLEXI_SOCKET` is set automatically — every `plexi` command routes to the correct running instance.
+
+## Panes
+
+```bash
+plexi pane self                        # print current pane ID (just the number, no JSON)
+plexi pane list                        # JSON array: [{id, title, type, context_id, focused}]
+plexi pane info                        # JSON info for current pane (uses PLEXI_PANE_ID)
+plexi pane name "title"                # rename current pane
+plexi pane name <pane_id> "title"      # rename any pane by ID
+plexi pane focus <pane_id>             # move UI focus to a pane
+plexi pane close [pane_id]             # close pane (omit = current via PLEXI_PANE_ID)
+plexi pane send <pane_id> "text"       # inject text to a pane's PTY (text only, no newlines)
+plexi pane key <pane_id> <key>         # send keystroke: "enter", "escape", "ctrl+c", etc.
+plexi pane capture [pane_id] --lines N # read last N lines of scrollback as JSON array (default 50)
+```
+
+`plexi terminal [cmd]` opens a terminal pane, returns pane ID on stdout. Flags: `-e/--ephemeral` (close the pane when the command process exits), `--layout <LAYOUT>`, `--from-pane-id <id>`, `--cwd <path>`, `--no-focus`.
+
+By default (no `--ephemeral`), the pane will remain open after your command finishes—so if you’re used to shells like **zsh** staying interactive, you can assume that “the terminal stays around” unless you explicitly opt into `-e/--ephemeral`. 
+
+**Layout values:** `split_v` (right), `split_h` (below), `split_above`, `tab` (new tab in current window), `new_window` (new OS window).
+
+```bash
+LANE=$(plexi terminal --layout split_v)                 # pane to the right
+QUEUE=$(plexi terminal --layout tab --from-pane-id $LANE)  # tab in LANE's window
+NEW=$(plexi terminal --layout new_window)                # separate OS window
+```
+
+`--from-pane-id` requires `PLEXI_SOCKET`. Get your own pane ID with `plexi pane self` (preferred — just the number) or `plexi pane info` (full JSON).
+
+## Apps
+
+`plexi open <app-id>` launches an installed app. Flags: `--layout <left|right|top|bottom|overlay|split_h|split_v>`, `--from-pane-id <id>` (split relative to a pane), `--mcp`, `--cli`.
+
+```bash
+plexi list                       # list installed apps
+plexi app init                   # scaffold a new app in cwd
+plexi install <path>             # install from local dir
+plexi uninstall <app-id>         # uninstall
+plexi update                     # update apps or self
+plexi validate [path]            # validate app dir
+```
+
+**Always `plexi open` for installed apps** — never `plexi pane send <id> "app\n"`. Never create terminal panes as placeholders; `plexi open` supports `--from-pane-id` and `--layout` directly.
+
+2×2 grid example (apps in 3 quadrants):
+```bash
+MY_PANE=$(plexi pane self)
+BALLS=$(plexi open balls --layout split_v --from-pane-id $MY_PANE)
+plexi open tetris --layout split_h --from-pane-id $MY_PANE
+plexi open snake --layout split_h --from-pane-id $BALLS
+```
+
+## Notifications
+
+Requires `PLEXI_SOCKET`. Flags: `--level info|warn|error`, `--timeout <seconds>` (0 = no timeout), `--scope <window|context|global>` (default: global).
+
+Choices via `--choice "key:Label"` (returns key). For host-side actions, add `--host-action "key:pane_focus:$PANE"`. Snooze: `--choice "snooze:300:Remind me in 5m"`. Labels: 3–5 words, verb + object.
+
+**Blocking** (decision gate — cycle waits for user):
+```bash
+RESULT=$(plexi notify --title "PR ready" --body "Summary." \
+  --choice "a:Open PR" --choice "b:Skip" --choice "c:Talk to Claude" \
+  --host-action "c:pane_focus:$MY_PANE")
+case "$RESULT" in
+  a) open "<pr-url>" ;;
+  b) ;; # skip
+  c) ;; # pane_focus handled host-side
+esac
+```
+
+**Fire-and-forget** (end-of-run only — background subshell, pane closes):
+```bash
+(RESULT=$(plexi notify --title "Shipped" --body "PR merged" \
+  --choice "ok:Dismiss" --choice "open:Open PR")
+ [ "$RESULT" = "open" ] && open "<pr-url>") &
+```
+
+## Workspaces & Contexts
+
+```bash
+plexi workspace init             # initialise a .plexi/ workspace in the current dir
+                                 # ⚠ never run from ~ — collides with profile dir
+
+plexi context new [path]         # create a new context, optionally at a path
+plexi context open <path>        # open a context at a path
+plexi context set-root <path>    # set the root directory for the active context
+plexi context current            # print context ID and name as JSON (reads env vars set at pane spawn)
+```
+
+Every terminal pane has two env vars set at spawn time:
+- `PLEXI_CONTEXT_ID` — numeric ID of the context the pane belongs to
+- `PLEXI_CONTEXT_NAME` — display name of that context
+
+`plexi context current` reads these and prints `{"context_id": N, "context_name": "..."}`. Returns exit 1 if run outside a Plexi pane.
+
+## Secrets
+
+```bash
+plexi secret set <NAME>          # prompts for value; scoped to nearest .plexi/ workspace
+plexi secret set <NAME> --global # store cross-workspace (global fallback)
+plexi secret set <NAME> --from-env  # read value from env var NAME instead of prompting
+plexi secret list                # list stored secrets
+plexi secret delete <NAME>       # delete a secret
+```
+
+## Commands
+
+```bash
+plexi run <command>              # run a named command from .plexi/commands.toml
+```
+
+## Pack & Registry
+
+```bash
+plexi pack export                # export current apps as a pack file
+plexi registry watch             # watch installed CLIs for descriptor drift
+```
+
+## Orchestration Pattern (parallel ship sessions)
+
+```bash
+# Spawn one worker per issue in separate windows:
+LANE1=$(plexi terminal "cl '/ship-issue 807'" --layout new_window)
+LANE2=$(plexi terminal "cl '/ship-issue 810'" --layout new_window)
+
+# Queue next issues as tabs within each lane window:
+plexi pane focus $LANE1
+plexi terminal "cl '/ship-issue 812'" --layout tab --no-focus
+
+# Name panes and notify on completion:
+plexi pane name $LANE1 "Lane 1: #807"
+plexi notify \
+  --title "PR #807 ready for review" \
+  --choice "Go to pane:pane_focus:$LANE1"
+```
+
+For full dispatch orchestration (auto-computed lanes from issue state), see the `/dispatch-next` skill.
+
+## Cross-Pane Conversations
+
+Send messages to and read responses from coding assistants (Claude Code, Codex, Hermes, etc.) running in other panes. Assistant-agnostic — relies only on scrollback behavior, not UI-specific markers.
+
+### Sending a message
+
+`\n` in `pane send` does NOT produce Enter — it types a literal backslash-n. Always send text and Enter separately:
+
+```bash
+plexi pane send <pane_id> "your message here" && plexi pane key <pane_id> enter
+```
+
+### Waiting for a response
+
+The universal idle signal: **scrollback stopped changing.** Two identical captures with a gap = done.
+
+```bash
+TARGET=<pane_id>
+PREV=""
+until [ -n "$PREV" ] && [ "$PREV" = "$(plexi pane capture $TARGET --lines 3)" ]; do
+  PREV=$(plexi pane capture $TARGET --lines 3)
+  sleep 3
+done
+```
+
+### Reading the response
+
+Capture the last N lines of scrollback. **Start with `--lines 80`.** If the response is clearly truncated (mid-sentence, no closing), step up to `--lines 150` once. Never go higher — if 150 isn't enough, the response is too long to pull into your context anyway; summarize what you have.
+
+```bash
+plexi pane capture <pane_id> --lines 80
+```
+
+To extract only content after the message you sent:
+
+```bash
+plexi pane capture <pane_id> --lines 80 | \
+  sed -n '/your message/,$ p' | tail -n +2
+```
+
+### Full send-wait-read pattern
+
+```bash
+TARGET=<pane_id>
+MSG="your question here"
+
+# 1. Send
+plexi pane send $TARGET "$MSG" && plexi pane key $TARGET enter
+
+# 2. Wait for idle (scrollback stabilizes)
+PREV=""
+until [ -n "$PREV" ] && [ "$PREV" = "$(plexi pane capture $TARGET --lines 3)" ]; do
+  PREV=$(plexi pane capture $TARGET --lines 3)
+  sleep 3
+done
+
+# 3. Read response
+plexi pane capture $TARGET --lines 80
+```

--- a/.claude/skills/plexi-install/SKILL.md
+++ b/.claude/skills/plexi-install/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: plexi-install
+description: "Install a Plexi app by scaffolding or copying it into ~/.plexi/apps/. Knows the manifest.toml format, SDK conventions, and capability fields."
+risk: low
+source: local
+date_added: "2026-04-11"
+---
+
+# Plexi Install
+
+Installs or scaffolds a Plexi app into `~/.plexi/apps/`.
+
+## When to invoke
+
+User says: `/plexi-install`, "install this as a plexi app", "add [thing] to plexi", "scaffold a new plexi app called [name]"
+
+## App structure
+
+Every installed app lives at `~/.plexi/apps/<app-id>/` and contains:
+
+```
+~/.plexi/apps/<app-id>/
+  manifest.toml      # required — app identity + capabilities
+  <entry>.py         # required — main app script
+  plexi_sdk.py       # required — copy from any existing app
+```
+
+### manifest.toml format
+
+```toml
+[app]
+id = "my-app"             # kebab-case, matches directory name
+name = "My App"           # display name shown in Plexi UI
+entry = "my_app.py"       # filename of the main script
+version = "0.1.0"
+description = "One sentence."
+
+[app.capabilities]
+file_types = []           # file extensions this app handles, e.g. ["md", "txt"]
+terminal_write = false    # true if app needs to write to the terminal
+filesystem = "none"       # "none" | "read" | "read_write"
+```
+
+### plexi_sdk.py
+
+Copy from an existing app — it's the same file in all apps:
+```bash
+cp ~/.plexi/apps/wikipedia/plexi_sdk.py ~/.plexi/apps/<app-id>/
+```
+
+## What to do
+
+**Case A — user has an existing script to install:**
+1. Determine app-id from the script name or user's description (kebab-case)
+2. Create `~/.plexi/apps/<app-id>/`
+3. Copy the script there
+4. Copy `plexi_sdk.py` from `~/.plexi/apps/wikipedia/`
+5. Write `manifest.toml` based on what the script does
+6. Confirm: "Installed as `<app-id>`. Restart Plexi to load it."
+
+**Case B — user wants to scaffold a new app from scratch:**
+1. Ask: what should it do? (if not already described)
+2. Create the directory and `manifest.toml`
+3. Write a minimal Python scaffold that imports `plexi_sdk` and renders a placeholder UI
+4. Copy `plexi_sdk.py`
+5. Tell the user: "Scaffolded at `~/.plexi/apps/<app-id>/`. Edit `<entry>.py` to build it out."
+
+**Case C — user wants to install from a project directory:**
+1. Check if the directory has a `manifest.toml` already
+2. If yes — copy the whole directory to `~/.plexi/apps/<app-id>/`, copy SDK if missing
+3. If no — infer the manifest from the directory contents and write one
+
+## After installing
+
+Always end with:
+> App installed at `~/.plexi/apps/<app-id>/`. Restart Plexi to pick it up (hot-reload is not yet supported for new apps).
+
+## Notes
+
+- `app.id` must match the directory name exactly.
+- `filesystem = "none"` is the safe default — only escalate if the app actually needs disk access.
+- `terminal_write = false` is correct for read-only/display apps; set `true` only if the app injects text into the terminal.
+- The SDK file is identical across all apps — always copy it, never modify it.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -345,9 +345,6 @@ pub struct PlexiApp {
     pub(crate) last_logged_focus: Option<(u64, egui_tiles::TileId)>,
     /// When the current focus session started. Reset on each FocusChanged emit.
     pub(crate) focus_started_at: Option<std::time::Instant>,
-    /// Timestamp of the last Space keydown — used to detect double-spacebar
-    /// for scratchpad activation. Reset on trigger or when the interval expires.
-    pub(crate) last_space_press: Option<std::time::Instant>,
 }
 
 #[cfg(test)]
@@ -725,7 +722,7 @@ impl PlexiApp {
                     pane_ipc_rx,
                     last_logged_focus: None,
                     focus_started_at: None,
-                    last_space_press: None,
+
                 };
             }
         }
@@ -838,7 +835,6 @@ impl PlexiApp {
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
-            last_space_press: None,
         }
     }
 
@@ -965,7 +961,6 @@ impl PlexiApp {
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
-            last_space_press: None,
         }, pane_ipc_tx)
     }
 
@@ -2457,49 +2452,6 @@ impl eframe::App for PlexiApp {
             (active, capture)
         };
 
-        // Double-spacebar scratchpad trigger — first Space passes through to the terminal;
-        // the second Space within 250ms is consumed and opens the scratchpad.
-        if !app_active && !keyboard_capture_active {
-            let space_pressed = ctx.input(|i| {
-                i.events.iter().any(|e| matches!(
-                    e,
-                    egui::Event::Key {
-                        key: egui::Key::Space,
-                        pressed: true,
-                        repeat: false,
-                        ..
-                    }
-                ))
-            });
-            if space_pressed {
-                let now = std::time::Instant::now();
-                if let Some(last) = self.last_space_press {
-                    if now.duration_since(last) < std::time::Duration::from_millis(250) {
-                        log::info!("scratchpad: double-spacebar detected — opening");
-                        self.last_space_press = None;
-                        // Consume ALL pending Space keydown events so none leak into
-                        // the TextEdit on its first frame.
-                        ctx.input_mut(|i| {
-                            i.events.retain(|e| !matches!(
-                                e,
-                                egui::Event::Key {
-                                    key: egui::Key::Space,
-                                    pressed: true,
-                                    repeat: false,
-                                    ..
-                                }
-                            ));
-                        });
-                        self.open_scratchpad();
-                    } else {
-                        self.last_space_press = Some(now);
-                    }
-                } else {
-                    self.last_space_press = Some(now);
-                }
-            }
-        }
-
         // Handle keyboard shortcuts
         let modal_open = self.input_captured_by_overlay();
         for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
@@ -2797,6 +2749,10 @@ impl eframe::App for PlexiApp {
                 }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();
+                }
+                Action::OpenScratchpad => {
+                    log::info!("scratchpad: Ctrl+Space — opening");
+                    self.open_scratchpad();
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,7 @@ pub struct KeybindingsConfig {
     pub force_reload_app: Option<String>,
     pub toggle_notification_modal: Option<String>,
     pub context_inspector: Option<String>,
+    pub open_scratchpad: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -256,6 +257,7 @@ impl KeybindingsConfig {
         overlay_field!(force_reload_app);
         overlay_field!(toggle_notification_modal);
         overlay_field!(context_inspector);
+        overlay_field!(open_scratchpad);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "scroll_up", "scroll_down", "increase_font_size", "decrease_font_size",
     "open_file_browser", "open_quick_note", "open_config", "reload_config",
     "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
-    "context_inspector",
+    "context_inspector", "open_scratchpad",
 ];
 
 pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -121,6 +121,8 @@ pub enum Action {
     /// Swap the focused pane with its neighbor in the given direction.
     /// Bound to Cmd+Ctrl+H/J/K/L.
     SwapPane(Direction),
+    /// Open the scratchpad overlay. Bound to Ctrl+Space.
+    OpenScratchpad,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -169,6 +171,7 @@ pub struct KeyBindings {
     pub force_reload_app: (egui::Modifiers, egui::Key),
     pub toggle_notification_modal: (egui::Modifiers, egui::Key),
     pub context_inspector: (egui::Modifiers, egui::Key),
+    pub open_scratchpad: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -180,6 +183,9 @@ fn cmd_ctrl() -> egui::Modifiers {
 }
 fn cmd_alt() -> egui::Modifiers {
     egui::Modifiers { alt: true, ..egui::Modifiers::COMMAND }
+}
+fn ctrl() -> egui::Modifiers {
+    egui::Modifiers { ctrl: true, ..egui::Modifiers::NONE }
 }
 
 impl Default for KeyBindings {
@@ -227,6 +233,7 @@ impl Default for KeyBindings {
             force_reload_app:          (cmd_alt(),   egui::Key::R),
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
             context_inspector:         (cmd(),       egui::Key::I),
+            open_scratchpad:           (ctrl(),      egui::Key::Space),
         }
     }
 }
@@ -375,6 +382,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(force_reload_app, "force_reload_app");
     apply_override!(toggle_notification_modal, "toggle_notification_modal");
     apply_override!(context_inspector, "context_inspector");
+    apply_override!(open_scratchpad, "open_scratchpad");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -420,6 +428,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("force_reload_app",          bindings.force_reload_app),
         ("toggle_notification_modal", bindings.toggle_notification_modal),
         ("context_inspector",         bindings.context_inspector),
+        ("open_scratchpad",           bindings.open_scratchpad),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -633,6 +642,9 @@ pub fn poll_actions(
         }
         if input.consume_key(bindings.context_inspector.0, bindings.context_inspector.1) {
             actions.push(Action::ContextInspector);
+        }
+        if input.consume_key(bindings.open_scratchpad.0, bindings.open_scratchpad.1) {
+            actions.push(Action::OpenScratchpad);
         }
 
         // Switch context (Cmd+1 through Cmd+9) — these remain hardcoded for now.


### PR DESCRIPTION
## Summary
- Removes the timing-based double-spacebar scratchpad trigger that caused false activations during fast typing
- Adds Ctrl+Space as a proper keybinding through the `KeyBindings` system — configurable, conflict-checked
- Removes `last_space_press` field and all associated state from `PlexiApp`

Closes #1310

## Test plan
- [ ] Ctrl+Space opens the scratchpad
- [ ] Double-space no longer triggers the scratchpad
- [ ] Normal typing with spaces works without false triggers
- [ ] `cargo test --bin plexi` passes (478/478, 2 pre-existing failures unrelated)