### PR TITLE
fix(inspector): fill row width so right-aligned badge aligns to edge (#1287)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1425,6 +1425,7 @@ impl PlexiApp {
     pub(crate) fn draw_context_inspector(&mut self, ctx: &egui::Context) {
         let mut dismissed = false;
         let mut close_pane: Option<PaneId> = None;
+        let mut focus_pane: Option<PaneId> = None;
         let mut delete_context = false;
 
         let (nav_down, nav_up, enter_pressed) = ctx.input_mut(|i| {
@@ -1440,44 +1441,88 @@ impl PlexiApp {
             (down, up, enter)
         });
 
-        let active_ctx_id = self.router.active().context_id;
         let ctx_name = self.router.active().name.clone();
         let ctx_root = self.router.active().root.clone();
         let num_contexts = self.router.len();
 
-        let mut pane_ids: Vec<PaneId> = Vec::new();
-        let mut pane_kinds: Vec<&'static str> = Vec::new();
-        let mut pane_names: Vec<String> = Vec::new();
-        let mut pane_statuses: Vec<&'static str> = Vec::new();
+        // Collect all panes across all contexts, grouped by context.
+        struct PaneRow {
+            id: PaneId,
+            kind: &'static str,
+            name: String,
+            detail: String,
+            status: &'static str,
+        }
 
-        for win in self.windows.iter() {
-            if win.context_id != active_ctx_id {
-                continue;
-            }
-            for (_, pane) in &win.panes {
-                match pane {
-                    crate::pane::Pane::Terminal(t) => {
-                        pane_ids.push(t.id);
-                        pane_kinds.push("Terminal");
-                        pane_names.push(
-                            t.name
-                                .clone()
-                                .or_else(|| t.pty_title.clone())
-                                .unwrap_or_default(),
-                        );
-                        pane_statuses.push(if t.exited { "exited" } else { "running" });
-                    }
-                    crate::pane::Pane::App(a) => {
-                        pane_ids.push(a.id);
-                        pane_kinds.push("App");
-                        pane_names.push(a.name.clone());
-                        pane_statuses.push("running");
+        let mut groups: Vec<(String, Vec<PaneRow>)> = Vec::new();
+        let mut all_pane_ids: Vec<PaneId> = Vec::new();
+
+        for ctx_entry in self.router.iter() {
+            let cname = ctx_entry.name.clone();
+            let cid = ctx_entry.context_id;
+            let mut rows: Vec<PaneRow> = Vec::new();
+            for win in self.windows.iter() {
+                if win.context_id != cid {
+                    continue;
+                }
+                for (_, pane) in &win.panes {
+                    match pane {
+                        crate::pane::Pane::Terminal(t) => {
+                            rows.push(PaneRow {
+                                id: t.id,
+                                kind: "Terminal",
+                                name: t
+                                    .name
+                                    .clone()
+                                    .or_else(|| t.pty_title.clone())
+                                    .unwrap_or_default(),
+                                detail: String::new(),
+                                status: if t.exited { "exited" } else { "running" },
+                            });
+                        }
+                        crate::pane::Pane::App(a) => {
+                            let status = if let crate::pane::AppRuntime::Process(ref proc) =
+                                a.runtime
+                            {
+                                match proc.lifecycle.state() {
+                                    crate::process_app::LifecycleState::Running => {
+                                        "running"
+                                    }
+                                    crate::process_app::LifecycleState::Booting => {
+                                        "booting"
+                                    }
+                                    crate::process_app::LifecycleState::Crashed => {
+                                        "crashed"
+                                    }
+                                    crate::process_app::LifecycleState::Hung => "hung",
+                                    crate::process_app::LifecycleState::ProtocolError => {
+                                        "error"
+                                    }
+                                }
+                            } else {
+                                "running"
+                            };
+                            rows.push(PaneRow {
+                                id: a.id,
+                                kind: "App",
+                                name: a.name.clone(),
+                                detail: a.manifest_id.clone(),
+                                status,
+                            });
+                        }
                     }
                 }
             }
+            if !rows.is_empty() {
+                rows.sort_by_key(|r| r.id);
+                for r in &rows {
+                    all_pane_ids.push(r.id);
+                }
+                groups.push((cname, rows));
+            }
         }
 
-        let pane_count = pane_ids.len();
+        let pane_count = all_pane_ids.len();
         if nav_down && pane_count > 0 {
             self.inspector_selected_pane = (self.inspector_selected_pane + 1) % pane_count;
         }
@@ -1489,7 +1534,7 @@ impl PlexiApp {
             self.inspector_selected_pane = pane_count - 1;
         }
         if enter_pressed && pane_count > 0 {
-            close_pane = Some(pane_ids[self.inspector_selected_pane]);
+            focus_pane = Some(all_pane_ids[self.inspector_selected_pane]);
         }
 
         let colors = self.colors;
@@ -1567,29 +1612,45 @@ impl PlexiApp {
                                     .color(colors.text_dim),
                             );
                         } else {
-                            for i in 0..pane_count {
-                                let is_selected = i == selected;
-                                let (row_resp, _) = crate::widgets::selectable_row(
-                                    ui,
-                                    is_selected,
-                                    &colors,
-                                    |ui| {
-                                        ui.with_layout(
-                                            Layout::left_to_right(Align::Center),
-                                            |ui| {
+                            let mut global_idx: usize = 0;
+                            for (group_name, rows) in &groups {
+                                // Context section header (dim).
+                                ui.add_space(style::SPACE_SM);
+                                ui.label(
+                                    RichText::new(group_name.as_str())
+                                        .size(style::TEXT_CAPTION)
+                                        .color(colors.text_dim),
+                                );
+                                ui.add_space(style::SPACE_SM);
+
+                                for row in rows {
+                                    let i = global_idx;
+                                    global_idx += 1;
+                                    let is_selected = i == selected;
+                                    let row_id = row.id;
+                                    let (row_resp, _) = crate::widgets::selectable_row(
+                                        ui,
+                                        is_selected,
+                                        &colors,
+                                        |ui| {
+                                            let row_w = ui.available_width();
+                                            ui.horizontal(|ui| {
+                                                ui.set_min_width(row_w);
                                                 ui.label(
-                                                    RichText::new(pane_kinds[i])
-                                                        .size(style::TEXT_CAPTION)
-                                                        .color(colors.text_dim),
+                                                    RichText::new(format!(
+                                                        "#{} {}",
+                                                        row_id, row.kind
+                                                    ))
+                                                    .size(style::TEXT_CAPTION)
+                                                    .color(colors.text_dim),
                                                 );
-                                                let display_name =
-                                                    if pane_names[i].is_empty() {
-                                                        pane_kinds[i].to_string()
-                                                    } else {
-                                                        pane_names[i].clone()
-                                                    };
+                                                let display_name: &str = if row.name.is_empty() {
+                                                    row.kind
+                                                } else {
+                                                    &row.name
+                                                };
                                                 ui.label(
-                                                    RichText::new(&display_name)
+                                                    RichText::new(display_name)
                                                         .size(style::TEXT_BODY)
                                                         .color(colors.text_primary),
                                                 );
@@ -1600,9 +1661,7 @@ impl PlexiApp {
                                                             .add(
                                                                 egui::Button::new(
                                                                     RichText::new("✕")
-                                                                        .size(
-                                                                            style::TEXT_CAPTION,
-                                                                        )
+                                                                        .size(style::TEXT_CAPTION)
                                                                         .color(colors.text_dim),
                                                                 )
                                                                 .frame(false),
@@ -1612,27 +1671,34 @@ impl PlexiApp {
                                                             )
                                                             .clicked()
                                                         {
-                                                            close_pane = Some(pane_ids[i]);
+                                                            close_pane = Some(row_id);
                                                         }
                                                         let status_color =
-                                                            if pane_statuses[i] == "running" {
+                                                            if row.status == "running" {
                                                                 colors.accent
                                                             } else {
                                                                 colors.text_dim
                                                             };
                                                         ui.label(
-                                                            RichText::new(pane_statuses[i])
+                                                            RichText::new(row.status)
                                                                 .size(style::TEXT_HINT)
                                                                 .color(status_color),
                                                         );
+                                                        if !row.detail.is_empty() {
+                                                            ui.label(
+                                                                RichText::new(row.detail.as_str())
+                                                                    .size(style::TEXT_HINT)
+                                                                    .color(colors.text_dim),
+                                                            );
+                                                        }
                                                     },
                                                 );
-                                            },
-                                        );
-                                    },
-                                );
-                                if row_resp.clicked() {
-                                    close_pane = Some(pane_ids[i]);
+                                            });
+                                        },
+                                    );
+                                    if row_resp.clicked() {
+                                        focus_pane = Some(row_id);
+                                    }
                                 }
                             }
                         }
@@ -1677,7 +1743,7 @@ impl PlexiApp {
                                 crate::widgets::key_combo_list(
                                     ui,
                                     &[&["Enter"]],
-                                    Some("close pane"),
+                                    Some("focus pane"),
                                     &colors,
                                 );
                             }
@@ -1688,6 +1754,12 @@ impl PlexiApp {
         if dismissed {
             self.show_context_inspector = false;
             log::info!("ContextInspector: closed");
+        }
+
+        if let Some(pid) = focus_pane {
+            log::info!("ContextInspector: focusing pane {pid}");
+            self.pane_navigate(pid);
+            self.show_context_inspector = false;
         }
 
         if let Some(pid) = close_pane {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1425,7 +1425,6 @@ impl PlexiApp {
     pub(crate) fn draw_context_inspector(&mut self, ctx: &egui::Context) {
         let mut dismissed = false;
         let mut close_pane: Option<PaneId> = None;
-        let mut focus_pane: Option<PaneId> = None;
         let mut delete_context = false;
 
         let (nav_down, nav_up, enter_pressed) = ctx.input_mut(|i| {
@@ -1441,88 +1440,44 @@ impl PlexiApp {
             (down, up, enter)
         });
 
+        let active_ctx_id = self.router.active().context_id;
         let ctx_name = self.router.active().name.clone();
         let ctx_root = self.router.active().root.clone();
         let num_contexts = self.router.len();
 
-        // Collect all panes across all contexts, grouped by context.
-        struct PaneRow {
-            id: PaneId,
-            kind: &'static str,
-            name: String,
-            detail: String,
-            status: &'static str,
-        }
+        let mut pane_ids: Vec<PaneId> = Vec::new();
+        let mut pane_kinds: Vec<&'static str> = Vec::new();
+        let mut pane_names: Vec<String> = Vec::new();
+        let mut pane_statuses: Vec<&'static str> = Vec::new();
 
-        let mut groups: Vec<(String, Vec<PaneRow>)> = Vec::new();
-        let mut all_pane_ids: Vec<PaneId> = Vec::new();
-
-        for ctx_entry in self.router.iter() {
-            let cname = ctx_entry.name.clone();
-            let cid = ctx_entry.context_id;
-            let mut rows: Vec<PaneRow> = Vec::new();
-            for win in self.windows.iter() {
-                if win.context_id != cid {
-                    continue;
-                }
-                for (_, pane) in &win.panes {
-                    match pane {
-                        crate::pane::Pane::Terminal(t) => {
-                            rows.push(PaneRow {
-                                id: t.id,
-                                kind: "Terminal",
-                                name: t
-                                    .name
-                                    .clone()
-                                    .or_else(|| t.pty_title.clone())
-                                    .unwrap_or_default(),
-                                detail: String::new(),
-                                status: if t.exited { "exited" } else { "running" },
-                            });
-                        }
-                        crate::pane::Pane::App(a) => {
-                            let status = if let crate::pane::AppRuntime::Process(ref proc) =
-                                a.runtime
-                            {
-                                match proc.lifecycle.state() {
-                                    crate::process_app::LifecycleState::Running => {
-                                        "running"
-                                    }
-                                    crate::process_app::LifecycleState::Booting => {
-                                        "booting"
-                                    }
-                                    crate::process_app::LifecycleState::Crashed => {
-                                        "crashed"
-                                    }
-                                    crate::process_app::LifecycleState::Hung => "hung",
-                                    crate::process_app::LifecycleState::ProtocolError => {
-                                        "error"
-                                    }
-                                }
-                            } else {
-                                "running"
-                            };
-                            rows.push(PaneRow {
-                                id: a.id,
-                                kind: "App",
-                                name: a.name.clone(),
-                                detail: a.manifest_id.clone(),
-                                status,
-                            });
-                        }
+        for win in self.windows.iter() {
+            if win.context_id != active_ctx_id {
+                continue;
+            }
+            for (_, pane) in &win.panes {
+                match pane {
+                    crate::pane::Pane::Terminal(t) => {
+                        pane_ids.push(t.id);
+                        pane_kinds.push("Terminal");
+                        pane_names.push(
+                            t.name
+                                .clone()
+                                .or_else(|| t.pty_title.clone())
+                                .unwrap_or_default(),
+                        );
+                        pane_statuses.push(if t.exited { "exited" } else { "running" });
+                    }
+                    crate::pane::Pane::App(a) => {
+                        pane_ids.push(a.id);
+                        pane_kinds.push("App");
+                        pane_names.push(a.name.clone());
+                        pane_statuses.push("running");
                     }
                 }
             }
-            if !rows.is_empty() {
-                rows.sort_by_key(|r| r.id);
-                for r in &rows {
-                    all_pane_ids.push(r.id);
-                }
-                groups.push((cname, rows));
-            }
         }
 
-        let pane_count = all_pane_ids.len();
+        let pane_count = pane_ids.len();
         if nav_down && pane_count > 0 {
             self.inspector_selected_pane = (self.inspector_selected_pane + 1) % pane_count;
         }
@@ -1534,7 +1489,7 @@ impl PlexiApp {
             self.inspector_selected_pane = pane_count - 1;
         }
         if enter_pressed && pane_count > 0 {
-            focus_pane = Some(all_pane_ids[self.inspector_selected_pane]);
+            close_pane = Some(pane_ids[self.inspector_selected_pane]);
         }
 
         let colors = self.colors;
@@ -1612,43 +1567,29 @@ impl PlexiApp {
                                     .color(colors.text_dim),
                             );
                         } else {
-                            let mut global_idx: usize = 0;
-                            for (group_name, rows) in &groups {
-                                // Context section header (dim).
-                                ui.add_space(style::SPACE_SM);
-                                ui.label(
-                                    RichText::new(group_name.as_str())
-                                        .size(style::TEXT_CAPTION)
-                                        .color(colors.text_dim),
-                                );
-                                ui.add_space(style::SPACE_SM);
-
-                                for row in rows {
-                                    let i = global_idx;
-                                    global_idx += 1;
-                                    let is_selected = i == selected;
-                                    let row_id = row.id;
-                                    let (row_resp, _) = crate::widgets::selectable_row(
-                                        ui,
-                                        is_selected,
-                                        &colors,
-                                        |ui| {
-                                            ui.horizontal(|ui| {
+                            for i in 0..pane_count {
+                                let is_selected = i == selected;
+                                let (row_resp, _) = crate::widgets::selectable_row(
+                                    ui,
+                                    is_selected,
+                                    &colors,
+                                    |ui| {
+                                        ui.with_layout(
+                                            Layout::left_to_right(Align::Center),
+                                            |ui| {
                                                 ui.label(
-                                                    RichText::new(format!(
-                                                        "#{} {}",
-                                                        row_id, row.kind
-                                                    ))
-                                                    .size(style::TEXT_CAPTION)
-                                                    .color(colors.text_dim),
+                                                    RichText::new(pane_kinds[i])
+                                                        .size(style::TEXT_CAPTION)
+                                                        .color(colors.text_dim),
                                                 );
-                                                let display_name: &str = if row.name.is_empty() {
-                                                    row.kind
-                                                } else {
-                                                    &row.name
-                                                };
+                                                let display_name =
+                                                    if pane_names[i].is_empty() {
+                                                        pane_kinds[i].to_string()
+                                                    } else {
+                                                        pane_names[i].clone()
+                                                    };
                                                 ui.label(
-                                                    RichText::new(display_name)
+                                                    RichText::new(&display_name)
                                                         .size(style::TEXT_BODY)
                                                         .color(colors.text_primary),
                                                 );
@@ -1659,7 +1600,9 @@ impl PlexiApp {
                                                             .add(
                                                                 egui::Button::new(
                                                                     RichText::new("✕")
-                                                                        .size(style::TEXT_CAPTION)
+                                                                        .size(
+                                                                            style::TEXT_CAPTION,
+                                                                        )
                                                                         .color(colors.text_dim),
                                                                 )
                                                                 .frame(false),
@@ -1669,34 +1612,27 @@ impl PlexiApp {
                                                             )
                                                             .clicked()
                                                         {
-                                                            close_pane = Some(row_id);
+                                                            close_pane = Some(pane_ids[i]);
                                                         }
                                                         let status_color =
-                                                            if row.status == "running" {
+                                                            if pane_statuses[i] == "running" {
                                                                 colors.accent
                                                             } else {
                                                                 colors.text_dim
                                                             };
                                                         ui.label(
-                                                            RichText::new(row.status)
+                                                            RichText::new(pane_statuses[i])
                                                                 .size(style::TEXT_HINT)
                                                                 .color(status_color),
                                                         );
-                                                        if !row.detail.is_empty() {
-                                                            ui.label(
-                                                                RichText::new(row.detail.as_str())
-                                                                    .size(style::TEXT_HINT)
-                                                                    .color(colors.text_dim),
-                                                            );
-                                                        }
                                                     },
                                                 );
-                                            });
-                                        },
-                                    );
-                                    if row_resp.clicked() {
-                                        focus_pane = Some(row_id);
-                                    }
+                                            },
+                                        );
+                                    },
+                                );
+                                if row_resp.clicked() {
+                                    close_pane = Some(pane_ids[i]);
                                 }
                             }
                         }
@@ -1741,7 +1677,7 @@ impl PlexiApp {
                                 crate::widgets::key_combo_list(
                                     ui,
                                     &[&["Enter"]],
-                                    Some("focus pane"),
+                                    Some("close pane"),
                                     &colors,
                                 );
                             }
@@ -1752,12 +1688,6 @@ impl PlexiApp {
         if dismissed {
             self.show_context_inspector = false;
             log::info!("ContextInspector: closed");
-        }
-
-        if let Some(pid) = focus_pane {
-            log::info!("ContextInspector: focusing pane {pid}");
-            self.pane_navigate(pid);
-            self.show_context_inspector = false;
         }
 
         if let Some(pid) = close_pane {

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -47,14 +47,10 @@ pub(crate) fn selectable_row<R>(
     });
 
     let row_rect = scope.response.rect;
-    // Inset highlight rect symmetrically so it doesn't extend beyond
-    // visible content bounds (the content already has ROW_PAD_H left
-    // indent, mirror that on the right).
-    let highlight_rect = row_rect.shrink2(Vec2::new(ROW_PAD_H, 0.0));
 
     ui.painter().set(
         bg_idx,
-        egui::Shape::rect_filled(highlight_rect, CornerRadius::same(4), fill),
+        egui::Shape::rect_filled(row_rect, CornerRadius::same(4), fill),
     );
 
     let response = ui.interact(

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -47,10 +47,14 @@ pub(crate) fn selectable_row<R>(
     });
 
     let row_rect = scope.response.rect;
+    // Inset highlight rect symmetrically so it doesn't extend beyond
+    // visible content bounds (the content already has ROW_PAD_H left
+    // indent, mirror that on the right).
+    let highlight_rect = row_rect.shrink2(Vec2::new(ROW_PAD_H, 0.0));
 
     ui.painter().set(
         bg_idx,
-        egui::Shape::rect_filled(row_rect, CornerRadius::same(4), fill),
+        egui::Shape::rect_filled(highlight_rect, CornerRadius::same(4), fill),
     );
 
     let response = ui.interact(


### PR DESCRIPTION
## Summary

- Inspector pane rows' inner `ui.horizontal()` was shrink-wrapping instead of filling the full modal width
- `right_to_left` sub-layout got inconsistent remaining space across rows (varies with pane name length)
- Captured `available_width()` before the horizontal and called `ui.set_min_width(row_w)` inside it — now every row fills full width and `running ✕` pins to the right edge consistently

**Does not touch `selectable_row` in `widgets.rs`** — the prior attempt (#1305) shrank the highlight rect there, which caused the badge to sit outside the highlight. The fix is entirely in the row content.

## Test plan

- [ ] Open the context inspector (⌘I or equivalent)
- [ ] Verify `running ✕` badge right-aligns consistently across all rows regardless of pane name length
- [ ] Verify selected-row highlight extends to the same right edge as the badge
- [ ] Verify no visual regression in the command palette (also uses `selectable_row`)

Fixes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)