### PR TITLE
ui(overlays): move coffee link below email, shrink to caption, rename label (#1329)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -35,11 +35,6 @@ const R6: CornerRadius = CornerRadius::same(6);
 
 fn draw_contact_footer(ui: &mut egui::Ui, colors: &Colors) {
     ui.vertical_centered(|ui| {
-        ui.hyperlink_to(
-            RichText::new("❤️  Buy Me a Coffee").size(style::TEXT_BODY),
-            "https://buymeacoffee.com/ianjamesbu8",
-        );
-        ui.add_space(style::SPACE_SM);
         ui.label(
             RichText::new(
                 "If you have any ideas, want to help, or just want to say what's up...",
@@ -75,6 +70,11 @@ fn draw_contact_footer(ui: &mut egui::Ui, colors: &Colors) {
                 );
             });
         }
+        ui.add_space(style::SPACE_SM / 2.0);
+        ui.hyperlink_to(
+            RichText::new("❤️  Support the project").size(style::TEXT_CAPTION),
+            "https://buymeacoffee.com/ianjamesbu8",
+        );
     });
 }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -72,7 +72,9 @@ fn draw_contact_footer(ui: &mut egui::Ui, colors: &Colors) {
         }
         ui.add_space(style::SPACE_SM / 2.0);
         ui.hyperlink_to(
-            RichText::new("❤️  Support the project").size(style::TEXT_CAPTION),
+            RichText::new("❤️  Support the project")
+                .size(style::TEXT_CAPTION)
+                .color(colors.text_dim),
             "https://buymeacoffee.com/ianjamesbu8",
         );
     });


### PR DESCRIPTION
Moves the "Buy Me a Coffee" hyperlink below the email row, shrinks it from `TEXT_BODY` to `TEXT_CAPTION`, and renames it to "❤️  Support the project".

## Done when
- Tagline (dim caption)
- Email row with copy button
- Smaller "❤️  Support the project" hyperlink below the email

## Changes
- `src/overlays.rs` — `draw_contact_footer`: reorder blocks, resize, rename label

Closes #1329