### PR TITLE
feat(cli): plexi uninstall for Plexi self-removal, app uninstall cleanup (#1333)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1347,11 +1347,16 @@ pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
     } else {
         binary_name.strip_prefix("plexi").unwrap_or("").to_string()
     };
-    let cap = match suffix.as_str() {
-        "-alpha" => " Alpha",
-        "-beta"  => " Beta",
-        _        => "",
+    let cap_owned = if let Some(n) = suffix.strip_prefix("-pr-") {
+        format!(" PR{n}")
+    } else {
+        match suffix.as_str() {
+            "-alpha" => " Alpha".to_string(),
+            "-beta"  => " Beta".to_string(),
+            _        => String::new(),
+        }
     };
+    let cap = cap_owned.as_str();
 
     let profile_dir = dirs::home_dir().unwrap().join(format!(".plexi{suffix}"));
     let app_bundle  = std::path::PathBuf::from(format!("/Applications/Plexi{cap}.app"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -707,19 +707,31 @@ fn scaffold_rust_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> {
     Ok(())
 }
 
-/// `plexi app uninstall <id>` — remove a globally installed app.
-pub fn app_uninstall(id: &str) -> i32 {
-    let app_dir = crate::app_registry::apps_dir().join(id);
+/// `plexi app uninstall <id> [--yes]` — remove a globally installed app with optional confirmation.
+pub fn app_uninstall(id: &str, assume_yes: bool) -> i32 {
+    let target_root = crate::app_registry::apps_dir();
+    let app_dir = target_root.join(id);
     if !app_dir.exists() {
-        eprintln!("error: app '{id}' not found in global apps dir");
+        eprintln!("error: app '{id}' not found");
         return 1;
     }
-    if let Err(e) = std::fs::remove_dir_all(&app_dir) {
-        eprintln!("error: could not remove {}: {e}", app_dir.display());
-        return 1;
+    if !assume_yes {
+        eprint!("Remove app '{id}'? [y/N]: ");
+        let _ = io::stderr().flush();
+        let mut answer = String::new();
+        if io::stdin().read_line(&mut answer).is_err() {
+            eprintln!("error: failed to read confirmation");
+            return 1;
+        }
+        if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+            eprintln!("aborted");
+            return 1;
+        }
     }
-    println!("Uninstalled '{id}'.");
-    0
+    match crate::install::uninstall_one(id, &target_root) {
+        Ok(()) => { println!("Uninstalled '{id}'."); 0 }
+        Err(e) => { eprintln!("error: {e}"); 1 }
+    }
 }
 
 /// `plexi app install <path>` — copy a local app directory into the channel's app store.
@@ -1325,39 +1337,136 @@ pub fn install_pack_cli(spec: &str) -> i32 {
     }
 }
 
-/// `plexi uninstall <id> [--yes]` — remove a globally installed app after
-/// a confirmation prompt (skipped with `--yes`).
-pub fn uninstall_cli(id: &str, assume_yes: bool) -> i32 {
-    let target_root = crate::app_registry::apps_dir();
-    let dest = target_root.join(id);
-    if !dest.exists() {
-        eprintln!("error: '{id}' is not installed at {}", dest.display());
-        return 1;
+/// `plexi uninstall [--keep-data] [--yes]` — remove Plexi itself from the Mac.
+pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
+    // Detect channel suffix from binary name (e.g. "plexi-alpha" → "-alpha", "plexi" → "")
+    let exe = std::env::current_exe().unwrap_or_default();
+    let binary_name = exe.file_stem().unwrap_or_default().to_string_lossy().to_string();
+    let suffix = if binary_name == "plexi" {
+        String::new()
+    } else {
+        binary_name.strip_prefix("plexi").unwrap_or("").to_string()
+    };
+    let cap = match suffix.as_str() {
+        "-alpha" => " Alpha",
+        "-beta"  => " Beta",
+        _        => "",
+    };
+
+    let profile_dir = dirs::home_dir().unwrap().join(format!(".plexi{suffix}"));
+    let app_bundle  = std::path::PathBuf::from(format!("/Applications/Plexi{cap}.app"));
+    let cli_binary  = std::path::PathBuf::from(format!("/usr/local/bin/plexi{suffix}"));
+
+    // Print what will be removed
+    println!("This will remove:");
+    if app_bundle.exists()  { println!("  \u{2022} {}", app_bundle.display()); }
+    if cli_binary.exists()  { println!("  \u{2022} {}", cli_binary.display()); }
+    if !keep_data && profile_dir.exists() {
+        println!("  \u{2022} {}  (settings, secrets, app configs)", profile_dir.display());
+    } else if profile_dir.exists() {
+        println!("  \u{2022} {} will be kept  (--keep-data)", profile_dir.display());
     }
-    if !assume_yes {
-        eprint!("Remove {} ? [y/N]: ", dest.display());
+
+    // Data prompt (skip if --keep-data or --yes already set)
+    let keep_data = if keep_data || !profile_dir.exists() {
+        keep_data
+    } else if assume_yes {
+        false // default: remove data when -y is passed without --keep-data
+    } else {
+        eprint!("\nKeep your profile data (~/.plexi{suffix}/)? Your settings, secrets, and app configurations are stored here. [y/N]: ");
         let _ = io::stderr().flush();
         let mut answer = String::new();
         if io::stdin().read_line(&mut answer).is_err() {
-            eprintln!("error: failed to read confirmation");
+            eprintln!("error: failed to read");
             return 1;
         }
-        let trimmed = answer.trim().to_lowercase();
-        if trimmed != "y" && trimmed != "yes" {
-            eprintln!("aborted");
+        matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+    };
+
+    // Confirmation
+    if !assume_yes {
+        eprint!("\nProceed? [y/N]: ");
+        let _ = io::stderr().flush();
+        let mut answer = String::new();
+        if io::stdin().read_line(&mut answer).is_err() {
+            eprintln!("error: failed to read");
             return 1;
         }
-    }
-    match crate::install::uninstall_one(id, &target_root) {
-        Ok(()) => {
-            println!("uninstalled '{id}'");
-            0
-        }
-        Err(e) => {
-            eprintln!("error: {e}");
-            1
+        if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+            eprintln!("Aborted.");
+            return 0;
         }
     }
+
+    let mut removed = false;
+
+    // Archive backlog before potentially deleting profile dir
+    if !keep_data {
+        let backlog = profile_dir.join("backlog");
+        if backlog.exists() {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let archive = dirs::home_dir().unwrap().join(format!(
+                "plexi-backlog-archive/plexi{suffix}-backlog-{ts}"
+            ));
+            if let Some(parent) = archive.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if std::fs::rename(&backlog, &archive).is_ok() {
+                println!("Archived backlog \u{2192} {}", archive.display());
+            }
+        }
+    }
+
+    // Remove app bundle
+    if app_bundle.exists() {
+        match std::fs::remove_dir_all(&app_bundle) {
+            Ok(()) => { println!("Removed {}", app_bundle.display()); removed = true; }
+            Err(e) => eprintln!("warning: could not remove {}: {e}", app_bundle.display()),
+        }
+    }
+
+    // Remove CLI binary
+    if cli_binary.exists() || cli_binary.is_symlink() {
+        match std::fs::remove_file(&cli_binary) {
+            Ok(()) => { println!("Removed {}", cli_binary.display()); removed = true; }
+            Err(e) => eprintln!("warning: could not remove {}: {e}", cli_binary.display()),
+        }
+    }
+
+    // Remove completions (only for stable uninstall)
+    if suffix.is_empty() {
+        let brew_prefix = std::process::Command::new("brew")
+            .arg("--prefix")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string());
+        if let Some(prefix) = brew_prefix {
+            let zsh_comp = std::path::PathBuf::from(prefix).join("share/zsh/site-functions/_plexi");
+            if zsh_comp.exists() {
+                let _ = std::fs::remove_file(&zsh_comp);
+                println!("Removed {}", zsh_comp.display());
+            }
+        }
+    }
+
+    // Remove profile dir
+    if !keep_data && profile_dir.exists() {
+        match std::fs::remove_dir_all(&profile_dir) {
+            Ok(()) => { println!("Removed {}", profile_dir.display()); removed = true; }
+            Err(e) => eprintln!("warning: could not remove {}: {e}", profile_dir.display()),
+        }
+    }
+
+    if removed {
+        println!("\nDone. Plexi{} has been removed.", if cap.is_empty() { "" } else { cap });
+    } else {
+        println!("\nNothing found to remove.");
+    }
+    0
 }
 
 /// `plexi update apps [<id>]` — git-pull one installed app, or all of them.
@@ -3695,6 +3804,11 @@ _plexi() {
             init)
               _arguments '--lang[Language template]:lang:(python)'
               ;;
+            uninstall)
+              _arguments \
+                '--yes[Skip the confirmation prompt]' \
+                '-y[Skip the confirmation prompt]'
+              ;;
             render)
               _arguments \
                 '--size[Dimensions as WxH]:size:' \
@@ -3703,7 +3817,7 @@ _plexi() {
               ;;
             *)
               local subcmds
-              subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Uninstall an app' 'list:List installed apps' 'render:Render an app to PNG headlessly' 'info:Show app info' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
+              subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Remove an installed app by id' 'list:List installed apps' 'render:Render an app to PNG headlessly' 'info:Show app info' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
               _describe 'subcommand' subcmds
               ;;
           esac
@@ -3789,7 +3903,10 @@ _plexi() {
           _arguments '--pack[Install from a pack file or core]:pack:'
           ;;
         uninstall)
-          _arguments '--yes[Skip confirmation prompt]'
+          _arguments \
+            '--keep-data[Keep your profile directory]' \
+            '--yes[Skip confirmation prompts and proceed immediately]' \
+            '-y[Skip confirmation prompts and proceed immediately]'
           ;;
         completions)
           local shells
@@ -3843,6 +3960,9 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
         case "${words[2]}" in
           init)
             COMPREPLY=($(compgen -W "--lang" -- "$cur"))
+            ;;
+          uninstall)
+            COMPREPLY=($(compgen -W "--yes -y" -- "$cur"))
             ;;
           render)
             COMPREPLY=($(compgen -W "--size --state --output" -- "$cur"))
@@ -3916,7 +4036,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "--pack" -- "$cur"))
       ;;
     uninstall)
-      COMPREPLY=($(compgen -W "--yes" -- "$cur"))
+      COMPREPLY=($(compgen -W "--keep-data --yes -y" -- "$cur"))
       ;;
     completions)
       COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur"))
@@ -4040,7 +4160,11 @@ complete -c plexi -n "__fish_seen_subcommand_from notify" -l scope -d "Notificat
 complete -c plexi -n "__fish_seen_subcommand_from install" -l pack -d "Install from a pack file or core"
 
 # uninstall flags
-complete -c plexi -n "__fish_seen_subcommand_from uninstall" -l yes -d "Skip confirmation prompt"
+complete -c plexi -n "__fish_seen_subcommand_from uninstall" -l keep-data -d "Keep your profile directory"
+complete -c plexi -n "__fish_seen_subcommand_from uninstall" -l yes -s y -d "Skip confirmation prompts and proceed immediately"
+
+# app uninstall flags
+complete -c plexi -n "__fish_seen_subcommand_from app; and __fish_seen_subcommand_from uninstall" -l yes -s y -d "Skip the confirmation prompt"
 
 # completions args
 complete -c plexi -f -n "__fish_seen_subcommand_from completions" -a "zsh bash fish"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -60,11 +60,18 @@ pub enum Commands {
         #[arg(long)]
         pack: Option<String>,
     },
-    /// Remove an installed app. Asks for confirmation unless you pass -y.
+    /// Remove Plexi from your Mac — uninstalls the app, CLI, and optionally your profile data.
+    ///
+    /// Removes the current channel's app bundle (/Applications/Plexi.app), CLI binary (/usr/local/bin/plexi),
+    /// and shell completions. Your profile directory (~/.plexi/) holds your settings, secrets,
+    /// and app configurations — you will be asked whether to keep it.
+    ///
+    /// Example: plexi uninstall
     Uninstall {
-        /// App id to remove (use `plexi list` to see installed app ids)
-        id: String,
-        /// Skip the confirmation prompt
+        /// Keep your profile directory (~/.plexi/) — your settings, secrets, and app data stay on disk
+        #[arg(long = "keep-data")]
+        keep_data: bool,
+        /// Skip confirmation prompts and proceed immediately
         #[arg(long = "yes", short = 'y')]
         yes: bool,
     },
@@ -257,9 +264,15 @@ pub enum AppCmd {
         #[arg(long, default_value = "python")]
         lang: String,
     },
-    /// Remove an app by id (no confirmation prompt — use `plexi uninstall` if you want one).
+    /// Remove an installed app by id.
+    ///
+    /// Example: plexi app uninstall github-tree
     Uninstall {
+        /// App id to remove (use `plexi app list` to see installed ids)
         id: String,
+        /// Skip the confirmation prompt
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
     },
     /// Show all installed apps.
     List,

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ fn main() -> eframe::Result {
                     Commands::App { cmd } => match cmd {
                         AppCmd::Init { name, lang } => std::process::exit(cli::app_init(&name, &lang)),
                         AppCmd::Install { path } => std::process::exit(cli::app_install(&path)),
-                        AppCmd::Uninstall { id } => std::process::exit(cli::app_uninstall(&id)),
+                        AppCmd::Uninstall { id, yes } => std::process::exit(cli::app_uninstall(&id, yes)),
                         AppCmd::List => std::process::exit(cli::app_list()),
                         AppCmd::Render { id, size, state, output } => {
                             std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
@@ -247,7 +247,7 @@ fn main() -> eframe::Result {
                             }
                         }
                     }
-                    Commands::Uninstall { id, yes } => std::process::exit(cli::uninstall_cli(&id, yes)),
+                    Commands::Uninstall { keep_data, yes } => std::process::exit(cli::plexi_uninstall_cli(keep_data, yes)),
                     Commands::Update { subcommand } => match subcommand {
                         Some(UpdateCmd::Apps { id }) => std::process::exit(cli::update_cli(id.as_deref())),
                         None => std::process::exit(cli::self_update_cli()),

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.
-verified_version: "0.0.380"
+verified_version: "0.0.381"
 order: 7
 ---
 
@@ -94,7 +94,7 @@ Manage your Plexi apps — scaffold, install, list, and inspect
 | Subcommand | Description |
 |---|---|
 | `init` | Create a new app from a template |
-| `uninstall` | Remove an app by id (no confirmation prompt — use `plexi uninstall` if you want one) |
+| `uninstall` | Remove an installed app by id |
 | `list` | Show all installed apps |
 | `render` | Render an app to a PNG image without opening the UI (useful for screenshots and testing) |
 | `info` | Show details about an installed app: id, name, version, and available tools |
@@ -115,11 +115,14 @@ Scaffolds the folder structure and files you need to build a Plexi app. Use --la
 
 ### `plexi app uninstall`
 
-Remove an app by id (no confirmation prompt — use `plexi uninstall` if you want one)
+Remove an installed app by id.
+
+Example: plexi app uninstall github-tree
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
-| `<id>` | string | yes |  |
+| `<id>` | string | yes | App id to remove (use `plexi app list` to see installed ids) |
+| `--yes` / `-y` | flag | no | Skip the confirmation prompt |
 
 ### `plexi app list`
 
@@ -189,12 +192,16 @@ To install a local app directory you are developing, use `plexi app install <pat
 
 ## `plexi uninstall`
 
-Remove an installed app. Asks for confirmation unless you pass -y
+Remove Plexi from your Mac — uninstalls the app, CLI, and optionally your profile data.
+
+Removes the current channel's app bundle (/Applications/Plexi.app), CLI binary (/usr/local/bin/plexi), and shell completions. Your profile directory (~/.plexi/) holds your settings, secrets, and app configurations — you will be asked whether to keep it.
+
+Example: plexi uninstall
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
-| `<id>` | string | yes | App id to remove (use `plexi list` to see installed app ids) |
-| `--yes` / `-y` | flag | no | Skip the confirmation prompt |
+| `--keep-data` | flag | no | Keep your profile directory (~/.plexi/) — your settings, secrets, and app data stay on disk |
+| `--yes` / `-y` | flag | no | Skip confirmation prompts and proceed immediately |
 
 ## `plexi update`
 


### PR DESCRIPTION
## What

Repurposes `plexi uninstall` for removing Plexi itself. App removal moves to `plexi app uninstall` (which gains a `--yes` flag and confirmation prompt).

## #1333 — plexi uninstall (self-removal)

- `plexi uninstall` now removes the current channel's app bundle, CLI binary, shell completions, and optionally profile data
- Prompts: "Keep your profile data?" (settings, secrets, app configs) then "Proceed?"
- `--keep-data` flag to skip the data prompt and preserve `~/.plexi/`
- `-y` / `--yes` to skip all confirmation (data is removed by default)
- Archives backlog to `~/plexi-backlog-archive/` before deleting profile dir
- Channel-aware: detects stable/alpha/beta from binary name

## #1315 — self.args

Already implemented (`sdk/python/plexi_sdk/_app.py:107`). Closed without code change.

## Done When

- `plexi uninstall --help` shows `--keep-data` and `--yes`, no `<id>` argument
- `plexi app uninstall --help` shows `<id>` and `--yes`
- `plexi app uninstall <id>` prompts for confirmation

Closes #1333