### PR TITLE
fix(ai): broadcast fresh AI config to all panes on reload (#1337)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3767,7 +3767,7 @@ impl PlexiApp {
         self.key_bindings = crate::keys::build_key_bindings(self.config.keybindings.as_ref());
         log::info!("keybindings: rebuilt after config reload");
 
-        // AI broker config — broadcast fresh snapshot to all living panes
+        // AI broker config — broadcast fresh snapshot to all living panes and background apps
         let fresh_ai = self.config.ai.clone();
         for win in &mut self.windows {
             for pane in win.panes.values_mut() {
@@ -3777,6 +3777,9 @@ impl PlexiApp {
                     }
                 }
             }
+        }
+        for app_entry in self.background_apps.values_mut() {
+            app_entry.1.update_ai_config(fresh_ai.clone());
         }
         log::info!("ai_broker: config reloaded");
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3767,6 +3767,19 @@ impl PlexiApp {
         self.key_bindings = crate::keys::build_key_bindings(self.config.keybindings.as_ref());
         log::info!("keybindings: rebuilt after config reload");
 
+        // AI broker config — broadcast fresh snapshot to all living panes
+        let fresh_ai = self.config.ai.clone();
+        for win in &mut self.windows {
+            for pane in win.panes.values_mut() {
+                if let Some(app) = pane.as_app_mut() {
+                    if let crate::pane::AppRuntime::Process(proc) = &mut app.runtime {
+                        proc.update_ai_config(fresh_ai.clone());
+                    }
+                }
+            }
+        }
+        log::info!("ai_broker: config reloaded");
+
         // Voice config
         let fresh_voice =
             crate::config::VoiceConfig::load_with_workspace(active_workspace.as_deref());

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1773,6 +1773,12 @@ impl App for ProcessApp {
     }
 }
 
+impl ProcessApp {
+    pub(crate) fn update_ai_config(&mut self, ai_config: Option<crate::config::AiConfig>) {
+        self.ai_broker = Arc::new(LiveAiBroker::new(ai_config));
+    }
+}
+
 /// Build a `LiveAiBroker` from the `[ai]` section of the current config.
 /// If the section is absent, the broker is constructed with `None` and will
 /// fail fast at dispatch time with a clear error directing the user to add


### PR DESCRIPTION
## Summary

- `LiveAiBroker` stored a stale snapshot of `[ai]` config taken at pane construction — enabling or changing AI config required a full restart to take effect
- On `reload_config()`, now iterates all living panes and reconstructs their `LiveAiBroker` with the fresh config
- Logs `ai_broker: config reloaded` at info level for visibility in `plexi.log`

## Done When

1. Launch Plexi with `[ai]` commented out
2. Open `ai-test` example app
3. Uncomment `[ai]`, save, press Cmd+Shift+Comma
4. Click the ai_query button → response displays successfully (no restart)
5. `plexi.log` contains `ai_broker: config reloaded`
6. `cargo test --bin plexi` passes (2 pre-existing failures unrelated to this change)

Closes #1337