### PR TITLE
feat(ui): configurable unfocused-pane opacity via ghost_opacity (#1350)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3031,6 +3031,28 @@ impl eframe::App for PlexiApp {
                     }
                 }
 
+                let unfocused_opacity = self.config.beta.as_ref().and_then(|b| {
+                    if let Some(opacity) = b.ghost_opacity {
+                        Some(opacity)
+                    } else if b.ghost.unwrap_or(false) {
+                        Some(0.9_f32)
+                    } else {
+                        None
+                    }
+                });
+                {
+                    let ghost_log_id = egui::Id::new("ghost_opacity_logged");
+                    let cur = unfocused_opacity.map(|v| (v * 100.0) as u32);
+                    let prev: Option<u32> = ui.ctx().data(|d| d.get_temp(ghost_log_id));
+                    if prev != Some(cur.unwrap_or(u32::MAX)) {
+                        match unfocused_opacity {
+                            Some(opacity) => log::info!("[ghost] unfocused pane opacity: {opacity:.2}"),
+                            None => log::info!("[ghost] disabled"),
+                        }
+                        ui.ctx().data_mut(|d| d.insert_temp(ghost_log_id, cur.unwrap_or(u32::MAX)));
+                    }
+                }
+
                 let mut behavior = PlexiBehavior {
                     panes: &mut ctx.panes,
                     focused_tile: if suppress_focus {
@@ -3048,6 +3070,7 @@ impl eframe::App for PlexiApp {
                     drag_cursor_pos,
                     hovered_files,
                     workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
+                    unfocused_opacity,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3031,25 +3031,25 @@ impl eframe::App for PlexiApp {
                     }
                 }
 
-                let unfocused_opacity = self.config.beta.as_ref().and_then(|b| {
-                    if let Some(opacity) = b.ghost_opacity {
-                        Some(opacity)
-                    } else if b.ghost.unwrap_or(false) {
-                        Some(0.9_f32)
-                    } else {
-                        None
-                    }
-                });
+                let unfocused_opacity =
+                    self.config.beta.as_ref().and_then(|b| b.unfocused_opacity());
                 {
                     let ghost_log_id = egui::Id::new("ghost_opacity_logged");
                     let cur = unfocused_opacity.map(|v| (v * 100.0) as u32);
                     let prev: Option<u32> = ui.ctx().data(|d| d.get_temp(ghost_log_id));
-                    if prev != Some(cur.unwrap_or(u32::MAX)) {
-                        match unfocused_opacity {
-                            Some(opacity) => log::info!("[ghost] unfocused pane opacity: {opacity:.2}"),
-                            None => log::info!("[ghost] disabled"),
+                    if prev != cur {
+                        if let Some(opacity) = unfocused_opacity {
+                            log::info!("[ghost] unfocused pane opacity: {opacity:.2}");
+                        } else if prev.is_some() {
+                            log::info!("[ghost] disabled");
                         }
-                        ui.ctx().data_mut(|d| d.insert_temp(ghost_log_id, cur.unwrap_or(u32::MAX)));
+                        ui.ctx().data_mut(|d| {
+                            if let Some(v) = cur {
+                                d.insert_temp(ghost_log_id, v);
+                            } else {
+                                d.remove_temp::<u32>(ghost_log_id);
+                            }
+                        });
                     }
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -996,6 +996,18 @@ impl BetaConfig {
             self.osc_pane_title = other.osc_pane_title;
         }
     }
+
+    /// Resolved unfocused-pane opacity.
+    /// `ghost_opacity` set → use it; `ghost = true` → 0.9; else → None (no dimming).
+    pub fn unfocused_opacity(&self) -> Option<f32> {
+        if let Some(opacity) = self.ghost_opacity {
+            Some(opacity)
+        } else if self.ghost.unwrap_or(false) {
+            Some(0.9)
+        } else {
+            None
+        }
+    }
 }
 
 impl LogConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ const KNOWN_THEME: &[&str] = &[
     "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
     "bright_foreground",
 ];
-const KNOWN_BETA: &[&str] = &["crt", "ghost", "osc_pane_title"];
+const KNOWN_BETA: &[&str] = &["crt", "ghost", "ghost_opacity", "osc_pane_title"];
 const KNOWN_LOG: &[&str] = &["level", "retention_days"];
 const KNOWN_NOTIFICATIONS: &[&str] = &["enabled", "focus_mode", "interrupt_threshold"];
 const KNOWN_AI: &[&str] = &["backend", "openrouter", "ollama"];
@@ -415,6 +415,9 @@ impl LogConfig {
 pub struct BetaConfig {
     pub crt: Option<bool>,
     pub ghost: Option<bool>,
+    /// Opacity for unfocused panes when ghost is enabled. Range 0.0–1.0; default 0.9.
+    /// Setting this implies ghost = true regardless of the `ghost` flag.
+    pub ghost_opacity: Option<f32>,
     pub osc_pane_title: Option<bool>,
 }
 
@@ -686,6 +689,7 @@ confirm_close = false
 [beta]
 # crt           = false    # Retro CRT scanlines + green phosphor tint
 # ghost         = false    # Unfocused panes render at reduced opacity
+# ghost_opacity = 0.9     # Opacity for unfocused panes (0.0–1.0). Setting this enables ghost automatically.
 # osc_pane_title = false   # Apply OSC 0/1/2 title sequences from running processes as pane names
 
 # ── Logging ────────────────────────────────────────────────────
@@ -984,6 +988,9 @@ impl BetaConfig {
         }
         if other.ghost.is_some() {
             self.ghost = other.ghost;
+        }
+        if other.ghost_opacity.is_some() {
+            self.ghost_opacity = other.ghost_opacity;
         }
         if other.osc_pane_title.is_some() {
             self.osc_pane_title = other.osc_pane_title;

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -54,6 +54,9 @@ pub struct PlexiBehavior<'a> {
     /// Used by `terminal_pane::render` to flag terminal panes whose CWD has
     /// drifted outside the workspace tree. See issue #308 Phase 1.
     pub workspace_root: Option<PathBuf>,
+    /// Opacity applied to unfocused panes when ghost mode is active.
+    /// `None` = no dimming. Values below 1.0 dim all non-focused panes.
+    pub unfocused_opacity: Option<f32>,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -80,6 +83,14 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         }
 
         let is_focused = self.focused_tile == Some(tile_id);
+
+        if !is_focused {
+            if let Some(opacity) = self.unfocused_opacity {
+                if opacity < 1.0 {
+                    ui.set_opacity(opacity);
+                }
+            }
+        }
 
         // Drop target: the zoomed overlay owns drops when a pane is zoomed,
         // so this path only runs when zoomed_pane.is_none() (guaranteed above).


### PR DESCRIPTION
## Summary

- Adds `ghost_opacity: Option<f32>` to `BetaConfig` alongside the existing `ghost` toggle
- Wires `ghost_opacity` through `BetaConfig::overlay` for project-level config merging
- Adds `unfocused_opacity: Option<f32>` to `PlexiBehavior` and applies `ui.set_opacity()` to non-focused panes in `pane_ui`
- Computes `unfocused_opacity` at render time: `ghost_opacity` set → use it; `ghost = true` (no explicit opacity) → 0.9; else → None (no dimming)
- Edge-triggered `log::info!("[ghost] ...")` fires once per config change, not per frame

## Done When

- `ghost = true` → unfocused panes render at ~90% opacity
- `ghost_opacity = 0.7` → unfocused panes render at 70% (implies ghost)
- `ghost` absent or `false` → all panes at full opacity (existing behavior)

## Test plan

- [ ] Add `ghost = true` to `[beta]` in `~/.plexi-pr-<N>/config.toml`, open multiple panes, confirm non-focused panes dim visibly
- [ ] Add `ghost_opacity = 0.7` (no `ghost = true`), confirm stronger dimming
- [ ] Remove both keys, confirm panes return to full opacity

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)