### PR TITLE
fix(app-init): auto-open passes workspace cwd so new app is found (#1358)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1207,10 +1207,10 @@ impl PlexiApp {
                         }
                     }
 
+                    let cwd_override: Option<std::path::PathBuf> = cwd.as_deref().map(std::path::PathBuf::from);
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
                         let initial_cmd = cmd_from_args(args);
-                        let cwd_override: Option<std::path::PathBuf> = cwd.as_deref().map(std::path::PathBuf::from);
                         if layout_str == "new_window" {
                             // Create a new spatial grid window to the right of the
                             // current context row instead of splitting the active pane.
@@ -1232,7 +1232,7 @@ impl PlexiApp {
                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, cwd_override);
                         }
                     } else {
-                        self.launch_app_by_id_with_layout(type_id, layout.clone(), args);
+                        self.launch_app_by_id_with_layout(type_id, layout.clone(), args, cwd_override);
                     }
 
                     // Restore original focus when no_focus is requested or from_pane_id overrode it.
@@ -1464,7 +1464,7 @@ impl PlexiApp {
                 let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, cwd_override);
             } else {
-                self.launch_app_by_id_with_layout(&type_id, layout, &args);
+                self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
             }
             if no_focus {
                 log::info!("spawn-queue: no_focus=true, retaining focus on pane_id={original_focused:?}");
@@ -1890,7 +1890,7 @@ impl eframe::App for PlexiApp {
                         });
 
                     let new_pane_id = self.host.next_pane_id();
-                    self.launch_app_by_id_with_layout(&type_id, layout, &args);
+                    self.launch_app_by_id_with_layout(&type_id, layout, &args, None);
 
                     // Confirm back to the requesting app.
                     if let Some(req_pane_id) = requesting_pane_id {
@@ -1992,7 +1992,7 @@ impl eframe::App for PlexiApp {
                         // CLI terminal uses the ephemeral flag exclusively — cmd alone does not close.
                         self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some(), None);
                     } else {
-                        self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args);
+                        self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args, None);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
                     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -532,8 +532,9 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                         },
                         Err(_) => None,
                     };
-                    log::info!("app_init: auto-opening '{name}' via socket from_pane_id={from_pane_id:?}");
-                    let exit_code = crate::cli::open_cli(name, &[], None, from_pane_id);
+                    let workspace_cwd = workspace_root.as_ref().and_then(|p| p.to_str()).map(|s| s.to_string());
+                    log::info!("app_init: auto-opening '{name}' via socket from_pane_id={from_pane_id:?} workspace_cwd={workspace_cwd:?}");
+                    let exit_code = crate::cli::open_cli(name, &[], None, from_pane_id, workspace_cwd.as_deref());
                     if exit_code != 0 {
                         eprintln!("warning: app created but could not auto-open '{name}' (exit {exit_code}) — run: plexi open {name}");
                     }
@@ -2553,7 +2554,7 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize) -> i32 {
 /// which the running host drains each second.
 ///
 /// Returns 0 on success, 1 on error.
-pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
+pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     if type_id == "terminal" {
         log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
         eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
@@ -2577,7 +2578,10 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
         if let Some(pid) = from_pane_id {
             payload["from_pane_id"] = serde_json::Value::Number(pid.into());
         }
-        log::info!("open:cli: sending via socket from_pane_id={from_pane_id:?} response_file={response_file:?}");
+        if let Some(cwd) = cwd {
+            payload["cwd"] = serde_json::Value::String(cwd.to_string());
+        }
+        log::info!("open:cli: sending via socket from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
@@ -2629,17 +2633,20 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let queue_payload = serde_json::json!({
+    let mut queue_payload = serde_json::json!({
         "type_id": type_id,
         "args": args,
         "layout": layout,
     });
+    if let Some(cwd) = cwd {
+        queue_payload["cwd"] = serde_json::Value::String(cwd.to_string());
+    }
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
-    log::info!("cli: open queued: type_id={type_id}");
+    log::info!("cli: open queued: type_id={type_id} cwd={cwd:?}");
     println!("queued: open {type_id}");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,10 +405,10 @@ fn main() -> eframe::Result {
                             std::process::exit(2);
                         }
                         if let Some(tid) = type_id {
-                            std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id));
+                            std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id, None));
                         } else if !mcp.is_empty() {
                             log::info!("open:mcp: launching mcp-renderer with command {:?}", mcp);
-                            std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id));
+                            std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id, None));
                         } else {
                             let binary = cli_flag.unwrap();
                             log::info!("open:cli-flag: running --help parser for `{binary}`");
@@ -423,7 +423,7 @@ fn main() -> eframe::Result {
                                     }
                                     let path = tmp.to_string_lossy().into_owned();
                                     log::info!("open:cli-flag: launching descriptor-renderer with descriptor at {path}");
-                                    std::process::exit(cli::open_cli("descriptor-renderer", &[path], layout.as_deref(), from_pane_id));
+                                    std::process::exit(cli::open_cli("descriptor-renderer", &[path], layout.as_deref(), from_pane_id, None));
                                 }
                                 Err(e) => {
                                     eprintln!("error: could not parse --help output for `{binary}`: {e}");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -502,7 +502,7 @@ impl PlexiApp {
     /// Launch an installed app by id in the focused pane.
     /// Respects the `layout_hint` from the app's manifest.toml.
     pub(crate) fn launch_app_by_id(&mut self, id: &str) {
-        self.launch_app_by_id_with_layout(id, None, &[]);
+        self.launch_app_by_id_with_layout(id, None, &[], None);
     }
 
     /// Launch an installed app with an explicit layout and args override.
@@ -515,6 +515,7 @@ impl PlexiApp {
         id: &str,
         layout: Option<String>,
         args: &[String],
+        cwd_override: Option<PathBuf>,
     ) {
         // "terminal" is a builtin pane type, not in the app registry.
         // Reached via SDK AppCommand::SpawnApp("terminal", ...) and legacy paths.
@@ -530,9 +531,13 @@ impl PlexiApp {
             return;
         }
 
-        let cwd = self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+        let cwd_explicit = cwd_override.is_some();
+        let cwd = cwd_override
+            .or_else(|| self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
-        log::info!("launch_app_by_id_with_layout: id={id} cwd={cwd:?} context_root={:?}", self.router.active().root);
+        log::info!("launch_app_by_id_with_layout: id={id} cwd={cwd:?} cwd_source={} context_root={:?}",
+            if cwd_explicit { "explicit" } else { "resolved" },
+            self.router.active().root);
 
         // Re-attach a parked background app if one is waiting
         if let Some((_park_context_id, mut parked)) = self.background_apps.remove(id) {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -201,6 +201,7 @@ impl PlexiApp {
                     &manifest_id,
                     Some(layout.to_string()),
                     &[],
+                    None,
                 );
             }
         }


### PR DESCRIPTION
## What

`plexi app init <name>` now correctly auto-opens the new app pane when the terminal's current context differs from the host's active workspace.

## Root Cause

Two-site bug:

1. `open_cli` had no `cwd` parameter — the spawn_pane payload never carried a `cwd` field.
2. `launch_app_by_id_with_layout` always derived its registry-rescan base from `resolve_new_pane_cwd` (the host's active context), ignoring any `cwd` from the socket payload.

## Fix

- `open_cli` gains `cwd: Option<&str>`, included in both socket and spawn-queue payloads.
- `app_init` passes `workspace_root` as cwd.
- `launch_app_by_id_with_layout` gains `cwd_override: Option<PathBuf>`, using it instead of `resolve_new_pane_cwd` when provided.
- SpawnPane and spawn-queue handlers forward `cwd_override` for non-terminal panes.

## Done When

`plexi app init <name>` in a terminal whose context differs from the active Plexi context auto-opens the new app pane next to the spawning terminal.

## Test Plan

- [ ] Run `plexi app init <name>` from a terminal pane whose workspace differs from Plexi's active context — new app pane should appear
- [ ] Existing `plexi open <app>` behavior unchanged
- [ ] 481 host tests pass; 2 pre-existing failures unrelated