### PR TITLE
fix(infra): atomic SDK swap in install.sh to prevent TOCTOU crash (#1324)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,8 +115,9 @@ if [[ ! "$channel" =~ ^pr- ]]; then
 fi
 
 mkdir -p "$profile_dir/sdk" "$profile_dir/apps"
+cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk.tmp"
 rm -rf "$profile_dir/sdk/plexi_sdk.py" "$profile_dir/sdk/plexi_sdk"
-cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk"
+mv "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk"
 find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
 rsync -a --delete examples/ "$profile_dir/apps/"
 find "$profile_dir/apps" -maxdepth 2 -name 'plexi_sdk.py' -delete 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,9 +115,11 @@ if [[ ! "$channel" =~ ^pr- ]]; then
 fi
 
 mkdir -p "$profile_dir/sdk" "$profile_dir/apps"
+rm -rf "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk.old"
 cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk.tmp"
-rm -rf "$profile_dir/sdk/plexi_sdk.py" "$profile_dir/sdk/plexi_sdk"
+mv "$profile_dir/sdk/plexi_sdk" "$profile_dir/sdk/plexi_sdk.old" 2>/dev/null || true
 mv "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk"
+rm -rf "$profile_dir/sdk/plexi_sdk.old" "$profile_dir/sdk/plexi_sdk.py"
 find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
 rsync -a --delete examples/ "$profile_dir/apps/"
 find "$profile_dir/apps" -maxdepth 2 -name 'plexi_sdk.py' -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

Replace the non-atomic delete-then-copy SDK installation with a copy-to-tmp, delete-old, atomic-mv pattern.

**Before:**
```bash
rm -rf "$profile_dir/sdk/plexi_sdk.py" "$profile_dir/sdk/plexi_sdk"
cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk"
```

**After:**
```bash
cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk.tmp"
rm -rf "$profile_dir/sdk/plexi_sdk.py" "$profile_dir/sdk/plexi_sdk"
mv "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk"
```

`mv` on the same filesystem is atomic on macOS — any concurrent app import sees either the old SDK fully or the new SDK fully, never a missing-module gap.

Closes #1324

## Test plan
- [ ] Verify diff: `cp → tmp`, `rm`, `mv` — three lines replacing two, no other changes
- [ ] Confirm no `ModuleNotFoundError` in plexi log after running `just install` while apps are active