### PR TITLE
feat(host): capability pre-flight check — error tile when app lacks required config (#1345)

### DIFF
--- a/src/app_permissions.rs
+++ b/src/app_permissions.rs
@@ -116,6 +116,24 @@ impl Capability {
             "panes.spawn",
         ]
     }
+
+    /// Returns a human-readable description of why this capability cannot be
+    /// satisfied by the current config, or `None` if it is satisfiable.
+    /// Called before spawning any app process — if any declared capability
+    /// returns `Some(...)`, the host shows an error tile instead of launching.
+    pub fn config_missing_reason(&self, config: &crate::config::PlexiConfig) -> Option<String> {
+        match self {
+            Capability::AiQuery => {
+                if config.ai.is_none() {
+                    Some("ai.query requires [ai] config".to_string())
+                } else {
+                    None
+                }
+            }
+            // All other capabilities are config-independent.
+            _ => None,
+        }
+    }
 }
 
 /// Error produced when a manifest or decision log names a capability that is not

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -623,6 +623,29 @@ impl AppRegistry {
             .unwrap_or(crate::app_protocol::NotifyScope::Window)
     }
 
+    /// Check whether an app's declared capabilities are satisfiable by the
+    /// current config. Returns human-readable missing-capability descriptions.
+    /// Empty = all satisfied. Does not spawn the process.
+    pub fn check_config_capabilities(
+        &self,
+        id: &str,
+        config: &crate::config::PlexiConfig,
+    ) -> Vec<String> {
+        let Some(installed) = self.apps.get(id) else {
+            return vec![];
+        };
+        let mut missing = Vec::new();
+        for cap_str in &installed.manifest.capabilities.capabilities {
+            let Ok(cap) = crate::app_permissions::Capability::try_from(cap_str.as_str()) else {
+                continue;
+            };
+            if let Some(reason) = cap.config_missing_reason(config) {
+                missing.push(reason);
+            }
+        }
+        missing
+    }
+
     /// Launch an app process for the given id.
     pub fn launch_process(&self, id: &str, cwd: &PathBuf, args: &[String]) -> Option<ProcessApp> {
         let installed = self.apps.get(id)?;

--- a/src/launch_failed.rs
+++ b/src/launch_failed.rs
@@ -1,0 +1,55 @@
+//! Built-in error tile rendered when a capability pre-flight check fails.
+
+use crate::app_trait::{App, AppCommand, AppRenderContext};
+use crate::style;
+use egui::RichText;
+
+/// Rendered as a `Pane::App(AppRuntime::Builtin(...))` when the host detects
+/// that an app's declared capabilities cannot be satisfied by the current
+/// config. No Python process is ever spawned for this pane.
+pub struct LaunchFailedApp {
+    pub app_id: String,
+    pub missing: Vec<String>,
+}
+
+impl App for LaunchFailedApp {
+    fn type_id(&self) -> &'static str {
+        "launch_failed"
+    }
+
+    fn display_name(&self) -> String {
+        format!("Cannot launch {}", self.app_id)
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+        ui.vertical_centered(|ui| {
+            ui.add_space(style::SPACE_XL * 2.0);
+            ui.label(
+                RichText::new(format!("Cannot launch {}", self.app_id))
+                    .size(style::TEXT_BODY)
+                    .color(colors.text_primary)
+                    .strong(),
+            );
+            ui.add_space(style::SPACE_MD);
+            for reason in &self.missing {
+                ui.label(
+                    RichText::new(format!("Missing: {reason}"))
+                        .size(style::TEXT_CAPTION)
+                        .color(colors.text_dim),
+                );
+            }
+            ui.add_space(style::SPACE_SM);
+            ui.label(
+                RichText::new("plexi config edit")
+                    .size(style::TEXT_CAPTION)
+                    .color(colors.text_dim)
+                    .monospace(),
+            );
+        });
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<AppCommand> {
+        vec![]
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod file_browser;
 mod host;
 mod input_intent;
 mod keys;
+mod launch_failed;
 mod logging;
 #[cfg(target_os = "macos")]
 mod finder_service;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -203,7 +203,7 @@ impl PlexiApp {
         workspace_root: std::path::PathBuf,
     ) {
         let active = self.active_window;
-        let share = crate::host::command::ShareRatio::new(1.0, 1.0).expect("1:1 is valid");
+        let share = Self::share_ratio_from_fraction(app_id, self.registry.share_for(app_id));
         let (new_id, share, vertical, new_pane_first) =
             self.open_pane_layout(app_id, None, hint, share);
         self.windows[active].panes.insert(
@@ -599,43 +599,27 @@ impl PlexiApp {
             return;
         }
 
-        // Pre-flight: check config-level capability requirements before spawning.
-        {
-            let missing = self.registry.check_config_capabilities(id, &self.config);
-            if !missing.is_empty() {
-                log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
-                let fail_hint = layout
-                    .clone()
-                    .or_else(|| self.registry.layout_hint_for(id))
-                    .or_else(|| Some("overlay".to_string()));
-                self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
-                return;
-            }
-        }
-
-        // Try registry first; if it returns None, rescan from disk (supports
-        // apps created mid-session via `plexi app init`) then fall through to Tier 4.
-        let registry_process = self.registry.launch_process(id, &cwd, args);
-        let registry_process = if registry_process.is_none() {
+        // Ensure the registry is up-to-date: rescan if the app was added mid-session
+        // via `plexi app init` and wasn't present at startup.
+        if self.registry.get(id).is_none() {
             log::info!("launch_app_by_id: '{id}' not in startup registry — rescanning from disk");
             self.registry = crate::app_registry::AppRegistry::load(&cwd);
-            // Pre-flight check for newly discovered (rescanned) app.
-            {
-                let missing_after_rescan = self.registry.check_config_capabilities(id, &self.config);
-                if !missing_after_rescan.is_empty() {
-                    log::warn!("pre-flight: '{id}' cannot launch — missing: {missing_after_rescan:?}");
-                    let fail_hint = layout
-                        .clone()
-                        .or_else(|| self.registry.layout_hint_for(id))
-                        .or_else(|| Some("overlay".to_string()));
-                    self.open_launch_failed_pane(id, fail_hint.as_deref(), missing_after_rescan, cwd);
-                    return;
-                }
-            }
-            self.registry.launch_process(id, &cwd, args)
-        } else {
-            registry_process
-        };
+        }
+
+        // Pre-flight: check config-level capability requirements before spawning.
+        let missing = self.registry.check_config_capabilities(id, &self.config);
+        if !missing.is_empty() {
+            log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
+            let fail_hint = layout
+                .clone()
+                .or_else(|| self.registry.layout_hint_for(id))
+                .or_else(|| Some("overlay".to_string()));
+            self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
+            return;
+        }
+
+        // Try registry first; if it returns None, fall through to Tier 4.
+        let registry_process = self.registry.launch_process(id, &cwd, args);
         // Query group/hint after any registry reload so metadata reflects the
         // actual registry that found the app.
         let group = self.registry.group_for(id);

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -192,6 +192,51 @@ impl PlexiApp {
         let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first);
     }
 
+    /// Open a built-in error tile pane when a capability pre-flight check fails.
+    /// Mirrors `open_process_app_pane` but uses `AppRuntime::Builtin` — no
+    /// Python process is spawned.
+    fn open_launch_failed_pane(
+        &mut self,
+        app_id: &str,
+        hint: Option<&str>,
+        missing: Vec<String>,
+        workspace_root: std::path::PathBuf,
+    ) {
+        let active = self.active_window;
+        let share = crate::host::command::ShareRatio::new(1.0, 1.0).expect("1:1 is valid");
+        let (new_id, share, vertical, new_pane_first) =
+            self.open_pane_layout(app_id, None, hint, share);
+        self.windows[active].panes.insert(
+            new_id,
+            crate::pane::Pane::App(Box::new(crate::pane::AppPane {
+                id: new_id,
+                runtime: crate::pane::AppRuntime::Builtin(
+                    Box::new(crate::launch_failed::LaunchFailedApp {
+                        app_id: app_id.to_string(),
+                        missing,
+                    }),
+                ),
+                workspace_root,
+                permissions: crate::app_permissions::AppPermissions::default(),
+                manifest_id: app_id.to_string(),
+                name: format!("Cannot launch {app_id}"),
+                pane_group: None,
+                linked_pane_id: None,
+                overlay_replaced: None,
+            })),
+        );
+        if self.windows[active].focused_pane.is_none() {
+            let ctx = &mut self.windows[active];
+            let root_tile = ctx.tree.tiles.insert_pane(new_id);
+            ctx.tree.root = Some(root_tile);
+            ctx.focused_pane = Some(root_tile);
+            log::info!("app::{app_id}: launch-failed tile inserted as root pane {new_id}");
+            return;
+        }
+        let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first);
+        log::info!("app::{app_id}: launch-failed tile inserted as pane {new_id}");
+    }
+
     /// Reload the `ProcessApp` inside the AppPane at `pane_id` (#83).
     ///
     /// Sends `Shutdown` to the existing subprocess (via `Drop` on the old
@@ -554,12 +599,39 @@ impl PlexiApp {
             return;
         }
 
+        // Pre-flight: check config-level capability requirements before spawning.
+        {
+            let missing = self.registry.check_config_capabilities(id, &self.config);
+            if !missing.is_empty() {
+                log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
+                let fail_hint = layout
+                    .clone()
+                    .or_else(|| self.registry.layout_hint_for(id))
+                    .or_else(|| Some("overlay".to_string()));
+                self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
+                return;
+            }
+        }
+
         // Try registry first; if it returns None, rescan from disk (supports
         // apps created mid-session via `plexi app init`) then fall through to Tier 4.
         let registry_process = self.registry.launch_process(id, &cwd, args);
         let registry_process = if registry_process.is_none() {
             log::info!("launch_app_by_id: '{id}' not in startup registry — rescanning from disk");
             self.registry = crate::app_registry::AppRegistry::load(&cwd);
+            // Pre-flight check for newly discovered (rescanned) app.
+            {
+                let missing_after_rescan = self.registry.check_config_capabilities(id, &self.config);
+                if !missing_after_rescan.is_empty() {
+                    log::warn!("pre-flight: '{id}' cannot launch — missing: {missing_after_rescan:?}");
+                    let fail_hint = layout
+                        .clone()
+                        .or_else(|| self.registry.layout_hint_for(id))
+                        .or_else(|| Some("overlay".to_string()));
+                    self.open_launch_failed_pane(id, fail_hint.as_deref(), missing_after_rescan, cwd);
+                    return;
+                }
+            }
             self.registry.launch_process(id, &cwd, args)
         } else {
             registry_process


### PR DESCRIPTION
## Summary

- Adds pre-flight config validation before spawning any app process: `Capability::config_missing_reason` + `AppRegistry::check_config_capabilities`
- When capabilities cannot be satisfied (e.g. `ai.query` with no `[ai]` config), renders a built-in `LaunchFailedApp` error tile in the pane instead of launching Python
- Logs at `warn` level: `pre-flight: '{id}' cannot launch — missing: ["ai.query requires [ai] config"]`
- Check runs in both initial registry lookup and post-rescan paths — no process is ever spawned for unsatisfied capabilities

## Done When

1. `plexi app open ai-test` with no `[ai]` config → error tile immediately, no Python spawned, warn log
2. `plexi app open ai-test` with valid `[ai]` config → launches normally (regression: none)
3. Compiler clean, `cargo build` green

## Test plan

- [ ] Install PR build: `just pr-install <N>` from feature worktree
- [ ] Open an app that declares `ai.query` capability with no `[ai]` section in config.toml → error tile visible immediately
- [ ] Add `[ai]` section to config.toml → same app launches normally
- [ ] Check `~/.plexi-pr-<N>/plexi.log` for `pre-flight:` warn line

🤖 Generated with [Claude Code](https://claude.com/claude-code)