### PR TITLE
feat(cli): channel-aware shell completions (#1316)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,37 +81,44 @@ fi
 # Called after the binary symlink is in place at $bin_dest.
 install_completions() {
   local binary="$1"
+  local binary_name
+  binary_name="$(basename "$binary")"
 
   # zsh: prefer Homebrew site-functions (already on fpath), else ~/.zfunc/
   if command -v brew &>/dev/null; then
     local brew_zsh_dir
     brew_zsh_dir="$(brew --prefix)/share/zsh/site-functions"
     if [[ -d "$brew_zsh_dir" ]]; then
-      "$binary" completions zsh > "$brew_zsh_dir/_plexi"
-      echo "Completions (zsh): $brew_zsh_dir/_plexi"
+      "$binary" completions zsh > "$brew_zsh_dir/_${binary_name}"
+      echo "Completions (zsh): $brew_zsh_dir/_${binary_name}"
     fi
   else
     mkdir -p "$HOME/.zfunc"
-    "$binary" completions zsh > "$HOME/.zfunc/_plexi"
-    echo "Completions (zsh): ~/.zfunc/_plexi"
+    "$binary" completions zsh > "$HOME/.zfunc/_${binary_name}"
+    echo "Completions (zsh): ~/.zfunc/_${binary_name}"
     echo "  note: add 'fpath=(~/.zfunc \$fpath)' to ~/.zshrc if not already present"
   fi
 
   # bash: ~/.bash_completion.d/
   mkdir -p "$HOME/.bash_completion.d"
-  "$binary" completions bash > "$HOME/.bash_completion.d/plexi"
-  echo "Completions (bash): ~/.bash_completion.d/plexi"
+  "$binary" completions bash > "$HOME/.bash_completion.d/${binary_name}"
+  echo "Completions (bash): ~/.bash_completion.d/${binary_name}"
 
   # fish: only if fish is installed
   if [[ -d "$HOME/.config/fish" ]]; then
     mkdir -p "$HOME/.config/fish/completions"
-    "$binary" completions fish > "$HOME/.config/fish/completions/plexi.fish"
-    echo "Completions (fish): ~/.config/fish/completions/plexi.fish"
+    "$binary" completions fish > "$HOME/.config/fish/completions/${binary_name}.fish"
+    echo "Completions (fish): ~/.config/fish/completions/${binary_name}.fish"
   fi
 }
 
 if [[ ! "$channel" =~ ^pr- ]]; then
   install_completions "$bin_dest"
+  # For non-stable channels, also install bare `plexi` completions so the bare
+  # symlink (pointing to this channel's binary) gets its own completion entry.
+  if [[ "$channel" != "stable" ]]; then
+    install_completions /usr/local/bin/plexi
+  fi
 fi
 
 mkdir -p "$profile_dir/sdk" "$profile_dir/apps"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3757,10 +3757,11 @@ pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
 }
 
 fn zsh_completion(binary: &str) -> String {
+    let fn_name = binary.replace('-', "_");
     ZSH_COMPLETION
         .replace("#compdef plexi", &format!("#compdef {binary}"))
-        .replace("\n_plexi()", &format!("\n_{binary}()"))
-        .replace("\n_plexi \"$@\"", &format!("\n_{binary} \"$@\""))
+        .replace("\n_plexi()", &format!("\n_{fn_name}()"))
+        .replace("\n_plexi \"$@\"", &format!("\n_{fn_name} \"$@\""))
 }
 
 fn bash_completion(binary: &str) -> String {
@@ -3773,7 +3774,7 @@ fn bash_completion(binary: &str) -> String {
 }
 
 fn fish_completion(binary: &str) -> String {
-    FISH_COMPLETION.replace("-c plexi ", &format!("-c {binary} "))
+    FISH_COMPLETION.replace("-c plexi", &format!("-c {binary}"))
 }
 
 const ZSH_COMPLETION: &str = r#"#compdef plexi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3744,16 +3744,36 @@ pub fn config_check() -> i32 {
     if has_errors { 1 } else { 0 }
 }
 
-pub fn completions_cli(shell: &str) -> i32 {
+pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     match shell {
-        "zsh" => { print!("{}", ZSH_COMPLETION); 0 }
-        "bash" => { print!("{}", BASH_COMPLETION); 0 }
-        "fish" => { print!("{}", FISH_COMPLETION); 0 }
+        "zsh" => { print!("{}", zsh_completion(binary_name)); 0 }
+        "bash" => { print!("{}", bash_completion(binary_name)); 0 }
+        "fish" => { print!("{}", fish_completion(binary_name)); 0 }
         other => {
             eprintln!("error: unsupported shell {other:?} — supported shells: zsh, bash, fish");
             1
         }
     }
+}
+
+fn zsh_completion(binary: &str) -> String {
+    ZSH_COMPLETION
+        .replace("#compdef plexi", &format!("#compdef {binary}"))
+        .replace("\n_plexi()", &format!("\n_{binary}()"))
+        .replace("\n_plexi \"$@\"", &format!("\n_{binary} \"$@\""))
+}
+
+fn bash_completion(binary: &str) -> String {
+    let fn_name = format!("_{}_completions", binary.replace('-', "_"));
+    let with_fn = BASH_COMPLETION.replace("_plexi_completions", &fn_name);
+    with_fn.replace(
+        &format!("complete -F {fn_name} plexi"),
+        &format!("complete -F {fn_name} {binary}"),
+    )
+}
+
+fn fish_completion(binary: &str) -> String {
+    FISH_COMPLETION.replace("-c plexi ", &format!("-c {binary} "))
 }
 
 const ZSH_COMPLETION: &str = r#"#compdef plexi

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,7 +460,14 @@ fn main() -> eframe::Result {
                     },
                     Commands::Completions { shell } => {
                         let s = shell.as_deref().unwrap_or("zsh");
-                        std::process::exit(cli::completions_cli(s));
+                        let binary_name = std::env::args()
+                            .next()
+                            .as_deref()
+                            .and_then(|p| std::path::Path::new(p).file_name())
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("plexi")
+                            .to_string();
+                        std::process::exit(cli::completions_cli(s, &binary_name));
                     }
                     Commands::Config { cmd: config_cmd } => match config_cmd {
                         ConfigCmd::Check => {


### PR DESCRIPTION
## Summary

- `plexi-alpha completions zsh` now outputs `#compdef plexi-alpha` / `_plexi-alpha()` instead of hardcoded `plexi`
- Binary name derived from `argv[0]` basename at runtime for any channel
- `install.sh` writes channel-specific filenames and also installs bare `_plexi` completions via the symlink for non-stable channels

## Done When

1. `plexi-alpha completions zsh` outputs `#compdef plexi-alpha` and `_plexi-alpha()`
2. `plexi completions zsh` still outputs `#compdef plexi` (stable unchanged)
3. `just install` from alpha produces both `_plexi` and `_plexi-alpha` in site-functions
4. After `exec zsh`, `plexi-alpha <TAB>` shows subcommand completions
5. Same for bash and fish

## Test plan

- [ ] Run `just install` from alpha worktree; confirm both `_plexi` and `_plexi-alpha` appear in site-functions
- [ ] `exec zsh` then `plexi-alpha <TAB>` — confirm subcommand list appears
- [ ] `complete -p plexi-alpha` in bash — confirm completion is registered
- [ ] Verify `plexi completions zsh | head -3` still shows `#compdef plexi`

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)