### PR TITLE
fix(website): remove MIT wording, sync version, fix blog date, first-person voice (#1372)

### DIFF
--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -6,7 +6,7 @@
       <h1>The last app you'll ever need.</h1>
       <p class="tagline">Your terminal, your agents, your apps — all in one window. Build tools with AI, run them side by side, and own everything you make.</p>
       <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
-      <div class="meta-under">macOS · open source · MIT</div>
+      <div class="meta-under">macOS · open source</div>
     </div>
   </div>
 

--- a/website/src/components/Story.astro
+++ b/website/src/components/Story.astro
@@ -26,7 +26,7 @@
       <h2>One home that stretches.</h2>
       <p>Three projects. Twelve panes. Your agents, your apps, your terminal — side by side. No context switching. No window management. Everything you build lives in one place, and everything you make is yours.</p>
       <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
-      <div class="meta-under">macOS · open source · MIT</div>
+      <div class="meta-under">macOS · open source</div>
     </div>
 
   </div>

--- a/website/src/lib/version.ts
+++ b/website/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = '3.6.19';
+export const CURRENT_VERSION = '0.0.395';

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -20,8 +20,7 @@ const fmt = (d: Date) =>
 
       {posts.length === 0 ? (
         <div class="coming-soon">
-          <div class="coming-label">First post</div>
-          <div class="coming-date">Sunday, May 3</div>
+          <div class="coming-label">First post coming soon</div>
           <p class="coming-sub">drop your email below and i'll send you a heads up when it's live.</p>
         </div>
       ) : (
@@ -64,13 +63,6 @@ const fmt = (d: Date) =>
     color: var(--fg-4);
     margin-bottom: 12px;
   }
-  .coming-date {
-    font-size: 48px;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    color: var(--fg);
-    margin-bottom: 20px;
-  }
   .coming-sub {
     font-size: 14px;
     color: var(--fg-3);
@@ -99,7 +91,6 @@ const fmt = (d: Date) =>
 
   @media (max-width: 640px) {
     .section-head h2 { font-size: 28px; }
-    .coming-date { font-size: 36px; }
     .post-row { grid-template-columns: 1fr; gap: 8px; }
     .date { padding-top: 0; }
   }

--- a/website/src/pages/support.astro
+++ b/website/src/pages/support.astro
@@ -10,11 +10,11 @@ const SPONSOR_URL = 'https://buymeacoffee.com/ianjamesbu8';
   <section class="support-page">
     <div class="wrap">
       <h1>Support the project</h1>
-      <p class="lead">Plexi is free and open source. No venture capital, no ads, no data harvesting. Just the work.</p>
+      <p class="lead">Plexi is free, open source, and community-funded. No venture capital, no ads, no data harvesting. Just the work.</p>
 
       <div class="vision">
         <h2>The vision</h2>
-        <p>AI is changing how software gets built. But right now, your tools are scattered — terminals, editors, agents, dashboards — all in separate windows fighting for your attention.</p>
+        <p>AI is changing how you build software. But right now, your tools are scattered — terminals, editors, agents, dashboards — all in separate windows fighting for your attention.</p>
         <p>Plexi puts everything in one place. Your terminal, your apps, and the AI agents that help you build them — running side by side in a single workspace. You own what you make. You keep your data. And every tool you build works with every agent you choose.</p>
         <p>I believe the best AI tools won't be locked inside someone else's platform. They'll be yours — built, trained, and shared by the people who use them.</p>
       </div>

--- a/website/src/pages/support.astro
+++ b/website/src/pages/support.astro
@@ -5,24 +5,24 @@ const SPONSOR_URL = 'https://buymeacoffee.com/ianjamesbu8';
 ---
 <Layout
   title="Support Plexi"
-  description="Plexi is free, open source, and community-funded. Here's where we're headed and how you can help."
+  description="Plexi is free, open source, and community-funded. Here's where I'm headed and how you can help."
 >
   <section class="support-page">
     <div class="wrap">
       <h1>Support the project</h1>
-      <p class="lead">Plexi is free, open source, and MIT licensed. No venture capital, no ads, no data harvesting. Just the work.</p>
+      <p class="lead">Plexi is free and open source. No venture capital, no ads, no data harvesting. Just the work.</p>
 
       <div class="vision">
         <h2>The vision</h2>
-        <p>AI is changing how we build software. But right now, your tools are scattered — terminals, editors, agents, dashboards — all in separate windows fighting for your attention.</p>
+        <p>AI is changing how software gets built. But right now, your tools are scattered — terminals, editors, agents, dashboards — all in separate windows fighting for your attention.</p>
         <p>Plexi puts everything in one place. Your terminal, your apps, and the AI agents that help you build them — running side by side in a single workspace. You own what you make. You keep your data. And every tool you build works with every agent you choose.</p>
-        <p>We believe the best AI tools won't be locked inside someone else's platform. They'll be yours — built, trained, and shared by a community of people who care about doing good work.</p>
+        <p>I believe the best AI tools won't be locked inside someone else's platform. They'll be yours — built, trained, and shared by the people who use them.</p>
       </div>
 
       <div class="how-to-help">
         <h2>How to help</h2>
         <ul>
-          <li><strong>Use it.</strong> Download Plexi, build something, and tell us what broke.</li>
+          <li><strong>Use it.</strong> Download Plexi, build something, and tell me what broke.</li>
           <li><strong>Share it.</strong> If Plexi helped you, tell someone who'd benefit.</li>
           <li><strong>Fund it.</strong> Donations go directly to development. No tiers, no perks — just the work.</li>
         </ul>


### PR DESCRIPTION
## Summary

- Remove `· MIT` from hero and story taglines (Hero.astro, Story.astro)
- Remove "MIT licensed" from support page lead; rewrite first-person voice (`we` → `I`) throughout support.astro
- Sync `version.ts` `CURRENT_VERSION` from `3.6.19` → `0.0.395` to match Cargo.toml
- Remove stale "Sunday, May 3" date from blog coming-soon block; clean up unused `.coming-date` CSS

Closes #1372

## Done When

- No "MIT" in `website/src/` ✓
- `version.ts` matches `Cargo.toml` ✓
- Blog index has no stale date ✓
- support.astro reads as solo developer project ✓