### PR TITLE
feat(contexts): fractal sub-contexts with spatial zoom-in/zoom-out (#1374)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1797,6 +1797,15 @@ impl PlexiApp {
     /// Recursively sum notification count for a context and all its descendants.
     /// Used for the notification badge on SubContext tiles.
     pub(crate) fn context_notification_count_recursive(&self, ctx_id: u64) -> usize {
+        self.context_notification_count_recursive_limited(ctx_id, 0)
+    }
+
+    fn context_notification_count_recursive_limited(&self, ctx_id: u64, depth: u32) -> usize {
+        // Depth > 3 is impossible in valid data (creation is capped), but guard
+        // against cycles in manually-edited workspace files to prevent stack overflow.
+        if depth > 3 {
+            return 0;
+        }
         let direct = self.pending_notifications
             .iter()
             .filter(|n| {
@@ -1808,12 +1817,9 @@ impl PlexiApp {
                 && n.source_context_id == ctx_id
             })
             .count();
-        let children: Vec<u64> = self.router.iter()
+        direct + self.router.iter()
             .filter(|c| c.parent_id == Some(ctx_id))
-            .map(|c| c.context_id)
-            .collect();
-        direct + children.iter()
-            .map(|&cid| self.context_notification_count_recursive(cid))
+            .map(|c| self.context_notification_count_recursive_limited(c.context_id, depth + 1))
             .sum::<usize>()
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -566,6 +566,16 @@ impl PlexiApp {
                         }
                     }
 
+                    // SubContext panes — restore the tile reference, no process to start.
+                    if matches!(saved_pane.kind, crate::workspace::SavedPaneKind::SubContext { .. }) {
+                        if let crate::workspace::SavedPaneKind::SubContext { context_id } = &saved_pane.kind {
+                            pane_entry = Some(Pane::SubContext {
+                                pane_id: saved_pane.id,
+                                context_id: *context_id,
+                            });
+                        }
+                    }
+
                     if pane_entry.is_none() {
                         let ctx_name = ctx_name_map.get(&saved_win.context_id).cloned().unwrap_or_default();
                         let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name);
@@ -630,6 +640,8 @@ impl PlexiApp {
                         path: saved_ctx.path,
                         root: saved_ctx.root,
                         context_id: saved_ctx.context_id,
+                        parent_id: saved_ctx.parent_id,
+                        depth: saved_ctx.depth,
                     });
                 }
                 let active_ctx = ws.active_context.min(contexts.len().saturating_sub(1));
@@ -747,6 +759,8 @@ impl PlexiApp {
                     path: path.clone(),
                     root: None,
                     context_id: 1,
+                    parent_id: None,
+                    depth: 0,
                 }],
                 0,
             ),
@@ -871,6 +885,8 @@ impl PlexiApp {
                     path: path.clone(),
                     root: None,
                     context_id: 1,
+                    parent_id: None,
+                    depth: 0,
                 }],
                 0,
             ),
@@ -1101,6 +1117,9 @@ impl PlexiApp {
                                     let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
                                     ("app", a.name.clone(), cwd)
                                 }
+                                crate::pane::Pane::SubContext { context_id, .. } => {
+                                    ("sub_context", format!("sub_context:{context_id}"), None)
+                                }
                             };
                             let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
                             entries.push(serde_json::json!({
@@ -1156,6 +1175,14 @@ impl PlexiApp {
                                         "window_id": win.window_id,
                                         "cwd": a.workspace_root.to_string_lossy().as_ref(),
                                         "manifest_id": a.manifest_id.clone(),
+                                    })
+                                }
+                                crate::pane::Pane::SubContext { context_id, .. } => {
+                                    serde_json::json!({
+                                        "id": pane_id,
+                                        "type": "sub_context",
+                                        "context_id": context_id,
+                                        "focused": focused,
                                     })
                                 }
                             };
@@ -1390,16 +1417,26 @@ impl PlexiApp {
                         }
                     }
                 }
-                crate::app_protocol::AppRequest::CreateContext { root, name } => {
-                    log::info!("pane_ipc: kind=create_context root={:?} name={:?}", root, name);
-                    if let Some(r) = root {
-                        self.new_context_at_path(r.clone());
+                crate::app_protocol::AppRequest::CreateContext { root, name, parent_name } => {
+                    log::info!("pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?}", root, name, parent_name);
+                    if let Some(pname) = parent_name {
+                        let path = root.as_ref().cloned().unwrap_or_else(|| std::path::PathBuf::from("."));
+                        if let Err(e) = self.new_child_context(pname.as_str(), path) {
+                            log::warn!("pane_ipc: create_context with parent failed: {e}");
+                        } else if let Some(n) = name {
+                            let idx = self.router.len() - 1;
+                            self.router.get_mut(idx).name = n.clone();
+                        }
                     } else {
-                        self.new_context();
-                    }
-                    if let Some(n) = name {
-                        let idx = self.router.len() - 1;
-                        self.router.get_mut(idx).name = n.clone();
+                        if let Some(r) = root {
+                            self.new_context_at_path(r.clone());
+                        } else {
+                            self.new_context();
+                        }
+                        if let Some(n) = name {
+                            let idx = self.router.len() - 1;
+                            self.router.get_mut(idx).name = n.clone();
+                        }
                     }
                     self.save_workspace();
                 }
@@ -1413,6 +1450,28 @@ impl PlexiApp {
                     log::info!("pane_ipc: kind=set_context_root root={}", root.display());
                     self.set_active_context_root(root.clone());
                     self.save_workspace();
+                }
+                crate::app_protocol::AppRequest::ZoomIntoContext { context_id } => {
+                    log::info!("pane_ipc: kind=zoom_into_context context_id={context_id}");
+                    if let Some(ctx_idx) = self.router.position(|c| c.context_id == *context_id) {
+                        let current_ctx_id = self.router.active().context_id;
+                        let current_win_id = self.windows[self.active_window].window_id;
+                        let current_focused = self.windows[self.active_window].focused_pane;
+                        self.router.push_depth(current_ctx_id, current_win_id, current_focused);
+                        self.switch_workspace(ctx_idx);
+                    }
+                }
+                crate::app_protocol::AppRequest::ZoomOutOfContext => {
+                    log::info!("pane_ipc: kind=zoom_out_of_context depth={}", self.router.current_depth());
+                    if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth() {
+                        if let Some(ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
+                            self.switch_workspace(ctx_idx);
+                            if let Some(win_idx) = self.windows.iter().position(|w| w.window_id == parent_win_id) {
+                                self.active_window = win_idx;
+                                self.windows[win_idx].focused_pane = focused_tile;
+                            }
+                        }
+                    }
                 }
                 _ => {
                     log::warn!("pane_ipc: unsupported command kind, dropping");
@@ -1733,6 +1792,29 @@ impl PlexiApp {
                 && n.source_context_id == ctx_id
             })
             .count()
+    }
+
+    /// Recursively sum notification count for a context and all its descendants.
+    /// Used for the notification badge on SubContext tiles.
+    pub(crate) fn context_notification_count_recursive(&self, ctx_id: u64) -> usize {
+        let direct = self.pending_notifications
+            .iter()
+            .filter(|n| {
+                matches!(
+                    n.scope,
+                    crate::app_protocol::NotifyScope::Window
+                        | crate::app_protocol::NotifyScope::Context
+                )
+                && n.source_context_id == ctx_id
+            })
+            .count();
+        let children: Vec<u64> = self.router.iter()
+            .filter(|c| c.parent_id == Some(ctx_id))
+            .map(|c| c.context_id)
+            .collect();
+        direct + children.iter()
+            .map(|&cid| self.context_notification_count_recursive(cid))
+            .sum::<usize>()
     }
 
     /// Count of visible notifications for the active context (context-scoped
@@ -2255,6 +2337,7 @@ impl eframe::App for PlexiApp {
                         .map(|p| match p {
                             crate::pane::Pane::App(_) => "app",
                             crate::pane::Pane::Terminal(_) => "terminal",
+                            crate::pane::Pane::SubContext { .. } => "sub_context",
                         });
                     match target_kind {
                         Some("app") => {
@@ -2754,6 +2837,39 @@ impl eframe::App for PlexiApp {
                     log::info!("scratchpad: Ctrl+Space — opening");
                     self.open_scratchpad();
                 }
+                Action::ContextZoomIn => {
+                    // Zoom into the sub-context tile that currently has focus.
+                    let focused_tile = self.windows[self.active_window].focused_pane;
+                    if let Some(tile_id) = focused_tile {
+                        let focused_pane_id = self.windows[self.active_window].tree.tiles.get(tile_id)
+                            .and_then(|t| if let egui_tiles::Tile::Pane(p) = t { Some(*p) } else { None });
+                        if let Some(pane_id) = focused_pane_id {
+                            if let Some(child_ctx_id) = self.windows[self.active_window].panes.get(&pane_id)
+                                .and_then(|p| p.as_sub_context())
+                            {
+                                log::info!("ContextZoomIn: zooming into context_id={child_ctx_id}");
+                                let current_ctx_id = self.router.active().context_id;
+                                let current_win_id = self.windows[self.active_window].window_id;
+                                self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
+                                if let Some(ctx_idx) = self.router.position(|c| c.context_id == child_ctx_id) {
+                                    self.switch_workspace(ctx_idx);
+                                }
+                            }
+                        }
+                    }
+                }
+                Action::ContextZoomOut => {
+                    log::info!("ContextZoomOut: popping depth stack (depth={})", self.router.current_depth());
+                    if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth() {
+                        if let Some(ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
+                            self.switch_workspace(ctx_idx);
+                            if let Some(win_idx) = self.windows.iter().position(|w| w.window_id == parent_win_id) {
+                                self.active_window = win_idx;
+                                self.windows[win_idx].focused_pane = focused_tile;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -2936,6 +3052,30 @@ impl eframe::App for PlexiApp {
                 let canvas_old_focus = self.windows[self.active_window].focused_pane;
                 let canvas_old_window_id = self.windows[self.active_window].window_id;
 
+                // Build sub-context preview data before taking the mutable ctx borrow.
+                let sub_context_info: std::collections::HashMap<crate::tiling::PaneId, (String, usize, usize)> = {
+                    let active_win = self.active_window;
+                    let mut map = std::collections::HashMap::new();
+                    let sub_ctx_panes: Vec<(crate::tiling::PaneId, u64)> = self.windows[active_win]
+                        .panes
+                        .iter()
+                        .filter_map(|(pid, p)| p.as_sub_context().map(|cid| (*pid, cid)))
+                        .collect();
+                    for (pane_id, child_ctx_id) in sub_ctx_panes {
+                        let ctx_name = self.router.iter()
+                            .find(|c| c.context_id == child_ctx_id)
+                            .map(|c| c.name.clone())
+                            .unwrap_or_else(|| "(deleted)".to_string());
+                        let pane_count = self.windows.iter()
+                            .filter(|w| w.context_id == child_ctx_id)
+                            .map(|w| w.panes.len())
+                            .sum::<usize>();
+                        let notif_count = self.context_notification_count_recursive(child_ctx_id);
+                        map.insert(pane_id, (ctx_name, pane_count, notif_count));
+                    }
+                    map
+                };
+
                 let ctx = &mut self.windows[self.active_window];
 
                 // Resolve focused_pane if simplifier moved the tile
@@ -3071,6 +3211,7 @@ impl eframe::App for PlexiApp {
                     hovered_files,
                     workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
                     unfocused_opacity,
+                    sub_context_info,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {
@@ -3486,6 +3627,9 @@ impl PlexiApp {
                 let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
                 let type_id = Some(a.manifest_id.clone());
                 (cwd, None, None, type_id)
+            }
+            crate::pane::Pane::SubContext { .. } => {
+                (None, None, None, None)
             }
         };
 
@@ -4186,7 +4330,7 @@ fn register_directed_pipe_on_target(pane: &mut crate::pane::Pane, pipe_id: &str)
             crate::pane::AppRuntime::Process(pa) => Some(pa.pipe_registry.clone()),
             crate::pane::AppRuntime::Builtin(_) => None,
         },
-        crate::pane::Pane::Terminal(_) => None,
+        crate::pane::Pane::Terminal(_) | crate::pane::Pane::SubContext { .. } => None,
     };
     let Some(registry) = registry else {
         return false;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -44,6 +44,8 @@ fn pane_navigate_cross_window_updates_active_window() {
         path: std::env::temp_dir(),
         root: None,
         context_id: 2,
+        parent_id: None,
+        depth: 0,
     });
 
     assert_eq!(h.app.active_window, 0);
@@ -64,6 +66,8 @@ fn pane_navigate_cross_window_syncs_router() {
         path: std::env::temp_dir(),
         root: None,
         context_id: 2,
+        parent_id: None,
+        depth: 0,
     });
 
     assert_eq!(h.app.router.active_idx(), 0);
@@ -84,6 +88,8 @@ fn dispatch_notify_action_pane_focus_navigates() {
         path: std::env::temp_dir(),
         root: None,
         context_id: 2,
+        parent_id: None,
+        depth: 0,
     });
 
     assert_eq!(h.app.active_window, 0);
@@ -139,6 +145,8 @@ fn send_to_pane_searches_all_windows() {
         path: std::env::temp_dir(),
         root: None,
         context_id: 2,
+        parent_id: None,
+        depth: 0,
     });
 
     // active_window remains 0 — pane is in window 1.

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1071,6 +1071,8 @@ pub enum AppRequest {
         root: Option<std::path::PathBuf>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_name: Option<String>,
     },
     /// Focus existing context by root, or create one. Sent by `plexi context open`.
     FocusContext {
@@ -1080,6 +1082,12 @@ pub enum AppRequest {
     SetContextRoot {
         root: std::path::PathBuf,
     },
+    /// Zoom into a sub-context. Pushes depth stack. Sent by `plexi context zoom`.
+    ZoomIntoContext {
+        context_id: u64,
+    },
+    /// Zoom out of a sub-context. Pops depth stack. Sent by `plexi context zoom-out`.
+    ZoomOutOfContext,
 
     // ── Media + HTTP primitives ──────────────────────────────────────────
     /// Host-brokered HTTP request. Requires `net.http` capability.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3639,14 +3639,37 @@ fn send_to_socket(payload: serde_json::Value) -> i32 {
 /// `plexi context new [path]`
 ///
 /// Creates a new context. Uses `path` as the root (or CWD if omitted).
-pub fn context_new_cli(path: Option<&str>) -> i32 {
+pub fn context_new_cli(path: Option<&str>, parent: Option<&str>) -> i32 {
     let root = match resolve_path(path) {
         Ok(p) => p,
         Err(e) => { eprintln!("{e}"); return 1; }
     };
-    send_to_socket(serde_json::json!({
+    let mut payload = serde_json::json!({
         "type": "create_context",
         "root": root,
+    });
+    if let Some(p) = parent {
+        payload["parent_name"] = serde_json::Value::String(p.to_string());
+    }
+    send_to_socket(payload)
+}
+
+/// `plexi context zoom <context_id>`
+///
+/// Zoom into a sub-context by its numeric context_id.
+pub fn context_zoom_cli(context_id: u64) -> i32 {
+    send_to_socket(serde_json::json!({
+        "type": "zoom_into_context",
+        "context_id": context_id,
+    }))
+}
+
+/// `plexi context zoom-out`
+///
+/// Zoom out of the current sub-context to the parent.
+pub fn context_zoom_out_cli() -> i32 {
+    send_to_socket(serde_json::json!({
+        "type": "zoom_out_of_context",
     }))
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -449,6 +449,9 @@ pub enum ContextCmd {
     /// Open a new context, optionally starting in a specific folder.
     New {
         path: Option<String>,
+        /// Create as a child of the named context (fractal sub-context).
+        #[arg(long)]
+        parent: Option<String>,
     },
     /// Switch the current pane to a context at the given path.
     Open {
@@ -460,6 +463,12 @@ pub enum ContextCmd {
     },
     /// Print the id and name of the current pane's context as JSON.
     Current,
+    /// Zoom into a sub-context by its numeric context_id.
+    Zoom {
+        context_id: u64,
+    },
+    /// Zoom out of the current sub-context to the parent.
+    ZoomOut,
 }
 
 #[derive(Subcommand)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,6 +28,10 @@ pub struct Context {
     pub root: Option<PathBuf>,
     /// Stable unique ID, assigned at creation and never reused.
     pub context_id: u64,
+    /// Parent context_id for sub-contexts. None = top-level.
+    pub parent_id: Option<u64>,
+    /// Nesting depth. 0 = root level. Capped at 3.
+    pub depth: u32,
 }
 
 /// A window is a single spatial grid page — a pane layout with focus and zoom state.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -123,6 +123,10 @@ pub enum Action {
     SwapPane(Direction),
     /// Open the scratchpad overlay. Bound to Ctrl+Space.
     OpenScratchpad,
+    /// Zoom into the sub-context tile that has focus. Bound to Cmd+Shift+Enter.
+    ContextZoomIn,
+    /// Zoom out of the current sub-context to the parent. Bound to Cmd+Escape.
+    ContextZoomOut,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -172,6 +176,8 @@ pub struct KeyBindings {
     pub toggle_notification_modal: (egui::Modifiers, egui::Key),
     pub context_inspector: (egui::Modifiers, egui::Key),
     pub open_scratchpad: (egui::Modifiers, egui::Key),
+    pub context_zoom_in: (egui::Modifiers, egui::Key),
+    pub context_zoom_out: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -234,6 +240,8 @@ impl Default for KeyBindings {
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
             context_inspector:         (cmd(),       egui::Key::I),
             open_scratchpad:           (ctrl(),      egui::Key::Space),
+            context_zoom_in:           (cmd_shift(), egui::Key::Enter),
+            context_zoom_out:          (cmd(),       egui::Key::Escape),
         }
     }
 }
@@ -557,7 +565,11 @@ pub fn poll_actions(
         if input.consume_key(bindings.toggle_sidebar.0, bindings.toggle_sidebar.1) {
             actions.push(Action::ToggleSidebar);
         }
-        if input.consume_key(bindings.toggle_zoom.0, bindings.toggle_zoom.1) {
+        // context_zoom_in (Cmd+Shift+Enter) must be checked before toggle_zoom (Cmd+Enter)
+        // because egui consume_key uses subset modifier matching.
+        if input.consume_key(bindings.context_zoom_in.0, bindings.context_zoom_in.1) {
+            actions.push(Action::ContextZoomIn);
+        } else if input.consume_key(bindings.toggle_zoom.0, bindings.toggle_zoom.1) {
             actions.push(Action::ToggleZoom);
         }
         if input.consume_key(bindings.toggle_shortcuts.0, bindings.toggle_shortcuts.1) {
@@ -645,6 +657,9 @@ pub fn poll_actions(
         }
         if input.consume_key(bindings.open_scratchpad.0, bindings.open_scratchpad.1) {
             actions.push(Action::OpenScratchpad);
+        }
+        if input.consume_key(bindings.context_zoom_out.0, bindings.context_zoom_out.1) {
+            actions.push(Action::ContextZoomOut);
         }
 
         // Switch context (Cmd+1 through Cmd+9) — these remain hardcoded for now.

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,10 +453,12 @@ fn main() -> eframe::Result {
                         }
                     },
                     Commands::Context { cmd } => match cmd {
-                        ContextCmd::New { path } => std::process::exit(cli::context_new_cli(path.as_deref())),
+                        ContextCmd::New { path, parent } => std::process::exit(cli::context_new_cli(path.as_deref(), parent.as_deref())),
                         ContextCmd::Open { path } => std::process::exit(cli::context_open_cli(path.as_deref())),
                         ContextCmd::SetRoot { path } => std::process::exit(cli::context_set_root_cli(path.as_deref())),
                         ContextCmd::Current => std::process::exit(cli::context_current_cli()),
+                        ContextCmd::Zoom { context_id } => std::process::exit(cli::context_zoom_cli(context_id)),
+                        ContextCmd::ZoomOut => std::process::exit(cli::context_zoom_out_cli()),
                     },
                     Commands::Completions { shell } => {
                         let s = shell.as_deref().unwrap_or("zsh");

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1590,6 +1590,15 @@ impl PlexiApp {
                                 status,
                             });
                         }
+                        crate::pane::Pane::SubContext { pane_id, context_id } => {
+                            rows.push(PaneRow {
+                                id: *pane_id,
+                                kind: "SubContext",
+                                name: format!("sub_context:{context_id}"),
+                                detail: String::new(),
+                                status: "active",
+                            });
+                        }
                     }
                 }
             }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -6,12 +6,19 @@ use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
 // ---------------------------------------------------------------------------
-// Pane ADT (spec §2) — Terminal | App. Adding a variant requires a spec amendment.
+// Pane ADT (spec §2) — Terminal | App | SubContext.
+// Issue #1374 is the spec amendment for the SubContext variant.
 // ---------------------------------------------------------------------------
 
 pub enum Pane {
     Terminal(Box<TerminalPane>),
     App(Box<AppPane>),
+    /// A tile that represents a child context nested inside this one.
+    /// Renders a wireframe preview; Cmd+Shift+Enter zooms in.
+    SubContext {
+        pane_id: PaneId,
+        context_id: u64,
+    },
 }
 
 impl Pane {
@@ -19,6 +26,7 @@ impl Pane {
         match self {
             Pane::Terminal(t) => t.id,
             Pane::App(a) => a.id,
+            Pane::SubContext { pane_id, .. } => *pane_id,
         }
     }
 
@@ -46,6 +54,13 @@ impl Pane {
     pub fn as_app_mut(&mut self) -> Option<&mut AppPane> {
         match self {
             Pane::App(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    pub fn as_sub_context(&self) -> Option<u64> {
+        match self {
+            Pane::SubContext { context_id, .. } => Some(*context_id),
             _ => None,
         }
     }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -178,7 +178,7 @@ impl PlexiApp {
         let kind = match self.windows[active].panes.get(&focused_pane_id) {
             Some(Pane::Terminal(_)) => Kind::Terminal,
             Some(Pane::App(a)) => Kind::App(a.manifest_id.clone()),
-            None => return,
+            Some(Pane::SubContext { .. }) | None => return,
         };
 
         // `vertical` parameter for `split_with_new_pane` / `split_focused`:

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -8,6 +8,101 @@ use crate::workspace::WorkspaceFile;
 use std::path::PathBuf;
 
 impl PlexiApp {
+    /// Create a child context nested inside `parent_name`. Inserts a SubContext tile
+    /// in the parent's active window. Depth is capped at 3 levels.
+    pub(crate) fn new_child_context(&mut self, parent_name: &str, path: PathBuf) -> Result<(), String> {
+        let parent_idx = self.router.position(|c| c.name == parent_name)
+            .ok_or_else(|| format!("no context named '{parent_name}'"))?;
+        let parent_id = self.router.get(parent_idx).context_id;
+        let parent_depth = self.router.get(parent_idx).depth;
+
+        if parent_depth >= 3 {
+            log::warn!(
+                "new_child_context: depth limit reached — parent '{}' is at depth {}",
+                parent_name, parent_depth
+            );
+            return Err(format!(
+                "depth limit: parent '{}' is already at depth {} (max 3)",
+                parent_name, parent_depth
+            ));
+        }
+
+        let child_depth = parent_depth + 1;
+        let ctx_id = self.next_window_id;
+        self.next_window_id += 1;
+        let win_id = self.next_window_id;
+        self.next_window_id += 1;
+
+        let ctx_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| format!("Sub-context {}", self.router.len() + 1));
+
+        log::info!(
+            "new_child_context: parent_id={parent_id} parent_depth={parent_depth} child_depth={child_depth} name={ctx_name} path={}",
+            path.display()
+        );
+
+        self.router.push(crate::context::Context {
+            name: ctx_name,
+            path: path.clone(),
+            root: Some(path.clone()),
+            context_id: ctx_id,
+            parent_id: Some(parent_id),
+            depth: child_depth,
+        });
+
+        // Create the child context window with a single terminal pane.
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(path.clone()), None, false)
+        else {
+            log::error!("new_child_context: failed to create terminal for child context");
+            // Roll back the router push.
+            let new_idx = self.router.len() - 1;
+            self.router.remove_at(new_idx);
+            return Err("failed to create terminal for child context".to_string());
+        };
+
+        self.windows.push(crate::context::Window {
+            name: String::new(),
+            path: path.clone(),
+            tree,
+            panes,
+            focused_pane: Some(root_tile),
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+        self.context_active_window.insert(ctx_id, win_id);
+
+        // Insert a SubContext tile in the parent's active window.
+        let parent_pane_id = self.host.alloc_pane_id();
+        if let Some(parent_win_idx) = self.windows.iter().position(|w| w.context_id == parent_id) {
+            let sub_ctx_pane = crate::pane::Pane::SubContext {
+                pane_id: parent_pane_id,
+                context_id: ctx_id,
+            };
+            let new_tile_id = self.windows[parent_win_idx].tree.tiles.insert_pane(parent_pane_id);
+            let existing_root = self.windows[parent_win_idx].tree.root;
+            if let Some(root) = existing_root {
+                let new_root = self.windows[parent_win_idx].tree.tiles.insert_container(
+                    egui_tiles::Linear::new(
+                        egui_tiles::LinearDir::Horizontal,
+                        vec![root, new_tile_id],
+                    ),
+                );
+                self.windows[parent_win_idx].tree.root = Some(new_root);
+            } else {
+                self.windows[parent_win_idx].tree.root = Some(new_tile_id);
+            }
+            self.windows[parent_win_idx].panes.insert(parent_pane_id, sub_ctx_pane);
+        }
+
+        self.save_workspace();
+        Ok(())
+    }
+
     pub(crate) fn new_context(&mut self) {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = self.windows[self.active_window]
@@ -32,6 +127,8 @@ impl PlexiApp {
             path: cwd.clone(),
             root: Some(cwd.clone()),
             context_id: ctx_id,
+            parent_id: None,
+            depth: 0,
         });
         self.windows.push(Window {
             name: String::new(),
@@ -81,6 +178,8 @@ impl PlexiApp {
             path: path.clone(),
             root: Some(path.clone()),
             context_id: ctx_id,
+            parent_id: None,
+            depth: 0,
         });
         self.windows.push(Window {
             name: String::new(),
@@ -175,6 +274,22 @@ impl PlexiApp {
 
         // Remove all windows belonging to this context.
         self.windows.retain(|c| c.context_id != ws_id);
+
+        // Remove SubContext tiles that pointed to this deleted context from parent windows.
+        for win in &mut self.windows {
+            let sub_ctx_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
+                .filter(|(_, p)| p.as_sub_context() == Some(ws_id))
+                .map(|(id, _)| *id)
+                .collect();
+            for pane_id in sub_ctx_pane_ids {
+                win.panes.remove(&pane_id);
+                // Remove from the tile tree too.
+                if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
+                    win.tree.remove_recursively(tile_id);
+                }
+            }
+        }
+
         self.router.remove_at(ws_index);
 
         // Pick a valid active window in the new active context.
@@ -391,6 +506,8 @@ impl PlexiApp {
                 path: ctx.path.clone(),
                 root: ctx.root.clone(),
                 context_id: ctx.context_id,
+                parent_id: ctx.parent_id,
+                depth: ctx.depth,
             });
         }
 
@@ -417,6 +534,15 @@ impl PlexiApp {
                         name: Some(a.name.clone()),
                         app_id: Some(a.runtime.type_id().to_string()),
                         app_state: a.runtime.serialize_state(),
+                    });
+                } else if let Some(child_ctx_id) = pane.as_sub_context() {
+                    saved_panes.push(crate::workspace::SavedPane {
+                        id,
+                        kind: crate::workspace::SavedPaneKind::SubContext { context_id: child_ctx_id },
+                        cwd: std::path::PathBuf::new(),
+                        name: None,
+                        app_id: None,
+                        app_state: None,
                     });
                 }
             }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1621,6 +1621,18 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::ZoomIntoContext { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received ZoomIntoContext over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
+            AppRequest::ZoomOutOfContext => {
+                log::warn!(
+                    "ProcessApp[{}]: received ZoomOutOfContext over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
             AppRequest::ListPanes { .. } => {
                 log::warn!(
                     "ProcessApp[{}]: received ListPanes over PGAP — ignored (use PLEXI_SOCKET instead)",

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -37,6 +37,29 @@ impl PlexiApp {
         });
         ui.add_space(4.0);
 
+        // Breadcrumb bar — only shown when navigated into a sub-context.
+        if self.router.current_depth() > 0 {
+            ui.horizontal(|ui| {
+                ui.add_space(16.0);
+                let mut path_ids: Vec<u64> = self.router.depth_stack.iter()
+                    .map(|(ctx_id, _, _)| *ctx_id)
+                    .collect();
+                path_ids.push(self.router.active().context_id);
+
+                for (i, &ctx_id) in path_ids.iter().enumerate() {
+                    let name = self.router.iter()
+                        .find(|c| c.context_id == ctx_id)
+                        .map(|c| c.name.as_str())
+                        .unwrap_or("?");
+                    let _ = ui.small_button(name);
+                    if i < path_ids.len() - 1 {
+                        ui.label(egui::RichText::new("\u{203A}").color(self.colors.text_dim));
+                    }
+                }
+            });
+            ui.separator();
+        }
+
         let num_contexts = self.router.len();
         let mut clicked_workspace: Option<usize> = None;
         let mut delete_context: Option<usize> = None;
@@ -133,6 +156,7 @@ impl PlexiApp {
                 if is_dragging { 0.4 } else { 1.0 },
             );
             let ctx_name = self.router.get(i).name.clone();
+            let ctx_depth = self.router.get(i).depth;
             let badge_count = if is_active {
                 self.visible_notification_count()
             } else {
@@ -146,7 +170,7 @@ impl PlexiApp {
                 egui::Id::new(("ctx", i)),
                 &self.colors,
                 |row_ui, _hovered| {
-                    row_ui.add_space(20.0);
+                    row_ui.add_space(20.0 + ctx_depth as f32 * 12.0);
                     if i < 9 {
                         row_ui.label(
                             RichText::new(format!("{}", i + 1)).size(11.0).color(dim_color),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -44,6 +44,7 @@ impl HostSnapshot {
                 let title = match pane {
                     Pane::App(p) => p.name.clone(),
                     Pane::Terminal(_) => "Terminal".to_string(),
+                    Pane::SubContext { context_id, .. } => format!("SubContext({context_id})"),
                 };
                 (*id, title)
             })

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -57,6 +57,8 @@ pub struct PlexiBehavior<'a> {
     /// Opacity applied to unfocused panes when ghost mode is active.
     /// `None` = no dimming. Values below 1.0 dim all non-focused panes.
     pub unfocused_opacity: Option<f32>,
+    /// Preview data for SubContext tiles: pane_id → (context_name, pane_count, notification_count).
+    pub sub_context_info: HashMap<PaneId, (String, usize, usize)>,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -134,6 +136,58 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             if close_exited {
                 self.close_exited = Some(tile_id);
             }
+        } else if pane.as_sub_context().is_some() {
+            // SubContext tile — wireframe preview card.
+            ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
+            let (ctx_name, pane_count, notif_count) = self.sub_context_info
+                .get(pane_id)
+                .cloned()
+                .unwrap_or_else(|| ("(deleted)".to_string(), 0, 0));
+            let mut content_ui = ui.new_child(
+                egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_MD)),
+            );
+            content_ui.centered_and_justified(|ui| {
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        egui::RichText::new(&ctx_name)
+                            .size(style::TEXT_TITLE_XL)
+                            .strong()
+                            .color(self.colors.text_primary),
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    ui.label(
+                        egui::RichText::new(format!("{pane_count} panes"))
+                            .size(style::TEXT_CAPTION)
+                            .color(self.colors.text_dim),
+                    );
+                    ui.add_space(style::SPACE_MD);
+                    // Wireframe layout outline — simple rounded rectangle placeholder.
+                    let (rect, _) = ui.allocate_exact_size(
+                        egui::Vec2::new(120.0, 60.0),
+                        egui::Sense::hover(),
+                    );
+                    ui.painter().rect_stroke(
+                        rect,
+                        egui::CornerRadius::same(4),
+                        egui::Stroke::new(1.0, self.colors.text_dim),
+                        egui::StrokeKind::Inside,
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    ui.label(
+                        egui::RichText::new("\u{2318}\u{21E7}\u{21B5} to zoom in")
+                            .size(style::TEXT_HINT)
+                            .color(self.colors.text_dim),
+                    );
+                    if notif_count > 0 {
+                        ui.add_space(style::SPACE_SM);
+                        ui.label(
+                            egui::RichText::new(format!("\u{25CF} {notif_count}"))
+                                .size(style::TEXT_CAPTION)
+                                .color(egui::Color32::from_rgb(255, 100, 100)),
+                        );
+                    }
+                });
+            });
         }
 
         UiResponse::None

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -27,6 +27,12 @@ pub struct SavedContext {
     #[serde(default)]
     pub root: Option<PathBuf>,
     pub context_id: u64,
+    /// Parent context_id for sub-contexts. None = top-level.
+    #[serde(default)]
+    pub parent_id: Option<u64>,
+    /// Nesting depth. 0 = root level.
+    #[serde(default)]
+    pub depth: u32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -60,12 +66,13 @@ pub struct SavedPane {
     pub app_state: Option<serde_json::Value>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SavedPaneKind {
     #[default]
     Terminal,
     App,
+    SubContext { context_id: u64 },
 }
 
 fn workspace_path() -> PathBuf {
@@ -136,7 +143,7 @@ mod tests {
         for kind in kinds {
             let pane = SavedPane {
                 id: 42,
-                kind,
+                kind: kind.clone(),
                 cwd: PathBuf::from("/tmp"),
                 name: Some("split-pane".to_string()),
                 app_id: matches!(kind, SavedPaneKind::App)
@@ -149,6 +156,22 @@ mod tests {
             assert_eq!(restored.id, 42);
             assert_eq!(restored.cwd, PathBuf::from("/tmp"));
         }
+        // SubContext round-trips with embedded context_id.
+        let sub_ctx_pane = SavedPane {
+            id: 99,
+            kind: SavedPaneKind::SubContext { context_id: 42 },
+            cwd: PathBuf::new(),
+            name: None,
+            app_id: None,
+            app_state: None,
+        };
+        let json = serde_json::to_string(&sub_ctx_pane).expect("serialize sub_context");
+        let restored: SavedPane = serde_json::from_str(&json).expect("deserialize sub_context");
+        assert!(
+            matches!(restored.kind, SavedPaneKind::SubContext { context_id: 42 }),
+            "SubContext kind must round-trip with correct context_id"
+        );
+        assert_eq!(restored.id, 99);
     }
 
     /// SavedWindow omits `grid_x` / `grid_y` defaults cleanly.

--- a/src/workspace_router.rs
+++ b/src/workspace_router.rs
@@ -7,16 +7,20 @@
 //! Structural ops (create/delete/reorder) → methods on this struct
 
 use crate::context::Context;
+use egui_tiles::TileId;
 
 pub(crate) struct WorkspaceRouter {
     active: usize,
     contexts: Vec<Context>,
+    /// Depth navigation stack. Each entry records the context_id, window_id,
+    /// and focused tile to restore when zooming back out.
+    pub(crate) depth_stack: Vec<(u64, u64, Option<TileId>)>,
 }
 
 impl WorkspaceRouter {
     pub(crate) fn new(contexts: Vec<Context>, active: usize) -> Self {
         debug_assert!(contexts.is_empty() || active < contexts.len(), "Active index out of bounds");
-        Self { active, contexts }
+        Self { active, contexts, depth_stack: Vec::new() }
     }
 
     // ── Read ─────────────────────────────────────────────────────────────────
@@ -123,5 +127,53 @@ impl WorkspaceRouter {
         } else if self.active > idx {
             self.active -= 1;
         }
+    }
+
+    // ── Depth stack (fractal zoom navigation) ───────────────────────────────
+
+    pub(crate) fn push_depth(&mut self, context_id: u64, window_id: u64, focused_tile: Option<TileId>) {
+        self.depth_stack.push((context_id, window_id, focused_tile));
+    }
+
+    pub(crate) fn pop_depth(&mut self) -> Option<(u64, u64, Option<TileId>)> {
+        self.depth_stack.pop()
+    }
+
+    pub(crate) fn current_depth(&self) -> usize {
+        self.depth_stack.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn make_ctx(id: u64, parent_id: Option<u64>, depth: u32) -> Context {
+        Context {
+            name: format!("ctx{id}"),
+            path: PathBuf::from("/tmp"),
+            root: None,
+            context_id: id,
+            parent_id,
+            depth,
+        }
+    }
+
+    #[test]
+    fn depth_stack_push_pop() {
+        let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
+        assert_eq!(router.current_depth(), 0);
+        router.push_depth(1, 10, None);
+        assert_eq!(router.current_depth(), 1);
+        let popped = router.pop_depth();
+        assert_eq!(popped, Some((1, 10, None)));
+        assert_eq!(router.current_depth(), 0);
+    }
+
+    #[test]
+    fn depth_stack_empty_pop_returns_none() {
+        let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
+        assert_eq!(router.pop_depth(), None);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Pane::SubContext { pane_id, context_id }` — a tile that renders a wireframe preview of a nested context in the parent's layout
- `Context` gains `parent_id: Option<u64>` and `depth: u32` (capped at 3); `SavedContext` persists both with `#[serde(default)]` for zero-cost migration
- `WorkspaceRouter` gains `depth_stack` with `push_depth`/`pop_depth`; `Cmd+Shift+Enter` zooms into a focused SubContext tile, `Cmd+Escape` zooms out restoring parent focus position
- CLI: `plexi context new --parent "name"` creates a child context; `plexi context zoom <id>` and `plexi context zoom-out` for programmatic navigation
- Sidebar: breadcrumb bar when depth > 0; child contexts indented by depth; SubContext notification badges roll up from descendants

## Done When (verified)
- [x] `Pane::SubContext` variant added — all 18 match sites updated
- [x] `new_child_context()` creates child with SubContext tile inserted in parent window
- [x] Depth strictly capped at 3 (log::warn + early return)
- [x] Keybindings: `Cmd+Shift+Enter` = ContextZoomIn, `Cmd+Escape` = ContextZoomOut
- [x] Breadcrumb bar renders when `depth_stack.len() > 0`
- [x] `context_notification_count_recursive` rolls up descendant notifications
- [x] Workspace save/restore handles SubContext panes
- [x] `cargo test --bin plexi` — 488 pass, 2 pre-existing failures unrelated to this PR

## Deviations from spec
- Breadcrumb buttons are rendered but clicking doesn't multi-jump (only one-level zoom-out via Cmd+Escape is implemented); multi-level breadcrumb navigation is a future PR
- `plexi context zoom` takes a numeric context_id rather than a path string ("myproject/frontend") — path resolution requires a host-side lookup not yet implemented