### PR TITLE
fix(examples/screen-time): shift clock ring up in narrow mode to clear legend (#1378)

### DIFF
--- a/examples/screen-time/screen_time.py
+++ b/examples/screen-time/screen_time.py
@@ -2,7 +2,7 @@
 """Screen Time — clock + monthly views from daily_log *_screen.jsonl files.
 
 Layout:
-  - Top bar chrome (AppBar, KeyRow hints, Footer) uses SDK v2 components.
+  - Top bar chrome (AppBar, KeyRow hints, Footer) uses the component API.
   - The clock face + month grid are drawn with primitive ctx.circle/arc/text —
     they're data surfaces, not chrome.
 """
@@ -460,7 +460,7 @@ class ScreenTimeApp(App):
         r_outer = min(clock_area_w / 2, available_h / 2) * 0.78
         r_inner = r_outer * 0.55
         cx = clock_area_w / 2
-        cy = top + (available_h / 2 if wide else available_h * 0.42)
+        cy = top + (available_h / 2 if wide else available_h * 0.38)
 
         self._draw_clock_ring(ctx, cx, cy, r_outer, r_inner)
         legend_y = top + (SPACE_MD if wide else available_h * 0.82)


### PR DESCRIPTION
## What

In narrow (portrait) pane mode, the "12p" hour label at 6 o'clock on the clock ring was overlapping the top legend row. The label lands at `cy + r_outer + 16 ≈ 81%` of available height; the legend starts at `available_h * 0.82`. In practice these are within a few pixels, so the "12p" text bled into the top legend entry and occluded right-aligned hours stats.

## Changes

- `_draw_clock` line 463: lower `cy` fraction from `0.42` to `0.38` in narrow mode, pulling the ring up so `cy + r_outer + 16 ≈ 79%` clears the `82%` legend threshold with comfortable margin
- Lines 5–7: update stale "SDK v2 components" docstring note — the SDK is at v0.5.0/PGAP v3; it's called the component API

## Done When

In a portrait pane with 6+ apps logged, the "12p" label is fully visible above the legend with no overlap. The bottom-row legend app hours stat is not occluded.

Closes #1378