### PR TITLE
Enable osc_pane_title by default

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -20,6 +20,11 @@ confirm_close = false
 # Maximum depth of pane focus history (Cmd+[ / Cmd+]).
 # focus_history_depth = 100
 
+# ── OSC & Terminal Features ────────────────────────────────────────
+# osc_pane_title applies OSC 0/1/2 title sequences from running
+# processes as pane names.
+osc_pane_title = true
+
 # ── Notifications ──────────────────────────────────────────────
 # The work-area modal is the one and only notification surface.
 # Apps emit `ctx.notify(...)`, `ctx.notify_choice(...)`, or
@@ -96,7 +101,6 @@ confirm_close = false
 # crt           = false    # Retro CRT scanlines + green phosphor tint
 # ghost         = false    # Unfocused panes render at reduced opacity
 # ghost_opacity = 0.9     # Opacity for unfocused panes (0.0–1.0). Setting this enables ghost automatically.
-# osc_pane_title = false   # Apply OSC 0/1/2 title sequences from running processes as pane names
 
 # ── Logging ────────────────────────────────────────────────────
 # [log]

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -35,7 +35,7 @@ QUEUE=$(plexi terminal --layout tab --from-pane-id $LANE)  # tab in LANE's windo
 NEW=$(plexi terminal --layout new_window)                # separate OS window
 ```
 
-`--from-pane-id` requires `PLEXI_SOCKET`. Get your own pane ID with `plexi pane self` (preferred — just the number) or `plexi pane info` (full JSON).
+`--from-pane-id` requires `PLEXI_SOCKET`. Use `$PLEXI_PANE_ID` (set automatically in every pane) — no extra round-trip needed. Only call `plexi pane self` if you need to capture the ID into a variable for reuse.
 
 ## Apps
 
@@ -54,9 +54,8 @@ plexi validate [path]            # validate app dir
 
 2×2 grid example (apps in 3 quadrants):
 ```bash
-MY_PANE=$(plexi pane self)
-BALLS=$(plexi open balls --layout split_v --from-pane-id $MY_PANE)
-plexi open tetris --layout split_h --from-pane-id $MY_PANE
+BALLS=$(plexi open balls --layout split_v --from-pane-id $PLEXI_PANE_ID)
+plexi open tetris --layout split_h --from-pane-id $PLEXI_PANE_ID
 plexi open snake --layout split_h --from-pane-id $BALLS
 ```
 


### PR DESCRIPTION
Move osc_pane_title out of experimental features and enable by default.

This setting applies OSC 0/1/2 title sequences from running processes as pane names, improving the user experience by reflecting dynamic window titles.