### PR TITLE
docs(config): add catppuccin-latte and solarized-light to preset header comment

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -7,7 +7,7 @@ font_size = 14.0
 
 # ── Theme ──────────────────────────────────────────────────────
 # Pick a preset OR customize individual colors below.
-# Presets: catppuccin-mocha, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark
+# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark, solarized-light
 theme_preset = "catppuccin-mocha"
 
 # ── Confirmation Dialogs ───────────────────────────────────────


### PR DESCRIPTION
Adds the two new light presets to the short preset list in the config.toml header comment (line 10). Companion to PR #1394.