### PR TITLE
feat(cli): add 'plexi config edit' command (#1387)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3767,6 +3767,35 @@ pub fn config_check() -> i32 {
     if has_errors { 1 } else { 0 }
 }
 
+pub fn config_edit() -> i32 {
+    let path = crate::config::config_path();
+    log::info!("config_edit: opening {} in editor", path.display());
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!("error: could not create config directory: {e}");
+                return 1;
+            }
+        }
+        if let Err(e) = std::fs::write(&path, "") {
+            eprintln!("error: could not create config file: {e}");
+            return 1;
+        }
+    }
+
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "open".to_string());
+    match std::process::Command::new(&editor).arg(&path).status() {
+        Ok(status) => {
+            if status.success() { 0 } else { status.code().unwrap_or(1) }
+        }
+        Err(e) => {
+            eprintln!("error: could not launch editor {editor:?}: {e}");
+            1
+        }
+    }
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     match shell {
         "zsh" => { print!("{}", zsh_completion(binary_name)); 0 }
@@ -3971,7 +4000,7 @@ _plexi() {
           ;;
         config)
           local subcmds
-          subcmds=('check:Validate config.toml and report errors')
+          subcmds=('check:Validate config.toml and report errors' 'edit:Open config.toml in $EDITOR')
           _describe 'subcommand' subcmds
           ;;
       esac
@@ -4098,7 +4127,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur"))
       ;;
     config)
-      COMPREPLY=($(compgen -W "check" -- "$cur"))
+      COMPREPLY=($(compgen -W "check edit" -- "$cur"))
       ;;
   esac
 }
@@ -4130,6 +4159,7 @@ complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret ap
 
 # config subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from config" -a check -d "Validate config.toml and report errors"
+complete -c plexi -f -n "__fish_seen_subcommand_from config" -a edit -d "Open config.toml in \$EDITOR"
 
 # secret subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from secret" -a set -d "Store a secret"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3768,29 +3768,18 @@ pub fn config_check() -> i32 {
 }
 
 pub fn config_edit() -> i32 {
-    let path = crate::config::config_path();
+    let path = crate::config::ensure_config_exists();
     log::info!("config_edit: opening {} in editor", path.display());
 
-    if !path.exists() {
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                eprintln!("error: could not create config directory: {e}");
-                return 1;
-            }
-        }
-        if let Err(e) = std::fs::write(&path, "") {
-            eprintln!("error: could not create config file: {e}");
-            return 1;
-        }
-    }
-
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "open".to_string());
-    match std::process::Command::new(&editor).arg(&path).status() {
+    let editor_env = std::env::var("EDITOR").unwrap_or_else(|_| "open".to_string());
+    let mut parts = editor_env.split_whitespace();
+    let editor_bin = parts.next().unwrap_or("open");
+    match std::process::Command::new(editor_bin).args(parts).arg(&path).status() {
         Ok(status) => {
             if status.success() { 0 } else { status.code().unwrap_or(1) }
         }
         Err(e) => {
-            eprintln!("error: could not launch editor {editor:?}: {e}");
+            eprintln!("error: could not launch editor {editor_bin:?}: {e}");
             1
         }
     }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -475,4 +475,6 @@ pub enum ContextCmd {
 pub enum ConfigCmd {
     /// Validate your config.toml and report any errors.
     Check,
+    /// Open config.toml in your $EDITOR.
+    Edit,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -594,6 +594,19 @@ pub fn config_dir() -> PathBuf {
 
 const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");
 
+/// Ensures the config file exists, creating it from the default template if not.
+/// Returns the config file path.
+pub fn ensure_config_exists() -> std::path::PathBuf {
+    let path = config_path();
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&path, CONFIG_TEMPLATE);
+    }
+    path
+}
+
 pub fn open_config_file() {
     let path = config_path();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,6 +475,9 @@ fn main() -> eframe::Result {
                         ConfigCmd::Check => {
                             std::process::exit(cli::config_check());
                         }
+                        ConfigCmd::Edit => {
+                            std::process::exit(cli::config_edit());
+                        }
                     },
                 }
             }


### PR DESCRIPTION
## What

Adds `plexi config edit` — opens `config.toml` in `$EDITOR` (falls back to `open` on macOS). Creates the config file if it doesn't yet exist.

Fixes the broken reference in the AI config missing error screen (`src/launch_failed.rs`), which already told users to run `plexi config edit` even though the command didn't exist.

## Done When

- [x] `plexi config edit` opens the config file in the user's editor
- [x] Error message in `launch_failed.rs` is accurate (was already correct text, now the command exists)

Closes #1387