### PR TITLE
fix(audio): eliminate save hang and improve pipe teardown (#1389)

### DIFF
--- a/examples/audio-recorder/audio_recorder.py
+++ b/examples/audio-recorder/audio_recorder.py
@@ -5,6 +5,7 @@ Demonstrates emit.list_audio_devices() + audio capture + WAV export.
 Keys: left/right to select device, r to record/stop, s to save WAV.
 """
 from __future__ import annotations
+import array
 import struct
 import threading
 import wave
@@ -124,11 +125,10 @@ class AudioRecorderApp(App):
         path = pathlib.Path.home() / "Desktop" / "recording.wav"
         n_floats = len(all_data) // 4
         samples = struct.unpack_from(f"<{n_floats}f", all_data)
-        # Convert f32 [-1, 1] → i16
-        pcm_i16 = b""
+        arr = array.array("h")
         for s in samples:
-            v = int(max(-1.0, min(1.0, s)) * 32767)
-            pcm_i16 += struct.pack("<h", v)
+            arr.append(int(max(-1.0, min(1.0, s)) * 32767))
+        pcm_i16 = arr.tobytes()
         with wave.open(str(path), "wb") as wf:
             wf.setnchannels(CHANNELS)
             wf.setsampwidth(2)  # 16-bit
@@ -136,7 +136,7 @@ class AudioRecorderApp(App):
             wf.writeframes(pcm_i16)
         duration = len(samples) / SAMPLE_RATE
         self._status = f"Saved: {path} ({duration:.1f}s)"
-        self.emit.info(f"audio-recorder: saved {path}")
+        self.emit.info(f"audio-recorder: saved {path} ({duration:.1f}s)")
 
     def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
         if key in ("left", "[") and not self._capturing:

--- a/examples/audio-recorder/audio_recorder.py
+++ b/examples/audio-recorder/audio_recorder.py
@@ -7,6 +7,7 @@ Keys: left/right to select device, r to record/stop, s to save WAV.
 from __future__ import annotations
 import array
 import struct
+import sys
 import threading
 import wave
 import pathlib
@@ -125,9 +126,9 @@ class AudioRecorderApp(App):
         path = pathlib.Path.home() / "Desktop" / "recording.wav"
         n_floats = len(all_data) // 4
         samples = struct.unpack_from(f"<{n_floats}f", all_data)
-        arr = array.array("h")
-        for s in samples:
-            arr.append(int(max(-1.0, min(1.0, s)) * 32767))
+        arr = array.array("h", (int(max(-1.0, min(1.0, s)) * 32767) for s in samples))
+        if sys.byteorder == "big":
+            arr.byteswap()
         pcm_i16 = arr.tobytes()
         with wave.open(str(path), "wb") as wf:
             wf.setnchannels(CHANNELS)

--- a/sdk/python/plexi_sdk/_pipe.py
+++ b/sdk/python/plexi_sdk/_pipe.py
@@ -40,7 +40,7 @@ class Pipe:
         return self._connected.wait(timeout=timeout)
 
     def read_frame(self) -> "bytes | None":
-        """Read one length-prefixed frame. Blocks. Returns None on EOF/error."""
+        """Read one length-prefixed frame. Blocks. Returns None on EOF/error/EOS."""
         if not self._sock:
             return None
         try:
@@ -48,6 +48,8 @@ class Pipe:
             if header is None:
                 return None
             length = struct.unpack(">I", header)[0]
+            if length == 0:
+                return None  # EOS sentinel from host
             return self._recv_exact(length)
         except OSError as e:
             self._app.emit.error(f"pipe read_frame error pipe_id={self.pipe_id}: {e}")
@@ -78,6 +80,11 @@ class Pipe:
 
     def close(self) -> None:
         if self._sock:
+            try:
+                # shutdown unblocks any thread blocked in recv() before close().
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
             try:
                 self._sock.close()
             except OSError:


### PR DESCRIPTION
## Summary

- **O(n²) save hang fixed**: `_save_wav()` replaced byte-by-byte concatenation (`pcm_i16 += struct.pack(...)`) with `array.array("h")`, reducing a 30s recording from O(n²) to O(n) — eliminates the event loop block that caused the host to SIGTERM the app.
- **Clean pipe teardown**: `Pipe.close()` now calls `socket.shutdown(SHUT_RDWR)` before `socket.close()`, which reliably unblocks any thread blocked in `recv()` on macOS. The reader thread exits within milliseconds instead of waiting the full 2s join timeout.
- **EOS sentinel handled**: `read_frame()` now returns `None` immediately on a length-0 frame (the host's end-of-stream sentinel), removing an unnecessary extra round-trip.

## Done When
- Record audio, stop, save — file saves without hanging
- No SIGTERM needed for clean shutdown
- Log shows clean capture stop → save → exit sequence

## Test plan
- Open audio-recorder app
- Record a few seconds of audio
- Press `r` to stop
- Press `s` to save — status should update immediately to "Saved: ~/Desktop/recording.wav (Xs)"
- Close the pane — no SIGTERM in the log

Closes #1389