### PR TITLE
feat(quick-note): add 'n' shortcut to open config from destination picker (#1402)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1044,6 +1044,16 @@ impl PlexiApp {
             }
         }
 
+        // N → open config file to add a new destination.
+        let add_dest = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::N)
+        });
+        if add_dest {
+            log::info!("QuickNote: opening config to add destination");
+            crate::config::open_config_file();
+            return;
+        }
+
         // Digit keys → fast-dispatch by number.
         let pressed = consume_digit_key(ctx);
 
@@ -1203,7 +1213,7 @@ impl PlexiApp {
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
-                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  H/Esc back")
+                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  n add dest  ·  H/Esc back")
                                 .color(self.colors.text_dim.linear_multiply(0.4))
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),
@@ -1411,6 +1421,16 @@ impl PlexiApp {
             }
         }
 
+        // N → open config file to add a new destination.
+        let add_dest = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::N)
+        });
+        if add_dest {
+            log::info!("QuickNote: opening config to add destination (from submenu)");
+            crate::config::open_config_file();
+            return;
+        }
+
         // Digit keys → fast-dispatch by number.
         let pressed = consume_digit_key(ctx);
         if let Some(key) = pressed {
@@ -1499,7 +1519,7 @@ impl PlexiApp {
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
-                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  L enter  ·  H/Esc back")
+                            RichText::new("↑↓/jk navigate  ·  Enter select  ·  L enter  ·  n add dest  ·  H/Esc back")
                                 .color(self.colors.text_dim.linear_multiply(0.4))
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),


### PR DESCRIPTION
## Summary

- Adds `n` key binding in the quick-note destination picker and submenu that opens `config.toml` in the user's default editor
- Config watcher auto-reloads on save, so new destinations appear immediately on return
- Updated hint text in both modals to show the new shortcut

## Test plan

- [ ] Open quick note (Cmd+0), type something, press Enter to reach destination picker
- [ ] Press `n` - config.toml should open in default editor
- [ ] Add a new `[[quick_note.destinations]]` entry, save, close editor
- [ ] Verify the new destination appears in the picker without restarting

Closes #1402