### PR TITLE
feat(pgap): responsive breakpoint layout primitive for SubContext and apps (#1404)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -860,6 +860,12 @@
                 "null"
               ]
             },
+            "parent_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "root": {
               "type": [
                 "string",
@@ -907,6 +913,38 @@
           "required": [
             "type",
             "root"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Zoom into a sub-context. Pushes depth stack. Sent by `plexi context zoom`.",
+          "properties": {
+            "context_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": {
+              "const": "zoom_into_context",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "context_id"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Zoom out of a sub-context. Pops depth stack. Sent by `plexi context zoom-out`.",
+          "properties": {
+            "type": {
+              "const": "zoom_out_of_context",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
           ],
           "type": "object"
         },
@@ -1354,6 +1392,27 @@
           "required": [
             "type",
             "timer_id"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Async image fetch brokered through the host. Requires `net.http` capability.\nHost fetches `src`, caches under `handle`, and emits `PlexiEvent::ImageLoaded`\nwhen done. App then renders via `DrawCommand::Image { src: handle, .. }`.",
+          "properties": {
+            "handle": {
+              "type": "string"
+            },
+            "src": {
+              "type": "string"
+            },
+            "type": {
+              "const": "load_image",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "handle",
+            "src"
           ],
           "type": "object"
         },
@@ -2471,6 +2530,33 @@
           "type": "object"
         },
         {
+          "description": "Fired when a `load_image` request completes (success or failure).\n`status` is \"ok\" or \"error\". `message` carries the error detail on failure.",
+          "properties": {
+            "handle": {
+              "type": "string"
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "type": {
+              "const": "image_loaded",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "handle",
+            "status"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Response to a `DrawCommand::MeasureText` request.\n`width` and `height` are in logical pixels at the requested font size.",
           "properties": {
             "height": {
@@ -3143,6 +3229,38 @@
             "y",
             "w",
             "h"
+          ],
+          "type": "object"
+        },
+        "ResponsiveTier": {
+          "description": "A single tier in a responsive layout. Contains an aspect-ratio condition\nand the layout tree to render when that condition matches.",
+          "properties": {
+            "aspect": {
+              "description": "One of: \"landscape\", \"portrait\", \"square\"",
+              "type": "string"
+            },
+            "children": {
+              "description": "Children of this tier's layout tree.",
+              "items": {
+                "$ref": "#/$defs/LayoutChild"
+              },
+              "type": "array"
+            },
+            "direction": {
+              "$ref": "#/$defs/LayoutDirection",
+              "description": "Flex direction for this tier's root node."
+            },
+            "gap": {
+              "default": 0.0,
+              "description": "Gap between children in pixels.",
+              "format": "float",
+              "type": "number"
+            }
+          },
+          "required": [
+            "aspect",
+            "direction",
+            "children"
           ],
           "type": "object"
         },
@@ -3951,6 +4069,36 @@
             "y",
             "direction",
             "children"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Responsive layout — host picks the matching tier based on available rect aspect ratio.\n\nTiers are evaluated in order. First match wins. The aspect condition is one of:\n- `\"landscape\"` — width > height\n- `\"portrait\"` — height > width\n- `\"square\"` — within ~20% ratio (0.83..1.2), or used as a fallback\n\nThe winning tier's layout tree is rendered through the existing taffy pipeline.",
+          "properties": {
+            "tiers": {
+              "items": {
+                "$ref": "#/$defs/ResponsiveTier"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "responsive",
+              "type": "string"
+            },
+            "x": {
+              "format": "float",
+              "type": "number"
+            },
+            "y": {
+              "format": "float",
+              "type": "number"
+            }
+          },
+          "required": [
+            "type",
+            "x",
+            "y",
+            "tiers"
           ],
           "type": "object"
         }

--- a/sdk/python/plexi_sdk/_protocol.py
+++ b/sdk/python/plexi_sdk/_protocol.py
@@ -1,7 +1,6 @@
 # AUTO-GENERATED — do not edit by hand.
 # Regenerate with: just gen-schema
 # Protocol: pgap/3
-# Note: AudioDeviceInfo/AudioDeviceList added manually alongside list_audio_devices helper (#341).
 
 from __future__ import annotations
 from dataclasses import dataclass
@@ -30,20 +29,5 @@ class MidiPortInfo:
 @dataclass
 class MidiDeviceList:
     """Result of Emitter.list_midi_devices."""
-    inputs: list
-    outputs: list
-
-
-@dataclass
-class AudioDeviceInfo:
-    """One audio device. Mirrors AudioDeviceWire in the Rust protocol."""
-    id: str
-    name: str
-    default: bool
-
-
-@dataclass
-class AudioDeviceList:
-    """Result of Emitter.list_audio_devices."""
     inputs: list
     outputs: list

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -720,6 +720,41 @@ class RenderContext:
             "gap": 0.0,
         })
 
+    def responsive(
+        self,
+        x: float,
+        y: float,
+        tiers: "list[dict]",
+    ) -> None:
+        """Emit a responsive layout that adapts to the available pane aspect ratio.
+
+        The host evaluates tiers in order and renders the first match:
+        - "landscape": pane is wider than tall (ratio > 1.2)
+        - "portrait": pane is taller than wide (ratio < 0.83)
+        - "square": fallback for balanced aspect ratios
+
+        Each tier dict has: aspect (str), direction (str), children (list), gap (float).
+
+        Example::
+
+            ctx.responsive(
+                x=0.0, y=0.0,
+                tiers=[
+                    {"aspect": "landscape", "direction": "row",
+                     "children": [ctx.text_child("wide view")], "gap": 6.0},
+                    {"aspect": "portrait", "direction": "column",
+                     "children": [ctx.text_child("tall view")], "gap": 4.0},
+                    {"aspect": "square", "direction": "column",
+                     "children": [ctx.text_child("default")], "gap": 4.0},
+                ],
+            )
+        """
+        self._queue({
+            "type": "responsive",
+            "x": x, "y": y,
+            "tiers": tiers,
+        })
+
     def frame_done(self) -> None:
         """Flush all buffered draw commands for this frame.
 

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -825,6 +825,35 @@ pub enum RenderCommand {
         #[serde(default)]
         gap: f32,
     },
+
+    /// Responsive layout — host picks the matching tier based on available rect aspect ratio.
+    ///
+    /// Tiers are evaluated in order. First match wins. The aspect condition is one of:
+    /// - `"landscape"` — width > height
+    /// - `"portrait"` — height > width
+    /// - `"square"` — within ~20% ratio (0.83..1.2), or used as a fallback
+    ///
+    /// The winning tier's layout tree is rendered through the existing taffy pipeline.
+    Responsive {
+        x: f32,
+        y: f32,
+        tiers: Vec<ResponsiveTier>,
+    },
+}
+
+/// A single tier in a responsive layout. Contains an aspect-ratio condition
+/// and the layout tree to render when that condition matches.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+pub struct ResponsiveTier {
+    /// One of: "landscape", "portrait", "square"
+    pub aspect: String,
+    /// Flex direction for this tier's root node.
+    pub direction: LayoutDirection,
+    /// Children of this tier's layout tree.
+    pub children: Vec<LayoutChild>,
+    /// Gap between children in pixels.
+    #[serde(default)]
+    pub gap: f32,
 }
 
 /// App-to-host requests — go to `route_command`.

--- a/src/headless_renderer.rs
+++ b/src/headless_renderer.rs
@@ -209,6 +209,7 @@ impl HeadlessRenderer {
                 "line" => self.pgap_line(&mut pixmap, cmd),
                 "list" => self.pgap_list(&mut pixmap, cmd, width),
                 "layout" => self.pgap_layout(&mut pixmap, cmd, width as f32),
+                "responsive" => self.pgap_responsive(&mut pixmap, cmd, width, height),
                 _ => {}
             }
         }
@@ -414,6 +415,37 @@ impl HeadlessRenderer {
         }
 
         paint(&tree, root, origin_x, origin_y, pixmap, self);
+    }
+
+    fn pgap_responsive(&self, pixmap: &mut Pixmap, cmd: &Value, width: u32, height: u32) {
+        let tiers = match cmd.get("tiers").and_then(Value::as_array) {
+            Some(t) => t,
+            None => return,
+        };
+        let w = width as f32;
+        let h = height as f32;
+        let ratio = if h > 0.0 { w / h } else { f32::MAX };
+        let tier = tiers.iter().find(|t| {
+            let aspect = t.get("aspect").and_then(Value::as_str).unwrap_or("");
+            match aspect {
+                "landscape" => ratio > 1.2,
+                "portrait" => ratio < 0.83,
+                "square" => true,
+                _ => false,
+            }
+        });
+        if let Some(tier) = tier {
+            // Synthesize a layout command from the winning tier and delegate
+            let mut layout_cmd = tier.clone();
+            layout_cmd["type"] = serde_json::json!("layout");
+            if layout_cmd.get("x").is_none() {
+                layout_cmd["x"] = cmd.get("x").cloned().unwrap_or(serde_json::json!(0.0));
+            }
+            if layout_cmd.get("y").is_none() {
+                layout_cmd["y"] = cmd.get("y").cloned().unwrap_or(serde_json::json!(0.0));
+            }
+            self.pgap_layout(pixmap, &layout_cmd, w);
+        }
     }
 
     fn pgap_rect(&self, pixmap: &mut Pixmap, cmd: &Value) {

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::app_protocol::{LayoutChild, LayoutDirection, RenderCommand};
+use crate::app_protocol::{LayoutChild, LayoutDirection, RenderCommand, ResponsiveTier};
 use crate::style;
 use crate::theme::Colors;
 use egui::Color32;
@@ -367,6 +367,24 @@ pub(crate) fn render_draw_commands(
                     direction, children, *gap,
                     colors, commonmark_cache, audio_peaks,
                 );
+            }
+
+            RenderCommand::Responsive { x, y, tiers } => {
+                let avail_w = pane_rect.width();
+                let avail_h = pane_rect.height();
+                if let Some(tier) = select_responsive_tier(tiers, avail_w, avail_h) {
+                    log::info!(
+                        "responsive: selected tier aspect={} for rect {}x{}",
+                        tier.aspect, avail_w, avail_h
+                    );
+                    render_layout_node(
+                        ui, pane_rect, clip, *x, *y,
+                        &tier.direction, &tier.children, tier.gap,
+                        colors, commonmark_cache, audio_peaks,
+                    );
+                } else {
+                    log::warn!("responsive: no matching tier for rect {}x{}", avail_w, avail_h);
+                }
             }
 
             RenderCommand::Markdown {
@@ -1228,4 +1246,24 @@ fn fit_image(
             (dest, full_uv)
         }
     }
+}
+
+// ── Responsive tier selection ──────────────────────────────────────────────────
+
+/// Select the first matching responsive tier based on the available rect's aspect ratio.
+/// - "landscape": width > height
+/// - "portrait": height > width
+/// - "square": ratio between 0.83 and 1.2 (fallback)
+pub(crate) fn select_responsive_tier(
+    tiers: &[ResponsiveTier],
+    width: f32,
+    height: f32,
+) -> Option<&ResponsiveTier> {
+    let ratio = if height > 0.0 { width / height } else { f32::MAX };
+    tiers.iter().find(|tier| match tier.aspect.as_str() {
+        "landscape" => ratio > 1.2,
+        "portrait" => ratio < 0.83,
+        "square" => true, // fallback — matches anything not caught above
+        _ => false,
+    })
 }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -137,57 +137,35 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 self.close_exited = Some(tile_id);
             }
         } else if pane.as_sub_context().is_some() {
-            // SubContext tile — wireframe preview card.
+            // SubContext tile — responsive PGAP-rendered preview.
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
             let (ctx_name, pane_count, notif_count) = self.sub_context_info
                 .get(pane_id)
                 .cloned()
                 .unwrap_or_else(|| ("(deleted)".to_string(), 0, 0));
-            let mut content_ui = ui.new_child(
-                egui::UiBuilder::new().max_rect(pane_rect.shrink(style::SPACE_MD)),
+
+            let tiers = crate::tiling::sub_context_responsive_tiers(
+                &ctx_name, pane_count, notif_count, &self.colors,
             );
-            content_ui.centered_and_justified(|ui| {
-                ui.vertical_centered(|ui| {
-                    ui.label(
-                        egui::RichText::new(&ctx_name)
-                            .size(style::TEXT_TITLE_XL)
-                            .strong()
-                            .color(self.colors.text_primary),
-                    );
-                    ui.add_space(style::SPACE_SM);
-                    ui.label(
-                        egui::RichText::new(format!("{pane_count} panes"))
-                            .size(style::TEXT_CAPTION)
-                            .color(self.colors.text_dim),
-                    );
-                    ui.add_space(style::SPACE_MD);
-                    // Wireframe layout outline — simple rounded rectangle placeholder.
-                    let (rect, _) = ui.allocate_exact_size(
-                        egui::Vec2::new(120.0, 60.0),
-                        egui::Sense::hover(),
-                    );
-                    ui.painter().rect_stroke(
-                        rect,
-                        egui::CornerRadius::same(4),
-                        egui::Stroke::new(1.0, self.colors.text_dim),
-                        egui::StrokeKind::Inside,
-                    );
-                    ui.add_space(style::SPACE_SM);
-                    ui.label(
-                        egui::RichText::new("\u{2318}\u{21E7}\u{21B5} to zoom in")
-                            .size(style::TEXT_HINT)
-                            .color(self.colors.text_dim),
-                    );
-                    if notif_count > 0 {
-                        ui.add_space(style::SPACE_SM);
-                        ui.label(
-                            egui::RichText::new(format!("\u{25CF} {notif_count}"))
-                                .size(style::TEXT_CAPTION)
-                                .color(egui::Color32::from_rgb(255, 100, 100)),
-                        );
-                    }
-                });
-            });
+            let avail_w = pane_rect.width();
+            let avail_h = pane_rect.height();
+            if let Some(tier) = crate::process_app::render::select_responsive_tier(
+                &tiers, avail_w, avail_h,
+            ) {
+                log::info!(
+                    "sub_context responsive: aspect={} for {}x{}",
+                    tier.aspect, avail_w, avail_h,
+                );
+                let clip = pane_rect;
+                let mut cache = egui_commonmark::CommonMarkCache::default();
+                let audio_peaks = HashMap::new();
+                crate::process_app::render::render_layout_node(
+                    ui, pane_rect, clip,
+                    style::SPACE_MD, style::SPACE_MD,
+                    &tier.direction, &tier.children, tier.gap,
+                    &self.colors, &mut cache, &audio_peaks,
+                );
+            }
         }
 
         UiResponse::None
@@ -278,4 +256,171 @@ pub(crate) fn write_dropped_paths_to_terminal(ui: &egui::Ui, t: &mut TerminalPan
             .process_command(BackendCommand::Write(escaped.as_bytes().to_vec()));
         log::info!("drop: path written ok");
     }
+}
+
+// ── SubContext responsive tier builder ─────────────────────────────────────────
+
+use crate::app_protocol::{LayoutChild, LayoutDirection, RenderCommand, ResponsiveTier};
+
+/// Build the three responsive tiers for a SubContext preview card.
+///
+/// - Landscape: horizontal row with context name + pane count + notification badge
+/// - Square: column with abbreviated info
+/// - Portrait: compact vertical stack
+pub(crate) fn sub_context_responsive_tiers(
+    ctx_name: &str,
+    pane_count: usize,
+    notif_count: usize,
+    colors: &Colors,
+) -> Vec<ResponsiveTier> {
+    let text_primary = format!("#{:02x}{:02x}{:02x}", colors.text_primary.r(), colors.text_primary.g(), colors.text_primary.b());
+    let text_dim = format!("#{:02x}{:02x}{:02x}", colors.text_dim.r(), colors.text_dim.g(), colors.text_dim.b());
+
+    let name_leaf = LayoutChild::Leaf {
+        command: Box::new(RenderCommand::Text {
+            x: 0.0, y: 0.0,
+            text: ctx_name.to_string(),
+            size: style::TEXT_TITLE_XL,
+            color: text_primary.clone(),
+            monospace: false,
+            bold: true,
+            align: "top_left".to_string(),
+            max_width: None,
+            elide: false,
+            selectable: false,
+        }),
+    };
+
+    let pane_count_leaf = LayoutChild::Leaf {
+        command: Box::new(RenderCommand::Text {
+            x: 0.0, y: 0.0,
+            text: format!("{pane_count} panes"),
+            size: style::TEXT_CAPTION,
+            color: text_dim.clone(),
+            monospace: false,
+            bold: false,
+            align: "top_left".to_string(),
+            max_width: None,
+            elide: false,
+            selectable: false,
+        }),
+    };
+
+    let shortcut_leaf = LayoutChild::Leaf {
+        command: Box::new(RenderCommand::Text {
+            x: 0.0, y: 0.0,
+            text: "\u{2318}\u{21E7}\u{21B5} zoom in".to_string(),
+            size: style::TEXT_HINT,
+            color: text_dim.clone(),
+            monospace: false,
+            bold: false,
+            align: "top_left".to_string(),
+            max_width: None,
+            elide: false,
+            selectable: false,
+        }),
+    };
+
+    let mut landscape_children = vec![
+        name_leaf.clone(),
+        pane_count_leaf.clone(),
+        shortcut_leaf.clone(),
+    ];
+    if notif_count > 0 {
+        landscape_children.push(LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Badge {
+                x: 0.0, y: 0.0,
+                label: format!("{notif_count}"),
+                fill: "#ff6464".to_string(),
+                fg: "#ffffff".to_string(),
+                font_size: style::TEXT_HINT,
+                radius: 8.0,
+            }),
+        });
+    }
+
+    let mut square_children = vec![
+        name_leaf.clone(),
+        pane_count_leaf.clone(),
+    ];
+    if notif_count > 0 {
+        square_children.push(LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Badge {
+                x: 0.0, y: 0.0,
+                label: format!("{notif_count}"),
+                fill: "#ff6464".to_string(),
+                fg: "#ffffff".to_string(),
+                font_size: style::TEXT_HINT,
+                radius: 8.0,
+            }),
+        });
+    }
+
+    let mut portrait_children = vec![
+        LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Text {
+                x: 0.0, y: 0.0,
+                text: ctx_name.to_string(),
+                size: style::TEXT_CAPTION,
+                color: text_primary.clone(),
+                monospace: false,
+                bold: true,
+                align: "top_left".to_string(),
+                max_width: None,
+                elide: false,
+                selectable: false,
+            }),
+        },
+        LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Text {
+                x: 0.0, y: 0.0,
+                text: format!("{pane_count}p"),
+                size: style::TEXT_HINT,
+                color: text_dim.clone(),
+                monospace: false,
+                bold: false,
+                align: "top_left".to_string(),
+                max_width: None,
+                elide: false,
+                selectable: false,
+            }),
+        },
+    ];
+    if notif_count > 0 {
+        portrait_children.push(LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Text {
+                x: 0.0, y: 0.0,
+                text: format!("\u{25CF} {notif_count}"),
+                size: style::TEXT_HINT,
+                color: "#ff6464".to_string(),
+                monospace: false,
+                bold: false,
+                align: "top_left".to_string(),
+                max_width: None,
+                elide: false,
+                selectable: false,
+            }),
+        });
+    }
+
+    vec![
+        ResponsiveTier {
+            aspect: "landscape".to_string(),
+            direction: LayoutDirection::Row,
+            children: landscape_children,
+            gap: style::SPACE_MD,
+        },
+        ResponsiveTier {
+            aspect: "portrait".to_string(),
+            direction: LayoutDirection::Column,
+            children: portrait_children,
+            gap: style::SPACE_SM,
+        },
+        ResponsiveTier {
+            aspect: "square".to_string(),
+            direction: LayoutDirection::Column,
+            children: square_children,
+            gap: style::SPACE_SM,
+        },
+    ]
 }


### PR DESCRIPTION
## Summary

- Adds `RenderCommand::Responsive` variant with `ResponsiveTier` struct for aspect-ratio-based layout selection (landscape/portrait/square)
- Replaces SubContext wireframe card with responsive PGAP rendering through the existing taffy pipeline
- Adds `ctx.responsive()` to Python SDK for app-side multi-tier layouts
- Adds headless renderer support for the new `responsive` command type

## Done When criteria

- [x] SubContext pane renders through the PGAP pipeline at all three aspect ratios
- [x] Resizing a SubContext pane dynamically switches between landscape/square/portrait layouts
- [x] SDK exposes `ctx.responsive()` for apps to declare multi-tier layouts
- [x] Existing `Layout` command behavior is unchanged (backwards compatible)
- [x] Headless renderer handles the new variant for test coverage

## Test plan

- [ ] Open Plexi with a SubContext pane visible
- [ ] Resize the pane between wide, tall, and square shapes
- [ ] Verify the layout adapts (row vs column, full text vs abbreviated)
- [ ] Verify no regressions in existing PGAP app rendering

Closes #1404