### PR TITLE
fix(keys): change scratchpad trigger from Ctrl+Space to Cmd+Shift+Space (#1380)

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -157,6 +157,7 @@ osc_pane_title = true
 # open_secrets_manager    = "cmd+shift+s"
 # force_reload_app        = "cmd+alt+r"
 # toggle_notification_modal = "cmd+shift+a"
+# open_scratchpad          = "cmd+shift+space"
 
 # ── Quick Note ─────────────────────────────────────────────────
 # Cmd+0 opens a compose modal. Enter advances to the destination

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2832,7 +2832,7 @@ impl eframe::App for PlexiApp {
                     self.minimap.toggle();
                 }
                 Action::OpenScratchpad => {
-                    log::info!("scratchpad: Ctrl+Space — opening");
+                    log::info!("scratchpad: Cmd+Shift+Space — opening");
                     self.open_scratchpad();
                 }
                 Action::ContextZoomIn => {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -121,7 +121,7 @@ pub enum Action {
     /// Swap the focused pane with its neighbor in the given direction.
     /// Bound to Cmd+Ctrl+H/J/K/L.
     SwapPane(Direction),
-    /// Open the scratchpad overlay. Bound to Ctrl+Space.
+    /// Open the scratchpad overlay. Bound to Cmd+Shift+Space.
     OpenScratchpad,
     /// Zoom into the sub-context tile that has focus. Bound to Cmd+Shift+Enter.
     ContextZoomIn,
@@ -239,7 +239,7 @@ impl Default for KeyBindings {
             force_reload_app:          (cmd_alt(),   egui::Key::R),
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
             context_inspector:         (cmd(),       egui::Key::I),
-            open_scratchpad:           (ctrl(),      egui::Key::Space),
+            open_scratchpad:           (cmd_shift(), egui::Key::Space),
             context_zoom_in:           (cmd_shift(), egui::Key::Enter),
             context_zoom_out:          (cmd(),       egui::Key::Escape),
         }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -190,10 +190,6 @@ fn cmd_ctrl() -> egui::Modifiers {
 fn cmd_alt() -> egui::Modifiers {
     egui::Modifiers { alt: true, ..egui::Modifiers::COMMAND }
 }
-fn ctrl() -> egui::Modifiers {
-    egui::Modifiers { ctrl: true, ..egui::Modifiers::NONE }
-}
-
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Summary

- Changes `open_scratchpad` default keybinding from `Ctrl+Space` to `Cmd+Shift+Space`
- `Ctrl+Space` conflicts with zsh/fzf completions and macOS input method switching
- `Cmd+Shift+Space` avoids all shell-level conflicts — terminal emulators don't pass Cmd chords to the shell
- Existing users with a custom `open_scratchpad` override in `config.toml` are unaffected

## Done when
- Scratchpad opens with Cmd+Shift+Space instead of Ctrl+Space
- Config override still works

Closes #1380