### PR TITLE
feat(website): add Download nav button and pre-release gate page

### DIFF
--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -14,6 +14,9 @@ import Logo from './Logo.astro';
       <a href="/docs">Docs</a>
       <a href="/support">Support</a>
     </div>
+    <div class="cta">
+      <a class="btn" href="/download">Download</a>
+    </div>
     <button class="mobile-menu-btn" aria-label="Menu" aria-expanded="false">
       <span class="bar"></span>
       <span class="bar"></span>
@@ -65,6 +68,7 @@ import Logo from './Logo.astro';
 
   @media (max-width: 980px) {
     .mobile-menu-btn { display: flex; }
+    .cta { display: none; }
     nav.top.open .mobile-menu { display: flex; }
     nav.top.open .mobile-menu-btn .bar:first-child { transform: rotate(45deg) translate(2px, 2px); }
     nav.top.open .mobile-menu-btn .bar:last-child { transform: rotate(-45deg) translate(2px, -2px); }

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -21,42 +21,35 @@ const platforms = [
 
   <section class="dl-section">
     <div class="wrap">
-      <div class="dl-grid">
-        {platforms.map((p) => (
-          <div class={`dl-card${p.comingSoon ? ' is-soon' : ''}`} data-os={p.id}>
-            <div class="dl-os">
-              {p.name}
-              {p.comingSoon && <span class="dl-badge">Coming soon</span>}
+      <div class="dl-gate-wrap">
+        <div class="dl-gate">
+          <p class="dl-gate-title">Plexi is currently in pre-release.</p>
+          <p class="dl-gate-body">
+            If you'd like to become an alpha tester, you can download the latest build on
+            <a href={RELEASES_LATEST}>GitHub</a>.
+          </p>
+        </div>
+        <div class="dl-grid dl-grid-blurred" aria-hidden="true">
+          {platforms.map((p) => (
+            <div class={`dl-card${p.comingSoon ? ' is-soon' : ''}`} data-os={p.id}>
+              <div class="dl-os">
+                {p.name}
+                {p.comingSoon && <span class="dl-badge">Coming soon</span>}
+              </div>
+              <div class="dl-note">{p.note}</div>
+              {p.comingSoon
+                ? <span class="btn btn-disabled">Download <span class="arrow">→</span></span>
+                : <span class="btn">Download <span class="arrow">→</span></span>
+              }
             </div>
-            <div class="dl-note">{p.note}</div>
-            {p.comingSoon
-              ? <span class="btn btn-disabled">Download <span class="arrow">→</span></span>
-              : <a class="btn" href={RELEASES_LATEST}>Download <span class="arrow">→</span></a>
-            }
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-      <p class="dl-foot">
-        Looking for an older version? <a href={RELEASES_ALL}>Browse all releases →</a>
-      </p>
     </div>
   </section>
 
   <Newsletter compact />
 </Layout>
-
-<script is:inline>
-  (function () {
-    var ua = navigator.userAgent || '';
-    var os = null;
-    if (/Mac/i.test(ua)) os = 'mac';
-    else if (/Win/i.test(ua)) os = 'windows';
-    else if (/Linux/i.test(ua)) os = 'linux';
-    if (!os) return;
-    var card = document.querySelector('.dl-card[data-os="' + os + '"]');
-    if (card) card.classList.add('is-detected');
-  })();
-</script>
 
 <style>
   .dl-hero { padding: 120px 0 40px; }
@@ -67,23 +60,47 @@ const platforms = [
   .dl-hero .tagline { font-size: 16px; color: var(--fg-2); max-width: 560px; }
 
   .dl-section { padding: 32px 0 120px; }
+
+  .dl-gate-wrap { position: relative; }
+
+  .dl-gate {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    text-align: center;
+    padding: 32px;
+  }
+  .dl-gate-title {
+    font-size: 20px; font-weight: 600; letter-spacing: -0.01em; color: var(--fg);
+  }
+  .dl-gate-body {
+    font-size: 15px; color: var(--fg-2); max-width: 380px; line-height: 1.6;
+  }
+  .dl-gate-body a { color: var(--accent-light); text-decoration: none; }
+  .dl-gate-body a:hover { color: var(--fg); }
+
   .dl-grid {
     display: grid; grid-template-columns: repeat(3, 1fr);
     gap: 20px; margin-bottom: 32px;
   }
+  .dl-grid-blurred {
+    opacity: 0.15;
+    filter: blur(3px);
+    pointer-events: none;
+    user-select: none;
+  }
+
   .dl-card {
     border: 1px solid var(--border-2);
     background: var(--bg-2);
     border-radius: 10px;
     padding: 28px 24px;
     display: flex; flex-direction: column; gap: 10px;
-    transition: border-color 150ms, background 150ms;
-  }
-  .dl-card:hover { border-color: var(--border-3); }
-  .dl-card.is-detected {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent), 0 0 32px var(--accent-dim);
-    background: linear-gradient(180deg, var(--accent-dim), var(--bg-2));
   }
   .dl-card .dl-os {
     font-size: 18px; font-weight: 600; letter-spacing: -0.01em; color: var(--fg);
@@ -93,10 +110,6 @@ const platforms = [
   }
   .dl-card .btn { align-self: flex-start; }
 
-  .dl-card.is-soon {
-    opacity: 0.45;
-    pointer-events: none;
-  }
   .dl-badge {
     display: inline-block;
     margin-left: 10px;
@@ -119,15 +132,11 @@ const platforms = [
     user-select: none;
   }
 
-  .dl-foot {
-    font-size: 12px; color: var(--fg-3); text-align: center;
-    text-transform: uppercase; letter-spacing: 0.06em;
-  }
-  .dl-foot a { color: var(--fg-2); }
-  .dl-foot a:hover { color: var(--fg); }
-
   @media (max-width: 720px) {
     .dl-hero h1 { font-size: 40px; }
     .dl-grid { grid-template-columns: 1fr; }
+    .dl-gate { padding: 24px 16px; }
+    .dl-gate-title { font-size: 17px; }
+    .dl-gate-body { font-size: 14px; }
   }
 </style>


### PR DESCRIPTION
## Summary

- Adds a **Download** button to the desktop nav (top right), hidden on mobile where it already exists in the hamburger menu
- Replaces the download page with a pre-release gate: platform cards are blurred/faded underneath, and a centered message explains Plexi is in pre-release with a link to GitHub releases for alpha testers

## Test plan

- [ ] Desktop nav shows purple Download button in top right
- [ ] At ≤980px, Download button disappears from nav (mobile menu still has it)
- [ ] `/download` shows the pre-release message centered over grayed-out platform cards
- [ ] GitHub link in the message goes to the latest release