### PR TITLE
feat(quick-note): show resolved CWD in compose modal (#1382)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -3300,22 +3300,36 @@ impl PlexiApp {
 /// Format a CWD path for compact display: tilde-abbreviate, then keep the last 3 components.
 /// e.g. `/Users/alice/Documents/GitHub/PLEXI` → `~/Documents/GitHub/PLEXI`
 ///      `/Users/alice/a/b/c/d/e` → `~/…/c/d/e`
+///      `/var/log/a/b/c/d` → `/…/b/c/d`
 fn format_cwd_short(path: &std::path::Path) -> String {
-    let tilde_path = dirs::home_dir()
-        .and_then(|home| path.strip_prefix(&home).ok().map(|rel| {
-            let rel_str = rel.to_string_lossy();
-            if rel_str.is_empty() { "~".to_string() } else { format!("~/{rel_str}") }
-        }))
-        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    use std::path::Component;
 
-    // Count components after the tilde abbreviation.
-    let after_tilde = tilde_path.strip_prefix("~/").unwrap_or(&tilde_path);
-    let parts: Vec<&str> = after_tilde.split('/').filter(|s| !s.is_empty()).collect();
+    let home = dirs::home_dir();
+    let in_home = home.as_ref().map_or(false, |h| path.starts_with(h));
+
+    let (prefix, components_path): (&str, &std::path::Path) = if in_home {
+        let rel = path.strip_prefix(home.as_ref().unwrap()).unwrap();
+        if rel.components().next().is_none() {
+            return "~".to_string();
+        }
+        ("~/", rel)
+    } else {
+        ("", path)
+    };
+
+    let parts: Vec<std::borrow::Cow<str>> = components_path
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s.to_string_lossy()),
+            _ => None,
+        })
+        .collect();
+
     if parts.len() <= 3 {
-        tilde_path
+        format!("{prefix}{}", components_path.to_string_lossy())
     } else {
         let tail = parts[parts.len() - 3..].join("/");
-        format!("~/\u{2026}/{tail}")
+        format!("{prefix}\u{2026}/{tail}")
     }
 }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -904,6 +904,16 @@ impl PlexiApp {
                                 .size(style::TEXT_HINT)
                                 .family(egui::FontFamily::Monospace),
                         );
+
+                        // CWD indicator — shows which directory {cwd} resolves to.
+                        let cwd_label = format_cwd_short(&self.quick_note_ctx.cwd);
+                        ui.label(
+                            RichText::new(format!("cwd: {cwd_label}"))
+                                .color(self.colors.text_dim.linear_multiply(0.4))
+                                .size(style::TEXT_HINT)
+                                .family(egui::FontFamily::Monospace),
+                        );
+
                         ui.add_space(style::SPACE_SM);
 
                         // Text input — starts at ~25% screen height, grows with content, caps at ~80%.
@@ -3284,6 +3294,28 @@ impl PlexiApp {
             log::info!("cli_setup: dismissed via Escape — will ask again next launch");
             self.show_cli_setup_prompt = false;
         }
+    }
+}
+
+/// Format a CWD path for compact display: tilde-abbreviate, then keep the last 3 components.
+/// e.g. `/Users/alice/Documents/GitHub/PLEXI` → `~/Documents/GitHub/PLEXI`
+///      `/Users/alice/a/b/c/d/e` → `~/…/c/d/e`
+fn format_cwd_short(path: &std::path::Path) -> String {
+    let tilde_path = dirs::home_dir()
+        .and_then(|home| path.strip_prefix(&home).ok().map(|rel| {
+            let rel_str = rel.to_string_lossy();
+            if rel_str.is_empty() { "~".to_string() } else { format!("~/{rel_str}") }
+        }))
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+
+    // Count components after the tilde abbreviation.
+    let after_tilde = tilde_path.strip_prefix("~/").unwrap_or(&tilde_path);
+    let parts: Vec<&str> = after_tilde.split('/').filter(|s| !s.is_empty()).collect();
+    if parts.len() <= 3 {
+        tilde_path
+    } else {
+        let tail = parts[parts.len() - 3..].join("/");
+        format!("~/\u{2026}/{tail}")
     }
 }
 


### PR DESCRIPTION
## What

Displays the focused pane's working directory in the Quick Note compose modal header, so users can see at a glance which directory `{cwd}` will resolve to before submitting.

## Done When

- [x] Quick Note modal shows the current working directory of the focused pane
- [x] User can see at a glance which directory `{cwd}` will resolve to before submitting

## Implementation

Added a `cwd: <path>` line in muted monospace text below the keyboard shortcuts hint in `draw_quick_note_modal()`. The CWD is already captured in `self.quick_note_ctx.cwd` at modal open time.

Path is formatted via `format_cwd_short()`: tilde-abbreviated, trimmed to last 3 segments if longer (e.g. `~/…/c/d/e`).

Closes #1382