### PR TITLE
fix(scratchpad): re-request focus on window regain after Cmd+Tab (#1381)

### DIFF
--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -123,9 +123,15 @@ impl App for ScratchpadApp {
             );
 
             let te_id = egui::Id::new("scratchpad_text");
-            if !self.focus_requested {
+            let window_regained_focus = ui.ctx().input(|i| {
+                i.events.iter().any(|e| matches!(e, egui::Event::WindowFocused(true)))
+            });
+            if !self.focus_requested || window_regained_focus {
                 ui.ctx().memory_mut(|m| m.request_focus(te_id));
                 self.focus_requested = true;
+                if window_regained_focus {
+                    log::info!("scratchpad: window regained focus — re-requesting text editor focus");
+                }
             }
 
             ui.allocate_new_ui(egui::UiBuilder::new().max_rect(text_rect), |ui| {
@@ -175,9 +181,15 @@ impl App for ScratchpadApp {
             }
 
             let te_id = egui::Id::new("scratchpad_filename");
-            if !self.save_focus_requested {
+            let window_regained_focus = ui.ctx().input(|i| {
+                i.events.iter().any(|e| matches!(e, egui::Event::WindowFocused(true)))
+            });
+            if !self.save_focus_requested || window_regained_focus {
                 ui.ctx().memory_mut(|m| m.request_focus(te_id));
                 self.save_focus_requested = true;
+                if window_regained_focus {
+                    log::info!("scratchpad: window regained focus — re-requesting filename field focus");
+                }
             }
 
             egui::Area::new(egui::Id::new("scratchpad_save_modal"))

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -90,6 +90,9 @@ impl App for ScratchpadApp {
 
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         let colors = ctx.colors;
+        let window_regained_focus = ui.ctx().input(|i| {
+            i.events.iter().any(|e| matches!(e, egui::Event::WindowFocused(true)))
+        });
 
         if self.mode == Mode::Editing {
             let save_pressed = ui.input_mut(|i| {
@@ -123,9 +126,6 @@ impl App for ScratchpadApp {
             );
 
             let te_id = egui::Id::new("scratchpad_text");
-            let window_regained_focus = ui.ctx().input(|i| {
-                i.events.iter().any(|e| matches!(e, egui::Event::WindowFocused(true)))
-            });
             if !self.focus_requested || window_regained_focus {
                 ui.ctx().memory_mut(|m| m.request_focus(te_id));
                 self.focus_requested = true;
@@ -177,13 +177,11 @@ impl App for ScratchpadApp {
             });
             if esc_pressed {
                 self.mode = Mode::Editing;
+                self.focus_requested = false;
                 return;
             }
 
             let te_id = egui::Id::new("scratchpad_filename");
-            let window_regained_focus = ui.ctx().input(|i| {
-                i.events.iter().any(|e| matches!(e, egui::Event::WindowFocused(true)))
-            });
             if !self.save_focus_requested || window_regained_focus {
                 ui.ctx().memory_mut(|m| m.request_focus(te_id));
                 self.save_focus_requested = true;


### PR DESCRIPTION
## Summary

- The `focus_requested` flag in `ScratchpadApp` is a one-shot guard: set to `true` on the first render, never reset. When the OS window loses focus (Cmd+Tab) and regains it, egui clears its internal focus state for all text widgets, but `focus_requested` stays `true` — so no re-request fires and the text editor is left un-focused.
- Fix: listen for `egui::Event::WindowFocused(true)` in both `Mode::Editing` (main text area) and `Mode::SaveModal` (filename field). When the event fires, `request_focus` is called for that frame's active field.
- Adds `log::info!` trace when the regain path is taken.

## Done When

- Switch away from Plexi while Scratchpad (Cmd+Shift+Space) is open, then switch back — text editor retains focus and accepts keystrokes immediately.

## Test plan

- [ ] Open Scratchpad (Cmd+Shift+Space)
- [ ] Type some text to confirm focus is working
- [ ] Cmd+Tab to another app and back
- [ ] Type immediately — keystrokes should appear in the editor without clicking

Closes #1381