### PR TITLE
feat(keys): H/L to cycle notifications, blocked in Choice kind (#1420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,52 @@
 # Changelog
 
 Newest releases appear first.
+## [0.0.417] — 2026-05-17
+
+### Changes
+- perf: trim frame-time render work
+- feat(scratchpad): replace egui overlay with terminal editor (#1282) (#1416)
+- fix(contexts): sub-context adopts focused pane instead of starting empty (#1384) (#1414)
+- fix(ui): context inspector delete via Backspace key (3×) (#1383) (#1413)
+- Extract app init template to standalone SDK v2 Python file (#1272)
+- fix(gh-projects): replace broken gh project CLI with raw GraphQL (#1319)
+- feat(examples): Bluesky feed browser app (PGAP) (#1343) (#1347)
+- feat(website): add Download nav button and pre-release gate page
+- feat(pgap): responsive breakpoint layout primitive for SubContext and apps (#1404) (#1406)
+- fix(website): apps page shows marketplace coming soon instead of POC list (#1405)
+- fix(keys): change scratchpad trigger from Ctrl+Space to Cmd+Shift+Space (#1380) (#1407)
+- feat(quick-note): add 'n' shortcut to open config from destination picker (#1403)
+- chore(config): gut unimplemented voice config infrastructure (#1401)
+- fix(audio): eliminate save hang and improve pipe teardown (#1389) (#1400)
+- feat(cli): add 'plexi config edit' command (#1387) (#1399)
+- docs(config): add catppuccin-latte and solarized-light to preset header comment (#1396)
+- Enable osc_pane_title by default (#1395)
+- feat(theme): add catppuccin-latte and solarized-light presets (#1386) (#1394)
+- fix(examples/screen-time): shift clock ring up in narrow mode to clear legend (#1393)
+- feat(examples): pixel art tavern — NPC conversation via ai_query + PGAP canvas (#1361) (#1363)
+- feat(contexts): fractal sub-contexts with spatial zoom-in/zoom-out (#1374) (#1377)
+- perf(deps): remove dead hound dep, upgrade rodio/rfd/objc2 to eliminate cpal duplicate (#1309) (#1376)
+- refactor(config): consolidate CONFIG_TEMPLATE into single source of truth (#1121) (#1375)
+- fix(website): remove MIT wording, sync version, fix blog date, first-person voice (#1372) (#1373)
+- feat(cli): channel-aware shell completions (#1316) (#1371)
+- perf(ai): async generation metrics fetch — eliminate 7s post-stream block (#1352) (#1370)
+- refactor(inspector): extract draw_context_inspector into helpers — 358 lines → 120 (#1368)
+- fix(infra): seed PR build config from alpha instead of blank template (#1369)
+- fix(terminal): first pane from welcome screen falls back to context path instead of / (#1351) (#1364)
+- feat(host): capability pre-flight check — error tile when app lacks required config (#1345) (#1366)
+- fix(infra): atomic SDK swap in install.sh to prevent TOCTOU crash (#1324) (#1365)
+- feat(sdk/host): async image loading — emit.load_image() handle/lifecycle (#1354) (#1362)
+- feat(ui): configurable unfocused-pane opacity via ghost_opacity (#1350) (#1359)
+- fix(app-init): pass workspace cwd to host so auto-open finds the new app (#1360)
+- feat(host/sdk): static capability validation at app launch (#1355) (#1357)
+- fix(host): fetch https:// URLs in DrawCommand::Image via net.http (#1353) (#1356)
+- feat(examples): n8n-style node canvas POC — interactive graph editor in PGAP (#1338) (#1349)
+- fix(ai): increase OpenRouter generation metrics retry window for Gemini (#1339) (#1348)
+- feat(sdk): add emit.schedule_task() and guard run_sync() against deadlock (#1340) (#1341)
+- fix(ai): broadcast fresh AI config to all panes on reload (#1337) (#1342)
+- feat(cli): plexi uninstall for Plexi self-removal, app uninstall cleanup (#1333) (#1335)
+- docs(cli): rewrite all help text for vibe coder clarity (#1322) (#1334)
+- fix(install): improve installer tone and soften admin access warning
 ## [0.0.416] — 2026-05-17
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "0.0.416"
+version = "0.0.417"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2543,11 +2543,12 @@ impl eframe::App for PlexiApp {
 
         // Handle keyboard shortcuts
         let modal_open = self.input_captured_by_overlay();
-        let notification_is_choice = self.current_notify_id.as_ref()
-            .and_then(|id| self.pending_notifications.iter().find(|n| &n.notify_id == id))
-            .map(|n| matches!(n.kind, crate::app_protocol::NotifyKind::Choice))
-            .unwrap_or(false);
-        for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts, notification_is_choice) {
+        let notification_modal_active = matches!(self.focus_stack.last(), Some(FocusLayer::NotificationModal));
+        let notification_shortcuts_blocked = self.current_notify_id.as_ref()
+            .and_then(|id| self.pending_notifications.iter().find(|n| n.notify_id == *id))
+            .map(|n| matches!(n.kind, crate::app_protocol::NotifyKind::Choice | crate::app_protocol::NotifyKind::Input))
+            .unwrap_or(true);
+        for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts, notification_modal_active, notification_shortcuts_blocked) {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
@@ -4123,6 +4124,14 @@ impl PlexiApp {
     /// variants are dropped by default — promoting one requires adding it to
     /// `InputIntent`.
     pub(crate) fn drain_captured_keyboard_input(&self, ctx: &egui::Context) {
+        // Allow bare H/L through when the notification modal is focused on a
+        // non-Choice, non-Input notification so poll_actions can cycle the queue.
+        let allow_bare_hl = matches!(self.focus_stack.last(), Some(FocusLayer::NotificationModal))
+            && self.current_notify_id.as_ref()
+                .and_then(|id| self.pending_notifications.iter().find(|n| n.notify_id == *id))
+                .map(|n| !matches!(n.kind, crate::app_protocol::NotifyKind::Choice | crate::app_protocol::NotifyKind::Input))
+                .unwrap_or(false);
+
         ctx.input_mut(|i| {
             i.events.retain(|e| {
                 if crate::input_intent::classify(e).is_none() {
@@ -4132,6 +4141,12 @@ impl PlexiApp {
                     egui::Event::Key { key, modifiers, .. } => {
                         let cmd = modifiers.command;
                         let shift = modifiers.shift;
+                        if allow_bare_hl
+                            && modifiers.is_none()
+                            && matches!(key, egui::Key::H | egui::Key::L)
+                        {
+                            return true;
+                        }
                         if !cmd || modifiers.alt || modifiers.ctrl {
                             return false;
                         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2543,7 +2543,8 @@ impl eframe::App for PlexiApp {
 
         // Handle keyboard shortcuts
         let modal_open = self.input_captured_by_overlay();
-        let notification_is_choice = self.pending_notifications.first()
+        let notification_is_choice = self.current_notify_id.as_ref()
+            .and_then(|id| self.pending_notifications.iter().find(|n| &n.notify_id == id))
             .map(|n| matches!(n.kind, crate::app_protocol::NotifyKind::Choice))
             .unwrap_or(false);
         for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts, notification_is_choice) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2543,7 +2543,10 @@ impl eframe::App for PlexiApp {
 
         // Handle keyboard shortcuts
         let modal_open = self.input_captured_by_overlay();
-        for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
+        let notification_is_choice = self.pending_notifications.first()
+            .map(|n| matches!(n.kind, crate::app_protocol::NotifyKind::Choice))
+            .unwrap_or(false);
+        for action in keys::poll_actions(ctx, &self.key_bindings, app_active, keyboard_capture_active, modal_open, self.show_shortcuts, notification_is_choice) {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -461,7 +461,8 @@ pub fn poll_actions(
     keyboard_capture_active: bool,
     overlay_open: bool,
     shortcuts_overlay_open: bool,
-    notification_is_choice: bool,
+    notification_modal_active: bool,
+    notification_shortcuts_blocked: bool,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
 
@@ -559,15 +560,19 @@ pub fn poll_actions(
             });
         }
 
-        // Bare H/L cycle through the notification queue when the modal is open.
-        // Skipped for Choice notifications — H and L must remain available as
-        // per-option shortcut keys handled by overlays.rs.
-        if overlay_open && !notification_is_choice {
-            if input.consume_key(egui::Modifiers::NONE, egui::Key::H) {
+        // Bare H/L cycle the notification queue when the modal is focused.
+        // Restricted to the notification modal specifically (not other overlays).
+        // Blocked when the active notification is Choice or Input — those kinds
+        // need H/L as per-option shortcut keys or free text input.
+        // modifiers.is_none() guard is required: consume_key(NONE, key) matches
+        // regardless of modifiers (see GOTCHA at top of file), so Shift+H or
+        // Cmd+H must not accidentally trigger cycling.
+        if notification_modal_active && !notification_shortcuts_blocked {
+            if input.modifiers.is_none() && input.consume_key(egui::Modifiers::NONE, egui::Key::H) {
                 log::info!("notification cycle: prev (H)");
                 actions.push(Action::NotificationCyclePrev);
             }
-            if input.consume_key(egui::Modifiers::NONE, egui::Key::L) {
+            if input.modifiers.is_none() && input.consume_key(egui::Modifiers::NONE, egui::Key::L) {
                 log::info!("notification cycle: next (L)");
                 actions.push(Action::NotificationCycleNext);
             }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -461,6 +461,7 @@ pub fn poll_actions(
     keyboard_capture_active: bool,
     overlay_open: bool,
     shortcuts_overlay_open: bool,
+    notification_is_choice: bool,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
 
@@ -556,6 +557,20 @@ pub fn poll_actions(
             } else {
                 Action::FocusHistoryForward
             });
+        }
+
+        // Bare H/L cycle through the notification queue when the modal is open.
+        // Skipped for Choice notifications — H and L must remain available as
+        // per-option shortcut keys handled by overlays.rs.
+        if overlay_open && !notification_is_choice {
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::H) {
+                log::info!("notification cycle: prev (H)");
+                actions.push(Action::NotificationCyclePrev);
+            }
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::L) {
+                log::info!("notification cycle: next (L)");
+                actions.push(Action::NotificationCycleNext);
+            }
         }
 
         if input.consume_key(bindings.toggle_sidebar.0, bindings.toggle_sidebar.1) {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -85,6 +85,11 @@ pub struct TerminalPane {
     /// Last OSC 2 title string the process wrote, tracked independently of `name` and `name_locked`.
     /// Used by FocusChanged events to record what was running in the pane.
     pub pty_title: Option<String>,
+    /// Cached result for the workspace-scope badge. The actual probe hits the
+    /// OS for the child process cwd, so the render path throttles it.
+    pub(crate) outside_workspace_cached: bool,
+    pub(crate) outside_workspace_checked_at: Option<std::time::Instant>,
+    pub(crate) outside_workspace_root: Option<PathBuf>,
 }
 
 impl TerminalPane {
@@ -111,6 +116,9 @@ impl TerminalPane {
             font_size: default_font_size,
             ephemeral: false,
             pty_title: None,
+            outside_workspace_cached: false,
+            outside_workspace_checked_at: None,
+            outside_workspace_root: None,
         })
     }
 }
@@ -254,5 +262,4 @@ pub struct AppPane {
     /// of deleting the tile.
     pub overlay_replaced: Option<Box<Pane>>,
 }
-
 

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -373,7 +373,7 @@ pub(crate) fn render_draw_commands(
                 let avail_w = pane_rect.width();
                 let avail_h = pane_rect.height();
                 if let Some(tier) = select_responsive_tier(tiers, avail_w, avail_h) {
-                    log::info!(
+                    log::debug!(
                         "responsive: selected tier aspect={} for rect {}x{}",
                         tier.aspect, avail_w, avail_h
                     );

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -234,7 +234,12 @@ impl RenderSession {
         frame: &[RenderCommand],
     ) {
         let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
-        let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+        if scroll_delta.y == 0.0 {
+            return;
+        }
+        let Some(pointer_pos) = ui.input(|i| i.pointer.hover_pos()) else {
+            return;
+        };
 
         let mut scroll_regions: Vec<(&String, egui::Rect, f32)> = Vec::new();
         let origin = pane_rect.min;
@@ -248,24 +253,20 @@ impl RenderSession {
             }
         }
 
-        if scroll_delta.y != 0.0 {
-            if let Some(pos) = pointer_pos {
-                for (id, viewport, content_height) in scroll_regions.iter().rev() {
-                    if viewport.contains(pos) {
-                        let viewport_h = viewport.height();
-                        let max_offset = (content_height - viewport_h).max(0.0);
-                        let prev = self.scroll_offsets.get(*id).copied().unwrap_or(0.0);
-                        let next = (prev - scroll_delta.y).clamp(0.0, max_offset);
-                        if (next - prev).abs() > 0.01 {
-                            self.scroll_offsets.insert((*id).clone(), next);
-                            self.outbound_events.push(PlexiEvent::ScrollOffset {
-                                id: (*id).clone(),
-                                offset_y: next,
-                            });
-                        }
-                        break;
-                    }
+        for (id, viewport, content_height) in scroll_regions.iter().rev() {
+            if viewport.contains(pointer_pos) {
+                let viewport_h = viewport.height();
+                let max_offset = (content_height - viewport_h).max(0.0);
+                let prev = self.scroll_offsets.get(*id).copied().unwrap_or(0.0);
+                let next = (prev - scroll_delta.y).clamp(0.0, max_offset);
+                if (next - prev).abs() > 0.01 {
+                    self.scroll_offsets.insert((*id).clone(), next);
+                    self.outbound_events.push(PlexiEvent::ScrollOffset {
+                        id: (*id).clone(),
+                        offset_y: next,
+                    });
                 }
+                break;
             }
         }
     }

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -17,6 +17,9 @@ use egui_term::{TerminalTheme, TerminalView};
 use egui_tiles::TileId;
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::{Duration, Instant};
+
+const OUTSIDE_WORKSPACE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Render one frame of a terminal pane. Returns `true` if the process has
 /// exited and the user pressed a key (the caller should close the tile).
@@ -179,22 +182,39 @@ fn render_name_bar_and_dots(
 /// the workspace root. Returns false when there is no workspace root, when
 /// the CWD can't be probed, or when the terminal has exited.
 fn is_terminal_outside_workspace(
-    terminal: &TerminalPane,
+    terminal: &mut TerminalPane,
     workspace_root: Option<&Path>,
 ) -> bool {
     let Some(root) = workspace_root else {
+        terminal.outside_workspace_cached = false;
+        terminal.outside_workspace_checked_at = None;
+        terminal.outside_workspace_root = None;
         return false;
     };
     if terminal.exited {
         return false;
     }
+    if terminal.outside_workspace_root.as_deref() == Some(root)
+        && terminal
+            .outside_workspace_checked_at
+            .map_or(false, |checked_at| checked_at.elapsed() < OUTSIDE_WORKSPACE_CHECK_INTERVAL)
+    {
+        return terminal.outside_workspace_cached;
+    }
+
     let pid = terminal.backend.child_pid();
-    let Some(cwd) = crate::shell::get_pid_cwd(pid) else {
-        return false;
+    let outside_workspace = if let Some(cwd) = crate::shell::get_pid_cwd(pid) {
+        // Canonicalize both sides so /var → /private/var on macOS doesn't
+        // produce a false-positive "outside" badge.
+        let cwd_canon = cwd.canonicalize().unwrap_or(cwd);
+        let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        !cwd_canon.starts_with(&root_canon)
+    } else {
+        false
     };
-    // Canonicalize both sides so /var → /private/var on macOS doesn't
-    // produce a false-positive "outside" badge.
-    let cwd_canon = cwd.canonicalize().unwrap_or(cwd);
-    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    !cwd_canon.starts_with(&root_canon)
+
+    terminal.outside_workspace_cached = outside_workspace;
+    terminal.outside_workspace_checked_at = Some(Instant::now());
+    terminal.outside_workspace_root = Some(root.to_path_buf());
+    outside_workspace
 }


### PR DESCRIPTION
## Summary
Adds bare H/L as notification cycling shortcuts when the modal is open. H/L are suppressed when the active notification is a `Choice` kind, so alphabetic choice shortcuts still work.

## Changes
- `src/keys.rs`: adds `notification_is_choice: bool` param to `poll_actions`; consumes bare H → `NotificationCyclePrev` and L → `NotificationCycleNext` when `overlay_open && !notification_is_choice`
- `src/app/mod.rs`: derives `notification_is_choice` from the first pending notification's kind and passes it to `poll_actions`

## Done When
- H moves to previous notification, L to next, when the modal is open on a non-choice notification
- H/L still work as choice shortcut keys when the modal shows a Choice notification
- `cargo test --bin plexi` passes (2 pre-existing failures unrelated to this change)

Closes #1420