### PR TITLE
feat(ui): reusable SearchableList widget with j/k clamping and scroll-to-me (#1390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,52 @@
 # Changelog
 
 Newest releases appear first.
+## [0.0.417] — 2026-05-17
+
+### Changes
+- perf: trim frame-time render work
+- feat(scratchpad): replace egui overlay with terminal editor (#1282) (#1416)
+- fix(contexts): sub-context adopts focused pane instead of starting empty (#1384) (#1414)
+- fix(ui): context inspector delete via Backspace key (3×) (#1383) (#1413)
+- Extract app init template to standalone SDK v2 Python file (#1272)
+- fix(gh-projects): replace broken gh project CLI with raw GraphQL (#1319)
+- feat(examples): Bluesky feed browser app (PGAP) (#1343) (#1347)
+- feat(website): add Download nav button and pre-release gate page
+- feat(pgap): responsive breakpoint layout primitive for SubContext and apps (#1404) (#1406)
+- fix(website): apps page shows marketplace coming soon instead of POC list (#1405)
+- fix(keys): change scratchpad trigger from Ctrl+Space to Cmd+Shift+Space (#1380) (#1407)
+- feat(quick-note): add 'n' shortcut to open config from destination picker (#1403)
+- chore(config): gut unimplemented voice config infrastructure (#1401)
+- fix(audio): eliminate save hang and improve pipe teardown (#1389) (#1400)
+- feat(cli): add 'plexi config edit' command (#1387) (#1399)
+- docs(config): add catppuccin-latte and solarized-light to preset header comment (#1396)
+- Enable osc_pane_title by default (#1395)
+- feat(theme): add catppuccin-latte and solarized-light presets (#1386) (#1394)
+- fix(examples/screen-time): shift clock ring up in narrow mode to clear legend (#1393)
+- feat(examples): pixel art tavern — NPC conversation via ai_query + PGAP canvas (#1361) (#1363)
+- feat(contexts): fractal sub-contexts with spatial zoom-in/zoom-out (#1374) (#1377)
+- perf(deps): remove dead hound dep, upgrade rodio/rfd/objc2 to eliminate cpal duplicate (#1309) (#1376)
+- refactor(config): consolidate CONFIG_TEMPLATE into single source of truth (#1121) (#1375)
+- fix(website): remove MIT wording, sync version, fix blog date, first-person voice (#1372) (#1373)
+- feat(cli): channel-aware shell completions (#1316) (#1371)
+- perf(ai): async generation metrics fetch — eliminate 7s post-stream block (#1352) (#1370)
+- refactor(inspector): extract draw_context_inspector into helpers — 358 lines → 120 (#1368)
+- fix(infra): seed PR build config from alpha instead of blank template (#1369)
+- fix(terminal): first pane from welcome screen falls back to context path instead of / (#1351) (#1364)
+- feat(host): capability pre-flight check — error tile when app lacks required config (#1345) (#1366)
+- fix(infra): atomic SDK swap in install.sh to prevent TOCTOU crash (#1324) (#1365)
+- feat(sdk/host): async image loading — emit.load_image() handle/lifecycle (#1354) (#1362)
+- feat(ui): configurable unfocused-pane opacity via ghost_opacity (#1350) (#1359)
+- fix(app-init): pass workspace cwd to host so auto-open finds the new app (#1360)
+- feat(host/sdk): static capability validation at app launch (#1355) (#1357)
+- fix(host): fetch https:// URLs in DrawCommand::Image via net.http (#1353) (#1356)
+- feat(examples): n8n-style node canvas POC — interactive graph editor in PGAP (#1338) (#1349)
+- fix(ai): increase OpenRouter generation metrics retry window for Gemini (#1339) (#1348)
+- feat(sdk): add emit.schedule_task() and guard run_sync() against deadlock (#1340) (#1341)
+- fix(ai): broadcast fresh AI config to all panes on reload (#1337) (#1342)
+- feat(cli): plexi uninstall for Plexi self-removal, app uninstall cleanup (#1333) (#1335)
+- docs(cli): rewrite all help text for vibe coder clarity (#1322) (#1334)
+- fix(install): improve installer tone and soften admin access warning
 ## [0.0.416] — 2026-05-17
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "0.0.416"
+version = "0.0.417"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -192,7 +192,7 @@ pub struct PlexiApp {
     pub(crate) quit_last_press: Option<std::time::Instant>,
     pub(crate) pending_close: bool,
     pub(crate) show_context_inspector: bool,
-    pub(crate) inspector_selected_pane: usize,
+    pub(crate) context_inspector_list: crate::widgets::SearchableList,
     pub(crate) inspector_delete_press_count: u8,
     pub(crate) inspector_delete_last_press: Option<std::time::Instant>,
     pub(crate) welcome_delete_press_count: u8,
@@ -241,8 +241,8 @@ pub struct PlexiApp {
     pub(crate) quick_note_text: String,
     /// Context captured at the time the quick note modal was opened.
     pub(crate) quick_note_ctx: QuickNoteCtx,
-    /// Cursor row in the destination picker (0 = global backlog, 1+ = config destinations).
-    pub(crate) quick_note_dest_cursor: usize,
+    /// Nav + search state for the destination picker (0 = global backlog, 1+ = config destinations).
+    pub(crate) quick_note_dest_list: crate::widgets::SearchableList,
     /// Cursor row in the sub-destination picker.
     pub(crate) quick_note_sub_cursor: usize,
     /// Cache of dynamically loaded children, keyed by full key path. Cleared on modal open.
@@ -668,7 +668,7 @@ impl PlexiApp {
                     quit_press_count: 0,
                     quit_last_press: None,
                     show_context_inspector: false,
-                    inspector_selected_pane: 0,
+                    context_inspector_list: crate::widgets::SearchableList::new(),
                     inspector_delete_press_count: 0,
                     inspector_delete_last_press: None,
                     welcome_delete_press_count: 0,
@@ -695,7 +695,7 @@ impl PlexiApp {
                     modal_input_buffer: String::new(),
                     quick_note_text: String::new(),
                     quick_note_ctx: QuickNoteCtx::default(),
-                    quick_note_dest_cursor: 0,
+                    quick_note_dest_list: crate::widgets::SearchableList::new(),
                     quick_note_sub_cursor: 0,
                     quick_note_children_cache: HashMap::new(),
                     quick_note_children_rx: None,
@@ -784,7 +784,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             show_context_inspector: false,
-            inspector_selected_pane: 0,
+            context_inspector_list: crate::widgets::SearchableList::new(),
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -811,7 +811,7 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
-            quick_note_dest_cursor: 0,
+            quick_note_dest_list: crate::widgets::SearchableList::new(),
             quick_note_sub_cursor: 0,
             quick_note_children_cache: HashMap::new(),
             quick_note_children_rx: None,
@@ -909,7 +909,7 @@ impl PlexiApp {
             quit_press_count: 0,
             quit_last_press: None,
             show_context_inspector: false,
-            inspector_selected_pane: 0,
+            context_inspector_list: crate::widgets::SearchableList::new(),
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -939,7 +939,7 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
-            quick_note_dest_cursor: 0,
+            quick_note_dest_list: crate::widgets::SearchableList::new(),
             quick_note_sub_cursor: 0,
             quick_note_children_cache: HashMap::new(),
             quick_note_children_rx: None,
@@ -2833,7 +2833,7 @@ impl eframe::App for PlexiApp {
                 }
                 Action::ContextInspector => {
                     self.show_context_inspector = !self.show_context_inspector;
-                    self.inspector_selected_pane = 0;
+                    self.context_inspector_list.reset();
                     log::info!("ContextInspector: toggled to {}", self.show_context_inspector);
                 }
                 Action::ToggleMinimap => {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -862,7 +862,7 @@ impl PlexiApp {
             }
         });
         if advance && !self.quick_note_text.trim().is_empty() {
-            self.quick_note_dest_cursor = 0;
+            self.quick_note_dest_list.reset();
             self.push_focus_layer(crate::app::FocusLayer::QuickNoteDestination);
             log::info!("QuickNote: advancing to destination picker");
             // Draw destination in the same frame to avoid a one-frame scrim flash.
@@ -949,7 +949,8 @@ impl PlexiApp {
             .unwrap_or(0);
         let total = 1 + dest_count;
 
-        // H or Esc → back to compose.
+        // H or Esc → back to compose. Consume before handle_nav so ArrowLeft
+        // doesn't also move the selection.
         let back = ctx.input_mut(|i| {
             i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)
                 || i.consume_key(egui::Modifiers::NONE, egui::Key::H)
@@ -957,37 +958,92 @@ impl PlexiApp {
         });
         if back {
             self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+            self.quick_note_dest_list.reset();
             log::info!("QuickNote: destination picker dismissed, back to composing");
             self.draw_quick_note_modal(ctx); // same-frame draw to avoid flash
             return;
         }
 
-        // Arrow / vim navigation.
-        let up = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+        // L / ArrowRight → enter submenu for selected item (zero-flash).
+        // Consume before handle_nav to prevent ArrowRight from moving selection.
+        let enter_sub = ctx.input_mut(|i| {
+            i.consume_key(egui::Modifiers::NONE, egui::Key::L)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight)
         });
-        let down = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::J)
-        });
-        if up {
-            self.quick_note_dest_cursor = if self.quick_note_dest_cursor == 0 {
-                total.saturating_sub(1)
-            } else {
-                self.quick_note_dest_cursor - 1
-            };
-            log::info!("QuickNote: dest cursor → {}", self.quick_note_dest_cursor);
-        }
-        if down {
-            self.quick_note_dest_cursor = (self.quick_note_dest_cursor + 1) % total.max(1);
-            log::info!("QuickNote: dest cursor → {}", self.quick_note_dest_cursor);
+        if enter_sub {
+            let cursor = self.quick_note_dest_list.selected;
+            if cursor > 0 {
+                let dest = self.config.quick_note.as_ref()
+                    .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
+                if let Some(dest) = dest {
+                    if dest.options.is_some() || dest.children_cmd.is_some() {
+                        let key = dest.key;
+                        self.quick_note_sub_cursor = 0;
+                        self.quick_note_children_cache.clear();
+                        self.quick_note_children_rx = None;
+                        self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
+                        log::info!("QuickNote: submenu opened via L: path=[{key}]");
+                        self.draw_quick_note_menu(ctx, &[key]);
+                        return;
+                    }
+                }
+            }
         }
 
-        // Enter → dispatch selected item.
-        let enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
-        if enter {
-            let cursor = self.quick_note_dest_cursor;
+        // N → open config file to add a new destination.
+        if ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::N)) {
+            log::info!("QuickNote: opening config to add destination");
+            crate::config::open_config_file();
+            return;
+        }
+
+        // Digit keys → fast-dispatch by number.
+        if let Some(key) = consume_digit_key(ctx) {
+            if key == 0 {
+                let text = self.quick_note_text.clone();
+                log::info!("QuickNote: destination selected: key=0 (global backlog)");
+                if self.commit_quick_note_global_backlog(&text) {
+                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                    self.quick_note_text.clear();
+                    self.quick_note_dest_list.reset();
+                }
+                return;
+            }
+            let dest = self.config.quick_note.as_ref()
+                .and_then(|qn| qn.destinations.iter().find(|d| d.key == key).cloned());
+            if let Some(dest) = dest {
+                log::info!("QuickNote: destination selected: key={key}");
+                if dest.options.is_some() || dest.children_cmd.is_some() {
+                    self.quick_note_sub_cursor = 0;
+                    self.quick_note_children_cache.clear();
+                    self.quick_note_children_rx = None;
+                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
+                    log::info!("QuickNote: submenu opened: path=[{key}]");
+                    self.draw_quick_note_menu(ctx, &[key]);
+                } else {
+                    let text = self.quick_note_text.clone();
+                    if self.commit_quick_note(&text, &dest) {
+                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
+                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                        self.quick_note_text.clear();
+                        self.quick_note_children_cache.clear();
+                        self.quick_note_children_rx = None;
+                        self.quick_note_dest_list.reset();
+                    }
+                }
+            }
+            return;
+        }
+
+        // j/k/arrows/Enter — delegated to SearchableList for clamped navigation
+        // and scroll-into-view behavior.
+        self.quick_note_dest_list.clamp(total);
+        let confirmed = self.quick_note_dest_list.handle_nav(ctx, total);
+        let selection_changed = self.quick_note_dest_list.selection_changed();
+        log::info!("QuickNote: dest cursor → {}", self.quick_note_dest_list.selected);
+
+        if let Some(cursor) = confirmed {
             if cursor == 0 {
                 let text = self.quick_note_text.clone();
                 log::info!("QuickNote: destination selected via Enter: cursor=0 (global backlog)");
@@ -995,6 +1051,7 @@ impl PlexiApp {
                     self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
                     self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
                     self.quick_note_text.clear();
+                    self.quick_note_dest_list.reset();
                 }
                 return;
             }
@@ -1018,80 +1075,7 @@ impl PlexiApp {
                         self.quick_note_text.clear();
                         self.quick_note_children_cache.clear();
                         self.quick_note_children_rx = None;
-                    }
-                }
-            }
-            return;
-        }
-
-        // L → enter submenu for selected item (zero-flash).
-        let enter_sub = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::L)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight)
-        });
-        if enter_sub {
-            let cursor = self.quick_note_dest_cursor;
-            if cursor > 0 {
-                let dest = self.config.quick_note.as_ref()
-                    .and_then(|qn| qn.destinations.get(cursor - 1).cloned());
-                if let Some(dest) = dest {
-                    if dest.options.is_some() || dest.children_cmd.is_some() {
-                        let key = dest.key;
-                        self.quick_note_sub_cursor = 0;
-                        self.quick_note_children_cache.clear();
-                        self.quick_note_children_rx = None;
-                        self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
-                        log::info!("QuickNote: submenu opened via L: path=[{key}]");
-                        self.draw_quick_note_menu(ctx, &[key]);
-                        return;
-                    }
-                }
-            }
-        }
-
-        // N → open config file to add a new destination.
-        let add_dest = ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::NONE, egui::Key::N)
-        });
-        if add_dest {
-            log::info!("QuickNote: opening config to add destination");
-            crate::config::open_config_file();
-            return;
-        }
-
-        // Digit keys → fast-dispatch by number.
-        let pressed = consume_digit_key(ctx);
-
-        if let Some(key) = pressed {
-            if key == 0 {
-                let text = self.quick_note_text.clone();
-                log::info!("QuickNote: destination selected: key=0 (global backlog)");
-                if self.commit_quick_note_global_backlog(&text) {
-                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
-                    self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
-                    self.quick_note_text.clear();
-                }
-                return;
-            }
-            let dest = self.config.quick_note.as_ref()
-                .and_then(|qn| qn.destinations.iter().find(|d| d.key == key).cloned());
-            if let Some(dest) = dest {
-                log::info!("QuickNote: destination selected: key={key}");
-                if dest.options.is_some() || dest.children_cmd.is_some() {
-                    self.quick_note_sub_cursor = 0;
-                    self.quick_note_children_cache.clear();
-                    self.quick_note_children_rx = None;
-                    self.push_focus_layer(crate::app::FocusLayer::QuickNoteSubDestination(vec![key]));
-                    log::info!("QuickNote: submenu opened: path=[{key}]");
-                    self.draw_quick_note_menu(ctx, &[key]);
-                } else {
-                    let text = self.quick_note_text.clone();
-                    if self.commit_quick_note(&text, &dest) {
-                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNoteDestination);
-                        self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
-                        self.quick_note_text.clear();
-                        self.quick_note_children_cache.clear();
-                        self.quick_note_children_rx = None;
+                        self.quick_note_dest_list.reset();
                     }
                 }
             }
@@ -1100,6 +1084,7 @@ impl PlexiApp {
 
         // Render
         let screen_rect = ctx.screen_rect();
+        let cursor = self.quick_note_dest_list.selected;
 
         egui::Area::new(egui::Id::new("quick_note_scrim"))
             .fixed_pos(screen_rect.min)
@@ -1113,7 +1098,6 @@ impl PlexiApp {
             });
 
         let modal_w = (screen_rect.width() * 0.6).min(672.0).max(408.0);
-        let cursor = self.quick_note_dest_cursor;
         let destinations = self.config.quick_note.as_ref()
             .map(|qn| qn.destinations.as_slice())
             .unwrap_or(&[]);
@@ -1162,59 +1146,63 @@ impl PlexiApp {
                         );
                         ui.add_space(style::SPACE_MD);
 
-                        // Row 0: global backlog
-                        let row0_frame = if cursor == 0 {
-                            egui::Frame::new()
-                                .fill(self.colors.bg_active)
-                                .corner_radius(egui::CornerRadius::same(4))
-                                .inner_margin(egui::Margin::symmetric(4, 2))
-                        } else {
-                            egui::Frame::new()
-                                .inner_margin(egui::Margin::symmetric(4, 2))
-                        };
-                        row0_frame.show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                ui.spacing_mut().item_spacing.x = style::SPACE_SM;
-                                widgets::key_chip(ui, "0", &self.colors);
-                                ui.label(
-                                    RichText::new("Backlog (global)")
-                                        .color(self.colors.text_dim)
-                                        .size(style::TEXT_BODY),
-                                );
-                            });
-                        });
-                        ui.add_space(style::SPACE_SM);
-
-                        // Config destinations
-                        for (idx, dest) in destinations.iter().enumerate() {
-                            let row_idx = idx + 1;
-                            let label = if dest.options.is_some() || dest.children_cmd.is_some() {
-                                format!("{} ›", dest.label)
-                            } else {
-                                dest.label.clone()
-                            };
-                            let row_frame = if cursor == row_idx {
-                                egui::Frame::new()
-                                    .fill(self.colors.bg_active)
+                        // Wrap in a ScrollArea so j/k keeps the selection visible
+                        // when there are more destinations than fit on screen.
+                        let max_list_h = (screen_rect.height() * 0.4).max(120.0);
+                        egui::ScrollArea::vertical()
+                            .max_height(max_list_h)
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| {
+                                // Row 0: global backlog
+                                let row0 = egui::Frame::new()
+                                    .fill(if cursor == 0 { self.colors.bg_active } else { egui::Color32::TRANSPARENT })
                                     .corner_radius(egui::CornerRadius::same(4))
                                     .inner_margin(egui::Margin::symmetric(4, 2))
-                            } else {
-                                egui::Frame::new()
-                                    .inner_margin(egui::Margin::symmetric(4, 2))
-                            };
-                            row_frame.show(ui, |ui| {
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = style::SPACE_SM;
-                                    widgets::key_chip(ui, &dest.key.to_string(), &self.colors);
-                                    ui.label(
-                                        RichText::new(&label)
-                                            .color(self.colors.text_dim)
-                                            .size(style::TEXT_BODY),
-                                    );
-                                });
+                                    .show(ui, |ui| {
+                                        ui.horizontal(|ui| {
+                                            ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                                            widgets::key_chip(ui, "0", &self.colors);
+                                            ui.label(
+                                                RichText::new("Backlog (global)")
+                                                    .color(self.colors.text_dim)
+                                                    .size(style::TEXT_BODY),
+                                            );
+                                        });
+                                    });
+                                if cursor == 0 && selection_changed {
+                                    row0.response.scroll_to_me(None);
+                                }
+                                ui.add_space(style::SPACE_SM);
+
+                                // Config destinations
+                                for (idx, dest) in destinations.iter().enumerate() {
+                                    let row_idx = idx + 1;
+                                    let label = if dest.options.is_some() || dest.children_cmd.is_some() {
+                                        format!("{} ›", dest.label)
+                                    } else {
+                                        dest.label.clone()
+                                    };
+                                    let row = egui::Frame::new()
+                                        .fill(if cursor == row_idx { self.colors.bg_active } else { egui::Color32::TRANSPARENT })
+                                        .corner_radius(egui::CornerRadius::same(4))
+                                        .inner_margin(egui::Margin::symmetric(4, 2))
+                                        .show(ui, |ui| {
+                                            ui.horizontal(|ui| {
+                                                ui.spacing_mut().item_spacing.x = style::SPACE_SM;
+                                                widgets::key_chip(ui, &dest.key.to_string(), &self.colors);
+                                                ui.label(
+                                                    RichText::new(&label)
+                                                        .color(self.colors.text_dim)
+                                                        .size(style::TEXT_BODY),
+                                                );
+                                            });
+                                        });
+                                    if cursor == row_idx && selection_changed {
+                                        row.response.scroll_to_me(None);
+                                    }
+                                    ui.add_space(style::SPACE_SM);
+                                }
                             });
-                            ui.add_space(style::SPACE_SM);
-                        }
 
                         ui.add_space(style::SPACE_XL);
                         ui.label(
@@ -1647,39 +1635,49 @@ impl PlexiApp {
         let mut delete_context = false;
 
         let num_contexts = self.router.len();
-        let (nav_down, nav_up, enter_pressed, backspace_pressed) = ctx.input_mut(|i| {
+
+        // Esc and Backspace are handled before SearchableList so we don't
+        // accidentally consume them inside the nav handler.
+        let backspace_pressed = ctx.input_mut(|i| {
             let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-            let down = i.consume_key(egui::Modifiers::NONE, egui::Key::J)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown);
-            let up = i.consume_key(egui::Modifiers::NONE, egui::Key::K)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
-            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-            let backspace = num_contexts > 1 && (
+            if esc { dismissed = true; }
+            num_contexts > 1 && (
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
                     || i.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
-            );
-            if esc { dismissed = true; }
-            (down, up, enter, backspace)
+            )
         });
 
         let ctx_name = self.router.active().name.clone();
         let ctx_root = self.router.active().root.clone();
         let (groups, all_pane_ids, all_context_ids) = self.collect_inspector_rows();
-        let pane_count = all_pane_ids.len();
 
-        if nav_down && pane_count > 0 {
-            self.inspector_selected_pane = (self.inspector_selected_pane + 1) % pane_count;
+        // Build a flat list of rows so SearchableList can index into it.
+        // Each entry: (group_name, row) — group_name drives the section header.
+        let query = self.context_inspector_list.query.to_lowercase();
+        let flat_rows: Vec<(String, &PaneRow)> = groups
+            .iter()
+            .flat_map(|(group_name, rows)| {
+                rows.iter().map(move |row| (group_name.clone(), row))
+            })
+            .filter(|(_, row)| {
+                query.is_empty()
+                    || row.name.to_lowercase().contains(&query)
+                    || row.kind.to_lowercase().contains(&query)
+            })
+            .collect();
+        let pane_count = flat_rows.len();
+        self.context_inspector_list.clamp(pane_count);
+
+        // Handle nav after filtering so j/k operates on the filtered list.
+        let confirmed = self.context_inspector_list.handle_nav(ctx, pane_count);
+        let selection_changed = self.context_inspector_list.selection_changed();
+
+        if let Some(i) = confirmed {
+            if let Some((_, row)) = flat_rows.get(i) {
+                focus_pane = Some(row.id);
+            }
         }
-        if nav_up && pane_count > 0 {
-            self.inspector_selected_pane =
-                (self.inspector_selected_pane + pane_count - 1) % pane_count;
-        }
-        if self.inspector_selected_pane >= pane_count && pane_count > 0 {
-            self.inspector_selected_pane = pane_count - 1;
-        }
-        if enter_pressed && pane_count > 0 {
-            focus_pane = Some(all_pane_ids[self.inspector_selected_pane]);
-        }
+
         if backspace_pressed {
             let now = std::time::Instant::now();
             let elapsed = self
@@ -1704,7 +1702,7 @@ impl PlexiApp {
         }
 
         let colors = self.colors;
-        let selected = self.inspector_selected_pane;
+        let selected = self.context_inspector_list.selected;
         let screen_rect = ctx.screen_rect();
 
         egui::Area::new(egui::Id::new("context_inspector_scrim"))
@@ -1729,26 +1727,43 @@ impl PlexiApp {
                     .show(ui, |ui| {
                         ui.set_width(style::MODAL_WIDTH_MD);
                         render_inspector_header(ui, &ctx_name, &ctx_root, &colors);
+                        ui.add_space(style::SPACE_SM);
+                        if self.context_inspector_list.show_search(
+                            ui, "Search panes…", "context_inspector", &colors,
+                        ) {
+                            log::info!(
+                                "ContextInspector: search query='{}'",
+                                self.context_inspector_list.query
+                            );
+                        }
+                        ui.add_space(style::SPACE_SM);
                         egui::ScrollArea::vertical()
                             .max_height(ctx.available_rect().height() * 0.6)
                             .auto_shrink([false, true])
                             .show(ui, |ui| {
                                 if pane_count == 0 {
-                                    ui.label(RichText::new("No panes").size(style::TEXT_BODY).color(colors.text_dim));
+                                    let msg = if self.context_inspector_list.query.is_empty() {
+                                        "No panes"
+                                    } else {
+                                        "No matching panes"
+                                    };
+                                    ui.label(RichText::new(msg).size(style::TEXT_BODY).color(colors.text_dim));
                                 } else {
-                                    let mut global_idx: usize = 0;
-                                    for (group_name, rows) in &groups {
-                                        ui.add_space(style::SPACE_SM);
-                                        ui.label(RichText::new(group_name.as_str()).size(style::TEXT_CAPTION).color(colors.text_dim));
-                                        ui.add_space(style::SPACE_SM);
-                                        for row in rows {
-                                            let (resp, to_close) = render_inspector_pane_row(
-                                                ui, row, global_idx == selected, &colors,
-                                            );
-                                            global_idx += 1;
-                                            if let Some(pid) = to_close { close_pane = Some(pid); }
-                                            if resp.clicked() { focus_pane = Some(row.id); }
+                                    let mut last_group = "";
+                                    for (i, (group_name, row)) in flat_rows.iter().enumerate() {
+                                        if group_name.as_str() != last_group {
+                                            ui.add_space(style::SPACE_SM);
+                                            ui.label(RichText::new(group_name.as_str()).size(style::TEXT_CAPTION).color(colors.text_dim));
+                                            ui.add_space(style::SPACE_SM);
+                                            last_group = group_name.as_str();
                                         }
+                                        let is_sel = i == selected;
+                                        let (resp, to_close) = render_inspector_pane_row(ui, row, is_sel, &colors);
+                                        if is_sel && selection_changed {
+                                            resp.scroll_to_me(None);
+                                        }
+                                        if let Some(pid) = to_close { close_pane = Some(pid); }
+                                        if resp.clicked() { focus_pane = Some(row.id); }
                                     }
                                 }
                             });
@@ -1763,6 +1778,7 @@ impl PlexiApp {
 
         if dismissed {
             self.show_context_inspector = false;
+            self.context_inspector_list.reset();
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
             log::info!("ContextInspector: closed");
@@ -1771,6 +1787,7 @@ impl PlexiApp {
             log::info!("ContextInspector: focusing pane {pid}");
             self.pane_navigate(pid);
             self.show_context_inspector = false;
+            self.context_inspector_list.reset();
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
         }
@@ -1780,7 +1797,16 @@ impl PlexiApp {
         }
         if delete_context {
             let ctx_idx = if pane_count > 0 {
-                let target_cid = all_context_ids[self.inspector_selected_pane];
+                // Use the selected row's context id from the filtered list.
+                let target_cid = flat_rows
+                    .get(selected)
+                    .and_then(|(_, row)| {
+                        all_pane_ids
+                            .iter()
+                            .position(|&id| id == row.id)
+                            .and_then(|pos| all_context_ids.get(pos).copied())
+                    })
+                    .unwrap_or_else(|| self.router.active().context_id);
                 self.router
                     .position(|c| c.context_id == target_cid)
                     .unwrap_or_else(|| self.router.active_idx())

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1638,10 +1638,13 @@ impl PlexiApp {
 
         // Esc and Backspace are handled before SearchableList so we don't
         // accidentally consume them inside the nav handler.
+        // Backspace/Delete are only consumed for the 3-tap delete when the
+        // search field is NOT focused — when typing a query those keys edit text.
+        let search_focused = self.context_inspector_list.search_has_focus(ctx);
         let backspace_pressed = ctx.input_mut(|i| {
             let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
             if esc { dismissed = true; }
-            num_contexts > 1 && (
+            num_contexts > 1 && !search_focused && (
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
                     || i.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
             )
@@ -1654,10 +1657,10 @@ impl PlexiApp {
         // Build a flat list of rows so SearchableList can index into it.
         // Each entry: (group_name, row) — group_name drives the section header.
         let query = self.context_inspector_list.query.to_lowercase();
-        let flat_rows: Vec<(String, &PaneRow)> = groups
+        let flat_rows: Vec<(&str, &PaneRow)> = groups
             .iter()
             .flat_map(|(group_name, rows)| {
-                rows.iter().map(move |row| (group_name.clone(), row))
+                rows.iter().map(move |row| (group_name.as_str(), row))
             })
             .filter(|(_, row)| {
                 query.is_empty()
@@ -1751,11 +1754,11 @@ impl PlexiApp {
                                 } else {
                                     let mut last_group = "";
                                     for (i, (group_name, row)) in flat_rows.iter().enumerate() {
-                                        if group_name.as_str() != last_group {
+                                        if *group_name != last_group {
                                             ui.add_space(style::SPACE_SM);
-                                            ui.label(RichText::new(group_name.as_str()).size(style::TEXT_CAPTION).color(colors.text_dim));
+                                            ui.label(RichText::new(*group_name).size(style::TEXT_CAPTION).color(colors.text_dim));
                                             ui.add_space(style::SPACE_SM);
-                                            last_group = group_name.as_str();
+                                            last_group = *group_name;
                                         }
                                         let is_sel = i == selected;
                                         let (resp, to_close) = render_inspector_pane_row(ui, row, is_sel, &colors);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -85,6 +85,11 @@ pub struct TerminalPane {
     /// Last OSC 2 title string the process wrote, tracked independently of `name` and `name_locked`.
     /// Used by FocusChanged events to record what was running in the pane.
     pub pty_title: Option<String>,
+    /// Cached result for the workspace-scope badge. The actual probe hits the
+    /// OS for the child process cwd, so the render path throttles it.
+    pub(crate) outside_workspace_cached: bool,
+    pub(crate) outside_workspace_checked_at: Option<std::time::Instant>,
+    pub(crate) outside_workspace_root: Option<PathBuf>,
 }
 
 impl TerminalPane {
@@ -111,6 +116,9 @@ impl TerminalPane {
             font_size: default_font_size,
             ephemeral: false,
             pty_title: None,
+            outside_workspace_cached: false,
+            outside_workspace_checked_at: None,
+            outside_workspace_root: None,
         })
     }
 }
@@ -254,5 +262,4 @@ pub struct AppPane {
     /// of deleting the tile.
     pub overlay_replaced: Option<Box<Pane>>,
 }
-
 

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -373,7 +373,7 @@ pub(crate) fn render_draw_commands(
                 let avail_w = pane_rect.width();
                 let avail_h = pane_rect.height();
                 if let Some(tier) = select_responsive_tier(tiers, avail_w, avail_h) {
-                    log::info!(
+                    log::debug!(
                         "responsive: selected tier aspect={} for rect {}x{}",
                         tier.aspect, avail_w, avail_h
                     );

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -234,7 +234,12 @@ impl RenderSession {
         frame: &[RenderCommand],
     ) {
         let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
-        let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+        if scroll_delta.y == 0.0 {
+            return;
+        }
+        let Some(pointer_pos) = ui.input(|i| i.pointer.hover_pos()) else {
+            return;
+        };
 
         let mut scroll_regions: Vec<(&String, egui::Rect, f32)> = Vec::new();
         let origin = pane_rect.min;
@@ -248,24 +253,20 @@ impl RenderSession {
             }
         }
 
-        if scroll_delta.y != 0.0 {
-            if let Some(pos) = pointer_pos {
-                for (id, viewport, content_height) in scroll_regions.iter().rev() {
-                    if viewport.contains(pos) {
-                        let viewport_h = viewport.height();
-                        let max_offset = (content_height - viewport_h).max(0.0);
-                        let prev = self.scroll_offsets.get(*id).copied().unwrap_or(0.0);
-                        let next = (prev - scroll_delta.y).clamp(0.0, max_offset);
-                        if (next - prev).abs() > 0.01 {
-                            self.scroll_offsets.insert((*id).clone(), next);
-                            self.outbound_events.push(PlexiEvent::ScrollOffset {
-                                id: (*id).clone(),
-                                offset_y: next,
-                            });
-                        }
-                        break;
-                    }
+        for (id, viewport, content_height) in scroll_regions.iter().rev() {
+            if viewport.contains(pointer_pos) {
+                let viewport_h = viewport.height();
+                let max_offset = (content_height - viewport_h).max(0.0);
+                let prev = self.scroll_offsets.get(*id).copied().unwrap_or(0.0);
+                let next = (prev - scroll_delta.y).clamp(0.0, max_offset);
+                if (next - prev).abs() > 0.01 {
+                    self.scroll_offsets.insert((*id).clone(), next);
+                    self.outbound_events.push(PlexiEvent::ScrollOffset {
+                        id: (*id).clone(),
+                        offset_y: next,
+                    });
                 }
+                break;
             }
         }
     }

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -17,6 +17,9 @@ use egui_term::{TerminalTheme, TerminalView};
 use egui_tiles::TileId;
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::{Duration, Instant};
+
+const OUTSIDE_WORKSPACE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Render one frame of a terminal pane. Returns `true` if the process has
 /// exited and the user pressed a key (the caller should close the tile).
@@ -179,22 +182,39 @@ fn render_name_bar_and_dots(
 /// the workspace root. Returns false when there is no workspace root, when
 /// the CWD can't be probed, or when the terminal has exited.
 fn is_terminal_outside_workspace(
-    terminal: &TerminalPane,
+    terminal: &mut TerminalPane,
     workspace_root: Option<&Path>,
 ) -> bool {
     let Some(root) = workspace_root else {
+        terminal.outside_workspace_cached = false;
+        terminal.outside_workspace_checked_at = None;
+        terminal.outside_workspace_root = None;
         return false;
     };
     if terminal.exited {
         return false;
     }
+    if terminal.outside_workspace_root.as_deref() == Some(root)
+        && terminal
+            .outside_workspace_checked_at
+            .map_or(false, |checked_at| checked_at.elapsed() < OUTSIDE_WORKSPACE_CHECK_INTERVAL)
+    {
+        return terminal.outside_workspace_cached;
+    }
+
     let pid = terminal.backend.child_pid();
-    let Some(cwd) = crate::shell::get_pid_cwd(pid) else {
-        return false;
+    let outside_workspace = if let Some(cwd) = crate::shell::get_pid_cwd(pid) {
+        // Canonicalize both sides so /var → /private/var on macOS doesn't
+        // produce a false-positive "outside" badge.
+        let cwd_canon = cwd.canonicalize().unwrap_or(cwd);
+        let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        !cwd_canon.starts_with(&root_canon)
+    } else {
+        false
     };
-    // Canonicalize both sides so /var → /private/var on macOS doesn't
-    // produce a false-positive "outside" badge.
-    let cwd_canon = cwd.canonicalize().unwrap_or(cwd);
-    let root_canon = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    !cwd_canon.starts_with(&root_canon)
+
+    terminal.outside_workspace_cached = outside_workspace;
+    terminal.outside_workspace_checked_at = Some(Instant::now());
+    terminal.outside_workspace_root = Some(root.to_path_buf());
+    outside_workspace
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -195,6 +195,153 @@ pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::
     resp
 }
 
+// ── SearchableList ────────────────────────────────────────────────────────
+//
+// Keyboard-navigable list with optional fuzzy search input. Extracted from
+// the command palette pattern so every overlay gets the same j/k + clamping
+// + scroll-into-view behavior for free.
+//
+// Usage:
+//     // in your state struct:
+//     my_list: crate::widgets::SearchableList,
+//
+//     // in your overlay draw fn (before rendering):
+//     let confirmed = self.my_list.handle_nav(ctx, item_count);
+//
+//     // inside the egui Area:
+//     let query_changed = self.my_list.show_search(ui, "Search…", "my_list", &colors);
+//     egui::ScrollArea::vertical().show(ui, |ui| {
+//         for (i, item) in items.iter().enumerate() {
+//             let is_sel = i == self.my_list.selected;
+//             let (resp, _) = selectable_row(ui, is_sel, &colors, |ui| { /* ... */ });
+//             if is_sel && self.my_list.selection_changed() { resp.scroll_to_me(None); }
+//             if resp.clicked() { /* activate item i */ }
+//         }
+//     });
+
+/// Shared keyboard-nav + search state for list overlays.
+pub(crate) struct SearchableList {
+    pub(crate) selected: usize,
+    pub(crate) query: String,
+    prev_selected: usize,
+}
+
+impl Default for SearchableList {
+    fn default() -> Self {
+        Self {
+            selected: 0,
+            query: String::new(),
+            prev_selected: 0,
+        }
+    }
+}
+
+impl SearchableList {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reset selection and search query (call when the overlay opens).
+    pub(crate) fn reset(&mut self) {
+        self.selected = 0;
+        self.prev_selected = 0;
+        self.query.clear();
+    }
+
+    /// Clamp `selected` to `count` items. Call after filtering items so an
+    /// existing selection can't point past the end of the filtered list.
+    pub(crate) fn clamp(&mut self, count: usize) {
+        if count > 0 {
+            self.selected = self.selected.min(count - 1);
+        }
+    }
+
+    /// True if the selected index changed since the last `handle_nav` call.
+    /// Use this to decide whether to call `resp.scroll_to_me(None)`.
+    pub(crate) fn selection_changed(&self) -> bool {
+        self.selected != self.prev_selected
+    }
+
+    /// Process j/k/arrow/Enter key events. Returns `Some(idx)` when Enter is
+    /// pressed; returns `None` otherwise. Does NOT consume Escape — callers
+    /// handle dismiss themselves.
+    ///
+    /// Call at `ctx` level before the egui Area so key events are consumed
+    /// before widgets inside the Area can see them.
+    pub(crate) fn handle_nav(
+        &mut self,
+        ctx: &egui::Context,
+        item_count: usize,
+    ) -> Option<usize> {
+        self.prev_selected = self.selected;
+        let mut confirmed: Option<usize> = None;
+
+        ctx.input_mut(|input| {
+            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::J))
+                && item_count > 0
+            {
+                self.selected = (self.selected + 1).min(item_count - 1);
+            }
+            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::K))
+                && item_count > 0
+            {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+                && item_count > 0
+            {
+                confirmed = Some(self.selected);
+            }
+        });
+
+        confirmed
+    }
+
+    /// Render a styled search text input, updating `self.query`.
+    /// Returns `true` if the query changed this frame (callers should
+    /// re-filter their item list and call `self.clamp(new_count)`).
+    ///
+    /// `id_salt` must be unique per call site so egui's Id doesn't collide
+    /// when multiple SearchableList instances are shown simultaneously.
+    pub(crate) fn show_search(
+        &mut self,
+        ui: &mut egui::Ui,
+        hint: &str,
+        id_salt: &str,
+        colors: &Colors,
+    ) -> bool {
+        let te_id = egui::Id::new(id_salt).with("search");
+        let changed = ui.scope(|ui| {
+            ui.visuals_mut().text_cursor.stroke.width = 1.5;
+            ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+            ui.visuals_mut().extreme_bg_color = colors.bg_active;
+            ui.visuals_mut().widgets.active.bg_stroke =
+                egui::Stroke::new(1.0, colors.accent);
+            ui.visuals_mut().widgets.inactive.bg_stroke =
+                egui::Stroke::new(1.0, colors.border);
+            ui.add(
+                egui::TextEdit::singleline(&mut self.query)
+                    .id(te_id)
+                    .desired_width(f32::INFINITY)
+                    .hint_text(hint)
+                    .font(egui::TextStyle::Body)
+                    .margin(egui::Margin::symmetric(8, 5)),
+            )
+        }).inner;
+        if !changed.has_focus() {
+            changed.request_focus();
+        }
+        if changed.changed() {
+            self.selected = 0;
+            self.prev_selected = 0;
+            return true;
+        }
+        false
+    }
+}
+
 /// Renders a dismissable centered modal overlay. Handles Escape and click-outside.
 /// Returns `true` if the user dismissed it this frame. Callers guard with
 /// `if !open { return; }` and apply `if dismissed { open = false; }` after.

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -224,6 +224,9 @@ pub(crate) struct SearchableList {
     pub(crate) selected: usize,
     pub(crate) query: String,
     prev_selected: usize,
+    /// Id of the search TextEdit, set by show_search(). Used by handle_nav()
+    /// to skip j/k when the user is actively typing in the search box.
+    search_te_id: Option<egui::Id>,
 }
 
 impl Default for SearchableList {
@@ -232,6 +235,7 @@ impl Default for SearchableList {
             selected: 0,
             query: String::new(),
             prev_selected: 0,
+            search_te_id: None,
         }
     }
 }
@@ -246,12 +250,15 @@ impl SearchableList {
         self.selected = 0;
         self.prev_selected = 0;
         self.query.clear();
+        self.search_te_id = None;
     }
 
     /// Clamp `selected` to `count` items. Call after filtering items so an
     /// existing selection can't point past the end of the filtered list.
     pub(crate) fn clamp(&mut self, count: usize) {
-        if count > 0 {
+        if count == 0 {
+            self.selected = 0;
+        } else {
             self.selected = self.selected.min(count - 1);
         }
     }
@@ -268,6 +275,10 @@ impl SearchableList {
     ///
     /// Call at `ctx` level before the egui Area so key events are consumed
     /// before widgets inside the Area can see them.
+    ///
+    /// When a search field is active and focused (after `show_search` has been
+    /// called at least once), j/k are NOT consumed so the user can type those
+    /// characters into the query. ArrowDown/Up always navigate.
     pub(crate) fn handle_nav(
         &mut self,
         ctx: &egui::Context,
@@ -276,17 +287,24 @@ impl SearchableList {
         self.prev_selected = self.selected;
         let mut confirmed: Option<usize> = None;
 
+        // Skip vim keys when the search field has keyboard focus so the user
+        // can type 'j' and 'k' into the query box without moving the selection.
+        let search_focused = self
+            .search_te_id
+            .map(|id| ctx.memory(|m| m.focused() == Some(id)))
+            .unwrap_or(false);
+
         ctx.input_mut(|input| {
-            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-                || input.consume_key(egui::Modifiers::NONE, egui::Key::J))
-                && item_count > 0
-            {
+            let down = input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || (!search_focused
+                    && input.consume_key(egui::Modifiers::NONE, egui::Key::J));
+            let up = input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || (!search_focused
+                    && input.consume_key(egui::Modifiers::NONE, egui::Key::K));
+            if down && item_count > 0 {
                 self.selected = (self.selected + 1).min(item_count - 1);
             }
-            if (input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-                || input.consume_key(egui::Modifiers::NONE, egui::Key::K))
-                && item_count > 0
-            {
+            if up && item_count > 0 {
                 self.selected = self.selected.saturating_sub(1);
             }
             if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
@@ -297,6 +315,14 @@ impl SearchableList {
         });
 
         confirmed
+    }
+
+    /// True if the search field managed by this list currently has keyboard focus.
+    /// Use this to guard keys that would conflict with text input (e.g. Backspace).
+    pub(crate) fn search_has_focus(&self, ctx: &egui::Context) -> bool {
+        self.search_te_id
+            .map(|id| ctx.memory(|m| m.focused() == Some(id)))
+            .unwrap_or(false)
     }
 
     /// Render a styled search text input, updating `self.query`.
@@ -313,6 +339,7 @@ impl SearchableList {
         colors: &Colors,
     ) -> bool {
         let te_id = egui::Id::new(id_salt).with("search");
+        self.search_te_id = Some(te_id);
         let changed = ui.scope(|ui| {
             ui.visuals_mut().text_cursor.stroke.width = 1.5;
             ui.visuals_mut().text_cursor.stroke.color = colors.accent;
@@ -335,7 +362,8 @@ impl SearchableList {
         }
         if changed.changed() {
             self.selected = 0;
-            self.prev_selected = 0;
+            // Leave prev_selected unchanged so selection_changed() returns
+            // true on the next frame, triggering scroll_to_me for index 0.
             return true;
         }
         false


### PR DESCRIPTION
## What

Extracts the command palette's keyboard-nav + search pattern into a shared `SearchableList` widget in `src/widgets.rs`, then adopts it in two overlays that had broken j/k scrolling.

## Why

The context inspector and quick-note destination picker both used modulo-based j/k wrapping (cursor wraps around at the end instead of clamping). Neither had `scroll_to_me`, so selecting items beyond the visible area wouldn't scroll. The context inspector also had no search at all.

## Changes

**`src/widgets.rs`** — New `SearchableList` struct:
- `selected: usize` + `query: String` state
- `handle_nav(ctx, count)` — j/k/arrows/Enter with clamping (no wrap-around). Returns `Some(idx)` on Enter.
- `show_search(ui, hint, id_salt, colors)` — styled text input, resets selection on query change
- `selection_changed()` — callers use this to decide when to call `resp.scroll_to_me(None)`
- `reset()` / `clamp()` helpers

**`src/overlays.rs`** — Two overlays adopt the primitive:
- `draw_context_inspector`: adds fuzzy pane search by name/kind, fixes j/k clamping, adds scroll-into-view
- `draw_quick_note_destination`: fixes j/k clamping (was modulo-wrapping past end), wraps items in `ScrollArea` so `scroll_to_me` works with many destinations

**`src/app/mod.rs`** — Replaces old manual cursor fields:
- `inspector_selected_pane: usize` → `context_inspector_list: SearchableList`
- `quick_note_dest_cursor: usize` → `quick_note_dest_list: SearchableList`

## Done When
- [x] Context selector uses the shared primitive — j/k scrolls correctly, search works
- [x] At least one other overlay (quick-note destination picker) also uses it
- [x] No scroll-past-bounds in any adopted list UI

## Test plan
- Open context inspector (⌥I or the context inspector binding): type to search panes, j/k to navigate, Enter to focus. Selection should never wrap past bounds. Moving selection should scroll the highlighted row into view.
- Open quick-note modal → advance to destination picker: j/k should clamp at top/bottom, not wrap. With many destinations, the list should scroll to keep the selected row visible.

Closes #1390