### PR TITLE
feat(overlays): TextInputOverlay primitive + context root management (#1426)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -81,6 +81,25 @@ pub(crate) enum FocusLayer {
     CliSetupPrompt,
     /// Context inspector modal — shows pane list, allows close/delete.
     ContextInspector,
+    /// Shared text-input overlay (context root, future: context rename).
+    TextInput,
+}
+
+/// What a `TextInputOverlay` commit should do.
+#[derive(Clone, Debug)]
+pub(crate) enum OverlayTarget {
+    /// Set (or clear) the root directory on the context at `idx`.
+    ContextRoot(usize),
+}
+
+/// Shared text-input overlay state. One instance per open modal.
+#[derive(Clone, Debug)]
+pub(crate) struct TextInputOverlay {
+    pub label: String,
+    pub hint: String,
+    pub buffer: String,
+    /// One-shot guard: true after the first `request_focus()` call.
+    pub focus_requested: bool,
 }
 
 #[derive(Clone)]
@@ -215,6 +234,10 @@ pub struct PlexiApp {
     /// first render. Prevents the focus from being re-requested every frame,
     /// which lets a later widget steal it on the same frame indefinitely.
     pub(crate) rename_pane_focus_requested: bool,
+    /// Active text-input overlay and its dispatch target.
+    pub(crate) text_overlay: Option<(TextInputOverlay, OverlayTarget)>,
+    /// Receiver for async folder-picker results (Browse button).
+    pub(crate) text_overlay_browse_rx: Option<mpsc::Receiver<Option<PathBuf>>>,
     pub(crate) features: crate::features::FeatureFlags,
     /// Notifications queued from apps via ShowNotification.
     pub(crate) pending_notifications: Vec<PendingNotification>,
@@ -686,6 +709,8 @@ impl PlexiApp {
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
                     rename_pane_focus_requested: false,
+                    text_overlay: None,
+                    text_overlay_browse_rx: None,
                     registry,
                     features: features.clone(),
                     pending_notifications: Vec::new(),
@@ -802,6 +827,8 @@ impl PlexiApp {
             context_visit_history: Vec::new(),
             renaming_pane: None,
             rename_pane_focus_requested: false,
+            text_overlay: None,
+            text_overlay_browse_rx: None,
             registry: AppRegistry::load(&std::env::current_dir().unwrap_or_default()),
             features,
             pending_notifications: Vec::new(),
@@ -927,6 +954,8 @@ impl PlexiApp {
             context_visit_history: Vec::new(),
             renaming_pane: None,
             rename_pane_focus_requested: false,
+            text_overlay: None,
+            text_overlay_browse_rx: None,
             registry: AppRegistry::load_with_global(
                 &path,
                 &path.join("nonexistent-apps-dir"),
@@ -1881,6 +1910,7 @@ impl eframe::App for PlexiApp {
         self.sync_context_rename_focus();
         self.sync_cli_setup_prompt_focus();
         self.sync_context_inspector_focus();
+        self.sync_text_input_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
         // notification modal's TextEdit for the `input` kind, the palette's
@@ -1923,6 +1953,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::ContextInspector) => {
                     self.draw_context_inspector(ctx);
                 }
+                Some(FocusLayer::TextInput) => {
+                    self.draw_text_input_overlay(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -1937,6 +1970,7 @@ impl eframe::App for PlexiApp {
             self.sync_context_rename_focus();
             self.sync_cli_setup_prompt_focus();
             self.sync_context_inspector_focus();
+            self.sync_text_input_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -3675,6 +3709,7 @@ impl PlexiApp {
                 | Some(FocusLayer::QuickNoteSubDestination(_))
                 | Some(FocusLayer::CliSetupPrompt)
                 | Some(FocusLayer::ContextInspector)
+                | Some(FocusLayer::TextInput)
         )
     }
 
@@ -4100,7 +4135,7 @@ impl PlexiApp {
     }
 
     /// Reconcile the context-rename focus layer. Active when `renaming_window`
-    /// is set AND the sidebar is hidden — in that case the inline sidebar row
+    /// is set AND the sidebar is hidden -- in that case the inline sidebar row
     /// never renders, so we promote the rename to a modal overlay instead.
     pub(crate) fn sync_context_rename_focus(&mut self) {
         let should_own = self.renaming_window.is_some() && !self.sidebar_visible;
@@ -4112,6 +4147,20 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::ContextRename);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::ContextRename);
+        }
+    }
+
+    /// Reconcile the text-input overlay focus layer with `text_overlay`.
+    pub(crate) fn sync_text_input_focus(&mut self) {
+        let should_own = self.text_overlay.is_some();
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::TextInput);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::TextInput);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::TextInput);
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,8 @@ pub(crate) enum WindowMenuAction {
     Delete,
     SetRoot(PathBuf),
     ClearRoot,
+    /// Open the text-input overlay to set the root interactively.
+    OpenRootOverlay,
 }
 
 /// A context is a sidebar item — a project or directory scope.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -36,6 +36,48 @@ use crate::app::PlexiApp;
 pub(crate) const MODAL_WIDTH: f32 = 400.0;
 const R6: CornerRadius = CornerRadius::same(6);
 
+/// Show a native macOS folder picker using rfd's async API.
+/// Blocks the calling (background) thread; must NOT be called on the main thread.
+fn pick_folder() -> Option<std::path::PathBuf> {
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::task::{Context, Poll, Wake, Waker};
+    use std::pin::pin;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        let signal = Arc::new((Mutex::new(false), Condvar::new()));
+        struct Signal(Arc<(Mutex<bool>, Condvar)>);
+        impl Wake for Signal {
+            fn wake(self: Arc<Self>) { self.signal(); }
+            fn wake_by_ref(self: &Arc<Self>) { self.signal(); }
+        }
+        impl Signal {
+            fn signal(&self) {
+                let (lock, cvar) = &*self.0;
+                *lock.lock().unwrap() = true;
+                cvar.notify_one();
+            }
+        }
+        let waker: Waker = Arc::new(Signal(Arc::clone(&signal))).into();
+        let mut cx = Context::from_waker(&waker);
+        let mut f = pin!(f);
+        loop {
+            match f.as_mut().poll(&mut cx) {
+                Poll::Ready(val) => return val,
+                Poll::Pending => {
+                    let (lock, cvar) = &*signal;
+                    let mut ready = lock.lock().unwrap();
+                    while !*ready { ready = cvar.wait(ready).unwrap(); }
+                    *ready = false;
+                }
+            }
+        }
+    }
+
+    let dialog = rfd::AsyncFileDialog::new();
+    let handle = block_on(dialog.pick_folder())?;
+    Some(handle.path().to_path_buf())
+}
+
 fn draw_contact_footer(ui: &mut egui::Ui, colors: &Colors) {
     ui.vertical_centered(|ui| {
         ui.label(
@@ -156,12 +198,15 @@ fn render_inspector_pane_row(
     (row_resp, close_pane)
 }
 
+/// Returns `true` if the user clicked "Set root..." or the edit button on an
+/// existing root, signaling the caller to open the text-input overlay.
 fn render_inspector_header(
     ui: &mut egui::Ui,
     ctx_name: &str,
     ctx_root: &Option<std::path::PathBuf>,
     colors: &Colors,
-) {
+) -> bool {
+    let mut open_root_overlay = false;
     ui.label(
         RichText::new(ctx_name)
             .size(style::TEXT_TITLE_XL)
@@ -174,11 +219,44 @@ fn render_inspector_header(
         ui.horizontal(|ui| {
             ui.label(RichText::new(&root_str).size(style::TEXT_CAPTION).color(colors.text_dim));
             crate::widgets::copy_button(ui, egui::Id::new("inspector_copy_root"), &root_str);
+            if ui
+                .add(
+                    egui::Button::new(
+                        RichText::new("\u{270e}")
+                            .size(style::TEXT_CAPTION)
+                            .color(colors.text_dim),
+                    )
+                    .frame(false),
+                )
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                .on_hover_text("Edit root path")
+                .clicked()
+            {
+                open_root_overlay = true;
+            }
         });
+    } else {
+        ui.add_space(style::SPACE_SM);
+        if ui
+            .add(
+                egui::Button::new(
+                    RichText::new("Set root\u{2026}")
+                        .size(style::TEXT_CAPTION)
+                        .color(colors.text_primary),
+                )
+                .frame(false),
+            )
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .on_hover_text("Set a project root directory for this context")
+            .clicked()
+        {
+            open_root_overlay = true;
+        }
     }
     ui.add_space(style::SPACE_XL);
     ui.label(RichText::new("Panes").size(style::TEXT_CAPTION).color(colors.text_dim).strong());
     ui.add_space(style::SPACE_SM);
+    open_root_overlay
 }
 
 fn render_inspector_hints(
@@ -664,6 +742,215 @@ impl PlexiApp {
         });
         if dismissed {
             self.show_changelog = false;
+        }
+    }
+
+    /// Shared text-input overlay. Renders a centered modal with a text field,
+    /// optional "Browse..." button (for folder targets), and Enter/Escape
+    /// commit/cancel. Dispatches commit to `OverlayTarget`.
+    pub(crate) fn draw_text_input_overlay(&mut self, ctx: &egui::Context) {
+        use crate::app::OverlayTarget;
+
+        if self.text_overlay.is_none() {
+            return;
+        }
+
+        // Consume Enter/Escape before the Area so they don't bleed through.
+        let (commit, cancel) = ctx.input_mut(|i| {
+            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            (enter, esc)
+        });
+
+        // Poll async folder-picker result.
+        if let Some(rx) = &self.text_overlay_browse_rx {
+            if let Ok(result) = rx.try_recv() {
+                if let Some(path) = result {
+                    let path_str = path.display().to_string();
+                    log::info!("TextInputOverlay: browse selected path={path_str}");
+                    if let Some((ref mut ov, _)) = self.text_overlay {
+                        ov.buffer = path_str;
+                    }
+                }
+                self.text_overlay_browse_rx = None;
+            }
+        }
+
+        // Re-borrow after potential mutation above.
+        let (overlay, target) = match self.text_overlay.as_mut() {
+            Some(pair) => pair,
+            None => return,
+        };
+        let label = overlay.label.clone();
+        let hint = overlay.hint.clone();
+        let show_browse = matches!(target, OverlayTarget::ContextRoot(_));
+        let mut browse_clicked = false;
+
+        // Scrim
+        let screen_rect = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("text_input_overlay_scrim"))
+            .fixed_pos(screen_rect.min)
+            .order(egui::Order::Middle)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(
+                    screen_rect,
+                    0.0,
+                    Color32::from_black_alpha(style::SCRIM_ALPHA),
+                );
+            });
+
+        egui::Area::new(egui::Id::new("text_input_overlay"))
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(self.colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, self.colors.border))
+                    .corner_radius(style::RADIUS_MD)
+                    .inner_margin(egui::Margin::symmetric(
+                        style::MODAL_PADDING_H,
+                        style::MODAL_PADDING_V,
+                    ))
+                    .show(ui, |ui| {
+                        ui.set_width(MODAL_WIDTH);
+                        ui.label(
+                            RichText::new(&label)
+                                .size(13.0)
+                                .color(self.colors.text_primary)
+                                .strong(),
+                        );
+                        ui.add_space(6.0);
+
+                        let te_id = egui::Id::new("text_input_overlay_field");
+                        let (overlay, _target) = self.text_overlay.as_mut().unwrap();
+                        let te = ui
+                            .scope(|ui| {
+                                ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                                ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                                ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
+                                ui.visuals_mut().widgets.active.bg_stroke =
+                                    egui::Stroke::new(1.0, self.colors.accent);
+                                ui.visuals_mut().widgets.inactive.bg_stroke =
+                                    egui::Stroke::new(1.0, self.colors.border);
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut overlay.buffer)
+                                        .id(te_id)
+                                        .desired_width(MODAL_WIDTH)
+                                        .hint_text(&hint)
+                                        .font(egui::TextStyle::Body)
+                                        .margin(egui::Margin::symmetric(8, 5)),
+                                )
+                            })
+                            .inner;
+
+                        // One-shot focus guard.
+                        if !overlay.focus_requested {
+                            te.request_focus();
+                            if let Some(mut state) =
+                                egui::TextEdit::load_state(ui.ctx(), te_id)
+                            {
+                                state
+                                    .cursor
+                                    .set_char_range(Some(egui::text::CCursorRange::two(
+                                        egui::text::CCursor::new(0),
+                                        egui::text::CCursor::new(overlay.buffer.len()),
+                                    )));
+                                state.store(ui.ctx(), te_id);
+                            }
+                            overlay.focus_requested = true;
+                            log::info!("TextInputOverlay: focus requested");
+                        }
+
+                        if show_browse {
+                            ui.add_space(style::SPACE_SM);
+                            ui.horizontal(|ui| {
+                                if ui
+                                    .add(
+                                        egui::Button::new(
+                                            RichText::new("Browse\u{2026}")
+                                                .size(style::TEXT_CAPTION)
+                                                .color(self.colors.text_primary),
+                                        )
+                                        .fill(self.colors.bg_active),
+                                    )
+                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                    .clicked()
+                                {
+                                    browse_clicked = true;
+                                }
+                                ui.add_space(style::SPACE_SM);
+                                ui.label(
+                                    RichText::new("Enter to confirm, Esc to cancel")
+                                        .size(style::TEXT_CAPTION)
+                                        .color(self.colors.text_dim),
+                                );
+                            });
+                        }
+                    });
+            });
+
+        if cancel {
+            log::info!("TextInputOverlay: cancelled");
+            self.text_overlay = None;
+            self.text_overlay_browse_rx = None;
+            return;
+        }
+
+        if browse_clicked && self.text_overlay_browse_rx.is_none() {
+            log::info!("TextInputOverlay: browse folder picker opened");
+            let (tx, rx) = std::sync::mpsc::channel();
+            self.text_overlay_browse_rx = Some(rx);
+            std::thread::spawn(move || {
+                let result = pick_folder();
+                let _ = tx.send(result);
+            });
+            return;
+        }
+
+        if commit {
+            // Take overlay state for dispatch.
+            let (overlay, target) = match self.text_overlay.take() {
+                Some(pair) => pair,
+                None => return,
+            };
+            self.text_overlay_browse_rx = None;
+            let raw = overlay.buffer.trim().to_string();
+
+            match target {
+                OverlayTarget::ContextRoot(idx) => {
+                    if raw.is_empty() {
+                        log::info!("TextInputOverlay: clear context root idx={idx}");
+                        self.router.get_mut(idx).root = None;
+                    } else {
+                        // Tilde expansion.
+                        let expanded = if raw.starts_with("~/") {
+                            if let Some(home) = dirs::home_dir() {
+                                home.join(&raw[2..])
+                            } else {
+                                std::path::PathBuf::from(&raw)
+                            }
+                        } else if raw.starts_with('~') && raw.len() == 1 {
+                            dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from(&raw))
+                        } else {
+                            std::path::PathBuf::from(&raw)
+                        };
+
+                        // Resolve relative paths against context path.
+                        let resolved = if expanded.is_relative() {
+                            self.router.get(idx).path.join(&expanded)
+                        } else {
+                            expanded
+                        };
+
+                        log::info!(
+                            "TextInputOverlay: set context root idx={idx} path={}",
+                            resolved.display()
+                        );
+                        self.router.get_mut(idx).root = Some(resolved);
+                    }
+                    self.save_workspace();
+                }
+            }
         }
     }
 
@@ -1645,6 +1932,7 @@ impl PlexiApp {
         let mut close_pane: Option<PaneId> = None;
         let mut focus_pane: Option<PaneId> = None;
         let mut delete_context = false;
+        let mut open_root_overlay = false;
 
         let num_contexts = self.router.len();
         let (nav_down, nav_up, enter_pressed, backspace_pressed) = ctx.input_mut(|i| {
@@ -1728,7 +2016,9 @@ impl PlexiApp {
                     ))
                     .show(ui, |ui| {
                         ui.set_width(style::MODAL_WIDTH_MD);
-                        render_inspector_header(ui, &ctx_name, &ctx_root, &colors);
+                        if render_inspector_header(ui, &ctx_name, &ctx_root, &colors) {
+                            open_root_overlay = true;
+                        }
                         egui::ScrollArea::vertical()
                             .max_height(ctx.available_rect().height() * 0.6)
                             .auto_shrink([false, true])
@@ -1795,6 +2085,24 @@ impl PlexiApp {
             self.inspector_delete_last_press = None;
             self.delete_context(ctx_idx);
             self.save_workspace();
+        }
+        if open_root_overlay {
+            let idx = self.router.active_idx();
+            let existing = self.router.active().root.as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            log::info!("TextInputOverlay: opened target=ContextRoot({idx})");
+            self.text_overlay = Some((
+                crate::app::TextInputOverlay {
+                    label: "Set context root".to_string(),
+                    hint: "/path/to/project or ~/...".to_string(),
+                    buffer: existing,
+                    focus_requested: false,
+                },
+                crate::app::OverlayTarget::ContextRoot(idx),
+            ));
+            // Close the inspector so the text overlay takes focus.
+            self.show_context_inspector = false;
         }
 
         if self.inspector_delete_press_count > 0 {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -940,7 +940,9 @@ impl PlexiApp {
                         };
 
                         // Resolve relative paths against context path.
-                        let resolved = if expanded.is_relative() {
+                        // Skip resolution if the raw input started with ~ (failed
+                        // tilde expansion should not be treated as relative).
+                        let resolved = if expanded.is_relative() && !raw.starts_with('~') {
                             self.router.get(idx).path.join(&expanded)
                         } else {
                             expanded

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -918,6 +918,10 @@ impl PlexiApp {
 
             match target {
                 OverlayTarget::ContextRoot(idx) => {
+                    if idx >= self.router.len() {
+                        log::warn!("TextInputOverlay: context idx={idx} no longer exists");
+                        return;
+                    }
                     if raw.is_empty() {
                         log::info!("TextInputOverlay: clear context root idx={idx}");
                         self.router.get_mut(idx).root = None;
@@ -2092,6 +2096,7 @@ impl PlexiApp {
                 .map(|p| p.display().to_string())
                 .unwrap_or_default();
             log::info!("TextInputOverlay: opened target=ContextRoot({idx})");
+            self.text_overlay_browse_rx = None;
             self.text_overlay = Some((
                 crate::app::TextInputOverlay {
                     label: "Set context root".to_string(),

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -293,8 +293,9 @@ impl PlexiApp {
                             ui.close_menu();
                         }
                     }
-                    if !has_root {
-                        if ui.button("Set root\u{2026}").clicked() {
+                    {
+                        let label = if has_root { "Edit root\u{2026}" } else { "Set root\u{2026}" };
+                        if ui.button(label).clicked() {
                             menu_action = Some((i, WindowMenuAction::OpenRootOverlay));
                             ui.close_menu();
                         }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -396,6 +396,7 @@ impl PlexiApp {
                         .map(|p| p.display().to_string())
                         .unwrap_or_default();
                     log::info!("TextInputOverlay: opened target=ContextRoot({i}) via sidebar");
+                    self.text_overlay_browse_rx = None;
                     self.text_overlay = Some((
                         crate::app::TextInputOverlay {
                             label: "Set context root".to_string(),

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -286,19 +286,23 @@ impl PlexiApp {
                         if ui.button("Move Down").clicked() { menu_action = Some((i, WindowMenuAction::MoveDown)); ui.close_menu(); }
                         if ui.button("Move to Bottom").clicked() { menu_action = Some((i, WindowMenuAction::MoveToBottom)); ui.close_menu(); }
                     }
-                    if cwd_for_menu.is_some() || has_root {
-                        ui.separator();
-                        if let Some(cwd) = &cwd_for_menu {
-                            if ui.button("Set root to current path").clicked() {
-                                menu_action = Some((i, WindowMenuAction::SetRoot(cwd.clone())));
-                                ui.close_menu();
-                            }
+                    ui.separator();
+                    if let Some(cwd) = &cwd_for_menu {
+                        if ui.button("Set root to current path").clicked() {
+                            menu_action = Some((i, WindowMenuAction::SetRoot(cwd.clone())));
+                            ui.close_menu();
                         }
-                        if has_root {
-                            if ui.button("Clear root").clicked() {
-                                menu_action = Some((i, WindowMenuAction::ClearRoot));
-                                ui.close_menu();
-                            }
+                    }
+                    if !has_root {
+                        if ui.button("Set root\u{2026}").clicked() {
+                            menu_action = Some((i, WindowMenuAction::OpenRootOverlay));
+                            ui.close_menu();
+                        }
+                    }
+                    if has_root {
+                        if ui.button("Clear root").clicked() {
+                            menu_action = Some((i, WindowMenuAction::ClearRoot));
+                            ui.close_menu();
                         }
                     }
                     if num_ctxs > 1 {
@@ -386,6 +390,21 @@ impl PlexiApp {
                     log::info!("sidebar: clear context root ctx_idx={i}");
                     self.router.get_mut(i).root = None;
                     self.save_workspace();
+                }
+                WindowMenuAction::OpenRootOverlay => {
+                    let existing = self.router.get(i).root.as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_default();
+                    log::info!("TextInputOverlay: opened target=ContextRoot({i}) via sidebar");
+                    self.text_overlay = Some((
+                        crate::app::TextInputOverlay {
+                            label: "Set context root".to_string(),
+                            hint: "/path/to/project or ~/...".to_string(),
+                            buffer: existing,
+                            focus_requested: false,
+                        },
+                        crate::app::OverlayTarget::ContextRoot(i),
+                    ));
                 }
                 WindowMenuAction::Delete => {
                     self.delete_context(i);


### PR DESCRIPTION
## Summary

- Add `TextInputOverlay` shared primitive with `FocusLayer::TextInput`, one-shot focus guard, Enter/Escape commit/cancel, and `OverlayTarget` dispatch
- Wire context root management: inspector header shows "Set root..." (no root) or path + edit button (has root); sidebar right-click adds "Set root..." for all contexts
- Browse... button opens native macOS folder picker via `rfd::AsyncFileDialog::pick_folder()` on a background thread
- Tilde expansion (`~/...`) and relative path resolution against context path on commit
- `log::info!` traces at every transition: open, commit, cancel, browse

## Test plan

- [ ] Open inspector (Cmd+I) on a context with no root -- "Set root..." link appears below the name
- [ ] Click "Set root..." -- centered modal with text input, pre-focused, "Browse..." button visible
- [ ] Type a path with `~/` prefix, press Enter -- root is set, log line appears
- [ ] Reopen inspector -- path shows with copy button and edit (pencil) button
- [ ] Click edit button -- modal reopens with existing path pre-filled
- [ ] Press Escape in modal -- closes overlay without changing root
- [ ] Click Browse... -- native folder picker opens; selecting a folder populates input and closes picker
- [ ] Right-click a context in sidebar -- "Set root..." appears in menu
- [ ] Verify FocusLayer::TextInput blocks key passthrough to panes while overlay is open

Closes #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)