### PR TITLE
feat(sidebar): unified context row with subtitle and pane dots

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,14 +1,14 @@
 use crate::context::WindowMenuAction;
-use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, ROW_HEIGHT};
+use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, SUBTITLE_LINE_HEIGHT, ROW_HEIGHT};
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
 
-const PANE_DOT_HEIGHT: f32 = 11.0;
 const PANE_DOT_RADIUS: f32 = 2.5;
 const PANE_DOT_SPACING: f32 = 8.0;
 const PANE_DOT_MAX: usize = 6;
+const SUBTITLE_MAX_CHARS: usize = 24;
 
 fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     for (i, rect) in rects.iter().enumerate() {
@@ -171,8 +171,48 @@ impl PlexiApp {
             }
 
             // --- Normal row via SidebarRow ---
-            // Zones are declared here, before any rendering.
-            let row = SidebarRow::new(ui, sidebar_width, num_contexts > 1 && !any_dragging)
+
+            // Derive subtitle: pty_title or CWD basename for the focused pane of this context.
+            let subtitle: Option<String> = {
+                // Find the window belonging to this context that has a focused pane.
+                let ctx_window = self.windows.iter()
+                    .find(|w| w.context_id == ctx_id && w.focused_pane.is_some());
+                ctx_window.and_then(|w| {
+                    let tile_id = w.focused_pane?;
+                    let pane_id = match w.tree.tiles.get(tile_id)? {
+                        Tile::Pane(pid) => *pid,
+                        _ => return None,
+                    };
+                    let pane = w.panes.get(&pane_id)?;
+                    if let Some(t) = pane.as_terminal() {
+                        // Prefer name (user-set or OSC), then pty_title, then CWD basename.
+                        t.name.clone()
+                            .or_else(|| t.pty_title.clone())
+                            .or_else(|| {
+                                crate::shell::get_pid_cwd(t.backend.child_pid())
+                                    .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                            })
+                    } else if let Some(app) = pane.as_app() {
+                        Some(app.name.clone())
+                    } else {
+                        None
+                    }
+                }).map(|s| {
+                    if s.len() > SUBTITLE_MAX_CHARS {
+                        let mut truncated: String = s.chars().take(SUBTITLE_MAX_CHARS - 1).collect();
+                        truncated.push('\u{2026}');
+                        truncated
+                    } else {
+                        s
+                    }
+                })
+            };
+
+            // Subtitle line shown when context has at least one pane.
+            let has_subtitle = pane_count > 0 && subtitle.is_some();
+            let subtitle_height = if has_subtitle { SUBTITLE_LINE_HEIGHT } else { 0.0 };
+
+            let row = SidebarRow::new(ui, sidebar_width, num_contexts > 1 && !any_dragging, subtitle_height)
                 .active(is_active)
                 .dragging(is_dragging, any_dragging);
 
@@ -194,10 +234,16 @@ impl PlexiApp {
             let dim_color = self.colors.text_dim;
             let accent_color = self.colors.accent;
 
+            // Capture subtitle rendering data before the closures.
+            let show_dots = pane_count > 1;
+            let subtitle_text = subtitle.clone();
+            let indent = 20.0 + ctx_depth as f32 * 12.0;
+
             let (action, response) = row.draw(
                 ui,
                 egui::Id::new(("ctx", i)),
                 &self.colors,
+                // Line 1: context name + badge
                 |row_ui, _hovered| {
                     row_ui.add_space(20.0 + ctx_depth as f32 * 12.0);
                     if i < 9 {
@@ -217,50 +263,57 @@ impl PlexiApp {
                         });
                     }
                 },
+                // Line 2: pane dots (if 2+ panes) + subtitle text
+                |painter, subtitle_rect, row_alpha| {
+                    let cy = subtitle_rect.center().y;
+                    let mut text_x = subtitle_rect.min.x + indent;
+
+                    // Pane dots (only when 2+ panes)
+                    if show_dots {
+                        let capped = pane_count.min(PANE_DOT_MAX);
+                        for dot_i in 0..capped {
+                            let cx = subtitle_rect.min.x + indent + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+                            let color = if focused_dot_idx == Some(dot_i) {
+                                with_alpha(accent_color, row_alpha)
+                            } else {
+                                with_alpha(dim_color, 0.35 * row_alpha)
+                            };
+                            painter.circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
+                        }
+                        if pane_count > PANE_DOT_MAX {
+                            let overflow_x = subtitle_rect.min.x + indent + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
+                            painter.text(
+                                egui::pos2(overflow_x, cy),
+                                egui::Align2::LEFT_CENTER,
+                                format!("+{}", pane_count - PANE_DOT_MAX),
+                                egui::FontId::proportional(8.0),
+                                with_alpha(dim_color, 0.5 * row_alpha),
+                            );
+                        }
+                        // Advance text_x past the dots
+                        let dots_width = (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+                        if pane_count > PANE_DOT_MAX {
+                            // Extra space for overflow text
+                            text_x += dots_width + 16.0;
+                        } else {
+                            text_x += dots_width + 6.0;
+                        }
+                    }
+
+                    // Subtitle text
+                    if let Some(ref text) = subtitle_text {
+                        painter.text(
+                            egui::pos2(text_x, cy),
+                            egui::Align2::LEFT_CENTER,
+                            text,
+                            egui::FontId::proportional(9.0),
+                            with_alpha(dim_color, 0.6 * row_alpha),
+                        );
+                    }
+                },
             );
 
-            // Pane dots — shown when 2+ panes exist in this context
-            let dot_area_height = if pane_count > 1 { PANE_DOT_HEIGHT } else { 0.0 };
-            if pane_count > 1 {
-                let dots_origin = ui.cursor().min;
-                let dots_rect = Rect::from_min_size(dots_origin, Vec2::new(sidebar_width, PANE_DOT_HEIGHT));
-                ui.allocate_space(Vec2::new(sidebar_width, PANE_DOT_HEIGHT));
-
-                if is_active {
-                    ui.painter().rect_filled(dots_rect, CornerRadius::ZERO, with_alpha(self.colors.bg_active, if is_dragging { 0.4 } else { 1.0 }));
-                    ui.painter().rect_filled(
-                        Rect::from_min_size(dots_rect.min, Vec2::new(3.0, PANE_DOT_HEIGHT)),
-                        CornerRadius::ZERO,
-                        with_alpha(self.colors.accent, if is_dragging { 0.4 } else { 1.0 }),
-                    );
-                }
-
-                let indent = 20.0 + ctx_depth as f32 * 12.0;
-                let cy = dots_rect.center().y;
-                let capped = pane_count.min(PANE_DOT_MAX);
-                for dot_i in 0..capped {
-                    let cx = dots_rect.min.x + indent + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
-                    let color = if focused_dot_idx == Some(dot_i) {
-                        with_alpha(self.colors.accent, if is_dragging { 0.4 } else { 1.0 })
-                    } else {
-                        with_alpha(self.colors.text_dim, if is_dragging { 0.15 } else { 0.35 })
-                    };
-                    ui.painter().circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
-                }
-                if pane_count > PANE_DOT_MAX {
-                    let overflow_x = dots_rect.min.x + indent + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
-                    ui.painter().text(
-                        egui::pos2(overflow_x, cy),
-                        egui::Align2::LEFT_CENTER,
-                        format!("+{}", pane_count - PANE_DOT_MAX),
-                        egui::FontId::proportional(8.0),
-                        with_alpha(self.colors.text_dim, 0.5),
-                    );
-                }
-            }
-
-            let item_origin = row_full.min;
-            row_rects.push(Rect::from_min_size(item_origin, Vec2::new(sidebar_width, ROW_HEIGHT + dot_area_height)));
+            row_rects.push(row_full);
 
             match action {
                 SidebarAction::DragStart => { self.drag_context = Some(i); }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -198,7 +198,7 @@ impl PlexiApp {
                         None
                     }
                 }).map(|s| {
-                    if s.len() > SUBTITLE_MAX_CHARS {
+                    if s.chars().count() > SUBTITLE_MAX_CHARS {
                         let mut truncated: String = s.chars().take(SUBTITLE_MAX_CHARS - 1).collect();
                         truncated.push('\u{2026}');
                         truncated

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::context::WindowMenuAction;
-use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, SUBTITLE_LINE_HEIGHT, ROW_HEIGHT};
-use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
+use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, ROW_HEIGHT};
+use egui::{Align, Color32, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
@@ -174,7 +174,6 @@ impl PlexiApp {
 
             // Derive subtitle: pty_title or CWD basename for the focused pane of this context.
             let subtitle: Option<String> = {
-                // Find the window belonging to this context that has a focused pane.
                 let ctx_window = self.windows.iter()
                     .find(|w| w.context_id == ctx_id && w.focused_pane.is_some());
                 ctx_window.and_then(|w| {
@@ -185,7 +184,6 @@ impl PlexiApp {
                     };
                     let pane = w.panes.get(&pane_id)?;
                     if let Some(t) = pane.as_terminal() {
-                        // Prefer name (user-set or OSC), then pty_title, then CWD basename.
                         t.name.clone()
                             .or_else(|| t.pty_title.clone())
                             .or_else(|| {
@@ -208,18 +206,13 @@ impl PlexiApp {
                 })
             };
 
-            // Subtitle line shown when context has at least one pane.
-            let has_subtitle = pane_count > 0 && subtitle.is_some();
-            let subtitle_height = if has_subtitle { SUBTITLE_LINE_HEIGHT } else { 0.0 };
-
-            let row = SidebarRow::new(ui, sidebar_width, num_contexts > 1 && !any_dragging, subtitle_height)
+            // Fixed-height row: every context is the same size.
+            let row = SidebarRow::new(ui, sidebar_width, num_contexts > 1 && !any_dragging)
                 .active(is_active)
                 .dragging(is_dragging, any_dragging);
 
-            // Snapshot the layout for drop-indicator tracking (must be before draw()).
             let row_full = row.layout.full;
 
-            // Prepare content data (borrows resolved before the closure).
             let text_color = with_alpha(
                 if is_active { self.colors.text_primary } else { self.colors.text_dim },
                 if is_dragging { 0.4 } else { 1.0 },
@@ -234,7 +227,6 @@ impl PlexiApp {
             let dim_color = self.colors.text_dim;
             let accent_color = self.colors.accent;
 
-            // Capture subtitle rendering data before the closures.
             let show_dots = pane_count > 1;
             let subtitle_text = subtitle.clone();
             let indent = 20.0 + ctx_depth as f32 * 12.0;
@@ -263,16 +255,32 @@ impl PlexiApp {
                         });
                     }
                 },
-                // Line 2: pane dots (if 2+ panes) + subtitle text
+                // Line 2: subtitle path first, then pane dots to the right
                 |painter, subtitle_rect, row_alpha| {
                     let cy = subtitle_rect.center().y;
-                    let mut text_x = subtitle_rect.min.x + indent;
+                    let mut cursor_x = subtitle_rect.min.x + indent;
 
-                    // Pane dots (only when 2+ panes)
+                    // Subtitle text (path/title) — always first
+                    if let Some(ref text) = subtitle_text {
+                        let text_galley = painter.layout_no_wrap(
+                            text.to_string(),
+                            egui::FontId::proportional(9.0),
+                            with_alpha(dim_color, 0.6 * row_alpha),
+                        );
+                        let text_width = text_galley.size().x;
+                        painter.galley(
+                            egui::pos2(cursor_x, cy - text_galley.size().y * 0.5),
+                            text_galley,
+                            Color32::TRANSPARENT,
+                        );
+                        cursor_x += text_width + 6.0;
+                    }
+
+                    // Pane dots (only when 2+ panes) — after the path
                     if show_dots {
                         let capped = pane_count.min(PANE_DOT_MAX);
                         for dot_i in 0..capped {
-                            let cx = subtitle_rect.min.x + indent + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+                            let cx = cursor_x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
                             let color = if focused_dot_idx == Some(dot_i) {
                                 with_alpha(accent_color, row_alpha)
                             } else {
@@ -281,7 +289,7 @@ impl PlexiApp {
                             painter.circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
                         }
                         if pane_count > PANE_DOT_MAX {
-                            let overflow_x = subtitle_rect.min.x + indent + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
+                            let overflow_x = cursor_x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
                             painter.text(
                                 egui::pos2(overflow_x, cy),
                                 egui::Align2::LEFT_CENTER,
@@ -290,25 +298,6 @@ impl PlexiApp {
                                 with_alpha(dim_color, 0.5 * row_alpha),
                             );
                         }
-                        // Advance text_x past the dots
-                        let dots_width = (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
-                        if pane_count > PANE_DOT_MAX {
-                            // Extra space for overflow text
-                            text_x += dots_width + 16.0;
-                        } else {
-                            text_x += dots_width + 6.0;
-                        }
-                    }
-
-                    // Subtitle text
-                    if let Some(ref text) = subtitle_text {
-                        painter.text(
-                            egui::pos2(text_x, cy),
-                            egui::Align2::LEFT_CENTER,
-                            text,
-                            egui::FontId::proportional(9.0),
-                            with_alpha(dim_color, 0.6 * row_alpha),
-                        );
                     }
                 },
             );

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -2,6 +2,7 @@ use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Pos2, Rect, Sen
 use crate::theme::Colors;
 
 pub const ROW_HEIGHT: f32 = 26.0;
+pub const SUBTITLE_LINE_HEIGHT: f32 = 14.0;
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
@@ -21,16 +22,19 @@ pub struct RowLayout {
 }
 
 impl RowLayout {
-    fn new(origin: Pos2, width: f32, action_enabled: bool) -> Self {
-        let full = Rect::from_min_size(origin, Vec2::new(width, ROW_HEIGHT));
+    fn new(origin: Pos2, width: f32, action_enabled: bool, subtitle_height: f32) -> Self {
+        let total_height = ROW_HEIGHT + subtitle_height;
+        let full = Rect::from_min_size(origin, Vec2::new(width, total_height));
         let action = action_enabled.then(|| {
             Rect::from_min_size(
                 egui::pos2(full.max.x - ACTION_ZONE_WIDTH, full.min.y),
-                Vec2::new(ACTION_ZONE_WIDTH, ROW_HEIGHT),
+                Vec2::new(ACTION_ZONE_WIDTH, total_height),
             )
         });
         let content = action.map(|a| full.with_max_x(a.min.x)).unwrap_or(full);
-        Self { full, content, action }
+        // Content rect for line 1 only (name row), restricted to ROW_HEIGHT.
+        let content_line1 = Rect::from_min_size(content.min, Vec2::new(content.width(), ROW_HEIGHT));
+        Self { full, content: content_line1, action }
     }
 
     fn in_action(&self, ui: &egui::Ui) -> bool {
@@ -68,6 +72,7 @@ pub enum SidebarAction {
 /// before any rendering or interaction registration occurs.
 pub struct SidebarRow {
     pub layout: RowLayout,
+    subtitle_height: f32,
     is_active: bool,
     is_this_dragging: bool,
     is_any_dragging: bool,
@@ -77,11 +82,12 @@ impl SidebarRow {
     /// Compute layout zones from the current cursor position.
     /// `action_enabled`: whether to carve out the action zone.
     /// Pass `false` when only one context exists or dragging is active.
-    /// The action glyph is gated on hover inside draw() — geometry is stable.
-    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool) -> Self {
+    /// `subtitle_height`: extra height for the subtitle line (0.0 when no subtitle).
+    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool, subtitle_height: f32) -> Self {
         let origin = ui.cursor().min;
         Self {
-            layout: RowLayout::new(origin, width, action_enabled),
+            layout: RowLayout::new(origin, width, action_enabled, subtitle_height),
+            subtitle_height,
             is_active: false,
             is_this_dragging: false,
             is_any_dragging: false,
@@ -98,8 +104,9 @@ impl SidebarRow {
 
     /// Render the row and return a typed action plus the full-row response.
     ///
-    /// `content_fn` receives a `&mut Ui` scoped to the content zone only.
-    /// It must not call `interact()` or set cursor icons — the row builder owns those.
+    /// `content_fn` receives a `&mut Ui` scoped to the content zone (line 1) only.
+    /// `subtitle_fn` receives the painter, the subtitle rect, and the row alpha for line 2.
+    /// Neither must call `interact()` or set cursor icons — the row builder owns those.
     ///
     /// The returned `Response` covers the full row and is intended for context_menu attachment.
     pub fn draw(
@@ -108,15 +115,16 @@ impl SidebarRow {
         id: Id,
         colors: &Colors,
         content_fn: impl FnOnce(&mut egui::Ui, bool),
+        subtitle_fn: impl FnOnce(&egui::Painter, Rect, f32),
     ) -> (SidebarAction, egui::Response) {
+        let total_height = ROW_HEIGHT + self.subtitle_height;
         let row_alpha = if self.is_this_dragging { 0.4_f32 } else { 1.0_f32 };
         let hovered = self.layout.hovered(ui);
 
-        // Advance the layout cursor — must happen before any allocate_new_ui calls
-        // that would otherwise try to use the same origin.
-        ui.allocate_space(Vec2::new(self.layout.full.width(), ROW_HEIGHT));
+        // Advance the layout cursor by the full item height.
+        ui.allocate_space(Vec2::new(self.layout.full.width(), total_height));
 
-        // Background
+        // Background — covers the full item (name + subtitle).
         let fill = if self.is_active {
             with_alpha(colors.bg_active, row_alpha)
         } else if hovered && !self.is_this_dragging {
@@ -126,16 +134,16 @@ impl SidebarRow {
         };
         ui.painter().rect_filled(self.layout.full, CornerRadius::ZERO, fill);
 
-        // Active accent bar
+        // Active accent bar — covers the full item height.
         if self.is_active {
             ui.painter().rect_filled(
-                Rect::from_min_size(self.layout.full.min, Vec2::new(3.0, ROW_HEIGHT)),
+                Rect::from_min_size(self.layout.full.min, Vec2::new(3.0, total_height)),
                 CornerRadius::ZERO,
                 with_alpha(colors.accent, row_alpha),
             );
         }
 
-        // Content zone — sub-Ui is restricted to the content rect
+        // Content zone (line 1) — sub-Ui restricted to the name row.
         ui.allocate_new_ui(
             UiBuilder::new()
                 .max_rect(self.layout.content)
@@ -143,8 +151,18 @@ impl SidebarRow {
             |ui| content_fn(ui, hovered),
         );
 
+        // Subtitle zone (line 2) — rendered via painter callback.
+        if self.subtitle_height > 0.0 {
+            let subtitle_rect = Rect::from_min_size(
+                Pos2::new(self.layout.full.min.x, self.layout.full.min.y + ROW_HEIGHT),
+                Vec2::new(self.layout.full.width(), self.subtitle_height),
+            );
+            subtitle_fn(ui.painter(), subtitle_rect, row_alpha);
+        }
+
         // Action zone — glyph only (no interact call). Click detection is via pointer-position
         // geometry against the single full-row interact registered below.
+        // Vertically center the glyph in the name row (line 1), not the full item.
         let in_action = self.layout.in_action(ui);
         if let Some(az) = self.layout.action {
             if hovered && !self.is_this_dragging {
@@ -152,8 +170,9 @@ impl SidebarRow {
                     if in_action { colors.text_primary } else { colors.text_dim },
                     row_alpha,
                 );
+                let action_line1_center = egui::pos2(az.center().x, az.min.y + ROW_HEIGHT * 0.5);
                 ui.painter().text(
-                    az.center(),
+                    action_line1_center,
                     egui::Align2::CENTER_CENTER,
                     "\u{2715}",
                     egui::FontId::proportional(13.0),
@@ -162,20 +181,13 @@ impl SidebarRow {
             }
         }
 
-        // Single interact on the full row. Priority chain encodes mutual exclusion:
-        // 1. double_clicked → Rename (full row is the target)
-        // 2. drag_started   → DragStart
-        // 3. drag_stopped   → DragEnd
-        // 4. clicked + in_action + hovered → Delete
-        // 5. clicked        → Activate
+        // Single interact on the full row.
         let response = ui.interact(self.layout.full, id, Sense::click_and_drag());
 
-        // Tooltip for the action zone — shown via the full-row response when pointer is in zone.
         if in_action {
             response.clone().on_hover_text("Delete context");
         }
 
-        // Cursor — single authority, derived from zones only
         if let Some(icon) = self.layout.resolve_cursor(ui, self.is_this_dragging, self.is_any_dragging) {
             ui.ctx().set_cursor_icon(icon);
         }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -1,8 +1,10 @@
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Pos2, Rect, Sense, UiBuilder, Vec2};
 use crate::theme::Colors;
 
-pub const ROW_HEIGHT: f32 = 26.0;
+pub const NAME_LINE_HEIGHT: f32 = 26.0;
 pub const SUBTITLE_LINE_HEIGHT: f32 = 14.0;
+/// Every context row is this height: name line + subtitle line (path + dots).
+pub const ROW_HEIGHT: f32 = NAME_LINE_HEIGHT + SUBTITLE_LINE_HEIGHT;
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
@@ -22,18 +24,17 @@ pub struct RowLayout {
 }
 
 impl RowLayout {
-    fn new(origin: Pos2, width: f32, action_enabled: bool, subtitle_height: f32) -> Self {
-        let total_height = ROW_HEIGHT + subtitle_height;
-        let full = Rect::from_min_size(origin, Vec2::new(width, total_height));
+    fn new(origin: Pos2, width: f32, action_enabled: bool) -> Self {
+        let full = Rect::from_min_size(origin, Vec2::new(width, ROW_HEIGHT));
         let action = action_enabled.then(|| {
             Rect::from_min_size(
                 egui::pos2(full.max.x - ACTION_ZONE_WIDTH, full.min.y),
-                Vec2::new(ACTION_ZONE_WIDTH, total_height),
+                Vec2::new(ACTION_ZONE_WIDTH, ROW_HEIGHT),
             )
         });
         let content = action.map(|a| full.with_max_x(a.min.x)).unwrap_or(full);
-        // Content rect for line 1 only (name row), restricted to ROW_HEIGHT.
-        let content_line1 = Rect::from_min_size(content.min, Vec2::new(content.width(), ROW_HEIGHT));
+        // Content rect for line 1 only (name row), restricted to NAME_LINE_HEIGHT.
+        let content_line1 = Rect::from_min_size(content.min, Vec2::new(content.width(), NAME_LINE_HEIGHT));
         Self { full, content: content_line1, action }
     }
 
@@ -72,7 +73,6 @@ pub enum SidebarAction {
 /// before any rendering or interaction registration occurs.
 pub struct SidebarRow {
     pub layout: RowLayout,
-    subtitle_height: f32,
     is_active: bool,
     is_this_dragging: bool,
     is_any_dragging: bool,
@@ -82,12 +82,10 @@ impl SidebarRow {
     /// Compute layout zones from the current cursor position.
     /// `action_enabled`: whether to carve out the action zone.
     /// Pass `false` when only one context exists or dragging is active.
-    /// `subtitle_height`: extra height for the subtitle line (0.0 when no subtitle).
-    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool, subtitle_height: f32) -> Self {
+    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool) -> Self {
         let origin = ui.cursor().min;
         Self {
-            layout: RowLayout::new(origin, width, action_enabled, subtitle_height),
-            subtitle_height,
+            layout: RowLayout::new(origin, width, action_enabled),
             is_active: false,
             is_this_dragging: false,
             is_any_dragging: false,
@@ -117,12 +115,11 @@ impl SidebarRow {
         content_fn: impl FnOnce(&mut egui::Ui, bool),
         subtitle_fn: impl FnOnce(&egui::Painter, Rect, f32),
     ) -> (SidebarAction, egui::Response) {
-        let total_height = ROW_HEIGHT + self.subtitle_height;
         let row_alpha = if self.is_this_dragging { 0.4_f32 } else { 1.0_f32 };
         let hovered = self.layout.hovered(ui);
 
-        // Advance the layout cursor by the full item height.
-        ui.allocate_space(Vec2::new(self.layout.full.width(), total_height));
+        // Advance the layout cursor by the fixed row height.
+        ui.allocate_space(Vec2::new(self.layout.full.width(), ROW_HEIGHT));
 
         // Background — covers the full item (name + subtitle).
         let fill = if self.is_active {
@@ -137,7 +134,7 @@ impl SidebarRow {
         // Active accent bar — covers the full item height.
         if self.is_active {
             ui.painter().rect_filled(
-                Rect::from_min_size(self.layout.full.min, Vec2::new(3.0, total_height)),
+                Rect::from_min_size(self.layout.full.min, Vec2::new(3.0, ROW_HEIGHT)),
                 CornerRadius::ZERO,
                 with_alpha(colors.accent, row_alpha),
             );
@@ -151,14 +148,12 @@ impl SidebarRow {
             |ui| content_fn(ui, hovered),
         );
 
-        // Subtitle zone (line 2) — rendered via painter callback.
-        if self.subtitle_height > 0.0 {
-            let subtitle_rect = Rect::from_min_size(
-                Pos2::new(self.layout.full.min.x, self.layout.full.min.y + ROW_HEIGHT),
-                Vec2::new(self.layout.full.width(), self.subtitle_height),
-            );
-            subtitle_fn(ui.painter(), subtitle_rect, row_alpha);
-        }
+        // Subtitle zone (line 2) — always allocated, rendered via painter callback.
+        let subtitle_rect = Rect::from_min_size(
+            Pos2::new(self.layout.full.min.x, self.layout.full.min.y + NAME_LINE_HEIGHT),
+            Vec2::new(self.layout.full.width(), SUBTITLE_LINE_HEIGHT),
+        );
+        subtitle_fn(ui.painter(), subtitle_rect, row_alpha);
 
         // Action zone — glyph only (no interact call). Click detection is via pointer-position
         // geometry against the single full-row interact registered below.
@@ -170,7 +165,7 @@ impl SidebarRow {
                     if in_action { colors.text_primary } else { colors.text_dim },
                     row_alpha,
                 );
-                let action_line1_center = egui::pos2(az.center().x, az.min.y + ROW_HEIGHT * 0.5);
+                let action_line1_center = egui::pos2(az.center().x, az.min.y + NAME_LINE_HEIGHT * 0.5);
                 ui.painter().text(
                     action_line1_center,
                     egui::Align2::CENTER_CENTER,


### PR DESCRIPTION
## Summary

Closes #1425.

Redesigns sidebar context rows from a name row + detached dot band into a single unified two-line item:

- **Line 1**: context number + name + notification badge (unchanged)
- **Line 2**: pane dots (left-aligned, 2+ panes only) + active pane subtitle (OSC title / pane name / CWD basename, dim 9px, truncated to 24 chars)

Single-pane contexts show subtitle without dots. Zero-pane contexts stay at default single-line height.

## Changes

- `src/sidebar_row.rs`: Added `subtitle_height` parameter to `RowLayout` and `SidebarRow`. Full rect, background, accent bar, and interaction all cover the combined height. Subtitle rendered via a painter callback on line 2. Delete glyph vertically centered on line 1 only.
- `src/sidebar.rs`: Removed separate `PANE_DOT_HEIGHT` allocation block. Subtitle string derived per context from the focused pane's name/pty_title/CWD basename. Dots and subtitle rendered inside the unified row via the new subtitle callback.

## Done When

- Multi-pane context: single unified item with name on top, dots + title on bottom
- Single-pane context: name on top, title on bottom, no dots
- Zero-pane context: name only, default height
- Drag reorder snaps correctly
- Active background and accent bar cover full item height