### PR TITLE
fix(cli): unify plexi list / plexi app list and fix command discovery (#1440)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,62 @@ pub struct CommandDef {
 
 /// Entry point for `plexi run <command_name>`.
 /// Returns the exit code.
+/// `plexi run` with no argument — list available commands from .plexi/commands.toml.
+pub fn run_list_commands() -> i32 {
+    log::info!("cli: run called with no command, listing available workspace commands");
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("error: could not determine current directory: {e}");
+            return 1;
+        }
+    };
+
+    let config_path = cwd.join(COMMANDS_FILE);
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => {
+            println!("No workspace commands configured.");
+            println!();
+            println!("To set up commands, create {COMMANDS_FILE} in your project:");
+            println!("  plexi workspace init");
+            println!();
+            println!("Then define commands in .plexi/commands.toml:");
+            println!("  [commands.dev]");
+            println!("  run = \"npm run dev\"");
+            return 0;
+        }
+    };
+
+    let config: PlexiCommands = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to parse {COMMANDS_FILE}: {e}");
+            return 1;
+        }
+    };
+
+    if config.commands.is_empty() {
+        println!("No commands defined in {COMMANDS_FILE}.");
+        println!();
+        println!("Add a command:");
+        println!("  [commands.dev]");
+        println!("  run = \"npm run dev\"");
+        return 0;
+    }
+
+    println!("Available commands:");
+    let mut names: Vec<&String> = config.commands.keys().collect();
+    names.sort();
+    for name in names {
+        let cmd = &config.commands[name];
+        println!("  {:20} {}", name, cmd.run);
+    }
+    println!();
+    println!("Run one with: plexi run <command>");
+    0
+}
+
 pub fn run_command(command_name: &str) -> i32 {
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
@@ -922,23 +978,10 @@ pub fn app_info(id: &str) -> i32 {
     0
 }
 
-/// `plexi app list` — list installed apps.
+/// `plexi app list` — unified alias for `plexi list`.
 pub fn app_list() -> i32 {
-    let registry =
-        crate::app_registry::AppRegistry::load(&std::env::current_dir().unwrap_or_default());
-    let apps = registry.list();
-    if apps.is_empty() {
-        println!("No apps installed.");
-        println!("Install one with: plexi install github:owner/repo");
-    } else {
-        for app in apps {
-            println!(
-                "{:20} {}  {}",
-                app.manifest.id, app.manifest.version, app.manifest.description
-            );
-        }
-    }
-    0
+    log::info!("cli: app_list delegating to list_cli (unified)");
+    list_cli()
 }
 
 /// `plexi app render <id> --size WxH [--state state.json] [--output path.png]`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,7 +45,7 @@ pub fn run_list_commands() -> i32 {
     let config_path = cwd.join(COMMANDS_FILE);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("No workspace commands configured.");
             println!();
             println!("To set up commands, create {COMMANDS_FILE} in your project:");
@@ -55,6 +55,10 @@ pub fn run_list_commands() -> i32 {
             println!("  [commands.dev]");
             println!("  run = \"npm run dev\"");
             return 0;
+        }
+        Err(e) => {
+            eprintln!("error: could not read {}: {e}", config_path.display());
+            return 1;
         }
     };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,9 +166,11 @@ pub fn run_command(command_name: &str) -> i32 {
         return 1;
     }
 
-    // Spawn the command via sh -c with secrets injected as env vars
+    // Spawn the command via sh -c with secrets injected as env vars.
+    // PLEXI_CONFIG_DIR lets scripts reference channel-correct paths without hardcoding ~/.plexi/.
     let mut child_cmd = Command::new("sh");
     child_cmd.arg("-c").arg(&cmd_def.run);
+    child_cmd.env("PLEXI_CONFIG_DIR", crate::config::config_dir());
     for (key, value) in &resolved {
         child_cmd.env(key, value);
     }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -20,6 +20,7 @@ use clap::{Parser, Subcommand};
 \x1b[1mWorkspace (per-project):\x1b[0m
   plexi workspace init      Set up a .plexi/ workspace
   plexi secret set <name>   Store a secret in your keychain
+  plexi run                 List available workspace commands
   plexi run <command>       Run a command from .plexi/commands.toml
 "
 )]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1,7 +1,28 @@
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "plexi", about = "Plexi — the last app you'll ever need", version = env!("CARGO_PKG_VERSION"))]
+#[command(
+    name = "plexi",
+    about = "Plexi — the last app you'll ever need",
+    version = env!("CARGO_PKG_VERSION"),
+    after_help = "\x1b[1mQuick start:\x1b[0m
+  plexi                     Launch the Plexi GUI
+  plexi list                Show installed apps
+  plexi open <app>          Open an app in a new pane
+  plexi install <source>    Install an app (e.g. github:owner/repo)
+  plexi app init <name>     Scaffold a new app
+
+\x1b[1mInside a Plexi pane:\x1b[0m
+  plexi terminal            Open a terminal pane
+  plexi pane list           List all open panes
+  plexi notify --title ...  Send a notification
+
+\x1b[1mWorkspace (per-project):\x1b[0m
+  plexi workspace init      Set up a .plexi/ workspace
+  plexi secret set <name>   Store a secret in your keychain
+  plexi run <command>       Run a command from .plexi/commands.toml
+"
+)]
 pub struct Cli {
     /// Profile name (e.g. alpha, beta)
     #[arg(long, global = true, hide = true)]
@@ -23,7 +44,8 @@ pub enum Commands {
     ///
     /// Example: plexi run dev
     Run {
-        command: String,
+        /// Command name to run (omit to list available commands)
+        command: Option<String>,
     },
     /// Set up a .plexi/ workspace in your project folder.
     ///
@@ -274,7 +296,7 @@ pub enum AppCmd {
         #[arg(long = "yes", short = 'y')]
         yes: bool,
     },
-    /// Show all installed apps.
+    /// Show all installed apps (alias for `plexi list`).
     List,
     /// Render an app to a PNG image without opening the UI (useful for screenshots and testing).
     Render {

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,9 +211,10 @@ fn main() -> eframe::Result {
         Ok(cli) => {
             if let Some(cmd) = cli.command {
                 match cmd {
-                    Commands::Run { command } => {
-                        std::process::exit(cli::run_command(&command));
-                    }
+                    Commands::Run { command } => match command {
+                        Some(cmd) => std::process::exit(cli::run_command(&cmd)),
+                        None => std::process::exit(cli::run_list_commands()),
+                    },
                     Commands::Workspace { cmd } => match cmd {
                         WorkspaceCmd::Init => std::process::exit(cli::workspace_init()),
                     },


### PR DESCRIPTION
## Summary

- **Unified `plexi list` and `plexi app list`:** `plexi app list` now delegates to `list_cli()`, so both commands produce the same grouped output (global + workspace apps with id, name, version). No more confusing duplicate commands with different output formats.
- **`plexi run` with no args lists available commands:** Instead of erroring on a missing positional argument, `plexi run` alone now reads `.plexi/commands.toml` and prints the available workspace commands. If no workspace is configured, it shows setup instructions.
- **Added quick-start guide to `plexi --help`:** An `after_help` section groups the most common commands by category (general, inside-pane, workspace) so new users can see what's available without reading docs.

## Test plan

- [ ] `plexi --help` shows the quick-start guide after the subcommand list
- [ ] `plexi list` and `plexi app list` produce identical output
- [ ] `plexi run` with no args shows available commands (or setup instructions if no workspace)
- [ ] Existing `plexi run <command>` behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Running `plexi run` without specifying a command now displays help guidance or lists all available commands with their execution definitions
  * Command execution environment now includes the configuration directory path, enabling scripts to access and reference configuration files

* **Chores**
  * Unified command listing by making `app list` an alias to the main `list` command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->