### PR TITLE
feat(contexts): remove depth-3 hard cap, allow unlimited nesting (#1392)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,7 @@ pub struct Context {
     pub context_id: u64,
     /// Parent context_id for sub-contexts. None = top-level.
     pub parent_id: Option<u64>,
-    /// Nesting depth. 0 = root level. Capped at 3.
+    /// Nesting depth. 0 = root level. No hard cap; a soft warning is emitted at depth 3+.
     pub depth: u32,
 }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 impl PlexiApp {
     /// Create a child context nested inside `parent_name`. Moves the parent's focused
     /// pane into the new child context and replaces it with a SubContext tile. Falls
-    /// back to a new terminal if no adoptable pane is focused. Depth is capped at 3.
+    /// back to a new terminal if no adoptable pane is focused. No hard depth limit.
     pub(crate) fn new_child_context(&mut self, parent_name: &str, path: PathBuf) -> Result<(), String> {
         let parent_idx = self.router.position(|c| c.name == parent_name)
             .ok_or_else(|| format!("no context named '{parent_name}'"))?;
@@ -18,14 +18,10 @@ impl PlexiApp {
         let parent_depth = self.router.get(parent_idx).depth;
 
         if parent_depth >= 3 {
-            log::warn!(
-                "new_child_context: depth limit reached — parent '{}' is at depth {}",
+            log::info!(
+                "new_child_context: deep nesting — parent '{}' is at depth {} (consider reorganizing)",
                 parent_name, parent_depth
             );
-            return Err(format!(
-                "depth limit: parent '{}' is already at depth {} (max 3)",
-                parent_name, parent_depth
-            ));
         }
 
         let child_depth = parent_depth + 1;

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -52,15 +52,47 @@ impl PlexiApp {
                     .collect();
                 path_ids.push(self.router.active().context_id);
 
-                for (i, &ctx_id) in path_ids.iter().enumerate() {
-                    let name = self.router.iter()
-                        .find(|c| c.context_id == ctx_id)
-                        .map(|c| c.name.as_str())
-                        .unwrap_or("?");
-                    let _ = ui.small_button(name);
-                    if i < path_ids.len() - 1 {
-                        ui.label(egui::RichText::new("\u{203A}").color(self.colors.text_dim));
+                // Truncate deep breadcrumbs: show first + ellipsis + last 2 when depth >= 4.
+                let total = path_ids.len();
+                let sep = egui::RichText::new("\u{203A}").color(self.colors.text_dim);
+                if total >= 5 {
+                    // first segment
+                    let first_name = self.router.iter()
+                        .find(|c| c.context_id == path_ids[0])
+                        .map(|c| c.name.clone())
+                        .unwrap_or_else(|| "?".to_string());
+                    let _ = ui.small_button(first_name);
+                    ui.label(sep.clone());
+                    ui.label(egui::RichText::new("\u{2026}").color(self.colors.text_dim));
+                    ui.label(sep.clone());
+                    // last 2 segments
+                    for (i, &ctx_id) in path_ids[total - 2..].iter().enumerate() {
+                        let name = self.router.iter()
+                            .find(|c| c.context_id == ctx_id)
+                            .map(|c| c.name.clone())
+                            .unwrap_or_else(|| "?".to_string());
+                        let _ = ui.small_button(name);
+                        if i == 0 {
+                            ui.label(sep.clone());
+                        }
                     }
+                } else {
+                    for (i, &ctx_id) in path_ids.iter().enumerate() {
+                        let name = self.router.iter()
+                            .find(|c| c.context_id == ctx_id)
+                            .map(|c| c.name.clone())
+                            .unwrap_or_else(|| "?".to_string());
+                        let _ = ui.small_button(name);
+                        if i < total - 1 {
+                            ui.label(sep.clone());
+                        }
+                    }
+                }
+
+                // Soft warning indicator at depth >= 3.
+                if total >= 3 {
+                    ui.add_space(4.0);
+                    ui.label(egui::RichText::new("deep").color(self.colors.text_dim).small());
                 }
             });
             ui.separator();


### PR DESCRIPTION
## Summary

- Removes the hard depth-3 cap in `new_child_context()` — users can now create sub-contexts at any depth
- Replaces the blocking `log::warn!` + early return with a non-blocking `log::info!` advisory at depth >= 3
- Breadcrumb bar truncates gracefully at depth 5+ (first + `…` + last 2 segments)
- Dim "deep" label appears in breadcrumb bar at depth >= 3 as a soft nudge

## Done When

- [x] Can create sub-contexts at depth 5, 10, whatever
- [x] Breadcrumb bar doesn't overflow or break at deep nesting
- [x] Soft warning appears at depth 3 but doesn't block creation

Closes #1392