### PR TITLE
refactor(sidebar): replace SidebarRow pixel math with ContextItem scope+shape layout (#1448)

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,14 +1,9 @@
 use crate::context::WindowMenuAction;
-use crate::sidebar_row::{with_alpha, SidebarAction, SidebarRow, ROW_HEIGHT};
+use crate::sidebar_row::{SidebarAction, ContextItem, PaneDots};
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
-
-const PANE_DOT_HEIGHT: f32 = 11.0;
-const PANE_DOT_RADIUS: f32 = 2.5;
-const PANE_DOT_SPACING: f32 = 8.0;
-const PANE_DOT_MAX: usize = 6;
 
 fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     for (i, rect) in rects.iter().enumerate() {
@@ -106,37 +101,25 @@ impl PlexiApp {
                 None
             };
 
-            // --- Renaming: special-cased before SidebarRow path ---
+            // --- Renaming: special-cased before ContextItem path ---
             if is_renaming {
-                let origin = ui.cursor().min;
-                let row_rect = Rect::from_min_size(origin, Vec2::new(sidebar_width, ROW_HEIGHT));
-                row_rects.push(row_rect);
-                ui.allocate_space(Vec2::new(sidebar_width, ROW_HEIGHT));
-
                 let fill = if is_active { self.colors.bg_active } else { self.colors.bg_sidebar_hover };
-                ui.painter().rect_filled(row_rect, CornerRadius::ZERO, fill);
-                if is_active {
-                    ui.painter().rect_filled(
-                        Rect::from_min_size(row_rect.min, Vec2::new(3.0, ROW_HEIGHT)),
-                        CornerRadius::ZERO,
-                        self.colors.accent,
-                    );
-                }
-
+                let bg_idx = ui.painter().add(egui::Shape::Noop);
                 let te_id = egui::Id::new(("rename_ctx", i));
-                let text_rect = row_rect.shrink2(egui::vec2(20.0, 2.0));
-                ui.allocate_new_ui(
-                    egui::UiBuilder::new()
-                        .max_rect(text_rect)
-                        .layout(Layout::left_to_right(Align::Center)),
-                    |ui| {
+                let accent = self.colors.accent;
+                let sidebar_w = sidebar_width;
+                let scope = ui.scope(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        ui.add_space(20.0);
                         let te = ui.scope(|ui| {
                             ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
+                            ui.visuals_mut().text_cursor.stroke.color = accent;
                             ui.add(
                                 egui::TextEdit::singleline(&mut self.rename_buffer)
                                     .id(te_id)
-                                    .desired_width(sidebar_width - 56.0)
+                                    .desired_width(sidebar_w - 56.0)
                                     .font(egui::TextStyle::Body),
                             )
                         }).inner;
@@ -165,25 +148,23 @@ impl PlexiApp {
                                 state.store(ui.ctx(), te_id);
                             }
                         }
-                    },
-                );
+                    });
+                    ui.add_space(4.0);
+                });
+                let row_rect = scope.response.rect;
+                row_rects.push(row_rect);
+                ui.painter().set(bg_idx, egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill));
+                if is_active {
+                    ui.painter().rect_filled(
+                        Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
+                        CornerRadius::ZERO,
+                        self.colors.accent,
+                    );
+                }
                 continue;
             }
 
-            // --- Normal row via SidebarRow ---
-            // Zones are declared here, before any rendering.
-            let row = SidebarRow::new(ui, sidebar_width, num_contexts > 1 && !any_dragging)
-                .active(is_active)
-                .dragging(is_dragging, any_dragging);
-
-            // Snapshot the layout for drop-indicator tracking (must be before draw()).
-            let row_full = row.layout.full;
-
-            // Prepare content data (borrows resolved before the closure).
-            let text_color = with_alpha(
-                if is_active { self.colors.text_primary } else { self.colors.text_dim },
-                if is_dragging { 0.4 } else { 1.0 },
-            );
+            // --- Normal row via ContextItem ---
             let ctx_name = self.router.get(i).name.clone();
             let ctx_depth = self.router.get(i).depth;
             let badge_count = if is_active {
@@ -191,76 +172,23 @@ impl PlexiApp {
             } else {
                 self.context_notification_count(i)
             };
-            let dim_color = self.colors.text_dim;
-            let accent_color = self.colors.accent;
+            let subtitle = self.router.get(i).root.as_ref()
+                .map(|p| p.display().to_string());
 
-            let (action, response) = row.draw(
-                ui,
-                egui::Id::new(("ctx", i)),
-                &self.colors,
-                |row_ui, _hovered| {
-                    row_ui.add_space(20.0 + ctx_depth as f32 * 12.0);
-                    if i < 9 {
-                        row_ui.label(
-                            RichText::new(format!("{}", i + 1)).size(11.0).color(dim_color),
-                        );
-                    }
-                    row_ui.add(
-                        egui::Label::new(RichText::new(&ctx_name).size(12.0).color(text_color))
-                            .selectable(false),
-                    );
-                    if badge_count > 0 {
-                        row_ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                            ui.add_space(8.0);
-                            let badge_text = if badge_count > 9 { "9+".to_string() } else { badge_count.to_string() };
-                            ui.label(RichText::new(badge_text).size(10.0).color(accent_color));
-                        });
-                    }
-                },
-            );
+            let (action, response) = ContextItem {
+                is_active,
+                is_dragging,
+                any_dragging,
+                action_enabled: num_contexts > 1 && !any_dragging,
+                ctx_depth,
+                ctx_name,
+                ctx_index: Some(i),
+                badge_count,
+                subtitle,
+                pane_dots: Some(PaneDots { count: pane_count, focused_idx: focused_dot_idx }),
+            }.draw(ui, egui::Id::new(("ctx", i)), &self.colors);
 
-            // Pane dots — shown when 2+ panes exist in this context
-            let dot_area_height = if pane_count > 1 { PANE_DOT_HEIGHT } else { 0.0 };
-            if pane_count > 1 {
-                let dots_origin = ui.cursor().min;
-                let dots_rect = Rect::from_min_size(dots_origin, Vec2::new(sidebar_width, PANE_DOT_HEIGHT));
-                ui.allocate_space(Vec2::new(sidebar_width, PANE_DOT_HEIGHT));
-
-                if is_active {
-                    ui.painter().rect_filled(dots_rect, CornerRadius::ZERO, with_alpha(self.colors.bg_active, if is_dragging { 0.4 } else { 1.0 }));
-                    ui.painter().rect_filled(
-                        Rect::from_min_size(dots_rect.min, Vec2::new(3.0, PANE_DOT_HEIGHT)),
-                        CornerRadius::ZERO,
-                        with_alpha(self.colors.accent, if is_dragging { 0.4 } else { 1.0 }),
-                    );
-                }
-
-                let indent = 20.0 + ctx_depth as f32 * 12.0;
-                let cy = dots_rect.center().y;
-                let capped = pane_count.min(PANE_DOT_MAX);
-                for dot_i in 0..capped {
-                    let cx = dots_rect.min.x + indent + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
-                    let color = if focused_dot_idx == Some(dot_i) {
-                        with_alpha(self.colors.accent, if is_dragging { 0.4 } else { 1.0 })
-                    } else {
-                        with_alpha(self.colors.text_dim, if is_dragging { 0.15 } else { 0.35 })
-                    };
-                    ui.painter().circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
-                }
-                if pane_count > PANE_DOT_MAX {
-                    let overflow_x = dots_rect.min.x + indent + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
-                    ui.painter().text(
-                        egui::pos2(overflow_x, cy),
-                        egui::Align2::LEFT_CENTER,
-                        format!("+{}", pane_count - PANE_DOT_MAX),
-                        egui::FontId::proportional(8.0),
-                        with_alpha(self.colors.text_dim, 0.5),
-                    );
-                }
-            }
-
-            let item_origin = row_full.min;
-            row_rects.push(Rect::from_min_size(item_origin, Vec2::new(sidebar_width, ROW_HEIGHT + dot_area_height)));
+            row_rects.push(response.rect);
 
             match action {
                 SidebarAction::DragStart => { self.drag_context = Some(i); }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -13,13 +13,15 @@ pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
 
 fn shorten_path(path: &str) -> String {
     let home = std::env::var("HOME").unwrap_or_default();
-    let shortened = if !home.is_empty() && path.starts_with(&home) {
-        format!("~{}", &path[home.len()..])
+    let shortened = if !home.is_empty() {
+        path.strip_prefix(&home).map_or_else(|| path.to_string(), |rest| format!("~{rest}"))
     } else {
         path.to_string()
     };
-    if shortened.len() > 40 {
-        format!("\u{2026}{}", &shortened[shortened.len() - 39..])
+    let char_count = shortened.chars().count();
+    if char_count > 40 {
+        let tail: String = shortened.chars().rev().take(39).collect::<Vec<_>>().into_iter().rev().collect();
+        format!("\u{2026}{tail}")
     } else {
         shortened
     }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -1,60 +1,30 @@
-use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Pos2, Rect, Sense, UiBuilder, Vec2};
+use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
 use crate::theme::Colors;
 
-pub const ROW_HEIGHT: f32 = 26.0;
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
+
+const PANE_DOT_RADIUS: f32 = 2.5;
+const PANE_DOT_SPACING: f32 = 8.0;
+const PANE_DOT_MAX: usize = 6;
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
 }
 
-/// Pre-computed, non-overlapping layout zones for a sidebar row.
-/// All rects are fixed at construction time from the row origin — never from content layout.
-pub struct RowLayout {
-    /// The full row rect: background, border, hover detection.
-    pub full: Rect,
-    /// The drag/click/context-menu zone (left portion). Stable regardless of hover state.
-    pub content: Rect,
-    /// The action zone (delete button) — right-anchored, None when the action is disabled.
-    /// Geometry is always carved out when Some; glyph is gated on hover in draw().
-    pub action: Option<Rect>,
-}
-
-impl RowLayout {
-    fn new(origin: Pos2, width: f32, action_enabled: bool) -> Self {
-        let full = Rect::from_min_size(origin, Vec2::new(width, ROW_HEIGHT));
-        let action = action_enabled.then(|| {
-            Rect::from_min_size(
-                egui::pos2(full.max.x - ACTION_ZONE_WIDTH, full.min.y),
-                Vec2::new(ACTION_ZONE_WIDTH, ROW_HEIGHT),
-            )
-        });
-        let content = action.map(|a| full.with_max_x(a.min.x)).unwrap_or(full);
-        Self { full, content, action }
-    }
-
-    fn in_action(&self, ui: &egui::Ui) -> bool {
-        self.action.map_or(false, |r| ui.rect_contains_pointer(r))
-    }
-
-    fn hovered(&self, ui: &egui::Ui) -> bool {
-        ui.rect_contains_pointer(self.full)
-    }
-
-    /// Single cursor authority — zone containment only, never widget responses.
-    fn resolve_cursor(&self, ui: &egui::Ui, is_this_dragging: bool, is_any_dragging: bool) -> Option<CursorIcon> {
-        if self.in_action(ui) {
-            Some(CursorIcon::PointingHand)
-        } else if ui.rect_contains_pointer(self.content) || is_this_dragging {
-            Some(if is_any_dragging { CursorIcon::Grabbing } else { CursorIcon::Grab })
-        } else {
-            None
-        }
+fn shorten_path(path: &str) -> String {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let shortened = if !home.is_empty() && path.starts_with(&home) {
+        format!("~{}", &path[home.len()..])
+    } else {
+        path.to_string()
+    };
+    if shortened.len() > 40 {
+        format!("\u{2026}{}", &shortened[shortened.len() - 39..])
+    } else {
+        shortened
     }
 }
 
-/// Single action returned from rendering a sidebar row. Priority is encoded inside draw() —
-/// at most one action fires per frame. The caller matches exhaustively.
 pub enum SidebarAction {
     None,
     Activate,
@@ -64,92 +34,188 @@ pub enum SidebarAction {
     DragEnd,
 }
 
-/// Builder that snapshots the cursor origin at construction and computes all zones
-/// before any rendering or interaction registration occurs.
-pub struct SidebarRow {
-    pub layout: RowLayout,
-    is_active: bool,
-    is_this_dragging: bool,
-    is_any_dragging: bool,
+pub struct PaneDots {
+    pub count: usize,
+    pub focused_idx: Option<usize>,
 }
 
-impl SidebarRow {
-    /// Compute layout zones from the current cursor position.
-    /// `action_enabled`: whether to carve out the action zone.
-    /// Pass `false` when only one context exists or dragging is active.
-    /// The action glyph is gated on hover inside draw() — geometry is stable.
-    pub fn new(ui: &egui::Ui, width: f32, action_enabled: bool) -> Self {
-        let origin = ui.cursor().min;
-        Self {
-            layout: RowLayout::new(origin, width, action_enabled),
-            is_active: false,
-            is_this_dragging: false,
-            is_any_dragging: false,
-        }
-    }
+pub struct ContextItem {
+    pub is_active: bool,
+    pub is_dragging: bool,
+    pub any_dragging: bool,
+    pub action_enabled: bool,
+    pub ctx_depth: u32,
+    pub ctx_name: String,
+    pub ctx_index: Option<usize>,
+    pub badge_count: usize,
+    pub subtitle: Option<String>,
+    pub pane_dots: Option<PaneDots>,
+}
 
-    pub fn active(mut self, v: bool) -> Self { self.is_active = v; self }
+impl ContextItem {
+    pub fn draw(self, ui: &mut egui::Ui, id: Id, colors: &Colors) -> (SidebarAction, egui::Response) {
+        let row_alpha = if self.is_dragging { 0.4_f32 } else { 1.0_f32 };
 
-    pub fn dragging(mut self, this_row: bool, any_row: bool) -> Self {
-        self.is_this_dragging = this_row;
-        self.is_any_dragging = any_row;
-        self
-    }
+        // Reserve background shape slot before rendering (same pattern as selectable_row in widgets.rs).
+        // Frame inner_margin interferes with ScrollArea height measurement — use scope + shape slot instead.
+        let bg_idx = ui.painter().add(egui::Shape::Noop);
 
-    /// Render the row and return a typed action plus the full-row response.
-    ///
-    /// `content_fn` receives a `&mut Ui` scoped to the content zone only.
-    /// It must not call `interact()` or set cursor icons — the row builder owns those.
-    ///
-    /// The returned `Response` covers the full row and is intended for context_menu attachment.
-    pub fn draw(
-        self,
-        ui: &mut egui::Ui,
-        id: Id,
-        colors: &Colors,
-        content_fn: impl FnOnce(&mut egui::Ui, bool),
-    ) -> (SidebarAction, egui::Response) {
-        let row_alpha = if self.is_this_dragging { 0.4_f32 } else { 1.0_f32 };
-        let hovered = self.layout.hovered(ui);
+        let indent = 20.0 + self.ctx_depth as f32 * 12.0;
 
-        // Advance the layout cursor — must happen before any allocate_new_ui calls
-        // that would otherwise try to use the same origin.
-        ui.allocate_space(Vec2::new(self.layout.full.width(), ROW_HEIGHT));
+        // Capture fields for use inside closure
+        let is_active = self.is_active;
+        let is_dragging = self.is_dragging;
+        let any_dragging = self.any_dragging;
+        let action_enabled = self.action_enabled;
+        let ctx_name = self.ctx_name.clone();
+        let ctx_index = self.ctx_index;
+        let badge_count = self.badge_count;
+        let subtitle = self.subtitle.clone();
+        let pane_dots = self.pane_dots;
+        let accent_color = colors.accent;
+        let text_primary = colors.text_primary;
+        let text_dim = colors.text_dim;
+        let bg_active = colors.bg_active;
 
-        // Background
-        let fill = if self.is_active {
-            with_alpha(colors.bg_active, row_alpha)
-        } else if hovered && !self.is_this_dragging {
+        let text_color = with_alpha(
+            if is_active { text_primary } else { text_dim },
+            row_alpha,
+        );
+
+        let name_row_height = ui.scope(|ui| {
+            ui.set_width(ui.available_width());
+
+            // --- Section 1: Name row ---
+            let y_before_name = ui.cursor().min.y;
+            ui.horizontal(|ui| {
+                ui.add_space(indent);
+                if let Some(idx) = ctx_index {
+                    if idx < 9 {
+                        ui.label(
+                            egui::RichText::new(format!("{}", idx + 1))
+                                .size(11.0)
+                                .color(with_alpha(text_dim, row_alpha)),
+                        );
+                    }
+                }
+                ui.add(
+                    egui::Label::new(
+                        egui::RichText::new(&ctx_name).size(12.0).color(text_color)
+                    )
+                    .selectable(false),
+                );
+                if badge_count > 0 {
+                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                        ui.add_space(8.0);
+                        let badge_text = if badge_count > 9 {
+                            "9+".to_string()
+                        } else {
+                            badge_count.to_string()
+                        };
+                        ui.label(
+                            egui::RichText::new(badge_text)
+                                .size(10.0)
+                                .color(with_alpha(accent_color, row_alpha)),
+                        );
+                    });
+                }
+            });
+            let name_row_height = ui.cursor().min.y - y_before_name;
+
+            // --- Section 2: Subtitle ---
+            if let Some(ref path) = subtitle {
+                ui.horizontal(|ui| {
+                    ui.add_space(indent);
+                    ui.label(
+                        egui::RichText::new(shorten_path(path))
+                            .size(9.5)
+                            .color(with_alpha(text_dim, row_alpha)),
+                    );
+                });
+            }
+
+            // --- Section 3: Pane dots ---
+            if let Some(ref dots) = pane_dots {
+                if dots.count > 1 {
+                    ui.horizontal(|ui| {
+                        ui.add_space(indent);
+                        let capped = dots.count.min(PANE_DOT_MAX);
+                        let dot_area_width = (capped as f32) * PANE_DOT_SPACING;
+                        let dot_size = Vec2::new(dot_area_width, PANE_DOT_RADIUS * 2.0 + 4.0);
+                        let (rect, _) = ui.allocate_exact_size(dot_size, Sense::hover());
+                        let painter = ui.painter();
+                        let cy = rect.center().y;
+                        for dot_i in 0..capped {
+                            let cx = rect.min.x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+                            let color = if dots.focused_idx == Some(dot_i) {
+                                with_alpha(accent_color, row_alpha)
+                            } else {
+                                with_alpha(text_dim, if is_dragging { 0.15 } else { 0.35 })
+                            };
+                            painter.circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
+                        }
+                        if dots.count > PANE_DOT_MAX {
+                            let overflow_x = rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
+                            painter.text(
+                                egui::pos2(overflow_x, cy),
+                                egui::Align2::LEFT_CENTER,
+                                format!("+{}", dots.count - PANE_DOT_MAX),
+                                egui::FontId::proportional(8.0),
+                                with_alpha(text_dim, 0.5),
+                            );
+                        }
+                    });
+                }
+            }
+
+            name_row_height
+        });
+
+        let row_rect = name_row_height.response.rect;
+        let name_row_h = name_row_height.inner;
+
+        // Interact on the full row
+        let response = ui.interact(row_rect, id, Sense::click_and_drag());
+        let hovered = response.hovered();
+
+        // Determine background fill
+        let fill = if is_active {
+            with_alpha(bg_active, row_alpha)
+        } else if hovered && !is_dragging {
             with_alpha(colors.bg_sidebar_hover, row_alpha)
         } else {
             Color32::TRANSPARENT
         };
-        ui.painter().rect_filled(self.layout.full, CornerRadius::ZERO, fill);
 
-        // Active accent bar
-        if self.is_active {
+        // Paint background behind content
+        ui.painter().set(bg_idx, egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill));
+
+        // Active accent bar — full row height
+        if is_active {
             ui.painter().rect_filled(
-                Rect::from_min_size(self.layout.full.min, Vec2::new(3.0, ROW_HEIGHT)),
+                Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
                 CornerRadius::ZERO,
-                with_alpha(colors.accent, row_alpha),
+                with_alpha(accent_color, row_alpha),
             );
         }
 
-        // Content zone — sub-Ui is restricted to the content rect
-        ui.allocate_new_ui(
-            UiBuilder::new()
-                .max_rect(self.layout.content)
-                .layout(Layout::left_to_right(Align::Center)),
-            |ui| content_fn(ui, hovered),
-        );
+        // Action zone — rightmost portion of the name row
+        let action_zone = if action_enabled {
+            Some(Rect::from_min_max(
+                egui::pos2(row_rect.max.x - ACTION_ZONE_WIDTH, row_rect.min.y),
+                egui::pos2(row_rect.max.x, row_rect.min.y + name_row_h),
+            ))
+        } else {
+            None
+        };
 
-        // Action zone — glyph only (no interact call). Click detection is via pointer-position
-        // geometry against the single full-row interact registered below.
-        let in_action = self.layout.in_action(ui);
-        if let Some(az) = self.layout.action {
-            if hovered && !self.is_this_dragging {
+        let in_action = action_zone.map_or(false, |az| ui.rect_contains_pointer(az));
+
+        // Action glyph (✕) — shown on hover
+        if let Some(az) = action_zone {
+            if hovered && !is_dragging {
                 let glyph_color = with_alpha(
-                    if in_action { colors.text_primary } else { colors.text_dim },
+                    if in_action { text_primary } else { text_dim },
                     row_alpha,
                 );
                 ui.painter().text(
@@ -162,24 +228,30 @@ impl SidebarRow {
             }
         }
 
-        // Single interact on the full row. Priority chain encodes mutual exclusion:
-        // 1. double_clicked → Rename (full row is the target)
-        // 2. drag_started   → DragStart
-        // 3. drag_stopped   → DragEnd
-        // 4. clicked + in_action + hovered → Delete
-        // 5. clicked        → Activate
-        let response = ui.interact(self.layout.full, id, Sense::click_and_drag());
-
-        // Tooltip for the action zone — shown via the full-row response when pointer is in zone.
+        // Tooltip for action zone
         if in_action {
             response.clone().on_hover_text("Delete context");
         }
 
-        // Cursor — single authority, derived from zones only
-        if let Some(icon) = self.layout.resolve_cursor(ui, self.is_this_dragging, self.is_any_dragging) {
-            ui.ctx().set_cursor_icon(icon);
+        // Cursor — single authority
+        if in_action {
+            ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+        } else {
+            let content_max_x = if action_enabled {
+                row_rect.max.x - ACTION_ZONE_WIDTH
+            } else {
+                row_rect.max.x
+            };
+            let in_content = ui.rect_contains_pointer(Rect::from_min_max(
+                row_rect.min,
+                egui::pos2(content_max_x, row_rect.max.y),
+            ));
+            if in_content || is_dragging {
+                ui.ctx().set_cursor_icon(if any_dragging { CursorIcon::Grabbing } else { CursorIcon::Grab });
+            }
         }
 
+        // Action priority chain
         let action = if response.double_clicked() {
             SidebarAction::Rename
         } else if response.drag_started() {

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -11,10 +11,12 @@ pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
 }
 
+static HOME_DIR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 fn shorten_path(path: &str) -> String {
-    let home = std::env::var("HOME").unwrap_or_default();
+    let home = HOME_DIR.get_or_init(|| std::env::var("HOME").unwrap_or_default());
     let shortened = if !home.is_empty() {
-        path.strip_prefix(&home).map_or_else(|| path.to_string(), |rest| format!("~{rest}"))
+        path.strip_prefix(home.as_str()).map_or_else(|| path.to_string(), |rest| format!("~{rest}"))
     } else {
         path.to_string()
     };


### PR DESCRIPTION
## Summary

Replaces the fixed-height `SidebarRow` (pre-computed rects from `ROW_HEIGHT` constants, root cause of two failed PRs) with `ContextItem`: a scope+shape-slot widget whose height emerges from egui layout.

**Root cause fixed:** `SidebarRow::draw()` called `allocate_space(ROW_HEIGHT)` then painted subtitle/dots at manually-computed Y-offsets. When subtitle or dots extended beyond 26px, they bled into the next row. This is now structurally impossible — children in `ui.vertical()` cannot overlap.

## Changes

- `src/sidebar_row.rs` — removed `SidebarRow`, `RowLayout`, `ROW_HEIGHT`; added `ContextItem`, `PaneDots`. Uses scope+shape-slot pattern (same as `selectable_row` in `widgets.rs`).
- `src/sidebar.rs` — removed `PANE_DOT_HEIGHT` and the separate dots rendering block; replaced with single `ContextItem { ... }.draw()` call. Renaming case updated to scope+shape-slot. `row_rects` now uses `response.rect` directly (emergent height).

## Three sections per row (structurally non-overlapping)

1. **Name row** — number label, context name, notification badge
2. **Subtitle** — root path shortened to `~/...` (only shown when root is set)
3. **Pane dots** — shown when 2+ panes exist in the context

Active accent bar now covers the full emergent row height, not a hardcoded 26px.

## Done When criteria

- [x] Three vertically stacked sections that never overlap
- [x] Active background, hover highlight, and accent bar cover the full item height
- [x] Click, double-click, drag, context-menu all work on the full item area
- [x] Drag-reorder snaps correctly at item boundaries (`row_rects.push(response.rect)`)
- [x] Renaming inline uses the same layout frame
- [x] `ROW_HEIGHT`, `PANE_DOT_HEIGHT` removed
- [x] `cargo test --bin plexi` passes with no new failures

Closes #1448
Closes #1425