### PR TITLE
fix(overlays): Cmd+0 quick note works when another modal is open (#1435)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4184,13 +4184,17 @@ impl PlexiApp {
 
         // Cmd+0 (quick note) is a global shortcut that must fire even when another
         // overlay is open — it pushes QuickNote on top of the current overlay.
-        // Block it when QuickNote is already active to prevent resetting mid-edit.
-        let allow_quick_note = !matches!(
-            self.focus_stack.last(),
-            Some(FocusLayer::QuickNote)
-                | Some(FocusLayer::QuickNoteDestination)
-                | Some(FocusLayer::QuickNoteSubDestination(_))
-        );
+        // Block it when ANY QuickNote layer is on the stack (not just the top),
+        // so a notification pushed on top of QuickNote doesn't re-open and reset
+        // the note mid-edit.
+        let allow_quick_note = !self.focus_stack.iter().any(|layer| {
+            matches!(
+                layer,
+                FocusLayer::QuickNote
+                    | FocusLayer::QuickNoteDestination
+                    | FocusLayer::QuickNoteSubDestination(_)
+            )
+        });
 
         ctx.input_mut(|i| {
             i.events.retain(|e| {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4182,6 +4182,16 @@ impl PlexiApp {
                 .map(|n| !matches!(n.kind, crate::app_protocol::NotifyKind::Choice | crate::app_protocol::NotifyKind::Input))
                 .unwrap_or(false);
 
+        // Cmd+0 (quick note) is a global shortcut that must fire even when another
+        // overlay is open — it pushes QuickNote on top of the current overlay.
+        // Block it when QuickNote is already active to prevent resetting mid-edit.
+        let allow_quick_note = !matches!(
+            self.focus_stack.last(),
+            Some(FocusLayer::QuickNote)
+                | Some(FocusLayer::QuickNoteDestination)
+                | Some(FocusLayer::QuickNoteSubDestination(_))
+        );
+
         ctx.input_mut(|i| {
             i.events.retain(|e| {
                 if crate::input_intent::classify(e).is_none() {
@@ -4201,6 +4211,9 @@ impl PlexiApp {
                             return false;
                         }
                         if !shift && matches!(key, egui::Key::Q | egui::Key::W) {
+                            return true;
+                        }
+                        if !shift && allow_quick_note && *key == egui::Key::Num0 {
                             return true;
                         }
                         if shift && matches!(key, egui::Key::A) {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -638,4 +638,103 @@ mod tests {
         }
     }
 
+    /// Cmd+0 (quick note) must pass through the drain when any non-quick-note
+    /// overlay is active so poll_actions can open the quick note modal.
+    #[test]
+    fn drain_allows_quick_note_key_through_other_overlays() {
+        use crate::app::FocusLayer;
+
+        let non_quick_note_layers = vec![
+            FocusLayer::ContextInspector,
+            FocusLayer::CommandPalette,
+            FocusLayer::NotificationModal,
+            FocusLayer::ConfirmClose,
+            FocusLayer::RenamePane,
+            FocusLayer::TextInput,
+        ];
+
+        for layer in non_quick_note_layers {
+            let mut h = HostHarness::new();
+            h.app.push_focus_layer(layer.clone());
+
+            let event = egui::Event::Key {
+                key: egui::Key::Num0,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers {
+                    command: true,
+                    ..Default::default()
+                },
+            };
+
+            h.app.ctx.input_mut(|i| {
+                i.events.push(event);
+            });
+
+            h.app.drain_captured_keyboard_input(&h.app.ctx.clone());
+
+            let mut found = false;
+            h.app.ctx.input(|i| {
+                found = i.events.iter().any(|e| matches!(
+                    e,
+                    egui::Event::Key { key: egui::Key::Num0, modifiers, .. }
+                        if modifiers.command && !modifiers.shift
+                ));
+            });
+            assert!(
+                found,
+                "Cmd+0 was incorrectly drained when {layer:?} was active — quick note should be reachable"
+            );
+        }
+    }
+
+    /// Cmd+0 must be drained when quick note is already the active overlay to
+    /// prevent resetting the modal state mid-edit.
+    #[test]
+    fn drain_blocks_quick_note_key_when_quick_note_active() {
+        use crate::app::FocusLayer;
+
+        let quick_note_layers = vec![
+            FocusLayer::QuickNote,
+            FocusLayer::QuickNoteDestination,
+            FocusLayer::QuickNoteSubDestination(vec![0]),
+        ];
+
+        for layer in quick_note_layers {
+            let mut h = HostHarness::new();
+            h.app.push_focus_layer(layer.clone());
+
+            let event = egui::Event::Key {
+                key: egui::Key::Num0,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers {
+                    command: true,
+                    ..Default::default()
+                },
+            };
+
+            h.app.ctx.input_mut(|i| {
+                i.events.push(event);
+            });
+
+            h.app.drain_captured_keyboard_input(&h.app.ctx.clone());
+
+            let mut found = false;
+            h.app.ctx.input(|i| {
+                found = i.events.iter().any(|e| matches!(
+                    e,
+                    egui::Event::Key { key: egui::Key::Num0, modifiers, .. }
+                        if modifiers.command
+                ));
+            });
+            assert!(
+                !found,
+                "Cmd+0 leaked through drain when {layer:?} was active — quick note should stay open"
+            );
+        }
+    }
+
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -651,6 +651,8 @@ mod tests {
             FocusLayer::ConfirmClose,
             FocusLayer::RenamePane,
             FocusLayer::TextInput,
+            FocusLayer::ContextRename,
+            FocusLayer::CliSetupPrompt,
         ];
 
         for layer in non_quick_note_layers {
@@ -690,7 +692,8 @@ mod tests {
     }
 
     /// Cmd+0 must be drained when quick note is already the active overlay to
-    /// prevent resetting the modal state mid-edit.
+    /// prevent resetting the modal state mid-edit. This includes when another
+    /// overlay is stacked on top of QuickNote (e.g. a notification pushed above it).
     #[test]
     fn drain_blocks_quick_note_key_when_quick_note_active() {
         use crate::app::FocusLayer;
@@ -700,6 +703,43 @@ mod tests {
             FocusLayer::QuickNoteDestination,
             FocusLayer::QuickNoteSubDestination(vec![0]),
         ];
+
+        // Also verify that a non-QuickNote layer on top of QuickNote still blocks Cmd+0.
+        {
+            let mut h = HostHarness::new();
+            h.app.push_focus_layer(FocusLayer::QuickNote);
+            h.app.push_focus_layer(FocusLayer::NotificationModal);
+
+            let event = egui::Event::Key {
+                key: egui::Key::Num0,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers {
+                    command: true,
+                    ..Default::default()
+                },
+            };
+
+            h.app.ctx.input_mut(|i| {
+                i.events.push(event);
+            });
+
+            h.app.drain_captured_keyboard_input(&h.app.ctx.clone());
+
+            let mut found = false;
+            h.app.ctx.input(|i| {
+                found = i.events.iter().any(|e| matches!(
+                    e,
+                    egui::Event::Key { key: egui::Key::Num0, modifiers, .. }
+                        if modifiers.command
+                ));
+            });
+            assert!(
+                !found,
+                "Cmd+0 leaked through drain when NotificationModal is on top of QuickNote"
+            );
+        }
 
         for layer in quick_note_layers {
             let mut h = HostHarness::new();


### PR DESCRIPTION
## Summary

- `drain_captured_keyboard_input` was blocking `Cmd+0` along with all other input when any overlay held focus
- Added `egui::Key::Num0` to the drain allowlist, gated on the active focus layer not being in the QuickNote family (to prevent resetting modal state mid-edit)
- `poll_actions` now sees the key, fires `Action::OpenQuickNote`, and `push_focus_layer(FocusLayer::QuickNote)` stacks the quick note modal on top of the existing overlay — when quick note is dismissed, the original overlay is still visible

## Done when
- Cmd+0 opens quick note overlay even when context inspector (or any other modal) is already open
- Cmd+0 is a no-op (not a state reset) when quick note is already the active overlay

## Test plan
- [ ] Open context inspector, press Cmd+0 — quick note should open on top
- [ ] Dismiss quick note (Esc) — context inspector should still be visible
- [ ] Open quick note, press Cmd+0 again — nothing should happen (no state reset)
- `cargo test drain` — all 6 drain tests pass including the 2 new ones

Closes #1435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Cmd+0 keyboard shortcut to open Quick Notes from anywhere in the app. The shortcut is automatically suppressed while editing Quick Notes to prevent interruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->