### PR TITLE
feat(config): [agents] block — tiered coding agent command templates (#1397)

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -207,3 +207,21 @@ hidden  = true
 # # Script stdout format: one entry per line as  key|label|command
 # # Example line: 1|PLEXI|cd ~/Documents/GitHub/PLEXI && plexi terminal --layout context-end -- claude -p {note}
 
+# ── Coding Agent Commands ──────────────────────────────────────
+# Command templates used when Plexi skills dispatch coding agent panes.
+# {cmd} is replaced with the prompt or slash command at dispatch time.
+#
+# Tiers:
+#   low    → fast/cheap tasks (e.g. haiku)
+#   medium → standard work   (e.g. sonnet)
+#   high   → complex/autonomous tasks (default model, max permissions)
+#
+# Set these to your own aliases if you have them:
+#   low    = "ch '{cmd}'"
+#   medium = "c '{cmd}'"
+#   high   = "ca '{cmd}'"
+[agents]
+low    = "claude --model claude-haiku-4-5 --dangerously-skip-permissions '{cmd}'"
+medium = "claude --model claude-sonnet-4-6 --dangerously-skip-permissions '{cmd}'"
+high   = "claude --dangerously-skip-permissions '{cmd}'"
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3832,7 +3832,9 @@ pub fn config_edit() -> i32 {
 
 pub fn config_get(key: &str) -> i32 {
     log::info!("config_get: resolving key={key}");
-    let config = crate::config::PlexiConfig::load();
+    let config = crate::config::PlexiConfig::load_with_workspace(
+        crate::config::active_workspace_root().as_deref(),
+    );
     let agents = config.agents.as_ref();
     let value = match key {
         "agents.low" => agents.map(|a| a.effective_low()).unwrap_or(crate::config::DEFAULT_AGENT_LOW),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3830,6 +3830,52 @@ pub fn config_edit() -> i32 {
     }
 }
 
+pub fn config_get(key: &str) -> i32 {
+    log::info!("config_get: resolving key={key}");
+    let config = crate::config::PlexiConfig::load();
+    let agents = config.agents.as_ref();
+    let value = match key {
+        "agents.low" => agents.map(|a| a.effective_low()).unwrap_or(crate::config::DEFAULT_AGENT_LOW),
+        "agents.medium" => agents.map(|a| a.effective_medium()).unwrap_or(crate::config::DEFAULT_AGENT_MEDIUM),
+        "agents.high" => agents.map(|a| a.effective_high()).unwrap_or(crate::config::DEFAULT_AGENT_HIGH),
+        _ => {
+            eprintln!("error: unknown config key {key:?} — supported keys: agents.low, agents.medium, agents.high");
+            return 1;
+        }
+    };
+    println!("{value}");
+    0
+}
+
+pub fn config_reset() -> i32 {
+    let path = crate::config::config_path();
+    log::info!("config_reset: writing default config to {}", path.display());
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("error: could not create config dir {}: {e}", parent.display());
+            return 1;
+        }
+    }
+    if path.exists() {
+        let bak = path.with_extension("toml.bak");
+        if let Err(e) = std::fs::copy(&path, &bak) {
+            eprintln!("error: could not back up config to {}: {e}", bak.display());
+            return 1;
+        }
+        eprintln!("backed up existing config to {}", bak.display());
+    }
+    match std::fs::write(&path, crate::config::CONFIG_TEMPLATE) {
+        Ok(()) => {
+            eprintln!("✓ wrote default config to {}", path.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: could not write config: {e}");
+            1
+        }
+    }
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     match shell {
         "zsh" => { print!("{}", zsh_completion(binary_name)); 0 }
@@ -4034,7 +4080,7 @@ _plexi() {
           ;;
         config)
           local subcmds
-          subcmds=('check:Validate config.toml and report errors' 'edit:Open config.toml in $EDITOR')
+          subcmds=('check:Validate config.toml and report errors' 'edit:Open config.toml in $EDITOR' 'get:Print resolved value of a config key' 'reset:Overwrite config.toml with built-in defaults')
           _describe 'subcommand' subcmds
           ;;
       esac
@@ -4161,7 +4207,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur"))
       ;;
     config)
-      COMPREPLY=($(compgen -W "check edit" -- "$cur"))
+      COMPREPLY=($(compgen -W "check edit get reset" -- "$cur"))
       ;;
   esac
 }
@@ -4194,6 +4240,8 @@ complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret ap
 # config subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from config" -a check -d "Validate config.toml and report errors"
 complete -c plexi -f -n "__fish_seen_subcommand_from config" -a edit -d "Open config.toml in \$EDITOR"
+complete -c plexi -f -n "__fish_seen_subcommand_from config" -a get -d "Print resolved value of a config key"
+complete -c plexi -f -n "__fish_seen_subcommand_from config" -a reset -d "Overwrite config.toml with built-in defaults"
 
 # secret subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from secret" -a set -d "Store a secret"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -508,4 +508,16 @@ pub enum ConfigCmd {
     Check,
     /// Open config.toml in your $EDITOR.
     Edit,
+    /// Print the resolved value of a config key to stdout.
+    ///
+    /// Supports dotted keys: agents.low, agents.medium, agents.high.
+    /// Returns the effective value (user setting or built-in default).
+    Get {
+        /// Dotted key to retrieve (e.g. agents.medium).
+        key: String,
+    },
+    /// Overwrite config.toml with the built-in default template.
+    ///
+    /// Creates a backup at config.toml.bak before overwriting.
+    Reset,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -277,6 +277,7 @@ pub struct PlexiConfig {
     pub keybindings: Option<KeybindingsConfig>,
     pub quick_note: Option<QuickNoteConfig>,
     pub focus_history_depth: Option<usize>,
+    pub agents: Option<AgentsConfig>,
 }
 
 /// Plexi AI broker configuration (`ai.query` capability).
@@ -369,6 +370,39 @@ impl OllamaBackendConfig {
         if other.model_high.is_some() {
             self.model_high = other.model_high;
         }
+    }
+}
+
+pub const DEFAULT_AGENT_LOW: &str = "claude --model claude-haiku-4-5 --dangerously-skip-permissions '{cmd}'";
+pub const DEFAULT_AGENT_MEDIUM: &str = "claude --model claude-sonnet-4-6 --dangerously-skip-permissions '{cmd}'";
+pub const DEFAULT_AGENT_HIGH: &str = "claude --dangerously-skip-permissions '{cmd}'";
+
+/// Coding agent command templates for dispatch. Each field is a shell command template
+/// where `{cmd}` is replaced with the prompt or slash command at dispatch time.
+#[derive(Deserialize, Default, Clone)]
+pub struct AgentsConfig {
+    /// Fast/cheap tasks. Default: claude haiku with --dangerously-skip-permissions.
+    pub low: Option<String>,
+    /// Standard work. Default: claude sonnet with --dangerously-skip-permissions.
+    pub medium: Option<String>,
+    /// Complex/autonomous tasks. Default: claude with --dangerously-skip-permissions.
+    pub high: Option<String>,
+}
+
+impl AgentsConfig {
+    pub fn effective_low(&self) -> &str {
+        self.low.as_deref().unwrap_or(DEFAULT_AGENT_LOW)
+    }
+    pub fn effective_medium(&self) -> &str {
+        self.medium.as_deref().unwrap_or(DEFAULT_AGENT_MEDIUM)
+    }
+    pub fn effective_high(&self) -> &str {
+        self.high.as_deref().unwrap_or(DEFAULT_AGENT_HIGH)
+    }
+    fn overlay(&mut self, other: Self) {
+        if other.low.is_some() { self.low = other.low; }
+        if other.medium.is_some() { self.medium = other.medium; }
+        if other.high.is_some() { self.high = other.high; }
     }
 }
 
@@ -592,7 +626,7 @@ pub fn config_dir() -> PathBuf {
         .join(config_dir_name())
 }
 
-const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");
+pub const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");
 
 /// Ensures the config file exists, creating it from the default template if not.
 /// Returns the config file path.
@@ -725,6 +759,11 @@ impl PlexiConfig {
         match (self.quick_note.as_mut(), other.quick_note) {
             (Some(existing), Some(incoming)) => existing.overlay(incoming),
             (None, Some(incoming)) => self.quick_note = Some(incoming),
+            _ => {}
+        }
+        match (self.agents.as_mut(), other.agents) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.agents = Some(incoming),
             _ => {}
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,8 +35,9 @@ impl std::fmt::Display for ConfigDiagnostic {
 const KNOWN_TOP_LEVEL: &[&str] = &[
     "font_size", "theme_preset", "theme", "beta", "log",
     "notifications", "ai", "confirm_quit", "confirm_close",
-    "keybindings", "quick_note",
+    "keybindings", "quick_note", "focus_history_depth", "agents",
 ];
+const KNOWN_AGENTS: &[&str] = &["low", "medium", "high"];
 const KNOWN_THEME: &[&str] = &[
     "bg_darkest", "bg_sidebar", "bg_toolbar", "terminal_bg", "bg_hover",
     "bg_sidebar_hover", "bg_active", "text_primary", "text_dim",
@@ -117,6 +118,9 @@ pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
             }
             if let Some(toml::Value::Table(t)) = table.get("keybindings") {
                 check_unknown_keys(t, "keybindings", KNOWN_KEYBINDINGS, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("agents") {
+                check_unknown_keys(t, "agents", KNOWN_AGENTS, &path_str, &mut diags);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,6 +479,12 @@ fn main() -> eframe::Result {
                         ConfigCmd::Edit => {
                             std::process::exit(cli::config_edit());
                         }
+                        ConfigCmd::Get { key } => {
+                            std::process::exit(cli::config_get(&key));
+                        }
+                        ConfigCmd::Reset => {
+                            std::process::exit(cli::config_reset());
+                        }
                     },
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `AgentsConfig` struct to `src/config.rs` with `low`/`medium`/`high` tier fields, each a shell command template where `{cmd}` is replaced at dispatch time
- Adds `[agents]` block to `scripts/default-config.toml` with defaults (`claude --model claude-haiku-4-5/sonnet-4-6/default --dangerously-skip-permissions '{cmd}'`)
- Adds `plexi config get <key>` subcommand — prints resolved value (user override or built-in default) for `agents.low/medium/high`
- Adds `plexi config reset` subcommand — overwrites `config.toml` with built-in defaults, backing up existing file to `.bak`
- Updates `dispatch-next` skill to read `agents.medium` via `plexi config get` instead of hardcoding the `c` alias
- Updates `plexi-cli` skill with `config get`/`config reset` docs

## Done when
- `~/.plexi/config.toml` contains `[agents]` section after fresh install or `plexi config reset`
- `plexi config get agents.medium` returns the configured (or default) command
- `/dispatch-next` skill no longer hardcodes `c`

## Test plan
- [ ] `plexi-pr-N config get agents.medium` prints the default command
- [ ] `plexi-pr-N config get agents.low` prints the haiku command
- [ ] `plexi-pr-N config get agents.high` prints the high-tier command
- [ ] `plexi-pr-N config reset` backs up existing config and writes fresh default (with `[agents]` block)
- [ ] `cargo test` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)