### PR TITLE
feat(cli): add `plexi app run <path>` and deprecate `app link`/`app unlink` (#1408)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1247,8 +1247,8 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, .. } => {
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
                     // Override focused_pane for the split if from_pane_id is specified,
@@ -1288,6 +1288,8 @@ impl PlexiApp {
                             log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, cwd_override);
                         }
+                    } else if let Some(path_str) = path {
+                        self.launch_app_by_path_with_layout(path_str, layout.clone());
                     } else {
                         self.launch_app_by_id_with_layout(type_id, layout.clone(), args, cwd_override);
                     }
@@ -1528,8 +1530,9 @@ impl PlexiApp {
                 continue;
             };
             let type_id = val["type_id"].as_str().unwrap_or("").to_string();
-            if type_id.is_empty() {
-                log::warn!("spawn-queue: entry missing type_id, skipping");
+            let path = val["path"].as_str().map(|s| s.to_string());
+            if type_id.is_empty() && path.is_none() {
+                log::warn!("spawn-queue: entry missing type_id and path, skipping");
                 continue;
             }
             let layout = val["layout"].as_str().map(|s| s.to_string());
@@ -1544,7 +1547,7 @@ impl PlexiApp {
                 .unwrap_or_default();
             let cwd_override: Option<std::path::PathBuf> = val["cwd"].as_str().map(std::path::PathBuf::from);
             let no_focus = val["no_focus"].as_bool().unwrap_or(false);
-            log::info!("spawn-queue: launching '{type_id}' layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd_override:?}");
+            log::info!("spawn-queue: launching '{type_id}' path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd_override:?}");
             let active = self.active_window;
             let original_focused = self.windows[active].focused_pane;
             if type_id == "terminal" {
@@ -1552,6 +1555,8 @@ impl PlexiApp {
                 let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
                 let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, cwd_override);
+            } else if let Some(ref path_str) = path {
+                self.launch_app_by_path_with_layout(path_str, layout);
             } else {
                 self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
             }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1031,6 +1031,10 @@ pub enum AppRequest {
         cwd: Option<String>,
         #[serde(default, skip_serializing_if = "is_false")]
         no_focus: bool,
+        /// When set, the host launches the app directly from this filesystem path
+        /// rather than looking it up in the registry by type_id.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -485,7 +485,7 @@ impl AppRegistry {
         }
     }
 
-    fn load_app(&self, app_dir: &PathBuf) -> Result<InstalledApp, String> {
+    pub(crate) fn load_app(&self, app_dir: &PathBuf) -> Result<InstalledApp, String> {
         let manifest_path = app_dir.join("manifest.toml");
         let manifest_str = std::fs::read_to_string(&manifest_path)
             .map_err(|e| format!("no manifest.toml: {e}"))?;
@@ -750,7 +750,7 @@ pub fn resolve_workspace_root(start: &Path) -> Option<PathBuf> {
 
 /// Resolve the `entry` field from manifest.toml to a path.
 /// Fails fast — no guessing, no fallbacks.
-fn resolve_entry(app_dir: &PathBuf, entry: &str) -> Result<PathBuf, String> {
+pub(crate) fn resolve_entry(app_dir: &PathBuf, entry: &str) -> Result<PathBuf, String> {
     let path = app_dir.join(entry);
 
     if !path.exists() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -542,11 +542,11 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
         }
     };
 
-    let workspace_root = crate::app_registry::resolve_workspace_root(&cwd);
-    let (app_dir, should_link) = if workspace_root.is_some() {
-        (cwd.join("apps").join(name), true)
+    let has_workspace = crate::app_registry::resolve_workspace_root(&cwd).is_some();
+    let app_dir = if has_workspace {
+        cwd.join("apps").join(name)
     } else {
-        (cwd.join(name), false)
+        cwd.join(name)
     };
 
     if app_dir.exists() {
@@ -567,42 +567,21 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
     match result {
         Ok(()) => {
             println!("Created app '{name}' at {}", app_dir.display());
-            if should_link {
-                let path_str = app_dir.to_string_lossy().to_string();
-                let rc = app_link(&path_str);
-                if rc != 0 {
-                    eprintln!("warning: created app but auto-link failed (run `plexi app link {}` manually)", app_dir.display());
-                }
-            }
             if lang == "rust" {
                 println!("\nNext steps:");
                 println!("  cd {}", app_dir.display());
                 println!("  cargo build --release");
-                println!("  # then run: plexi open {name}");
+                println!("  # then run: plexi app run {}", app_dir.display());
             } else {
+                println!("  Run with: plexi app run {}", app_dir.display());
                 // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
-                // The host rescans the registry on cache miss, so newly scaffolded
-                // apps are immediately openable without restarting Plexi.
                 if std::env::var("PLEXI_SOCKET").is_ok() {
-                    let from_pane_id = match std::env::var("PLEXI_PANE_ID") {
-                        Ok(s) => match s.parse::<u64>() {
-                            Ok(id) => Some(id),
-                            Err(_) => {
-                                log::warn!("app_init: PLEXI_PANE_ID is set but not a valid number: {s}");
-                                None
-                            }
-                        },
-                        Err(_) => None,
-                    };
-                    let workspace_cwd = workspace_root.as_ref().and_then(|p| p.to_str()).map(|s| s.to_string());
-                    log::info!("app_init: auto-opening '{name}' via socket from_pane_id={from_pane_id:?} workspace_cwd={workspace_cwd:?}");
-                    let exit_code = crate::cli::open_cli(name, &[], None, from_pane_id, workspace_cwd.as_deref());
+                    let path_str = app_dir.to_string_lossy().to_string();
+                    log::info!("app_init: auto-opening '{name}' via app_run from_path={path_str}");
+                    let exit_code = app_run(&path_str);
                     if exit_code != 0 {
-                        eprintln!("warning: app created but could not auto-open '{name}' (exit {exit_code}) — run: plexi open {name}");
+                        eprintln!("warning: app created but could not auto-open (exit {exit_code}) — run: plexi app run {}", app_dir.display());
                     }
-                } else {
-                    println!("\nRun inside a Plexi pane to open it immediately:");
-                    println!("  plexi open {name}");
                 }
             }
             0
@@ -784,6 +763,7 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> 
 
 /// `plexi app link <path>` — register a local app directory with the nearest workspace.
 pub fn app_link(path: &str) -> i32 {
+    eprintln!("deprecated: `plexi app link` is deprecated — use `plexi app run <path>` instead");
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => { eprintln!("error: {e}"); return 1; }
@@ -881,6 +861,7 @@ pub fn app_link(path: &str) -> i32 {
 
 /// `plexi app unlink <path>` — remove a linked app directory from the workspace registry.
 pub fn app_unlink(path: &str) -> i32 {
+    eprintln!("deprecated: `plexi app unlink` is deprecated — use `plexi app run <path>` instead");
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => { eprintln!("error: {e}"); return 1; }
@@ -943,6 +924,122 @@ pub fn app_unlink(path: &str) -> i32 {
     }
 
     println!("Unlinked: {}", app_dir.display());
+    0
+}
+
+/// `plexi app run <path>` — open any directory with a valid manifest.toml as an app pane.
+///
+/// No install, no link required. Edits take effect on next launch.
+pub fn app_run(path: &str) -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: {e}"); return 1; }
+    };
+    let app_dir = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        cwd.join(path)
+    };
+    let app_dir = match app_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {path}: {e}");
+            return 1;
+        }
+    };
+    // Validate manifest.toml exists and parses
+    let manifest_path = app_dir.join("manifest.toml");
+    if !manifest_path.exists() {
+        eprintln!("error: no manifest.toml found in {}", app_dir.display());
+        eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
+        return 1;
+    }
+    let manifest_str = match std::fs::read_to_string(&manifest_path) {
+        Ok(s) => s,
+        Err(e) => { eprintln!("error: could not read manifest.toml: {e}"); return 1; }
+    };
+    let _: toml::Value = match toml::from_str(&manifest_str) {
+        Ok(v) => v,
+        Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
+    };
+    let abs_path = app_dir.to_string_lossy().to_string();
+    log::info!("app_run:cli: launching app from path={abs_path}");
+
+    if std::env::var("PLEXI_SOCKET").is_ok() {
+        let id = uuid::Uuid::new_v4();
+        let response_file = crate::config::config_dir()
+            .join(format!("spawn-pane-response-{id}.json"))
+            .to_string_lossy()
+            .into_owned();
+        let from_pane_id = std::env::var("PLEXI_PANE_ID")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok());
+        let mut payload = serde_json::json!({
+            "type": "spawn_pane",
+            "type_id": "",
+            "path": abs_path,
+            "response_file": response_file,
+        });
+        if let Some(pid) = from_pane_id {
+            payload["from_pane_id"] = serde_json::Value::Number(pid.into());
+        }
+        log::info!("app_run:cli: sending via socket path={abs_path} response_file={response_file}");
+        let code = send_to_socket(payload);
+        if code != 0 {
+            return code;
+        }
+        let response_path = std::path::PathBuf::from(&response_file);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if response_path.exists() {
+                match std::fs::read_to_string(&response_path) {
+                    Ok(content) => {
+                        let _ = std::fs::remove_file(&response_path);
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+                                println!("{pid}");
+                                return 0;
+                            }
+                        }
+                        print!("{content}");
+                        return 0;
+                    }
+                    Err(e) => {
+                        eprintln!("error: could not read response file: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("error: timed out waiting for open response");
+                return 1;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    // Fallback: write to spawn-queue
+    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
+        eprintln!("error: could not create spawn queue: {e}");
+        return 1;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let queue_payload = serde_json::json!({
+        "type_id": "",
+        "path": abs_path,
+    });
+    let file = queue_dir.join(format!("{ts}.json"));
+    if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
+        eprintln!("error: could not write spawn request: {e}");
+        return 1;
+    }
+    log::info!("app_run:cli: queued path={abs_path}");
+    println!("queued: run {abs_path}");
+    println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0
 }
 
@@ -4380,5 +4477,33 @@ mod secret_set_tests {
         // a bare temp dir with no .plexi returns None, proving the walk stops.
         let bare: TempDir = tempfile::tempdir().unwrap();
         assert!(crate::app_registry::resolve_workspace_root(bare.path()).is_none());
+    }
+}
+
+#[cfg(test)]
+mod app_run_tests {
+    use tempfile::TempDir;
+
+    #[test]
+    fn app_run_nonexistent_path_returns_1() {
+        let code = super::app_run("/tmp/plexi-test-nonexistent-path-xyzzy-12345");
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn app_run_dir_without_manifest_returns_1() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+        let code = super::app_run(&path);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn app_run_invalid_manifest_returns_1() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("manifest.toml"), "this is not valid toml ][[[").unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+        let code = super::app_run(&path);
+        assert_eq!(code, 1);
     }
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -337,6 +337,14 @@ pub enum AppCmd {
         /// Path to the app folder (the same path you passed to `link`)
         path: String,
     },
+    /// Run an app directly from a local directory without installing or linking.
+    ///
+    /// Opens the app in a pane immediately. Edits to the app take effect on next launch.
+    /// Replaces `plexi app link` for development workflows.
+    Run {
+        /// Path to the app folder containing manifest.toml
+        path: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,7 @@ fn main() -> eframe::Result {
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                         AppCmd::Link { path } => std::process::exit(cli::app_link(&path)),
                         AppCmd::Unlink { path } => std::process::exit(cli::app_unlink(&path)),
+                        AppCmd::Run { path } => std::process::exit(cli::app_run(&path)),
                     },
                     Commands::Install { spec, pack } => {
                         if let Some(p) = pack {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -649,6 +649,71 @@ impl PlexiApp {
         }
     }
 
+    /// Launch an app directly from a filesystem path without looking it up in the registry.
+    ///
+    /// Used by `plexi app run <path>` and the `SpawnPane` IPC when `path` is set.
+    /// The app runs in-place; its own directory is used as `workspace_root`.
+    pub(crate) fn launch_app_by_path_with_layout(
+        &mut self,
+        app_path: &str,
+        layout: Option<String>,
+    ) {
+        let app_dir = PathBuf::from(app_path);
+        log::info!("launch_app_by_path_with_layout: path={app_path}");
+
+        let installed = match self.registry.load_app(&app_dir) {
+            Ok(a) => a,
+            Err(e) => {
+                log::warn!("launch_app_by_path_with_layout: failed to load manifest at {app_path}: {e}");
+                return;
+            }
+        };
+
+        let perms = installed.manifest.capabilities.to_permissions();
+        let caps = perms.capabilities.clone();
+        let keyboard_capture = installed.launch.keyboard_capture;
+        let app_id = installed.manifest.id.clone();
+
+        let layout_hint = layout.or_else(|| {
+            installed.launch.layout_hint.as_ref().map(|h| match h.side.as_str() {
+                "below" => "split_v".to_string(),
+                "above" => "split_above".to_string(),
+                "overlay" => "overlay".to_string(),
+                _ => "split_h".to_string(),
+            })
+        }).or_else(|| {
+            log::info!("launch_app_by_path_with_layout: no layout_hint — defaulting to overlay");
+            Some("overlay".to_string())
+        });
+
+        let cwd = self
+            .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+
+        match crate::process_app::ProcessApp::launch(
+            installed.manifest.id.clone(),
+            installed.manifest.name.clone(),
+            &installed.bin_path,
+            &cwd,
+            &[],
+            app_dir.clone(),
+            caps,
+            keyboard_capture,
+            installed.manifest.mcp.as_ref(),
+        ) {
+            Ok(mut process) => {
+                process.permissions.allowed_hosts = perms.allowed_hosts;
+                log::info!(
+                    "launch_app_by_path_with_layout: launched '{app_id}' from {app_path}"
+                );
+                self.open_process_app_pane(&app_id, process, app_dir, None, layout_hint.as_deref());
+            }
+            Err(e) => {
+                log::error!("launch_app_by_path_with_layout: failed to launch '{app_id}' from {app_path}: {e}");
+            }
+        }
+    }
+
     /// Attempt to spawn a PGAP process from the CLI's native `--plexi` descriptor
     /// `plexi_app` field. Returns `None` if the CLI is not found, does not support
     /// `--plexi`, or has no `plexi_app` field.
@@ -1079,6 +1144,7 @@ mod tests {
             ephemeral: false,
             cwd: None,
             no_focus: false,
+            path: None,
         });
         h.run_frames(2);
 
@@ -1116,6 +1182,7 @@ mod tests {
             ephemeral: false,
             cwd: None,
             no_focus: false,
+            path: None,
         });
         h.run_frames(2);
 
@@ -1156,6 +1223,7 @@ mod tests {
             ephemeral: false,
             cwd: None,
             no_focus: false,
+            path: None,
         });
         h.run_frames(2);
 
@@ -1195,6 +1263,7 @@ mod tests {
             ephemeral: false,
             cwd: None,
             no_focus: false,
+            path: None,
         });
         h.run_frames(2);
 
@@ -1244,6 +1313,7 @@ mod tests {
             ephemeral: false,
             cwd: None,
             no_focus: false,
+            path: None,
         });
         h.run_frames(2);
 
@@ -1291,6 +1361,7 @@ mod tests {
                 ephemeral: false,
                 cwd: None,
                 no_focus: false,
+                path: None,
             });
             h.run_frames(2);
         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -703,10 +703,11 @@ impl PlexiApp {
         ) {
             Ok(mut process) => {
                 process.permissions.allowed_hosts = perms.allowed_hosts;
+                let group = installed.launch.join_group.clone();
                 log::info!(
-                    "launch_app_by_path_with_layout: launched '{app_id}' from {app_path}"
+                    "launch_app_by_path_with_layout: launched '{app_id}' from {app_path} group={group:?}"
                 );
-                self.open_process_app_pane(&app_id, process, app_dir, None, layout_hint.as_deref());
+                self.open_process_app_pane(&app_id, process, app_dir, group, layout_hint.as_deref());
             }
             Err(e) => {
                 log::error!("launch_app_by_path_with_layout: failed to launch '{app_id}' from {app_path}: {e}");

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -772,6 +772,7 @@ impl ProcessApp {
                 ephemeral: _,
                 cwd: _,
                 no_focus: _,
+                path: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)


### PR DESCRIPTION
## Summary
- Adds `plexi app run <path>` — opens any directory with a valid `manifest.toml` as an app pane, no install or link required
- `app link` and `app unlink` now print a deprecation warning pointing to `app run`
- `plexi app init` no longer auto-links; prints "Run with: plexi app run ./<name>" and uses `app_run` for in-pane auto-open

## Done When
1. `plexi app run ./examples/node-canvas` opens the node-canvas app in a pane (from inside Plexi)
2. `plexi app run /absolute/path/to/any-valid-app` works the same
3. `plexi app link` prints a deprecation warning pointing to `app run`
4. `plexi app init foo` prints "Run with: plexi app run ./foo" instead of auto-linking

## Implementation Notes
- `SpawnPane` gains an optional `path` field (serde default None — backward compat preserved)
- Host routes to `launch_app_by_path_with_layout()` when `path` is set, bypassing registry lookup
- Same capability/permission flow as registry-launched apps (uses `AppRegistry::load_app` now `pub(crate)`)
- `workspace_root` for the spawned process is the app directory itself
- spawn-queue fallback also supports `path` field for outside-pane usage