### PR TITLE
fix(overlays): context inspector pre-selects focused pane on open (#1434)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2878,8 +2878,25 @@ impl eframe::App for PlexiApp {
                 }
                 Action::ContextInspector => {
                     self.show_context_inspector = !self.show_context_inspector;
-                    self.inspector_selected_pane = 0;
-                    log::info!("ContextInspector: toggled to {}", self.show_context_inspector);
+                    if self.show_context_inspector {
+                        let focused_pane_id = self.windows[self.active_window]
+                            .focused_pane
+                            .and_then(|tile_id| match self.windows[self.active_window].tree.tiles.get(tile_id) {
+                                Some(Tile::Pane(pane_id)) => Some(*pane_id),
+                                _ => None,
+                            });
+                        let pane_order = self.inspector_pane_order();
+                        self.inspector_selected_pane = focused_pane_id
+                            .and_then(|fpid| pane_order.iter().position(|&pid| pid == fpid))
+                            .unwrap_or(0);
+                        log::info!(
+                            "ContextInspector: opened — pre-selected pane idx={} (focused={:?})",
+                            self.inspector_selected_pane,
+                            focused_pane_id
+                        );
+                    } else {
+                        log::info!("ContextInspector: closed via toggle");
+                    }
                 }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1866,25 +1866,8 @@ impl PlexiApp {
         }
     }
 
-    /// Returns the flat ordered list of pane IDs as they appear in the context inspector,
-    /// matching the ordering produced by [`collect_inspector_rows`].
     pub(crate) fn inspector_pane_order(&self) -> Vec<PaneId> {
-        let mut result: Vec<PaneId> = Vec::new();
-        for ctx_entry in self.router.iter() {
-            let cid = ctx_entry.context_id;
-            let mut pane_ids: Vec<PaneId> = Vec::new();
-            for win in self.windows.iter() {
-                if win.context_id != cid {
-                    continue;
-                }
-                for (pane_id, _) in &win.panes {
-                    pane_ids.push(*pane_id);
-                }
-            }
-            pane_ids.sort_unstable();
-            result.extend(pane_ids);
-        }
-        result
+        self.collect_inspector_rows().1
     }
 
     fn collect_inspector_rows(&self) -> (Vec<(String, Vec<PaneRow>)>, Vec<PaneId>, Vec<u64>) {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1866,6 +1866,27 @@ impl PlexiApp {
         }
     }
 
+    /// Returns the flat ordered list of pane IDs as they appear in the context inspector,
+    /// matching the ordering produced by [`collect_inspector_rows`].
+    pub(crate) fn inspector_pane_order(&self) -> Vec<PaneId> {
+        let mut result: Vec<PaneId> = Vec::new();
+        for ctx_entry in self.router.iter() {
+            let cid = ctx_entry.context_id;
+            let mut pane_ids: Vec<PaneId> = Vec::new();
+            for win in self.windows.iter() {
+                if win.context_id != cid {
+                    continue;
+                }
+                for (pane_id, _) in &win.panes {
+                    pane_ids.push(*pane_id);
+                }
+            }
+            pane_ids.sort_unstable();
+            result.extend(pane_ids);
+        }
+        result
+    }
+
     fn collect_inspector_rows(&self) -> (Vec<(String, Vec<PaneRow>)>, Vec<PaneId>, Vec<u64>) {
         let mut groups: Vec<(String, Vec<PaneRow>)> = Vec::new();
         let mut all_pane_ids: Vec<PaneId> = Vec::new();


### PR DESCRIPTION
## Summary

- When opening the context inspector (Cmd+I), `inspector_selected_pane` was always reset to `0`, so the first pane in the first context was highlighted regardless of what was actually focused
- Now computes the flat inspector index matching the currently focused pane in the active window
- Adds `inspector_pane_order()` as a `pub(crate)` helper on `App` (in `overlays.rs`) to expose the same ordering used by the inspector's rendering without leaking the private `PaneRow` type

## Done when
- Open Plexi with multiple panes, focus a pane that is **not** the first one, press Cmd+I — the inspector opens with that pane already highlighted

Closes #1434