### PR TITLE
feat(inspector): smarter pane status — idle vs busy shell, OSC title awareness (#1288)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,4 +10,8 @@ fn main() {
     };
     println!("cargo:rustc-env=PLEXI_APP_TITLE={title}");
     println!("cargo:rerun-if-changed=.channel");
+    // Link libproc for proc_listchildpids used in shell::has_foreground_child.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-lib=proc");
+    }
 }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1911,7 +1911,6 @@ impl PlexiApp {
                                     None
                                 };
                                 let status = if busy { "busy" } else { "idle" };
-                                log::debug!("inspector: terminal pane {} status={status}", t.id);
                                 (status, badge)
                             };
                             rows.push(PaneRow {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -141,6 +141,8 @@ struct PaneRow {
     name: String,
     detail: String,
     status: &'static str,
+    /// Supplementary label shown next to status (e.g. agent name from OSC title when busy).
+    osc_badge: Option<String>,
 }
 
 fn render_inspector_pane_row(
@@ -179,12 +181,23 @@ fn render_inspector_pane_row(
                 {
                     close_pane = Some(row_id);
                 }
-                let status_color = if row.status == "running" { colors.accent } else { colors.text_dim };
+                let status_color = if matches!(row.status, "busy" | "running") {
+                    colors.accent
+                } else {
+                    colors.text_dim
+                };
                 ui.label(
                     RichText::new(row.status)
                         .size(style::TEXT_HINT)
                         .color(status_color),
                 );
+                if let Some(badge) = &row.osc_badge {
+                    ui.label(
+                        RichText::new(format!("· {badge}"))
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                }
                 if !row.detail.is_empty() {
                     ui.label(
                         RichText::new(row.detail.as_str())
@@ -1881,12 +1894,33 @@ impl PlexiApp {
                 for (_, pane) in &win.panes {
                     match pane {
                         crate::pane::Pane::Terminal(t) => {
+                            let (status, osc_badge) = if t.exited {
+                                ("exited", None)
+                            } else {
+                                let busy = crate::shell::has_foreground_child(t.backend.child_pid());
+                                let badge = if busy {
+                                    // Surface agent activity when OSC title contains a known indicator.
+                                    t.pty_title.as_deref().and_then(|title| {
+                                        if title.to_ascii_lowercase().contains("claude") {
+                                            Some("Claude Code".to_string())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                } else {
+                                    None
+                                };
+                                let status = if busy { "busy" } else { "idle" };
+                                log::debug!("inspector: terminal pane {} status={status}", t.id);
+                                (status, badge)
+                            };
                             rows.push(PaneRow {
                                 id: t.id,
                                 kind: "Terminal",
                                 name: t.name.clone().or_else(|| t.pty_title.clone()).unwrap_or_default(),
                                 detail: String::new(),
-                                status: if t.exited { "exited" } else { "running" },
+                                status,
+                                osc_badge,
                             });
                         }
                         crate::pane::Pane::App(a) => {
@@ -1907,6 +1941,7 @@ impl PlexiApp {
                                 name: a.name.clone(),
                                 detail: a.manifest_id.clone(),
                                 status,
+                                osc_badge: None,
                             });
                         }
                         crate::pane::Pane::SubContext { pane_id, context_id } => {
@@ -1916,6 +1951,7 @@ impl PlexiApp {
                                 name: format!("sub_context:{context_id}"),
                                 detail: String::new(),
                                 status: "active",
+                                osc_badge: None,
                             });
                         }
                     }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -5,6 +5,64 @@ use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+// ---------------------------------------------------------------------------
+// Foreground child detection — used by the context inspector for idle/busy status
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn proc_listchildpids(
+        ppid: libc::c_int,
+        buffer: *mut libc::c_void,
+        buffersize: libc::c_int,
+    ) -> libc::c_int;
+}
+
+static BUSY_CACHE: LazyLock<Mutex<HashMap<u32, (bool, Instant)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+const BUSY_CACHE_TTL: Duration = Duration::from_millis(500);
+
+/// Returns true if `pid` has at least one immediate child process.
+/// Cached at 500 ms so the inspector can call it per-pane without per-frame syscall cost.
+pub fn has_foreground_child(pid: u32) -> bool {
+    if let Ok(cache) = BUSY_CACHE.lock() {
+        if let Some((busy, ts)) = cache.get(&pid) {
+            if ts.elapsed() < BUSY_CACHE_TTL {
+                return *busy;
+            }
+        }
+    }
+    let busy = check_has_children(pid);
+    log::debug!("shell::has_foreground_child: pid={pid} → busy={busy}");
+    if let Ok(mut cache) = BUSY_CACHE.lock() {
+        cache.insert(pid, (busy, Instant::now()));
+    }
+    busy
+}
+
+fn check_has_children(pid: u32) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // proc_listchildpids with null buffer returns n_children * sizeof(pid_t) bytes needed.
+        // A positive return means at least one child exists.
+        let ret = unsafe {
+            proc_listchildpids(pid as libc::c_int, std::ptr::null_mut(), 0)
+        };
+        ret > 0
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string(format!("/proc/{pid}/task/{pid}/children"))
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
 pub fn detect_shell() -> String {
     if let Ok(shell) = std::env::var("SHELL") {
         if Path::new(&shell).exists() {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -45,21 +45,25 @@ fn check_has_children(pid: u32) -> bool {
     {
         // proc_listchildpids with null buffer returns n_children * sizeof(pid_t) bytes needed.
         // A positive return means at least one child exists.
+        // Negative return is an error — default to true (busy) to avoid false idle display.
         let ret = unsafe {
             proc_listchildpids(pid as libc::c_int, std::ptr::null_mut(), 0)
         };
-        ret > 0
+        if ret < 0 { true } else { ret > 0 }
     }
     #[cfg(target_os = "linux")]
     {
+        // /proc/<pid>/task/<pid>/children lists immediate children space-separated.
+        // On read failure (kernel too old, pid gone) default to true to avoid false idle.
         std::fs::read_to_string(format!("/proc/{pid}/task/{pid}/children"))
             .map(|s| !s.trim().is_empty())
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
+        // Detection not implemented for this platform — show busy to match old "running" behavior.
         let _ = pid;
-        false
+        true
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the static `"running"` status in the context inspector with dynamic `idle`/`busy` detection for terminal panes
- On macOS, uses `proc_listchildpids` FFI (private libproc) to check if the shell process has any immediate child processes — busy if yes, idle if no
- When a terminal is busy and its OSC title contains "Claude", the inspector shows a `· Claude Code` badge next to the status
- Results are cached at 500 ms per pid (shared across all panes) to avoid per-frame syscall overhead

## Files changed

- `build.rs` — links `libproc` on macOS targets
- `src/shell.rs` — adds `has_foreground_child(pid)` with TTL cache and `proc_listchildpids` FFI
- `src/overlays.rs` — updates `PaneRow` with `osc_badge` field; updates terminal status computation and render

## Done When (from issue)

- [x] Idle terminals at a shell prompt show "idle" instead of "running"
- [x] Terminals with an active foreground process show "busy"
- [x] Exited terminals still show "exited"
- [x] When a terminal's OSC title indicates agent activity (contains "Claude"), inspector shows "busy · Claude Code"
- [x] Status detection doesn't measurably impact frame time (cached per-frame at 500 ms TTL)

Closes #1288