### PR TITLE
feat(context): sub-context creation auto-zooms in, ChildPaneSummary for tile previews (#1409)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1453,11 +1453,21 @@ impl PlexiApp {
                     log::info!("pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?}", root, name, parent_name);
                     if let Some(pname) = parent_name {
                         let path = root.as_ref().cloned().unwrap_or_else(|| std::path::PathBuf::from("."));
+                        let current_ctx_id = self.router.active().context_id;
+                        let current_win_id = self.windows[self.active_window].window_id;
+                        let current_focused = self.windows[self.active_window].focused_pane;
                         if let Err(e) = self.new_child_context(pname.as_str(), path) {
                             log::warn!("pane_ipc: create_context with parent failed: {e}");
-                        } else if let Some(n) = name {
-                            let idx = self.router.len() - 1;
-                            self.router.get_mut(idx).name = n.clone();
+                        } else {
+                            if let Some(n) = name {
+                                let idx = self.router.len() - 1;
+                                self.router.get_mut(idx).name = n.clone();
+                            }
+                            let new_ctx_idx = self.router.len() - 1;
+                            let new_ctx_id = self.router.get(new_ctx_idx).context_id;
+                            self.router.push_depth(current_ctx_id, current_win_id, current_focused);
+                            self.switch_workspace(new_ctx_idx);
+                            log::info!("pane_ipc: auto-zoomed into new child context ctx_id={new_ctx_id}");
                         }
                     } else {
                         if let Some(r) = root {
@@ -3121,7 +3131,7 @@ impl eframe::App for PlexiApp {
                 let canvas_old_window_id = self.windows[self.active_window].window_id;
 
                 // Build sub-context preview data before taking the mutable ctx borrow.
-                let sub_context_info: std::collections::HashMap<crate::tiling::PaneId, (String, usize, usize)> = {
+                let sub_context_info: std::collections::HashMap<crate::tiling::PaneId, crate::tiling::SubContextPreview> = {
                     let active_win = self.active_window;
                     let mut map = std::collections::HashMap::new();
                     let sub_ctx_panes: Vec<(crate::tiling::PaneId, u64)> = self.windows[active_win]
@@ -3134,12 +3144,35 @@ impl eframe::App for PlexiApp {
                             .find(|c| c.context_id == child_ctx_id)
                             .map(|c| c.name.clone())
                             .unwrap_or_else(|| "(deleted)".to_string());
-                        let pane_count = self.windows.iter()
+                        let pane_summaries: Vec<crate::tiling::ChildPaneSummary> = self.windows.iter()
                             .filter(|w| w.context_id == child_ctx_id)
-                            .map(|w| w.panes.len())
-                            .sum::<usize>();
+                            .flat_map(|w| w.panes.iter())
+                            .filter_map(|(_, p)| match p {
+                                crate::pane::Pane::Terminal(t) => {
+                                    let cwd = crate::shell::get_pid_cwd(t.backend.child_pid())
+                                        .map(|path| path.to_string_lossy().into_owned());
+                                    Some(crate::tiling::ChildPaneSummary {
+                                        pane_name: t.name.clone().or_else(|| t.pty_title.clone()),
+                                        cwd,
+                                        app_type: "terminal".to_string(),
+                                    })
+                                }
+                                crate::pane::Pane::App(a) => {
+                                    Some(crate::tiling::ChildPaneSummary {
+                                        pane_name: Some(a.name.clone()),
+                                        cwd: Some(a.workspace_root.to_string_lossy().into_owned()),
+                                        app_type: a.runtime.type_id().to_string(),
+                                    })
+                                }
+                                crate::pane::Pane::SubContext { .. } => None,
+                            })
+                            .collect();
                         let notif_count = self.context_notification_count_recursive(child_ctx_id);
-                        map.insert(pane_id, (ctx_name, pane_count, notif_count));
+                        map.insert(pane_id, crate::tiling::SubContextPreview {
+                            context_name: ctx_name,
+                            panes: pane_summaries,
+                            notification_count: notif_count,
+                        });
                     }
                     map
                 };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3144,10 +3144,13 @@ impl eframe::App for PlexiApp {
                             .find(|c| c.context_id == child_ctx_id)
                             .map(|c| c.name.clone())
                             .unwrap_or_else(|| "(deleted)".to_string());
-                        let pane_summaries: Vec<crate::tiling::ChildPaneSummary> = self.windows.iter()
+                        let mut pane_entries: Vec<(crate::tiling::PaneId, &crate::pane::Pane)> = self.windows.iter()
                             .filter(|w| w.context_id == child_ctx_id)
-                            .flat_map(|w| w.panes.iter())
-                            .filter_map(|(_, p)| match p {
+                            .flat_map(|w| w.panes.iter().map(|(id, p)| (*id, p)))
+                            .collect();
+                        pane_entries.sort_by_key(|(id, _)| *id);
+                        let pane_summaries: Vec<crate::tiling::ChildPaneSummary> = pane_entries.iter()
+                            .filter_map(|(_, p)| match *p {
                                 crate::pane::Pane::Terminal(t) => {
                                     let cwd = crate::shell::get_pid_cwd(t.backend.child_pid())
                                         .map(|path| path.to_string_lossy().into_owned());

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -761,6 +761,10 @@ fn new_child_context_case_insensitive_parent() {
     let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
+    // Set up a focused pane so the adoption path is taken (not the PTY fallback).
+    let (tile_id, _pane_id) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_id);
+
     // The initial context is named "Test" (from new_for_test).
     // Lookup with lowercase "test" must succeed.
     let result = app.new_child_context("test", std::path::PathBuf::from("/tmp/child_ci"));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -753,3 +753,50 @@ fn new_child_context_fallback_when_no_focused_pane() {
         );
     }
 }
+
+/// Issue #1409: parent name lookup must be case-insensitive.
+#[test]
+fn new_child_context_case_insensitive_parent() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    // The initial context is named "Test" (from new_for_test).
+    // Lookup with lowercase "test" must succeed.
+    let result = app.new_child_context("test", std::path::PathBuf::from("/tmp/child_ci"));
+    assert!(result.is_ok(), "case-insensitive lookup should succeed: {result:?}");
+}
+
+/// Issue #1409: creating a child context with a parent should auto-zoom into it.
+#[test]
+fn create_child_context_auto_zooms() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_id, _pane_id) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_id);
+
+    let parent_ctx_id = app.router.active().context_id;
+
+    // Simulate what the CreateContext handler does: capture current state,
+    // call new_child_context, then push_depth + switch_workspace.
+    let current_win_id = app.windows[app.active_window].window_id;
+    let current_focused = app.windows[app.active_window].focused_pane;
+    app.new_child_context("Test", std::path::PathBuf::from("/tmp/child_zoom"))
+        .expect("should succeed");
+    let new_ctx_idx = app.router.len() - 1;
+    let new_ctx_id = app.router.get(new_ctx_idx).context_id;
+    app.router.push_depth(parent_ctx_id, current_win_id, current_focused);
+    app.switch_workspace(new_ctx_idx);
+
+    // Active context must now be the child.
+    assert_eq!(
+        app.router.active().context_id,
+        new_ctx_id,
+        "should be zoomed into child context after creation"
+    );
+
+    // Depth stack must have one entry (parent pushed).
+    assert_eq!(app.router.current_depth(), 1);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3693,8 +3693,21 @@ pub fn context_new_cli(name: Option<&str>, path: Option<&str>, parent: Option<&s
     };
     // Default parent: current context when inside a Plexi pane and --parent omitted.
     let resolved_parent = parent
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
-        .or_else(|| std::env::var("PLEXI_CONTEXT_NAME").ok());
+        .or_else(|| {
+            std::env::var("PLEXI_CONTEXT_NAME")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+    log::info!(
+        "context_new_cli: name={:?} root={} parent={:?}",
+        name,
+        root.display(),
+        resolved_parent.as_deref()
+    );
     let mut payload = serde_json::json!({
         "type": "create_context",
         "root": root,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3681,20 +3681,29 @@ fn send_to_socket(payload: serde_json::Value) -> i32 {
     0
 }
 
-/// `plexi context new [path]`
+/// `plexi context new [name] [--path <path>] [--parent <parent>]`
 ///
-/// Creates a new context. Uses `path` as the root (or CWD if omitted).
-pub fn context_new_cli(path: Option<&str>, parent: Option<&str>) -> i32 {
+/// Creates a new context. `name` is the display name (positional). `--path` sets
+/// the root directory (defaults to CWD). When run inside a Plexi pane and `--parent`
+/// is not given, defaults to creating a child of the current context.
+pub fn context_new_cli(name: Option<&str>, path: Option<&str>, parent: Option<&str>) -> i32 {
     let root = match resolve_path(path) {
         Ok(p) => p,
         Err(e) => { eprintln!("{e}"); return 1; }
     };
+    // Default parent: current context when inside a Plexi pane and --parent omitted.
+    let resolved_parent = parent
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("PLEXI_CONTEXT_NAME").ok());
     let mut payload = serde_json::json!({
         "type": "create_context",
         "root": root,
     });
-    if let Some(p) = parent {
-        payload["parent_name"] = serde_json::Value::String(p.to_string());
+    if let Some(n) = name {
+        payload["name"] = serde_json::Value::String(n.to_string());
+    }
+    if let Some(p) = resolved_parent {
+        payload["parent_name"] = serde_json::Value::String(p);
     }
     send_to_socket(payload)
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -477,10 +477,14 @@ pub enum RegistryCmd {
 
 #[derive(Subcommand)]
 pub enum ContextCmd {
-    /// Open a new context, optionally starting in a specific folder.
+    /// Open a new context with an optional name.
     New {
+        /// Name for the new context. Defaults to the directory basename.
+        name: Option<String>,
+        /// Root path for the new context. Defaults to current working directory.
+        #[arg(long)]
         path: Option<String>,
-        /// Create as a child of the named context (fractal sub-context).
+        /// Create as a child of the named context. Defaults to current context if inside one.
         #[arg(long)]
         parent: Option<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,7 +454,7 @@ fn main() -> eframe::Result {
                         }
                     },
                     Commands::Context { cmd } => match cmd {
-                        ContextCmd::New { path, parent } => std::process::exit(cli::context_new_cli(path.as_deref(), parent.as_deref())),
+                        ContextCmd::New { name, path, parent } => std::process::exit(cli::context_new_cli(name.as_deref(), path.as_deref(), parent.as_deref())),
                         ContextCmd::Open { path } => std::process::exit(cli::context_open_cli(path.as_deref())),
                         ContextCmd::SetRoot { path } => std::process::exit(cli::context_set_root_cli(path.as_deref())),
                         ContextCmd::Current => std::process::exit(cli::context_current_cli()),

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -12,7 +12,7 @@ impl PlexiApp {
     /// pane into the new child context and replaces it with a SubContext tile. Falls
     /// back to a new terminal if no adoptable pane is focused. Depth is capped at 3.
     pub(crate) fn new_child_context(&mut self, parent_name: &str, path: PathBuf) -> Result<(), String> {
-        let parent_idx = self.router.position(|c| c.name == parent_name)
+        let parent_idx = self.router.position(|c| c.name.eq_ignore_ascii_case(parent_name))
             .ok_or_else(|| format!("no context named '{parent_name}'"))?;
         let parent_id = self.router.get(parent_idx).context_id;
         let parent_depth = self.router.get(parent_idx).depth;

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -36,6 +36,32 @@ pub(crate) fn paint_tab_dots(
     }
 }
 
+/// Per-pane summary carried in SubContext tile preview data.
+#[derive(Clone, Default)]
+pub struct ChildPaneSummary {
+    pub pane_name: Option<String>,
+    pub cwd: Option<String>,
+    pub app_type: String,
+}
+
+/// Preview data for a SubContext tile.
+#[derive(Clone)]
+pub struct SubContextPreview {
+    pub context_name: String,
+    pub panes: Vec<ChildPaneSummary>,
+    pub notification_count: usize,
+}
+
+impl Default for SubContextPreview {
+    fn default() -> Self {
+        SubContextPreview {
+            context_name: "(deleted)".to_string(),
+            panes: Vec::new(),
+            notification_count: 0,
+        }
+    }
+}
+
 pub struct PlexiBehavior<'a> {
     pub panes: &'a mut HashMap<PaneId, Pane>,
     pub focused_tile: Option<TileId>,
@@ -57,8 +83,8 @@ pub struct PlexiBehavior<'a> {
     /// Opacity applied to unfocused panes when ghost mode is active.
     /// `None` = no dimming. Values below 1.0 dim all non-focused panes.
     pub unfocused_opacity: Option<f32>,
-    /// Preview data for SubContext tiles: pane_id → (context_name, pane_count, notification_count).
-    pub sub_context_info: HashMap<PaneId, (String, usize, usize)>,
+    /// Preview data for SubContext tiles.
+    pub sub_context_info: HashMap<PaneId, SubContextPreview>,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -139,14 +165,12 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         } else if pane.as_sub_context().is_some() {
             // SubContext tile — responsive PGAP-rendered preview.
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
-            let (ctx_name, pane_count, notif_count) = self.sub_context_info
+            let preview = self.sub_context_info
                 .get(pane_id)
                 .cloned()
-                .unwrap_or_else(|| ("(deleted)".to_string(), 0, 0));
+                .unwrap_or_default();
 
-            let tiers = crate::tiling::sub_context_responsive_tiers(
-                &ctx_name, pane_count, notif_count, &self.colors,
-            );
+            let tiers = crate::tiling::sub_context_responsive_tiers(&preview, &self.colors);
             let avail_w = pane_rect.width();
             let avail_h = pane_rect.height();
             if let Some(tier) = crate::process_app::render::select_responsive_tier(
@@ -268,11 +292,12 @@ use crate::app_protocol::{LayoutChild, LayoutDirection, RenderCommand, Responsiv
 /// - Square: column with abbreviated info
 /// - Portrait: compact vertical stack
 pub(crate) fn sub_context_responsive_tiers(
-    ctx_name: &str,
-    pane_count: usize,
-    notif_count: usize,
+    preview: &SubContextPreview,
     colors: &Colors,
 ) -> Vec<ResponsiveTier> {
+    let ctx_name = &preview.context_name;
+    let pane_count = preview.panes.len();
+    let notif_count = preview.notification_count;
     let text_primary = format!("#{:02x}{:02x}{:02x}", colors.text_primary.r(), colors.text_primary.g(), colors.text_primary.b());
     let text_dim = format!("#{:02x}{:02x}{:02x}", colors.text_dim.r(), colors.text_dim.g(), colors.text_dim.b());
 
@@ -321,11 +346,35 @@ pub(crate) fn sub_context_responsive_tiers(
         }),
     };
 
+    // Wide/landscape: show last cwd segment per pane.
+    let pane_detail_leaves: Vec<LayoutChild> = preview.panes.iter().take(3).map(|p| {
+        let label = p.cwd.as_deref()
+            .and_then(|c| std::path::Path::new(c).file_name())
+            .map(|s| s.to_string_lossy().into_owned())
+            .or_else(|| p.pane_name.clone())
+            .unwrap_or_else(|| p.app_type.clone());
+        LayoutChild::Leaf {
+            command: Box::new(RenderCommand::Text {
+                x: 0.0, y: 0.0,
+                text: label,
+                size: style::TEXT_HINT,
+                color: text_dim.clone(),
+                monospace: true,
+                bold: false,
+                align: "top_left".to_string(),
+                max_width: None,
+                elide: false,
+                selectable: false,
+            }),
+        }
+    }).collect();
+
     let mut landscape_children = vec![
         name_leaf.clone(),
         pane_count_leaf.clone(),
-        shortcut_leaf.clone(),
     ];
+    landscape_children.extend(pane_detail_leaves);
+    landscape_children.push(shortcut_leaf.clone());
     if notif_count > 0 {
         landscape_children.push(LayoutChild::Leaf {
             command: Box::new(RenderCommand::Badge {


### PR DESCRIPTION
## Summary

- `plexi context new [name]` — positional arg is now a **name** (not a path). Add `--path` for explicit root. When run inside a Plexi pane and `--parent` is omitted, defaults to creating a child of the current context via `PLEXI_CONTEXT_NAME`.
- Case-insensitive parent name lookup (`--parent "default"` matches `"Default"`).
- Auto-zoom into newly created child context after creation (push_depth + switch_workspace).
- Replace `(ctx_name, pane_count, notif_count)` tuple with `SubContextPreview` / `ChildPaneSummary` structs carrying per-pane name/cwd/app_type.
- SubContext tile landscape tier now renders per-pane last-cwd-segment detail leaves.

## Done When

- `plexi context new "work"` inside a context creates a child named "work" and immediately zooms in
- Cmd+Escape returns to parent showing the SubContext preview tile
- `--parent "default"` matches `"Default"` context
- SubContext tile shows last directory segment per pane in landscape tier

## Test plan

- [ ] Run `cargo test --bin plexi` — 490 pass, 2 pre-existing unrelated failures
- [ ] `new_child_context_case_insensitive_parent` — passes
- [ ] `create_child_context_auto_zooms` — passes
- [ ] Install PR build and run `plexi-pr-N context new "mywork"` from inside a Plexi pane — should create child context and auto-zoom in
- [ ] Cmd+Escape reveals parent with SubContext preview tile

Closes #1409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional naming support for creating child contexts via CLI.
  * Sub-context tiles now display detailed pane information (names, paths, types).
  * Auto-zoom behavior when creating child contexts from the UI.

* **Bug Fixes**
  * Parent context matching now case-insensitive during child context creation.

* **Tests**
  * Added regression tests for case-insensitive parent matching and auto-zoom behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->