### PR TITLE
fix(keys): swap Cmd+D / Cmd+Shift+D split polarity (#1465)

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -196,8 +196,8 @@ impl Default for KeyBindings {
             quit:                      (cmd(),       egui::Key::Q),
             close_pane:                (cmd(),       egui::Key::W),
             toggle_command_palette:    (cmd(),       egui::Key::P),
-            split_horizontal:          (cmd_shift(), egui::Key::D),
-            split_vertical:            (cmd(),       egui::Key::D),
+            split_horizontal:          (cmd(),       egui::Key::D),
+            split_vertical:            (cmd_shift(), egui::Key::D),
             split_right:               (cmd(),       egui::Key::Backslash),
             split_down:                (cmd_shift(), egui::Key::Backslash),
             swap_pane_left:            (cmd_ctrl(),  egui::Key::H),
@@ -482,11 +482,11 @@ pub fn poll_actions(
             return;
         }
 
-        // Check split_horizontal (Cmd+Shift+D) before split_vertical (Cmd+D) — more specific first.
-        if input.consume_key(bindings.split_horizontal.0, bindings.split_horizontal.1) {
-            actions.push(Action::SplitHorizontal);
-        } else if input.consume_key(bindings.split_vertical.0, bindings.split_vertical.1) {
+        // Check split_vertical (Cmd+Shift+D) before split_horizontal (Cmd+D) — more specific first.
+        if input.consume_key(bindings.split_vertical.0, bindings.split_vertical.1) {
             actions.push(Action::SplitVertical);
+        } else if input.consume_key(bindings.split_horizontal.0, bindings.split_horizontal.1) {
+            actions.push(Action::SplitHorizontal);
         }
 
         // Pane swap — check before plain pane navigation.


### PR DESCRIPTION
## Summary

Swaps the key bindings for horizontal/vertical split so the simpler shortcut maps to the more common direction:

- **Cmd+D** → side-by-side split (horizontal, Split right)
- **Cmd+Shift+D** → top/bottom split (vertical, Split down)

Previously these were reversed: Cmd+D triggered a top/bottom split and Cmd+Shift+D triggered side-by-side.

Also reorders the `consume_key` checks so the more specific modifier (Cmd+Shift+D) is checked first, preserving the guard ordering pattern.

## Changes

- `src/keys.rs:199-200` — swap `cmd()` and `cmd_shift()` for `split_horizontal`/`split_vertical`
- `src/keys.rs:485` — update comment to reflect new binding order
- `src/keys.rs:486-490` — swap if/else branches to test more-specific binding first

The overlay hints in `src/overlays.rs` already described the correct intended behavior ("Split right" for Cmd+D, "Split down" for Cmd+Shift+D) and required no changes.

## Done When

- Cmd+D produces a side-by-side (horizontal) split ✓
- Cmd+Shift+D produces a top/bottom (vertical) split ✓
- Shortcut hints in the UI reflect the correct mapping ✓ (unchanged — already correct)
- No regressions in other Cmd+D-adjacent bindings ✓

Closes #1465