### PR TITLE
feat(contexts): unlimited nesting + safe delete-context (#1392)

### DIFF
--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 impl PlexiApp {
     /// Create a child context nested inside `parent_name`. Moves the parent's focused
     /// pane into the new child context and replaces it with a SubContext tile. Falls
-    /// back to a new terminal if no adoptable pane is focused. Depth is capped at 3.
+    /// back to a new terminal if no adoptable pane is focused. No hard depth limit.
     pub(crate) fn new_child_context(&mut self, parent_name: &str, path: PathBuf) -> Result<(), String> {
         let parent_idx = self.router.position(|c| c.name.eq_ignore_ascii_case(parent_name))
             .ok_or_else(|| format!("no context named '{parent_name}'"))?;
@@ -19,13 +19,9 @@ impl PlexiApp {
 
         if parent_depth >= 3 {
             log::warn!(
-                "new_child_context: depth limit reached — parent '{}' is at depth {}",
+                "new_child_context: deep nesting — parent '{}' is at depth {} (consider reorganizing)",
                 parent_name, parent_depth
             );
-            return Err(format!(
-                "depth limit: parent '{}' is already at depth {} (max 3)",
-                parent_name, parent_depth
-            ));
         }
 
         let child_depth = parent_depth + 1;
@@ -335,33 +331,85 @@ impl PlexiApp {
         }
         let ws_id = self.router.get(ws_index).context_id;
 
-        // Remove all windows belonging to this context.
-        self.windows.retain(|c| c.context_id != ws_id);
+        // Cascade: collect ws_id and all descendants so children are deleted together
+        // with their parent instead of becoming orphaned with a dangling parent_id.
+        let ids_to_delete = self.collect_descendant_ids(ws_id);
+        if self.router.len() <= ids_to_delete.len() {
+            // Cascade would remove every context — refuse rather than panic.
+            log::warn!(
+                "delete_context: refused cascade of {} context(s) — would remove all contexts",
+                ids_to_delete.len()
+            );
+            return;
+        }
+        log::info!(
+            "delete_context: removing {} context(s) (root={ws_id} ids={ids_to_delete:?})",
+            ids_to_delete.len()
+        );
 
-        // Remove SubContext tiles that pointed to this deleted context from parent windows.
-        for win in &mut self.windows {
-            let sub_ctx_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
-                .filter(|(_, p)| p.as_sub_context() == Some(ws_id))
-                .map(|(id, _)| *id)
-                .collect();
-            for pane_id in sub_ctx_pane_ids {
-                win.panes.remove(&pane_id);
-                // Remove from the tile tree too.
-                if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
-                    win.tree.remove_recursively(tile_id);
+        // If the active context is being deleted, find a surviving ancestor in the depth
+        // stack to land on.  depth_stack entries are (parent_ctx_id, parent_win_id, tile)
+        // ordered oldest-first; the last entry is the direct parent of the current active.
+        let active_id = self.router.active().context_id;
+        let active_deleted = ids_to_delete.contains(&active_id);
+
+        // Strip deleted contexts from depth_stack first.
+        self.router.depth_stack.retain(|(ctx_id, _, _)| !ids_to_delete.contains(ctx_id));
+
+        // Pop the top of the cleaned stack to get the surviving parent we'll land on.
+        let override_active: Option<(u64, u64)> = if active_deleted {
+            self.router.depth_stack.pop().map(|(ctx_id, win_id, _)| (ctx_id, win_id))
+        } else {
+            None
+        };
+
+        // Remove windows and SubContext tiles for all deleted contexts.
+        for &id in &ids_to_delete {
+            self.windows.retain(|w| w.context_id != id);
+            for win in &mut self.windows {
+                let sub_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
+                    .filter(|(_, p)| p.as_sub_context() == Some(id))
+                    .map(|(pid, _)| *pid)
+                    .collect();
+                for pane_id in sub_pane_ids {
+                    win.panes.remove(&pane_id);
+                    if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
+                        win.tree.remove_recursively(tile_id);
+                    }
                 }
             }
         }
 
-        self.router.remove_at(ws_index);
+        // Remove contexts from the router largest-index-first so earlier indices stay valid.
+        let mut indices: Vec<usize> = ids_to_delete.iter()
+            .filter_map(|&id| self.router.position(|c| c.context_id == id))
+            .collect();
+        indices.sort_unstable_by(|a, b| b.cmp(a));
+        for idx in indices {
+            self.router.remove_at(idx);
+        }
 
-        // Pick a valid active window in the new active context.
-        self.pick_active_context_from_workspace();
+        // Apply the active-context override (surviving ancestor from depth_stack),
+        // or fall back to the default picker which uses whatever remove_at settled on.
+        if let Some((ctx_id, win_id)) = override_active {
+            if let Some(idx) = self.router.position(|c| c.context_id == ctx_id) {
+                self.router.set_active(idx);
+                if let Some(win_idx) = self.windows.iter().position(|w| w.window_id == win_id) {
+                    self.active_window = win_idx;
+                } else {
+                    self.pick_active_context_from_workspace();
+                }
+            } else {
+                self.pick_active_context_from_workspace();
+            }
+        } else {
+            self.pick_active_context_from_workspace();
+        }
 
-        // Notifications scoped to this context are dropped.
+        // Drop notifications scoped to any deleted context.
         self.pending_notifications.retain(|n| {
             !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
-                && n.source_context_id == ws_id)
+                && ids_to_delete.contains(&n.source_context_id))
         });
         if let Some(ref id) = self.current_notify_id.clone() {
             let still_present = self.pending_notifications.iter().any(|n| &n.notify_id == id);
@@ -378,6 +426,25 @@ impl PlexiApp {
             .get(&new_ws_id)
             .copied()
             .unwrap_or(page_count > 1);
+    }
+
+    /// Returns `root_id` plus the context_ids of all its descendants.
+    fn collect_descendant_ids(&self, root_id: u64) -> Vec<u64> {
+        let mut ids = vec![root_id];
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for ctx in self.router.iter() {
+                if ids.contains(&ctx.context_id) {
+                    continue;
+                }
+                if ctx.parent_id.map_or(false, |pid| ids.contains(&pid)) {
+                    ids.push(ctx.context_id);
+                    changed = true;
+                }
+            }
+        }
+        ids
     }
 
     pub(crate) fn delete_window(&mut self, index: usize) {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -363,19 +363,20 @@ impl PlexiApp {
             None
         };
 
-        // Remove windows and SubContext tiles for all deleted contexts.
-        for &id in &ids_to_delete {
-            self.windows.retain(|w| w.context_id != id);
-            for win in &mut self.windows {
-                let sub_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
-                    .filter(|(_, p)| p.as_sub_context() == Some(id))
-                    .map(|(pid, _)| *pid)
-                    .collect();
-                for pane_id in sub_pane_ids {
-                    win.panes.remove(&pane_id);
-                    if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
-                        win.tree.remove_recursively(tile_id);
-                    }
+        // Build a HashSet for O(1) membership checks during window cleanup.
+        let ids_set: std::collections::HashSet<u64> = ids_to_delete.iter().copied().collect();
+
+        // Single-pass window removal and SubContext tile cleanup.
+        self.windows.retain(|w| !ids_set.contains(&w.context_id));
+        for win in &mut self.windows {
+            let sub_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
+                .filter(|(_, p)| p.as_sub_context().map_or(false, |id| ids_set.contains(&id)))
+                .map(|(pid, _)| *pid)
+                .collect();
+            for pane_id in sub_pane_ids {
+                win.panes.remove(&pane_id);
+                if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
+                    win.tree.remove_recursively(tile_id);
                 }
             }
         }
@@ -409,7 +410,7 @@ impl PlexiApp {
         // Drop notifications scoped to any deleted context.
         self.pending_notifications.retain(|n| {
             !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
-                && ids_to_delete.contains(&n.source_context_id))
+                && ids_set.contains(&n.source_context_id))
         });
         if let Some(ref id) = self.current_notify_id.clone() {
             let still_present = self.pending_notifications.iter().any(|n| &n.notify_id == id);
@@ -430,21 +431,20 @@ impl PlexiApp {
 
     /// Returns `root_id` plus the context_ids of all its descendants.
     fn collect_descendant_ids(&self, root_id: u64) -> Vec<u64> {
-        let mut ids = vec![root_id];
+        let mut ids: std::collections::HashSet<u64> = std::collections::HashSet::from([root_id]);
         let mut changed = true;
         while changed {
             changed = false;
             for ctx in self.router.iter() {
-                if ids.contains(&ctx.context_id) {
-                    continue;
-                }
-                if ctx.parent_id.map_or(false, |pid| ids.contains(&pid)) {
-                    ids.push(ctx.context_id);
-                    changed = true;
+                if !ids.contains(&ctx.context_id) {
+                    if ctx.parent_id.map_or(false, |pid| ids.contains(&pid)) {
+                        ids.insert(ctx.context_id);
+                        changed = true;
+                    }
                 }
             }
         }
-        ids
+        ids.into_iter().collect()
     }
 
     pub(crate) fn delete_window(&mut self, index: usize) {

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -47,15 +47,48 @@ impl PlexiApp {
                     .collect();
                 path_ids.push(self.router.active().context_id);
 
-                for (i, &ctx_id) in path_ids.iter().enumerate() {
-                    let name = self.router.iter()
+                let total = path_ids.len();
+                let is_deep = total >= 3;
+                let sep = egui::RichText::new("\u{203A}").color(self.colors.text_dim);
+                let name_color = if is_deep { self.colors.text_dim } else { self.colors.text_primary };
+
+                let ctx_name = |ctx_id: u64| -> String {
+                    self.router.iter()
                         .find(|c| c.context_id == ctx_id)
-                        .map(|c| c.name.as_str())
-                        .unwrap_or("?");
-                    let _ = ui.small_button(name);
-                    if i < path_ids.len() - 1 {
-                        ui.label(egui::RichText::new("\u{203A}").color(self.colors.text_dim));
+                        .map(|c| c.name.clone())
+                        .unwrap_or_else(|| "?".to_string())
+                };
+
+                if total >= 5 {
+                    // first + … + last 2
+                    let _ = ui.small_button(
+                        egui::RichText::new(ctx_name(path_ids[0])).color(name_color)
+                    );
+                    ui.label(sep.clone());
+                    ui.label(egui::RichText::new("\u{2026}").color(self.colors.text_dim));
+                    ui.label(sep.clone());
+                    let _ = ui.small_button(
+                        egui::RichText::new(ctx_name(path_ids[total - 2])).color(name_color)
+                    );
+                    ui.label(sep.clone());
+                    let _ = ui.small_button(
+                        egui::RichText::new(ctx_name(path_ids[total - 1])).color(name_color)
+                    );
+                } else {
+                    for (i, &ctx_id) in path_ids.iter().enumerate() {
+                        let _ = ui.small_button(
+                            egui::RichText::new(ctx_name(ctx_id)).color(name_color)
+                        );
+                        if i < total - 1 {
+                            ui.label(sep.clone());
+                        }
                     }
+                }
+
+                // Soft indicator when nesting is >= 3 levels deep.
+                if is_deep {
+                    ui.add_space(4.0);
+                    ui.label(egui::RichText::new("deep").color(self.colors.text_dim).small());
                 }
             });
             ui.separator();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -777,4 +777,146 @@ mod tests {
         }
     }
 
+    // -- Context nesting (issue #1392) ───────────────────────────────────────
+
+    /// Regression guard: deleting a parent context while zoomed past it into a
+    /// grandchild must not leave dangling entries in depth_stack.
+    /// Attempt 1 (PR #1453) removed the depth cap but skipped this fix,
+    /// causing breadcrumb to render "?".
+    ///
+    /// Hierarchy: root → child_A → child_B (active)
+    /// Zoomed: depth_stack = [(root_id, ...), (child_A_id, ...)]
+    /// Delete child_A → cascade deletes child_B → land on root, depth_stack = [].
+    #[test]
+    fn delete_parent_context_cleans_depth_stack() {
+        use std::path::PathBuf;
+
+        let mut h = HostHarness::new();
+
+        let root_name = h.app.router.active().name.clone();
+        let root_id   = h.app.router.active().context_id;
+        let root_win_id = h.app.windows[0].window_id;
+
+        // Create child_A under root.
+        h.app.new_child_context(&root_name, PathBuf::from("/tmp/child_a"))
+            .expect("new_child_context at depth 1");
+        let child_a_id = h.app.router.iter()
+            .find(|c| c.parent_id == Some(root_id))
+            .map(|c| c.context_id)
+            .expect("child_A must exist");
+        let child_a_name = h.app.router.iter()
+            .find(|c| c.context_id == child_a_id)
+            .map(|c| c.name.clone())
+            .unwrap();
+
+        // Create child_B under child_A.
+        h.app.new_child_context(&child_a_name, PathBuf::from("/tmp/child_b"))
+            .expect("new_child_context at depth 2");
+        let child_b_id = h.app.router.iter()
+            .find(|c| c.parent_id == Some(child_a_id))
+            .map(|c| c.context_id)
+            .expect("child_B must exist");
+
+        assert_eq!(h.app.router.len(), 3, "root + child_A + child_B");
+
+        // Simulate being zoomed root → child_A → child_B (active).
+        h.app.router.push_depth(root_id, root_win_id, None);
+        let child_a_idx = h.app.router.position(|c| c.context_id == child_a_id).unwrap();
+        h.app.router.set_active(child_a_idx);
+        // Fake a second window id for child_A for the depth entry.
+        h.app.router.push_depth(child_a_id, root_win_id + 1, None);
+        let child_b_idx = h.app.router.position(|c| c.context_id == child_b_id).unwrap();
+        h.app.router.set_active(child_b_idx);
+
+        assert_eq!(h.app.router.current_depth(), 2, "zoomed 2 levels deep");
+        assert_eq!(h.app.router.active().context_id, child_b_id);
+
+        // Delete child_A while active is child_B.
+        // Cascade: child_B is deleted too. We should land on root.
+        let child_a_idx2 = h.app.router.position(|c| c.context_id == child_a_id).unwrap();
+        h.app.delete_context(child_a_idx2);
+
+        // depth_stack must be empty — no dangling entries.
+        assert_eq!(
+            h.app.router.depth_stack.len(),
+            0,
+            "depth_stack must be empty after deleting all zoomed contexts"
+        );
+
+        // Neither child_A nor child_B must survive.
+        for ctx in h.app.router.iter() {
+            assert_ne!(ctx.context_id, child_a_id, "child_A must be gone");
+            assert_ne!(ctx.context_id, child_b_id, "child_B must be cascade-deleted");
+        }
+
+        // Root must still be present and active.
+        assert_eq!(h.app.router.active().context_id, root_id, "must land on root");
+    }
+
+    /// Deleting the active child context while zoomed into it must pop back to
+    /// the parent and leave depth_stack consistent.
+    #[test]
+    fn delete_active_child_context_lands_on_parent() {
+        use std::path::PathBuf;
+
+        let mut h = HostHarness::new();
+
+        let root_name = h.app.router.active().name.clone();
+        let root_id   = h.app.router.active().context_id;
+
+        h.app.new_child_context(&root_name, PathBuf::from("/tmp/child"))
+            .expect("new_child_context at depth 1");
+
+        let child_id = h.app.router.iter()
+            .find(|c| c.parent_id == Some(root_id))
+            .map(|c| c.context_id)
+            .expect("child must exist");
+
+        // Zoom into child.
+        h.app.router.push_depth(root_id, 1, None);
+        let child_idx = h.app.router.position(|c| c.context_id == child_id).unwrap();
+        h.app.router.set_active(child_idx);
+
+        // Delete the active child context.
+        let child_idx2 = h.app.router.position(|c| c.context_id == child_id).unwrap();
+        h.app.delete_context(child_idx2);
+
+        // Must land back on root, depth_stack empty.
+        assert_eq!(
+            h.app.router.current_depth(),
+            0,
+            "depth_stack must be empty after deleting the only child"
+        );
+        assert_eq!(
+            h.app.router.active().context_id,
+            root_id,
+            "active context must be the root after child deletion"
+        );
+    }
+
+    /// depth > 3 must succeed: new_child_context must not return Err at depth 3+.
+    #[test]
+    fn new_child_context_succeeds_beyond_depth_3() {
+        use std::path::PathBuf;
+
+        let mut h = HostHarness::new();
+
+        // Build: root → d1 → d2 → d3 → d4
+        let mut parent_name = h.app.router.active().name.clone();
+        for depth in 1..=4u32 {
+            let path = PathBuf::from(format!("/tmp/depth{depth}"));
+            let result = h.app.new_child_context(&parent_name, path.clone());
+            assert!(result.is_ok(), "new_child_context must not error at depth {depth}");
+            parent_name = path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+        }
+
+        // All 5 contexts (root + 4 children) must exist.
+        assert_eq!(h.app.router.len(), 5, "must have root + 4 child contexts");
+        let max_depth = h.app.router.iter().map(|c| c.depth).max().unwrap_or(0);
+        assert_eq!(max_depth, 4, "deepest context must be at depth 4");
+    }
 }


### PR DESCRIPTION
## Summary

- **Removes the depth-3 hard cap** from `new_child_context()` — users can now nest contexts as deep as they want. A `log::warn` fires at depth 3+ as a soft hint but never blocks creation.
- **Fixes `delete_context()` referential integrity** — the root cause of Attempt 1's failure. The old code never touched `depth_stack`, leaving dangling context IDs that caused breadcrumb to render `?`. Now:
  - Child contexts are cascade-deleted with their parent (no orphaned `parent_id` references)
  - `depth_stack` entries for deleted contexts are stripped before any structural changes
  - Active context recovery pops to the nearest surviving ancestor in the depth stack
  - A guard refuses cascade that would remove all contexts
- **Breadcrumb truncation** at depth 5+: shows `first › … › second-to-last › last`
- **Dim breadcrumb labels** at depth 3+ with a small "deep" indicator

## Test plan

- [x] 3 new HostHarness regression tests all pass: `delete_parent_context_cleans_depth_stack`, `delete_active_child_context_lands_on_parent`, `new_child_context_succeeds_beyond_depth_3`
- [x] Full test suite: 493 pass, 2 pre-existing failures unrelated to this change
- [x] `cargo build` clean

### Manual golden path

1. Open Plexi, create a workspace
2. `plexi context new --name child1 --path /tmp/c1` — should succeed
3. Navigate into child1, create `child2` under it — should succeed
4. Continue to depth 5+ — should not error
5. While zoomed deep, delete an ancestor context via sidebar — breadcrumb should not render `?`, should land on nearest surviving ancestor
6. Breadcrumb at depth 3+ should show dim labels + "deep" indicator

Closes #1392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Context deletion now properly cascades to child contexts, preventing orphaned references
  * Improved breadcrumb navigation for deeply nested contexts with optimized layout

* **New Features**
  * Removed hard nesting depth limit; now displays "consider reorganizing" guidance for very deep nesting
  * Added visual indicator for deeply nested contexts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->