### PR TITLE
refactor(widgets): styled_text_input() helper — unified modal text input (#1109)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -823,25 +823,13 @@ impl PlexiApp {
 
                         let te_id = egui::Id::new("text_input_overlay_field");
                         let (overlay, _target) = self.text_overlay.as_mut().unwrap();
-                        let te = ui
-                            .scope(|ui| {
-                                ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                                ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
-                                ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
-                                ui.visuals_mut().widgets.active.bg_stroke =
-                                    egui::Stroke::new(1.0, self.colors.accent);
-                                ui.visuals_mut().widgets.inactive.bg_stroke =
-                                    egui::Stroke::new(1.0, self.colors.border);
-                                ui.add(
-                                    egui::TextEdit::singleline(&mut overlay.buffer)
-                                        .id(te_id)
-                                        .desired_width(MODAL_WIDTH)
-                                        .hint_text(&hint)
-                                        .font(egui::TextStyle::Body)
-                                        .margin(egui::Margin::symmetric(8, 5)),
-                                )
-                            })
-                            .inner;
+                        let te = crate::widgets::styled_text_input(
+                            ui,
+                            &mut overlay.buffer,
+                            hint.as_str(),
+                            te_id,
+                            &self.colors,
+                        );
 
                         // One-shot focus guard.
                         if !overlay.focus_requested {
@@ -995,21 +983,13 @@ impl PlexiApp {
                         ui.add_space(6.0);
 
                         let te_id = egui::Id::new("rename_pane_input");
-                        let te = ui.scope(|ui| {
-                            ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
-                            ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
-                            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
-                            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
-                            ui.add(
-                                egui::TextEdit::singleline(&mut self.rename_buffer)
-                                    .id(te_id)
-                                    .desired_width(MODAL_WIDTH)
-                                    .hint_text("Pane name...")
-                                    .font(egui::TextStyle::Body)
-                                    .margin(egui::Margin::symmetric(8, 5)),
-                            )
-                        }).inner;
+                        let te = crate::widgets::styled_text_input(
+                            ui,
+                            &mut self.rename_buffer,
+                            "Pane name...",
+                            te_id,
+                            &self.colors,
+                        );
 
                         // One-shot focus: only request on the first render frame.
                         // Re-requesting every frame (guarded by `!te.has_focus()`) lets
@@ -1092,21 +1072,13 @@ impl PlexiApp {
                         ui.add_space(6.0);
 
                         let te_id = egui::Id::new("rename_context_input");
-                        let te = ui.scope(|ui| {
-                            ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                            ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
-                            ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
-                            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
-                            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
-                            ui.add(
-                                egui::TextEdit::singleline(&mut self.rename_buffer)
-                                    .id(te_id)
-                                    .desired_width(MODAL_WIDTH)
-                                    .hint_text("Context name...")
-                                    .font(egui::TextStyle::Body)
-                                    .margin(egui::Margin::symmetric(8, 5)),
-                            )
-                        }).inner;
+                        let te = crate::widgets::styled_text_input(
+                            ui,
+                            &mut self.rename_buffer,
+                            "Context name...",
+                            te_id,
+                            &self.colors,
+                        );
 
                         if !te.has_focus() {
                             te.request_focus();

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -170,6 +170,36 @@ pub(crate) fn key_combo_list(
     });
 }
 
+/// Renders a styled singleline text input with the standard modal visual treatment:
+/// accent cursor, accent active border, muted inactive border, `bg_active` fill,
+/// `Body` font, and `8×5` inner margin. Width fills available space.
+///
+/// Returns the egui `Response`; callers handle focus requests and key events themselves.
+pub(crate) fn styled_text_input(
+    ui: &mut egui::Ui,
+    buf: &mut String,
+    hint: impl Into<egui::WidgetText>,
+    id: egui::Id,
+    colors: &Colors,
+) -> egui::Response {
+    ui.scope(|ui| {
+        ui.visuals_mut().text_cursor.stroke.width = 1.5;
+        ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+        ui.visuals_mut().extreme_bg_color = colors.bg_active;
+        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+        ui.add(
+            egui::TextEdit::singleline(buf)
+                .id(id)
+                .desired_width(f32::INFINITY)
+                .hint_text(hint)
+                .font(egui::TextStyle::Body)
+                .margin(egui::Margin::symmetric(8, 5)),
+        )
+    })
+    .inner
+}
+
 /// 📋 / ✓ copy-to-clipboard button. Shows the clipboard icon normally; switches
 /// to ✓ for 2 seconds after a successful copy. `id` must be unique per call site.
 pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::Response {


### PR DESCRIPTION
## What

Extracts the repeated `ui.scope()` + `visuals_mut()` pattern for modal text inputs into a `styled_text_input(ui, buf, hint, id, colors)` helper in `src/widgets.rs`.

## Why

The 5-line visual setup block (cursor width, accent border, bg_active fill) was duplicated verbatim across 3 singleline call sites in `src/overlays.rs`. A shared helper means visual changes apply everywhere from one edit, and new modals get polished inputs for free.

## Changes

- `src/widgets.rs`: new `styled_text_input()` — applies standard visual treatment, returns `egui::Response`
- `src/overlays.rs`: 3 call sites replaced (text_input_overlay, rename_pane, rename_context)

## Out of scope

- Multiline call sites (quick_note, modal_input_buffer): visual configs diverge; not worth a shared helper
- Secret password input in `prompts.rs`: needs `.password(true)`, no ID or hint — different shape

## Done When

- [x] `styled_text_input` exists in `src/widgets.rs`  
- [x] 3 singleline call sites in `src/overlays.rs` use it
- [x] `cargo build` passes, no regressions in `cargo test`

Closes #1109