### PR TITLE
feat(contexts): close-context dialog with pane list and dissolve option (#1385)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,6 +83,8 @@ pub(crate) enum FocusLayer {
     ContextInspector,
     /// Shared text-input overlay (context root, future: context rename).
     TextInput,
+    /// Close-context confirmation dialog with pane inventory and dissolve option.
+    ContextCloseConfirm,
 }
 
 /// What a `TextInputOverlay` commit should do.
@@ -90,6 +92,21 @@ pub(crate) enum FocusLayer {
 pub(crate) enum OverlayTarget {
     /// Set (or clear) the root directory on the context at `idx`.
     ContextRoot(usize),
+}
+
+/// A single pane entry shown in the context-close confirmation dialog.
+#[derive(Clone, Debug)]
+pub(crate) struct ContextCloseItem {
+    pub kind: &'static str,
+    pub name: String,
+}
+
+/// State for the context-close confirmation dialog.
+#[derive(Clone, Debug)]
+pub(crate) struct ContextCloseState {
+    pub context_id: u64,
+    pub context_name: String,
+    pub items: Vec<ContextCloseItem>,
 }
 
 /// Shared text-input overlay state. One instance per open modal.
@@ -244,6 +261,7 @@ pub struct PlexiApp {
     pub(crate) quit_press_count: u8,
     pub(crate) quit_last_press: Option<std::time::Instant>,
     pub(crate) pending_close: bool,
+    pub(crate) pending_context_close: Option<ContextCloseState>,
     pub(crate) show_context_inspector: bool,
     pub(crate) inspector_selected_pane: usize,
     pub(crate) inspector_delete_press_count: u8,
@@ -856,6 +874,7 @@ impl PlexiApp {
                     config: config.clone(),
                     key_bindings: key_bindings.clone(),
                     pending_close: false,
+                    pending_context_close: None,
                     frame_tick: frame_tick.clone(),
                     renaming_window: None,
                     rename_buffer: String::new(),
@@ -975,6 +994,7 @@ impl PlexiApp {
             config,
             key_bindings,
             pending_close: false,
+            pending_context_close: None,
             frame_tick,
             renaming_window: None,
             rename_buffer: String::new(),
@@ -1104,6 +1124,7 @@ impl PlexiApp {
             config,
             key_bindings,
             pending_close: false,
+            pending_context_close: None,
             frame_tick,
             renaming_window: None,
             rename_buffer: String::new(),
@@ -2162,6 +2183,7 @@ impl eframe::App for PlexiApp {
         // `input_captured_by_overlay()` answers correctly this frame.
         self.sync_notification_modal_focus();
         self.sync_confirm_close_focus();
+        self.sync_context_close_focus();
         self.sync_command_palette_focus();
         self.sync_rename_pane_focus();
         self.sync_context_rename_focus();
@@ -2213,6 +2235,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::TextInput) => {
                     self.draw_text_input_overlay(ctx);
                 }
+                Some(FocusLayer::ContextCloseConfirm) => {
+                    self.draw_context_close_confirm(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -2222,6 +2247,7 @@ impl eframe::App for PlexiApp {
             // rest of this frame.
             self.sync_notification_modal_focus();
             self.sync_confirm_close_focus();
+            self.sync_context_close_focus();
             self.sync_command_palette_focus();
             self.sync_rename_pane_focus();
             self.sync_context_rename_focus();
@@ -2932,7 +2958,21 @@ impl eframe::App for PlexiApp {
                     // (via PushNav), Escape routes NavBack to the app
                     // instead of closing the pane.
                     if !self.try_nav_back_focused() {
-                        if self.confirm_close() {
+                        if let Some(child_ctx_id) = self.get_focused_sub_context_id() {
+                            let state = self.build_context_close_state(child_ctx_id);
+                            if state.items.is_empty() {
+                                // Empty context — close immediately, no dialog needed.
+                                let idx = self.router.iter().position(|c| c.context_id == child_ctx_id);
+                                if let Some(i) = idx {
+                                    log::info!("context_close: empty ctx={child_ctx_id} — closing immediately");
+                                    self.delete_context(i);
+                                    self.save_workspace();
+                                }
+                            } else {
+                                log::info!("context_close: ctx={child_ctx_id} has {} panes — showing dialog", state.items.len());
+                                self.pending_context_close = Some(state);
+                            }
+                        } else if self.confirm_close() {
                             self.pending_close = true;
                         } else if self.execute_close_pane() {
                             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
@@ -4012,6 +4052,7 @@ impl PlexiApp {
                 | Some(FocusLayer::CliSetupPrompt)
                 | Some(FocusLayer::ContextInspector)
                 | Some(FocusLayer::TextInput)
+                | Some(FocusLayer::ContextCloseConfirm)
         )
     }
 
@@ -4318,6 +4359,71 @@ impl PlexiApp {
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::ConfirmClose);
         }
+    }
+
+    pub(crate) fn sync_context_close_focus(&mut self) {
+        let should_own = self.pending_context_close.is_some();
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::ContextCloseConfirm);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::ContextCloseConfirm);
+        } else if !should_own && has_layer {
+            self.pop_focus_layer(&FocusLayer::ContextCloseConfirm);
+        }
+    }
+
+    /// Returns the `context_id` of the child context if the focused pane is a SubContext tile.
+    pub(crate) fn get_focused_sub_context_id(&self) -> Option<u64> {
+        let win = &self.windows[self.active_window];
+        let focused_tile = win.focused_pane?;
+        let pane_id = match win.tree.tiles.get(focused_tile) {
+            Some(egui_tiles::Tile::Pane(id)) => *id,
+            _ => return None,
+        };
+        win.panes.get(&pane_id)?.as_sub_context()
+    }
+
+    /// Collect the pane inventory for a child context close dialog.
+    pub(crate) fn build_context_close_state(&self, context_id: u64) -> ContextCloseState {
+        let context_name = self
+            .router
+            .iter()
+            .find(|c| c.context_id == context_id)
+            .map(|c| c.name.clone())
+            .unwrap_or_default();
+
+        let mut items = Vec::new();
+        for win in &self.windows {
+            if win.context_id != context_id {
+                continue;
+            }
+            for (_, pane) in &win.panes {
+                match pane {
+                    crate::pane::Pane::Terminal(t) => {
+                        let name = t.name.clone()
+                            .or_else(|| t.pty_title.clone())
+                            .unwrap_or_else(|| "Terminal".to_string());
+                        items.push(ContextCloseItem { kind: "Terminal", name });
+                    }
+                    crate::pane::Pane::App(a) => {
+                        items.push(ContextCloseItem { kind: "App", name: a.name.clone() });
+                    }
+                    crate::pane::Pane::SubContext { context_id: child_id, .. } => {
+                        let name = self
+                            .router
+                            .iter()
+                            .find(|c| c.context_id == *child_id)
+                            .map(|c| c.name.clone())
+                            .unwrap_or_else(|| "Sub-context".to_string());
+                        items.push(ContextCloseItem { kind: "Context", name });
+                    }
+                }
+            }
+        }
+
+        ContextCloseState { context_id, context_name, items }
     }
 
     pub(crate) fn sync_notification_modal_focus(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4399,7 +4399,9 @@ impl PlexiApp {
             if win.context_id != context_id {
                 continue;
             }
-            for (_, pane) in &win.panes {
+            let mut pane_entries: Vec<_> = win.panes.iter().collect();
+            pane_entries.sort_by_key(|(id, _)| *id);
+            for (_, pane) in pane_entries {
                 match pane {
                     crate::pane::Pane::Terminal(t) => {
                         let name = t.name.clone()

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2359,6 +2359,172 @@ impl PlexiApp {
         }
     }
 
+    /// Context-close confirmation dialog. Shows pane inventory with three choices:
+    /// Close All (Enter), Dissolve (D), Cancel (Escape).
+    pub(crate) fn draw_context_close_confirm(&mut self, ctx: &egui::Context) {
+        let state = match self.pending_context_close.take() {
+            Some(s) => s,
+            None => return,
+        };
+
+        let mut close_all = false;
+        let mut dissolve = false;
+        let mut cancelled = false;
+
+        ctx.input_mut(|i| {
+            if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
+                close_all = true;
+            }
+            if i.consume_key(egui::Modifiers::NONE, egui::Key::D) {
+                dissolve = true;
+            }
+            if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+                cancelled = true;
+            }
+        });
+
+        let screen_rect = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("ctx_close_confirm_scrim"))
+            .fixed_pos(screen_rect.min)
+            .order(egui::Order::Middle)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(120));
+                let scrim_resp = ui.allocate_rect(screen_rect, egui::Sense::click());
+                if scrim_resp.clicked() {
+                    cancelled = true;
+                }
+            });
+
+        let colors = self.colors;
+        egui::Area::new(egui::Id::new("ctx_close_confirm_modal"))
+            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(colors.bg_sidebar)
+                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(20, 16))
+                    .show(ui, |ui| {
+                        ui.set_width(MODAL_WIDTH);
+
+                        let title = if state.context_name.is_empty() {
+                            "Close context?".to_string()
+                        } else {
+                            format!("Close \"{}\"?", state.context_name)
+                        };
+                        ui.label(
+                            RichText::new(&title)
+                                .size(13.0)
+                                .color(colors.text_primary)
+                                .strong(),
+                        );
+                        ui.add_space(8.0);
+
+                        for item in &state.items {
+                            let label = format!("{} — {}", item.kind, item.name);
+                            ui.label(
+                                RichText::new(&label)
+                                    .size(style::TEXT_HINT)
+                                    .color(colors.text_dim),
+                            );
+                        }
+
+                        ui.add_space(12.0);
+                        ui.horizontal(|ui| {
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        RichText::new("Close all")
+                                            .size(12.0)
+                                            .color(colors.text_primary),
+                                    )
+                                    .fill(colors.bg_active),
+                                )
+                                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                .clicked()
+                            {
+                                close_all = true;
+                            }
+                            ui.add_space(6.0);
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        RichText::new("Dissolve")
+                                            .size(12.0)
+                                            .color(colors.text_primary),
+                                    )
+                                    .fill(colors.bg_active),
+                                )
+                                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                .clicked()
+                            {
+                                dissolve = true;
+                            }
+                            ui.add_space(6.0);
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        RichText::new("Cancel")
+                                            .size(12.0)
+                                            .color(colors.text_dim),
+                                    )
+                                    .frame(false),
+                                )
+                                .on_hover_cursor(egui::CursorIcon::PointingHand)
+                                .clicked()
+                            {
+                                cancelled = true;
+                            }
+                        });
+
+                        ui.add_space(8.0);
+                        ui.horizontal(|ui| {
+                            crate::widgets::key_chip(ui, "Enter", &colors);
+                            ui.label(
+                                RichText::new("close all")
+                                    .size(style::TEXT_HINT)
+                                    .color(colors.text_dim),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            crate::widgets::key_chip(ui, "D", &colors);
+                            ui.label(
+                                RichText::new("dissolve")
+                                    .size(style::TEXT_HINT)
+                                    .color(colors.text_dim),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            crate::widgets::key_chip(ui, "Esc", &colors);
+                            ui.label(
+                                RichText::new("cancel")
+                                    .size(style::TEXT_HINT)
+                                    .color(colors.text_dim),
+                            );
+                        });
+                    });
+            });
+
+        if close_all {
+            let idx = self.router.iter().position(|c| c.context_id == state.context_id);
+            if let Some(i) = idx {
+                log::info!("context_close: close_all ctx={} name={:?}", state.context_id, state.context_name);
+                self.delete_context(i);
+                self.save_workspace();
+            } else {
+                log::warn!("context_close: close_all ctx={} not found in router", state.context_id);
+            }
+        } else if dissolve {
+            log::info!("context_close: dissolve ctx={} name={:?}", state.context_id, state.context_name);
+            self.dissolve_sub_context(state.context_id);
+            self.save_workspace();
+        } else if cancelled {
+            log::info!("context_close: cancelled ctx={}", state.context_id);
+        } else {
+            // No input yet — put state back for the next frame.
+            self.pending_context_close = Some(state);
+        }
+    }
+
     /// Primary notification surface: a keyboard-first centered modal over the
     /// work area. Renders the front of the queue.
     ///

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -600,10 +600,11 @@ impl PlexiApp {
             .map(|(i, _)| i)
             .collect();
 
-        // Drain panes from child windows into a staging list.
+        // Drain panes from child windows into a staging list (sorted by ID for deterministic order).
         let mut adopted: Vec<(crate::tiling::PaneId, crate::pane::Pane)> = Vec::new();
         for &win_idx in &child_win_indices {
-            let pane_ids: Vec<crate::tiling::PaneId> = self.windows[win_idx].panes.keys().copied().collect();
+            let mut pane_ids: Vec<crate::tiling::PaneId> = self.windows[win_idx].panes.keys().copied().collect();
+            pane_ids.sort();
             for pane_id in pane_ids {
                 if let Some(pane) = self.windows[win_idx].panes.remove(&pane_id) {
                     adopted.push((pane_id, pane));
@@ -664,16 +665,17 @@ impl PlexiApp {
             });
         }
 
+        // Fix up active_window index BEFORE the retain shifts indices.
+        // Count how many child windows sit before parent_idx — each removal shifts the index down by 1.
+        let removed_before = child_win_indices.iter().filter(|&&i| i < parent_idx).count();
+
         // Remove child context windows and router entry.
         self.windows.retain(|w| w.context_id != child_ctx_id);
         if let Some(idx) = self.router.position(|c| c.context_id == child_ctx_id) {
             self.router.remove_at(idx);
         }
 
-        // Fix up active_window index after removing child windows.
-        if self.active_window >= self.windows.len() {
-            self.active_window = self.windows.len().saturating_sub(1);
-        }
+        self.active_window = parent_idx - removed_before;
 
         // Focus the first pane in the parent window.
         let new_focus = self.windows[self.active_window].tree.root

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -560,6 +560,127 @@ impl PlexiApp {
         self.router.get_mut(idx).root = Some(root);
     }
 
+    /// Dissolve a sub-context: reparent all its panes into the parent window (the active
+    /// window that contains the SubContext tile), replace the SubContext tile with the
+    /// adopted panes, then delete the now-empty child context.
+    ///
+    /// Only promotes one level. Nested sub-contexts inside the dissolved context remain
+    /// intact — their tiles are moved to the parent window alongside the regular panes.
+    pub(crate) fn dissolve_sub_context(&mut self, child_ctx_id: u64) {
+        use egui_tiles::{Container, Tile};
+
+        // Find the SubContext tile in the active (parent) window.
+        let parent_idx = self.active_window;
+        let sub_ctx_pane_id = {
+            let win = &self.windows[parent_idx];
+            win.panes.iter()
+                .find(|(_, p)| p.as_sub_context() == Some(child_ctx_id))
+                .map(|(id, _)| *id)
+        };
+        let sub_ctx_pane_id = match sub_ctx_pane_id {
+            Some(id) => id,
+            None => {
+                log::warn!("dissolve_sub_context: no SubContext tile for ctx={child_ctx_id} in active window");
+                return;
+            }
+        };
+
+        let sub_ctx_tile_id = self.windows[parent_idx].tree.tiles.find_pane(&sub_ctx_pane_id);
+        let sub_ctx_tile_id = match sub_ctx_tile_id {
+            Some(id) => id,
+            None => {
+                log::warn!("dissolve_sub_context: SubContext pane {sub_ctx_pane_id} has no tile");
+                return;
+            }
+        };
+
+        // Collect panes from all child windows — extract them so we can move ownership.
+        let child_win_indices: Vec<usize> = self.windows.iter().enumerate()
+            .filter(|(_, w)| w.context_id == child_ctx_id)
+            .map(|(i, _)| i)
+            .collect();
+
+        // Drain panes from child windows into a staging list.
+        let mut adopted: Vec<(crate::tiling::PaneId, crate::pane::Pane)> = Vec::new();
+        for &win_idx in &child_win_indices {
+            let pane_ids: Vec<crate::tiling::PaneId> = self.windows[win_idx].panes.keys().copied().collect();
+            for pane_id in pane_ids {
+                if let Some(pane) = self.windows[win_idx].panes.remove(&pane_id) {
+                    adopted.push((pane_id, pane));
+                }
+            }
+        }
+
+        log::info!("dissolve_sub_context: ctx={child_ctx_id} adopting {} panes into parent win={parent_idx}", adopted.len());
+
+        // Insert adopted panes into the parent window.
+        // Strategy: add each new tile alongside the SubContext tile.
+        // After all siblings are added, remove the SubContext tile.
+        for (pane_id, pane) in adopted {
+            let new_tile = self.windows[parent_idx].tree.tiles.insert_pane(pane_id);
+            self.windows[parent_idx].panes.insert(pane_id, pane);
+
+            // Add the new tile as a sibling of the SubContext tile.
+            let parent_of_sub = self.windows[parent_idx].tree.tiles.parent_of(sub_ctx_tile_id);
+            if let Some(parent_tile) = parent_of_sub {
+                if let Some(Tile::Container(Container::Linear(lin))) =
+                    self.windows[parent_idx].tree.tiles.get_mut(parent_tile)
+                {
+                    if let Some(pos) = lin.children.iter().position(|&c| c == sub_ctx_tile_id) {
+                        lin.children.insert(pos, new_tile);
+                    } else {
+                        lin.children.push(new_tile);
+                    }
+                } else {
+                    // Parent is Tabs or another container — append via a new horizontal split at root.
+                    let existing_root = self.windows[parent_idx].tree.root;
+                    if let Some(root) = existing_root {
+                        let new_root = self.windows[parent_idx].tree.tiles.insert_horizontal_tile(vec![root, new_tile]);
+                        self.windows[parent_idx].tree.root = Some(new_root);
+                    } else {
+                        self.windows[parent_idx].tree.root = Some(new_tile);
+                    }
+                }
+            } else {
+                // SubContext tile is the root — wrap everything in a horizontal container.
+                let new_root = self.windows[parent_idx].tree.tiles.insert_horizontal_tile(vec![new_tile, sub_ctx_tile_id]);
+                self.windows[parent_idx].tree.root = Some(new_root);
+            }
+        }
+
+        // Remove the SubContext tile from the parent window.
+        {
+            let win = &mut self.windows[parent_idx];
+            win.panes.remove(&sub_ctx_pane_id);
+            if let Some(parent_tile) = win.tree.tiles.parent_of(sub_ctx_tile_id) {
+                if let Some(Tile::Container(parent_container)) = win.tree.tiles.get_mut(parent_tile) {
+                    parent_container.remove_child(sub_ctx_tile_id);
+                }
+            }
+            win.tree.tiles.remove(sub_ctx_tile_id);
+            win.tree.simplify(&egui_tiles::SimplificationOptions {
+                all_panes_must_have_tabs: true,
+                ..egui_tiles::SimplificationOptions::default()
+            });
+        }
+
+        // Remove child context windows and router entry.
+        self.windows.retain(|w| w.context_id != child_ctx_id);
+        if let Some(idx) = self.router.position(|c| c.context_id == child_ctx_id) {
+            self.router.remove_at(idx);
+        }
+
+        // Fix up active_window index after removing child windows.
+        if self.active_window >= self.windows.len() {
+            self.active_window = self.windows.len().saturating_sub(1);
+        }
+
+        // Focus the first pane in the parent window.
+        let new_focus = self.windows[self.active_window].tree.root
+            .and_then(|root| self.windows[self.active_window].find_first_pane_in(root));
+        self.windows[self.active_window].focused_pane = new_focus;
+    }
+
     pub(crate) fn save_workspace(&self) {
         let mut saved_contexts = Vec::new();
         let mut saved_windows = Vec::new();


### PR DESCRIPTION
## Summary

- Cmd+W on a SubContext tile shows a modal listing all panes inside with 3 choices: **Close All** (Enter), **Dissolve** (D), **Cancel** (Esc)
- Empty contexts still close immediately with no dialog
- Dissolve reparents every pane from the child context into the parent window and removes the context grouping

## Done When

- [x] Closing a context with 3 panes shows a modal listing all 3 with their names/processes
- [x] "Close all" destroys context and panes
- [x] "Dissolve" moves panes to parent, removes the sub-context grouping
- [x] "Cancel" does nothing
- [x] Empty contexts close immediately without the dialog

## Test plan

- [ ] Open Plexi with two panes in a sub-context
- [ ] Press Cmd+W while focused on the SubContext tile — dialog appears listing panes
- [ ] Press Esc — dialog closes, nothing changes
- [ ] Press Cmd+W again — press D — panes are promoted to parent, context grouping gone
- [ ] Press Cmd+W on SubContext tile with no panes inside — closes immediately, no dialog

Closes #1385