### PR TITLE
feat(layout): add split_left layout value (#1430)

### DIFF
--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -27,7 +27,7 @@ plexi pane capture [pane_id] --lines N # read last N lines of scrollback as JSON
 
 By default (no `--ephemeral`), the pane will remain open after your command finishes—so if you’re used to shells like **zsh** staying interactive, you can assume that “the terminal stays around” unless you explicitly opt into `-e/--ephemeral`. 
 
-**Layout values:** `split_h` (right), `split_right` (alias for split_h), `split_v` (below), `split_below` (alias for split_v), `split_above`, `tab` (new tab in current window), `new_window` (new OS window).
+**Layout values:** `split_h` (right), `split_left` (left), `split_right` (alias for split_h), `split_v` (below), `split_below` (alias for split_v), `split_above`, `tab` (new tab in current window), `new_window` (new OS window).
 
 ```bash
 LANE=$(plexi terminal --layout split_h)                 # pane to the right
@@ -39,7 +39,7 @@ NEW=$(plexi terminal --layout new_window)                # separate OS window
 
 ## Apps
 
-`plexi open <app-id>` launches an installed app. Flags: `--layout <overlay|split_h|split_v|split_right|split_below|split_above>`, `--from-pane-id <id>` (split relative to a pane), `--mcp`, `--cli`.
+`plexi open <app-id>` launches an installed app. Flags: `--layout <overlay|split_h|split_left|split_v|split_right|split_below|split_above>`, `--from-pane-id <id>` (split relative to a pane), `--mcp`, `--cli`.
 
 ```bash
 plexi list                       # list installed apps

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1285,8 +1285,9 @@ impl PlexiApp {
                             self.new_tab(initial_cmd.as_deref(), *ephemeral);
                         } else {
                             let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
-                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                            self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, cwd_override);
+                            let new_pane_first = matches!(layout_str, "split_above" | "split_left");
+                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                            self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, new_pane_first, cwd_override);
                         }
                     } else if let Some(path_str) = path {
                         self.launch_app_by_path_with_layout(path_str, layout.clone());
@@ -1563,8 +1564,9 @@ impl PlexiApp {
             if type_id == "terminal" {
                 let layout_str = layout.as_deref().unwrap_or("split_v");
                 let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
+                let new_pane_first = matches!(layout_str, "split_above" | "split_left");
                 let initial_cmd = cmd_from_args(&args);
-                self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, cwd_override);
+                self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, new_pane_first, cwd_override);
             } else if let Some(ref path_str) = path {
                 self.launch_app_by_path_with_layout(path_str, layout);
             } else {
@@ -2122,13 +2124,14 @@ impl eframe::App for PlexiApp {
                         //   split_focused(true)  → insert_vertical_tile   → stacked (BELOW)
                         // So: split_h/split_right (right) → false, split_v/split_below/split_above (below/above) → true.
                         let vertical = matches!(layout.as_str(), "split_v" | "split_below" | "split_above");
+                        let new_pane_first = matches!(layout.as_str(), "split_above" | "split_left");
                         let initial_cmd = cmd_from_args(&effective_args);
                         log::info!(
-                            "SpawnPane: terminal layout='{layout}' vertical={vertical} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
+                            "SpawnPane: terminal layout='{layout}' vertical={vertical} new_pane_first={new_pane_first} pane_id={new_pane_id} initial_cmd={initial_cmd:?}"
                         );
                         // SDK-spawned terminal with a cmd closes on exit (matches historical behavior).
                         // CLI terminal uses the ephemeral flag exclusively — cmd alone does not close.
-                        self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some(), None);
+                        self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some(), new_pane_first, None);
                     } else {
                         self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args, None);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
@@ -2603,13 +2606,13 @@ impl eframe::App for PlexiApp {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
-                    self.split_focused(false, None, false, None);
+                    self.split_focused(false, None, false, false, None);
                     self.save_workspace();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].zoomed_pane = None;
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
-                    self.split_focused(true, None, false, None);
+                    self.split_focused(true, None, false, false, None);
                     self.save_workspace();
                 }
                 Action::SplitRight => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4041,7 +4041,7 @@ _plexi() {
         terminal)
           _arguments \
             '(-e --ephemeral)'{-e,--ephemeral}'[Close the pane when the process exits]' \
-            '--layout[Layout hint]:layout:(split_h split_right split_v split_below split_above tab new_window)' \
+            '--layout[Layout hint]:layout:(split_h split_left split_right split_v split_below split_above tab new_window)' \
             '--from-pane-id[Split relative to this pane ID]:pane_id:' \
             '--cwd[Working directory for the new terminal pane]:directory:_directories' \
             '--no-focus[Keep focus on the originating pane]'
@@ -4083,7 +4083,7 @@ _plexi() {
           ;;
         open)
           _arguments \
-            '--layout[Layout hint]:layout:(split_h split_right split_v split_below split_above tab new_window overlay)' \
+            '--layout[Layout hint]:layout:(split_h split_left split_right split_v split_below split_above tab new_window overlay)' \
             '--from-pane-id[Split relative to this pane ID]:pane_id:' \
             '--mcp[Wrap stdio MCP server command in mcp-renderer]:cmd:' \
             '--cli[Wrap CLI binary in descriptor-renderer]:binary:_command_names'
@@ -4181,7 +4181,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       ;;
     terminal)
       if [[ $prev == "--layout" ]]; then
-        COMPREPLY=($(compgen -W "split_h split_right split_v split_below split_above tab new_window" -- "$cur"))
+        COMPREPLY=($(compgen -W "split_h split_left split_right split_v split_below split_above tab new_window" -- "$cur"))
       elif [[ $prev == "--cwd" ]]; then
         COMPREPLY=($(compgen -d -- "$cur"))
       else
@@ -4190,7 +4190,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       ;;
     open)
       if [[ $prev == "--layout" ]]; then
-        COMPREPLY=($(compgen -W "split_h split_right split_v split_below split_above tab new_window overlay" -- "$cur"))
+        COMPREPLY=($(compgen -W "split_h split_left split_right split_v split_below split_above tab new_window overlay" -- "$cur"))
       else
         COMPREPLY=($(compgen -W "--layout --from-pane-id --mcp --cli" -- "$cur"))
       fi
@@ -4363,12 +4363,12 @@ complete -c plexi -f -n "__fish_seen_subcommand_from completions" -a "zsh bash f
 
 # terminal flags
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -s e -l ephemeral -d "Close the pane when the process exits"
-complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_h split_right split_v split_below split_above tab new_window"
+complete -c plexi -n "__fish_seen_subcommand_from terminal" -l layout -d "Layout hint" -a "split_h split_left split_right split_v split_below split_above tab new_window"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l from-pane-id -d "Split relative to this pane ID"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l cwd -d "Working directory for the new terminal pane" -a "(__fish_complete_directories)"
 complete -c plexi -n "__fish_seen_subcommand_from terminal" -l no-focus -d "Keep focus on the originating pane"
 # open flags
-complete -c plexi -n "__fish_seen_subcommand_from open" -l layout -d "Layout hint" -a "split_h split_right split_v split_below split_above tab new_window overlay"
+complete -c plexi -n "__fish_seen_subcommand_from open" -l layout -d "Layout hint" -a "split_h split_left split_right split_v split_below split_above tab new_window overlay"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l from-pane-id -d "Split relative to this pane ID"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l mcp -d "Wrap stdio MCP server command in mcp-renderer"
 complete -c plexi -n "__fish_seen_subcommand_from open" -l cli -d "Wrap CLI binary in descriptor-renderer" -a "(__fish_complete_command)"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -158,7 +158,7 @@ pub enum Commands {
         /// Close the pane automatically when the command finishes
         #[arg(long, short = 'e')]
         ephemeral: bool,
-        /// Where to place the new pane: split_h (right), split_v (below), split_right, split_below, split_above, tab, or new_window
+        /// Where to place the new pane: split_h (right), split_left (left), split_v (below), split_right, split_below, split_above, tab, or new_window
         #[arg(long)]
         layout: Option<String>,
         /// Open the new pane relative to this pane ID instead of the focused pane
@@ -189,7 +189,7 @@ pub enum Commands {
         /// Example: plexi open --cli git
         #[arg(long, value_name = "BINARY", conflicts_with = "mcp")]
         cli: Option<String>,
-        /// Where to place the new pane: split_h (right), split_v (below), split_right, split_below, split_above, tab, or new_window
+        /// Where to place the new pane: split_h (right), split_left (left), split_v (below), split_right, split_below, split_above, tab, or new_window
         #[arg(long)]
         layout: Option<String>,
         /// Open the new pane relative to this pane ID instead of the focused pane

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -60,8 +60,8 @@ impl PlexiApp {
         hint: Option<&str>,
         share: ShareRatio,
     ) -> (PaneId, ShareRatio, bool, bool) {
-        let new_pane_first = matches!(hint, Some("split_above"));
-        let vertical = matches!(hint, Some("split_h") | Some("split_right"));
+        let new_pane_first = matches!(hint, Some("split_above") | Some("split_left"));
+        let vertical = matches!(hint, Some("split_h") | Some("split_right") | Some("split_left"));
         let placement = if vertical {
             Placement::Right
         } else {
@@ -569,11 +569,12 @@ impl PlexiApp {
         if id == "terminal" {
             let layout_str = layout.as_deref().unwrap_or("split_v");
             let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
+            let new_pane_first = matches!(layout_str, "split_above" | "split_left");
             let initial_cmd = if args.is_empty() { None } else { Some(crate::shell::shell_join(args)) };
             log::info!(
-                "SpawnPane: terminal layout='{layout_str}' vertical={vertical} initial_cmd={initial_cmd:?}"
+                "SpawnPane: terminal layout='{layout_str}' vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?}"
             );
-            self.split_focused(vertical, initial_cmd.as_deref(), false, None);
+            self.split_focused(vertical, initial_cmd.as_deref(), false, new_pane_first, None);
             return;
         }
 
@@ -905,7 +906,7 @@ impl PlexiApp {
                 match position {
                     "context-end" => self.open_at_context_end(&cmd, stay_alive),
                     "context-start" => self.open_at_context_start(&cmd, stay_alive),
-                    _ => self.split_focused(false, Some(&cmd), !stay_alive, None),
+                    _ => self.split_focused(false, Some(&cmd), !stay_alive, false, None),
                 }
             }
             true
@@ -995,7 +996,7 @@ impl PlexiApp {
     pub(crate) fn open_at_context_end(&mut self, cmd: &str, stay_alive: bool) {
         let did_insert = self.try_insert_at_root(cmd, false, stay_alive);
         if !did_insert {
-            self.split_focused(false, Some(cmd), !stay_alive, None);
+            self.split_focused(false, Some(cmd), !stay_alive, false, None);
         }
     }
 
@@ -1003,7 +1004,7 @@ impl PlexiApp {
     pub(crate) fn open_at_context_start(&mut self, cmd: &str, stay_alive: bool) {
         let did_insert = self.try_insert_at_root(cmd, true, stay_alive);
         if !did_insert {
-            self.split_focused(false, Some(cmd), !stay_alive, None);
+            self.split_focused(false, Some(cmd), !stay_alive, false, None);
         }
     }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -90,7 +90,8 @@ impl PlexiApp {
             {
                 if linear.dir == split_dir {
                     if let Some(pos) = linear.children.iter().position(|&c| c == split_target) {
-                        linear.children.insert(pos + 1, new_tile);
+                        let insert_pos = if new_pane_first { pos } else { pos + 1 };
+                        linear.children.insert(insert_pos, new_tile);
                         true
                     } else {
                         false
@@ -189,7 +190,7 @@ impl PlexiApp {
         match kind {
             Kind::Terminal => {
                 // Reuse the existing terminal split path.
-                self.split_focused(vertical, None, false, None);
+                self.split_focused(vertical, None, false, false, None);
             }
             Kind::App(manifest_id) => {
                 // Fresh instance of the same app at the requested placement.
@@ -207,7 +208,7 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool, cwd_override: Option<std::path::PathBuf>) {
+    pub(crate) fn split_focused(&mut self, vertical: bool, initial_cmd: Option<&str>, close_on_exit: bool, new_pane_first: bool, cwd_override: Option<std::path::PathBuf>) {
         let old_window_id = self.windows[self.active_window].window_id;
         let old_focus = self.windows[self.active_window].focused_pane;
         let Some(focused) = self.windows[self.active_window].focused_pane else {
@@ -220,7 +221,7 @@ impl PlexiApp {
             HostAction::SplitHorizontal
         };
         let effects = self.submit(cmd);
-        log::debug!("split_focused(vertical={vertical}) effects: {:?}", effects);
+        log::debug!("split_focused(vertical={vertical} new_pane_first={new_pane_first}) effects: {:?}", effects);
         let (new_id, vertical) = effects
             .iter()
             .find_map(|e| match e {
@@ -281,7 +282,8 @@ impl PlexiApp {
             {
                 if linear.dir == split_dir {
                     if let Some(pos) = linear.children.iter().position(|&c| c == split_target) {
-                        linear.children.insert(pos + 1, new_tile);
+                        let insert_pos = if new_pane_first { pos } else { pos + 1 };
+                        linear.children.insert(insert_pos, new_tile);
                         true
                     } else {
                         false
@@ -297,14 +299,15 @@ impl PlexiApp {
         };
 
         if !inserted_as_sibling {
-            let container_tile = if vertical {
-                ctx.tree
-                    .tiles
-                    .insert_vertical_tile(vec![split_target, new_tile])
+            let ordered = if new_pane_first {
+                vec![new_tile, split_target]
             } else {
-                ctx.tree
-                    .tiles
-                    .insert_horizontal_tile(vec![split_target, new_tile])
+                vec![split_target, new_tile]
+            };
+            let container_tile = if vertical {
+                ctx.tree.tiles.insert_vertical_tile(ordered)
+            } else {
+                ctx.tree.tiles.insert_horizontal_tile(ordered)
             };
 
             if let Some(parent_id) = parent {


### PR DESCRIPTION
## Summary

- Adds `split_left` to the layout vocabulary for `plexi terminal --layout split_left` and `plexi open <app> --layout split_left`
- Routes `split_left` through all three terminal dispatch paths (IPC, spawn-queue, SDK SpawnPane) and the app `open_pane_layout` path
- Adds `new_pane_first: bool` param to `split_focused` (5th arg) — all existing callers pass `false`
- Fixes sibling-insertion in both `split_focused` and `split_with_new_pane` to respect `new_pane_first` when focused pane is already inside a matching linear container
- Updates zsh/bash/fish completions, CLI help text, and `skills/plexi-cli/SKILL.md`

## Done When
- `plexi terminal --layout split_left` opens a new pane to the LEFT of the focused pane ✓
- `plexi open <app> --layout split_left` does the same for apps ✓
- Both show up in shell completions ✓

Closes #1430