### PR TITLE
ux(notifications): replace ⌘[ / ⌘] cycle hint with H / L in modal header (#1424)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2667,22 +2667,13 @@ impl PlexiApp {
                             );
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                 if queue_len > 1 {
-                                    // Reversed order because the layout is
-                                    // right-to-left: trailing text first,
-                                    // then combos in reverse, then the
-                                    // position/total label on the far left.
+                                    // RTL layout: L first (rightmost), then H.
                                     crate::widgets::key_chip(
-                                        ui, "]", &self.colors,
+                                        ui, "L", &self.colors,
                                     );
+                                    ui.add_space(4.0);
                                     crate::widgets::key_chip(
-                                        ui, "\u{2318}", &self.colors,
-                                    );
-                                    ui.add_space(8.0);
-                                    crate::widgets::key_chip(
-                                        ui, "[", &self.colors,
-                                    );
-                                    crate::widgets::key_chip(
-                                        ui, "\u{2318}", &self.colors,
+                                        ui, "H", &self.colors,
                                     );
                                     ui.add_space(8.0);
                                     ui.label(


### PR DESCRIPTION
## Summary

Replace the four `key_chip` calls rendering `⌘[` / `⌘]` in the notification modal queue-position header with two chips: `H` and `L`.

## Changes

- `src/overlays.rs`: replace the four `⌘`, `[`, `⌘`, `]` chip calls with `L`, `add_space(4.0)`, `H` (RTL order so renders as `H  L` left-to-right)

## Done When

Notification modal header shows `1 of N  ·  cycle  H  L` instead of `1 of N  ·  cycle  ⌘[ ⌘]`.

Closes #1424