### PR TITLE
feat(scheduler): workspace-scoped routines — shell commands on schedule (#1098)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -194,6 +194,7 @@ pub struct PlexiApp {
     pub(crate) pty_event_rx: mpsc::Receiver<(u64, PtyEvent)>,
     pub(crate) pty_event_tx: mpsc::Sender<(u64, PtyEvent)>,
     pub(crate) last_notify_poll: std::time::Instant,
+    pub(crate) scheduler: crate::scheduler::Scheduler,
     pub(crate) theme: TerminalTheme,
     pub(crate) colors: Colors,
     pub(crate) default_font_size: f32,
@@ -736,6 +737,7 @@ impl PlexiApp {
                     pane_focus_future: Vec::new(),
                     navigating_history: false,
                     last_notify_poll: std::time::Instant::now(),
+                    scheduler: crate::scheduler::Scheduler::new(),
                     host,
                     host_services: crate::host::services::HostServices::new(),
                     background_apps: HashMap::new(),
@@ -854,6 +856,7 @@ impl PlexiApp {
             pane_focus_future: Vec::new(),
             navigating_history: false,
             last_notify_poll: std::time::Instant::now(),
+            scheduler: crate::scheduler::Scheduler::new(),
             host: crate::host::model::HostModel::new(),
             host_services: crate::host::services::HostServices::new(),
             background_apps: HashMap::new(),
@@ -902,6 +905,7 @@ impl PlexiApp {
             pty_event_rx: rx,
             pty_event_tx: tx,
             last_notify_poll: std::time::Instant::now(),
+            scheduler: crate::scheduler::Scheduler::new(),
             theme: theme::terminal_theme(&theme_cfg),
             colors,
             default_font_size: theme::FONT_SIZE,
@@ -1533,6 +1537,70 @@ impl PlexiApp {
         }
     }
 
+    fn tick_scheduler(&mut self) {
+        // Load routines from every context that has a root set
+        let roots: Vec<std::path::PathBuf> = self.router.iter()
+            .filter_map(|ctx| ctx.root.clone())
+            .collect();
+        for root in &roots {
+            self.scheduler.load_from_root(root);
+        }
+
+        let now = chrono::Local::now();
+        let due = self.scheduler.due_routines(now);
+        for idx in due {
+            let (name, command, context_name, ephemeral) = {
+                let entry = &self.scheduler.entries[idx];
+                (
+                    entry.routine.name.clone(),
+                    entry.routine.command.clone(),
+                    entry.routine.context.clone(),
+                    entry.routine.ephemeral,
+                )
+            };
+            self.scheduler.mark_fired(idx, now);
+            self.fire_routine(&name, &command, &context_name, ephemeral);
+        }
+    }
+
+    fn fire_routine(&mut self, name: &str, command: &str, context_name: &str, ephemeral: bool) {
+        log::info!("scheduler: routine '{}' fired context='{}' ephemeral={}", name, context_name, ephemeral);
+
+        // Find target context index
+        let target_ctx_idx = if context_name.is_empty() {
+            self.router.active_idx()
+        } else {
+            match self.router.position(|c| c.name == context_name) {
+                Some(idx) => idx,
+                None => {
+                    log::warn!("scheduler: routine '{}' — context '{}' not found, skipping", name, context_name);
+                    return;
+                }
+            }
+        };
+
+        let original_ctx_idx = self.router.active_idx();
+        let original_active_win = self.active_window;
+
+        // Temporarily switch to target context's window if different from current
+        if target_ctx_idx != original_ctx_idx {
+            self.router.set_active(target_ctx_idx);
+            let target_ctx_id = self.router.get(target_ctx_idx).context_id;
+            if let Some(win_idx) = self.windows.iter().position(|w| w.context_id == target_ctx_id) {
+                self.active_window = win_idx;
+            }
+        }
+
+        let cwd = self.router.get(target_ctx_idx).root.clone();
+        self.split_focused(false, Some(command), ephemeral, cwd);
+
+        // Restore original context
+        if target_ctx_idx != original_ctx_idx {
+            self.router.set_active(original_ctx_idx);
+            self.active_window = original_active_win;
+        }
+    }
+
     fn drain_spawn_queue(&mut self) {
         let queue_dir = crate::config::config_dir().join("spawn-queue");
         let Ok(entries) = std::fs::read_dir(&queue_dir) else {
@@ -1914,6 +1982,7 @@ impl eframe::App for PlexiApp {
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             self.last_notify_poll = std::time::Instant::now();
             self.drain_spawn_queue();
+            self.tick_scheduler();
             self.tick_notification_timeouts();
         }
         self.drain_pane_cmd_channel();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -184,6 +184,130 @@ pub fn run_command(command_name: &str) -> i32 {
     }
 }
 
+// ── plexi routine subcommands ─────────────────────────────────────────────────
+
+const ROUTINES_FILE: &str = ".plexi/routines.toml";
+
+/// Parsed `.plexi/routines.toml` for CLI use
+#[derive(serde::Deserialize)]
+struct RoutinesCliConfig {
+    #[serde(default)]
+    routine: Vec<RoutineCliDef>,
+}
+
+#[derive(serde::Deserialize)]
+struct RoutineCliDef {
+    name: String,
+    command: String,
+    schedule: String,
+    #[serde(default)]
+    context: String,
+    #[serde(default)]
+    ephemeral: bool,
+}
+
+/// `plexi routine list` — list routines from .plexi/routines.toml
+pub fn routine_list() -> i32 {
+    log::info!("cli: routine list");
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: could not determine current directory: {e}"); return 1; }
+    };
+    let config_path = cwd.join(ROUTINES_FILE);
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("No routines configured.");
+            println!();
+            println!("To set up routines, create {} in your project:", ROUTINES_FILE);
+            println!("  [[routine]]");
+            println!("  name = \"morning-sync\"");
+            println!("  command = \"./scripts/morning.sh\"");
+            println!("  schedule = \"weekdays at 9am\"");
+            println!("  context = \"work\"");
+            return 0;
+        }
+        Err(e) => { eprintln!("error: could not read {}: {e}", config_path.display()); return 1; }
+    };
+    let config: RoutinesCliConfig = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => { eprintln!("error: failed to parse {ROUTINES_FILE}: {e}"); return 1; }
+    };
+    if config.routine.is_empty() {
+        println!("No routines defined in {ROUTINES_FILE}.");
+        return 0;
+    }
+    println!("Routines:");
+    for r in &config.routine {
+        let next = match crate::scheduler::parse_schedule(&r.schedule) {
+            Some(s) => crate::scheduler::next_fire_description(&s, None),
+            None => "invalid schedule".to_string(),
+        };
+        let ctx_label = if r.context.is_empty() { "(active context)".to_string() } else { r.context.clone() };
+        let ephemeral_label = if r.ephemeral { " [ephemeral]" } else { "" };
+        println!("  {:20} {:<30} next: {}  context: {}{}",
+            r.name, r.schedule, next, ctx_label, ephemeral_label);
+    }
+    0
+}
+
+/// `plexi routine run <name>` — manually fire a routine
+pub fn routine_run(name: &str) -> i32 {
+    log::info!("cli: routine run '{name}'");
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: could not determine current directory: {e}"); return 1; }
+    };
+    let config_path = cwd.join(ROUTINES_FILE);
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("error: no {ROUTINES_FILE} found in {}", cwd.display());
+            return 1;
+        }
+        Err(e) => { eprintln!("error: could not read {}: {e}", config_path.display()); return 1; }
+    };
+    let config: RoutinesCliConfig = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => { eprintln!("error: failed to parse {ROUTINES_FILE}: {e}"); return 1; }
+    };
+    let routine = match config.routine.iter().find(|r| r.name == name) {
+        Some(r) => r,
+        None => {
+            eprintln!("error: routine '{name}' not found in {ROUTINES_FILE}");
+            if !config.routine.is_empty() {
+                let names: Vec<&str> = config.routine.iter().map(|r| r.name.as_str()).collect();
+                eprintln!("Available routines: {}", names.join(", "));
+            }
+            return 1;
+        }
+    };
+
+    // Spawn via spawn-queue as a terminal pane
+    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
+        eprintln!("error: could not create spawn queue: {e}");
+        return 1;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let payload = serde_json::json!({
+        "type_id": "terminal",
+        "args": [routine.command.clone()],
+        "ephemeral": routine.ephemeral,
+        "no_focus": false,
+    });
+    let file = queue_dir.join(format!("{ts}.json"));
+    if let Err(e) = std::fs::write(&file, payload.to_string()) {
+        eprintln!("error: could not write spawn request: {e}");
+        return 1;
+    }
+    println!("queued: run routine '{name}' — command: {}", routine.command);
+    0
+}
+
 // ── plexi workspace subcommands (issue #322) ──────────────────────────────────
 
 /// `plexi workspace init` — scaffold `.plexi/workspace.toml` (UUID) and

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -227,6 +227,14 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: ConfigCmd,
     },
+    /// Manage workspace routines — scheduled shell commands.
+    ///
+    /// Routines are declared in `.plexi/routines.toml` and run automatically on schedule.
+    /// Use `plexi routine list` to see configured routines, or `plexi routine run <name>` to fire one manually.
+    Routine {
+        #[command(subcommand)]
+        cmd: RoutineCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -527,4 +535,15 @@ pub enum ConfigCmd {
     ///
     /// Creates a backup at config.toml.bak before overwriting.
     Reset,
+}
+
+#[derive(Subcommand)]
+pub enum RoutineCmd {
+    /// List routines defined in .plexi/routines.toml with their schedule and next fire time.
+    List,
+    /// Manually trigger a named routine from .plexi/routines.toml.
+    Run {
+        /// Name of the routine to run
+        name: String,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ mod secrets;
 mod secrets_app;
 mod workspace_router;
 mod workspace_secrets;
+mod scheduler;
 mod shell;
 mod minimap;
 mod sidebar;
@@ -204,7 +205,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd};
+    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -217,6 +218,10 @@ fn main() -> eframe::Result {
                     },
                     Commands::Workspace { cmd } => match cmd {
                         WorkspaceCmd::Init => std::process::exit(cli::workspace_init()),
+                    },
+                    Commands::Routine { cmd } => match cmd {
+                        RoutineCmd::List => std::process::exit(cli::routine_list()),
+                        RoutineCmd::Run { name } => std::process::exit(cli::routine_run(&name)),
                     },
                     Commands::Secret { cmd } => match cmd {
                         SecretCmd::Set { friendly_name, from_env, global } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,6 +595,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "context",
         "completions",
         "config",
+        "routine",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,438 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const ROUTINES_FILE: &str = ".plexi/routines.toml";
+
+/// Parsed `.plexi/routines.toml`
+#[derive(Deserialize, Default)]
+pub(crate) struct RoutinesConfig {
+    #[serde(default)]
+    pub routine: Vec<Routine>,
+}
+
+#[derive(Deserialize, Clone)]
+pub(crate) struct Routine {
+    pub name: String,
+    pub command: String,
+    pub schedule: String,
+    #[serde(default)]
+    pub context: String,
+    #[serde(default)]
+    pub ephemeral: bool,
+}
+
+#[derive(Clone)]
+pub(crate) enum ParsedSchedule {
+    /// Run every N seconds
+    Interval { secs: u64 },
+    /// Run when this cron expression matches (checked at minute-level)
+    Cron(CronExpr),
+}
+
+#[derive(Clone)]
+pub(crate) struct CronExpr {
+    pub minute: CronField,
+    pub hour: CronField,
+    pub day_of_month: CronField,
+    pub month: CronField,
+    pub day_of_week: CronField,
+}
+
+#[derive(Clone)]
+pub(crate) enum CronField {
+    Any,
+    Single(u32),
+    Range(u32, u32),
+    List(Vec<u32>),
+}
+
+pub(crate) struct SchedulerEntry {
+    pub routine: Routine,
+    pub schedule: ParsedSchedule,
+    pub last_fire: Option<chrono::DateTime<chrono::Local>>,
+}
+
+pub(crate) struct Scheduler {
+    pub entries: Vec<SchedulerEntry>,
+    /// Per-workspace-root → last loaded entries (avoid re-parsing every tick)
+    loaded_roots: HashMap<PathBuf, std::time::Instant>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        Self { entries: Vec::new(), loaded_roots: HashMap::new() }
+    }
+
+    /// Load (or reload) routines from `root/.plexi/routines.toml`.
+    /// Called once per context root. Re-reads if not yet loaded or file changed.
+    pub fn load_from_root(&mut self, root: &Path) {
+        let path = root.join(ROUTINES_FILE);
+        if !path.exists() {
+            return;
+        }
+        // Only reload every 60 seconds per root
+        if let Some(last) = self.loaded_roots.get(root) {
+            if last.elapsed().as_secs() < 60 {
+                return;
+            }
+        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("scheduler: failed to read {}: {e}", path.display());
+                return;
+            }
+        };
+        let config: RoutinesConfig = match toml::from_str(&contents) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("scheduler: failed to parse {}: {e}", path.display());
+                return;
+            }
+        };
+        // Remove old entries from this root (they may have been re-configured)
+        // For simplicity: remove all entries whose routine names are in the new config,
+        // then re-add them. Since we don't track source root per entry, just reload all.
+        // This is fine — routines.toml is small.
+        let new_names: std::collections::HashSet<&str> = config.routine.iter().map(|r| r.name.as_str()).collect();
+        self.entries.retain(|e| !new_names.contains(e.routine.name.as_str()));
+        let count = config.routine.len();
+        for routine in config.routine {
+            let schedule = match parse_schedule(&routine.schedule) {
+                Some(s) => s,
+                None => {
+                    log::warn!("scheduler: routine '{}' has unparseable schedule '{}', skipping", routine.name, routine.schedule);
+                    continue;
+                }
+            };
+            self.entries.push(SchedulerEntry { routine, schedule, last_fire: None });
+        }
+        self.loaded_roots.insert(root.to_path_buf(), std::time::Instant::now());
+        log::info!("scheduler: loaded {count} routines from {}", path.display());
+    }
+
+    /// Check which routines are due. Returns their indices.
+    pub fn due_routines(&mut self, now: chrono::DateTime<chrono::Local>) -> Vec<usize> {
+        let mut due = Vec::new();
+        for (i, entry) in self.entries.iter().enumerate() {
+            if is_due(&entry.schedule, now, entry.last_fire.as_ref()) {
+                due.push(i);
+            }
+        }
+        due
+    }
+
+    pub fn mark_fired(&mut self, idx: usize, now: chrono::DateTime<chrono::Local>) {
+        if let Some(entry) = self.entries.get_mut(idx) {
+            entry.last_fire = Some(now);
+        }
+    }
+}
+
+fn is_due(schedule: &ParsedSchedule, now: chrono::DateTime<chrono::Local>, last_fire: Option<&chrono::DateTime<chrono::Local>>) -> bool {
+    match schedule {
+        ParsedSchedule::Interval { secs } => {
+            match last_fire {
+                None => true,
+                Some(lf) => (now - *lf).num_seconds() >= *secs as i64,
+            }
+        }
+        ParsedSchedule::Cron(expr) => {
+            if !cron_matches(expr, &now) {
+                return false;
+            }
+            // Only fire once per minute matching the expression
+            match last_fire {
+                None => true,
+                Some(lf) => {
+                    use chrono::Timelike;
+                    // Different minute than last fire
+                    let now_min = now.with_second(0).and_then(|t| t.with_nanosecond(0));
+                    let lf_min = lf.with_second(0).and_then(|t| t.with_nanosecond(0));
+                    match (now_min, lf_min) {
+                        (Some(n), Some(l)) => n != l,
+                        _ => true,
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn cron_matches(expr: &CronExpr, now: &chrono::DateTime<chrono::Local>) -> bool {
+    use chrono::{Datelike, Timelike};
+    let minute = now.minute();
+    let hour = now.hour();
+    let day = now.day();
+    let month = now.month();
+    // chrono: weekday().num_days_from_monday() gives 0=Mon..6=Sun; cron 1=Mon..7=Sun
+    let weekday = now.weekday().num_days_from_monday() + 1;
+    field_matches(&expr.minute, minute)
+        && field_matches(&expr.hour, hour)
+        && field_matches(&expr.day_of_month, day)
+        && field_matches(&expr.month, month)
+        && field_matches(&expr.day_of_week, weekday)
+}
+
+fn field_matches(field: &CronField, value: u32) -> bool {
+    match field {
+        CronField::Any => true,
+        CronField::Single(n) => *n == value,
+        CronField::Range(a, b) => value >= *a && value <= *b,
+        CronField::List(vals) => vals.contains(&value),
+    }
+}
+
+/// Parse a schedule string into a `ParsedSchedule`.
+/// Returns `None` if the string cannot be parsed.
+pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
+    let s = s.trim();
+
+    // "every 30m" / "every 2h" / "every 5s"
+    if let Some(rest) = s.strip_prefix("every ").or_else(|| s.strip_prefix("Every ")) {
+        let rest = rest.trim();
+        if let Some(n_str) = rest.strip_suffix('m') {
+            let n: u64 = n_str.trim().parse().ok()?;
+            return Some(ParsedSchedule::Interval { secs: n * 60 });
+        }
+        if let Some(n_str) = rest.strip_suffix('h') {
+            let n: u64 = n_str.trim().parse().ok()?;
+            return Some(ParsedSchedule::Interval { secs: n * 3600 });
+        }
+        if let Some(n_str) = rest.strip_suffix('s') {
+            let n: u64 = n_str.trim().parse().ok()?;
+            return Some(ParsedSchedule::Interval { secs: n });
+        }
+        // "every minute" / "every hour"
+        if rest.eq_ignore_ascii_case("minute") { return Some(ParsedSchedule::Interval { secs: 60 }); }
+        if rest.eq_ignore_ascii_case("hour") { return Some(ParsedSchedule::Interval { secs: 3600 }); }
+        return None;
+    }
+
+    // "daily at 9am" / "daily at 10:30am"
+    if let Some(rest) = s.strip_prefix("daily at ").or_else(|| s.strip_prefix("Daily at ")) {
+        let (hour, minute) = parse_time(rest)?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute: CronField::Single(minute),
+            hour: CronField::Single(hour),
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Any,
+        }));
+    }
+
+    // "weekdays at 9am"
+    if let Some(rest) = s.strip_prefix("weekdays at ").or_else(|| s.strip_prefix("Weekdays at ")) {
+        let (hour, minute) = parse_time(rest)?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute: CronField::Single(minute),
+            hour: CronField::Single(hour),
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Range(1, 5), // Mon-Fri
+        }));
+    }
+
+    // "weekends at 9am"
+    if let Some(rest) = s.strip_prefix("weekends at ").or_else(|| s.strip_prefix("Weekends at ")) {
+        let (hour, minute) = parse_time(rest)?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute: CronField::Single(minute),
+            hour: CronField::Single(hour),
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::List(vec![6, 7]), // Sat-Sun
+        }));
+    }
+
+    // Raw 5-field cron: "0 9 * * 1-5"
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() == 5 {
+        let minute = parse_cron_field(parts[0])?;
+        let hour = parse_cron_field(parts[1])?;
+        let dom = parse_cron_field(parts[2])?;
+        let month = parse_cron_field(parts[3])?;
+        let dow = parse_cron_field_dow(parts[4])?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute,
+            hour,
+            day_of_month: dom,
+            month,
+            day_of_week: dow,
+        }));
+    }
+
+    None
+}
+
+/// Parse "9am", "10pm", "9:30am", "14:00" → (hour_24, minute)
+fn parse_time(s: &str) -> Option<(u32, u32)> {
+    let s = s.trim();
+    // Strip am/pm
+    let (s, pm) = if let Some(stripped) = s.strip_suffix("pm") {
+        (stripped.trim(), true)
+    } else if let Some(stripped) = s.strip_suffix("am") {
+        (stripped.trim(), false)
+    } else {
+        (s, false)
+    };
+    // Try "H:MM"
+    if let Some((h_str, m_str)) = s.split_once(':') {
+        let mut h: u32 = h_str.parse().ok()?;
+        let m: u32 = m_str.parse().ok()?;
+        if pm && h != 12 { h += 12; }
+        if !pm && h == 12 { h = 0; }
+        return Some((h, m));
+    }
+    // Just hour
+    let mut h: u32 = s.parse().ok()?;
+    if pm && h != 12 { h += 12; }
+    if !pm && h == 12 { h = 0; }
+    Some((h, 0))
+}
+
+fn parse_cron_field(s: &str) -> Option<CronField> {
+    if s == "*" { return Some(CronField::Any); }
+    if let Some((a, b)) = s.split_once('-') {
+        let a: u32 = a.parse().ok()?;
+        let b: u32 = b.parse().ok()?;
+        return Some(CronField::Range(a, b));
+    }
+    if s.contains(',') {
+        let vals: Option<Vec<u32>> = s.split(',').map(|v| v.parse().ok()).collect();
+        return Some(CronField::List(vals?));
+    }
+    let n: u32 = s.parse().ok()?;
+    Some(CronField::Single(n))
+}
+
+/// Parse day-of-week field, supporting mon-fri names
+fn parse_cron_field_dow(s: &str) -> Option<CronField> {
+    let s_lower = s.to_lowercase();
+    // Named day ranges like "mon-fri"
+    let day_names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    let s_lo = s_lower.as_str();
+    // Check for named range
+    if let Some((a_str, b_str)) = s_lo.split_once('-') {
+        let a_idx = day_names.iter().position(|&d| d == a_str);
+        let b_idx = day_names.iter().position(|&d| d == b_str);
+        if let (Some(a), Some(b)) = (a_idx, b_idx) {
+            // Convert sun=0 to sun=7 for standard cron (1=Mon..7=Sun)
+            let a = if a == 0 { 7 } else { a as u32 };
+            let b = if b == 0 { 7 } else { b as u32 };
+            return Some(CronField::Range(a, b));
+        }
+    }
+    // Named single day
+    if let Some(idx) = day_names.iter().position(|&d| d == s_lo) {
+        let n = if idx == 0 { 7 } else { idx as u32 };
+        return Some(CronField::Single(n));
+    }
+    // Numeric
+    parse_cron_field(s)
+}
+
+/// Compute human-readable next-fire description for CLI display.
+pub(crate) fn next_fire_description(schedule: &ParsedSchedule, last_fire: Option<&chrono::DateTime<chrono::Local>>) -> String {
+    let now = chrono::Local::now();
+    match schedule {
+        ParsedSchedule::Interval { secs } => {
+            match last_fire {
+                None => format!("in {}s (never fired)", secs),
+                Some(lf) => {
+                    let elapsed = (now - *lf).num_seconds().max(0) as u64;
+                    if elapsed >= *secs {
+                        "now (overdue)".to_string()
+                    } else {
+                        let remaining = secs - elapsed;
+                        if remaining >= 3600 {
+                            format!("in {}h {}m", remaining / 3600, (remaining % 3600) / 60)
+                        } else if remaining >= 60 {
+                            format!("in {}m {}s", remaining / 60, remaining % 60)
+                        } else {
+                            format!("in {}s", remaining)
+                        }
+                    }
+                }
+            }
+        }
+        ParsedSchedule::Cron(expr) => {
+            // Find the next minute that matches
+            use chrono::Duration;
+            let mut t = now + Duration::minutes(1);
+            for _ in 0..1500 {  // search up to ~24h
+                if cron_matches(expr, &t) {
+                    use chrono::Timelike;
+                    return format!("at {:02}:{:02}", t.hour(), t.minute());
+                }
+                t = t + Duration::minutes(1);
+            }
+            "unknown".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_interval_minutes() {
+        match parse_schedule("every 30m") {
+            Some(ParsedSchedule::Interval { secs: 1800 }) => {}
+            other => panic!("expected Interval(1800), got {:?}", other.as_ref().map(|_| "Some")),
+        }
+    }
+
+    #[test]
+    fn parse_interval_hours() {
+        match parse_schedule("every 2h") {
+            Some(ParsedSchedule::Interval { secs: 7200 }) => {}
+            other => panic!("expected Interval(7200), got {:?}", other.as_ref().map(|_| "Some")),
+        }
+    }
+
+    #[test]
+    fn parse_daily_at() {
+        let s = parse_schedule("daily at 9am").expect("should parse");
+        match s {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.hour, CronField::Single(9)));
+                assert!(matches!(expr.minute, CronField::Single(0)));
+                assert!(matches!(expr.day_of_week, CronField::Any));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn parse_weekdays() {
+        let s = parse_schedule("weekdays at 9am").expect("should parse");
+        match s {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.day_of_week, CronField::Range(1, 5)));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn parse_raw_cron() {
+        let s = parse_schedule("0 9 * * 1-5").expect("should parse");
+        match s {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.minute, CronField::Single(0)));
+                assert!(matches!(expr.hour, CronField::Single(9)));
+                assert!(matches!(expr.day_of_week, CronField::Range(1, 5)));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn parse_invalid_returns_none() {
+        assert!(parse_schedule("garbage schedule").is_none());
+        assert!(parse_schedule("").is_none());
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -51,6 +51,7 @@ pub(crate) struct SchedulerEntry {
     pub routine: Routine,
     pub schedule: ParsedSchedule,
     pub last_fire: Option<chrono::DateTime<chrono::Local>>,
+    pub source_root: PathBuf,
 }
 
 pub(crate) struct Scheduler {
@@ -65,17 +66,21 @@ impl Scheduler {
     }
 
     /// Load (or reload) routines from `root/.plexi/routines.toml`.
-    /// Called once per context root. Re-reads if not yet loaded or file changed.
+    /// Called once per context root. Re-reads if not yet loaded or 60s have passed.
     pub fn load_from_root(&mut self, root: &Path) {
-        let path = root.join(ROUTINES_FILE);
-        if !path.exists() {
-            return;
-        }
-        // Only reload every 60 seconds per root
+        // Cache check first — avoids path.exists() syscall every second
         if let Some(last) = self.loaded_roots.get(root) {
             if last.elapsed().as_secs() < 60 {
                 return;
             }
+        }
+        self.loaded_roots.insert(root.to_path_buf(), std::time::Instant::now());
+
+        let path = root.join(ROUTINES_FILE);
+        if !path.exists() {
+            // Prune any entries that came from this root (file was deleted)
+            self.entries.retain(|e| e.source_root != root);
+            return;
         }
         let contents = match std::fs::read_to_string(&path) {
             Ok(c) => c,
@@ -91,12 +96,15 @@ impl Scheduler {
                 return;
             }
         };
-        // Remove old entries from this root (they may have been re-configured)
-        // For simplicity: remove all entries whose routine names are in the new config,
-        // then re-add them. Since we don't track source root per entry, just reload all.
-        // This is fine — routines.toml is small.
-        let new_names: std::collections::HashSet<&str> = config.routine.iter().map(|r| r.name.as_str()).collect();
-        self.entries.retain(|e| !new_names.contains(e.routine.name.as_str()));
+        // Preserve last_fire for routines that survive the reload (avoid re-firing immediately)
+        let mut last_fires: HashMap<String, Option<chrono::DateTime<chrono::Local>>> = HashMap::new();
+        for e in &self.entries {
+            if e.source_root == root {
+                last_fires.insert(e.routine.name.clone(), e.last_fire);
+            }
+        }
+        // Replace all entries from this root with the freshly parsed set
+        self.entries.retain(|e| e.source_root != root);
         let count = config.routine.len();
         for routine in config.routine {
             let schedule = match parse_schedule(&routine.schedule) {
@@ -106,10 +114,22 @@ impl Scheduler {
                     continue;
                 }
             };
-            self.entries.push(SchedulerEntry { routine, schedule, last_fire: None });
+            let last_fire = last_fires.get(&routine.name).copied().flatten();
+            self.entries.push(SchedulerEntry {
+                routine,
+                schedule,
+                last_fire,
+                source_root: root.to_path_buf(),
+            });
         }
-        self.loaded_roots.insert(root.to_path_buf(), std::time::Instant::now());
         log::info!("scheduler: loaded {count} routines from {}", path.display());
+    }
+
+    /// Remove all entries whose source root is no longer in the active context list.
+    /// Call this when a context is removed or closed.
+    pub fn prune_root(&mut self, root: &Path) {
+        self.entries.retain(|e| e.source_root != root);
+        self.loaded_roots.remove(root);
     }
 
     /// Check which routines are due. Returns their indices.
@@ -329,8 +349,14 @@ fn parse_cron_field_dow(s: &str) -> Option<CronField> {
         let n = if idx == 0 { 7 } else { idx as u32 };
         return Some(CronField::Single(n));
     }
-    // Numeric
-    parse_cron_field(s)
+    // Numeric — normalize 0 to 7 (both mean Sunday; chrono gives 7 for Sunday via num_days_from_monday+1)
+    let field = parse_cron_field(s)?;
+    Some(match field {
+        CronField::Single(0) => CronField::Single(7),
+        CronField::Range(0, b) => CronField::Range(7, b),
+        CronField::Range(a, 0) => CronField::Range(a, 7),
+        other => other,
+    })
 }
 
 /// Compute human-readable next-fire description for CLI display.
@@ -361,7 +387,7 @@ pub(crate) fn next_fire_description(schedule: &ParsedSchedule, last_fire: Option
             // Find the next minute that matches
             use chrono::Duration;
             let mut t = now + Duration::minutes(1);
-            for _ in 0..1500 {  // search up to ~24h
+            for _ in 0..10080 {  // search up to 7 days
                 if cron_matches(expr, &t) {
                     use chrono::Timelike;
                     return format!("at {:02}:{:02}", t.hour(), t.minute());

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -125,13 +125,6 @@ impl Scheduler {
         log::info!("scheduler: loaded {count} routines from {}", path.display());
     }
 
-    /// Remove all entries whose source root is no longer in the active context list.
-    /// Call this when a context is removed or closed.
-    pub fn prune_root(&mut self, root: &Path) {
-        self.entries.retain(|e| e.source_root != root);
-        self.loaded_roots.remove(root);
-    }
-
     /// Check which routines are due. Returns their indices.
     pub fn due_routines(&mut self, now: chrono::DateTime<chrono::Local>) -> Vec<usize> {
         let mut due = Vec::new();


### PR DESCRIPTION
## Summary

- Adds `.plexi/routines.toml` support: declare shell commands with a schedule and target context; the host spawns terminal panes automatically
- Supports human-readable schedules (`every 30m`, `daily at 9am`, `weekdays at 9am`) and raw 5-field cron expressions (`0 9 * * 1-5`)
- `ephemeral = true` closes the pane after the command exits
- CLI: `plexi routine list` shows all routines with next-fire time; `plexi routine run <name>` manually fires a routine via the spawn queue

## Test plan

- [ ] Create a `.plexi/routines.toml` with `schedule = "every 1m"` and confirm a pane appears each minute
- [ ] Set `ephemeral = true` and confirm pane closes after command exits
- [ ] `plexi routine list` shows routines with correct next-fire times
- [ ] `plexi routine run <name>` fires the routine immediately

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)