### PR TITLE
feat(cli): pane capture — strip trailing empty lines by default, add --full-output (#1235)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1376,8 +1376,8 @@ impl PlexiApp {
                         }
                     }
                 }
-                crate::app_protocol::AppRequest::CapturePane { pane_id, lines, response_file } => {
-                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} response_file={:?}", response_file);
+                crate::app_protocol::AppRequest::CapturePane { pane_id, lines, response_file, full_output } => {
+                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} full_output={full_output} response_file={:?}", response_file);
                     let result = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
                         None => {
                             log::warn!("pane_ipc: capture_pane: pane_id={pane_id} not found");
@@ -1388,7 +1388,17 @@ impl PlexiApp {
                                 log::warn!("pane_ipc: capture_pane: pane_id={pane_id} is not a terminal pane");
                                 Err(format!("pane {pane_id} is not a terminal pane"))
                             }
-                            Some(term) => Ok(term.backend.capture_lines(*lines)),
+                            Some(term) => {
+                                let mut captured = term.backend.capture_lines(*lines);
+                                if !full_output {
+                                    let trimmed = captured.iter().rposition(|l| !l.trim().is_empty())
+                                        .map(|pos| pos + 1)
+                                        .unwrap_or(0);
+                                    captured.truncate(trimmed);
+                                    log::info!("pane_ipc: capture_pane: stripped trailing empty lines, result len={}", captured.len());
+                                }
+                                Ok(captured)
+                            }
                         },
                     };
                     let json_str = match result {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1096,6 +1096,9 @@ pub enum AppRequest {
         /// Number of lines to capture from the end of the scrollback.
         lines: usize,
         response_file: String,
+        /// When true, preserve trailing empty lines. Defaults to false (strip them).
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        full_output: bool,
     },
 
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
@@ -2818,15 +2821,27 @@ mod tests {
         let json = r#"{"type":"capture_pane","pane_id":7,"lines":20,"response_file":"capture.json"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Host(AppRequest::CapturePane { pane_id, lines, response_file }) => {
+            DrawCommand::Host(AppRequest::CapturePane { pane_id, lines, response_file, full_output }) => {
                 assert_eq!(*pane_id, 7);
                 assert_eq!(*lines, 20);
                 assert_eq!(response_file, "capture.json");
+                assert!(!full_output, "full_output should default to false");
             }
             other => panic!("expected CapturePane, got {other:?}"),
         }
         let serialised = serde_json::to_string(&cmd).expect("serialise");
         assert!(serialised.contains(r#""type":"capture_pane""#), "wire tag missing: {serialised}");
+        assert!(!serialised.contains("full_output"), "full_output=false should be omitted from wire format: {serialised}");
+
+        // full_output=true should round-trip
+        let json_full = r#"{"type":"capture_pane","pane_id":7,"lines":20,"response_file":"capture.json","full_output":true}"#;
+        let cmd_full: DrawCommand = serde_json::from_str(json_full).expect("deserialise full_output");
+        match &cmd_full {
+            DrawCommand::Host(AppRequest::CapturePane { full_output, .. }) => {
+                assert!(*full_output, "full_output should be true when set");
+            }
+            other => panic!("expected CapturePane, got {other:?}"),
+        }
 
         // Missing required fields must fail
         let bad = r#"{"type":"capture_pane","pane_id":1}"#;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2523,7 +2523,7 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
 /// Reads the last N lines from a pane's PTY scrollback buffer and prints a JSON array
 /// of strings to stdout. If `pane_id` is omitted, defaults to PLEXI_PANE_ID.
 /// Returns 0 on success, 1 on error.
-pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize) -> i32 {
+pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -> i32 {
     let resolved_pane_id = match pane_id {
         Some(id) => id,
         None => match std::env::var("PLEXI_PANE_ID") {
@@ -2547,12 +2547,13 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize) -> i32 {
         .to_string_lossy()
         .into_owned();
 
-    log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} response_file={response_file:?}");
+    log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} full_output={full_output} response_file={response_file:?}");
 
     let code = send_to_socket(serde_json::json!({
         "type": "capture_pane",
         "pane_id": resolved_pane_id,
         "lines": lines,
+        "full_output": full_output,
         "response_file": response_file,
     }));
     if code != 0 {
@@ -4029,7 +4030,7 @@ _plexi() {
         pane)
           case $line[2] in
             capture)
-              _arguments '--lines[Number of lines to read]:lines:'
+              _arguments '--lines[Number of lines to read]:lines:' '--full-output[Preserve trailing empty lines]'
               ;;
             *)
               local subcmds
@@ -4174,7 +4175,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       else
         case "${words[2]}" in
           capture)
-            COMPREPLY=($(compgen -W "--lines" -- "$cur"))
+            COMPREPLY=($(compgen -W "--lines --full-output" -- "$cur"))
             ;;
         esac
       fi
@@ -4321,6 +4322,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a s
 
 # pane capture flags
 complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l lines -d "Number of lines to read"
+complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l full-output -d "Preserve trailing empty lines"
 
 # descriptor subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from descriptor" -a probe -d "Probe a CLI for its Plexi descriptor"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -430,6 +430,9 @@ pub enum PaneCmd {
         /// How many lines to read from the end of the output
         #[arg(long, default_value = "50")]
         lines: usize,
+        /// Preserve trailing empty lines (by default they are stripped)
+        #[arg(long)]
+        full_output: bool,
     },
     /// Send a key press to a pane. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
-                        PaneCmd::Capture { pane_id, lines } => std::process::exit(cli::pane_capture_cli(pane_id, lines)),
+                        PaneCmd::Capture { pane_id, lines, full_output } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output)),
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));


### PR DESCRIPTION
## What

Strip trailing empty lines from `plexi pane capture` output by default. Add `--full-output` flag to preserve them when exact buffer state is needed.

## Why

Terminal scrollback buffers always have empty lines below the cursor. These are noise for the common case (agents monitoring pane state, scripts processing output). The `--full-output` flag provides backward-compat / exact-state reads.

## Changes

- `src/cli_args.rs` — add `--full-output: bool` to `PaneCmd::Capture`
- `src/app_protocol.rs` — add `full_output: bool` (serde default false, skipped when false) to `CapturePane`
- `src/cli.rs` — thread `full_output` through `pane_capture_cli`, include in socket message, update completions (zsh/bash/fish)
- `src/main.rs` — destructure and pass `full_output`
- `src/app/mod.rs` — strip trailing empty lines with `rposition` when `!full_output`

## Done When

- [x] `plexi pane capture --lines 50 <id>` returns only non-empty/content-bearing lines
- [x] `--full-output` preserves trailing empty lines
- [x] Serde round-trip tests pass (full_output defaults false, omitted from wire when false)

Closes #1235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--full-output` flag to `plexi pane capture` command to preserve trailing empty lines in captured terminal output (disabled by default)
  * Updated shell completion scripts to include the new flag option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->