### PR TITLE
feat(notify): persist pending notifications across restarts (#705)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -148,6 +148,38 @@ pub(crate) struct PendingNotification {
     pub deliver_after: Option<std::time::Instant>,
 }
 
+/// Serializable snapshot of a `PendingNotification`. Session-only handles
+/// (`image_pipe_id`, `response_file`, `deliver_after`) are dropped on save and
+/// restored as `None`; `tombstoned` is forced to `true` on load because the
+/// source pane is gone after a restart.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedNotification {
+    notify_id: String,
+    sender_pane_id: u64,
+    source_context_id: u64,
+    level: String,
+    title: String,
+    body: String,
+    kind: crate::app_protocol::NotifyKind,
+    options: Vec<crate::app_protocol::NotifyOption>,
+    #[serde(default)]
+    input_prompt: Option<String>,
+    required: bool,
+    priority: u32,
+    scope: crate::app_protocol::NotifyScope,
+    #[serde(default)]
+    image_inline: Option<crate::app_protocol::NotificationImage>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    on_dismiss: Option<String>,
+    /// Unix timestamp (seconds since UNIX_EPOCH) when the notification was enqueued.
+    enqueued_at_secs: u64,
+    tombstoned: bool,
+    // deliver_after (snooze) is session-only — not persisted.
+    // image_pipe_id and response_file are session handles — not persisted.
+}
+
 /// Render state for a notification's image attachment. Computed once and
 /// cached on `PlexiApp::notification_images` keyed by `notify_id`.
 #[derive(Clone)]
@@ -423,7 +455,130 @@ fn spawn_socket_listener(
     });
 }
 
+// ---------------------------------------------------------------------------
+// Notification persistence helpers
+// ---------------------------------------------------------------------------
+
+/// Write `notifications` to `path` atomically (write temp, then rename).
+/// Called at every mutation site so unread notifications survive restarts.
+pub(crate) fn save_pending_notifications_to(
+    notifications: &[PendingNotification],
+    path: &std::path::Path,
+) {
+    let now_sys = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let persisted: Vec<PersistedNotification> = notifications
+        .iter()
+        .map(|n| {
+            let age_secs = std::time::Instant::now()
+                .duration_since(n.enqueued_at)
+                .as_secs();
+            let enqueued_at_secs = now_sys.saturating_sub(age_secs);
+            PersistedNotification {
+                notify_id: n.notify_id.clone(),
+                sender_pane_id: n.sender_pane_id,
+                source_context_id: n.source_context_id,
+                level: n.level.clone(),
+                title: n.title.clone(),
+                body: n.body.clone(),
+                kind: n.kind.clone(),
+                options: n.options.clone(),
+                input_prompt: n.input_prompt.clone(),
+                required: n.required,
+                priority: n.priority,
+                scope: n.scope,
+                image_inline: n.image_inline.clone(),
+                timeout_secs: n.timeout_secs,
+                on_dismiss: n.on_dismiss.clone(),
+                enqueued_at_secs,
+                tombstoned: n.tombstoned,
+            }
+        })
+        .collect();
+    match serde_json::to_string(&persisted) {
+        Ok(json) => {
+            let tmp = path.with_extension("json.tmp");
+            match std::fs::write(&tmp, &json).and_then(|_| std::fs::rename(&tmp, path)) {
+                Ok(_) => log::info!(
+                    "notify:persist: saved {} notification(s)",
+                    notifications.len()
+                ),
+                Err(e) => log::warn!("notify:persist: failed to write {:?}: {e}", path),
+            }
+        }
+        Err(e) => log::warn!("notify:persist: failed to serialize: {e}"),
+    }
+}
+
+/// Load persisted notifications from `path`. Drops entries older than 7 days.
+/// All restored notifications are tombstoned — their source pane is gone.
+pub(crate) fn load_pending_notifications_from(
+    path: &std::path::Path,
+) -> Vec<PendingNotification> {
+    let Ok(json) = std::fs::read_to_string(path) else {
+        return vec![];
+    };
+    let Ok(persisted) = serde_json::from_str::<Vec<PersistedNotification>>(&json) else {
+        log::warn!("notify:persist: failed to deserialize {:?}", path);
+        return vec![];
+    };
+    let now_sys = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    const TTL_SECS: u64 = 7 * 24 * 3600;
+    let restored: Vec<PendingNotification> = persisted
+        .into_iter()
+        .filter_map(|p| {
+            let age_secs = now_sys.saturating_sub(p.enqueued_at_secs);
+            if age_secs > TTL_SECS {
+                return None;
+            }
+            let enqueued_at = std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(age_secs))
+                .unwrap_or_else(std::time::Instant::now);
+            Some(PendingNotification {
+                notify_id: p.notify_id,
+                sender_pane_id: p.sender_pane_id,
+                source_context_id: p.source_context_id,
+                level: p.level,
+                title: p.title,
+                body: p.body,
+                kind: p.kind,
+                options: p.options,
+                input_prompt: p.input_prompt,
+                required: p.required,
+                priority: p.priority,
+                scope: p.scope,
+                image_inline: p.image_inline,
+                image_pipe_id: None,   // pipe handle gone after restart
+                response_file: None,   // file handle gone after restart
+                timeout_secs: p.timeout_secs,
+                on_dismiss: p.on_dismiss,
+                enqueued_at,
+                tombstoned: true,      // source pane is gone
+                deliver_after: None,   // snooze is session-only
+            })
+        })
+        .collect();
+    log::info!(
+        "notify:persist: restored {} notification(s) from disk",
+        restored.len()
+    );
+    restored
+}
+
 impl PlexiApp {
+    /// Persist current pending notifications to `config_dir()/notifications.json`.
+    pub(crate) fn save_notifications(&self) {
+        save_pending_notifications_to(
+            &self.pending_notifications,
+            &crate::config::config_dir().join("notifications.json"),
+        );
+    }
+
     pub fn new(cc: &eframe::CreationContext<'_>, frame_tick: crate::logging::FrameTick) -> Self {
         #[cfg(target_os = "macos")]
         crate::macos_menu::customize_app_menu();
@@ -715,7 +870,7 @@ impl PlexiApp {
                     text_overlay_browse_rx: None,
                     registry,
                     features: features.clone(),
-                    pending_notifications: Vec::new(),
+                    pending_notifications: load_pending_notifications_from(&crate::config::config_dir().join("notifications.json")),
                     show_notification_modal: false,
                     current_notify_id: None,
                     modal_focused_option: 0,
@@ -834,7 +989,7 @@ impl PlexiApp {
             text_overlay_browse_rx: None,
             registry: AppRegistry::load(&std::env::current_dir().unwrap_or_default()),
             features,
-            pending_notifications: Vec::new(),
+            pending_notifications: load_pending_notifications_from(&crate::config::config_dir().join("notifications.json")),
             show_notification_modal: false,
             current_notify_id: None,
             modal_focused_option: 0,
@@ -1455,6 +1610,7 @@ impl PlexiApp {
                         tombstoned: false,
                         deliver_after: None,
                     });
+                    self.save_notifications();
                     let should_auto_open = !self.notifications_focus_mode
                         && *priority >= self.notifications_interrupt_threshold;
                     if should_auto_open {
@@ -1858,8 +2014,8 @@ impl PlexiApp {
                 self.current_notify_id = self.select_highest_priority();
             }
         }
-        for id in expired_ids {
-            let Some(pos) = self.pending_notifications.iter().position(|n| n.notify_id == id) else {
+        for id in &expired_ids {
+            let Some(pos) = self.pending_notifications.iter().position(|n| &n.notify_id == id) else {
                 continue;
             };
             let n = self.pending_notifications.remove(pos);
@@ -1887,6 +2043,9 @@ impl PlexiApp {
                 self.current_notify_id = None;
             }
         }
+        if !expired_ids.is_empty() {
+            self.save_notifications();
+        }
     }
 
     /// Mark all pending notifications from `pane_id` as tombstoned. Called
@@ -1899,6 +2058,7 @@ impl PlexiApp {
                 log::info!("notification '{}' tombstoned (pane {pane_id} closed)", n.title);
             }
         }
+        self.save_notifications();
     }
 
     /// Count of window- or context-scoped notifications whose source_context_id == the id of ctx_idx.
@@ -2322,6 +2482,7 @@ impl eframe::App for PlexiApp {
                         tombstoned: false,
                         deliver_after: None,
                     });
+                    self.save_notifications();
                     // Auto-open rules:
                     //   1. Visibility — Global always; Window/Context only when
                     //      source_context_id == active context id.
@@ -4065,6 +4226,7 @@ impl PlexiApp {
                 tombstoned: false,
                 deliver_after: None,
             });
+            self.save_notifications();
             if !self.notifications_focus_mode {
                 self.show_notification_modal = true;
                 if self.current_notify_id.is_none() {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -804,3 +804,68 @@ fn create_child_context_auto_zooms() {
     // Depth stack must have one entry (parent pushed).
     assert_eq!(app.router.current_depth(), 1);
 }
+
+#[test]
+fn persist_roundtrip() {
+    let dir = std::env::temp_dir().join(format!("plexi_test_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("notifications.json");
+
+    let n = PendingNotification {
+        notify_id: "test-id".into(),
+        sender_pane_id: 0,
+        source_context_id: 1,
+        level: "info".into(),
+        title: "Test".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        priority: 50,
+        scope: crate::app_protocol::NotifyScope::Global,
+        image_inline: None,
+        image_pipe_id: None,
+        response_file: Some("/tmp/resp".into()),
+        timeout_secs: None,
+        on_dismiss: None,
+        enqueued_at: std::time::Instant::now(),
+        tombstoned: false,
+        deliver_after: None,
+    };
+
+    save_pending_notifications_to(&[n], &path);
+    let restored = load_pending_notifications_from(&path);
+
+    assert_eq!(restored.len(), 1);
+    assert_eq!(restored[0].notify_id, "test-id");
+    assert_eq!(restored[0].title, "Test");
+    assert!(restored[0].tombstoned, "restored notification must be tombstoned");
+    assert!(restored[0].response_file.is_none(), "response_file must be cleared on restore");
+    assert!(restored[0].image_pipe_id.is_none(), "image_pipe_id must be cleared on restore");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn persist_ttl_drops_old_notifications() {
+    let dir = std::env::temp_dir().join(format!("plexi_test_ttl_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("notifications.json");
+
+    let now_sys = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let eight_days_ago = now_sys.saturating_sub(8 * 24 * 3600);
+    let json = format!(
+        r#"[{{"notify_id":"old","sender_pane_id":0,"source_context_id":1,"level":"info","title":"Old","body":"","kind":"message","options":[],"required":false,"priority":0,"scope":"global","enqueued_at_secs":{},"tombstoned":false}}]"#,
+        eight_days_ago
+    );
+    std::fs::write(&path, json).unwrap();
+
+    let restored = load_pending_notifications_from(&path);
+    assert!(restored.is_empty(), "notification older than 7 days must be dropped");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2750,6 +2750,7 @@ impl PlexiApp {
                                     {
                                         self.pending_notifications
                                             .retain(|x| x.notify_id != current_id);
+                                        self.save_notifications();
                                         self.current_notify_id = None;
                                         if !n.notify_id.is_empty()
                                             && !n.notify_id.starts_with("__host__:")
@@ -3173,6 +3174,7 @@ impl PlexiApp {
             if !is_snooze {
                 // Real answer: remove from queue and deliver NotifyAction to app.
                 self.pending_notifications.retain(|n| n.notify_id != current_id);
+                self.save_notifications();
                 cmds.push(cmd);
             }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -363,6 +363,7 @@ impl PlexiApp {
             !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
                 && n.source_context_id == ws_id)
         });
+        self.save_notifications();
         if let Some(ref id) = self.current_notify_id.clone() {
             let still_present = self.pending_notifications.iter().any(|n| &n.notify_id == id);
             if !still_present {


### PR DESCRIPTION
## Summary

- Serializes `pending_notifications` to `config_dir/notifications.json` on every mutation (push, dismiss, tombstone, timeout)
- Restores persisted notifications on startup via `PlexiApp::new()` — both the workspace-restore and default paths
- Restored notifications are tombstoned (source pane is gone), session handles cleared (`response_file`, `image_pipe_id`, `deliver_after`)
- Notifications older than 7 days are dropped on load (TTL filter)
- Atomic write (write `.json.tmp` → rename) prevents corrupt state from partial writes

## Done When

1. Unread notification on close → reappears in panel on next launch ✓
2. Dismissed notification → does not reappear ✓ (removed from vec before save)
3. Tombstoned notification → reappears with "Source ended" label ✓ (tombstoned=true on restore)
4. Notifications older than 7 days are dropped on load ✓ (TTL filter)
5. `cargo test` green ✓

## Test plan

- [ ] Send a notification via `plexi notify "Test" "body"`, leave it unread, quit and relaunch — verify it reappears tombstoned in the panel
- [ ] Send a notification, dismiss it, quit and relaunch — verify it does not reappear
- [ ] Verify `cargo test` passes (two new tests: `persist_roundtrip`, `persist_ttl_drops_old_notifications`)