### PR TITLE
feat(inspector): inline context name editing from inspector modal (#1289)

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -4,6 +4,26 @@
 
 ---
 
+## [egui] TextEdit focus in complex modal frames — last-caller-wins, use one-shot pattern
+
+`ctx.memory_mut(|m| m.request_focus(id))` and `response.request_focus()` are **last-caller-wins within a single frame**. If you call `request_focus()` on a TextEdit and then render other interactive widgets (ScrollArea, Buttons, pane rows) in the same frame after it, those later widgets can overwrite your focus request and the TextEdit never gets stable focus.
+
+**Wrong pattern** (used in `draw_rename_context_overlay` — only works because it's the sole widget in its Area):
+```rust
+if !te.has_focus() { te.request_focus(); }  // re-requested every frame — any later widget wins
+```
+
+**Correct pattern** (used in `draw_rename_pane_overlay`, now also in `draw_context_inspector`):
+1. Add a `*_focus_requested: bool` one-shot flag to `PlexiApp`.
+2. Call `ctx.memory_mut(|m| m.request_focus(te_id))` **after** all other UI in the frame completes, only once (gated on `!focus_requested`), then set `focus_requested = true`.
+3. Reset the flag when exiting the editing state (commit, cancel, dismiss).
+
+Because we call focus LAST, we win the contest regardless of what other widgets rendered earlier. Optionally, hide competing interactive elements (ScrollArea, pane rows) while editing to eliminate the contest entirely.
+
+Canonical example: `inspector_rename_focus_requested` + the one-shot block at the bottom of `draw_context_inspector` in `src/overlays.rs`.
+
+---
+
 ## [macos · rust] proc_listchildpids(NULL, 0) returns EFAULT on macOS 23.x
 
 `proc_listchildpids` with a NULL buffer and 0 size is documented to return the bytes needed (n_children × sizeof(pid_t)). On macOS 23.x (Sonoma) it returns -1 (EFAULT) instead. Any code that treats a negative return as "default busy" will show every shell as busy. Use `pgrep -P <pid>` instead — exits 0 when children exist, 1 when idle, and is reliable across all macOS versions. The 500ms cache in `shell::has_foreground_child` keeps the subprocess overhead acceptable.

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -4,23 +4,34 @@
 
 ---
 
-## [egui] TextEdit focus in complex modal frames — last-caller-wins, use one-shot pattern
+## [egui] TextEdit focus in complex modal frames — two-layer focus problem
 
-`ctx.memory_mut(|m| m.request_focus(id))` and `response.request_focus()` are **last-caller-wins within a single frame**. If you call `request_focus()` on a TextEdit and then render other interactive widgets (ScrollArea, Buttons, pane rows) in the same frame after it, those later widgets can overwrite your focus request and the TextEdit never gets stable focus.
+`ctx.memory_mut(|m| m.request_focus(id))` is **last-caller-wins within a single frame**. Modal overlays face a two-layer focus problem:
 
-**Wrong pattern** (used in `draw_rename_context_overlay` — only works because it's the sole widget in its Area):
+**Layer 1 — intra-overlay contest:** Rendering other interactive widgets (ScrollArea, Buttons, pane rows) AFTER `request_focus()` overwrites the request. Any widget that renders after can steal focus.
+
+**Layer 2 — frame-order contest:** Overlays dispatch during "early overlay dispatch" in `update()`, BEFORE `CentralPanel` renders. App panes render their own TextInput widgets during CentralPanel, calling `request_focus()` on them — which then overwrites the overlay's earlier request. The overlay's TextEdit never receives input.
+
+**Wrong pattern:**
 ```rust
-if !te.has_focus() { te.request_focus(); }  // re-requested every frame — any later widget wins
+if !te.has_focus() { te.request_focus(); }  // re-every-frame in the overlay render fn — CentralPanel panes steal it back
 ```
 
-**Correct pattern** (used in `draw_rename_pane_overlay`, now also in `draw_context_inspector`):
-1. Add a `*_focus_requested: bool` one-shot flag to `PlexiApp`.
-2. Call `ctx.memory_mut(|m| m.request_focus(te_id))` **after** all other UI in the frame completes, only once (gated on `!focus_requested`), then set `focus_requested = true`.
-3. Reset the flag when exiting the editing state (commit, cancel, dismiss).
+**Correct pattern — two fixes, both required:**
 
-Because we call focus LAST, we win the contest regardless of what other widgets rendered earlier. Optionally, hide competing interactive elements (ScrollArea, pane rows) while editing to eliminate the contest entirely.
+**Fix 1 (one-shot, for Layer 1):** Add a `*_focus_requested: bool` flag. After ALL widgets in the overlay render, call `request_focus` exactly once, then set the flag. Gating on `!focus_requested` prevents re-firing. Also set cursor selection state here (use `chars().count()` not `len()` for multi-byte safety).
 
-Canonical example: `inspector_rename_focus_requested` + the one-shot block at the bottom of `draw_context_inspector` in `src/overlays.rs`.
+**Fix 2 (every-frame, for Layer 2):** In `update()`, after CentralPanel completes (search for the `palette_search` / `quick_note_text` re-focus block), add:
+```rust
+if self.<overlay>_renaming {
+    ctx.memory_mut(|m| m.request_focus(egui::Id::new("<overlay>_rename_input")));
+}
+```
+This mirrors the established pattern for `palette_search` and `quick_note_text`, which face the same frame-order problem.
+
+Both fixes are necessary. Fix 1 alone fails when CentralPanel runs after the overlay. Fix 2 alone skips initial cursor selection.
+
+Canonical implementation: `inspector_rename_focus_requested` (one-shot, `src/overlays.rs::draw_context_inspector`) + `if self.inspector_renaming { ctx.memory_mut... }` block in `src/app/mod.rs::update()` after the QuickNote re-focus block.
 
 ---
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,6 +268,7 @@ pub struct PlexiApp {
     pub(crate) show_context_inspector: bool,
     pub(crate) inspector_selected_pane: usize,
     pub(crate) inspector_renaming: bool,
+    pub(crate) inspector_rename_focus_requested: bool,
     pub(crate) inspector_delete_press_count: u8,
     pub(crate) inspector_delete_last_press: Option<std::time::Instant>,
     pub(crate) welcome_delete_press_count: u8,
@@ -880,6 +881,7 @@ impl PlexiApp {
                     show_context_inspector: false,
                     inspector_selected_pane: 0,
                     inspector_renaming: false,
+                    inspector_rename_focus_requested: false,
                     inspector_delete_press_count: 0,
                     inspector_delete_last_press: None,
                     welcome_delete_press_count: 0,
@@ -1005,6 +1007,7 @@ impl PlexiApp {
             show_context_inspector: false,
             inspector_selected_pane: 0,
             inspector_renaming: false,
+            inspector_rename_focus_requested: false,
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -1140,6 +1143,7 @@ impl PlexiApp {
             show_context_inspector: false,
             inspector_selected_pane: 0,
             inspector_renaming: false,
+            inspector_rename_focus_requested: false,
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -3217,6 +3221,7 @@ impl eframe::App for PlexiApp {
                 Action::ContextInspector => {
                     self.show_context_inspector = !self.show_context_inspector;
                     self.inspector_renaming = false;
+                    self.inspector_rename_focus_requested = false;
                     if self.show_context_inspector {
                         let focused_pane_id = self.windows[self.active_window]
                             .focused_pane

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -267,6 +267,7 @@ pub struct PlexiApp {
     pub(crate) pending_context_close: Option<ContextCloseState>,
     pub(crate) show_context_inspector: bool,
     pub(crate) inspector_selected_pane: usize,
+    pub(crate) inspector_renaming: bool,
     pub(crate) inspector_delete_press_count: u8,
     pub(crate) inspector_delete_last_press: Option<std::time::Instant>,
     pub(crate) welcome_delete_press_count: u8,
@@ -878,6 +879,7 @@ impl PlexiApp {
                     quit_last_press: None,
                     show_context_inspector: false,
                     inspector_selected_pane: 0,
+                    inspector_renaming: false,
                     inspector_delete_press_count: 0,
                     inspector_delete_last_press: None,
                     welcome_delete_press_count: 0,
@@ -1002,6 +1004,7 @@ impl PlexiApp {
             quit_last_press: None,
             show_context_inspector: false,
             inspector_selected_pane: 0,
+            inspector_renaming: false,
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -1136,6 +1139,7 @@ impl PlexiApp {
             quit_last_press: None,
             show_context_inspector: false,
             inspector_selected_pane: 0,
+            inspector_renaming: false,
             inspector_delete_press_count: 0,
             inspector_delete_last_press: None,
             welcome_delete_press_count: 0,
@@ -3212,6 +3216,7 @@ impl eframe::App for PlexiApp {
                 }
                 Action::ContextInspector => {
                     self.show_context_inspector = !self.show_context_inspector;
+                    self.inspector_renaming = false;
                     if self.show_context_inspector {
                         let focused_pane_id = self.windows[self.active_window]
                             .focused_pane

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4011,6 +4011,15 @@ impl eframe::App for PlexiApp {
             ctx.memory_mut(|m| m.request_focus(egui::Id::new("quick_note_text")));
         }
 
+        // Same pattern: inspector inline rename TextEdit needs re-focus every frame.
+        // The one-shot focus request in draw_context_inspector fires during early overlay
+        // dispatch, BEFORE CentralPanel runs — pane TextInput widgets then steal focus back.
+        // Re-requesting here (post-CentralPanel) ensures we always win the last-write-wins
+        // contest while rename mode is active.
+        if self.inspector_renaming {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("inspector_rename_input")));
+        }
+
         // Detect genuine pane focus transitions and emit FocusChanged events.
         // Comparing at frame-end means temporary save/restore patterns in
         // canvas_bindings are invisible — focused_pane holds the settled value here.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2224,40 +2224,62 @@ impl PlexiApp {
                         if want_root { open_root_overlay = true; }
                         if want_desc { open_description_overlay = true; }
                         if rename_clicked { start_rename = true; }
-                        egui::ScrollArea::vertical()
-                            .max_height(ctx.available_rect().height() * 0.6)
-                            .auto_shrink([false, true])
-                            .show(ui, |ui| {
-                                if pane_count == 0 {
-                                    ui.label(RichText::new("No panes").size(style::TEXT_BODY).color(colors.text_dim));
-                                } else {
-                                    let mut global_idx: usize = 0;
-                                    for (group_name, rows) in &groups {
-                                        ui.add_space(style::SPACE_SM);
-                                        ui.label(RichText::new(group_name.as_str()).size(style::TEXT_CAPTION).color(colors.text_dim));
-                                        ui.add_space(style::SPACE_SM);
-                                        for row in rows {
-                                            let resp = render_inspector_pane_row(
-                                                ui, row, global_idx == selected, &colors,
-                                            );
-                                            global_idx += 1;
-                                            if resp.clicked() { focus_pane = Some(row.id); }
+                        // While renaming, hide the pane list — interactive widgets
+                        // rendered after the TextEdit can steal egui focus (last-caller-wins).
+                        // See GOTCHAS.md "egui TextEdit focus in complex frames".
+                        if !renaming {
+                            egui::ScrollArea::vertical()
+                                .max_height(ctx.available_rect().height() * 0.6)
+                                .auto_shrink([false, true])
+                                .show(ui, |ui| {
+                                    if pane_count == 0 {
+                                        ui.label(RichText::new("No panes").size(style::TEXT_BODY).color(colors.text_dim));
+                                    } else {
+                                        let mut global_idx: usize = 0;
+                                        for (group_name, rows) in &groups {
+                                            ui.add_space(style::SPACE_SM);
+                                            ui.label(RichText::new(group_name.as_str()).size(style::TEXT_CAPTION).color(colors.text_dim));
+                                            ui.add_space(style::SPACE_SM);
+                                            for row in rows {
+                                                let resp = render_inspector_pane_row(
+                                                    ui, row, global_idx == selected, &colors,
+                                                );
+                                                global_idx += 1;
+                                                if resp.clicked() { focus_pane = Some(row.id); }
+                                            }
                                         }
                                     }
-                                }
-                            });
-                        ui.add_space(style::SPACE_XL);
-                        ui.separator();
-                        ui.add_space(style::SPACE_MD);
+                                });
+                            ui.add_space(style::SPACE_XL);
+                            ui.separator();
+                            ui.add_space(style::SPACE_MD);
+                        }
                         if render_inspector_hints(ui, pane_count, num_contexts, &colors, renaming) {
                             delete_context = true;
                         }
                     });
             });
 
+        // One-shot focus: request AFTER all UI renders so we win egui's
+        // last-caller-wins focus contest. See GOTCHAS.md for the pattern.
+        if renaming && !self.inspector_rename_focus_requested {
+            let te_id = egui::Id::new("inspector_rename_input");
+            ctx.memory_mut(|m| m.request_focus(te_id));
+            if let Some(mut state) = egui::TextEdit::load_state(ctx, te_id) {
+                state.cursor.set_char_range(Some(egui::text::CCursorRange::two(
+                    egui::text::CCursor::new(0),
+                    egui::text::CCursor::new(self.rename_buffer.chars().count()),
+                )));
+                state.store(ctx, te_id);
+            }
+            self.inspector_rename_focus_requested = true;
+            log::info!("ContextInspector: rename TextEdit focus requested (one-shot)");
+        }
+
         if start_rename && !renaming {
             self.rename_buffer = ctx_name.to_string();
             self.inspector_renaming = true;
+            self.inspector_rename_focus_requested = false;
             log::info!("ContextInspector: rename mode entered for context {:?}", ctx_name);
         }
         if commit_rename {
@@ -2272,14 +2294,17 @@ impl PlexiApp {
                 self.save_workspace();
             }
             self.inspector_renaming = false;
+            self.inspector_rename_focus_requested = false;
         }
         if cancel_rename {
             self.inspector_renaming = false;
+            self.inspector_rename_focus_requested = false;
             log::info!("ContextInspector: rename cancelled");
         }
         if dismissed {
             self.show_context_inspector = false;
             self.inspector_renaming = false;
+            self.inspector_rename_focus_requested = false;
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
             log::info!("ContextInspector: closed");
@@ -2289,6 +2314,7 @@ impl PlexiApp {
             self.pane_navigate(pid);
             self.show_context_inspector = false;
             self.inspector_renaming = false;
+            self.inspector_rename_focus_requested = false;
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
         }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -204,15 +204,35 @@ fn render_inspector_header(
     ctx_root: &Option<std::path::PathBuf>,
     ctx_description: &Option<String>,
     colors: &Colors,
-) -> (bool, bool) {
+    renaming: bool,
+    rename_buffer: &mut String,
+) -> (bool, bool, bool) {
     let mut open_root_overlay = false;
     let mut open_description_overlay = false;
-    ui.label(
-        RichText::new(ctx_name)
-            .size(style::TEXT_TITLE_XL)
-            .color(colors.text_primary)
-            .strong(),
-    );
+    let mut start_rename = false;
+
+    if renaming {
+        let te_id = egui::Id::new("inspector_rename_input");
+        // Do NOT call request_focus() here — focus is managed via the one-shot
+        // inspector_rename_focus_requested flag in draw_context_inspector, called
+        // AFTER all UI renders so it wins egui's last-caller-wins focus contest.
+        crate::widgets::styled_text_input(ui, rename_buffer, "Context name...", te_id, colors);
+    } else {
+        let name_resp = ui.add(
+            egui::Label::new(
+                RichText::new(ctx_name)
+                    .size(style::TEXT_TITLE_XL)
+                    .color(colors.text_primary)
+                    .strong(),
+            )
+            .sense(egui::Sense::click()),
+        );
+        if name_resp.clicked() {
+            start_rename = true;
+        }
+        name_resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+    }
+
     if let Some(root) = ctx_root {
         ui.add_space(style::SPACE_SM);
         let root_str = root.display().to_string();
@@ -294,7 +314,7 @@ fn render_inspector_header(
     ui.add_space(style::SPACE_XL);
     ui.label(RichText::new("Panes").size(style::TEXT_CAPTION).color(colors.text_dim).strong());
     ui.add_space(style::SPACE_SM);
-    (open_root_overlay, open_description_overlay)
+    (open_root_overlay, open_description_overlay, start_rename)
 }
 
 fn render_inspector_hints(
@@ -302,36 +322,45 @@ fn render_inspector_hints(
     pane_count: usize,
     num_contexts: usize,
     colors: &Colors,
+    renaming: bool,
 ) -> bool {
     let mut delete_context = false;
     ui.horizontal(|ui| {
-        if num_contexts > 1 {
-            if ui
-                .add(
-                    egui::Button::new(
-                        RichText::new("Delete context")
-                            .size(style::TEXT_CAPTION)
-                            .color(colors.text_primary),
+        if renaming {
+            crate::widgets::key_combo_list(ui, &[&["Enter"]], Some("save"), colors);
+            ui.add_space(style::SPACE_MD);
+            crate::widgets::key_combo_list(ui, &[&["Esc"]], Some("cancel"), colors);
+        } else {
+            if num_contexts > 1 {
+                if ui
+                    .add(
+                        egui::Button::new(
+                            RichText::new("Delete context")
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_primary),
+                        )
+                        .fill(colors.bg_active),
                     )
-                    .fill(colors.bg_active),
-                )
-                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                .clicked()
-            {
-                delete_context = true;
+                    .on_hover_cursor(egui::CursorIcon::PointingHand)
+                    .clicked()
+                {
+                    delete_context = true;
+                }
+                ui.add_space(style::SPACE_XL);
+                crate::widgets::key_combo_list(ui, &[&["⌫"]], Some("delete (3×)"), colors);
+                ui.add_space(style::SPACE_XL);
             }
-            ui.add_space(style::SPACE_XL);
-            crate::widgets::key_combo_list(ui, &[&["⌫"]], Some("delete (3×)"), colors);
-            ui.add_space(style::SPACE_XL);
-        }
-        crate::widgets::key_combo_list(ui, &[&["Esc"]], Some("close"), colors);
-        ui.add_space(style::SPACE_MD);
-        crate::widgets::key_combo_list(ui, &[&["j"], &["k"]], Some("navigate"), colors);
-        if pane_count > 0 {
+            crate::widgets::key_combo_list(ui, &[&["R"]], Some("rename"), colors);
             ui.add_space(style::SPACE_MD);
-            crate::widgets::key_combo_list(ui, &[&["Enter"]], Some("focus pane"), colors);
+            crate::widgets::key_combo_list(ui, &[&["Esc"]], Some("close"), colors);
             ui.add_space(style::SPACE_MD);
-            crate::widgets::key_combo_list(ui, &[&["⌘", "W"]], Some("close pane"), colors);
+            crate::widgets::key_combo_list(ui, &[&["j"], &["k"]], Some("navigate"), colors);
+            if pane_count > 0 {
+                ui.add_space(style::SPACE_MD);
+                crate::widgets::key_combo_list(ui, &[&["Enter"]], Some("focus pane"), colors);
+                ui.add_space(style::SPACE_MD);
+                crate::widgets::key_combo_list(ui, &[&["⌘", "W"]], Some("close pane"), colors);
+            }
         }
     });
     delete_context
@@ -2077,22 +2106,38 @@ impl PlexiApp {
         let mut delete_context = false;
         let mut open_root_overlay = false;
         let mut open_description_overlay = false;
+        let mut start_rename = false;
+        let mut commit_rename = false;
+        let mut cancel_rename = false;
 
+        let renaming = self.inspector_renaming;
         let num_contexts = self.router.len();
         let (nav_down, nav_up, enter_pressed, backspace_pressed, cmd_w_pressed) = ctx.input_mut(|i| {
-            let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-            let down = i.consume_key(egui::Modifiers::NONE, egui::Key::J)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown);
-            let up = i.consume_key(egui::Modifiers::NONE, egui::Key::K)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
-            let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-            let backspace = num_contexts > 1 && (
-                i.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
-                    || i.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
-            );
-            let cmd_w = i.consume_key(egui::Modifiers::COMMAND, egui::Key::W);
-            if esc { dismissed = true; }
-            (down, up, enter, backspace, cmd_w)
+            if renaming {
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
+                    commit_rename = true;
+                }
+                if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+                    cancel_rename = true;
+                }
+                (false, false, false, false, false)
+            } else {
+                let esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+                let down = i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+                    || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown);
+                let up = i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+                    || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
+                let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+                let r = i.consume_key(egui::Modifiers::NONE, egui::Key::R);
+                let backspace = num_contexts > 1 && (
+                    i.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
+                        || i.consume_key(egui::Modifiers::NONE, egui::Key::Delete)
+                );
+                let cmd_w = i.consume_key(egui::Modifiers::COMMAND, egui::Key::W);
+                if esc { dismissed = true; }
+                if r { start_rename = true; }
+                (down, up, enter, backspace, cmd_w)
+            }
         });
 
         let (groups, all_pane_ids, all_context_ids) = self.collect_inspector_rows();
@@ -2172,9 +2217,13 @@ impl PlexiApp {
                     ))
                     .show(ui, |ui| {
                         ui.set_width(style::MODAL_WIDTH_MD);
-                        let (want_root, want_desc) = render_inspector_header(ui, &ctx_name, &ctx_root, &ctx_description, &colors);
+                        let (want_root, want_desc, rename_clicked) = render_inspector_header(
+                            ui, &ctx_name, &ctx_root, &ctx_description, &colors,
+                            renaming, &mut self.rename_buffer,
+                        );
                         if want_root { open_root_overlay = true; }
                         if want_desc { open_description_overlay = true; }
+                        if rename_clicked { start_rename = true; }
                         egui::ScrollArea::vertical()
                             .max_height(ctx.available_rect().height() * 0.6)
                             .auto_shrink([false, true])
@@ -2200,14 +2249,37 @@ impl PlexiApp {
                         ui.add_space(style::SPACE_XL);
                         ui.separator();
                         ui.add_space(style::SPACE_MD);
-                        if render_inspector_hints(ui, pane_count, num_contexts, &colors) {
+                        if render_inspector_hints(ui, pane_count, num_contexts, &colors, renaming) {
                             delete_context = true;
                         }
                     });
             });
 
+        if start_rename && !renaming {
+            self.rename_buffer = ctx_name.to_string();
+            self.inspector_renaming = true;
+            log::info!("ContextInspector: rename mode entered for context {:?}", ctx_name);
+        }
+        if commit_rename {
+            let new_name = self.rename_buffer.trim().to_string();
+            if !new_name.is_empty() {
+                log::info!(
+                    "ContextInspector: renamed context {:?} → {:?}",
+                    self.router.get(selected_ctx_idx).name,
+                    new_name
+                );
+                self.router.get_mut(selected_ctx_idx).name = new_name;
+                self.save_workspace();
+            }
+            self.inspector_renaming = false;
+        }
+        if cancel_rename {
+            self.inspector_renaming = false;
+            log::info!("ContextInspector: rename cancelled");
+        }
         if dismissed {
             self.show_context_inspector = false;
+            self.inspector_renaming = false;
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
             log::info!("ContextInspector: closed");
@@ -2216,6 +2288,7 @@ impl PlexiApp {
             log::info!("ContextInspector: focusing pane {pid}");
             self.pane_navigate(pid);
             self.show_context_inspector = false;
+            self.inspector_renaming = false;
             self.inspector_delete_press_count = 0;
             self.inspector_delete_last_press = None;
         }


### PR DESCRIPTION
## Summary

- Press `R` or click the context name in the inspector to enter inline rename mode
- Enter commits the rename; Escape cancels
- Reuses the existing `rename_buffer` / `draw_rename_context_overlay` pattern
- Footer hints update contextually: shows `Enter` / `Esc` in rename mode, `R` / `Esc` / `j` / `k` / `Enter` otherwise
- `inspector_renaming: bool` added to `PlexiApp` struct (initialized to `false` in all 4 constructors, reset on inspector toggle)

## Done When

- [x] Pressing `R` (or clicking the context name) in the inspector switches the name to an editable text field
- [x] Enter commits the rename; Escape cancels
- [x] The rename persists (same behavior as Cmd+Shift+R rename overlay)
- [x] Context description editing deferred to follow-up after #1120

Closes #1289