### PR TITLE
feat(cli): add tips system with config toggle (#1323)

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -226,6 +226,6 @@ medium = "claude --model claude-sonnet-4-6 --dangerously-skip-permissions '{cmd}
 high   = "claude --dangerously-skip-permissions '{cmd}'"
 
 # ── CLI Behavior ───────────────────────────────────────────────
-# [cli]
-# tips = true   # Set to false to suppress contextual tips after CLI commands.
+[cli]
+tips = true   # Set to false to suppress contextual tips after CLI commands.
 

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -225,3 +225,7 @@ low    = "claude --model claude-haiku-4-5 --dangerously-skip-permissions '{cmd}'
 medium = "claude --model claude-sonnet-4-6 --dangerously-skip-permissions '{cmd}'"
 high   = "claude --dangerously-skip-permissions '{cmd}'"
 
+# ── CLI Behavior ───────────────────────────────────────────────
+# [cli]
+# tips = true   # Set to false to suppress contextual tips after CLI commands.
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,17 @@ pub struct CommandDef {
     pub secrets: Vec<String>,
 }
 
+fn print_tip(msg: &str) {
+    let config = crate::config::PlexiConfig::load_with_workspace(
+        crate::config::active_workspace_root().as_deref(),
+    );
+    let enabled = config.cli.as_ref().and_then(|c| c.tips).unwrap_or(true);
+    if enabled {
+        log::info!("cli:tip: {msg}");
+        eprintln!("\x1b[2mtip: {msg}\x1b[0m");
+    }
+}
+
 /// Entry point for `plexi run <command_name>`.
 /// Returns the exit code.
 /// `plexi run` with no argument — list available commands from .plexi/commands.toml.
@@ -176,7 +187,13 @@ pub fn run_command(command_name: &str) -> i32 {
     }
 
     match child_cmd.status() {
-        Ok(status) => status.code().unwrap_or(1),
+        Ok(status) => {
+            let code = status.code().unwrap_or(1);
+            if code == 0 {
+                print_tip("run `plexi run list` to see all available commands.");
+            }
+            code
+        }
         Err(e) => {
             eprintln!("error: failed to spawn command: {e}");
             1
@@ -345,6 +362,7 @@ pub fn workspace_init() -> i32 {
             println!("Initialized workspace at {}", cwd.display());
             println!("  workspace id: {}", cfg.id);
             println!("  router:       .plexi/secrets.toml (fallback = true)");
+            print_tip("define runnable commands in .plexi/commands.toml, then run them with `plexi run <name>`.");
             0
         }
         Err(e) => {
@@ -441,6 +459,7 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
                 Ok(()) => {
                     log::info!("secret_set:cli: stored globally account={account}");
                     eprintln!("Stored '{friendly}' globally (plexi:user:{friendly})");
+                    print_tip("reference secrets in commands.toml under `[secrets] required = [\"...\"]`.");
                     0
                 }
                 Err(e) => {
@@ -475,6 +494,7 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
                     root.display(),
                     cfg.id
                 );
+                print_tip("reference secrets in commands.toml under `[secrets] required = [\"...\"]`.");
                 0
             }
             Err(e) => {
@@ -696,6 +716,7 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 println!("  cd {}", app_dir.display());
                 println!("  cargo build --release");
                 println!("  # then run: plexi app run {}", app_dir.display());
+                print_tip("link your app globally with `plexi app link .` so you can open it from any context.");
             } else {
                 println!("  Run with: plexi app run {}", app_dir.display());
                 // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
@@ -706,6 +727,8 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                     if exit_code != 0 {
                         eprintln!("warning: app created but could not auto-open (exit {exit_code}) — run: plexi app run {}", app_dir.display());
                     }
+                } else {
+                    print_tip("link your app globally with `plexi app link .` so you can open it from any context.");
                 }
             }
             0
@@ -1421,6 +1444,7 @@ pub fn install_cli(spec: &str) -> i32 {
         Ok(outcome) => match outcome.status {
             crate::install::InstallStatus::Installed(path) => {
                 println!("installed '{}' at {}", outcome.id, path.display());
+                print_tip(&format!("open your app with `plexi open {}`.", outcome.id));
                 0
             }
             crate::install::InstallStatus::AlreadyAtVersion => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,11 @@ fn print_tip(msg: &str) {
     let enabled = config.cli.as_ref().and_then(|c| c.tips).unwrap_or(true);
     if enabled {
         log::info!("cli:tip: {msg}");
-        eprintln!("\x1b[2mtip: {msg}\x1b[0m");
+        if std::env::var_os("NO_COLOR").is_none() {
+            eprintln!("\x1b[2mtip: {msg}\x1b[0m");
+        } else {
+            eprintln!("tip: {msg}");
+        }
     }
 }
 
@@ -190,7 +194,7 @@ pub fn run_command(command_name: &str) -> i32 {
         Ok(status) => {
             let code = status.code().unwrap_or(1);
             if code == 0 {
-                print_tip("run `plexi run list` to see all available commands.");
+                print_tip("run `plexi run` to see all available commands.");
             }
             code
         }
@@ -716,7 +720,7 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 println!("  cd {}", app_dir.display());
                 println!("  cargo build --release");
                 println!("  # then run: plexi app run {}", app_dir.display());
-                print_tip("link your app globally with `plexi app link .` so you can open it from any context.");
+                print_tip("install your app globally with `plexi app install .` so you can open it from any context.");
             } else {
                 println!("  Run with: plexi app run {}", app_dir.display());
                 // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
@@ -728,7 +732,7 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                         eprintln!("warning: app created but could not auto-open (exit {exit_code}) — run: plexi app run {}", app_dir.display());
                     }
                 } else {
-                    print_tip("link your app globally with `plexi app link .` so you can open it from any context.");
+                    print_tip("install your app globally with `plexi app install .` so you can open it from any context.");
                 }
             }
             0

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,9 +35,10 @@ impl std::fmt::Display for ConfigDiagnostic {
 const KNOWN_TOP_LEVEL: &[&str] = &[
     "font_size", "theme_preset", "theme", "beta", "log",
     "notifications", "ai", "confirm_quit", "confirm_close",
-    "keybindings", "quick_note", "focus_history_depth", "agents",
+    "keybindings", "quick_note", "focus_history_depth", "agents", "cli",
 ];
 const KNOWN_AGENTS: &[&str] = &["low", "medium", "high"];
+const KNOWN_CLI: &[&str] = &["tips"];
 const KNOWN_THEME: &[&str] = &[
     "bg_darkest", "bg_sidebar", "bg_toolbar", "terminal_bg", "bg_hover",
     "bg_sidebar_hover", "bg_active", "text_primary", "text_dim",
@@ -121,6 +122,9 @@ pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
             }
             if let Some(toml::Value::Table(t)) = table.get("agents") {
                 check_unknown_keys(t, "agents", KNOWN_AGENTS, &path_str, &mut diags);
+            }
+            if let Some(toml::Value::Table(t)) = table.get("cli") {
+                check_unknown_keys(t, "cli", KNOWN_CLI, &path_str, &mut diags);
             }
         }
     }
@@ -282,6 +286,14 @@ pub struct PlexiConfig {
     pub quick_note: Option<QuickNoteConfig>,
     pub focus_history_depth: Option<usize>,
     pub agents: Option<AgentsConfig>,
+    pub cli: Option<CliConfig>,
+}
+
+/// CLI behavior configuration.
+#[derive(Deserialize, Default, Clone)]
+pub struct CliConfig {
+    /// Print contextual tips after CLI commands. Default: `true`. Set to `false` to suppress.
+    pub tips: Option<bool>,
 }
 
 /// Plexi AI broker configuration (`ai.query` capability).


### PR DESCRIPTION
Adds a git-style hints system that prints contextual tips to stderr after key CLI commands.

## What changed
- `src/config.rs` — added `CliConfig { tips: Option<bool> }`, wired into `PlexiConfig`, added `[cli]` to validation
- `src/cli.rs` — added `print_tip()` helper (loads config, prints dim ANSI tip to stderr), added 5 tips to key commands
- `scripts/default-config.toml` — added commented `[cli]` section

## Tips added
- `plexi run <name>` → "run `plexi run list` to see all available commands."
- `plexi workspace init` → "define runnable commands in .plexi/commands.toml..."
- `plexi app init` → "link your app globally with `plexi app link .`..."
- `plexi secret set` → "reference secrets in commands.toml under `[secrets] required`..."
- `plexi app install` → "open your app with `plexi open <id>`."

## Done when
1. `plexi run <name>` prints a contextual tip after execution (when tips enabled) ✓
2. `plexi config check` shows `[cli]` section as valid ✓
3. Setting `tips = false` in config.toml suppresses all tips ✓
4. Tips print to stderr (not stdout) ✓

Closes #1323