### PR TITLE
docs(sdk): keyboard conventions and SelectList guidance (#242)

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,3 +1,105 @@
 # plexi-sdk
 
 Python SDK for building Plexi apps via the PGAP v3 protocol.
+
+Full API reference: `plexi_sdk/__init__.py` docstring.
+
+---
+
+## Keyboard Conventions
+
+Apps should follow these standard navigation bindings so users get consistent behavior across all Plexi apps.
+
+### Key name strings
+
+Keys arrive in `on_key(ctx, key, mods)` as **lowercase canonical strings**:
+
+| Physical key | `key` string |
+|---|---|
+| Enter / Return | `"return"` |
+| Escape | `"escape"` |
+| Backspace | `"backspace"` |
+| Tab | `"tab"` |
+| Space | `"space"` |
+| Arrow keys | `"up"` / `"down"` / `"left"` / `"right"` |
+
+The SDK normalizes egui's internal key names automatically. Always match against
+the lowercase canonical strings — `key == "return"`, not `key == "Enter"`.
+
+### Focus / modal conventions
+
+| Action | Key |
+|---|---|
+| Open item / confirm / select | `"return"` |
+| Exit focused view / go back | `"escape"` |
+| Exit focused view (fallback) | `"backspace"` (optional second binding) |
+
+Any view that opens a focused sub-view (detail panel, modal, inline editor) must
+let the user exit with `"escape"`. No view should be a dead end.
+
+**TextInput exception:** `"return"` fires `on_text_submitted`, so the TextInput
+widget owns that key while focused. `"escape"` should still dismiss the
+surrounding view or cancel the input mode.
+
+```python
+def on_key(self, ctx, key, mods):
+    if self.detail_open:
+        if key in ("escape", "backspace"):
+            self.detail_open = False
+            return
+        if key == "return":
+            self._confirm()
+            return
+    # list navigation below
+```
+
+### List navigation
+
+Standard bindings for any scrollable list:
+
+| Key | Action |
+|---|---|
+| `j` / `"down"` | Move selection down |
+| `k` / `"up"` | Move selection up |
+| `"return"` | Open selected item |
+| `"escape"` | Exit list / go back |
+
+---
+
+## List + Detail Views
+
+For any app with a list-and-detail pattern, prefer `SelectList` from
+`plexi_sdk.ui` over managing selection state manually. It handles j/k/arrow
+navigation, scroll-to-keep-selected-visible, and click hit-testing.
+
+```python
+from plexi_sdk import App
+from plexi_sdk.ui import SelectList, Column
+
+class MyApp(App):
+    async def on_init(self, ctx):
+        self.items = [{"name": "Alpha"}, {"name": "Beta"}, {"name": "Gamma"}]
+        self.list = SelectList(self.items)  # stateful — create once, not per frame
+        self.detail_open = False
+
+    def on_key(self, ctx, key, mods):
+        if self.detail_open:
+            if key in ("escape", "backspace"):
+                self.detail_open = False
+            return
+        if key == "return":
+            self.detail_open = True
+            return
+        self.list.handle_key(key)  # handles j/k/up/down
+
+    def on_render(self, ctx):
+        if self.detail_open:
+            ctx.text(20, 40, self.items[self.list.selected_idx]["name"])
+        else:
+            ctx.draw(Column([self.list.render(self.items)]))
+```
+
+`SelectList` is stateful — create it in `on_init`, not `on_render`.
+
+For the lower-level `ctx.list_view()` primitive (draw only, no state) see the
+`ListItem` shape in the API reference.

--- a/sdk/python/SKILL.md
+++ b/sdk/python/SKILL.md
@@ -1,0 +1,35 @@
+---
+skill_version: "0.0.440"
+description: SDK guidance for building Plexi Python apps — conventions, gotchas, and patterns to follow when writing or reviewing SDK app code.
+---
+
+# Plexi SDK — Agent Guidance
+
+This file is a stub for accumulating SDK-level guidance. Expand it when new
+patterns are established or when a recurring mistake is worth preventing.
+
+## Key Conventions
+
+- Key canonical names are **lowercase**: `"return"`, `"escape"`, `"backspace"`. Never match `"Enter"` or `"Escape"` — the SDK normalizes those from egui's internal names.
+- Enter = open/confirm. Escape (+ optional Backspace) = exit/cancel. Every focused sub-view must be escapable.
+- See `README.md` for the full keyboard conventions table.
+
+## Widget Selection
+
+- For list+detail navigation: use `SelectList` from `plexi_sdk.ui` — it handles j/k/arrow keys, scrolling, and click hit-testing. Never reimplement this by hand.
+- For raw draw-only list: `ctx.list_view()` with `ListItem` dicts.
+- For text entry: `ctx.text_input()` or `widgets.TextInput`. Never read raw keys for text — use `on_text_submitted`.
+
+## State
+
+- Stateful widgets (`SelectList`, `ListView`, `TextArea`, `Keymap`) must be created in `on_init`, not `on_render`. Creating them per frame resets state every render.
+
+## Logging
+
+- Always log at init and key state transitions: `ctx.info(...)` inside a frame, `emit.info(...)` outside.
+- Log escapes and errors: `ctx.warn("app_id: exiting detail view")` on Escape, `ctx.error(...)` on unrecoverable failures.
+
+## Known Gotchas
+
+- `plexi_sdk` is only importable from processes spawned by Plexi. Test by opening the app in a pane, not by running `python3 -c "import plexi_sdk"` in a terminal.
+- SDK proxy wrappers are not auto-generated — check `plexi_sdk/` source for what actually exists before writing code that calls undocumented methods.


### PR DESCRIPTION
## Summary

- Expands `sdk/python/README.md` with a **Keyboard Conventions** section: canonical lowercase key names (`"return"`, `"escape"`, `"backspace"`), Enter-to-open / Escape-to-close convention for focused views, and standard list navigation bindings (j/k/return/escape)
- Documents `SelectList` from `plexi_sdk.ui` as the preferred widget for list+detail views, with a working example
- Creates `sdk/python/SKILL.md` stub for SDK agent guidance covering key conventions, widget selection, state lifecycle, logging, and known gotchas

## Done When

- `sdk/python/README.md` has the Keyboard Conventions section with key name table, focus/modal convention table, and SelectList example
- `sdk/python/SKILL.md` exists with guidance on key names, widget selection, state, logging, and gotchas

Closes #242