### PR TITLE
feat(apps): app startup message in companion terminal on launch (#185)

### DIFF
--- a/examples/startup-message/app.py
+++ b/examples/startup-message/app.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import plexi
+
+emit = plexi.Emitter()
+emit.info("startup-message demo: initialized")
+
+for frame in plexi.frames():
+    with frame.canvas() as canvas:
+        canvas.text(10, 10, "Startup Message Demo", size=18)
+        canvas.text(10, 40, "Check the companion terminal — it should show:", size=13)
+        canvas.text(10, 60, "  Starting Startup Message Demo…", size=13)
+        canvas.text(10, 90, "This message was written by the host on launch", size=11)
+        canvas.text(10, 108, "via [launch] startup_message in manifest.toml.", size=11)

--- a/examples/startup-message/manifest.toml
+++ b/examples/startup-message/manifest.toml
@@ -1,0 +1,13 @@
+schema_version = 1
+
+[app]
+id = "startup-message"
+type = "app"
+name = "Startup Message Demo"
+version = "0.1.0"
+description = "Demo app for issue #185 — shows startup_message in the companion terminal on launch."
+entry = "app.py"
+
+[launch]
+layout_hint = { side = "right", split = 0.4 }
+startup_message = "Starting Startup Message Demo…"

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -223,6 +223,10 @@ pub struct LaunchSection {
     /// regular/full size-class threshold (logical px). None = use SDK default (480).
     #[serde(default)]
     pub regular: Option<f32>,
+    /// Message written into the companion terminal's PTY on launch. Gives the
+    /// user immediate feedback that the app started. Omit to launch silently.
+    #[serde(default)]
+    pub startup_message: Option<String>,
 }
 
 /// Structured layout hint. `side` ∈ {`"right"`, `"below"`, `"overlay"`}.
@@ -635,6 +639,11 @@ impl AppRegistry {
             .get(app_id)
             .map(|a| a.launch.notification_scope.clone().into())
             .unwrap_or(crate::app_protocol::NotifyScope::Window)
+    }
+
+    /// Return the manifest-declared startup message, if any.
+    pub fn startup_message_for(&self, app_id: &str) -> Option<String> {
+        self.apps.get(app_id).and_then(|a| a.launch.startup_message.clone())
     }
 
     /// Check whether an app's declared capabilities are satisfiable by the
@@ -1287,5 +1296,44 @@ notification_scope = \"context\"
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         let scope = registry.default_notification_scope_for("ctx-scoped");
         assert_eq!(scope, crate::app_protocol::NotifyScope::Context);
+    }
+
+    #[test]
+    fn startup_message_round_trips_from_manifest() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("greeter");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"greeter\"
+type = \"app\"
+name = \"Greeter\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+startup_message = \"Starting Greeter…\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert_eq!(
+            registry.startup_message_for("greeter"),
+            Some("Starting Greeter…".to_string())
+        );
+        assert_eq!(registry.startup_message_for("unknown"), None);
+    }
+
+    #[test]
+    fn startup_message_absent_returns_none() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app(global.path(), "silent-app", "Silent App");
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert_eq!(registry.startup_message_for("silent-app"), None);
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -191,6 +191,21 @@ impl PlexiApp {
         }
 
         let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first);
+
+        if let (Some(msg), Some(term_id)) =
+            (self.registry.startup_message_for(app_id), linked_pane_id)
+        {
+            if let Some(term) = self.windows[active]
+                .panes
+                .get_mut(&term_id)
+                .and_then(|p| p.as_terminal_mut())
+            {
+                let quoted = crate::shell::shell_quote(&msg);
+                let cmd = format!("\x15printf '%s\\n' {quoted}\n");
+                term.backend.process_command(BackendCommand::Write(cmd.into_bytes()));
+                log::info!("app::{app_id}: startup message written to terminal pane {term_id}");
+            }
+        }
     }
 
     /// Open a built-in error tile pane when a capability pre-flight check fails.


### PR DESCRIPTION
## Summary

- Adds `startup_message = "..."` to `[launch]` in `manifest.toml`
- On app launch, if a companion terminal is present, the host injects the message via `printf` into the terminal PTY
- Apps without `startup_message` (or launched as root/overlay panes) behave unchanged

## Done when

- `startup_message = "Starting X…"` in an app manifest causes the string to appear in the companion terminal when the app launches
- Apps without `startup_message` launch silently (no regression)
- `registry.startup_message_for()` returns `None` for apps without the field

## Test Plan

- `examples/startup-message/` POC app demonstrates the feature — open from a terminal pane to see the message
- 2 unit tests cover `startup_message_for` round-trip and absence case

Closes #185