### PR TITLE
feat(scratchpad): timestamped per-session notes and CLI browser (#1419)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4053,6 +4053,88 @@ pub fn config_reset() -> i32 {
     }
 }
 
+fn binary_in_path(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).any(|dir| dir.join(name).is_file()))
+        .unwrap_or(false)
+}
+
+/// `plexi notes list` — print paths of all scratchpad notes, newest first.
+pub fn notes_list_cli() -> i32 {
+    let notes_dir = crate::config::config_dir().join("notes");
+    log::info!("notes_list: scanning {:?}", notes_dir);
+    let entries = match std::fs::read_dir(&notes_dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::info!("notes_list: notes dir does not exist yet");
+            return 0;
+        }
+        Err(e) => {
+            eprintln!("error: could not read notes directory: {e}");
+            return 1;
+        }
+    };
+    let mut paths: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |x| x == "md"))
+        .filter_map(|e| {
+            let p = e.path();
+            let mtime = e.metadata().and_then(|m| m.modified()).ok()?;
+            Some((mtime, p))
+        })
+        .collect();
+    paths.sort_by(|a, b| b.0.cmp(&a.0));
+    log::info!("notes_list: found {} notes", paths.len());
+    for (_, path) in &paths {
+        println!("{}", path.display());
+    }
+    0
+}
+
+/// `plexi notes open` — inject fzf note picker into the focused terminal pane.
+///
+/// Falls back to printing the notes directory when PLEXI_SOCKET is unset or fzf is absent.
+pub fn notes_open_cli() -> i32 {
+    let notes_dir = crate::config::config_dir().join("notes");
+    let notes_dir_str = notes_dir.display().to_string();
+
+    let socket_set = std::env::var("PLEXI_SOCKET").is_ok();
+    let fzf_available = binary_in_path("fzf");
+
+    if !socket_set || !fzf_available {
+        if !fzf_available {
+            eprintln!("hint: install fzf (`brew install fzf`) for an interactive picker");
+        }
+        if !socket_set {
+            eprintln!("hint: run inside a Plexi pane for interactive note picking");
+        }
+        println!("{notes_dir_str}");
+        return 0;
+    }
+
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not set — run inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+    let pane_id: u64 = match pane_id_str.parse() {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+            return 1;
+        }
+    };
+
+    let editor = if binary_in_path("micro") { "micro" } else if binary_in_path("nano") { "nano" } else { "vim" };
+    let cmd = format!(
+        "selected=$(ls -t {notes_dir_str}/*.md 2>/dev/null | fzf --header='Select note'); [ -n \"$selected\" ] && {editor} \"$selected\"\r"
+    );
+    log::info!("notes_open: injecting fzf picker into pane {pane_id}");
+    pane_send_cli(pane_id, &cmd)
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     match shell {
         "zsh" => { print!("{}", zsh_completion(binary_name)); 0 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -235,6 +235,14 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: RoutineCmd,
     },
+    /// Browse and open scratchpad notes created with Cmd+Shift+Space.
+    ///
+    /// Each scratchpad session writes a timestamped file to `<config_dir>/notes/`.
+    /// Use `plexi notes list` to print note paths, or `plexi notes open` to pick one with fzf.
+    Notes {
+        #[command(subcommand)]
+        cmd: Option<NotesCmd>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -546,4 +554,15 @@ pub enum RoutineCmd {
         /// Name of the routine to run
         name: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum NotesCmd {
+    /// Print paths of all scratchpad notes, newest first.
+    List,
+    /// Open a note picker with fzf in the focused terminal pane.
+    ///
+    /// Requires fzf to be installed. Falls back to printing the notes directory when fzf
+    /// is not available or PLEXI_SOCKET is not set.
+    Open,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd};
+    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd, NotesCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -490,6 +490,10 @@ fn main() -> eframe::Result {
                         ConfigCmd::Reset => {
                             std::process::exit(cli::config_reset());
                         }
+                    },
+                    Commands::Notes { cmd } => match cmd {
+                        Some(NotesCmd::List) | None => std::process::exit(cli::notes_list_cli()),
+                        Some(NotesCmd::Open) => std::process::exit(cli::notes_open_cli()),
                     },
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,6 +600,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "completions",
         "config",
         "routine",
+        "notes",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -835,6 +835,13 @@ impl PlexiApp {
         };
 
         let path = scratchpad_file();
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::warn!("scratchpad: could not create notes dir {:?}: {e}", parent);
+            } else {
+                log::info!("scratchpad: notes dir {:?} ready", parent);
+            }
+        }
         let path_str = path.display().to_string();
         let escaped = crate::shell::shell_quote(&path_str);
         let editor = preferred_editor();
@@ -1565,9 +1572,11 @@ mod quick_note_tests {
     }
 }
 
-/// Stable scratchpad file path: `<config_dir>/scratchpad.md`.
+/// Timestamped scratchpad file path: `<config_dir>/notes/YYYY-MM-DD_HHMMSS.md`.
 fn scratchpad_file() -> PathBuf {
-    crate::config::config_dir().join("scratchpad.md")
+    use chrono::Local;
+    let timestamp = Local::now().format("%Y-%m-%d_%H%M%S").to_string();
+    crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
 }
 
 /// Resolve the preferred terminal editor: `micro` if available, else `nano`, then `vim`.


### PR DESCRIPTION
## Summary

- Each `Cmd+Shift+Space` press now creates a new `YYYY-MM-DD_HHMMSS.md` file under `<config_dir>/notes/` — no more overwriting the same `scratchpad.md`
- `plexi notes list` prints all note paths sorted newest-first
- `plexi notes open` injects an fzf picker into the focused terminal pane; falls back to printing the notes directory path when fzf is absent or `PLEXI_SOCKET` is unset

Closes #1419

## Done When

- Cmd+Shift+Space opens a new timestamped file in `<config_dir>/notes/` — confirmed by checking the dir after two presses
- `plexi notes list` prints existing note filenames to stdout
- `plexi notes open` (inside a Plexi pane with fzf installed) injects an fzf selector into the focused terminal

## Test plan

- [ ] Press `Cmd+Shift+Space` twice, verify two distinct timestamped files appear in `~/.plexi-pr-<N>/notes/`
- [ ] Run `plexi-pr-<N> notes list` — should print the note paths
- [ ] Run `plexi-pr-<N> notes open` inside a Plexi terminal pane with fzf installed — should inject picker
- [ ] Run `plexi-pr-<N> notes open` outside a Plexi pane — should print notes dir path with hint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `plexi notes` CLI command for managing workspace notes
  * `plexi notes list` displays notes sorted by modification time
  * `plexi notes open` provides an interactive note picker in your terminal
  * Scratchpad now creates timestamped note files in a dedicated notes directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->