### PR TITLE
fix(overlays): prevent terminal panes from stealing egui focus while a modal is open (#1491)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3463,6 +3463,10 @@ impl eframe::App for PlexiApp {
                     map
                 };
 
+                // Computed before the mutable borrow of `ctx` — needed by PlexiBehavior
+                // to prevent terminal panes from stealing egui focus while a modal is open.
+                let modal_open = self.input_captured_by_overlay();
+
                 let ctx = &mut self.windows[self.active_window];
 
                 // Resolve focused_pane if simplifier moved the tile
@@ -3599,6 +3603,7 @@ impl eframe::App for PlexiApp {
                     workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
                     unfocused_opacity,
                     sub_context_info,
+                    modal_open,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -85,6 +85,10 @@ pub struct PlexiBehavior<'a> {
     pub unfocused_opacity: Option<f32>,
     /// Preview data for SubContext tiles.
     pub sub_context_info: HashMap<PaneId, SubContextPreview>,
+    /// True when an overlay or modal has captured keyboard input this frame.
+    /// Prevents terminal panes from calling `request_focus()` and stealing
+    /// egui focus from the active overlay (egui resolves focus last-caller-wins).
+    pub modal_open: bool,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -110,7 +114,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             self.new_focused = Some(tile_id);
         }
 
-        let is_focused = self.focused_tile == Some(tile_id);
+        let is_focused = self.focused_tile == Some(tile_id) && !self.modal_open;
 
         if !is_focused {
             if let Some(opacity) = self.unfocused_opacity {


### PR DESCRIPTION
## Summary

- Adds `modal_open: bool` field to `PlexiBehavior` in `src/tiling.rs`
- Gates `is_focused` on `!self.modal_open` — terminal panes stop calling `request_focus()` while any overlay is active
- Pre-computes `modal_open = self.input_captured_by_overlay()` before the mutable borrow of `ctx` in `src/app/mod.rs` (required for borrow checker)

**Root cause fixed:** `PlexiBehavior` had no awareness of overlay state, so the tiling pass always called `request_focus()` on the focused terminal — which fires *after* the overlay draws, winning egui's last-caller-wins focus resolution every frame.

## Done When
- Opening any text-input overlay (quick note, context description, rename pane, etc.) and typing immediately routes input to the overlay — no focus loss, no keyboard stealing by the background terminal.
- `cargo test --bin plexi` passes (498 tests pass; 7 pre-existing failures unrelated to this change).

Closes #1491