### PR TITLE
fix(app): plexi-logs — ctx.button() for filter chips, ctx.badge() for level labels (#1504)

### DIFF
--- a/examples/logs/logs.py
+++ b/examples/logs/logs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Logs — live tail of ~/.plexi-beta/plexi.log, newest-first, color-coded by level."""
+"""Logs — live tail of the Plexi host log, newest-first, color-coded by level."""
 
 import os
 import re
@@ -9,48 +9,57 @@ from plexi_sdk.ui import (
     BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, YELLOW,
     TEXT_HINT, TEXT_CAPTION,
     SPACE_SM,
-    RADIUS_SM,
 )
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
-LOG_PATH = os.path.expanduser("~/.plexi-beta/plexi.log")
 POLL_MS  = 2_000
 TIMER_ID = "poll"
 
 ROW_H    = 20.0
 BAR_H    = 32.0
-FOOT_H   = 22.0
+FOOT_H   = 24.0
 PAD      = SPACE_SM
+CHIP_W   = 54.0   # fixed-width filter buttons — consistent across all labels
+CHIP_GAP = 4.0
+BADGE_ADV = 44.0  # fixed x-advance after a 4-char badge at 10pt
 
-TIME_W   = 66.0   # "HH:MM:SS" at hint size
-BADGE_W  = 38.0   # "WARN" widest label
-TARGET_W = 150.0
+FILTERS    = ["ALL", "ERROR", "WARN", "INFO", "DEBUG"]
+FILTER_KEY = {"a": 0, "e": 1, "w": 2, "i": 3, "d": 4}
 
-FILTERS = ["ALL", "ERROR", "WARN", "INFO", "DEBUG"]
-
-LEVEL_COLOR: dict[str, str] = {
+# Solid fill colours for ctx.badge() — readable on dark rows
+LEVEL_BADGE_FILL: dict[str, str] = {
     "ERROR": RED,
     "WARN":  YELLOW,
     "INFO":  ACCENT,
-    "DEBUG": MUTED,
-    "TRACE": "#585b70",
+    "DEBUG": "#585b70",
+    "TRACE": "#45475a",
 }
 
-# "#rrggbb33" — 20% alpha tint for badge background
-LEVEL_BG: dict[str, str] = {
-    "ERROR": "#f38ba833",
-    "WARN":  "#f9e2af33",
-    "INFO":  "#89b4fa33",
-    "DEBUG": "#6c708633",
-    "TRACE": "#58597033",
-}
-
-ROW_ALT = "#1a1a2a"   # alternating row tint
+ROW_ALT = "#1a1a2a"
 
 _LOG_RE = re.compile(
     r"^\[(\d{4}-\d{2}-\d{2} (\d{2}:\d{2}:\d{2}))\] \[(\w+)\] \[([^\]]+)\] (.*)$"
 )
+
+# ── Log path detection ─────────────────────────────────────────────────────────
+
+def _detect_log_path() -> str:
+    env = os.environ.get("PLEXI_CONFIG_DIR")
+    if env:
+        return os.path.join(env, "plexi.log")
+    candidates = [
+        os.path.expanduser(p) for p in (
+            "~/.plexi-alpha/plexi.log",
+            "~/.plexi-beta/plexi.log",
+            "~/.plexi/plexi.log",
+        )
+    ]
+    existing = [(os.path.getmtime(p), p) for p in candidates if os.path.exists(p)]
+    return max(existing)[1] if existing else candidates[0]
+
+
+LOG_PATH = _detect_log_path()
 
 # ── Data ───────────────────────────────────────────────────────────────────────
 
@@ -64,7 +73,7 @@ class LogLine:
         self.message = message
 
 
-def _parse(raw: str) -> LogLine | None:
+def _parse(raw: str) -> "LogLine | None":
     m = _LOG_RE.match(raw.rstrip())
     if not m:
         return None
@@ -93,8 +102,10 @@ class LogsApp(App):
         self._filter_idx: int   = 0
         self._scroll:     float = 0.0
         self._viewport_h: float = 400.0
+        ctx.emit.set_mouse_tracking(True)
         ctx.status_summary("Logs")
-        ctx.set_timer(TIMER_ID, 50)   # near-immediate first load
+        ctx.set_timer(TIMER_ID, 50)
+        self.emit.info(f"logs: ready — {LOG_PATH}")
 
     def on_timer(self, ctx: RenderContext, timer_id: str) -> None:
         if timer_id != TIMER_ID:
@@ -104,18 +115,18 @@ class LogsApp(App):
 
     def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
         step = ROW_H * 4
-        if key in ("j", "down", "down"):
+        if key in ("j", "down"):
             self._scroll += step
             self._clamp()
-        elif key in ("k", "up", "up"):
+        elif key in ("k", "up"):
             self._scroll = max(0.0, self._scroll - step)
         elif key == "g":
             self._scroll = 0.0
         elif key == "G":
             self._scroll = 999_999.0
             self._clamp()
-        elif key in ("1", "2", "3", "4", "5"):
-            self._filter_idx = int(key) - 1
+        elif key in FILTER_KEY:
+            self._filter_idx = FILTER_KEY[key]
             self._scroll = 0.0
 
     def _clamp(self) -> None:
@@ -127,7 +138,7 @@ class LogsApp(App):
         level = FILTERS[self._filter_idx]
         if level == "ALL":
             return self._lines
-        return [l for l in self._lines if l.level == level]
+        return [ll for ll in self._lines if ll.level == level]
 
     def on_render(self, ctx: RenderContext) -> None:
         w, h = ctx.w, ctx.h
@@ -141,23 +152,33 @@ class LogsApp(App):
         ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "Logs",
                  size=TEXT_CAPTION, color=FG, bold=True)
 
-        chip_x = 48.0
+        chip_x = 50.0
         for i, label in enumerate(FILTERS):
-            active  = i == self._filter_idx
-            chip_w  = len(label) * 6.5 + PAD * 2
-            chip_bg = ACCENT if active else HIGHLIGHT
-            chip_fg = BG     if active else MUTED
-            ctx.rect(chip_x, 6, chip_w, BAR_H - 12, chip_bg, radius=RADIUS_SM)
-            ctx.text(chip_x + PAD, 6 + (BAR_H - 12) / 2 - TEXT_HINT / 2,
-                     label, size=TEXT_HINT, color=chip_fg, bold=active)
-            chip_x += chip_w + 4
+            active = i == self._filter_idx
+            if ctx.button(
+                f"filter_{i}", chip_x, 5.0, CHIP_W, BAR_H - 10.0, label,
+                fill=ACCENT if active else HIGHLIGHT,
+                hover_fill="#a6c5f5" if active else "#45475a",
+                active_fill="#6ea8f5" if active else "#585b70",
+                text_color=BG if active else MUTED,
+                font_size=12.0,
+                radius=5.0,
+            ):
+                self._filter_idx = i
+                self._scroll = 0.0
+            chip_x += CHIP_W + CHIP_GAP
 
         # ── footer ──────────────────────────────────────────────────────────
         foot_y = h - FOOT_H
         ctx.rect(0, foot_y, w, FOOT_H, SURFACE)
-        ctx.text(PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
-                 f"j/k scroll · g/G top/bottom · 1–5 filter · {len(filtered)} lines",
-                 size=TEXT_HINT, color=MUTED)
+        ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
+            (["a", "e", "w", "i", "d"], "filter"),
+            (["j", "k"], "scroll"),
+            (["g", "G"], "top/btm"),
+        ], font_size=10.0)
+        ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
+                 f"{len(filtered)} lines", size=TEXT_HINT, color=MUTED,
+                 align="right")
 
         # ── log rows ────────────────────────────────────────────────────────
         list_y = BAR_H
@@ -170,38 +191,39 @@ class LogsApp(App):
 
         ctx.push_clip(0, list_y, w, list_h)
 
-        first = int(self._scroll / ROW_H)
-        count = int(list_h / ROW_H) + 2
+        time_w   = 66.0
+        target_w = 140.0
+        first    = int(self._scroll / ROW_H)
+        count    = int(list_h / ROW_H) + 2
 
         for i in range(first, min(first + count, len(filtered))):
-            ll  = filtered[i]
+            ll    = filtered[i]
             row_y = list_y + i * ROW_H - self._scroll
 
-            # alternating stripe
             if i % 2 == 0:
                 ctx.rect(0, row_y, w, ROW_H, ROW_ALT)
 
-            x = PAD
+            x      = PAD
             text_y = row_y + ROW_H / 2 - TEXT_HINT / 2
 
             # timestamp
             ctx.text(x, text_y, ll.time,
                      size=TEXT_HINT, color=MUTED, monospace=True)
-            x += TIME_W
+            x += time_w
 
-            # level badge
-            lc = LEVEL_COLOR.get(ll.level, MUTED)
-            lb = LEVEL_BG.get(ll.level, "#6c708633")
-            ctx.rect(x, row_y + 3, BADGE_W, ROW_H - 6, lb, radius=RADIUS_SM)
-            ctx.text(x + 4, row_y + 3 + (ROW_H - 6) / 2 - TEXT_HINT / 2,
-                     ll.level[:4], size=TEXT_HINT, color=lc, bold=True, monospace=True)
-            x += BADGE_W + PAD
+            # level badge — solid fill, host-measured, readable at any size
+            badge_fill = LEVEL_BADGE_FILL.get(ll.level, "#45475a")
+            badge_fg   = BG if ll.level in ("ERROR", "WARN", "INFO") else FG
+            ctx.badge(x, row_y + ROW_H / 2, ll.level[:4],
+                      fill=badge_fill, fg=badge_fg,
+                      font_size=10.0, radius=4.0)
+            x += BADGE_ADV
 
             # target
             ctx.text(x, text_y, ll.target,
                      size=TEXT_HINT, color=MUTED,
-                     max_width=TARGET_W, elide=True)
-            x += TARGET_W + PAD
+                     max_width=target_w, elide=True)
+            x += target_w + PAD
 
             # message
             ctx.text(x, text_y, ll.message,
@@ -214,9 +236,9 @@ class LogsApp(App):
         total_h = len(filtered) * ROW_H
         if total_h > list_h and list_h > 0:
             thumb_ratio = list_h / total_h
-            thumb_h = max(20.0, list_h * thumb_ratio)
-            thumb_y = list_y + (self._scroll / total_h) * list_h
-            thumb_y = min(thumb_y, list_y + list_h - thumb_h)
+            thumb_h     = max(20.0, list_h * thumb_ratio)
+            thumb_y     = list_y + (self._scroll / total_h) * list_h
+            thumb_y     = min(thumb_y, list_y + list_h - thumb_h)
             ctx.rect(w - 4, list_y, 4, list_h, HIGHLIGHT)
             ctx.rect(w - 4, thumb_y, 4, thumb_h, MUTED)
 

--- a/examples/logs/manifest.toml
+++ b/examples/logs/manifest.toml
@@ -4,9 +4,13 @@ schema_version = 1
 id = "logs"
 type = "app"
 name = "Logs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Live tail of the Plexi host log, color-coded by level."
 entry = "logs.py"
+mouse_tracking = true
+
+[app.capabilities]
+capabilities = ["fs.read", "timer"]
 
 [launch]
 layout_hint = { side = "right", split = 0.5 }


### PR DESCRIPTION
## Summary
- Filter chips now use `ctx.button()` — hover + click detection, not just keyboard
- Level badges use `ctx.badge()` — solid fill, host-measured (no manual width math, no clipping)
- Letter shortcuts `a/e/w/i/d` replace undiscoverable `1–5` keypresses
- Footer uses `ctx.shortcuts()` for key chip widgets
- `mouse_tracking = true` added to manifest
- Log path auto-detected from `PLEXI_CONFIG_DIR` env or most-recently-modified channel log

## Closes
Fixes #1504

## Test plan
- [ ] Open `plexi-alpha open logs` — chips in toolbar are clickable with mouse
- [ ] Click each chip (ALL/ERROR/WARN/INFO/DEBUG) — filter changes and chip highlights
- [ ] Press `a`, `e`, `w`, `i`, `d` — same filter change via keyboard
- [ ] Scroll log rows — level badges are solid color, text readable at any pane width
- [ ] Footer shows key chip shortcut hints (not plain text)