### PR TITLE
fix(install): resolve bundle path from cargo metadata target dir

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,11 @@ _git_channel() {
 
 channel="${1:-$(_git_channel)}"
 
+# Respect a custom target-dir from .cargo/config.toml or CARGO_TARGET_DIR.
+# Without this, install.sh resolves "target/" relative to CWD and finds a stale
+# bundle when the config points cargo to a shared absolute path.
+TARGET_DIR="${CARGO_TARGET_DIR:-$(cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "target")}"
+
 if [[ "$channel" == "stable" ]]; then
   cap=""
   suffix=""
@@ -35,7 +40,7 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-app_src="target/release/bundle/osx/Plexi.app"
+app_src="$TARGET_DIR/release/bundle/osx/Plexi.app"
 app_dest="/Applications/${display}.app"
 bin_dest="/usr/local/bin/plexi${suffix}"
 profile_dir="$HOME/.plexi${suffix}"


### PR DESCRIPTION
## Summary

- `install.sh` hardcoded `target/release/bundle/osx/Plexi.app` as a relative path
- When `.cargo/config.toml` sets `target-dir` to a shared absolute path, `cargo bundle` writes the bundle there but the script looked in `./target/` relative to CWD
- Result: install picked up the old stale bundle in `worktrees/beta/target/` instead of the freshly built one

## Fix

Derive `TARGET_DIR` from `cargo metadata --format-version 1` (respects `.cargo/config.toml`), with fallback to `CARGO_TARGET_DIR` env var and then `"target"` for repos without a custom target dir.

## Breaks if

`just install` errors with "bundle not found at ..." or installs an outdated binary version after the fix is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability to correctly locate the app bundle regardless of build directory configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->