### PR TITLE
fix(infra): override hardcoded target-dir in release workflow (#1522)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      CARGO_TARGET_DIR: target
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Release workflow fails because `.cargo/config.toml` hardcodes `target-dir` to a local machine path
- Adds `CARGO_TARGET_DIR: target` job-level env var so CI uses a relative path, overriding the local config

Closes #1522

## Test plan
- [ ] Merge to alpha, promote to main, push tag, verify Release workflow succeeds