### PR TITLE
feat(context): context tree rework — unified types, portals, agent spawning, anchors (#1516, #1517, #1518, #1520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Newest releases appear first.
+## [0.0.454] — 2026-05-18
+
+### Changes
 ## [0.0.453] — 2026-05-18
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "0.0.453"
+version = "0.0.454"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "0.0.453"
+version = "0.0.454"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,9 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-app_src="target/release/bundle/osx/Plexi.app"
+# Resolve target-dir from .cargo/config.toml (worktrees share a single target/).
+_target_dir="$(cargo metadata --format-version=1 --no-deps 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "target")"
+app_src="${_target_dir}/release/bundle/osx/Plexi.app"
 app_dest="/Applications/${display}.app"
 bin_dest="/usr/local/bin/plexi${suffix}"
 profile_dir="$HOME/.plexi${suffix}"

--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -654,6 +654,15 @@
                 "null"
               ]
             },
+            "target_context": {
+              "description": "When set, spawn the pane into this child context instead of the\nrequesting app's own context. The target context must exist and be\na descendant of the requesting app's context (#1518).",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "type": {
               "const": "spawn_pane",
               "type": "string"
@@ -973,6 +982,25 @@
           },
           "required": [
             "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Query the rolled-up `ContextState` for a context (#1518).\nThe requesting app must be in an ancestor (or the same) context.\nHost responds with `PlexiEvent::ContextStateResponse`.",
+          "properties": {
+            "context_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": {
+              "const": "query_context_state",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "context_id"
           ],
           "type": "object"
         },
@@ -1889,6 +1917,63 @@
           ],
           "type": "object"
         },
+        "ContextState": {
+          "description": "Rolled-up status for a single context. Stub for lib target.",
+          "properties": {
+            "active_agents": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "children": {
+              "items": {
+                "$ref": "#/$defs/ContextState"
+              },
+              "type": "array"
+            },
+            "context_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "label": {
+              "type": "string"
+            },
+            "pane_count": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_summaries": {
+              "items": {
+                "$ref": "#/$defs/PaneSummary"
+              },
+              "type": "array"
+            },
+            "status": {
+              "$ref": "#/$defs/ContextStatus"
+            }
+          },
+          "required": [
+            "context_id",
+            "label",
+            "pane_count",
+            "active_agents",
+            "status",
+            "pane_summaries",
+            "children"
+          ],
+          "type": "object"
+        },
+        "ContextStatus": {
+          "enum": [
+            "Idle",
+            "Working",
+            "Error",
+            "Done"
+          ],
+          "type": "string"
+        },
         "MidiPortWire": {
           "description": "On-the-wire shape of one MIDI port. Mirrors `midi::MidiPortInfo` but lives\non the protocol surface so SDKs in other languages can map it without\ndepending on the midi module.",
           "properties": {
@@ -1936,6 +2021,35 @@
           "enum": [
             "primary",
             "secondary"
+          ],
+          "type": "string"
+        },
+        "PaneSummary": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "pane_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "$ref": "#/$defs/PaneSummaryStatus"
+            }
+          },
+          "required": [
+            "pane_id",
+            "label",
+            "status"
+          ],
+          "type": "object"
+        },
+        "PaneSummaryStatus": {
+          "enum": [
+            "Idle",
+            "Active",
+            "Error"
           ],
           "type": "string"
         },
@@ -2450,6 +2564,23 @@
           "required": [
             "type",
             "reason"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Response to `AppRequest::QueryContextState` (#1518).",
+          "properties": {
+            "state": {
+              "$ref": "#/$defs/ContextState"
+            },
+            "type": {
+              "const": "context_state_response",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "state"
           ],
           "type": "object"
         },

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -85,6 +85,7 @@ class App:
         on_app_spawned(pane_id, type_id)             — app spawn succeeded
         on_pane_spawned(pane_id, request_id)         — pane spawn succeeded
         on_pane_spawn_error(reason, request_id)      — pane spawn failed
+        on_context_state(state)                      — context state query result
         on_midi_input_opened(pipe_id, port_id, port_name) — MIDI input opened
 
     Task handlers are dispatched as asyncio tasks — the event loop does not
@@ -221,6 +222,14 @@ class App:
 
     def on_pane_spawn_error(self, _reason: str, _request_id: "str | None" = None) -> None:
         """Called when a SpawnPane request failed (#592). Override to handle the error."""
+
+    def on_context_state(self, _state: dict) -> None:
+        """Called when a QueryContextState response arrives (#1518).
+
+        ``_state`` is a dict with keys: context_id, name, path, status,
+        pane_count, panes (list of pane summaries), children (list of child
+        context ids).
+        """
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
@@ -905,6 +914,12 @@ class App:
                         self.on_pane_spawn_error,
                         str(ev.get("reason", "")),
                         str(req_id) if req_id is not None else None,
+                    )
+
+                elif t == "context_state_response":
+                    self._dispatch_hook_task(
+                        self.on_context_state,
+                        ev.get("state", {}),
                     )
 
                 elif t == "nav_back":

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -619,6 +619,7 @@ class Emitter:
         pipe_id: "str | None" = None,
         from_pane_id: "int | None" = None,
         request_id: "str | None" = None,
+        target_context: "int | None" = None,
     ) -> None:
         """Request the host to open a new pane with the given app (#592).
 
@@ -637,6 +638,8 @@ class Emitter:
                           currently focused pane.
             request_id: Optional correlation id echoed back in on_pane_spawned /
                         on_pane_spawn_error.
+            target_context: Optional context_id to spawn the pane into. Must be
+                            the calling pane's own context or a descendant (#1518).
         """
         cmd: "dict[str, object]" = {
             "type": "spawn_pane",
@@ -650,7 +653,22 @@ class Emitter:
             cmd["from_pane_id"] = from_pane_id
         if request_id is not None:
             cmd["request_id"] = request_id
+        if target_context is not None:
+            cmd["target_context"] = target_context
         _emit(cmd)
+
+    def query_context_state(self, context_id: int) -> None:
+        """Query the state of a context (#1518).
+
+        The host responds with ``on_context_state(state)`` containing pane
+        count, child contexts, and aggregate status. The requesting pane must
+        be in the queried context itself or in an ancestor context (visibility
+        boundary). Non-descendant queries are silently denied.
+
+        Args:
+            context_id: The context to query.
+        """
+        _emit({"type": "query_context_state", "context_id": context_id})
 
     def cd_to(self, cwd: str) -> None:
         """Request the host to cd all terminals in the same pane group to `cwd`."""

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -718,10 +718,16 @@ class RenderContext:
                    args: "list[str] | None" = None,
                    pipe_id: "str | None" = None,
                    from_pane_id: "int | None" = None,
-                   request_id: "str | None" = None) -> None:
+                   request_id: "str | None" = None,
+                   target_context: "int | None" = None) -> None:
         """Request the host to open a new pane. Requires panes.spawn capability."""
         self.emit.spawn_pane(type_id, layout=layout, args=args, pipe_id=pipe_id,
-                             from_pane_id=from_pane_id, request_id=request_id)
+                             from_pane_id=from_pane_id, request_id=request_id,
+                             target_context=target_context)
+
+    def query_context_state(self, context_id: int) -> None:
+        """Query the state of a context. Host responds via on_context_state."""
+        self.emit.query_context_state(context_id)
 
     # ── Declarative layout ──────────────────────────────────────────────────────
 

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -27,8 +27,6 @@ pub struct ContextDefaults {
 pub struct Anchor {
     /// The project root directory (parent of `.plexi/`).
     pub root: PathBuf,
-    /// Workspace UUID from `workspace.toml`, if present.
-    pub workspace_id: Option<String>,
     /// Context defaults from `[context]` in `workspace.toml`.
     pub context_defaults: Option<ContextDefaults>,
 }
@@ -60,19 +58,18 @@ impl Anchor {
         // Try to read workspace.toml for ID and context defaults.
         // Reuse WorkspaceConfig from workspace_secrets to avoid duplicate
         // parsing structs and dead-code warnings.
-        let (workspace_id, context_defaults) =
+        let context_defaults =
             match crate::workspace_secrets::WorkspaceConfig::load(path) {
                 Ok(Some(cfg)) => {
-                    let defaults = cfg.context.map(|c| ContextDefaults {
+                    cfg.context.map(|c| ContextDefaults {
                         name: c.name,
                         description: c.description,
-                    });
-                    (Some(cfg.id), defaults)
+                    })
                 }
-                Ok(None) => (None, None),
+                Ok(None) => None,
                 Err(e) => {
                     log::warn!("anchor: workspace.toml parse error: {e}");
-                    (None, None)
+                    None
                 }
             };
 
@@ -86,7 +83,6 @@ impl Anchor {
 
         Some(Anchor {
             root: path.to_path_buf(),
-            workspace_id,
             context_defaults,
         })
     }
@@ -129,21 +125,7 @@ mod tests {
         std::fs::create_dir(dir.path().join(".plexi")).unwrap();
         let anchor = Anchor::detect(dir.path()).unwrap();
         assert_eq!(anchor.root, dir.path());
-        assert!(anchor.workspace_id.is_none());
         assert!(anchor.context_defaults.is_none());
-    }
-
-    #[test]
-    fn detect_reads_workspace_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let dot_plexi = dir.path().join(".plexi");
-        std::fs::create_dir(&dot_plexi).unwrap();
-        std::fs::write(
-            dot_plexi.join("workspace.toml"),
-            "id = \"test-uuid-123\"\n",
-        ).unwrap();
-        let anchor = Anchor::detect(dir.path()).unwrap();
-        assert_eq!(anchor.workspace_id.as_deref(), Some("test-uuid-123"));
     }
 
     #[test]

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -1,0 +1,200 @@
+//! Anchor — the `.plexi/` directory as a canonical context entry point.
+//!
+//! When a project directory contains `.plexi/`, that directory is an *anchor*:
+//! opening Plexi from it attaches to a root context with pre-configured
+//! metadata, secrets, and app layout. The anchor is purely local — no cloud
+//! state.
+//!
+//! # Profile dir guard
+//!
+//! The home directory's `~/.plexi/` is the stable profile dir, NOT an anchor.
+//! [`Anchor::detect`] explicitly excludes it (and all `~/.plexi-*` profile
+//! dirs) to prevent the profile from masquerading as a workspace anchor.
+
+use std::path::{Path, PathBuf};
+
+/// Optional context defaults read from `[context]` in `workspace.toml`.
+/// These are suggestions, not mandates — user overrides always win.
+#[derive(Debug, Clone, Default)]
+pub struct ContextDefaults {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+/// A `.plexi/` directory anchor. Wraps the project root that contains the
+/// `.plexi/` dir, plus any defaults parsed from `workspace.toml`.
+#[derive(Debug, Clone)]
+pub struct Anchor {
+    /// The project root directory (parent of `.plexi/`).
+    pub root: PathBuf,
+    /// Workspace UUID from `workspace.toml`, if present.
+    pub workspace_id: Option<String>,
+    /// Context defaults from `[context]` in `workspace.toml`.
+    pub context_defaults: Option<ContextDefaults>,
+}
+
+impl Anchor {
+    /// Detect an anchor at `path`. Returns `Some` if `path/.plexi/` exists
+    /// and `path` is not a profile directory (`~/.plexi*`).
+    ///
+    /// Reads `workspace.toml` for workspace_id and context defaults if present.
+    pub fn detect(path: &Path) -> Option<Self> {
+        let dot_plexi = path.join(".plexi");
+        if !dot_plexi.is_dir() {
+            return None;
+        }
+
+        // Guard: never treat home dir as an anchor. ~/.plexi/ is the stable
+        // profile dir, and ~/  would cause the AppRegistry to load stable
+        // apps instead of the active channel's apps (issue #1064).
+        if is_profile_dir(path) {
+            log::info!(
+                "anchor::detect: skipping profile dir at {}",
+                path.display()
+            );
+            return None;
+        }
+
+        log::info!("anchor::detect: found .plexi/ anchor at {}", path.display());
+
+        // Try to read workspace.toml for ID and context defaults.
+        // Reuse WorkspaceConfig from workspace_secrets to avoid duplicate
+        // parsing structs and dead-code warnings.
+        let (workspace_id, context_defaults) =
+            match crate::workspace_secrets::WorkspaceConfig::load(path) {
+                Ok(Some(cfg)) => {
+                    let defaults = cfg.context.map(|c| ContextDefaults {
+                        name: c.name,
+                        description: c.description,
+                    });
+                    (Some(cfg.id), defaults)
+                }
+                Ok(None) => (None, None),
+                Err(e) => {
+                    log::warn!("anchor: workspace.toml parse error: {e}");
+                    (None, None)
+                }
+            };
+
+        if let Some(ref defaults) = context_defaults {
+            log::info!(
+                "anchor::detect: context defaults name={:?} description={:?}",
+                defaults.name,
+                defaults.description
+            );
+        }
+
+        Some(Anchor {
+            root: path.to_path_buf(),
+            workspace_id,
+            context_defaults,
+        })
+    }
+}
+
+/// Returns true if `path` is the home directory or looks like a profile dir
+/// (`~/.plexi`, `~/.plexi-alpha`, `~/.plexi-pr-123`, etc.).
+fn is_profile_dir(path: &Path) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    if path == home {
+        return true;
+    }
+    // Check if path is directly inside home and starts with `.plexi`
+    if path.parent() == Some(&home) {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name == ".plexi" || name.starts_with(".plexi-") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_none_without_dot_plexi() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(Anchor::detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn detect_returns_anchor_with_dot_plexi() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".plexi")).unwrap();
+        let anchor = Anchor::detect(dir.path()).unwrap();
+        assert_eq!(anchor.root, dir.path());
+        assert!(anchor.workspace_id.is_none());
+        assert!(anchor.context_defaults.is_none());
+    }
+
+    #[test]
+    fn detect_reads_workspace_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let dot_plexi = dir.path().join(".plexi");
+        std::fs::create_dir(&dot_plexi).unwrap();
+        std::fs::write(
+            dot_plexi.join("workspace.toml"),
+            "id = \"test-uuid-123\"\n",
+        ).unwrap();
+        let anchor = Anchor::detect(dir.path()).unwrap();
+        assert_eq!(anchor.workspace_id.as_deref(), Some("test-uuid-123"));
+    }
+
+    #[test]
+    fn detect_reads_context_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let dot_plexi = dir.path().join(".plexi");
+        std::fs::create_dir(&dot_plexi).unwrap();
+        std::fs::write(
+            dot_plexi.join("workspace.toml"),
+            "id = \"abc\"\n\n[context]\nname = \"My Project\"\ndescription = \"The main dev workspace\"\n",
+        ).unwrap();
+        let anchor = Anchor::detect(dir.path()).unwrap();
+        let defaults = anchor.context_defaults.unwrap();
+        assert_eq!(defaults.name.as_deref(), Some("My Project"));
+        assert_eq!(defaults.description.as_deref(), Some("The main dev workspace"));
+    }
+
+    #[test]
+    fn detect_partial_context_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let dot_plexi = dir.path().join(".plexi");
+        std::fs::create_dir(&dot_plexi).unwrap();
+        std::fs::write(
+            dot_plexi.join("workspace.toml"),
+            "id = \"abc\"\n\n[context]\nname = \"Just Name\"\n",
+        ).unwrap();
+        let anchor = Anchor::detect(dir.path()).unwrap();
+        let defaults = anchor.context_defaults.unwrap();
+        assert_eq!(defaults.name.as_deref(), Some("Just Name"));
+        assert!(defaults.description.is_none());
+    }
+
+    #[test]
+    fn is_profile_dir_rejects_home() {
+        if let Some(home) = dirs::home_dir() {
+            assert!(is_profile_dir(&home));
+        }
+    }
+
+    #[test]
+    fn is_profile_dir_rejects_plexi_profiles() {
+        if let Some(home) = dirs::home_dir() {
+            assert!(is_profile_dir(&home.join(".plexi")));
+            assert!(is_profile_dir(&home.join(".plexi-alpha")));
+            assert!(is_profile_dir(&home.join(".plexi-pr-123")));
+        }
+    }
+
+    #[test]
+    fn is_profile_dir_allows_normal_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_profile_dir(dir.path()));
+    }
+}

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -232,7 +232,8 @@ impl PlexiApp {
                     | AppCommand::RunInLinkedTerminal { .. }
                     | AppCommand::InsertPathToken { .. }
                     | AppCommand::RequestCommandPreview { .. }
-                    | AppCommand::OpenArtifact { .. } => deferred.push(cmd),
+                    | AppCommand::OpenArtifact { .. }
+                    | AppCommand::QueryContextState { .. } => deferred.push(cmd),
                     AppCommand::CdRequest { cwd, .. } => {
                         deferred.push(AppCommand::CdRequest { cwd, sender_pane_id: pane_id });
                     }
@@ -378,5 +379,68 @@ mod ownership_tests {
         // Should not panic; shell_open is a no-op in cfg(test) environments
         // because no real shell is available — we just verify clean exit.
         h.run_frames(1);
+    }
+
+    /// QueryContextState for own context: drain_all_app_commands collects
+    /// the command with the correct sender_pane_id and context_id.
+    #[test]
+    fn query_context_state_own_context_collected() {
+        let mut h = HostHarness::new();
+        let pane_id = h.add_test_pane();
+
+        push_command(
+            &mut h,
+            pane_id,
+            AppCommand::QueryContextState {
+                sender_pane_id: pane_id,
+                context_id: 1,
+            },
+        );
+
+        let cmds = h.app.drain_all_app_commands();
+        let found = cmds.iter().any(|c| {
+            matches!(c, AppCommand::QueryContextState {
+                sender_pane_id: sid, context_id: cid
+            } if *sid == pane_id && *cid == 1)
+        });
+        assert!(found, "QueryContextState must appear in drained commands");
+    }
+
+    /// QueryContextState for non-descendant context: the dispatch handler
+    /// must NOT produce a ContextStateResponse (visibility denied).
+    /// We run a full frame so the deferred dispatch executes, then verify
+    /// outbound_events is empty (the frame flush sends events to a dead
+    /// stdin channel which is harmless in tests, but even if something
+    /// slipped through, the denial path skips queue_outbound_event entirely).
+    #[test]
+    fn query_context_state_non_descendant_produces_no_response() {
+        let mut h = HostHarness::new();
+        let pane_id = h.add_test_pane();
+
+        // Context 99 is a sibling (parent=None), not a descendant of context 1.
+        h.app.host.add_context(99, None);
+
+        push_command(
+            &mut h,
+            pane_id,
+            AppCommand::QueryContextState {
+                sender_pane_id: pane_id,
+                context_id: 99,
+            },
+        );
+
+        h.run_frames(1);
+
+        // After the frame, outbound_events should be empty. Even though
+        // flush_outbound_events() runs during the frame, the denial path
+        // never queues anything, so nothing gets sent.
+        let effects = h.effects_drain(pane_id);
+        let has_response = effects.iter().any(|e| {
+            matches!(e, crate::app_protocol::PlexiEvent::ContextStateResponse { .. })
+        });
+        assert!(
+            !has_response,
+            "non-descendant QueryContextState must not produce ContextStateResponse"
+        );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -948,11 +948,34 @@ impl PlexiApp {
         }
 
         // Default: empty context — welcome screen is shown until the user creates a pane.
+        // If CWD has a .plexi/ anchor, use its context defaults for name/description
+        // and set root to the anchor path.
         let panes: HashMap<u64, Pane> = HashMap::new();
         let tree = Tree::empty("plexi");
 
         let path = std::env::current_dir()
             .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+
+        let anchor = crate::anchor::Anchor::detect(&path);
+        let (default_name, default_description, default_root) = match anchor.as_ref() {
+            Some(a) => {
+                let defaults = a.context_defaults.as_ref();
+                let name = defaults
+                    .and_then(|d| d.name.clone())
+                    .unwrap_or_else(|| {
+                        path.file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| "Default".to_string())
+                    });
+                let desc = defaults.and_then(|d| d.description.clone());
+                log::info!(
+                    "anchor detected at CWD: name={:?} description={:?} root={}",
+                    name, desc, a.root.display()
+                );
+                (name, desc, Some(a.root.clone()))
+            }
+            None => ("Default".to_string(), None, None),
+        };
 
         Self {
             pty_event_rx: rx,
@@ -963,10 +986,10 @@ impl PlexiApp {
             ctx: cc.egui_ctx.clone(),
             router: crate::workspace_router::WorkspaceRouter::new(
                 vec![crate::context::Context {
-                    name: "Default".into(),
+                    name: default_name,
                     path: path.clone(),
-                    root: None,
-                    description: None,
+                    root: default_root,
+                    description: default_description,
                     context_id: 1,
                     parent_id: None,
                     depth: 0,
@@ -974,7 +997,7 @@ impl PlexiApp {
                 0,
             ),
             windows: vec![Window {
-                name: "Default".into(),
+                name: String::new(),
                 path,
                 tree,
                 panes,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -772,13 +772,14 @@ impl PlexiApp {
                         }
                     }
 
-                    // SubContext panes — restore the tile reference, no process to start.
-                    if matches!(saved_pane.kind, crate::workspace::SavedPaneKind::SubContext { .. }) {
-                        if let crate::workspace::SavedPaneKind::SubContext { context_id } = &saved_pane.kind {
-                            pane_entry = Some(Pane::SubContext {
+                    // Portal panes — restore the tile reference, no process to start.
+                    if matches!(saved_pane.kind, crate::workspace::SavedPaneKind::Portal { .. }) {
+                        if let crate::workspace::SavedPaneKind::Portal { context_id } = &saved_pane.kind {
+                            pane_entry = Some(Pane::Portal(Box::new(crate::pane::PortalPane {
                                 pane_id: saved_pane.id,
-                                context_id: *context_id,
-                            });
+                                target_context_id: *context_id,
+                                context_state: None,
+                            })));
                         }
                     }
 
@@ -1355,8 +1356,8 @@ impl PlexiApp {
                                     let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
                                     ("app", a.name.clone(), cwd)
                                 }
-                                crate::pane::Pane::SubContext { context_id, .. } => {
-                                    ("sub_context", format!("sub_context:{context_id}"), None)
+                                crate::pane::Pane::Portal(p) => {
+                                    ("portal", format!("portal:{}", p.target_context_id), None)
                                 }
                             };
                             let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
@@ -1415,11 +1416,11 @@ impl PlexiApp {
                                         "manifest_id": a.manifest_id.clone(),
                                     })
                                 }
-                                crate::pane::Pane::SubContext { context_id, .. } => {
+                                crate::pane::Pane::Portal(p) => {
                                     serde_json::json!({
                                         "id": pane_id,
-                                        "type": "sub_context",
-                                        "context_id": context_id,
+                                        "type": "portal",
+                                        "context_id": p.target_context_id,
                                         "focused": focused,
                                     })
                                 }
@@ -2136,7 +2137,7 @@ impl PlexiApp {
     }
 
     /// Recursively sum notification count for a context and all its descendants.
-    /// Used for the notification badge on SubContext tiles.
+    /// Used for the notification badge on Portal tiles.
     pub(crate) fn context_notification_count_recursive(&self, ctx_id: u64) -> usize {
         self.context_notification_count_recursive_limited(ctx_id, 0)
     }
@@ -2700,7 +2701,7 @@ impl eframe::App for PlexiApp {
                         .map(|p| match p {
                             crate::pane::Pane::App(_) => "app",
                             crate::pane::Pane::Terminal(_) => "terminal",
-                            crate::pane::Pane::SubContext { .. } => "sub_context",
+                            crate::pane::Pane::Portal(_) => "portal",
                         });
                     match target_kind {
                         Some("app") => {
@@ -2996,7 +2997,7 @@ impl eframe::App for PlexiApp {
                     // (via PushNav), Escape routes NavBack to the app
                     // instead of closing the pane.
                     if !self.try_nav_back_focused() {
-                        if let Some(child_ctx_id) = self.get_focused_sub_context_id() {
+                        if let Some(child_ctx_id) = self.get_focused_portal_context_id() {
                             let state = self.build_context_close_state(child_ctx_id);
                             if state.items.is_empty() {
                                 // Empty context — close immediately, no dialog needed.
@@ -3246,7 +3247,7 @@ impl eframe::App for PlexiApp {
                             .and_then(|t| if let egui_tiles::Tile::Pane(p) = t { Some(*p) } else { None });
                         if let Some(pane_id) = focused_pane_id {
                             if let Some(child_ctx_id) = self.windows[self.active_window].panes.get(&pane_id)
-                                .and_then(|p| p.as_sub_context())
+                                .and_then(|p| p.portal_target())
                             {
                                 log::info!("ContextZoomIn: zooming into context_id={child_ctx_id}");
                                 let current_ctx_id = self.router.active().context_id;
@@ -3453,16 +3454,16 @@ impl eframe::App for PlexiApp {
                 let canvas_old_focus = self.windows[self.active_window].focused_pane;
                 let canvas_old_window_id = self.windows[self.active_window].window_id;
 
-                // Build sub-context preview data before taking the mutable ctx borrow.
-                let sub_context_info: std::collections::HashMap<crate::tiling::PaneId, crate::tiling::SubContextPreview> = {
+                // Build portal preview data before taking the mutable ctx borrow.
+                let portal_info: std::collections::HashMap<crate::tiling::PaneId, crate::tiling::PortalPreview> = {
                     let active_win = self.active_window;
                     let mut map = std::collections::HashMap::new();
-                    let sub_ctx_panes: Vec<(crate::tiling::PaneId, u64)> = self.windows[active_win]
+                    let portal_panes: Vec<(crate::tiling::PaneId, u64)> = self.windows[active_win]
                         .panes
                         .iter()
-                        .filter_map(|(pid, p)| p.as_sub_context().map(|cid| (*pid, cid)))
+                        .filter_map(|(pid, p)| p.portal_target().map(|cid| (*pid, cid)))
                         .collect();
-                    for (pane_id, child_ctx_id) in sub_ctx_panes {
+                    for (pane_id, child_ctx_id) in portal_panes {
                         let ctx_name = self.router.iter()
                             .find(|c| c.context_id == child_ctx_id)
                             .map(|c| c.name.clone())
@@ -3490,11 +3491,11 @@ impl eframe::App for PlexiApp {
                                         app_type: a.runtime.type_id().to_string(),
                                     })
                                 }
-                                crate::pane::Pane::SubContext { .. } => None,
+                                crate::pane::Pane::Portal(_) => None,
                             })
                             .collect();
                         let notif_count = self.context_notification_count_recursive(child_ctx_id);
-                        map.insert(pane_id, crate::tiling::SubContextPreview {
+                        map.insert(pane_id, crate::tiling::PortalPreview {
                             context_name: ctx_name,
                             panes: pane_summaries,
                             notification_count: notif_count,
@@ -3502,6 +3503,38 @@ impl eframe::App for PlexiApp {
                     }
                     map
                 };
+
+                // Update cached ContextState on portal panes (recomputed each frame for now;
+                // future: throttle to change events only).
+                {
+                    let contexts: Vec<crate::context::Context> = self.router.iter().cloned().collect();
+                    let active_win = self.active_window;
+                    let portal_pane_ids: Vec<(crate::tiling::PaneId, u64)> = self.windows[active_win]
+                        .panes
+                        .iter()
+                        .filter_map(|(pid, p)| p.portal_target().map(|cid| (*pid, cid)))
+                        .collect();
+                    for (pid, child_ctx_id) in portal_pane_ids {
+                        let state = crate::context_state::ContextState::compute(
+                            child_ctx_id,
+                            &contexts,
+                            &self.windows,
+                        );
+                        if let Some(portal) = self.windows[active_win].panes.get_mut(&pid)
+                            .and_then(|p| p.as_portal_mut())
+                        {
+                            let old_status = portal.context_state.as_ref().map(|s| s.status.clone());
+                            let new_status = state.status.clone();
+                            if old_status.as_ref() != Some(&new_status) {
+                                log::info!(
+                                    "portal state change: pane_id={pid} ctx={child_ctx_id} status={:?} panes={} agents={}",
+                                    new_status, state.pane_count, state.active_agents,
+                                );
+                            }
+                            portal.context_state = Some(state);
+                        }
+                    }
+                }
 
                 // Computed before the mutable borrow of `ctx` — needed by PlexiBehavior
                 // to prevent terminal panes from stealing egui focus while a modal is open.
@@ -3642,7 +3675,7 @@ impl eframe::App for PlexiApp {
                     hovered_files,
                     workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
                     unfocused_opacity,
-                    sub_context_info,
+                    portal_info,
                     modal_open,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
@@ -4070,7 +4103,7 @@ impl PlexiApp {
                 let type_id = Some(a.manifest_id.clone());
                 (cwd, None, None, type_id)
             }
-            crate::pane::Pane::SubContext { .. } => {
+            crate::pane::Pane::Portal(_) => {
                 (None, None, None, None)
             }
         };
@@ -4431,15 +4464,15 @@ impl PlexiApp {
         }
     }
 
-    /// Returns the `context_id` of the child context if the focused pane is a SubContext tile.
-    pub(crate) fn get_focused_sub_context_id(&self) -> Option<u64> {
+    /// Returns the `context_id` of the child context if the focused pane is a Portal tile.
+    pub(crate) fn get_focused_portal_context_id(&self) -> Option<u64> {
         let win = &self.windows[self.active_window];
         let focused_tile = win.focused_pane?;
         let pane_id = match win.tree.tiles.get(focused_tile) {
             Some(egui_tiles::Tile::Pane(id)) => *id,
             _ => return None,
         };
-        win.panes.get(&pane_id)?.as_sub_context()
+        win.panes.get(&pane_id)?.portal_target()
     }
 
     /// Collect the pane inventory for a child context close dialog.
@@ -4469,13 +4502,13 @@ impl PlexiApp {
                     crate::pane::Pane::App(a) => {
                         items.push(ContextCloseItem { kind: "App", name: a.name.clone() });
                     }
-                    crate::pane::Pane::SubContext { context_id: child_id, .. } => {
+                    crate::pane::Pane::Portal(p) => {
                         let name = self
                             .router
                             .iter()
-                            .find(|c| c.context_id == *child_id)
+                            .find(|c| c.context_id == p.target_context_id)
                             .map(|c| c.name.clone())
-                            .unwrap_or_else(|| "Sub-context".to_string());
+                            .unwrap_or_else(|| "Portal".to_string());
                         items.push(ContextCloseItem { kind: "Context", name });
                     }
                 }
@@ -4881,7 +4914,7 @@ fn register_directed_pipe_on_target(pane: &mut crate::pane::Pane, pipe_id: &str)
             crate::pane::AppRuntime::Process(pa) => Some(pa.pipe_registry.clone()),
             crate::pane::AppRuntime::Builtin(_) => None,
         },
-        crate::pane::Pane::Terminal(_) | crate::pane::Pane::SubContext { .. } => None,
+        crate::pane::Pane::Terminal(_) | crate::pane::Pane::Portal(_) => None,
     };
     let Some(registry) = registry else {
         return false;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2357,6 +2357,7 @@ impl eframe::App for PlexiApp {
                     pipe_id,
                     from_pane_id,
                     request_id,
+                    target_context,
                 } => {
                     // "background" layout is not yet implemented (blocked on #291).
                     if layout == "background" {
@@ -2393,6 +2394,59 @@ impl eframe::App for PlexiApp {
                     let mut effective_args = args;
                     if let Some(ref pid) = pipe_id {
                         effective_args.push(format!("--pipe={pid}"));
+                    }
+
+                    // target_context validation (#1518): if set, verify the
+                    // target exists and is a descendant of the requester's
+                    // context. Switch active_window temporarily so the spawn
+                    // lands in the right context.
+                    let original_active_window = self.active_window;
+                    if let Some(target_ctx_id) = target_context {
+                        let requester_context_id = self.windows[self.active_window].context_id;
+                        let target_exists = self.router.iter().any(|c| c.context_id == target_ctx_id);
+                        let is_descendant = self.host.ancestors_of(target_ctx_id).contains(&requester_context_id);
+
+                        if !target_exists || (!is_descendant && requester_context_id != target_ctx_id) {
+                            log::warn!(
+                                "SpawnPane: target_context={target_ctx_id} invalid or not a descendant of requester context {requester_context_id}"
+                            );
+                            // Send error back to requesting pane.
+                            let active = self.active_window;
+                            let requesting_pane_id = self.windows[active]
+                                .focused_pane
+                                .and_then(|tile| self.windows[active].tree.tiles.get(tile))
+                                .and_then(|tile| {
+                                    if let egui_tiles::Tile::Pane(pid) = tile { Some(*pid) } else { None }
+                                });
+                            if let Some(req_pane_id) = requesting_pane_id {
+                                if let Some(pane) = self.windows[active].panes.get_mut(&req_pane_id) {
+                                    if let Some(a) = pane.as_app_mut() {
+                                        a.runtime.queue_outbound_event(
+                                            crate::app_protocol::PlexiEvent::PaneSpawnError {
+                                                reason: format!(
+                                                    "target_context {target_ctx_id} is not a descendant of context {requester_context_id}"
+                                                ),
+                                                request_id: request_id.clone(),
+                                            },
+                                        );
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
+                        // Switch to a window in the target context for the spawn.
+                        if let Some(win_idx) = self.windows.iter().position(|w| w.context_id == target_ctx_id) {
+                            log::info!(
+                                "SpawnPane: target_context={target_ctx_id} — switching to window index {win_idx}"
+                            );
+                            self.active_window = win_idx;
+                        } else {
+                            log::warn!(
+                                "SpawnPane: target_context={target_ctx_id} exists but has no window"
+                            );
+                            continue;
+                        }
                     }
 
                     // Capture requesting_pane_id from the CURRENT focused pane (the calling app pane).
@@ -2444,17 +2498,23 @@ impl eframe::App for PlexiApp {
                     // Restore focused_pane after the split so the coordinator app keeps focus.
                     self.windows[active].focused_pane = original_focused;
 
-                    // Send PaneSpawned back to the requesting pane.
+                    // Restore active_window if we switched for target_context.
+                    self.active_window = original_active_window;
+
+                    // Send PaneSpawned back to the requesting pane (may be
+                    // in a different window than where the spawn landed).
                     if let Some(req_pane_id) = requesting_pane_id {
-                        let active = self.active_window;
-                        if let Some(pane) = self.windows[active].panes.get_mut(&req_pane_id) {
-                            if let Some(a) = pane.as_app_mut() {
-                                a.runtime.queue_outbound_event(
-                                    crate::app_protocol::PlexiEvent::PaneSpawned {
-                                        pane_id: new_pane_id,
-                                        request_id,
-                                    },
-                                );
+                        let win_idx = self.windows.iter().position(|w| w.panes.contains_key(&req_pane_id));
+                        if let Some(wi) = win_idx {
+                            if let Some(pane) = self.windows[wi].panes.get_mut(&req_pane_id) {
+                                if let Some(a) = pane.as_app_mut() {
+                                    a.runtime.queue_outbound_event(
+                                        crate::app_protocol::PlexiEvent::PaneSpawned {
+                                            pane_id: new_pane_id,
+                                            request_id,
+                                        },
+                                    );
+                                }
                             }
                         }
                     }
@@ -2778,6 +2838,53 @@ impl eframe::App for PlexiApp {
                 }
                 AppCommand::OpenArtifact { sender_pane_id, path, mode } => {
                     self.dispatch_open_artifact(sender_pane_id, path, mode);
+                }
+                AppCommand::QueryContextState { sender_pane_id, context_id } => {
+                    // Visibility check: the requesting pane must be in the
+                    // queried context itself or in an ancestor of it.
+                    let requester_context_id = self.windows.iter()
+                        .find(|w| w.panes.contains_key(&sender_pane_id))
+                        .map(|w| w.context_id)
+                        .unwrap_or(0);
+
+                    let is_self = requester_context_id == context_id;
+                    let is_ancestor = if !is_self {
+                        self.host.ancestors_of(context_id).contains(&requester_context_id)
+                    } else {
+                        false
+                    };
+
+                    if !is_self && !is_ancestor {
+                        log::warn!(
+                            "QueryContextState: pane {sender_pane_id} in context {requester_context_id} \
+                             cannot query context {context_id} — not an ancestor"
+                        );
+                        continue;
+                    }
+
+                    let state = crate::context_state::ContextState::compute(
+                        context_id,
+                        self.router.as_slice(),
+                        &self.windows,
+                    );
+                    log::info!(
+                        "QueryContextState: context_id={context_id} pane_count={} children={} status={:?}",
+                        state.pane_count,
+                        state.children.len(),
+                        state.status,
+                    );
+
+                    // Send response back to the requesting pane.
+                    let window_idx = self.windows.iter().position(|w| w.panes.contains_key(&sender_pane_id));
+                    if let Some(win_idx) = window_idx {
+                        if let Some(pane) = self.windows[win_idx].panes.get_mut(&sender_pane_id) {
+                            if let Some(app) = pane.as_app_mut() {
+                                app.runtime.queue_outbound_event(
+                                    crate::app_protocol::PlexiEvent::ContextStateResponse { state },
+                                );
+                            }
+                        }
+                    }
                 }
                 AppCommand::DeliverRunUpdate { originator_type_id, event } => {
                     let active = self.active_window;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -840,18 +840,7 @@ impl PlexiApp {
                         next_id = next_id.max(win.window_id + 1);
                     }
                 }
-                let mut contexts = Vec::new();
-                for saved_ctx in ws.contexts {
-                    contexts.push(crate::context::Context {
-                        name: saved_ctx.name,
-                        path: saved_ctx.path,
-                        root: saved_ctx.root,
-                        description: saved_ctx.description,
-                        context_id: saved_ctx.context_id,
-                        parent_id: saved_ctx.parent_id,
-                        depth: saved_ctx.depth,
-                    });
-                }
+                let contexts = ws.contexts;
                 let active_ctx = ws.active_context.min(contexts.len().saturating_sub(1));
                 let active_ctx_id = contexts[active_ctx].context_id;
                 let active = ws.context_active_window.get(&active_ctx_id)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -671,7 +671,7 @@ fn split_with_new_pane_pushes_focus_history() {
 
 /// Issue #1392: creating a child context must NOT remove or replace the parent's
 /// focused pane (adoption branch was removed). The parent should have:
-/// (count_before + 1) panes — its original pane(s) plus the new SubContext tile.
+/// (count_before + 1) panes — its original pane(s) plus the new Portal tile.
 #[test]
 fn new_child_context_does_not_adopt_focused_pane() {
     let ctx = egui::Context::default();
@@ -694,17 +694,17 @@ fn new_child_context_does_not_adopt_focused_pane() {
     assert!(parent_win.panes.contains_key(&orig_pane_id),
         "original focused pane must NOT be adopted away");
 
-    // Pane count grew by exactly 1 (the new SubContext tile).
+    // Pane count grew by exactly 1 (the new Portal tile).
     assert_eq!(parent_win.panes.len(), orig_count + 1,
         "parent should have orig_count + 1 panes after new_child_context");
 
-    // The new pane is a SubContext.
-    let has_sub_ctx = parent_win.panes.values().any(|p| p.as_sub_context().is_some());
-    assert!(has_sub_ctx, "parent must contain a SubContext tile");
+    // The new pane is a Portal.
+    let has_sub_ctx = parent_win.panes.values().any(|p| p.portal_target().is_some());
+    assert!(has_sub_ctx, "parent must contain a Portal tile");
 }
 
 /// When no pane is focused, new_child_context still creates the child context with
-/// a fresh terminal. The parent gets a SubContext tile inserted as root (no focused
+/// a fresh terminal. The parent gets a Portal tile inserted as root (no focused
 /// split target). The parent's focused_pane remains None.
 #[test]
 fn new_child_context_no_focused_pane_inserts_sub_ctx() {
@@ -724,12 +724,12 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     assert_eq!(app.windows[0].focused_pane, None, "parent focused_pane untouched");
 
     if result.is_ok() {
-        // Parent gained exactly 1 SubContext pane.
+        // Parent gained exactly 1 Portal pane.
         let parent_win = app.windows.iter().find(|w| w.context_id == parent_id).unwrap();
         assert_eq!(parent_win.panes.len(), parent_pane_count_before + 1,
             "parent pane count grew by 1");
-        let has_sub_ctx = parent_win.panes.values().any(|p| p.as_sub_context().is_some());
-        assert!(has_sub_ctx, "parent has a SubContext tile");
+        let has_sub_ctx = parent_win.panes.values().any(|p| p.portal_target().is_some());
+        assert!(has_sub_ctx, "parent has a Portal tile");
     } else {
         // PTY failed in test env — parent panes unchanged.
         assert_eq!(app.windows[0].panes.len(), parent_pane_count_before,
@@ -802,7 +802,7 @@ fn create_child_context_auto_zooms() {
 
 /// Issue #1392: unlimited nesting after killing the depth cap and adoption branch.
 /// Build a 4-level chain (root → A → B → C → D) and verify that each parent's
-/// window contains a SubContext tile pointing at the corresponding child.
+/// window contains a Portal tile pointing at the corresponding child.
 /// Note: new_child_context always creates a fresh terminal. In test envs without PTY
 /// this returns Err — if so, verify depth metadata still incremented correctly for
 /// any contexts that were created before the first failure.
@@ -839,17 +839,17 @@ fn depth_four_chain_has_portal_tiles() {
         assert_eq!(c.depth as usize, level, "context at chain[{level}] should have depth {level}");
     }
 
-    // Verify each parent's window has a SubContext tile pointing at its child.
+    // Verify each parent's window has a Portal tile pointing at its child.
     for i in 0..chain_ids.len().saturating_sub(1) {
         let parent_id = chain_ids[i];
         let child_id = chain_ids[i + 1];
         let parent_win = app.windows.iter().find(|w| w.context_id == parent_id)
             .expect("parent window must exist");
         let found = parent_win.panes.values()
-            .any(|p| p.as_sub_context() == Some(child_id));
+            .any(|p| p.portal_target() == Some(child_id));
         assert!(
             found,
-            "parent ctx_id={parent_id} must contain a SubContext tile pointing at child {child_id}"
+            "parent ctx_id={parent_id} must contain a Portal tile pointing at child {child_id}"
         );
     }
 }
@@ -949,12 +949,12 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     assert!(app.router.depth_stack.iter().all(|(cid, _, _)| *cid != b_id),
         "depth_stack must not contain deleted ctx_id={b_id}");
 
-    // No SubContext tile pointing to A or B should remain in any window.
+    // No Portal tile pointing to A or B should remain in any window.
     for win in &app.windows {
         for pane in win.panes.values() {
-            if let Some(target) = pane.as_sub_context() {
-                assert_ne!(target, a_id, "stale SubContext tile pointing to deleted A");
-                assert_ne!(target, b_id, "stale SubContext tile pointing to deleted B");
+            if let Some(target) = pane.portal_target() {
+                assert_ne!(target, a_id, "stale Portal tile pointing to deleted A");
+                assert_ne!(target, b_id, "stale Portal tile pointing to deleted B");
             }
         }
     }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -131,6 +131,10 @@ pub enum PlexiEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         request_id: Option<String>,
     },
+    /// Response to `AppRequest::QueryContextState` (#1518).
+    ContextStateResponse {
+        state: crate::context_state::ContextState,
+    },
     /// Binary pipe opened — app connects to `socket_path` as a unix socket client.
     PipeOpened {
         pipe_id: String,
@@ -1041,6 +1045,11 @@ pub enum AppRequest {
         /// rather than looking it up in the registry by type_id.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<String>,
+        /// When set, spawn the pane into this child context instead of the
+        /// requesting app's own context. The target context must exist and be
+        /// a descendant of the requesting app's context (#1518).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_context: Option<u64>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`
@@ -1134,6 +1143,13 @@ pub enum AppRequest {
     },
     /// Zoom out of a sub-context. Pops depth stack. Sent by `plexi context zoom-out`.
     ZoomOutOfContext,
+
+    /// Query the rolled-up `ContextState` for a context (#1518).
+    /// The requesting app must be in an ancestor (or the same) context.
+    /// Host responds with `PlexiEvent::ContextStateResponse`.
+    QueryContextState {
+        context_id: u64,
+    },
 
     // ── Media + HTTP primitives ──────────────────────────────────────────
     /// Host-brokered HTTP request. Requires `net.http` capability.

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -25,6 +25,7 @@ pub enum AppCommand {
         pipe_id: Option<String>,
         from_pane_id: Option<u64>,
         request_id: Option<String>,
+        target_context: Option<u64>,
     },
     /// Request the host to cd sibling terminals (same split container) to `cwd`.
     CdRequest { cwd: String, sender_pane_id: u64 },
@@ -152,6 +153,12 @@ pub enum AppCommand {
         sender_pane_id: u64,
         path: String,
         mode: crate::app_protocol::ArtifactOpenMode,
+    },
+    /// Query rolled-up ContextState for a context (#1518).
+    /// Forwarded to the host because only it has the full context tree.
+    QueryContextState {
+        sender_pane_id: u64,
+        context_id: u64,
     },
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use crate::pane::Pane;
 use crate::shell;
 use crate::tiling::PaneId;
 use egui_tiles::{Container, Tile, TileId, Tree};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -23,19 +24,30 @@ pub(crate) enum WindowMenuAction {
 /// A context is a sidebar item — a project or directory scope.
 /// It does not own panes directly; pane layouts live in `Window` pages
 /// that reference this context via `context_id`.
+///
+/// This is the canonical context type used everywhere: live GUI state,
+/// persistence (workspace save/restore), and test harness. Replaces the
+/// former `SavedContext` and unifies with `HostContext`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Context {
     pub name: String,
     pub path: PathBuf,
     /// Optional project root. When set, new panes in this context open at
     /// this directory rather than inheriting the focused pane's CWD.
+    #[serde(default)]
     pub root: Option<PathBuf>,
     /// Optional description — ambient intent for what you're doing in this context.
+    #[serde(default)]
     pub description: Option<String>,
     /// Stable unique ID, assigned at creation and never reused.
     pub context_id: u64,
     /// Parent context_id for sub-contexts. None = top-level.
+    #[serde(default)]
     pub parent_id: Option<u64>,
     /// Nesting depth. 0 = root level. Capped at 3.
+    /// Kept for backward-compatible deserialization but should be derived
+    /// from `parent_id` chain at runtime.
+    #[serde(default)]
     pub depth: u32,
 }
 

--- a/src/context_state.rs
+++ b/src/context_state.rs
@@ -6,7 +6,7 @@
 use crate::tiling::PaneId;
 
 /// Rolled-up status for a single context, including recursive children.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ContextState {
     pub context_id: u64,
     pub label: String,
@@ -18,7 +18,7 @@ pub struct ContextState {
 }
 
 /// Overall status of a context, derived from its pane summaries.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub enum ContextStatus {
     Idle,
     Working,
@@ -27,7 +27,7 @@ pub enum ContextStatus {
 }
 
 /// Summary of a single pane within a context.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct PaneSummary {
     pub pane_id: PaneId,
     pub label: String,
@@ -35,7 +35,7 @@ pub struct PaneSummary {
 }
 
 /// Status of an individual pane.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub enum PaneSummaryStatus {
     Idle,
     Active,

--- a/src/context_state.rs
+++ b/src/context_state.rs
@@ -1,0 +1,215 @@
+//! ContextState — rolled-up status summary for a context and its children.
+//!
+//! Reads existing status channels only (StatusSummary for apps, pty_title for
+//! terminals). No new protocol messages.
+
+use crate::tiling::PaneId;
+
+/// Rolled-up status for a single context, including recursive children.
+#[derive(Clone, Debug)]
+pub struct ContextState {
+    pub context_id: u64,
+    pub label: String,
+    pub pane_count: u32,
+    pub active_agents: u32,
+    pub status: ContextStatus,
+    pub pane_summaries: Vec<PaneSummary>,
+    pub children: Vec<ContextState>,
+}
+
+/// Overall status of a context, derived from its pane summaries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContextStatus {
+    Idle,
+    Working,
+    Error,
+    Done,
+}
+
+/// Summary of a single pane within a context.
+#[derive(Clone, Debug)]
+pub struct PaneSummary {
+    pub pane_id: PaneId,
+    pub label: String,
+    pub status: PaneSummaryStatus,
+}
+
+/// Status of an individual pane.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PaneSummaryStatus {
+    Idle,
+    Active,
+    Error,
+}
+
+impl ContextState {
+    /// Compute the context state for a given context by walking panes and
+    /// recursing into child contexts.
+    ///
+    /// `contexts` is the full router slice, `windows` is all windows.
+    /// Reads existing status: `StatusSummary` text for apps, `pty_title` for terminals.
+    pub fn compute(
+        context_id: u64,
+        contexts: &[crate::context::Context],
+        windows: &[crate::context::Window],
+    ) -> Self {
+        let label = contexts
+            .iter()
+            .find(|c| c.context_id == context_id)
+            .map(|c| c.name.clone())
+            .unwrap_or_else(|| "(unknown)".to_string());
+
+        let mut pane_summaries = Vec::new();
+        let mut active_agents: u32 = 0;
+        let mut has_error = false;
+
+        for win in windows.iter().filter(|w| w.context_id == context_id) {
+            let mut entries: Vec<_> = win.panes.iter().collect();
+            entries.sort_by_key(|(id, _)| *id);
+            for (&pid, pane) in entries {
+                let (plabel, pstatus) = match pane {
+                    crate::pane::Pane::Terminal(t) => {
+                        let name = t.name.clone()
+                            .or_else(|| t.pty_title.clone())
+                            .unwrap_or_else(|| "Terminal".to_string());
+                        let status = if t.exited {
+                            PaneSummaryStatus::Idle
+                        } else {
+                            PaneSummaryStatus::Active
+                        };
+                        if status == PaneSummaryStatus::Active {
+                            active_agents += 1;
+                        }
+                        (name, status)
+                    }
+                    crate::pane::Pane::App(a) => {
+                        let status_text = if let crate::pane::AppRuntime::Process(pa) = &a.runtime {
+                            pa.status_summary.clone()
+                        } else {
+                            None
+                        };
+                        let status = match status_text.as_deref() {
+                            Some(t) if t.contains("error") || t.contains("Error") => {
+                                has_error = true;
+                                PaneSummaryStatus::Error
+                            }
+                            Some(_) => {
+                                active_agents += 1;
+                                PaneSummaryStatus::Active
+                            }
+                            None => PaneSummaryStatus::Idle,
+                        };
+                        (a.name.clone(), status)
+                    }
+                    crate::pane::Pane::Portal(_) => continue,
+                };
+                pane_summaries.push(PaneSummary {
+                    pane_id: pid,
+                    label: plabel,
+                    status: pstatus,
+                });
+            }
+        }
+
+        // Recurse into child contexts.
+        let child_ids: Vec<u64> = contexts
+            .iter()
+            .filter(|c| c.parent_id == Some(context_id))
+            .map(|c| c.context_id)
+            .collect();
+
+        let children: Vec<ContextState> = child_ids
+            .iter()
+            .map(|&cid| Self::compute(cid, contexts, windows))
+            .collect();
+
+        // Roll up child status.
+        for child in &children {
+            if child.status == ContextStatus::Error {
+                has_error = true;
+            }
+            if child.status == ContextStatus::Working {
+                active_agents += child.active_agents;
+            }
+        }
+
+        let pane_count = pane_summaries.len() as u32;
+        let status = if has_error {
+            ContextStatus::Error
+        } else if active_agents > 0 {
+            ContextStatus::Working
+        } else {
+            ContextStatus::Idle
+        };
+
+        Self {
+            context_id,
+            label,
+            pane_count,
+            active_agents,
+            status,
+            pane_summaries,
+            children,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::{Context, Window};
+    use std::path::PathBuf;
+
+    fn make_context(id: u64, name: &str, parent: Option<u64>) -> Context {
+        Context {
+            name: name.to_string(),
+            path: PathBuf::from("/tmp"),
+            root: None,
+            description: None,
+            context_id: id,
+            parent_id: parent,
+            depth: if parent.is_some() { 1 } else { 0 },
+        }
+    }
+
+    fn make_empty_window(context_id: u64, window_id: u64) -> Window {
+        Window {
+            name: String::new(),
+            path: PathBuf::from("/tmp"),
+            tree: egui_tiles::Tree::empty("test"),
+            panes: std::collections::HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id,
+            context_id,
+        }
+    }
+
+    #[test]
+    fn empty_context_is_idle() {
+        let contexts = vec![make_context(1, "Root", None)];
+        let windows = vec![make_empty_window(1, 100)];
+        let state = ContextState::compute(1, &contexts, &windows);
+        assert_eq!(state.status, ContextStatus::Idle);
+        assert_eq!(state.pane_count, 0);
+        assert_eq!(state.label, "Root");
+    }
+
+    #[test]
+    fn child_error_rolls_up() {
+        let contexts = vec![
+            make_context(1, "Root", None),
+            make_context(2, "Child", Some(1)),
+        ];
+        let windows = vec![
+            make_empty_window(1, 100),
+            make_empty_window(2, 101),
+        ];
+        // Child has no panes but we test the rollup structure.
+        let state = ContextState::compute(1, &contexts, &windows);
+        assert_eq!(state.children.len(), 1);
+        assert_eq!(state.children[0].label, "Child");
+    }
+}

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -13,12 +13,28 @@ pub struct HostPane {
     pub group: Option<String>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HostContext {
     pub panes: Vec<HostPane>,
     pub focused_pane: Option<PaneId>,
     /// group name → member pane IDs
     pub groups: HashMap<String, Vec<PaneId>>,
+    /// Stable unique ID matching `Context::context_id`.
+    pub context_id: u64,
+    /// Parent context_id for sub-contexts. None = top-level.
+    pub parent_id: Option<u64>,
+}
+
+impl Default for HostContext {
+    fn default() -> Self {
+        Self {
+            panes: Vec::new(),
+            focused_pane: None,
+            groups: HashMap::new(),
+            context_id: 0,
+            parent_id: None,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -188,12 +204,56 @@ impl HostModel {
         self.next_pane_id = id;
     }
 
+    /// Add a new context with the given ID and optional parent.
+    /// Used by the test harness to set up sub-context hierarchies.
+    pub fn add_context(&mut self, context_id: u64, parent_id: Option<u64>) {
+        log::info!(
+            "HostModel::add_context(context_id={context_id}, parent_id={parent_id:?})"
+        );
+        self.contexts.push(HostContext {
+            context_id,
+            parent_id,
+            ..Default::default()
+        });
+    }
+
     fn context(&self) -> &HostContext {
         &self.contexts[self.active_context]
     }
 
     fn context_mut(&mut self) -> &mut HostContext {
         &mut self.contexts[self.active_context]
+    }
+
+    /// Return context IDs whose `parent_id` matches the given `context_id`.
+    pub fn children_of(&self, context_id: u64) -> Vec<u64> {
+        log::info!("HostModel::children_of(context_id={context_id})");
+        self.contexts
+            .iter()
+            .filter(|c| c.parent_id == Some(context_id))
+            .map(|c| c.context_id)
+            .collect()
+    }
+
+    /// Return the ancestor chain for `context_id`, from immediate parent to root.
+    /// Returns an empty vec if `context_id` is top-level or not found.
+    pub fn ancestors_of(&self, context_id: u64) -> Vec<u64> {
+        log::info!("HostModel::ancestors_of(context_id={context_id})");
+        let mut result = Vec::new();
+        let mut current = context_id;
+        // Guard against cycles with a max depth.
+        for _ in 0..16 {
+            let parent = self.contexts.iter().find(|c| c.context_id == current)
+                .and_then(|c| c.parent_id);
+            match parent {
+                Some(pid) => {
+                    result.push(pid);
+                    current = pid;
+                }
+                None => break,
+            }
+        }
+        result
     }
 }
 
@@ -250,5 +310,53 @@ mod tests {
             })
             .expect("SplitOpened effect must be emitted");
         assert_eq!(placement, Placement::Right);
+    }
+
+    #[test]
+    fn add_context_stores_hierarchy_fields() {
+        let mut model = HostModel::new();
+        model.add_context(10, None);
+        model.add_context(20, Some(10));
+
+        assert_eq!(model.contexts.len(), 3); // default + 2 added
+        assert_eq!(model.contexts[1].context_id, 10);
+        assert_eq!(model.contexts[1].parent_id, None);
+        assert_eq!(model.contexts[2].context_id, 20);
+        assert_eq!(model.contexts[2].parent_id, Some(10));
+    }
+
+    #[test]
+    fn children_of_returns_direct_children() {
+        let mut model = HostModel::new();
+        model.add_context(1, None);
+        model.add_context(2, Some(1));
+        model.add_context(3, Some(1));
+        model.add_context(4, Some(2));
+
+        let children = model.children_of(1);
+        assert_eq!(children.len(), 2);
+        assert!(children.contains(&2));
+        assert!(children.contains(&3));
+
+        let grandchildren = model.children_of(2);
+        assert_eq!(grandchildren, vec![4]);
+
+        assert!(model.children_of(99).is_empty());
+    }
+
+    #[test]
+    fn ancestors_of_returns_parent_chain() {
+        let mut model = HostModel::new();
+        model.add_context(1, None);
+        model.add_context(2, Some(1));
+        model.add_context(3, Some(2));
+
+        let ancestors = model.ancestors_of(3);
+        assert_eq!(ancestors, vec![2, 1]);
+
+        let ancestors_of_root = model.ancestors_of(1);
+        assert!(ancestors_of_root.is_empty());
+
+        assert!(model.ancestors_of(99).is_empty());
     }
 }

--- a/src/host/model.rs
+++ b/src/host/model.rs
@@ -204,12 +204,8 @@ impl HostModel {
         self.next_pane_id = id;
     }
 
-    /// Add a new context with the given ID and optional parent.
-    /// Used by the test harness to set up sub-context hierarchies.
+    #[cfg(test)]
     pub fn add_context(&mut self, context_id: u64, parent_id: Option<u64>) {
-        log::info!(
-            "HostModel::add_context(context_id={context_id}, parent_id={parent_id:?})"
-        );
         self.contexts.push(HostContext {
             context_id,
             parent_id,
@@ -225,9 +221,8 @@ impl HostModel {
         &mut self.contexts[self.active_context]
     }
 
-    /// Return context IDs whose `parent_id` matches the given `context_id`.
+    #[cfg(test)]
     pub fn children_of(&self, context_id: u64) -> Vec<u64> {
-        log::info!("HostModel::children_of(context_id={context_id})");
         self.contexts
             .iter()
             .filter(|c| c.parent_id == Some(context_id))
@@ -238,7 +233,6 @@ impl HostModel {
     /// Return the ancestor chain for `context_id`, from immediate parent to root.
     /// Returns an empty vec if `context_id` is top-level or not found.
     pub fn ancestors_of(&self, context_id: u64) -> Vec<u64> {
-        log::info!("HostModel::ancestors_of(context_id={context_id})");
         let mut result = Vec::new();
         let mut current = context_id;
         // Guard against cycles with a max depth.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,42 @@ pub mod audio {
     }
 }
 
+pub mod context_state {
+    /// Rolled-up status for a single context. Stub for lib target.
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+    pub struct ContextState {
+        pub context_id: u64,
+        pub label: String,
+        pub pane_count: u32,
+        pub active_agents: u32,
+        pub status: ContextStatus,
+        pub pane_summaries: Vec<PaneSummary>,
+        pub children: Vec<ContextState>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+    pub enum ContextStatus {
+        Idle,
+        Working,
+        Error,
+        Done,
+    }
+
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+    pub struct PaneSummary {
+        pub pane_id: u64,
+        pub label: String,
+        pub status: PaneSummaryStatus,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+    pub enum PaneSummaryStatus {
+        Idle,
+        Active,
+        Error,
+    }
+}
+
 pub mod video {
     /// Video playback state. Stub for the lib target (full impl in binary target).
     #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 // PLEXI_AUDIO=mock://. Stubs must return `Err(NotImplemented)` instead.
 #![deny(clippy::todo, clippy::unimplemented)]
 
+mod anchor;
 mod app;
 mod app_permissions;
 mod app_protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod command_palette;
 mod config;
 mod config_watcher;
 mod context;
+mod context_state;
 mod event_log;
 mod features;
 mod file_browser;

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2074,11 +2074,11 @@ impl PlexiApp {
                                 osc_badge: None,
                             });
                         }
-                        crate::pane::Pane::SubContext { pane_id, context_id } => {
+                        crate::pane::Pane::Portal(p) => {
                             rows.push(PaneRow {
-                                id: *pane_id,
-                                kind: "SubContext",
-                                name: format!("sub_context:{context_id}"),
+                                id: p.pane_id,
+                                kind: "Portal",
+                                name: format!("portal:{}", p.target_context_id),
                                 detail: String::new(),
                                 status: "active",
                                 osc_badge: None,
@@ -2764,7 +2764,7 @@ impl PlexiApp {
             }
         } else if dissolve {
             log::info!("context_close: dissolve ctx={} name={:?}", state.context_id, state.context_name);
-            self.dissolve_sub_context(state.context_id);
+            self.dissolve_portal(state.context_id);
             self.save_workspace();
         } else if cancelled {
             log::info!("context_close: cancelled ctx={}", state.context_id);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -6,19 +6,24 @@ use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
 // ---------------------------------------------------------------------------
-// Pane ADT (spec §2) — Terminal | App | SubContext.
-// Issue #1374 is the spec amendment for the SubContext variant.
+// Pane ADT (spec §2) — Terminal | App | Portal.
+// Issue #1374 added the Portal variant (formerly SubContext).
 // ---------------------------------------------------------------------------
 
 pub enum Pane {
     Terminal(Box<TerminalPane>),
     App(Box<AppPane>),
     /// A tile that represents a child context nested inside this one.
-    /// Renders a wireframe preview; Cmd+Shift+Enter zooms in.
-    SubContext {
-        pane_id: PaneId,
-        context_id: u64,
-    },
+    /// Renders a summary card with pane count, status, and per-pane summaries.
+    /// Cmd+Shift+Enter zooms in.
+    Portal(Box<PortalPane>),
+}
+
+/// A portal pane points at a child context and caches its rolled-up state.
+pub struct PortalPane {
+    pub pane_id: PaneId,
+    pub target_context_id: u64,
+    pub context_state: Option<crate::context_state::ContextState>,
 }
 
 impl Pane {
@@ -26,7 +31,7 @@ impl Pane {
         match self {
             Pane::Terminal(t) => t.id,
             Pane::App(a) => a.id,
-            Pane::SubContext { pane_id, .. } => *pane_id,
+            Pane::Portal(p) => p.pane_id,
         }
     }
 
@@ -58,9 +63,24 @@ impl Pane {
         }
     }
 
-    pub fn as_sub_context(&self) -> Option<u64> {
+    pub fn as_portal(&self) -> Option<&PortalPane> {
         match self {
-            Pane::SubContext { context_id, .. } => Some(*context_id),
+            Pane::Portal(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    pub fn as_portal_mut(&mut self) -> Option<&mut PortalPane> {
+        match self {
+            Pane::Portal(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Returns the target context_id if this is a Portal pane.
+    pub fn portal_target(&self) -> Option<u64> {
+        match self {
+            Pane::Portal(p) => Some(p.target_context_id),
             _ => None,
         }
     }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1176,6 +1176,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            target_context: None,
         });
         h.run_frames(2);
 
@@ -1214,6 +1215,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            target_context: None,
         });
         h.run_frames(2);
 
@@ -1255,6 +1257,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            target_context: None,
         });
         h.run_frames(2);
 
@@ -1295,6 +1298,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            target_context: None,
         });
         h.run_frames(2);
 
@@ -1345,6 +1349,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            target_context: None,
         });
         h.run_frames(2);
 
@@ -1393,6 +1398,7 @@ mod tests {
                 cwd: None,
                 no_focus: false,
                 path: None,
+                target_context: None,
             });
             h.run_frames(2);
         }
@@ -1592,6 +1598,92 @@ mod quick_note_tests {
         let result = PlexiApp::substitute_note_tokens_static("echo {context_root}", "note", &c);
         // When context_root is None, {context_root} substitutes to shell_quote("") = ''
         assert!(result.contains("''") || result.ends_with("echo "), "unexpected result: {result}");
+    }
+
+    // ── Agent context spawning tests (#1518) ─────────────────────────────────
+
+    /// Verify that QueryContextState for the pane's own context produces
+    /// the correct AppCommand via route_command.
+    #[test]
+    fn query_context_state_routes_to_pending_commands() {
+        use crate::app_protocol::{AppRequest, DrawCommand};
+        use crate::pane::{AppRuntime, Pane};
+        use crate::testing::HostHarness;
+
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+
+        h.inject(pane, DrawCommand::Host(
+            AppRequest::QueryContextState { context_id: 1 },
+        ));
+        // Drain the draw channel via background_tick.
+        {
+            let win = &mut h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(ref mut proc) = app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            proc.background_tick();
+        }
+
+        // Verify pending_commands contains QueryContextState with the
+        // correct sender_pane_id.
+        let win = &mut h.app.windows[0];
+        let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+            panic!("expected App pane");
+        };
+        let AppRuntime::Process(ref mut proc) = app_pane.runtime else {
+            panic!("expected Process runtime");
+        };
+        let has_cmd = proc.pending_commands.iter().any(|c| {
+            matches!(c, crate::app_trait::AppCommand::QueryContextState {
+                sender_pane_id, context_id
+            } if *sender_pane_id == pane && *context_id == 1)
+        });
+        assert!(
+            has_cmd,
+            "QueryContextState should be in pending_commands after route_command"
+        );
+    }
+
+    #[test]
+    fn spawn_pane_target_context_invalid_returns_error() {
+        use crate::testing::HostHarness;
+
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile");
+        h.app.windows[0].focused_pane = Some(root);
+
+        // Spawn into a non-existent context via the PGAP draw channel
+        // (inject, not inject_ipc) so it routes through ProcessApp ->
+        // pending_commands -> deferred dispatch with target_context validation.
+        h.inject(pane, crate::app_protocol::DrawCommand::Host(
+            crate::app_protocol::AppRequest::SpawnPane {
+                type_id: "terminal".to_string(),
+                layout: Some("split_v".to_string()),
+                args: vec![],
+                pipe_id: None,
+                from_pane_id: None,
+                request_id: Some("req-ctx-bad".to_string()),
+                response_file: None,
+                ephemeral: false,
+                cwd: None,
+                no_focus: false,
+                path: None,
+                target_context: Some(999),
+            },
+        ));
+        h.run_frames(1);
+
+        // The pane count should NOT have increased (spawn was rejected).
+        let snap = h.state();
+        assert_eq!(
+            snap.open_panes.len(), 1,
+            "SpawnPane with invalid target_context must not create a pane"
+        );
     }
 }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -191,7 +191,7 @@ impl PlexiApp {
         let kind = match self.windows[active].panes.get(&focused_pane_id) {
             Some(Pane::Terminal(_)) => Kind::Terminal,
             Some(Pane::App(a)) => Kind::App(a.manifest_id.clone()),
-            Some(Pane::SubContext { .. }) | None => return,
+            Some(Pane::Portal(_)) | None => return,
         };
 
         // `vertical` here follows split_with_new_pane semantics (not split_focused):

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 impl PlexiApp {
     /// Create a child context nested inside `parent_name`. Always creates a fresh
-    /// terminal in the child (portal model — no pane adoption). Inserts a SubContext
+    /// terminal in the child (portal model — no pane adoption). Inserts a Portal
     /// tile into the parent window as a sibling of the focused tile. No depth cap.
     pub(crate) fn new_child_context(&mut self, parent_name: &str, path: PathBuf) -> Result<(), String> {
         let parent_idx = self.router.position(|c| c.name.eq_ignore_ascii_case(parent_name))
@@ -42,7 +42,7 @@ impl PlexiApp {
             return Err("failed to create terminal for child context".to_string());
         };
 
-        // 2. Insert SubContext tile into the parent window via the standard split path.
+        // 2. Insert Portal tile into the parent window via the standard split path.
         let parent_win_idx = {
             let preferred = self.context_active_window.get(&parent_id).copied();
             preferred
@@ -62,10 +62,14 @@ impl PlexiApp {
             );
             self.windows[parent_win_idx].panes.insert(
                 sub_ctx_pane_id,
-                crate::pane::Pane::SubContext { pane_id: sub_ctx_pane_id, context_id: ctx_id },
+                crate::pane::Pane::Portal(Box::new(crate::pane::PortalPane {
+                    pane_id: sub_ctx_pane_id,
+                    target_context_id: ctx_id,
+                    context_state: None,
+                })),
             );
         } else {
-            log::warn!("new_child_context: parent ctx_id={parent_id} has no window — child context has no portal");
+            log::warn!("new_child_context: parent ctx_id={parent_id} has no window — child context has no Portal tile");
         }
 
         // 3. Register the child context + window.
@@ -286,13 +290,13 @@ impl PlexiApp {
         // 3. Remove all windows belonging to any deleted context.
         self.windows.retain(|c| !deleted.contains(&c.context_id));
 
-        // 4. Remove SubContext tiles in surviving windows that point to any deleted ctx.
+        // 4. Remove Portal tiles in surviving windows that point to any deleted ctx.
         for win in &mut self.windows {
-            let sub_ctx_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
-                .filter(|(_, p)| p.as_sub_context().map(|cid| deleted.contains(&cid)).unwrap_or(false))
+            let portal_pane_ids: Vec<crate::tiling::PaneId> = win.panes.iter()
+                .filter(|(_, p)| p.portal_target().map(|cid| deleted.contains(&cid)).unwrap_or(false))
                 .map(|(id, _)| *id)
                 .collect();
-            for pane_id in sub_ctx_pane_ids {
+            for pane_id in portal_pane_ids {
                 win.panes.remove(&pane_id);
                 if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
                     win.tree.remove_recursively(tile_id);
@@ -522,36 +526,36 @@ impl PlexiApp {
         self.router.get_mut(idx).root = Some(root);
     }
 
-    /// Dissolve a sub-context: reparent all its panes into the parent window (the active
-    /// window that contains the SubContext tile), replace the SubContext tile with the
+    /// Dissolve a portal: reparent all its panes into the parent window (the active
+    /// window that contains the Portal tile), replace the Portal tile with the
     /// adopted panes, then delete the now-empty child context.
     ///
-    /// Only promotes one level. Nested sub-contexts inside the dissolved context remain
+    /// Only promotes one level. Nested portals inside the dissolved context remain
     /// intact — their tiles are moved to the parent window alongside the regular panes.
-    pub(crate) fn dissolve_sub_context(&mut self, child_ctx_id: u64) {
+    pub(crate) fn dissolve_portal(&mut self, child_ctx_id: u64) {
         use egui_tiles::{Container, Tile};
 
-        // Find the SubContext tile in the active (parent) window.
+        // Find the Portal tile in the active (parent) window.
         let parent_idx = self.active_window;
-        let sub_ctx_pane_id = {
+        let portal_pane_id = {
             let win = &self.windows[parent_idx];
             win.panes.iter()
-                .find(|(_, p)| p.as_sub_context() == Some(child_ctx_id))
+                .find(|(_, p)| p.portal_target() == Some(child_ctx_id))
                 .map(|(id, _)| *id)
         };
-        let sub_ctx_pane_id = match sub_ctx_pane_id {
+        let portal_pane_id = match portal_pane_id {
             Some(id) => id,
             None => {
-                log::warn!("dissolve_sub_context: no SubContext tile for ctx={child_ctx_id} in active window");
+                log::warn!("dissolve_portal: no Portal tile for ctx={child_ctx_id} in active window");
                 return;
             }
         };
 
-        let sub_ctx_tile_id = self.windows[parent_idx].tree.tiles.find_pane(&sub_ctx_pane_id);
-        let sub_ctx_tile_id = match sub_ctx_tile_id {
+        let portal_tile_id = self.windows[parent_idx].tree.tiles.find_pane(&portal_pane_id);
+        let portal_tile_id = match portal_tile_id {
             Some(id) => id,
             None => {
-                log::warn!("dissolve_sub_context: SubContext pane {sub_ctx_pane_id} has no tile");
+                log::warn!("dissolve_portal: Portal pane {portal_pane_id} has no tile");
                 return;
             }
         };
@@ -574,22 +578,22 @@ impl PlexiApp {
             }
         }
 
-        log::info!("dissolve_sub_context: ctx={child_ctx_id} adopting {} panes into parent win={parent_idx}", adopted.len());
+        log::info!("dissolve_portal: ctx={child_ctx_id} adopting {} panes into parent win={parent_idx}", adopted.len());
 
         // Insert adopted panes into the parent window.
-        // Strategy: add each new tile alongside the SubContext tile.
-        // After all siblings are added, remove the SubContext tile.
+        // Strategy: add each new tile alongside the Portal tile.
+        // After all siblings are added, remove the Portal tile.
         for (pane_id, pane) in adopted {
             let new_tile = self.windows[parent_idx].tree.tiles.insert_pane(pane_id);
             self.windows[parent_idx].panes.insert(pane_id, pane);
 
-            // Add the new tile as a sibling of the SubContext tile.
-            let parent_of_sub = self.windows[parent_idx].tree.tiles.parent_of(sub_ctx_tile_id);
-            if let Some(parent_tile) = parent_of_sub {
+            // Add the new tile as a sibling of the Portal tile.
+            let parent_of_portal = self.windows[parent_idx].tree.tiles.parent_of(portal_tile_id);
+            if let Some(parent_tile) = parent_of_portal {
                 if let Some(Tile::Container(Container::Linear(lin))) =
                     self.windows[parent_idx].tree.tiles.get_mut(parent_tile)
                 {
-                    if let Some(pos) = lin.children.iter().position(|&c| c == sub_ctx_tile_id) {
+                    if let Some(pos) = lin.children.iter().position(|&c| c == portal_tile_id) {
                         lin.children.insert(pos, new_tile);
                     } else {
                         lin.children.push(new_tile);
@@ -605,22 +609,22 @@ impl PlexiApp {
                     }
                 }
             } else {
-                // SubContext tile is the root — wrap everything in a horizontal container.
-                let new_root = self.windows[parent_idx].tree.tiles.insert_horizontal_tile(vec![new_tile, sub_ctx_tile_id]);
+                // Portal tile is the root — wrap everything in a horizontal container.
+                let new_root = self.windows[parent_idx].tree.tiles.insert_horizontal_tile(vec![new_tile, portal_tile_id]);
                 self.windows[parent_idx].tree.root = Some(new_root);
             }
         }
 
-        // Remove the SubContext tile from the parent window.
+        // Remove the Portal tile from the parent window.
         {
             let win = &mut self.windows[parent_idx];
-            win.panes.remove(&sub_ctx_pane_id);
-            if let Some(parent_tile) = win.tree.tiles.parent_of(sub_ctx_tile_id) {
+            win.panes.remove(&portal_pane_id);
+            if let Some(parent_tile) = win.tree.tiles.parent_of(portal_tile_id) {
                 if let Some(Tile::Container(parent_container)) = win.tree.tiles.get_mut(parent_tile) {
-                    parent_container.remove_child(sub_ctx_tile_id);
+                    parent_container.remove_child(portal_tile_id);
                 }
             }
-            win.tree.tiles.remove(sub_ctx_tile_id);
+            win.tree.tiles.remove(portal_tile_id);
             win.tree.simplify(&egui_tiles::SimplificationOptions {
                 all_panes_must_have_tabs: true,
                 ..egui_tiles::SimplificationOptions::default()
@@ -677,10 +681,10 @@ impl PlexiApp {
                         app_id: Some(a.runtime.type_id().to_string()),
                         app_state: a.runtime.serialize_state(),
                     });
-                } else if let Some(child_ctx_id) = pane.as_sub_context() {
+                } else if let Some(child_ctx_id) = pane.portal_target() {
                     saved_panes.push(crate::workspace::SavedPane {
                         id,
-                        kind: crate::workspace::SavedPaneKind::SubContext { context_id: child_ctx_id },
+                        kind: crate::workspace::SavedPaneKind::Portal { context_id: child_ctx_id },
                         cwd: std::path::PathBuf::new(),
                         name: None,
                         app_id: None,

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -650,15 +650,7 @@ impl PlexiApp {
         let mut saved_windows = Vec::new();
 
         for ctx in self.router.iter() {
-            saved_contexts.push(crate::workspace::SavedContext {
-                name: ctx.name.clone(),
-                path: ctx.path.clone(),
-                root: ctx.root.clone(),
-                description: ctx.description.clone(),
-                context_id: ctx.context_id,
-                parent_id: ctx.parent_id,
-                depth: ctx.depth,
-            });
+            saved_contexts.push(ctx.clone());
         }
 
         for win in &self.windows {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -23,10 +23,25 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        let ctx_name = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| format!("Sub-context {}", self.router.len() + 1));
+        // Check for anchor defaults from .plexi/workspace.toml [context] section.
+        let anchor = crate::anchor::Anchor::detect(&path);
+        let (ctx_name, ctx_description) = match anchor.as_ref().and_then(|a| a.context_defaults.as_ref()) {
+            Some(defaults) => {
+                let name = defaults.name.clone().unwrap_or_else(|| {
+                    path.file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| format!("Sub-context {}", self.router.len() + 1))
+                });
+                (name, defaults.description.clone())
+            }
+            None => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| format!("Sub-context {}", self.router.len() + 1));
+                (name, None)
+            }
+        };
 
         log::info!(
             "new_child_context: parent_id={parent_id} parent_depth={parent_depth} \
@@ -77,7 +92,7 @@ impl PlexiApp {
             name: ctx_name,
             path: path.clone(),
             root: Some(path.clone()),
-            description: None,
+            description: ctx_description,
             context_id: ctx_id,
             parent_id: Some(parent_id),
             depth: child_depth,
@@ -153,7 +168,8 @@ impl PlexiApp {
 
     /// Create a new context at a specific directory path. The terminal pane
     /// opens at `path` and the context root is set to it. Named after the
-    /// directory basename. Callers must call `save_workspace()` afterward.
+    /// directory basename, unless the path has a `.plexi/workspace.toml` with
+    /// `[context]` defaults. Callers must call `save_workspace()` afterward.
     pub(crate) fn new_context_at_path(&mut self, path: PathBuf) {
         log::info!("new_context_at_path: path={}", path.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(path.clone()), None, false)
@@ -167,15 +183,35 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        let ctx_name = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| format!("Context {}", self.router.len() + 1));
+        // Check for anchor defaults from .plexi/workspace.toml [context] section.
+        let anchor = crate::anchor::Anchor::detect(&path);
+        let (ctx_name, ctx_description) = match anchor.as_ref().and_then(|a| a.context_defaults.as_ref()) {
+            Some(defaults) => {
+                let name = defaults.name.clone().unwrap_or_else(|| {
+                    path.file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| format!("Context {}", self.router.len() + 1))
+                });
+                log::info!(
+                    "new_context_at_path: applying anchor defaults name={:?} description={:?}",
+                    name, defaults.description
+                );
+                (name, defaults.description.clone())
+            }
+            None => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| format!("Context {}", self.router.len() + 1));
+                (name, None)
+            }
+        };
+
         self.router.push(crate::context::Context {
             name: ctx_name,
             path: path.clone(),
             root: Some(path.clone()),
-            description: None,
+            description: ctx_description,
             context_id: ctx_id,
             parent_id: None,
             depth: 0,

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -773,6 +773,7 @@ impl ProcessApp {
                 cwd: _,
                 no_focus: _,
                 path: _,
+                target_context,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)
@@ -784,7 +785,7 @@ impl ProcessApp {
                 }
                 let layout_str = layout.unwrap_or_else(|| "overlay".to_string());
                 log::info!(
-                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout_str}' args={args:?} pipe_id={pipe_id:?} from_pane_id={from_pane_id:?} request_id={request_id:?}",
+                    "ProcessApp[{}]: SpawnPane type_id='{type_id}' layout='{layout_str}' args={args:?} pipe_id={pipe_id:?} from_pane_id={from_pane_id:?} request_id={request_id:?} target_context={target_context:?}",
                     self.type_id
                 );
                 self.pending_commands.push(AppCommand::SpawnPane {
@@ -794,6 +795,7 @@ impl ProcessApp {
                     pipe_id,
                     from_pane_id,
                     request_id,
+                    target_context,
                 });
             }
 
@@ -1714,6 +1716,18 @@ impl ProcessApp {
                     "ProcessApp[{}]: CapturePane pane_id={pane_id} received in app routing — ignored (use PLEXI_SOCKET instead)",
                     self.type_id
                 );
+            }
+
+            // ── Query context state (#1518) ───────────────────────────────
+            AppRequest::QueryContextState { context_id } => {
+                log::info!(
+                    "ProcessApp[{}]: QueryContextState context_id={context_id}",
+                    self.type_id
+                );
+                self.pending_commands.push(AppCommand::QueryContextState {
+                    sender_pane_id: self.pane_id,
+                    context_id,
+                });
             }
         }
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -208,6 +208,13 @@ impl HostHarness {
         })
     }
 
+    // ── Context management ────────────────────────────────────────────────────
+
+    /// Add a sub-context under the given parent context in the host model.
+    pub fn add_sub_context(&mut self, context_id: u64, parent_id: u64) {
+        self.app.host.add_context(context_id, Some(parent_id));
+    }
+
     // ── State inspection ─────────────────────────────────────────────────────
 
     /// Snapshot observable state from the app after the last frame.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -44,7 +44,7 @@ impl HostSnapshot {
                 let title = match pane {
                     Pane::App(p) => p.name.clone(),
                     Pane::Terminal(_) => "Terminal".to_string(),
-                    Pane::SubContext { context_id, .. } => format!("SubContext({context_id})"),
+                    Pane::Portal(p) => format!("Portal({})", p.target_context_id),
                 };
                 (*id, title)
             })

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -36,7 +36,7 @@ pub(crate) fn paint_tab_dots(
     }
 }
 
-/// Per-pane summary carried in SubContext tile preview data.
+/// Per-pane summary carried in Portal tile preview data.
 #[derive(Clone, Default)]
 pub struct ChildPaneSummary {
     pub pane_name: Option<String>,
@@ -44,17 +44,17 @@ pub struct ChildPaneSummary {
     pub app_type: String,
 }
 
-/// Preview data for a SubContext tile.
+/// Preview data for a Portal tile.
 #[derive(Clone)]
-pub struct SubContextPreview {
+pub struct PortalPreview {
     pub context_name: String,
     pub panes: Vec<ChildPaneSummary>,
     pub notification_count: usize,
 }
 
-impl Default for SubContextPreview {
+impl Default for PortalPreview {
     fn default() -> Self {
-        SubContextPreview {
+        PortalPreview {
             context_name: "(deleted)".to_string(),
             panes: Vec::new(),
             notification_count: 0,
@@ -83,8 +83,8 @@ pub struct PlexiBehavior<'a> {
     /// Opacity applied to unfocused panes when ghost mode is active.
     /// `None` = no dimming. Values below 1.0 dim all non-focused panes.
     pub unfocused_opacity: Option<f32>,
-    /// Preview data for SubContext tiles.
-    pub sub_context_info: HashMap<PaneId, SubContextPreview>,
+    /// Preview data for Portal tiles.
+    pub portal_info: HashMap<PaneId, PortalPreview>,
     /// True when an overlay or modal has captured keyboard input this frame.
     /// Prevents terminal panes from calling `request_focus()` and stealing
     /// egui focus from the active overlay (egui resolves focus last-caller-wins).
@@ -166,22 +166,22 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             if close_exited {
                 self.close_exited = Some(tile_id);
             }
-        } else if pane.as_sub_context().is_some() {
-            // SubContext tile — responsive PGAP-rendered preview.
+        } else if pane.as_portal().is_some() {
+            // Portal tile — responsive PGAP-rendered preview.
             ui.painter().rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
-            let preview = self.sub_context_info
+            let preview = self.portal_info
                 .get(pane_id)
                 .cloned()
                 .unwrap_or_default();
 
-            let tiers = crate::tiling::sub_context_responsive_tiers(&preview, &self.colors);
+            let tiers = crate::tiling::portal_responsive_tiers(&preview, &self.colors);
             let avail_w = pane_rect.width();
             let avail_h = pane_rect.height();
             if let Some(tier) = crate::process_app::render::select_responsive_tier(
                 &tiers, avail_w, avail_h,
             ) {
                 log::info!(
-                    "sub_context responsive: aspect={} for {}x{}",
+                    "portal responsive: aspect={} for {}x{}",
                     tier.aspect, avail_w, avail_h,
                 );
                 let clip = pane_rect;
@@ -286,17 +286,17 @@ pub(crate) fn write_dropped_paths_to_terminal(ui: &egui::Ui, t: &mut TerminalPan
     }
 }
 
-// ── SubContext responsive tier builder ─────────────────────────────────────────
+// ── Portal responsive tier builder ────────────────────────────────────────────
 
 use crate::app_protocol::{LayoutChild, LayoutDirection, RenderCommand, ResponsiveTier};
 
-/// Build the three responsive tiers for a SubContext preview card.
+/// Build the three responsive tiers for a Portal preview card.
 ///
 /// - Landscape: horizontal row with context name + pane count + notification badge
 /// - Square: column with abbreviated info
 /// - Portrait: compact vertical stack
-pub(crate) fn sub_context_responsive_tiers(
-    preview: &SubContextPreview,
+pub(crate) fn portal_responsive_tiers(
+    preview: &PortalPreview,
     colors: &Colors,
 ) -> Vec<ResponsiveTier> {
     let ctx_name = &preview.context_name;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -57,7 +57,8 @@ pub enum SavedPaneKind {
     #[default]
     Terminal,
     App,
-    SubContext { context_id: u64 },
+    #[serde(alias = "sub_context")]
+    Portal { context_id: u64 },
 }
 
 fn workspace_path() -> PathBuf {
@@ -141,22 +142,30 @@ mod tests {
             assert_eq!(restored.id, 42);
             assert_eq!(restored.cwd, PathBuf::from("/tmp"));
         }
-        // SubContext round-trips with embedded context_id.
-        let sub_ctx_pane = SavedPane {
+        // Portal round-trips with embedded context_id.
+        let portal_pane = SavedPane {
             id: 99,
-            kind: SavedPaneKind::SubContext { context_id: 42 },
+            kind: SavedPaneKind::Portal { context_id: 42 },
             cwd: PathBuf::new(),
             name: None,
             app_id: None,
             app_state: None,
         };
-        let json = serde_json::to_string(&sub_ctx_pane).expect("serialize sub_context");
-        let restored: SavedPane = serde_json::from_str(&json).expect("deserialize sub_context");
+        let json = serde_json::to_string(&portal_pane).expect("serialize portal");
+        let restored: SavedPane = serde_json::from_str(&json).expect("deserialize portal");
         assert!(
-            matches!(restored.kind, SavedPaneKind::SubContext { context_id: 42 }),
-            "SubContext kind must round-trip with correct context_id"
+            matches!(restored.kind, SavedPaneKind::Portal { context_id: 42 }),
+            "Portal kind must round-trip with correct context_id"
         );
         assert_eq!(restored.id, 99);
+
+        // Backward compat: old "sub_context" JSON still deserializes to Portal.
+        let legacy_json = r#"{"id":99,"kind":{"sub_context":{"context_id":42}},"cwd":"","name":null,"app_id":null,"app_state":null}"#;
+        let legacy: SavedPane = serde_json::from_str(legacy_json).expect("deserialize legacy sub_context");
+        assert!(
+            matches!(legacy.kind, SavedPaneKind::Portal { context_id: 42 }),
+            "legacy sub_context must deserialize to Portal"
+        );
     }
 
     /// SavedWindow omits `grid_x` / `grid_y` defaults cleanly.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,3 +1,4 @@
+use crate::context::Context;
 use crate::tiling::PaneId;
 use egui_tiles::{TileId, Tree};
 use serde::{Deserialize, Serialize};
@@ -12,30 +13,11 @@ pub struct WorkspaceFile {
     pub active_context: usize,
     pub sidebar_visible: bool,
     pub next_pane_id: u64,
-    pub contexts: Vec<SavedContext>,
+    pub contexts: Vec<Context>,
     pub windows: Vec<SavedWindow>,
     /// context_id → last active window_id for that context.
     #[serde(default)]
     pub context_active_window: HashMap<u64, u64>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct SavedContext {
-    pub name: String,
-    pub path: PathBuf,
-    /// Optional project root — persisted so contexts restore their root on relaunch.
-    #[serde(default)]
-    pub root: Option<PathBuf>,
-    /// Optional description — ambient intent for what you're doing in this context.
-    #[serde(default)]
-    pub description: Option<String>,
-    pub context_id: u64,
-    /// Parent context_id for sub-contexts. None = top-level.
-    #[serde(default)]
-    pub parent_id: Option<u64>,
-    /// Nesting depth. 0 = root level.
-    #[serde(default)]
-    pub depth: u32,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -213,5 +195,45 @@ mod tests {
         let restored: SavedPane = serde_json::from_str(legacy_json)
             .expect("legacy SavedPane must deserialize");
         assert_eq!(restored.kind, SavedPaneKind::Terminal);
+    }
+
+    /// Context (formerly SavedContext) round-trips through JSON and handles
+    /// legacy files missing optional fields (root, description, parent_id, depth).
+    #[test]
+    fn context_serde_round_trip() {
+        let ctx = Context {
+            name: "dev".to_string(),
+            path: PathBuf::from("/projects/dev"),
+            root: Some(PathBuf::from("/projects/dev/src")),
+            description: Some("main workspace".to_string()),
+            context_id: 42,
+            parent_id: Some(1),
+            depth: 1,
+        };
+        let json = serde_json::to_string(&ctx).expect("serialize");
+        let restored: Context = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.name, "dev");
+        assert_eq!(restored.context_id, 42);
+        assert_eq!(restored.parent_id, Some(1));
+        assert_eq!(restored.depth, 1);
+        assert_eq!(restored.root, Some(PathBuf::from("/projects/dev/src")));
+    }
+
+    /// Legacy workspace JSON without optional Context fields deserializes with defaults.
+    #[test]
+    fn legacy_context_without_optional_fields_deserializes() {
+        let legacy_json = r#"{
+            "name": "old-ctx",
+            "path": "/tmp",
+            "context_id": 7
+        }"#;
+        let restored: Context = serde_json::from_str(legacy_json)
+            .expect("legacy Context must deserialize");
+        assert_eq!(restored.name, "old-ctx");
+        assert_eq!(restored.context_id, 7);
+        assert_eq!(restored.parent_id, None);
+        assert_eq!(restored.depth, 0);
+        assert_eq!(restored.root, None);
+        assert_eq!(restored.description, None);
     }
 }

--- a/src/workspace_router.rs
+++ b/src/workspace_router.rs
@@ -49,6 +49,10 @@ impl WorkspaceRouter {
         self.contexts.iter()
     }
 
+    pub(crate) fn as_slice(&self) -> &[Context] {
+        &self.contexts
+    }
+
     pub(crate) fn position<F: Fn(&Context) -> bool>(&self, f: F) -> Option<usize> {
         self.contexts.iter().position(f)
     }

--- a/src/workspace_secrets.rs
+++ b/src/workspace_secrets.rs
@@ -328,6 +328,18 @@ impl SecretStore for InMemoryKeychain {
 #[derive(Deserialize, Debug, Clone)]
 pub struct WorkspaceConfig {
     pub id: String,
+    /// Optional `[context]` section — default name/description for the root
+    /// context when this workspace is first opened. User overrides always win.
+    #[serde(default)]
+    pub context: Option<WorkspaceContextConfig>,
+}
+
+/// `[context]` section in workspace.toml. Provides default name and
+/// description for the anchor's root context. Both fields are optional.
+#[derive(Deserialize, Debug, Clone)]
+pub struct WorkspaceContextConfig {
+    pub name: Option<String>,
+    pub description: Option<String>,
 }
 
 impl WorkspaceConfig {
@@ -361,7 +373,7 @@ impl WorkspaceConfig {
         let path = dir.join("workspace.toml");
         std::fs::write(&path, format!("id = \"{id}\"\n"))
             .map_err(|e| format!("write {}: {e}", path.display()))?;
-        Ok(Self { id })
+        Ok(Self { id, context: None })
     }
 }
 


### PR DESCRIPTION
## Summary

Complete context tree rework across 4 sequential issues:

- **#1516** — Unified `Context`/`SavedContext`/`HostContext` into a single recursive `Context` type. Removed `SavedContext`, added hierarchy helpers (`children_of`, `ancestors_of`) to `HostModel`.
- **#1517** — Renamed `Pane::SubContext` → `Pane::Portal(Box<PortalPane>)`. Added `ContextState`/`ContextStatus`/`PaneSummary` types with bottom-up rollup computation. Portal tiles render summary cards.
- **#1518** — Added `target_context: Option<u64>` to `SpawnPane` and new `QueryContextState` AppRequest with visibility boundary enforcement. Python SDK gains `spawn_in_context()` and `query_context_state()`.
- **#1520** — Formalized `.plexi/` as the canonical context anchor. `Anchor::detect()` reads `workspace.toml [context]` defaults, guards against profile dir collision. New contexts auto-populate name/description from anchor.

## Files Changed (28 files, +1265 / -199)

**New files:** `src/anchor.rs`, `src/context_state.rs`
**Rust host:** `context.rs`, `pane.rs`, `tiling.rs`, `workspace.rs`, `app/mod.rs`, `app/dispatch.rs`, `app/tests.rs`, `app_protocol.rs`, `app_trait.rs`, `host/model.rs`, `testing.rs`, `overlays.rs`, `pane_ops/create.rs`, `pane_ops/layout.rs`, `pane_ops/workspace.rs`, `process_app/routing.rs`, `workspace_router.rs`, `workspace_secrets.rs`, `main.rs`, `lib.rs`
**Python SDK:** `_app.py`, `_emitter.py`, `_render_context.py`

## Test plan

- [ ] `cargo test --bin plexi` passes (533 tests, 7 pre-existing failures)
- [ ] Existing saved workspaces with old `sub_context` pane kind still deserialize
- [ ] `.plexi/workspace.toml` with `[context]` section populates new context name/description
- [ ] `~/.plexi/` is NOT treated as a workspace anchor (profile dir guard)
- [ ] Portal panes show context summary when sub-contexts exist

Closes #1516, closes #1517, closes #1518, closes #1520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can query and receive rolled-up context state (per-context status and pane summaries).
  * Spawn new panes targeted at descendant contexts.
  * Detect project anchors to prefill context name/description from workspace metadata.

* **Refactor**
  * Child contexts represented and surfaced as "Portals" instead of prior sub-context tiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->