### PR TITLE
fix(terminal): always use TERM=xterm-256color, drop xterm-ghostty (#1532)

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -219,12 +219,8 @@ fn fallback_path_with_homebrew() -> Option<String> {
 pub fn build_env() -> HashMap<String, String> {
     let mut env = HashMap::new();
 
-    if let Some(terminfo_dir) = detect_ghostty_terminfo_dir() {
-        env.insert("TERM".into(), "xterm-ghostty".into());
-        env.insert("TERMINFO".into(), terminfo_dir);
-    } else {
-        env.insert("TERM".into(), "xterm-256color".into());
-    }
+    env.insert("TERM".into(), "xterm-256color".into());
+    log::info!("shell::build_env: TERM=xterm-256color");
     env.insert("COLORTERM".into(), "truecolor".into());
     env.insert("PLEXI_RUNNING".into(), "1".into());
     if let Some(channel) = crate::config::build_channel() {
@@ -274,33 +270,6 @@ pub fn build_env() -> HashMap<String, String> {
     env
 }
 
-fn detect_ghostty_terminfo_dir() -> Option<String> {
-    let candidates = [
-        "/Applications/Ghostty.app/Contents/Resources/terminfo",
-        "/opt/homebrew/Cellar/ghostty",
-        "/usr/local/Cellar/ghostty",
-    ];
-
-    for candidate in candidates {
-        let path = Path::new(candidate);
-        if path.join("78/xterm-ghostty").is_file() {
-            return Some(path.to_string_lossy().into_owned());
-        }
-
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
-                let terminfo_path = entry.path().join("share/terminfo/78/xterm-ghostty");
-                if terminfo_path.is_file() {
-                    if let Some(dir) = terminfo_path.parent().and_then(Path::parent) {
-                        return Some(dir.to_string_lossy().into_owned());
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
 
 static CWD_CACHE: LazyLock<Mutex<HashMap<u32, (PathBuf, Instant)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));


### PR DESCRIPTION
## Summary

- Removes `detect_ghostty_terminfo_dir()` entirely — Plexi is not Ghostty and borrowing its terminfo was a mistake
- Always sets `TERM=xterm-256color` (universally supported; was already the fallback)
- Never injects `TERMINFO` — remote hosts don't have xterm-ghostty terminfo, causing stty erase mismatch that broke backspace in SSH
- `COLORTERM=truecolor` is unchanged — this is what actually gates true-color in apps like `bat` and `delta`

## Root Cause

`shell::build_env()` was setting `TERM=xterm-ghostty` when Ghostty.app was installed. SSH propagates TERM to the remote host via the PTY request. Remote readline/stty mapped erase to `^H` (0x08); egui_term sends `\x7f` (DEL). Mismatch → backspace did nothing.

## Done When
- SSH to a remote host and backspace deletes characters correctly
- `echo $TERM` inside a Plexi pane shows `xterm-256color`
- `cargo build` passes ✅

Closes #1532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified terminal environment configuration. The `TERM` variable is now unconditionally set to `xterm-256color` instead of using conditional detection logic. Terminal-specific probing behavior has been removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->