### PR TITLE
fix(pane-ops): Cmd+N from welcome screen opens at context root (#1534)

### DIFF
--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -287,8 +287,9 @@ impl PlexiApp {
     }
 
     pub(crate) fn reset_active_context(&mut self) {
-        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(home.clone()), None, false)
+        let cwd = self.cwd_for_welcome_tab();
+        log::info!("reset_active_context: cwd={} context_root={:?}", cwd.display(), self.router.active().root);
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd), None, false)
         else {
             log::error!("Failed to create terminal for reset context");
             return;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -784,4 +784,35 @@ mod tests {
         }
     }
 
+    // -- Context root CWD resolution ------------------------------------------
+
+    /// Regression guard for #1534: `reset_active_context` (Cmd+N from welcome
+    /// screen) must use `cwd_for_welcome_tab()` — which checks the context root
+    /// — rather than hardcoding `home_dir()`.
+    #[test]
+    fn cwd_for_welcome_tab_returns_context_root_when_set() {
+        let root = std::path::PathBuf::from("/tmp");
+        let mut h = HostHarness::new();
+        h.app.set_active_context_root(root.clone());
+        assert_eq!(
+            h.app.cwd_for_welcome_tab(),
+            root,
+            "cwd_for_welcome_tab must return the context root when one is set"
+        );
+    }
+
+    /// Regression guard for #1534: without a context root, `cwd_for_welcome_tab`
+    /// must fall back to the window launch path, not panic or return an arbitrary dir.
+    #[test]
+    fn cwd_for_welcome_tab_falls_back_to_window_path_when_no_root() {
+        let h = HostHarness::new();
+        let window_path = h.app.windows[0].path.clone();
+        // No root set — fallback chain: None → window.path
+        assert_eq!(
+            h.app.cwd_for_welcome_tab(),
+            window_path,
+            "cwd_for_welcome_tab must fall back to window.path when no context root is set"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

- `reset_active_context` (triggered by Cmd+N when window is empty) was hardcoding `home_dir()` as the working directory, bypassing the context root
- All other pane-creation paths (Cmd+T, splits, Cmd+D) already called `cwd_for_welcome_tab()` which checks `router.active().root` first
- Fix: replace the one-liner `home_dir()` call with `self.cwd_for_welcome_tab()`, making Cmd+N consistent with all other pane-open paths

## Done When

- [x] Pressing Cmd+N from the welcome screen in a context with a root opens the terminal at that root path
- [x] "↗ outside workspace" badge does not appear on first-window panes when the CWD matches the context root
- [x] HostHarness tests for `cwd_for_welcome_tab` with and without context root pass

Closes #1534