### PR TITLE
feat(widgets): overlay layout primitives — section_header, pane_type_badge, status_chip, description_label (#1540)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,12 @@ Before writing any keyboard shortcut display, badge, chip, or inline label widge
 
 **Use `key_combo_list` for any shortcut hint row.** Do not render key shortcuts as plain `Label` text — it produces a visually inconsistent result that requires a separate pass to fix.
 
+**Overlay layout primitives** — four shared widgets every overlay should use instead of inlining:
+- `section_header(ui, label, is_active, colors)` — group/context label at `TEXT_CAPTION` weight; `is_active` switches color from `text_dim` to `accent`.
+- `pane_type_badge(ui, kind, colors)` — renders `"T"` for Terminal, `"A"` for App (first letter of kind) as a `key_chip`. Saves horizontal space vs. full word.
+- `status_chip(ui, status, colors)` — centralized status color mapping: `"busy"`/`"running"` → `accent`; `"crashed"`/`"hung"`/`"error"`/`"exited"` → `danger`; everything else → `text_dim`.
+- `description_label(ui, text, colors)` — single-line `TEXT_HINT` label with `truncate()`. **Caller must call `ui.set_max_width(n)` first** or truncation never fires.
+
 ## Channel-Agnostic CLI Rule
 
 Every CLI command and feature must work identically on alpha, beta, stable, and PR builds. This is non-negotiable — the release channel is an implementation detail, not something callers should need to know.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Before writing any keyboard shortcut display, badge, chip, or inline label widge
 - `section_header(ui, label, is_active, colors)` — group/context label at `TEXT_CAPTION` weight; `is_active` switches color from `text_dim` to `accent`.
 - `pane_type_badge(ui, kind, colors)` — renders `"T"` for Terminal, `"A"` for App (first letter of kind) as a `key_chip`. Saves horizontal space vs. full word.
 - `status_chip(ui, status, colors)` — centralized status color mapping: `"busy"`/`"running"` → `accent`; `"crashed"`/`"hung"`/`"error"`/`"exited"` → `danger`; everything else → `text_dim`.
-- `description_label(ui, text, colors)` — single-line `TEXT_HINT` label with `truncate()`. **Caller must call `ui.set_max_width(n)` first** or truncation never fires.
+- `description_label(ui, text, colors)` — single-line `TEXT_HINT` label with `truncate()`. **Always wrap in `ui.scope()` and set `ui.set_max_width(n)` inside the scope** — setting it on a shared `Ui` corrupts layout of other widgets in the same row.
 
 ## Channel-Agnostic CLI Rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Before writing any keyboard shortcut display, badge, chip, or inline label widge
 
 **Overlay layout primitives** — four shared widgets every overlay should use instead of inlining:
 - `section_header(ui, label, is_active, colors)` — group/context label at `TEXT_CAPTION` weight; `is_active` switches color from `text_dim` to `accent`.
-- `pane_type_badge(ui, kind, colors)` — renders `"T"` for Terminal, `"A"` for App (first letter of kind) as a `key_chip`. Saves horizontal space vs. full word.
+- `pane_type_badge(ui, kind, colors)` — renders `"term"` for Terminal, `"app"` for App as a `key_chip`. Compact vs. full word.
 - `status_chip(ui, status, colors)` — centralized status color mapping: `"busy"`/`"running"` → `accent`; `"crashed"`/`"hung"`/`"error"`/`"exited"` → `danger`; everything else → `text_dim`.
 - `description_label(ui, text, colors)` — single-line `TEXT_HINT` label with `truncate()`. **Always wrap in `ui.scope()` and set `ui.set_max_width(n)` inside the scope** — setting it on a shared `Ui` corrupts layout of other widgets in the same row.
 

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -341,6 +341,7 @@ fn default_colors() -> Colors {
         text_section: Color32::from_rgb(0x58, 0x5b, 0x70),
         accent: Color32::from_rgb(0x89, 0xb4, 0xfa),
         border: Color32::from_rgb(0x2a, 0x2a, 0x3c),
+        danger: Color32::from_rgb(0xff, 0x55, 0x55),
         terminal_fg_bytes: [0xe8, 0xe6, 0xed],
         terminal_bg_bytes: [0x29, 0x2a, 0x44],
     }

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -176,8 +176,10 @@ fn render_inspector_pane_row(
                     );
                 }
                 if !row.detail.is_empty() {
-                    ui.set_max_width(120.0);
-                    crate::widgets::description_label(ui, row.detail.as_str(), colors);
+                    ui.scope(|ui| {
+                        ui.set_max_width(120.0);
+                        crate::widgets::description_label(ui, row.detail.as_str(), colors);
+                    });
                 }
             });
         });

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -155,10 +155,11 @@ fn render_inspector_pane_row(
     let (row_resp, _) = crate::widgets::selectable_row(ui, is_selected, colors, |ui| {
         ui.horizontal_centered(|ui| {
             ui.label(
-                RichText::new(format!("#{} {}", row_id, row.kind))
+                RichText::new(format!("#{}", row_id))
                     .size(style::TEXT_CAPTION)
                     .color(colors.text_dim),
             );
+            crate::widgets::pane_type_badge(ui, row.kind, colors);
             let display_name: &str = if row.name.is_empty() { row.kind } else { &row.name };
             ui.label(
                 RichText::new(display_name)
@@ -166,16 +167,7 @@ fn render_inspector_pane_row(
                     .color(colors.text_primary),
             );
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                let status_color = if matches!(row.status, "busy" | "running") {
-                    colors.accent
-                } else {
-                    colors.text_dim
-                };
-                ui.label(
-                    RichText::new(row.status)
-                        .size(style::TEXT_HINT)
-                        .color(status_color),
-                );
+                crate::widgets::status_chip(ui, row.status, colors);
                 if let Some(badge) = &row.osc_badge {
                     ui.label(
                         RichText::new(format!("· {badge}"))
@@ -184,11 +176,8 @@ fn render_inspector_pane_row(
                     );
                 }
                 if !row.detail.is_empty() {
-                    ui.label(
-                        RichText::new(row.detail.as_str())
-                            .size(style::TEXT_HINT)
-                            .color(colors.text_dim),
-                    );
+                    ui.set_max_width(120.0);
+                    crate::widgets::description_label(ui, row.detail.as_str(), colors);
                 }
             });
         });
@@ -312,7 +301,7 @@ fn render_inspector_header(
         }
     }
     ui.add_space(style::SPACE_XL);
-    ui.label(RichText::new("Panes").size(style::TEXT_CAPTION).color(colors.text_dim).strong());
+    crate::widgets::section_header(ui, "Panes", false, colors);
     ui.add_space(style::SPACE_SM);
     (open_root_overlay, open_description_overlay, start_rename)
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,6 +31,8 @@ pub struct Colors {
     // Accent / borders
     pub accent: Color32,
     pub border: Color32,
+    // Semantic state colors
+    pub danger: Color32,
     // Terminal fg/bg as bytes for dynamic colors
     pub terminal_fg_bytes: [u8; 3],
     pub terminal_bg_bytes: [u8; 3],
@@ -51,6 +53,8 @@ impl Colors {
             text_section: parse_hex_or(&cfg.text_section, Color32::from_rgb(0x58, 0x5b, 0x70)),
             accent: parse_hex_or(&cfg.accent, Color32::from_rgb(0x89, 0xb4, 0xfa)),
             border: parse_hex_or(&cfg.border, Color32::from_rgb(0x2a, 0x2a, 0x3c)),
+            // Derive from the theme's ANSI red; fallback matches the Dracula red used in event_log.rs.
+            danger: parse_hex_or(&cfg.red, Color32::from_rgb(0xff, 0x55, 0x55)),
             terminal_fg_bytes: hex_to_bytes(cfg.foreground.as_deref(), [0xe8, 0xe6, 0xed]),
             terminal_bg_bytes: hex_to_bytes(cfg.background.as_deref(), [0x29, 0x2a, 0x44]),
         }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -243,7 +243,8 @@ pub(crate) fn section_header(ui: &mut egui::Ui, label: &str, is_active: bool, co
     ui.label(
         egui::RichText::new(label)
             .size(style::TEXT_CAPTION)
-            .color(color),
+            .color(color)
+            .strong(),
     );
 }
 
@@ -273,10 +274,19 @@ pub(crate) fn status_chip(ui: &mut egui::Ui, status: &str, colors: &Colors) {
 }
 
 /// Renders a single-line label that truncates with an ellipsis at the available
-/// width. **Callers must call `ui.set_max_width(n)` before calling this** (or
-/// use `ui.scope()` with a constrained width) — `egui::Label::truncate` clips
-/// at `available_width()`, so without a bound the label expands naturally and
-/// truncation never fires.
+/// width. `egui::Label::truncate` clips at `available_width()`, so without a
+/// constraint the label expands naturally and truncation never fires.
+///
+/// **Always wrap in `ui.scope()`** and set `ui.set_max_width(n)` inside the
+/// scope — setting max_width on a shared `Ui` corrupts the layout of other
+/// widgets already rendered in the same row (especially inside right_to_left
+/// layouts):
+/// ```ignore
+/// ui.scope(|ui| {
+///     ui.set_max_width(120.0);
+///     description_label(ui, text, colors);
+/// });
+/// ```
 pub(crate) fn description_label(ui: &mut egui::Ui, text: &str, colors: &Colors) {
     ui.add(
         egui::Label::new(

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -248,12 +248,16 @@ pub(crate) fn section_header(ui: &mut egui::Ui, label: &str, is_active: bool, co
     );
 }
 
-/// Renders the pane type as a single-letter monospace chip: `"T"` for Terminal,
-/// `"A"` for App, or the first uppercase character of any other kind string.
+/// Renders the pane type as a short lowercase chip: `"term"` for Terminal,
+/// `"app"` for App, or the lowercased kind string for anything else.
 /// Uses `key_chip` so the visual weight matches keyboard shortcut chips.
 pub(crate) fn pane_type_badge(ui: &mut egui::Ui, kind: &str, colors: &Colors) {
-    let letter = kind.chars().next().unwrap_or('?').to_uppercase().next().unwrap_or('?');
-    key_chip(ui, &letter.to_string(), colors);
+    let label = match kind {
+        "Terminal" => "term",
+        "App" => "app",
+        other => other,
+    };
+    key_chip(ui, label, colors);
 }
 
 /// Renders a status string with centralized color mapping:

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -225,6 +225,69 @@ pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::
     resp
 }
 
+// ── Overlay layout primitives ────────────────────────────────────────────
+//
+// Every overlay (inspector, sub-context UX, unified overlays) was hand-rolling
+// the same section label, pane-type badge, status chip, and truncating text
+// label. Each diverged in color logic and spacing. These four primitives
+// centralize that rendering so future overlays look identical with zero extra
+// work.
+//
+// Status color mapping lives here — not in individual overlays — so adding a
+// new status value is a one-line change that applies everywhere.
+
+/// Renders a section / group header label (context name, group title, etc.).
+/// `is_active` tints the label with `colors.accent` instead of `colors.text_dim`.
+pub(crate) fn section_header(ui: &mut egui::Ui, label: &str, is_active: bool, colors: &Colors) {
+    let color = if is_active { colors.accent } else { colors.text_dim };
+    ui.label(
+        egui::RichText::new(label)
+            .size(style::TEXT_CAPTION)
+            .color(color),
+    );
+}
+
+/// Renders the pane type as a single-letter monospace chip: `"T"` for Terminal,
+/// `"A"` for App, or the first uppercase character of any other kind string.
+/// Uses `key_chip` so the visual weight matches keyboard shortcut chips.
+pub(crate) fn pane_type_badge(ui: &mut egui::Ui, kind: &str, colors: &Colors) {
+    let letter = kind.chars().next().unwrap_or('?').to_uppercase().next().unwrap_or('?');
+    key_chip(ui, &letter.to_string(), colors);
+}
+
+/// Renders a status string with centralized color mapping:
+/// - `"busy"` / `"running"` → `colors.accent`
+/// - `"crashed"` / `"hung"` / `"error"` / `"exited"` → `colors.danger`
+/// - everything else (`"idle"`, `"booting"`, ...) → `colors.text_dim`
+pub(crate) fn status_chip(ui: &mut egui::Ui, status: &str, colors: &Colors) {
+    let color = match status {
+        "busy" | "running" => colors.accent,
+        "crashed" | "hung" | "error" | "exited" => colors.danger,
+        _ => colors.text_dim,
+    };
+    ui.label(
+        egui::RichText::new(status)
+            .size(style::TEXT_HINT)
+            .color(color),
+    );
+}
+
+/// Renders a single-line label that truncates with an ellipsis at the available
+/// width. **Callers must call `ui.set_max_width(n)` before calling this** (or
+/// use `ui.scope()` with a constrained width) — `egui::Label::truncate` clips
+/// at `available_width()`, so without a bound the label expands naturally and
+/// truncation never fires.
+pub(crate) fn description_label(ui: &mut egui::Ui, text: &str, colors: &Colors) {
+    ui.add(
+        egui::Label::new(
+            egui::RichText::new(text)
+                .size(style::TEXT_HINT)
+                .color(colors.text_dim),
+        )
+        .truncate(),
+    );
+}
+
 /// Renders a dismissable centered modal overlay. Handles Escape and click-outside.
 /// Returns `true` if the user dismissed it this frame. Callers guard with
 /// `if !open { return; }` and apply `if dismissed { open = false; }` after.


### PR DESCRIPTION
## Summary

Adds four shared egui widget primitives to `src/widgets.rs` so every overlay stops hand-rolling its own spacing, typography, and badge rendering:

- `section_header(ui, label, is_active, colors)` — `TEXT_CAPTION` group label; `is_active` switches `text_dim` → `accent`
- `pane_type_badge(ui, kind, colors)` — renders `"T"`/`"A"` as a `key_chip` (saves row width vs full word)
- `status_chip(ui, status, colors)` — centralized status→color mapping: `busy/running` → `accent`; `crashed/hung/error/exited` → `danger`; everything else → `text_dim`
- `description_label(ui, text, colors)` — truncating `TEXT_HINT` label; caller must set `ui.set_max_width()` first

Also adds `colors.danger` to `Colors` struct (derived from theme `red`, fallback `#ff5555`) and wires all four primitives into `render_inspector_pane_row` as the smoke-test migration. `CLAUDE.md` "Host UI Systems" section updated.

## Done When
- [x] `cargo build` passes with the four new functions in `src/widgets.rs`
- [x] `render_inspector_pane_row` uses `pane_type_badge`, `status_chip`, and `description_label`
- [x] CLAUDE.md "Host UI Systems" section lists all four new widgets
- [ ] Inspector rows visibly show `T` / `A` instead of `Terminal` / `App` after `just install`

## Test plan
- Open context inspector (⌘I or via overlay)
- Verify pane rows show `T` or `A` badge chips instead of the full words "Terminal" / "App"
- Verify status coloring: idle panes show dim text, busy/running shows accent blue
- Open an app pane and crash it if possible — status should show in red/danger color

Closes #1540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added danger color to theme palette for enhanced UI state styling.

* **Style**
  * Improved visual consistency and layout of inspector pane headers across overlays.
  * Enhanced presentation of pane details with better text handling and width constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->