### PR TITLE
fix(file-browser): open at ~ instead of / when launched as GUI app (#1561)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -953,8 +953,17 @@ impl PlexiApp {
         let panes: HashMap<u64, Pane> = HashMap::new();
         let tree = Tree::empty("plexi");
 
-        let path = std::env::current_dir()
-            .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+        let path = {
+            let cwd = std::env::current_dir()
+                .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+            // macOS GUI apps launch with CWD = /. Use home_dir instead so
+            // the initial context and all derived CWDs start at ~.
+            if cwd == PathBuf::from("/") {
+                dirs::home_dir().unwrap_or(cwd)
+            } else {
+                cwd
+            }
+        };
 
         let anchor = crate::anchor::Anchor::detect(&path);
         let (default_name, default_description, default_root) = match anchor.as_ref() {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -540,6 +540,14 @@ impl PlexiApp {
             let ctx = &self.windows[self.active_window];
             ctx.focused_pane
                 .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
+                .filter(|p| {
+                    if p == &PathBuf::from("/") {
+                        log::debug!("open_file_browser: CWD is /, falling back to home_dir (GUI launch)");
+                        false
+                    } else {
+                        true
+                    }
+                })
                 .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
         };
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -120,6 +120,7 @@ impl PlexiApp {
         let cwd = self.windows[self.active_window]
             .focused_pane
             .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
+            .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or_else(|| home.clone());
         log::info!("new_context: cwd={}", cwd.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), None, false)
@@ -257,6 +258,7 @@ impl PlexiApp {
         let old_focus = self.windows[self.active_window].focused_pane;
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
         log::info!("create_page_at({grid_x},{grid_y}): cwd={} context_root={:?} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}", cwd.display(), self.router.active().root);
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), initial_cmd, close_on_exit)


### PR DESCRIPTION
## Summary

- macOS GUI apps launch with CWD = `/`
- `get_focused_pane_cwd` returned `Some(PathBuf::from("/"))` when an app pane was focused, bypassing the `home_dir` fallback in `open_file_browser`
- Fix: filter out `/` before `unwrap_or_else`, so the fallback to `dirs::home_dir()` fires correctly

Closes #1561

## Test plan
- [ ] Launch Plexi from Dock (not terminal)
- [ ] Press Cmd+E with an app pane focused
- [ ] File browser opens at `~` (home directory), not `/`