### PR TITLE
chore(skills): add create-plexi-app gate to ship-issue Phase 3 (#1509)

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -228,6 +228,12 @@ Surface every match under a **Gotchas found:** heading in your context. Each mat
 
 If nothing matches, write "Gotchas found: none." and proceed. Do not skip this step.
 
+**If any changed file is a Python app under `examples/`** (new app, rewrite, or behavioral change to an existing app): invoke the `create-plexi-app` skill before writing any code. Then verify the skill is current:
+```bash
+plexi-alpha --version
+```
+Compare the version output against the `skill_version:` field in the frontmatter of `.claude/skills/create-plexi-app/SKILL.md`. If they differ: **stop**. File a `load:S` issue to update the skill, label it `P1 ready`, and surface it to the user before proceeding. Do not write any app code against a stale skill.
+
 **Assess scope:** count the files that will likely change.
 
 **If the issue involves a third-party library or framework** (egui, egui_tiles, tokio, etc.) and the expected behavior isn't immediately obvious from the code: invoke the `coding-conventions` skill and read the relevant section before speculating on the approach. Unexpected API behavior not yet documented there is a signal to add it via `/improve` after the session.


### PR DESCRIPTION
## Summary

Adds a gate to Phase 3 of the ship-issue skill: when any file under `examples/` is in scope, the implementing agent must invoke `create-plexi-app` before writing any code, and verify its `skill_version` matches `plexi-alpha --version`. A mismatch blocks the ship and files a P1 issue to update the skill first.

## Why

PR #1500 (plexi-logs rewrite) failed visual QA because the agent used `ctx.rect()+ctx.text()` for filter chips and level badges instead of the SDK's `ctx.button()` and `ctx.badge()` — both explicitly listed in the `create-plexi-app` skill. The gate was missing. This adds it.

## Done When

- [x] Phase 3 of ship-issue contains the create-plexi-app invocation gate
- [x] The gate explicitly requires a version-match check before any app code is written
- [x] `grep -n "create-plexi-app" .claude/skills/ship-issue/SKILL.md` returns a hit in the Phase 3 section

Closes #1509