### PR TITLE
fix(inspector): fix non-Process app status, drop raw delete Button from footer (#1539)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -314,8 +314,7 @@ fn render_inspector_hints(
     num_contexts: usize,
     colors: &Colors,
     renaming: bool,
-) -> bool {
-    let mut delete_context = false;
+) {
     ui.horizontal(|ui| {
         if renaming {
             crate::widgets::key_combo_list(ui, &[&["Enter"]], Some("save"), colors);
@@ -323,22 +322,7 @@ fn render_inspector_hints(
             crate::widgets::key_combo_list(ui, &[&["Esc"]], Some("cancel"), colors);
         } else {
             if num_contexts > 1 {
-                if ui
-                    .add(
-                        egui::Button::new(
-                            RichText::new("Delete context")
-                                .size(style::TEXT_CAPTION)
-                                .color(colors.text_primary),
-                        )
-                        .fill(colors.bg_active),
-                    )
-                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .clicked()
-                {
-                    delete_context = true;
-                }
-                ui.add_space(style::SPACE_XL);
-                crate::widgets::key_combo_list(ui, &[&["⌫"]], Some("delete (3×)"), colors);
+                crate::widgets::key_combo_list(ui, &[&["⌫"]], Some("delete"), colors);
                 ui.add_space(style::SPACE_XL);
             }
             crate::widgets::key_combo_list(ui, &[&["R"]], Some("rename"), colors);
@@ -354,7 +338,6 @@ fn render_inspector_hints(
             }
         }
     });
-    delete_context
 }
 
 impl PlexiApp {
@@ -2054,7 +2037,7 @@ impl PlexiApp {
                                     crate::process_app::LifecycleState::ProtocolError => "error",
                                 }
                             } else {
-                                "running"
+                                "active"
                             };
                             rows.push(PaneRow {
                                 id: a.id,
@@ -2250,9 +2233,7 @@ impl PlexiApp {
                             ui.separator();
                             ui.add_space(style::SPACE_MD);
                         }
-                        if render_inspector_hints(ui, pane_count, num_contexts, &colors, renaming) {
-                            delete_context = true;
-                        }
+                        render_inspector_hints(ui, pane_count, num_contexts, &colors, renaming);
                     });
             });
 


### PR DESCRIPTION
## Summary

- Builtin app panes (non-Process `AppRuntime`) showed `"running"` hardcoded regardless of actual state; now correctly shows `"active"`.
- Footer `render_inspector_hints`: removed raw `egui::Button` for "Delete context" — replaced with `key_combo_list` hint consistent with every other footer entry.
- Simplified label from `"delete (3×)"` to `"delete"` — the 3-press confirmation counter is visible in the delete overlay.
- `render_inspector_hints` return type changed from `bool` → `()` since the Button was the only click source; deletion is keyboard-only via ⌫ ×3.

## Done When
- [x] A non-Process app pane does not show `running` when it is not running — shows `active` instead
- [x] Footer has no raw `egui::Button` — delete action uses `key_combo_list` like the rest

Closes #1539