### PR TITLE
feat(cli): simplify uninstall to single confirmation prompt (#1574)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1626,35 +1626,50 @@ pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
     let app_bundle  = std::path::PathBuf::from(format!("/Applications/Plexi{cap}.app"));
     let cli_binary  = std::path::PathBuf::from(format!("/usr/local/bin/plexi{suffix}"));
 
-    // Print what will be removed
+    // Single confirmation prompt: keep data or remove everything?
+    // Resolved before the banner so the preview accurately reflects the outcome.
+    let keep_data = if keep_data || !profile_dir.exists() {
+        log::info!("uninstall: keep_data=flag({keep_data}) profile_exists={}", profile_dir.exists());
+        keep_data
+    } else if assume_yes {
+        log::info!("uninstall: keep_data=false (assume_yes, no --keep-data)");
+        false
+    } else {
+        eprint!("Keep your ~/.plexi{suffix} data for future installs? [y/n, Enter=abort]: ");
+        let _ = io::stderr().flush();
+        let mut answer = String::new();
+        if let Err(e) = io::stdin().read_line(&mut answer) {
+            log::warn!("uninstall: failed to read keep-data confirmation: {e}");
+            eprintln!("error: failed to read: {e}");
+            return 1;
+        }
+        match answer.trim().to_lowercase().as_str() {
+            "y" | "yes" => {
+                log::info!("uninstall: keep_data=true (user chose y)");
+                true
+            }
+            "n" | "no" => {
+                log::info!("uninstall: keep_data=false (user chose n)");
+                eprintln!("Removing everything.");
+                false
+            }
+            other => {
+                log::info!("uninstall: aborted (user input {:?})", other);
+                eprintln!("Aborted.");
+                return 0;
+            }
+        }
+    };
+
+    // Print what will be removed (after keep_data is resolved so the preview is accurate)
     println!("This will remove:");
     if app_bundle.exists()  { println!("  \u{2022} {}", app_bundle.display()); }
     if cli_binary.exists()  { println!("  \u{2022} {}", cli_binary.display()); }
     if !keep_data && profile_dir.exists() {
         println!("  \u{2022} {}  (settings, secrets, app configs)", profile_dir.display());
     } else if profile_dir.exists() {
-        println!("  \u{2022} {} will be kept  (--keep-data)", profile_dir.display());
+        println!("  \u{2022} {} will be kept", profile_dir.display());
     }
-
-    // Single confirmation prompt: keep data or remove everything?
-    let keep_data = if keep_data || !profile_dir.exists() {
-        keep_data
-    } else if assume_yes {
-        false // default: remove data when -y is passed without --keep-data
-    } else {
-        eprint!("\nKeep your ~/.plexi{suffix} data for future installs? [y/N]: ");
-        let _ = io::stderr().flush();
-        let mut answer = String::new();
-        if io::stdin().read_line(&mut answer).is_err() {
-            eprintln!("error: failed to read");
-            return 1;
-        }
-        let keep = matches!(answer.trim().to_lowercase().as_str(), "y" | "yes");
-        if !keep {
-            eprintln!("Removing everything.");
-        }
-        keep
-    };
 
     let mut removed = false;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1636,36 +1636,25 @@ pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
         println!("  \u{2022} {} will be kept  (--keep-data)", profile_dir.display());
     }
 
-    // Data prompt (skip if --keep-data or --yes already set)
+    // Single confirmation prompt: keep data or remove everything?
     let keep_data = if keep_data || !profile_dir.exists() {
         keep_data
     } else if assume_yes {
         false // default: remove data when -y is passed without --keep-data
     } else {
-        eprint!("\nKeep your profile data (~/.plexi{suffix}/)? Your settings, secrets, and app configurations are stored here. [y/N]: ");
+        eprint!("\nKeep your ~/.plexi{suffix} data for future installs? [y/N]: ");
         let _ = io::stderr().flush();
         let mut answer = String::new();
         if io::stdin().read_line(&mut answer).is_err() {
             eprintln!("error: failed to read");
             return 1;
         }
-        matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+        let keep = matches!(answer.trim().to_lowercase().as_str(), "y" | "yes");
+        if !keep {
+            eprintln!("Removing everything.");
+        }
+        keep
     };
-
-    // Confirmation
-    if !assume_yes {
-        eprint!("\nProceed? [y/N]: ");
-        let _ = io::stderr().flush();
-        let mut answer = String::new();
-        if io::stdin().read_line(&mut answer).is_err() {
-            eprintln!("error: failed to read");
-            return 1;
-        }
-        if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
-            eprintln!("Aborted.");
-            return 0;
-        }
-    }
 
     let mut removed = false;
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -94,7 +94,7 @@ pub enum Commands {
         /// Keep your profile directory (~/.plexi/) — your settings, secrets, and app data stay on disk
         #[arg(long = "keep-data")]
         keep_data: bool,
-        /// Skip confirmation prompts and proceed immediately
+        /// Skip the confirmation prompt and proceed immediately (removes data unless --keep-data is set)
         #[arg(long = "yes", short = 'y')]
         yes: bool,
     },


### PR DESCRIPTION
Removes the redundant `Proceed? [y/N]` gate from `plexi uninstall`.

## Before
```
Keep your profile data (~/.plexi/)? Your settings, secrets, and app configurations are stored here. [y/N]: y

Proceed? [y/N]: y
```

## After
```
Keep your ~/.plexi data for future installs? [y/N]: y
```

`--keep-data` and `--yes` flags unchanged.

## Done When
- [ ] Single prompt on `plexi uninstall` (interactive)
- [ ] `--yes` skips the prompt entirely
- [ ] `--keep-data` skips the data question (no prompt shown)

Closes #1574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Simplified uninstall confirmation flow from multiple prompts to a single confirmation step
* Clarified `--keep-data` flag behavior in help text to better explain data retention during uninstall
* Improved confirmation messages for clarity when removing everything

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->