### PR TITLE
fix(apps): replace misleading empty-state in Backlog app (#1572)

### DIFF
--- a/examples/backlog/backlog.py
+++ b/examples/backlog/backlog.py
@@ -41,6 +41,7 @@ class BacklogApp(App):
         self.status = ""
         self._item_list = SelectList([])
         self._load()
+        self.emit.info("BacklogApp ready")
 
     # ── Data ────────────────────────────────────────────────────────────────────
 
@@ -170,9 +171,11 @@ class BacklogApp(App):
                  max_width=80)
 
         if not self.backlog_dir.exists():
-            ctx.text(12, TOP + 12, "No backlog directory found.", size=13, color=FG)
-            ctx.text(12, TOP + 34, f"mkdir -p {self.backlog_dir}",
-                     size=11, color=MUTED, monospace=True)
+            self.emit.info("backlog: dir not found — showing empty-state guide")
+            ctx.text(12, TOP + 12, "No notes yet.", size=13, color=FG)
+            ctx.text(12, TOP + 34,
+                     "Press ⌘0 to open Quick Note, then press Enter twice to send to your backlog.",
+                     size=11, color=MUTED, max_width=w - 24)
             return
 
         # Divider


### PR DESCRIPTION
Fixes #1572

## What changed

When the backlog directory doesn't exist, the app previously showed a raw shell command (`mkdir -p <long-absolute-path>`) as its guidance text. This was confusing — users saw terminal syntax with no context.

Now shows:
- **"No notes yet."** — clear, plain-English empty state
- **"Press ⌘0 to open Quick Note, then press Enter twice to send to your backlog."** — actionable guide using the actual shortcut

Also adds the required `on_init` info trace (`BacklogApp ready`) and a warn trace when the empty-state guide is displayed.

## Done when

- Backlog app with no `.plexi/backlog/` directory shows the friendly guide message instead of a `mkdir -p` command