### PR TITLE
fix(cli): show help inside pane, hint on missing script (#1570, #1571)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,7 +123,7 @@ if [[ ! "$channel" =~ ^pr- ]]; then
   fi
 fi
 
-mkdir -p "$profile_dir/sdk" "$profile_dir/apps"
+mkdir -p "$profile_dir/sdk" "$profile_dir/apps" "$profile_dir/scripts"
 rm -rf "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk.old"
 cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk.tmp"
 mv "$profile_dir/sdk/plexi_sdk" "$profile_dir/sdk/plexi_sdk.old" 2>/dev/null || true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,8 +198,8 @@ pub fn run_command(command_name: &str) -> i32 {
             } else if code == 127 {
                 eprintln!(
                     "hint: command exited with 'not found' (127). If your command references \
-                     $PLEXI_CONFIG_DIR, check that the script exists in {}scripts/",
-                    crate::config::config_dir().display()
+                     $PLEXI_CONFIG_DIR, check that the script exists in '{}'",
+                    crate::config::config_dir().join("scripts").display()
                 );
             }
             code

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,6 +195,12 @@ pub fn run_command(command_name: &str) -> i32 {
             let code = status.code().unwrap_or(1);
             if code == 0 {
                 print_tip("run `plexi run` to see all available commands.");
+            } else if code == 127 {
+                eprintln!(
+                    "hint: command exited with 'not found' (127). If your command references \
+                     $PLEXI_CONFIG_DIR, check that the script exists in {}scripts/",
+                    crate::config::config_dir().display()
+                );
             }
             code
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,7 +527,9 @@ fn main() -> eframe::Result {
             }
             dir = dir.parent().unwrap();
         }
-        eprintln!("plexi: already running inside Plexi. Use Cmd+T to open a new pane.");
+        use clap::CommandFactory;
+        let _ = Cli::command().print_help();
+        println!();
         std::process::exit(0);
     }
 


### PR DESCRIPTION
## Summary

- **#1570** — `plexi run <command>` now emits a clear hint when the spawned command exits 127 (bash "file not found"), pointing to `$PLEXI_CONFIG_DIR/scripts/`. `install.sh` also creates `$profile_dir/scripts/` on every install so the directory always exists.
- **#1571** — `plexi` with no args inside a Plexi pane now prints full help text (including the "Inside a Plexi pane:" section) instead of the dead-end "Use Cmd+T to open a new pane." message.

## Done When

**#1570:**
- `plexi run workspace` (with a missing script) shows the 127 hint mentioning `$PLEXI_CONFIG_DIR/scripts/`
- `~/.plexi-alpha/scripts/` exists after `just install`

**#1571:**
- Running `plexi` with no args inside a Plexi pane prints the full help text
- No "already running" dead-end message is shown

## Test plan
- [ ] Run `plexi-pr-<N>` with no args inside a Plexi pane — confirms help text output
- [ ] Add a broken script reference to `.plexi/commands.toml`, run it — confirms 127 hint message
- [ ] Verify `~/.plexi-pr-<N>/scripts/` dir exists after `just pr-install`