### PR TITLE
fix(apps): request audio.record capability on init in audio-recorder (#1568)

### DIFF
--- a/examples/audio-recorder/audio_recorder.py
+++ b/examples/audio-recorder/audio_recorder.py
@@ -38,6 +38,13 @@ class AudioRecorderApp(App):
         self._status: str = "Loading devices..."
         self.emit.info("audio-recorder: starting")
 
+        granted = await self.emit.capability_request("audio.record")
+        if not granted:
+            self._status = "Microphone access denied. Grant audio.record to use this app."
+            self.emit.warn("audio-recorder: audio.record capability denied")
+            ctx.status_summary("Audio Recorder")
+            return
+
         try:
             device_list = await self.emit.list_audio_devices()
             self._devices = device_list.inputs


### PR DESCRIPTION
## Summary

- Audio recorder app broken on fresh install because `audio.record` is a sensitive capability requiring first-run consent
- Without calling `capability_request("audio.record")` first, the host silently denies all capture attempts
- Reader thread times out after 5s with no feedback; app stuck showing "Recording..."
- Fix: same pattern as Wikipedia/Bluesky (#1567, #1569) — `await capability_request("audio.record")` in `on_init` before listing devices or capturing

## Done When

- App launches on a fresh profile and immediately shows the consent modal for microphone access
- If denied: shows "Microphone access denied. Grant audio.record to use this app."
- If granted: shows device list and is fully functional

Closes #1568