### PR TITLE
feat(cli): first-launch completions detection and banner (#1577)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -260,6 +260,7 @@ pub struct PlexiApp {
     pub(crate) show_cli_setup_prompt: bool,
     /// `None` = idle/success (modal closes on success), `Some(false)` = not found.
     pub(crate) cli_setup_check_result: Option<bool>,
+    pub(crate) show_completions_banner: bool,
     pub(crate) quitting: bool,
     pub(crate) quit_press_count: u8,
     pub(crate) quit_last_press: Option<std::time::Instant>,
@@ -865,6 +866,7 @@ impl PlexiApp {
                     show_changelog: false,
                     show_cli_setup_prompt: crate::cli_setup::should_prompt(),
                     cli_setup_check_result: None,
+                    show_completions_banner: crate::cli_setup::should_prompt_completions(),
                     quitting: false,
                     quit_press_count: 0,
                     quit_last_press: None,
@@ -1023,6 +1025,7 @@ impl PlexiApp {
             show_changelog: false,
             show_cli_setup_prompt: crate::cli_setup::should_prompt(),
             cli_setup_check_result: None,
+            show_completions_banner: crate::cli_setup::should_prompt_completions(),
             quitting: false,
             quit_press_count: 0,
             quit_last_press: None,
@@ -1234,6 +1237,7 @@ impl PlexiApp {
             edge_pulse: None,
             show_cli_setup_prompt: false,
             cli_setup_check_result: None,
+            show_completions_banner: false,
             update_rx: None,
             update_available: None,
             pane_ipc_rx,
@@ -4123,6 +4127,9 @@ impl eframe::App for PlexiApp {
 
         // Changelog overlay
         self.draw_changelog_overlay(ctx);
+
+        // First-launch completions nudge
+        self.draw_completions_banner(ctx);
 
         // Minimap overlay — auto-hidden when current workspace has <2 windows.
         let ws_id = self.router.active().context_id;

--- a/src/cli_setup.rs
+++ b/src/cli_setup.rs
@@ -1,5 +1,94 @@
 use std::path::PathBuf;
 
+pub fn completions_sentinel_path() -> PathBuf {
+    crate::config::config_dir().join("completions_setup_done")
+}
+
+pub fn completions_was_prompted() -> bool {
+    completions_sentinel_path().exists()
+}
+
+pub fn completions_mark_prompted() {
+    let _ = std::fs::write(completions_sentinel_path(), "");
+}
+
+/// Check whether shell completions for this build are installed.
+///
+/// Detects the current shell from `$SHELL` and checks the expected location.
+/// Returns `true` for unknown shells to avoid a spurious banner.
+pub fn completions_installed() -> bool {
+    let cli = cli_name();
+    let shell = std::env::var("SHELL").unwrap_or_default();
+
+    if shell.contains("zsh") {
+        // Prefer Homebrew site-functions; fall back to ~/.zfunc
+        let brew_ok = std::process::Command::new("brew")
+            .arg("--prefix")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|prefix| {
+                PathBuf::from(prefix.trim())
+                    .join("share/zsh/site-functions")
+                    .join(format!("_{cli}"))
+                    .exists()
+            })
+            .unwrap_or(false);
+        if brew_ok {
+            log::info!("cli_setup: completions found in brew site-functions for {cli}");
+            return true;
+        }
+        let zfunc_ok = dirs::home_dir()
+            .map(|h| h.join(".zfunc").join(format!("_{cli}")).exists())
+            .unwrap_or(false);
+        if zfunc_ok {
+            log::info!("cli_setup: completions found in ~/.zfunc for {cli}");
+        } else {
+            log::info!("cli_setup: zsh completions not found for {cli}");
+        }
+        zfunc_ok
+    } else if shell.contains("bash") {
+        let found = dirs::home_dir()
+            .map(|h| h.join(".bash_completion.d").join(&cli).exists())
+            .unwrap_or(false);
+        log::info!("cli_setup: bash completions found={found} for {cli}");
+        found
+    } else if shell.contains("fish") {
+        let found = dirs::home_dir()
+            .map(|h| {
+                h.join(".config/fish/completions")
+                    .join(format!("{cli}.fish"))
+                    .exists()
+            })
+            .unwrap_or(false);
+        log::info!("cli_setup: fish completions found={found} for {cli}");
+        found
+    } else {
+        log::info!("cli_setup: unknown shell {shell:?} — skipping completions check");
+        true
+    }
+}
+
+/// Show the completions banner once when the CLI is installed but completions are not.
+/// Dismissed permanently via sentinel; session-only via the banner's "Not now" button.
+pub fn should_prompt_completions() -> bool {
+    if completions_was_prompted() {
+        log::info!("cli_setup: completions sentinel present — skipping banner");
+        return false;
+    }
+    if !is_installed() {
+        // Wait until the CLI is installed before nudging about completions.
+        return false;
+    }
+    if completions_installed() {
+        log::info!("cli_setup: completions already installed — writing sentinel");
+        completions_mark_prompted();
+        return false;
+    }
+    log::info!("cli_setup: completions not installed — showing banner");
+    true
+}
+
 /// CLI name for the running build variant (e.g. `plexi`, `plexi-alpha`).
 pub fn cli_name() -> String {
     std::env::current_exe()

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -4074,6 +4074,86 @@ impl PlexiApp {
             self.show_cli_setup_prompt = false;
         }
     }
+
+    pub(crate) fn draw_completions_banner(&mut self, ctx: &egui::Context) {
+        if !self.show_completions_banner {
+            return;
+        }
+        let colors = self.colors;
+        let cmd = crate::cli_setup::INSTALL_COMMAND;
+
+        egui::Area::new(egui::Id::new("completions_banner"))
+            .anchor(egui::Align2::CENTER_BOTTOM, egui::vec2(0.0, -20.0))
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(colors.bg_sidebar)
+                    .stroke(Stroke::new(1.0, colors.border))
+                    .corner_radius(R6)
+                    .inner_margin(egui::Margin::symmetric(16, 10))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(
+                                RichText::new("Shell completions aren't set up.")
+                                    .size(style::TEXT_CAPTION)
+                                    .color(colors.text_dim),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            egui::Frame::new()
+                                .fill(colors.bg_darkest)
+                                .corner_radius(R6)
+                                .inner_margin(egui::Margin::symmetric(8, 4))
+                                .show(ui, |ui| {
+                                    ui.horizontal(|ui| {
+                                        ui.label(
+                                            RichText::new(cmd)
+                                                .size(style::TEXT_HINT)
+                                                .color(colors.text_primary)
+                                                .monospace(),
+                                        );
+                                        ui.add_space(4.0);
+                                        crate::widgets::copy_button(
+                                            ui,
+                                            egui::Id::new("completions_banner_copy"),
+                                            cmd,
+                                        );
+                                    });
+                                });
+                            ui.add_space(style::SPACE_SM);
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        RichText::new("Done")
+                                            .size(style::TEXT_CAPTION)
+                                            .color(colors.text_primary),
+                                    )
+                                    .fill(colors.bg_active)
+                                    .min_size(egui::vec2(50.0, 22.0)),
+                                )
+                                .clicked()
+                            {
+                                log::info!("cli_setup: completions banner — user clicked Done, marking sentinel");
+                                crate::cli_setup::completions_mark_prompted();
+                                self.show_completions_banner = false;
+                            }
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        RichText::new("Not now")
+                                            .size(style::TEXT_CAPTION)
+                                            .color(colors.text_dim),
+                                    )
+                                    .min_size(egui::vec2(60.0, 22.0)),
+                                )
+                                .clicked()
+                            {
+                                log::info!("cli_setup: completions banner — user clicked Not now (session-only dismiss)");
+                                self.show_completions_banner = false;
+                            }
+                        });
+                    });
+            });
+    }
 }
 
 fn parse_children_cmd_output(stdout: &str) -> Vec<crate::config::QuickNoteNode> {


### PR DESCRIPTION
## Summary

- Adds `completions_installed()` to `cli_setup.rs` — detects whether shell completions are present by checking the shell-appropriate paths (zsh: brew site-functions or `~/.zfunc`; bash: `~/.bash_completion.d`; fish: `~/.config/fish/completions`)
- Adds `should_prompt_completions()` — only prompts when CLI is installed but completions are absent; writes a sentinel on permanent dismiss
- Adds `show_completions_banner: bool` app state and a non-blocking `draw_completions_banner()` overlay — a bottom-of-window bar with the install command, a copy button, "Done" (writes sentinel), and "Not now" (session-only dismiss)

## Done When

- On first launch after install when completions are absent, the banner appears at the bottom of the window
- The banner shows `curl -fsSL https://plexiapp.com/install | sh` with a copy button
- "Done" dismisses permanently; "Not now" dismisses until next launch
- No banner shown when completions are already installed
- No regressions on existing CLI setup modal behavior

Closes #1577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shell completions setup prompt that displays on first launch if shell completions aren't configured, allowing users to install completions or dismiss the notification for the current session.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->