### PR TITLE
fix: inspector Cmd+R rename, skill version, registry rename (#1508, #1510, #1537)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ plexi install git+https://example.com/repo.git    # explicit git URL
 plexi install --pack path/to/pack.toml     # apply a whole pack at once
 ```
 
-Registry IDs resolve against the [Plexi app registry](https://github.com/ianjamesburke/plexi-registry). Git URLs clone the repo directly — no registry needed.
+Registry IDs resolve against the [Plexi app registry](https://github.com/ianjamesburke/plexi-app-registry). Git URLs clone the repo directly — no registry needed.
 
 ### Manage installed apps
 
@@ -236,7 +236,7 @@ emit.info("App starting up")    # outside frames / at module level
 
 App logs forward into the host log tagged `app::<app_id>`. Check `~/.plexi/plexi.log` (or `~/.plexi-alpha/plexi.log` on alpha) when debugging.
 
-To share your app: push the repo to GitHub, then anyone can install it with `plexi install github:you/your-app`. To add it to the public registry, open a PR against [plexi-registry](https://github.com/ianjamesburke/plexi-registry).
+To share your app: push the repo to GitHub, then anyone can install it with `plexi install github:you/your-app`. To add it to the public registry, open a PR against [plexi-app-registry](https://github.com/ianjamesburke/plexi-app-registry).
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1431,7 +1431,7 @@ fn is_github_shorthand(s: &str) -> bool {
 /// `github:owner/repo`.
 fn resolve_registry_id(id: &str) -> Result<String, String> {
     const REGISTRY_URL: &str =
-        "https://raw.githubusercontent.com/ianjamesburke/plexi-registry/main/registry.json";
+        "https://raw.githubusercontent.com/ianjamesburke/plexi-app-registry/main/registry.json";
 
     let agent = ureq::AgentBuilder::new()
         .timeout_connect(std::time::Duration::from_secs(10))

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -325,7 +325,7 @@ fn render_inspector_hints(
                 crate::widgets::key_combo_list(ui, &[&["⌫"]], Some("delete"), colors);
                 ui.add_space(style::SPACE_XL);
             }
-            crate::widgets::key_combo_list(ui, &[&["R"]], Some("rename"), colors);
+            crate::widgets::key_combo_list(ui, &[&["⌘", "R"]], Some("rename"), colors);
             ui.add_space(style::SPACE_MD);
             crate::widgets::key_combo_list(ui, &[&["Esc"]], Some("close"), colors);
             ui.add_space(style::SPACE_MD);
@@ -2102,7 +2102,7 @@ impl PlexiApp {
                 let up = i.consume_key(egui::Modifiers::NONE, egui::Key::K)
                     || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
                 let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-                let r = i.consume_key(egui::Modifiers::NONE, egui::Key::R);
+                let r = i.consume_key(egui::Modifiers::COMMAND, egui::Key::R);
                 let backspace = num_contexts > 1 && (
                     i.consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
                         || i.consume_key(egui::Modifiers::NONE, egui::Key::Delete)


### PR DESCRIPTION
## Summary

Three small bundled fixes.

## Issue #1508 — Inspector inline rename: R → Cmd+R

**Done When:** Opening the context inspector and pressing Cmd+R enters inline rename mode. Pressing bare R while the inspector is open does nothing.

Changes:
- `src/overlays.rs` — `consume_key(Modifiers::NONE, Key::R)` → `consume_key(Modifiers::COMMAND, Key::R)`
- `src/overlays.rs` — footer hint chip `["R"]` → `["⌘", "R"]`

## Issue #1510 — create-plexi-app skill version header

**Done When:** `grep "skill_version" ~/.claude/skills/create-plexi-app/SKILL.md` returns `0.0.469`.

Changes:
- `~/.claude/skills/create-plexi-app/SKILL.md` — `skill_version` bumped from `0.0.461` to `0.0.469` (applied directly, outside repo)

## Issue #1537 — Rename plexi-registry → plexi-app-registry

**Done When:** `grep -r 'plexi-registry' src/ README.md` returns no matches. `plexi install` resolves registry IDs correctly.

Changes:
- GitHub repo renamed via API (`ianjamesburke/plexi-registry` → `ianjamesburke/plexi-app-registry`)
- `src/cli.rs` — hardcoded `raw.githubusercontent.com` URL updated
- `README.md` — two references updated (lines 180 and 239)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for app registry setup

* **Chores**
  * Updated app registry data source
  * Changed context rename shortcut to Command+R

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->