### PR TITLE
feat(host): emit SESSION START/END log markers on process app lifecycle (#1511)

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -643,6 +643,7 @@ impl ProcessApp {
             pane_id: 0,
             timestamp: event_log::now_timestamp(),
         });
+        log::info!("app::{}: === SESSION START ===", type_id);
 
         Ok(Self {
             type_id,
@@ -2242,6 +2243,7 @@ impl Drop for ProcessApp {
             reason: None,
             timestamp: event_log::now_timestamp(),
         });
+        log::info!("app::{}: === SESSION END ===", self.type_id);
         if let Some(mut child) = self.process.take() {
             // Three-phase shutdown escalation (#83):
             //   1. Wait up to 2s for the child to exit cleanly after the


### PR DESCRIPTION
## Summary

- Adds `log::info!("app::{}: === SESSION START ===", type_id)` immediately after `HostEvent::AppSpawned` is emitted in `ProcessApp::launch`
- Adds `log::info!("app::{}: === SESSION END ===", self.type_id)` in `impl Drop for ProcessApp`, after `HostEvent::AppClosed` is emitted

These produce log lines like:
```
[INFO] app::logs === SESSION START ===
[INFO] app::logs === SESSION END ===
```

No protocol change — host-side `log::info!` only.

Closes #1511

## Test plan
- [ ] Open a Python app on the alpha build
- [ ] Check `~/.plexi-alpha/plexi.log` — `=== SESSION START ===` appears for that app's type_id
- [ ] Close the app
- [ ] Check log again — `=== SESSION END ===` appears
- [ ] `grep "SESSION" ~/.plexi-alpha/plexi.log` shows both markers after one open/close cycle