### PR TITLE
fix(cli): plexi open exits 0 with pane ID when app launch silently fails (#1542)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1510,6 +1510,7 @@ impl PlexiApp {
                     }
 
                     let cwd_override: Option<std::path::PathBuf> = cwd.as_deref().map(std::path::PathBuf::from);
+                    let mut launch_result: Result<(), String> = Ok(());
                     if type_id == "terminal" {
                         let layout_str = layout.as_deref().unwrap_or("split_v");
                         let initial_cmd = cmd_from_args(args);
@@ -1535,9 +1536,9 @@ impl PlexiApp {
                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, new_pane_first, cwd_override);
                         }
                     } else if let Some(path_str) = path {
-                        self.launch_app_by_path_with_layout(path_str, layout.clone());
+                        launch_result = self.launch_app_by_path_with_layout(path_str, layout.clone());
                     } else {
-                        self.launch_app_by_id_with_layout(type_id, layout.clone(), args, cwd_override);
+                        launch_result = self.launch_app_by_id_with_layout(type_id, layout.clone(), args, cwd_override);
                     }
 
                     // Restore original focus when no_focus is requested or from_pane_id overrode it.
@@ -1551,7 +1552,13 @@ impl PlexiApp {
                         self.windows[active].focused_pane = original_focused;
                     }
                     if let Some(rf) = response_file {
-                        let json = format!("{{\"pane_id\":{new_pane_id}}}");
+                        let json = match &launch_result {
+                            Ok(()) => format!("{{\"pane_id\":{new_pane_id}}}"),
+                            Err(msg) => {
+                                log::warn!("pane_ipc: spawn_pane: launch failed, returning error to caller: {msg}");
+                                format!("{{\"error\":{}}}", serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\"")))
+                            }
+                        };
                         if let Err(e) = std::fs::write(rf, &json) {
                             log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
                         }
@@ -1895,9 +1902,9 @@ impl PlexiApp {
                 let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, new_pane_first, cwd_override);
             } else if let Some(ref path_str) = path {
-                self.launch_app_by_path_with_layout(path_str, layout);
+                let _ = self.launch_app_by_path_with_layout(path_str, layout);
             } else {
-                self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
+                let _ = self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
             }
             if no_focus {
                 log::info!("spawn-queue: no_focus=true, retaining focus on pane_id={original_focused:?}");
@@ -2370,7 +2377,7 @@ impl eframe::App for PlexiApp {
                         });
 
                     let new_pane_id = self.host.next_pane_id();
-                    self.launch_app_by_id_with_layout(&type_id, layout, &args, None);
+                    let _ = self.launch_app_by_id_with_layout(&type_id, layout, &args, None);
 
                     // Confirm back to the requesting app.
                     if let Some(req_pane_id) = requesting_pane_id {
@@ -2527,7 +2534,7 @@ impl eframe::App for PlexiApp {
                         // CLI terminal uses the ephemeral flag exclusively — cmd alone does not close.
                         self.split_focused(vertical, initial_cmd.as_deref(), initial_cmd.is_some(), new_pane_first, None);
                     } else {
-                        self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args, None);
+                        let _ = self.launch_app_by_id_with_layout(&type_id, Some(layout), &effective_args, None);
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
                     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1213,6 +1213,10 @@ pub fn app_run(path: &str) -> i32 {
                     Ok(content) => {
                         let _ = std::fs::remove_file(&response_path);
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                                eprintln!("error: {msg}");
+                                return 1;
+                            }
                             if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
                                 println!("{pid}");
                                 return 0;
@@ -2861,8 +2865,11 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
                 match std::fs::read_to_string(&response_path) {
                     Ok(content) => {
                         let _ = std::fs::remove_file(&response_path);
-                        // Parse {"pane_id": N} and print just the number
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                                eprintln!("error: {msg}");
+                                return 1;
+                            }
                             if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
                                 println!("{pid}");
                                 return 0;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -572,7 +572,7 @@ impl PlexiApp {
     /// Launch an installed app by id in the focused pane.
     /// Respects the `layout_hint` from the app's manifest.toml.
     pub(crate) fn launch_app_by_id(&mut self, id: &str) {
-        self.launch_app_by_id_with_layout(id, None, &[], None);
+        let _ = self.launch_app_by_id_with_layout(id, None, &[], None);
     }
 
     /// Launch an installed app with an explicit layout and args override.
@@ -586,7 +586,7 @@ impl PlexiApp {
         layout: Option<String>,
         args: &[String],
         cwd_override: Option<PathBuf>,
-    ) {
+    ) -> Result<(), String> {
         // "terminal" is a builtin pane type, not in the app registry.
         // Reached via SDK AppCommand::SpawnApp("terminal", ...) and legacy paths.
         // Socket IPC and spawn-queue handle terminal inline in app/mod.rs.
@@ -599,7 +599,7 @@ impl PlexiApp {
                 "SpawnPane: terminal layout='{layout_str}' vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?}"
             );
             self.split_focused(vertical, initial_cmd.as_deref(), false, new_pane_first, None);
-            return;
+            return Ok(());
         }
 
         let cwd_explicit = cwd_override.is_some();
@@ -622,7 +622,7 @@ impl PlexiApp {
                     Some("overlay".to_string())
                 });
             self.open_process_app_pane(id, *parked, cwd, group, hint.as_deref());
-            return;
+            return Ok(());
         }
 
         // Ensure the registry is up-to-date: rescan if the app was added mid-session
@@ -641,7 +641,7 @@ impl PlexiApp {
                 .or_else(|| self.registry.layout_hint_for(id))
                 .or_else(|| Some("overlay".to_string()));
             self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
-            return;
+            return Ok(());
         }
 
         // Try registry first; if it returns None, fall through to Tier 4.
@@ -663,14 +663,16 @@ impl PlexiApp {
                 );
             }
             self.open_process_app_pane(id, process, cwd, group, hint.as_deref());
-            return;
+            return Ok(());
         }
 
         // Tier 4 — CLI native descriptor (plexi_app field).
         if let Some(process) = self.try_launch_cli_pgap_app(id, &cwd) {
             self.open_process_app_pane(&format!("cli:{id}"), process, cwd, group, hint.as_deref());
+            Ok(())
         } else {
             log::warn!("launch_app_by_id: app '{id}' not found or failed to launch");
+            Err(format!("app '{id}' not found"))
         }
     }
 
@@ -682,7 +684,7 @@ impl PlexiApp {
         &mut self,
         app_path: &str,
         layout: Option<String>,
-    ) {
+    ) -> Result<(), String> {
         let app_dir = PathBuf::from(app_path);
         log::info!("launch_app_by_path_with_layout: path={app_path}");
 
@@ -690,7 +692,7 @@ impl PlexiApp {
             Ok(a) => a,
             Err(e) => {
                 log::warn!("launch_app_by_path_with_layout: failed to load manifest at {app_path}: {e}");
-                return;
+                return Err(format!("failed to load app at '{app_path}': {e}"));
             }
         };
 
@@ -733,9 +735,11 @@ impl PlexiApp {
                     "launch_app_by_path_with_layout: launched '{app_id}' from {app_path} group={group:?}"
                 );
                 self.open_process_app_pane(&app_id, process, app_dir, group, layout_hint.as_deref());
+                Ok(())
             }
             Err(e) => {
                 log::error!("launch_app_by_path_with_layout: failed to launch '{app_id}' from {app_path}: {e}");
+                Err(format!("failed to launch '{app_id}': {e}"))
             }
         }
     }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -210,7 +210,7 @@ impl PlexiApp {
                 //   Placement::Right → "split_h" (side-by-side, new pane right)
                 //   Placement::Below → "split_v" (stacked,      new pane below)
                 let layout = if vertical { "split_h" } else { "split_v" };
-                self.launch_app_by_id_with_layout(
+                let _ = self.launch_app_by_id_with_layout(
                     &manifest_id,
                     Some(layout.to_string()),
                     &[],


### PR DESCRIPTION
## Summary

- `launch_app_by_id_with_layout` and `launch_app_by_path_with_layout` return `Result<(), String>` instead of `()`
- `SpawnPane` IPC handler captures the result and writes `{"error":"..."}` to the response file on failure instead of unconditionally writing `{"pane_id": N}`
- `open_cli` and `app_run` check for the `error` field before `pane_id` — exit 1 with `eprintln` on failure
- All non-IPC callers (spawn-queue, SDK SpawnPane, layout duplication, command palette) use `let _ =` to discard the result

## Root cause of prior attempt failure (PR #1563)

The code changes were correct. Tester used wrong binary (alpha instead of PR build) — CLI was never seeing the error response.

## Test plan

- [ ] `plexi-pr-N open <app-with-capability-mismatch>` prints error to stderr, exits 1, no pane ID
- [ ] `plexi-pr-N open <valid-app>` still prints pane ID, exits 0
- [ ] `plexi-pr-N app run <path-with-capability-mismatch>` exits 1 with error