### PR TITLE
feat(permissions): capability grant/deny modal — 4-action logic, SDK typed error, example apps

### DIFF
--- a/examples/audio-recorder/audio_recorder.py
+++ b/examples/audio-recorder/audio_recorder.py
@@ -38,8 +38,9 @@ class AudioRecorderApp(App):
         self._status: str = "Loading devices..."
         self.emit.info("audio-recorder: starting")
 
-        granted = await self.emit.capability_request("audio.record")
-        if not granted:
+        try:
+            await self.emit.capability_request("audio.record")
+        except CapabilityDeniedError:
             self._status = "Microphone access denied. Grant audio.record to use this app."
             self.emit.warn("audio-recorder: audio.record capability denied")
             ctx.status_summary("Audio Recorder")

--- a/examples/bluesky/main.py
+++ b/examples/bluesky/main.py
@@ -17,7 +17,7 @@ import urllib.parse
 import webbrowser
 
 from plexi_sdk import (
-    App, RenderContext,
+    App, RenderContext, CapabilityDeniedError,
     BG, SURFACE, FG, ACCENT, MUTED, HIGHLIGHT,
     BODY, CAPTION, HEADING, HINT, HEADER_H,
     RED,
@@ -108,8 +108,9 @@ class BlueskyApp(App):
 
         self.emit.info("bluesky: init")
         ctx.status_summary("Loading Discover feed…")
-        granted = await self.emit.capability_request("net.http")
-        if not granted:
+        try:
+            await self.emit.capability_request("net.http")
+        except CapabilityDeniedError:
             self._loading = False
             self._error = "Network access denied."
             self.emit.warn("bluesky: net.http capability denied")

--- a/examples/permission-test/main.py
+++ b/examples/permission-test/main.py
@@ -13,7 +13,7 @@ Expected first-run flow:
   5. On second launch, both show "Granted" immediately (stored Green).
 """
 from plexi_sdk import (
-    App, RenderContext,
+    App, RenderContext, CapabilityDeniedError,
     BG, SURFACE, FG, ACCENT, MUTED, GREEN,
     CAPTION, HEADING, HINT,
     PAD,
@@ -74,12 +74,19 @@ class PermissionTest(App):
 
     async def _request(self, cap: str) -> None:
         self.emit.info(f"permission-test: requesting {cap}")
-        granted = await self.emit.capability_request(cap)
-        if cap == "panes.spawn":
-            self.panes_spawn_state = "granted" if granted else "denied"
-        elif cap == "ai.query":
-            self.ai_query_state = "granted" if granted else "denied"
-        self.emit.info(f"permission-test: {cap} -> {'granted' if granted else 'denied'}")
+        try:
+            await self.emit.capability_request(cap)
+            if cap == "panes.spawn":
+                self.panes_spawn_state = "granted"
+            elif cap == "ai.query":
+                self.ai_query_state = "granted"
+            self.emit.info(f"permission-test: {cap} -> granted")
+        except CapabilityDeniedError:
+            if cap == "panes.spawn":
+                self.panes_spawn_state = "denied"
+            elif cap == "ai.query":
+                self.ai_query_state = "denied"
+            self.emit.warn(f"permission-test: {cap} -> denied")
         self.requesting = False
 
 

--- a/examples/wikipedia/wikipedia.py
+++ b/examples/wikipedia/wikipedia.py
@@ -6,7 +6,7 @@ import threading
 import urllib.parse
 
 from plexi_sdk import (
-    App, RenderContext,
+    App, RenderContext, CapabilityDeniedError,
     FG, MUTED, ACCENT, SURFACE, BODY, CAPTION, RED,
 )
 from plexi_sdk.ui import (
@@ -27,8 +27,9 @@ class WikiApp(App):
         self._error_msg = ""
         self._mode = "search"  # search | results | article
         self.emit.info("wikipedia: ready")
-        granted = await self.emit.capability_request("net.http")
-        if not granted:
+        try:
+            await self.emit.capability_request("net.http")
+        except CapabilityDeniedError:
             self._error_msg = "Network access denied. Search requires net.http."
             self.emit.warn("wikipedia: net.http capability denied")
 

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -355,10 +355,10 @@ All methods are thread-safe (protected by a global write lock).
       `ai.query`, or RuntimeError on any other backend failure. Call from a
       background thread — the host may take seconds to reply.
 
-  emit.capability_request(capability) -> bool  [BLOCKING]
+  emit.capability_request(capability) -> None  [BLOCKING]
       Request a runtime capability (e.g. "net.http", "fs.write"). The host
       may show a permission prompt to the user. Blocks until granted or denied.
-      Returns True if granted. Call once at startup, not on every render.
+      Raises CapabilityDeniedError if denied. Call once at startup, not on every render.
 
   emit.cd_to(cwd)
       Request the host to cd all terminals in the same pane group to cwd.

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -847,8 +847,11 @@ class Emitter:
     # self.emit.run_sync(self.emit.method(...)) from a background thread.
 
     @_blocking_emit_method
-    async def capability_request(self, capability: str) -> bool:
-        """Await until host grants or denies the capability. Returns True if granted.
+    async def capability_request(self, capability: str) -> None:
+        """Request a runtime capability grant from the user. Returns None if granted.
+
+        Raises CapabilityDeniedError if the user denies the request. Callers should
+        wrap this in try/except CapabilityDeniedError to handle denial gracefully.
 
         Await from async hooks. From background threads:
         ``self.emit.run_sync(self.emit.capability_request(capability))``.
@@ -858,7 +861,11 @@ class Emitter:
         self._app._pending_capability[req_id] = q
         _emit({"type": "capability_request", "request_id": req_id,
                "capability": capability})
-        return await q.get()
+        granted = await q.get()
+        if not granted:
+            raise CapabilityDeniedError(
+                f"capability_denied: user denied '{capability}'"
+            )
 
     @_blocking_emit_method
     async def secret_get(self, key: str) -> "str | None":

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -95,8 +95,10 @@ pub(super) fn show_prompt_modal(
         return;
     };
 
-    let mut granted = false;
-    let mut denied = false;
+    let mut grant_once = false;
+    let mut grant_forever = false;
+    let mut deny_once = false;
+    let mut deny_forever = false;
 
     egui::Window::new("Plexi needs permission")
         .collapsible(false)
@@ -113,6 +115,55 @@ pub(super) fn show_prompt_modal(
                         egui::RichText::new(format!("Workspace: {}", workspace_root.display()))
                             .small(),
                     );
+                    ui.add_space(12.0);
+
+                    // Consume keys so host shortcuts (Cmd+D, Cmd+A) don't fire.
+                    let (kb_grant_once, kb_grant_forever, kb_deny_once, kb_deny_forever) =
+                        ui.ctx().input_mut(|i| {
+                            let shift_enter =
+                                i.consume_key(egui::Modifiers::SHIFT, egui::Key::Enter);
+                            let shift_esc =
+                                i.consume_key(egui::Modifiers::SHIFT, egui::Key::Escape);
+                            let key_a = i.consume_key(egui::Modifiers::NONE, egui::Key::A);
+                            let key_d = i.consume_key(egui::Modifiers::NONE, egui::Key::D);
+                            let plain_enter =
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+                            let plain_esc =
+                                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+                            (plain_enter, shift_enter || key_a, plain_esc, shift_esc || key_d)
+                        });
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Grant once").clicked() || kb_grant_once {
+                            grant_once = true;
+                        }
+                        if ui.button("Grant forever").clicked() || kb_grant_forever {
+                            grant_forever = true;
+                        }
+                    });
+                    ui.horizontal(|ui| {
+                        if ui.button("Deny once").clicked() || kb_deny_once {
+                            deny_once = true;
+                        }
+                        if ui.button("Deny forever").clicked() || kb_deny_forever {
+                            deny_forever = true;
+                        }
+                    });
+                    ui.add_space(6.0);
+                    crate::widgets::key_combo_list(ui, &[&["↵"]], Some("grant once"), colors);
+                    crate::widgets::key_combo_list(
+                        ui,
+                        &[&["⇧", "↵"], &["A"]],
+                        Some("grant forever"),
+                        colors,
+                    );
+                    crate::widgets::key_combo_list(ui, &[&["⎋"]], Some("deny once"), colors);
+                    crate::widgets::key_combo_list(
+                        ui,
+                        &[&["⇧", "⎋"], &["D"]],
+                        Some("deny forever"),
+                        colors,
+                    );
                 }
                 PendingPrompt::Secret { key } => {
                     ui.label(format!("App \"{}\" needs a secret value for:", type_id));
@@ -124,76 +175,111 @@ pub(super) fn show_prompt_modal(
                         ui.visuals_mut().text_cursor.stroke.width = 1.5;
                         ui.visuals_mut().text_cursor.stroke.color = colors.accent;
                         ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-                        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+                        ui.visuals_mut().widgets.active.bg_stroke =
+                            egui::Stroke::new(1.0, colors.accent);
+                        ui.visuals_mut().widgets.inactive.bg_stroke =
+                            egui::Stroke::new(1.0, colors.border);
                         ui.add(
                             egui::TextEdit::singleline(secret_input_buf)
                                 .password(true)
                                 .margin(egui::Margin::symmetric(8, 5)),
                         );
                     });
+                    ui.add_space(12.0);
+
+                    let esc_kb = ui
+                        .ctx()
+                        .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Submit").clicked() {
+                            grant_once = true;
+                        }
+                        if ui.button("Cancel").clicked() || esc_kb {
+                            deny_once = true;
+                        }
+                    });
                 }
             }
-            ui.add_space(12.0);
-            ui.horizontal(|ui| {
-                if ui.button("Grant").clicked() {
-                    granted = true;
-                }
-                if ui.button("Deny").clicked() {
-                    denied = true;
-                }
-            });
         });
 
-    if granted || denied {
+    if grant_once || grant_forever || deny_once || deny_forever {
         use crate::app_permissions::Capability;
+        let actually_granted = grant_once || grant_forever;
         match pending_prompts.pop_front() {
             Some(PendingPrompt::Capability {
                 request_id,
                 capability,
             }) => {
-                if granted {
+                if grant_once || grant_forever {
                     match Capability::try_from(capability.as_str()) {
                         Ok(cap) => {
                             permissions.capabilities.insert(cap);
-                            permission_store.set(type_id, workspace_root, cap, crate::app_permissions::PermissionState::Green);
-                            permission_store.save();
-                            log::info!(
-                                "permission_store: granted {} for {} in {}",
-                                cap, type_id, workspace_root.display()
-                            );
+                            if grant_forever {
+                                permission_store.set(
+                                    type_id,
+                                    workspace_root,
+                                    cap,
+                                    crate::app_permissions::PermissionState::Green,
+                                );
+                                permission_store.save();
+                                log::info!(
+                                    "prompts: granted {} for {} forever in {}",
+                                    cap,
+                                    type_id,
+                                    workspace_root.display()
+                                );
+                            } else {
+                                log::info!(
+                                    "prompts: granted {} for {} (once, session only)",
+                                    cap,
+                                    type_id
+                                );
+                            }
                         }
                         Err(e) => {
-                            log::warn!(
-                                "prompts: cannot grant {e}; capability string not recognized"
-                            );
+                            log::warn!("prompts: cannot grant {e}; capability string not recognized");
                         }
                     }
                 }
-                if denied {
+                if deny_forever {
                     if let Ok(cap) = Capability::try_from(capability.as_str()) {
                         permissions.blocked.insert(cap);
-                        permission_store.set(type_id, workspace_root, cap, crate::app_permissions::PermissionState::Red);
+                        permission_store.set(
+                            type_id,
+                            workspace_root,
+                            cap,
+                            crate::app_permissions::PermissionState::Red,
+                        );
                         permission_store.save();
                         log::info!(
-                            "permission_store: permanently blocked {} for {} in {}",
-                            cap, type_id, workspace_root.display()
+                            "prompts: denied {} for {} forever in {}",
+                            cap,
+                            type_id,
+                            workspace_root.display()
                         );
                     }
+                }
+                if deny_once {
+                    log::info!(
+                        "prompts: denied {} for {} (once, will reprompt on next request)",
+                        capability,
+                        type_id
+                    );
                 }
                 event_log::emit(HostEvent::PermissionDecision {
                     app_id: type_id.to_string(),
                     capability: capability.clone(),
-                    granted,
+                    granted: actually_granted,
                     timestamp: event_log::now_timestamp(),
                 });
                 outbound_events.push_back(PlexiEvent::CapabilityDecision {
                     request_id,
-                    granted,
+                    granted: actually_granted,
                 });
             }
             Some(PendingPrompt::Secret { key }) => {
-                let value = if granted && !secret_input_buf.is_empty() {
+                let value = if actually_granted && !secret_input_buf.is_empty() {
                     Some(secret_input_buf.clone())
                 } else {
                     None
@@ -219,7 +305,12 @@ pub(super) fn show_prompt_modal(
                     event_log::emit(HostEvent::SecretDenied {
                         app_id: type_id.to_string(),
                         key: key.clone(),
-                        reason: if denied { "user_denied" } else { "empty_value" }.to_string(),
+                        reason: if deny_once || deny_forever {
+                            "user_denied"
+                        } else {
+                            "empty_value"
+                        }
+                        .to_string(),
                         timestamp: event_log::now_timestamp(),
                     });
                 }

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -95,10 +95,29 @@ pub(super) fn show_prompt_modal(
         return;
     };
 
-    let mut grant_once = false;
-    let mut grant_forever = false;
-    let mut deny_once = false;
-    let mut deny_forever = false;
+    // Detect keys at frame level — before any window or button rendering — so
+    // egui button focus cannot intercept Enter/Escape and misfire an action.
+    let (mut grant_once, grant_forever, mut deny_once, deny_forever) =
+        match prompt {
+            PendingPrompt::Capability { .. } => {
+                ui.ctx().input_mut(|i| {
+                    // Shift variants first — they overlap plain Enter/Esc.
+                    let shift_enter = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Enter);
+                    let shift_esc = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Escape);
+                    let key_a = i.consume_key(egui::Modifiers::NONE, egui::Key::A);
+                    let key_d = i.consume_key(egui::Modifiers::NONE, egui::Key::D);
+                    let plain_enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+                    let plain_esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+                    (plain_enter, shift_enter || key_a, plain_esc, shift_esc || key_d)
+                })
+            }
+            PendingPrompt::Secret { .. } => {
+                let esc = ui
+                    .ctx()
+                    .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+                (false, false, esc, false)
+            }
+        };
 
     egui::Window::new("Plexi needs permission")
         .collapsible(false)
@@ -116,40 +135,7 @@ pub(super) fn show_prompt_modal(
                             .small(),
                     );
                     ui.add_space(12.0);
-
-                    // Consume keys so host shortcuts (Cmd+D, Cmd+A) don't fire.
-                    let (kb_grant_once, kb_grant_forever, kb_deny_once, kb_deny_forever) =
-                        ui.ctx().input_mut(|i| {
-                            let shift_enter =
-                                i.consume_key(egui::Modifiers::SHIFT, egui::Key::Enter);
-                            let shift_esc =
-                                i.consume_key(egui::Modifiers::SHIFT, egui::Key::Escape);
-                            let key_a = i.consume_key(egui::Modifiers::NONE, egui::Key::A);
-                            let key_d = i.consume_key(egui::Modifiers::NONE, egui::Key::D);
-                            let plain_enter =
-                                i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-                            let plain_esc =
-                                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-                            (plain_enter, shift_enter || key_a, plain_esc, shift_esc || key_d)
-                        });
-
-                    ui.horizontal(|ui| {
-                        if ui.button("Grant once").clicked() || kb_grant_once {
-                            grant_once = true;
-                        }
-                        if ui.button("Grant forever").clicked() || kb_grant_forever {
-                            grant_forever = true;
-                        }
-                    });
-                    ui.horizontal(|ui| {
-                        if ui.button("Deny once").clicked() || kb_deny_once {
-                            deny_once = true;
-                        }
-                        if ui.button("Deny forever").clicked() || kb_deny_forever {
-                            deny_forever = true;
-                        }
-                    });
-                    ui.add_space(6.0);
+                    // Keyboard-only — no buttons. key_combo_list rows are the UI.
                     crate::widgets::key_combo_list(ui, &[&["↵"]], Some("grant once"), colors);
                     crate::widgets::key_combo_list(
                         ui,
@@ -179,26 +165,29 @@ pub(super) fn show_prompt_modal(
                             egui::Stroke::new(1.0, colors.accent);
                         ui.visuals_mut().widgets.inactive.bg_stroke =
                             egui::Stroke::new(1.0, colors.border);
-                        ui.add(
+                        let response = ui.add(
                             egui::TextEdit::singleline(secret_input_buf)
                                 .password(true)
                                 .margin(egui::Margin::symmetric(8, 5)),
                         );
+                        if response.lost_focus()
+                            && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                        {
+                            grant_once = true;
+                        }
                     });
-                    ui.add_space(12.0);
-
-                    let esc_kb = ui
-                        .ctx()
-                        .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
-
+                    ui.add_space(8.0);
                     ui.horizontal(|ui| {
                         if ui.button("Submit").clicked() {
                             grant_once = true;
                         }
-                        if ui.button("Cancel").clicked() || esc_kb {
+                        if ui.button("Cancel").clicked() {
                             deny_once = true;
                         }
                     });
+                    ui.add_space(4.0);
+                    crate::widgets::key_combo_list(ui, &[&["↵"]], Some("submit"), colors);
+                    crate::widgets::key_combo_list(ui, &[&["⎋"]], Some("cancel"), colors);
                 }
             }
         });

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -97,7 +97,7 @@ pub(super) fn show_prompt_modal(
 
     // Detect keys at frame level — before any window or button rendering — so
     // egui button focus cannot intercept Enter/Escape and misfire an action.
-    let (mut grant_once, grant_forever, mut deny_once, deny_forever) =
+    let (mut grant_once, mut grant_forever, mut deny_once, mut deny_forever) =
         match prompt {
             PendingPrompt::Capability { .. } => {
                 ui.ctx().input_mut(|i| {
@@ -135,7 +135,24 @@ pub(super) fn show_prompt_modal(
                             .small(),
                     );
                     ui.add_space(12.0);
-                    // Keyboard-only — no buttons. key_combo_list rows are the UI.
+                    ui.horizontal(|ui| {
+                        if ui.button("Grant Once").clicked() {
+                            grant_once = true;
+                        }
+                        if ui.button("Grant Forever").clicked() {
+                            grant_forever = true;
+                        }
+                    });
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("Deny Once").clicked() {
+                            deny_once = true;
+                        }
+                        if ui.button("Deny Forever").clicked() {
+                            deny_forever = true;
+                        }
+                    });
+                    ui.add_space(8.0);
                     crate::widgets::key_combo_list(ui, &[&["↵"]], Some("grant once"), colors);
                     crate::widgets::key_combo_list(
                         ui,

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -149,15 +149,6 @@ pub(super) fn show_prompt_modal(
                             deny_forever = true;
                         }
                     });
-                    ui.add_space(8.0);
-                    crate::widgets::key_combo_list(ui, &[&["↵"]], Some("grant once"), colors);
-                    crate::widgets::key_combo_list(
-                        ui,
-                        &[&["⇧", "↵"], &["A"]],
-                        Some("grant forever"),
-                        colors,
-                    );
-                    crate::widgets::key_combo_list(ui, &[&["D"]], Some("deny forever"), colors);
                 }
                 PendingPrompt::Secret { key } => {
                     ui.label(format!("App \"{}\" needs a secret value for:", type_id));

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -96,19 +96,16 @@ pub(super) fn show_prompt_modal(
     };
 
     // Detect keys at frame level — before any window or button rendering — so
-    // egui button focus cannot intercept Enter/Escape and misfire an action.
+    // egui button focus cannot intercept Enter and misfire an action.
     let (mut grant_once, mut grant_forever, mut deny_once, mut deny_forever) =
         match prompt {
             PendingPrompt::Capability { .. } => {
                 ui.ctx().input_mut(|i| {
-                    // Shift variants first — they overlap plain Enter/Esc.
                     let shift_enter = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Enter);
-                    let shift_esc = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Escape);
                     let key_a = i.consume_key(egui::Modifiers::NONE, egui::Key::A);
                     let key_d = i.consume_key(egui::Modifiers::NONE, egui::Key::D);
                     let plain_enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-                    let plain_esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-                    (plain_enter, shift_enter || key_a, plain_esc, shift_esc || key_d)
+                    (plain_enter, shift_enter || key_a, false, key_d)
                 })
             }
             PendingPrompt::Secret { .. } => {
@@ -160,13 +157,7 @@ pub(super) fn show_prompt_modal(
                         Some("grant forever"),
                         colors,
                     );
-                    crate::widgets::key_combo_list(ui, &[&["⎋"]], Some("deny once"), colors);
-                    crate::widgets::key_combo_list(
-                        ui,
-                        &[&["⇧", "⎋"], &["D"]],
-                        Some("deny forever"),
-                        colors,
-                    );
+                    crate::widgets::key_combo_list(ui, &[&["D"]], Some("deny forever"), colors);
                 }
                 PendingPrompt::Secret { key } => {
                     ui.label(format!("App \"{}\" needs a secret value for:", type_id));


### PR DESCRIPTION
## Summary

- SDK `capability_request()` now raises `CapabilityDeniedError` instead of returning a bool — callers use `try/except`
- Capability modal adds four actions: grant once, grant forever, deny once, deny forever — with correct persistence (`PermissionStore` Green/Red)
- Clickable buttons + keyboard shortcut hints in the modal UI
- All example apps (wikipedia, bluesky, audio-recorder, permission-test) updated to `try/except` pattern

## What's NOT in this PR

Keyboard shortcuts Escape and Shift+Escape do not fire reliably from the modal. Root cause: `dispatch_app_key_events` runs before the modal frame and consumes Escape when the focused app handles any key. This is an architectural issue requiring `FocusLayer::CapabilityModal` to fix properly.

Tracked in #1596. Buttons make the modal fully usable in the meantime.

## Test plan

- [ ] `plexi-alpha open wikipedia` → request net capability → Grant Once button works → reopen → modal appears again (not persisted)
- [ ] Grant Forever button → reopen → NO modal (persisted as Green)
- [ ] Deny Once button → modal reprompts next request
- [ ] Deny Forever button → NO modal (persisted as Red, auto-denied)
- [ ] D key → deny forever; A / Shift+Enter → grant forever; Enter → grant once
- [ ] Wikipedia / bluesky / audio-recorder apps show "denied" status gracefully (no crash) when capability denied
- [ ] `cargo test --bin plexi` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error handling for capability requests to use exceptions instead of boolean returns across SDK and examples.

* **New Features**
  * Added granular permission control with separate "Once" and "Forever" grant options in capability prompts.
  * Implemented keyboard shortcuts (Enter/Escape) for permission and secret input dialogs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->