### PR TITLE
feat(logs): search, copy mode, and row/badge spacing polish

### DIFF
--- a/examples/logs/logs.py
+++ b/examples/logs/logs.py
@@ -22,7 +22,9 @@ FOOT_H   = 24.0
 PAD      = SPACE_SM
 CHIP_W   = 54.0   # fixed-width filter buttons — consistent across all labels
 CHIP_GAP = 4.0
-BADGE_ADV = 44.0  # fixed x-advance after a 4-char badge at 10pt
+# Badge advance: widest label "WARN"/"INFO"/"ERRO" at 10pt ~30 px glyph width
+# + 8 px pad each side = ~46 px. Use 50 for a consistent gutter.
+BADGE_ADV = 50.0
 
 FILTERS    = ["ALL", "ERROR", "WARN", "INFO", "DEBUG"]
 FILTER_KEY = {"a": 0, "e": 1, "w": 2, "i": 3, "d": 4}
@@ -36,7 +38,9 @@ LEVEL_BADGE_FILL: dict[str, str] = {
     "TRACE": "#45475a",
 }
 
-ROW_ALT = "#1a1a2a"
+ROW_ALT     = "#1a1a2a"
+COPY_ROW_BG = "#1e2d1e"   # subtle green tint for copy-mode cursor row
+COPY_ROW_FG = "#a6e3a1"   # soft green text for selected row
 
 _LOG_RE = re.compile(
     r"^\[(\d{4}-\d{2}-\d{2} (\d{2}:\d{2}:\d{2}))\] \[(\w+)\] \[([^\]]+)\] (.*)$"
@@ -72,6 +76,9 @@ class LogLine:
         self.target  = target
         self.message = message
 
+    def as_text(self) -> str:
+        return f"[{self.time}] [{self.level}] [{self.target}] {self.message}"
+
 
 def _parse(raw: str) -> "LogLine | None":
     m = _LOG_RE.match(raw.rstrip())
@@ -98,10 +105,16 @@ def _read_log(max_lines: int = 5_000) -> list[LogLine]:
 
 class LogsApp(App):
     def on_init(self, ctx: RenderContext) -> None:
-        self._lines:      list[LogLine] = []
-        self._filter_idx: int   = 0
-        self._scroll:     float = 0.0
-        self._viewport_h: float = 400.0
+        self._lines:       list[LogLine] = []
+        self._filter_idx:  int   = 0
+        self._scroll:      float = 0.0
+        self._viewport_h:  float = 400.0
+        # search
+        self._search_mode: bool = False
+        self._search_q:    str  = ""
+        # copy mode
+        self._copy_mode:   bool = False
+        self._copy_row:    int  = 0   # index into filtered list
         ctx.emit.set_mouse_tracking(True)
         ctx.status_summary("Logs")
         ctx.set_timer(TIMER_ID, 50)
@@ -113,7 +126,41 @@ class LogsApp(App):
         self._lines = _read_log()
         ctx.set_timer(TIMER_ID, POLL_MS)
 
-    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_text_submitted(self, ctx: RenderContext, id: str, text: str) -> None:
+        if id == "search":
+            self._search_q    = text.strip()
+            self._search_mode = False
+            self._scroll      = 0.0
+            self._copy_row    = 0
+
+    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+        # ── search mode: only Esc is handled here; host owns the text field ──
+        if self._search_mode:
+            if key == "escape":
+                self._search_mode = False
+                self._search_q    = ""
+                self._scroll      = 0.0
+                self._copy_row    = 0
+            return
+
+        # ── copy mode ─────────────────────────────────────────────────────
+        if self._copy_mode:
+            filtered = self._filtered()
+            if key == "escape":
+                self._copy_mode = False
+            elif key in ("j", "down"):
+                self._copy_row = min(len(filtered) - 1, self._copy_row + 1)
+                self._ensure_copy_row_visible()
+            elif key in ("k", "up"):
+                self._copy_row = max(0, self._copy_row - 1)
+                self._ensure_copy_row_visible()
+            elif key == "y":
+                if filtered and 0 <= self._copy_row < len(filtered):
+                    ctx.copy_to_clipboard(filtered[self._copy_row].as_text())
+                self._copy_mode = False
+            return
+
+        # ── normal mode ───────────────────────────────────────────────────
         step = ROW_H * 4
         if key in ("j", "down"):
             self._scroll += step
@@ -128,6 +175,26 @@ class LogsApp(App):
         elif key in FILTER_KEY:
             self._filter_idx = FILTER_KEY[key]
             self._scroll = 0.0
+            self._copy_row = 0
+        elif key == "/":
+            self._search_mode = True
+        elif key == "escape" and self._search_q:
+            self._search_q = ""
+            self._scroll   = 0.0
+            self._copy_row = 0
+        elif key == "y":
+            filtered = self._filtered()
+            if filtered:
+                self._copy_mode = True
+                self._copy_row  = min(self._copy_row, len(filtered) - 1)
+
+    def _ensure_copy_row_visible(self) -> None:
+        row_top = self._copy_row * ROW_H
+        row_bot = row_top + ROW_H
+        if row_top < self._scroll:
+            self._scroll = row_top
+        elif row_bot > self._scroll + self._viewport_h:
+            self._scroll = row_bot - self._viewport_h
 
     def _clamp(self) -> None:
         filtered = self._filtered()
@@ -136,9 +203,13 @@ class LogsApp(App):
 
     def _filtered(self) -> list[LogLine]:
         level = FILTERS[self._filter_idx]
-        if level == "ALL":
-            return self._lines
-        return [ll for ll in self._lines if ll.level == level]
+        lines = self._lines if level == "ALL" else [
+            ll for ll in self._lines if ll.level == level
+        ]
+        if not self._search_q:
+            return lines
+        q = self._search_q.lower()
+        return [ll for ll in lines if q in ll.target.lower() or q in ll.message.lower()]
 
     def on_render(self, ctx: RenderContext) -> None:
         w, h = ctx.w, ctx.h
@@ -149,36 +220,81 @@ class LogsApp(App):
 
         # ── top bar ─────────────────────────────────────────────────────────
         ctx.rect(0, 0, w, BAR_H, SURFACE)
-        ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "Logs",
-                 size=TEXT_CAPTION, color=FG, bold=True)
 
-        chip_x = 50.0
-        for i, label in enumerate(FILTERS):
-            active = i == self._filter_idx
-            if ctx.button(
-                f"filter_{i}", chip_x, 5.0, CHIP_W, BAR_H - 10.0, label,
-                fill=ACCENT if active else HIGHLIGHT,
-                hover_fill="#a6c5f5" if active else "#45475a",
-                active_fill="#6ea8f5" if active else "#585b70",
-                text_color=BG if active else MUTED,
-                font_size=12.0,
-                radius=5.0,
-            ):
-                self._filter_idx = i
-                self._scroll = 0.0
-            chip_x += CHIP_W + CHIP_GAP
+        if self._search_mode:
+            ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "/",
+                     size=TEXT_CAPTION, color=ACCENT, bold=True)
+            search_x = PAD + 14.0
+            submitted = ctx.text_input(
+                "search",
+                x=search_x, y=4.0,
+                w=w - search_x - PAD,
+                placeholder="filter by target or message…",
+                h=BAR_H - 8.0,
+            )
+            if submitted is not None:
+                self._search_q    = submitted.strip()
+                self._search_mode = False
+                self._scroll      = 0.0
+                self._copy_row    = 0
+        else:
+            ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "Logs",
+                     size=TEXT_CAPTION, color=FG, bold=True)
+
+            chip_x = 50.0
+            for i, label in enumerate(FILTERS):
+                active = i == self._filter_idx
+                if ctx.button(
+                    f"filter_{i}", chip_x, 5.0, CHIP_W, BAR_H - 10.0, label,
+                    fill=ACCENT if active else HIGHLIGHT,
+                    hover_fill="#a6c5f5" if active else "#45475a",
+                    active_fill="#6ea8f5" if active else "#585b70",
+                    text_color=BG if active else MUTED,
+                    font_size=12.0,
+                    radius=5.0,
+                ):
+                    self._filter_idx = i
+                    self._scroll = 0.0
+                    self._copy_row = 0
+                chip_x += CHIP_W + CHIP_GAP
+
+            if self._search_q:
+                ctx.text(w - PAD, BAR_H / 2 - TEXT_HINT / 2,
+                         f"/{self._search_q}",
+                         size=TEXT_HINT, color=ACCENT, align="right")
 
         # ── footer ──────────────────────────────────────────────────────────
         foot_y = h - FOOT_H
         ctx.rect(0, foot_y, w, FOOT_H, SURFACE)
-        ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
-            (["a", "e", "w", "i", "d"], "filter"),
-            (["j", "k"], "scroll"),
-            (["g", "G"], "top/btm"),
-        ], font_size=10.0)
-        ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
-                 f"{len(filtered)} lines", size=TEXT_HINT, color=MUTED,
-                 align="right")
+
+        if self._copy_mode:
+            ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
+                (["j", "k"], "move"),
+                (["y"], "copy line"),
+                (["esc"], "exit"),
+            ], font_size=10.0)
+            ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
+                     "COPY MODE", size=TEXT_HINT, color=COPY_ROW_FG,
+                     align="right")
+        elif self._search_mode:
+            ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
+                (["enter"], "apply"),
+                (["esc"], "cancel"),
+            ], font_size=10.0)
+            ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
+                     "SEARCH", size=TEXT_HINT, color=ACCENT,
+                     align="right")
+        else:
+            ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
+                (["a", "e", "w", "i", "d"], "filter"),
+                (["j", "k"], "scroll"),
+                (["g", "G"], "top/btm"),
+                (["/"], "search"),
+                (["y"], "copy"),
+            ], font_size=10.0)
+            ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
+                     f"{len(filtered)} lines", size=TEXT_HINT, color=MUTED,
+                     align="right")
 
         # ── log rows ────────────────────────────────────────────────────────
         list_y = BAR_H
@@ -200,15 +316,21 @@ class LogsApp(App):
             ll    = filtered[i]
             row_y = list_y + i * ROW_H - self._scroll
 
-            if i % 2 == 0:
+            is_copy_cursor = self._copy_mode and i == self._copy_row
+
+            if is_copy_cursor:
+                ctx.rect(0, row_y, w, ROW_H, COPY_ROW_BG)
+            elif i % 2 == 0:
                 ctx.rect(0, row_y, w, ROW_H, ROW_ALT)
 
             x      = PAD
             text_y = row_y + ROW_H / 2 - TEXT_HINT / 2
+            dim_fg = COPY_ROW_FG if is_copy_cursor else MUTED
+            msg_fg = COPY_ROW_FG if is_copy_cursor else FG
 
             # timestamp
             ctx.text(x, text_y, ll.time,
-                     size=TEXT_HINT, color=MUTED, monospace=True)
+                     size=TEXT_HINT, color=dim_fg, monospace=True)
             x += time_w
 
             # level badge — solid fill, host-measured, readable at any size
@@ -221,13 +343,13 @@ class LogsApp(App):
 
             # target
             ctx.text(x, text_y, ll.target,
-                     size=TEXT_HINT, color=MUTED,
+                     size=TEXT_HINT, color=dim_fg,
                      max_width=target_w, elide=True)
             x += target_w + PAD
 
             # message
             ctx.text(x, text_y, ll.message,
-                     size=TEXT_HINT, color=FG,
+                     size=TEXT_HINT, color=msg_fg,
                      max_width=w - x - PAD, elide=True)
 
         ctx.pop_clip()

--- a/examples/logs/logs.py
+++ b/examples/logs/logs.py
@@ -126,14 +126,14 @@ class LogsApp(App):
         self._lines = _read_log()
         ctx.set_timer(TIMER_ID, POLL_MS)
 
-    def on_text_submitted(self, ctx: RenderContext, id: str, text: str) -> None:
+    def on_text_submitted(self, _ctx: RenderContext, id: str, text: str) -> None:  # noqa: ARG002
         if id == "search":
             self._search_q    = text.strip()
             self._search_mode = False
             self._scroll      = 0.0
             self._copy_row    = 0
 
-    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:  # noqa: ARG002
         # ── search mode: only Esc is handled here; host owns the text field ──
         if self._search_mode:
             if key == "escape":


### PR DESCRIPTION
Closes #1592

## Summary

- **Badge spacing:** `BADGE_ADV` bumped 44→50 px for a consistent post-badge column gutter across all level label widths at 10pt
- **Text search:** `/` opens a host-owned `text_input` in the top bar; Enter applies the query (filters rows by target + message substring), Esc cancels without changing the active filter; active query shown inline as `/query`
- **Copy mode:** `y` enters copy mode with a green-highlighted cursor row; `j`/`k` move the cursor; `y` again copies that line to clipboard via `ctx.copy_to_clipboard()`; Esc exits; footer hints update per mode

## Test plan

- [ ] Open the logs app on alpha (`plexi-alpha open logs`)
- [ ] Press `/`, type `sdk`, Enter — rows filter to only lines containing "sdk" in target or message
- [ ] Active query `/sdk` appears in top bar; line count updates
- [ ] Press Esc — filter clears, all rows return
- [ ] Press `y` — footer changes to COPY MODE with j/k/y/esc hints
- [ ] Press `j`/`k` — cursor row moves (green highlight)
- [ ] Press `y` — line copied to clipboard, mode exits
- [ ] Press Esc in copy mode — exits without copying
- [ ] Badge column visually aligns consistently across ERROR / WARN / INFO / DEBUG rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added search functionality to the log viewer — press `/` to search logs by target or message
* Added copy mode to select and copy log entries to clipboard with cursor navigation
* Enhanced UI with visual highlighting for selected log lines and updated mode indicators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->