### PR TITLE
feat(skills): composable ship pipeline — implement-issue, open-pr, validate-pr, merge-pr, test-pr

### DIFF
--- a/.claude/skills/dispatch-issue/SKILL.md
+++ b/.claude/skills/dispatch-issue/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dispatch-issue
+description: "Long-horizon orchestrator for the ship pipeline. Spawns implement-issue → open-pr → validate-pr → merge-pr as sequential Plexi panes, watching each for exit and reading the issue body Ship Log to determine outcome before dispatching the next phase. Resumes mid-pipeline automatically. Input: issue number."
+risk: medium
+source: local
+date_added: "2026-05-20"
+---
+
+# Dispatch Issue
+
+Orchestrates the full ship pipeline for a single issue without manual handoffs.
+
+**Entry:** `/dispatch-issue <issue-number>`
+
+The skill runs a shell script that:
+1. Reads the issue body's `## Ship Log` to determine which phase to resume at
+2. Spawns each phase skill in a new Plexi terminal pane
+3. Polls `plexi pane list` every 60s until the phase pane exits
+4. Reads the Ship Log for the completion marker
+5. Dispatches the next phase, or surfaces a failure notification
+
+**Phases dispatched in order:**
+
+| Phase | Skill | Completion marker |
+|---|---|---|
+| 1 | `/implement-issue <n>` | `[IMPLEMENTED]` |
+| 2 | `/open-pr <branch>` | `[PR OPENED]` |
+| 3 | `/validate-pr <pr>` | `[VALIDATED]` |
+| 4 | `/merge-pr <pr>` | `[COMPLETE]` |
+
+**validate-pr requires human interaction.** The orchestrator polls the Ship Log every 5 minutes and surfaces status updates while waiting. The user tests in the spawned pane; the orchestrator picks up after the pane exits.
+
+**Resume behavior:** if the issue already has Ship Log entries, the orchestrator skips completed phases and starts at the right one. Call `/dispatch-issue <n>` at any point — it won't re-run phases that already succeeded.
+
+**Hard reject:** if `validate-pr` hard-rejects a PR, the orchestrator fires a `plexi notify`, exits with a non-zero status, and leaves the issue re-labeled `ready`. The issue body contains the `## Prior Attempts` section for the next run.
+
+---
+
+## How to invoke
+
+The skill runs the orchestrator script directly. When invoked, run:
+
+```bash
+bash /Users/ianburke/Documents/GitHub/PLEXI/.claude/skills/dispatch-issue/scripts/run.sh <issue-number>
+```
+
+Or from any worktree:
+```bash
+bash "$(git rev-parse --show-toplevel)/.claude/skills/dispatch-issue/scripts/run.sh" <issue-number>
+```
+
+The script logs each phase transition to stdout and fires a `plexi notify` on completion or failure.
+
+---
+
+## What the orchestrator does NOT do
+
+- Does not make any implementation decisions — each phase skill owns its logic
+- Does not retry on hard reject — that requires human review of the issue body
+- Does not bypass the human testing gate in validate-pr — it waits for the pane to exit naturally
+- Does not handle bundle mode specially — pass the issue number; implement-issue handles bundles internally
+
+---
+
+## Failure modes
+
+**Phase pane exited but marker missing:** the phase skill crashed or the agent hit a context limit. The issue body will still have partial Ship Log entries. Call `/dispatch-issue <n>` again — it resumes from the last successful marker.
+
+**Branch or PR number not in Ship Log:** the phase skill didn't write its completion entry. Check the issue body and add the missing entry manually, then re-run. Format:
+```markdown
+**Branch:** feature/<n>-short-description
+**PR:** #<pr-number> — <url>
+```
+
+**Orchestrator itself crashes:** safe to re-run. It reads Ship Log state fresh on every invocation.

--- a/.claude/skills/dispatch-issue/scripts/run.sh
+++ b/.claude/skills/dispatch-issue/scripts/run.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Orchestrates the full ship pipeline for a single issue.
+# Spawns each phase in a new Plexi pane, waits for exit, reads the Ship Log,
+# then dispatches the next phase. Resumes mid-pipeline if called on an issue
+# that's already in flight.
+#
+# Usage: run.sh <issue-number>
+
+set -euo pipefail
+
+ISSUE=$1
+POLL_INTERVAL=60   # seconds between pane-alive checks
+LOG_POLL_INTERVAL=300  # seconds between Ship Log checks when pane is still alive
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+log() { echo "[dispatch-issue #$ISSUE] $*"; }
+
+issue_body() {
+  gh issue view "$ISSUE" --json body --jq '.body'
+}
+
+ship_log() {
+  issue_body | awk '/^## Ship Log/,0'
+}
+
+last_marker() {
+  # Returns the last [MARKER] line found in the Ship Log section
+  ship_log | grep -oE '\[(IMPLEMENTED|PR OPENED|VALIDATED|HARD REJECT|COMPLETE)\]' | tail -1
+}
+
+pane_alive() {
+  local pane_id=$1
+  plexi pane list --json | jq -e ".[] | select(.id == $pane_id)" > /dev/null 2>&1
+}
+
+wait_for_pane_exit() {
+  local pane_id=$1
+  local phase=$2
+  log "Waiting for $phase pane ($pane_id) to exit..."
+  while pane_alive "$pane_id"; do
+    sleep "$POLL_INTERVAL"
+  done
+  log "$phase pane exited."
+}
+
+spawn() {
+  local cmd=$1
+  local pane_id
+  pane_id=$(plexi terminal -- bash -c "c '$cmd'; echo '[dispatch] pane done'; sleep 2" 2>/dev/null)
+  echo "$pane_id"
+}
+
+notify_orch() {
+  local title=$1
+  local body=$2
+  plexi notify \
+    --title "$title" \
+    --body "$body" \
+    --choice "ok:Dismiss" \
+    2>/dev/null || true
+}
+
+fail() {
+  local reason=$1
+  log "FAILED: $reason"
+  notify_orch "dispatch-issue #$ISSUE failed" "$reason"
+  exit 1
+}
+
+# ── determine resume point ────────────────────────────────────────────────────
+
+MARKER=$(last_marker || true)
+log "Current Ship Log marker: ${MARKER:-none}"
+
+case "$MARKER" in
+  "")
+    START_PHASE="implement"
+    ;;
+  "[IMPLEMENTED]")
+    START_PHASE="open-pr"
+    ;;
+  "[PR OPENED]")
+    START_PHASE="validate"
+    ;;
+  "[VALIDATED]")
+    START_PHASE="merge"
+    ;;
+  "[COMPLETE]")
+    log "Issue #$ISSUE is already complete."
+    notify_orch "dispatch-issue #$ISSUE" "Already complete — nothing to do."
+    exit 0
+    ;;
+  "[HARD REJECT]")
+    log "Issue #$ISSUE was hard-rejected. Review the issue body before re-dispatching."
+    notify_orch "dispatch-issue #$ISSUE — hard reject" "Previous attempt hard-rejected. Issue body has Prior Attempts section. Review before re-dispatching."
+    exit 1
+    ;;
+  *)
+    fail "Unknown Ship Log marker: $MARKER"
+    ;;
+esac
+
+log "Resuming at phase: $START_PHASE"
+
+# ── phase: implement ──────────────────────────────────────────────────────────
+
+if [[ "$START_PHASE" == "implement" ]]; then
+  log "Spawning /implement-issue $ISSUE..."
+  PANE=$(spawn "/implement-issue $ISSUE")
+  wait_for_pane_exit "$PANE" "implement-issue"
+
+  MARKER=$(last_marker || true)
+  if [[ "$MARKER" != "[IMPLEMENTED]" ]]; then
+    fail "implement-issue exited but Ship Log shows '$MARKER' — expected [IMPLEMENTED]. Check pane output."
+  fi
+  log "implement-issue completed."
+fi
+
+# ── phase: open-pr ────────────────────────────────────────────────────────────
+
+if [[ "$START_PHASE" == "implement" || "$START_PHASE" == "open-pr" ]]; then
+  # Extract branch from Ship Log
+  BRANCH=$(ship_log | grep "^\*\*Branch:\*\*" | tail -1 | awk '{print $2}')
+  if [[ -z "$BRANCH" ]]; then
+    fail "Could not extract branch name from Ship Log. Check issue #$ISSUE body."
+  fi
+  log "Spawning /open-pr $BRANCH..."
+  PANE=$(spawn "/open-pr $BRANCH")
+  wait_for_pane_exit "$PANE" "open-pr"
+
+  MARKER=$(last_marker || true)
+  if [[ "$MARKER" != "[PR OPENED]" ]]; then
+    fail "open-pr exited but Ship Log shows '$MARKER' — expected [PR OPENED]."
+  fi
+  log "open-pr completed."
+fi
+
+# ── phase: validate ───────────────────────────────────────────────────────────
+
+if [[ "$START_PHASE" == "implement" || "$START_PHASE" == "open-pr" || "$START_PHASE" == "validate" ]]; then
+  # Extract PR number from Ship Log
+  PR_NUMBER=$(ship_log | grep -oE 'PR #([0-9]+)' | tail -1 | grep -oE '[0-9]+')
+  if [[ -z "$PR_NUMBER" ]]; then
+    fail "Could not extract PR number from Ship Log. Check issue #$ISSUE body."
+  fi
+  log "Spawning /validate-pr $PR_NUMBER..."
+  PANE=$(spawn "/validate-pr $PR_NUMBER")
+
+  # validate-pr requires human interaction — we wait for pane exit but also
+  # poll the Ship Log to surface status updates to the orchestrator output.
+  log "validate-pr requires human testing. Polling every ${LOG_POLL_INTERVAL}s for updates..."
+  while pane_alive "$PANE"; do
+    CURRENT=$(last_marker || true)
+    log "  Ship Log: ${CURRENT:-in progress}"
+    sleep "$LOG_POLL_INTERVAL"
+  done
+
+  MARKER=$(last_marker || true)
+  if [[ "$MARKER" == "[HARD REJECT]" ]]; then
+    log "validate-pr hard-rejected PR #$PR_NUMBER. Issue #$ISSUE updated. Stopping."
+    notify_orch "dispatch-issue #$ISSUE — hard reject" "PR #$PR_NUMBER hard-rejected after 3 attempts. Issue body updated with Prior Attempts."
+    exit 1
+  fi
+  if [[ "$MARKER" != "[VALIDATED]" ]]; then
+    fail "validate-pr exited but Ship Log shows '$MARKER' — expected [VALIDATED] or [HARD REJECT]."
+  fi
+  log "validate-pr: PR approved."
+fi
+
+# ── phase: merge ──────────────────────────────────────────────────────────────
+
+PR_NUMBER=$(ship_log | grep -oE 'PR #([0-9]+)' | tail -1 | grep -oE '[0-9]+')
+if [[ -z "$PR_NUMBER" ]]; then
+  fail "Could not extract PR number from Ship Log before merge."
+fi
+log "Spawning /merge-pr $PR_NUMBER..."
+PANE=$(spawn "/merge-pr $PR_NUMBER")
+wait_for_pane_exit "$PANE" "merge-pr"
+
+MARKER=$(last_marker || true)
+if [[ "$MARKER" != "[COMPLETE]" ]]; then
+  fail "merge-pr exited but Ship Log shows '$MARKER' — expected [COMPLETE]."
+fi
+
+VERSION=$(ship_log | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+log "Done. Issue #$ISSUE shipped as $VERSION."
+notify_orch "Shipped #$ISSUE" "Issue #$ISSUE closed — $VERSION"

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: implement-issue
+description: "Phase 1 of the PLEXI ship pipeline. Finds an issue, sets up a worktree, and implements the code changes. Stops before creating a PR — output is a pushed feature branch. Entry points: /implement-issue (auto-find), /implement-issue <n> (specific), /implement-issue P1 (by priority), /implement-issue <n> <m> [...] (bundle)."
+risk: medium
+source: local
+date_added: "2026-05-20"
+---
+
+# Implement Issue
+
+Phase 1 of the ship pipeline. Output: a pushed feature branch ready for `/open-pr`.
+
+| Invocation | Behavior |
+|---|---|
+| `/implement-issue` | Auto-find next unblocked issue (P0→P4) |
+| `/implement-issue <n>` | Specific issue |
+| `/implement-issue P1` | First unblocked at that priority |
+| `/implement-issue <n> <m> [...]` | Bundle — implement multiple issues in one branch |
+
+On completion, **append a Ship Log entry to the issue body** (see Ship Log Format below) and output:
+
+```
+[IMPLEMENTED] Issue #<n>
+Branch: feature/<n>-short-description
+Files changed: <N>
+Next: /open-pr feature/<n>-short-description
+```
+
+---
+
+## Phase 0 — Find the Issue
+
+Run in parallel:
+```bash
+git log --oneline -10
+gh issue list --label "in progress" --json number,title
+```
+
+Surface the in-progress list as context.
+
+**Determine search scope from argument:**
+- No arg → try P0, P1 (no `ready` filter), then P2→P4 filtered to `ready`
+- Priority arg → search only that level; apply `ready` filter for P2+
+
+```bash
+# P0/P1:
+gh issue list --label "<priority>" --state open --json number,title,labels,body --limit 50
+
+# P2/P3/P4:
+gh issue list --label "<priority>" --label "ready" --state open --json number,title,labels,body --limit 50
+```
+
+Sort ascending by issue number. For each:
+1. Skip if labeled `in progress`
+2. If labeled `blocked`: parse `depends_on` from front matter; skip if any dependency is OPEN. If all CLOSED: strip `blocked`, add `ready`
+3. Skip if body contains "Do not implement here" (epic tracker)
+4. Skip if body has unlabeled "Depends on" section with open issues — add `blocked` label
+5. Otherwise: this is the target → proceed to Phase 1
+
+Advance to next priority level if no unblocked issues found (no-arg mode only).
+
+**Front matter convention** — every issue body opens with:
+```
+---
+depends_on: []
+---
+```
+
+---
+
+## Phase 1 — Pre-flight
+
+**Check issue state first:**
+```bash
+gh issue view <number> --json state,title,labels --jq '{state: .state, title: .title, labels: [.labels[].name]}'
+```
+
+If `CLOSED`: stop. "Issue #<n> is already closed — nothing to do."
+
+If labeled `in progress`: surface existing worktree + PR before proceeding. Ask for takeover confirmation — do not proceed until user confirms.
+
+**Check if already done:**
+```bash
+gh issue view <number> --json body --jq '.body'
+```
+Grep `src/` on alpha and `git log --oneline -20` against Done When criteria. If all criteria met: close the issue and stop.
+
+**Sync alpha:**
+```bash
+git fetch origin && git status --porcelain
+```
+
+If dirty: auto-stash:
+```bash
+git stash push -m "implement-issue auto-stash before #<number>"
+IMPL_STASHED=true
+```
+
+**Check for unpushed commits:**
+```bash
+git log origin/alpha..HEAD --oneline
+```
+If any listed: STOP. Tell user to push first. Pop stash, exit.
+
+Then: `git pull --rebase origin alpha`
+
+**Label + pane setup:**
+```bash
+gh issue edit <number> --add-label "in progress"
+IMPL_PANE=$PLEXI_PANE_ID
+plexi pane name "#<number> — <short-title>"
+_PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=<number> --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
+[ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="47fc9ee4" > /dev/null
+```
+
+---
+
+## Phase 1b — Implementation Audit
+
+Re-read Done When criteria against alpha `src/` and `git log --oneline -20`.
+
+- Partial: surface what's done vs missing, state the plan, ask open design questions. Wait for confirmation.
+- Nothing done: proceed, note "Audit: nothing on alpha yet."
+
+---
+
+## Phase 2 — Worktree Setup
+
+**Check for remote branch ownership:**
+```bash
+EXISTING=$(git ls-remote origin "refs/heads/feature/<issue-number>-*" | head -1)
+```
+If non-empty: another agent owns this. Surface branch + any existing PR, then stop.
+
+Create worktree:
+```bash
+wtp add -b feature/<issue-number>-short-description
+```
+
+If "branch already exists": check `git worktree list`. If no worktree, `wtp add` without `-b`. Check for prior commits.
+
+**Verify base immediately:**
+```bash
+git -C worktrees/<branch> log --oneline -1
+git log --oneline -1
+```
+If mismatch: delete worktree and branch, redo.
+
+---
+
+## Phase 3 — Formulate
+
+Before writing code, produce a tight implementation spec.
+
+**Read in parallel:**
+- Full issue body: `gh issue view <number> --json title,body,labels`
+- Relevant source files (grep for affected modules, then read them)
+
+**Grep GOTCHAS.md and DEV_LOG.md (required):**
+```bash
+grep -in "<term1>\|<term2>\|<term3>" GOTCHAS.md DEV_LOG.md
+```
+Surface every match under **Gotchas found:**. Each requires disposition: **NOTED** or **N/A**.
+
+**If any changed file is a Python app under `examples/`:** invoke `create-plexi-app` skill before writing code.
+
+**If issue involves a third-party library:** invoke `coding-conventions` skill.
+
+**Write implementation spec (in context only, not to disk):**
+```
+Files to change:
+  - src/foo.rs:42 — <exactly what>
+
+Files NOT to touch:
+  - <adjacent but out of scope>
+
+CLI rename check:
+  - grep -rn "<old-command>" .claude/skills/ if renaming a subcommand
+
+Test that must pass:
+  - cargo test <test_name>
+
+Invariants to preserve:
+  - <constraints from GOTCHAS.md or CLAUDE.md>
+
+Assumptions to validate:
+  - <what must be true> — validated by: <cheapest check>
+
+Logging plan (required):
+  - Every new AppRequest/HostEffect/DrawCommand handler → log::info! at entry
+  - Every user-visible state change → log::info! with what changed
+  - Every early-return bail-out → log::warn! naming app/command/reason
+  - Every unrecoverable failure → log::error! with full context
+```
+
+---
+
+## Phase 4 — Implement
+
+> **Worktree path rule:** All Read/Edit/Write tool calls must target the WORKTREE absolute path. Never the repo root.
+
+**Scope gate:**
+- ≤ 3 files: implement inline. Write tests first, run `cargo test`.
+- > 3 files or multiple subsystems: dispatch Sonnet subagent.
+
+### Subagent dispatch
+
+Prompt must include: full implementation spec, contents of every file it will touch, worktree path, and the rule "stage changes but do NOT commit."
+
+Report back: `DONE` | `DONE_WITH_CONCERNS <details>` | `NEEDS_CONTEXT <what>` | `BLOCKED <reason>`
+
+- `DONE`: review staged diff, run `cargo test`, commit.
+- `DONE_WITH_CONCERNS`: read concerns first.
+- `NEEDS_CONTEXT`: provide + redispatch.
+- `BLOCKED`: provide context or escalate.
+
+**Orchestrator owns the commit:**
+```bash
+git -C worktrees/<branch> add <files>
+git -C worktrees/<branch> commit -m "<message>"
+git -C worktrees/<branch> push -u origin HEAD
+```
+
+**Bundle mode:** branch name `feature/bundle-<n1>-<n2>`, implement all issues before pushing.
+
+---
+
+## Ship Log Format
+
+After pushing, append this section to the issue body. If a `## Ship Log` section already exists (prior attempt), append a new entry under it. If not, add the section.
+
+```markdown
+## Ship Log
+
+### Attempt <N> — <YYYY-MM-DD>
+**Branch:** feature/<n>-short-description
+**Files changed:** <list key files>
+**Spec summary:** <one-line description of approach>
+```
+
+Append with:
+```bash
+CURRENT_BODY=$(gh issue view <number> --json body --jq '.body')
+NEW_BODY=$(printf '%s\n\n## Ship Log\n\n### Attempt 1 — %s\n**Branch:** feature/<branch>\n**Files changed:** <files>\n**Spec summary:** <summary>' "$CURRENT_BODY" "$(date +%Y-%m-%d)")
+gh issue edit <number> --body "$NEW_BODY"
+```
+If `## Ship Log` already exists in the body, append only the new `### Attempt N` block (don't duplicate the section header).
+
+---
+
+## Abort / Stash Pop
+
+At every exit point (success, blocked, fail):
+```bash
+[ "$IMPL_STASHED" = "true" ] && git stash pop
+```
+
+---
+
+## Rules
+
+- Never branch from main — always from repo root (alpha)
+- Never skip base verification after `wtp add`
+- No `todo!()` or `unimplemented!()` outside `#[cfg(test)]`
+- No `#[allow(dead_code)]` or `#[allow(unused)]`
+- `cargo build` must pass after all changes
+- Subagents stage only — orchestrator owns the commit
+- Never dispatch subagent without the Phase 3 spec
+- Every implementation needs a logging plan
+- CLI changes must update `~/.claude/skills/plexi-cli/SKILL.md` in same PR
+- `cargo build --manifest-path <worktree>/Cargo.toml` — never rely on CWD
+- On unrecoverable failure: close PR if open, comment on issue under `## Prior Attempts`, remove `in progress`, add `ready`, exit

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -241,10 +241,16 @@ After pushing, append this section to the issue body. If a `## Ship Log` section
 Append with:
 ```bash
 CURRENT_BODY=$(gh issue view <number> --json body --jq '.body')
-NEW_BODY=$(printf '%s\n\n## Ship Log\n\n### Attempt 1 — %s\n**Branch:** feature/<branch>\n**Files changed:** <files>\n**Spec summary:** <summary>' "$CURRENT_BODY" "$(date +%Y-%m-%d)")
+ATTEMPT_N=$(printf '%s' "$CURRENT_BODY" | grep -c '^### Attempt ' || true)
+ATTEMPT_N=$((ATTEMPT_N + 1))
+ATTEMPT_BLOCK=$(printf '### Attempt %s — %s\n**Branch:** feature/<branch>\n**Files changed:** <files>\n**Spec summary:** <summary>' "$ATTEMPT_N" "$(date +%Y-%m-%d)")
+if printf '%s' "$CURRENT_BODY" | grep -q '^## Ship Log$'; then
+  NEW_BODY=$(printf '%s\n\n%s' "$CURRENT_BODY" "$ATTEMPT_BLOCK")
+else
+  NEW_BODY=$(printf '%s\n\n## Ship Log\n\n%s' "$CURRENT_BODY" "$ATTEMPT_BLOCK")
+fi
 gh issue edit <number> --body "$NEW_BODY"
 ```
-If `## Ship Log` already exists in the body, append only the new `### Attempt N` block (don't duplicate the section header).
 
 ---
 

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -38,7 +38,7 @@ Extract:
 
 **CWD for all steps: the repo root. Set it now:**
 ```bash
-cd /Users/ianburke/Documents/GitHub/PLEXI
+cd "$(git rev-parse --show-toplevel)"
 ```
 
 ---

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: merge-pr
+description: "Phase 4 of the PLEXI ship pipeline. Takes an approved PR number, squash-merges to alpha, bumps the version, installs, closes the issue, and cleans up. Input: PR number. Output: installed alpha build at new version."
+risk: medium
+source: local
+date_added: "2026-05-20"
+---
+
+# Merge PR
+
+Phase 4 of the ship pipeline. Input: approved PR number. Output: clean alpha at new version.
+
+**Entry:** `/merge-pr <pr-number>`
+
+On completion, appends final entry to the issue's Ship Log and outputs:
+
+```
+[COMPLETE]
+- Merged: PR #<n> — <title>
+- Closed: Issue #<n> — <title>
+- Version: v<x.y.z>
+```
+
+---
+
+## Step 0 — Read Context
+
+```bash
+gh pr view <pr-number> --json title,headRefName,number,baseRefName,state,mergeStateStatus
+```
+
+Extract:
+- `BRANCH` = `headRefName`
+- `ISSUE_NUMBER` = parse from branch name (or from PR body `Closes #<n>`)
+- `PR_STATE` = check if already `MERGED`
+
+**If already MERGED:** skip to Step 5 (close issue). Another session merged it.
+
+**CWD for all steps: the repo root. Set it now:**
+```bash
+cd /Users/ianburke/Documents/GitHub/PLEXI
+```
+
+---
+
+## Step 1 — Discard Artifacts, Stash Local Edits
+
+```bash
+git restore Cargo.toml
+git -C worktrees/$BRANCH restore Cargo.toml
+DIRTY=$(git status --porcelain | grep -v "^??" | grep -v "Cargo.toml")
+if [ -n "$DIRTY" ]; then
+  git stash push -m "session edits — restore after merge"
+  STASHED=1
+fi
+```
+
+---
+
+## Step 2 — Rebase and Push
+
+```bash
+git fetch origin
+git -C worktrees/$BRANCH rebase origin/alpha
+# On conflict: git -C worktrees/$BRANCH add <files> && GIT_EDITOR=true git -C worktrees/$BRANCH rebase --continue
+git -C worktrees/$BRANCH push --force-with-lease origin HEAD
+```
+
+> If anything non-obvious happened this PR: add one entry to `GOTCHAS.md` in the feature worktree and commit it there before pushing. It lands in the squash commit. Do not write to alpha's GOTCHAS.md directly.
+
+---
+
+## Step 3 — Squash Merge
+
+```bash
+gh pr merge $PR_NUMBER --squash
+```
+
+If branch protection blocks: `gh pr merge $PR_NUMBER --squash --admin`
+
+Wait ~10 seconds for GitHub's merge state to update before proceeding.
+
+---
+
+## Step 4 — Sync Alpha
+
+```bash
+git fetch origin
+git reset --hard origin/alpha
+```
+
+Restore stash if created:
+```bash
+if [ "${STASHED:-0}" = 1 ]; then
+  git stash pop
+  PR_FILES=$(git show origin/alpha --name-only --format="" | grep .)
+  while IFS= read -r f; do
+    if ! printf '%s\n' "$PR_FILES" | grep -qxF "$f"; then
+      printf 'WARNING: %s from stash is unrelated to PR — discarding\n' "$f"
+      git restore "$f"
+    fi
+  done < <(git diff --name-only)
+  REMAINING=$(git diff --name-only)
+  if [ -n "$REMAINING" ]; then
+    git add -u && git commit -m "chore: restore session edits carried through merge"
+  fi
+fi
+```
+
+If `stash pop` conflicts: take squash version (`git checkout --theirs <file>`).
+
+---
+
+## Step 5 — Cleanup
+
+```bash
+rm -f test_pr$PR_NUMBER.py
+just pr-clean $PR_NUMBER        # skip if no pr-install was run (diff-review path)
+wtp remove $BRANCH --force
+git push origin --delete $BRANCH
+```
+
+---
+
+## Step 6 — Bump, Install, Push
+
+```bash
+just bump && just install
+git push
+```
+
+Read the new version:
+```bash
+VERSION=$(grep '^version' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+```
+
+---
+
+## Step 7 — Close Issue and Update Project Board
+
+```bash
+gh issue close $ISSUE_NUMBER --comment "Closed by PR #$PR_NUMBER — verified on alpha v$VERSION"
+_PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=$ISSUE_NUMBER --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
+[ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="98236657" > /dev/null
+```
+
+**Bundle mode:** close all issues:
+```bash
+for N in <n1> <n2> ...; do
+  gh issue close $N --comment "Closed by PR #$PR_NUMBER — verified on alpha v$VERSION"
+done
+```
+
+---
+
+## Step 8 — Append Final Ship Log Entry
+
+```bash
+CURRENT_BODY=$(gh issue view $ISSUE_NUMBER --json body --jq '.body')
+# Append to Ship Log:
+# **Merged:** PR #<pr-number> → alpha v<version> (<YYYY-MM-DD>)
+gh issue edit $ISSUE_NUMBER --body "<updated body>"
+```
+
+---
+
+## Step 9 — Unblock Downstream Issues
+
+```bash
+gh issue-ext blocking list $ISSUE_NUMBER --json number,title,state 2>/dev/null \
+  | jq '.[] | select(.state == "OPEN") | {number, title}'
+```
+
+For each match, check if all its blockers are now closed:
+```bash
+gh issue-ext blocking list <blocking-issue-number> --json number,state 2>/dev/null \
+  | jq 'all(.state == "CLOSED")'
+```
+
+If true: `gh issue edit <n> --remove-label "blocked" --add-label "ready"`
+
+Report any issues unblocked.
+
+---
+
+## Step 10 — Notify and Close Pane
+
+```bash
+git status  # must be clean
+```
+
+**Clean exit (no deferred threads):**
+```bash
+(RESULT=$(plexi notify \
+  --title "Shipped #$ISSUE_NUMBER" \
+  --body "<title> — v$VERSION" \
+  --choice "ok:Dismiss" \
+  --choice "open:Open PR")
+ [ "$RESULT" = "open" ] && open "<pr-url>") &
+plexi pane close
+```
+
+**Soft exit (deferred threads / improvements proposed):**
+```bash
+plexi notify \
+  --title "Shipped #$ISSUE_NUMBER — review needed" \
+  --body "<title> — v$VERSION. <N> improvement(s) proposed." \
+  --choice "a:Talk to Claude:pane_focus:$PLEXI_PANE_ID" \
+  --choice "b:Approve all" \
+  --choice "c:Skip all"
+```
+
+---
+
+## Rules
+
+- CWD must be repo root for all commands in this skill
+- `just pr-clean`, `just bump`, `just install` run from repo root
+- `just pr-install` runs from the feature worktree (only if re-needed)
+- Never pass `--delete-branch` to `gh pr merge` — git refuses to delete a branch checked out by a worktree
+- Never commit directly to alpha, beta, or main
+- Alpha must be clean when this skill exits
+- On unrecoverable failure: comment on issue, remove `in progress` label, add `ready`, exit
+- `git status` clean check is the final gate before notify

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: open-pr
+description: "Phase 2 of the PLEXI ship pipeline. Takes a pushed feature branch, creates a PR targeting alpha, runs AI review (CodeRabbit + Gemini), and appends results to the issue body. Input: branch name or auto-detect from CWD. Output: PR URL."
+risk: medium
+source: local
+date_added: "2026-05-20"
+---
+
+# Open PR
+
+Phase 2 of the ship pipeline. Input: a pushed feature branch. Output: PR URL ready for `/validate-pr`.
+
+**Entry points:**
+- `/open-pr` — auto-detect branch from CWD (must be inside a feature worktree)
+- `/open-pr <branch-name>` — explicit branch (e.g. `feature/1234-something`)
+- `/open-pr <pr-number>` — re-run AI review on an existing PR, skip PR creation
+
+On completion, **append to the issue body's Ship Log** (see Ship Log Append below) and output:
+
+```
+[PR OPENED] PR #<n> — <title>
+PR: <url>
+AI Review: <N> fixes applied | no changes needed
+Next: /validate-pr <pr-number>
+```
+
+---
+
+## Step 1 — Detect Branch and Issue
+
+**If branch-name given:**
+```bash
+git ls-remote origin "refs/heads/<branch>"
+```
+Fail loudly if branch doesn't exist on origin.
+
+**If auto-detecting from CWD:**
+```bash
+git branch --show-current
+```
+Must be a `feature/` or `fix/` branch. Fail if on `alpha`, `beta`, or `main`.
+
+**Extract issue number from branch:**
+- `feature/<number>-...` → issue number is the first segment after `feature/`
+- Bundle: `feature/bundle-<n1>-<n2>-...` → multiple issue numbers
+
+**Fetch issue for PR body:**
+```bash
+gh issue view <number> --json title,body,labels --jq '{title: .title, body: .body}'
+```
+
+---
+
+## Step 2 — Create PR
+
+```bash
+PR_URL=$(gh pr create \
+  --base alpha \
+  --head <branch> \
+  --title "<issue-title> (#<number>)" \
+  --body "$(cat <<'EOF'
+Closes #<number>
+
+## Summary
+
+<2-3 bullet points summarizing what changed and why>
+
+## Done When
+
+<paste Done When checklist from issue body>
+
+## Notes
+
+<any non-obvious implementation decisions or gotchas>
+EOF
+)")
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+```
+
+Update pane title:
+```bash
+plexi pane name "#<number> / PR #${PR_NUMBER} — <short-title>"
+```
+
+Update project board to "In Review":
+```bash
+_PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=<number> --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
+[ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="f1399a59" > /dev/null
+```
+
+**Bundle mode:** PR title `<summary> (#<n1>, #<n2>[, ...])`. Body lists each issue's Done When separately.
+
+---
+
+## Step 3 — AI Review
+
+**Skip gate:**
+```bash
+CHANGED_LINES=$(gh pr diff $PR_NUMBER --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+')
+DELETED_LINES=$(gh pr diff $PR_NUMBER --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+')
+TOTAL_CHANGED=$(( ${CHANGED_LINES:-0} + ${DELETED_LINES:-0} ))
+if [ "$TOTAL_CHANGED" -le 10 ]; then
+  echo "[AI REVIEW] Skipped — diff is $TOTAL_CHANGED lines (threshold: 10)."
+  # Skip to Ship Log Append
+fi
+```
+
+**1. CodeRabbit local review** (run from inside the feature worktree):
+```bash
+cr 2>&1
+```
+Fix `error`/`warning` severity findings. `info`/`suggestion` are advisory — apply if trivial. If fixes made: commit, push, re-run to confirm clean.
+
+**2. Poll for Gemini / CodeRabbit bot:**
+
+Wait 5 minutes, then check every 60s up to 10 minutes (6 checks):
+```bash
+echo "Waiting 5 minutes for AI reviewers..."
+sleep 300
+for i in $(seq 1 6); do
+  COMMENT_COUNT=$(gh pr view $PR_NUMBER --json comments \
+    --jq '[.comments[] | select(.author.login | test("gemini|coderabbit"; "i"))] | length')
+  REVIEW_COUNT=$(gh api repos/ianjamesburke/PLEXI/pulls/$PR_NUMBER/reviews \
+    --jq '[.[] | select(.user.login | test("gemini|coderabbit"; "i"))] | length')
+  INLINE_COUNT=$(gh api repos/ianjamesburke/PLEXI/pulls/$PR_NUMBER/comments \
+    --jq '[.[] | select(.user.login | test("gemini|coderabbit"; "i"))] | length')
+  TOTAL=$((COMMENT_COUNT + REVIEW_COUNT + INLINE_COUNT))
+  if [ "$TOTAL" -gt 0 ]; then
+    gh pr view $PR_NUMBER --json comments \
+      --jq '.comments[] | select(.author.login | test("gemini|coderabbit"; "i")) | "[\(.author.login)] \(.body)"'
+    gh api repos/ianjamesburke/PLEXI/pulls/$PR_NUMBER/reviews \
+      --jq '.[] | select(.user.login | test("gemini|coderabbit"; "i")) | "[\(.user.login)] \(.body)"'
+    gh api repos/ianjamesburke/PLEXI/pulls/$PR_NUMBER/comments \
+      --jq '.[] | select(.user.login | test("gemini|coderabbit"; "i")) | "[\(.user.login)] \(.body)"'
+    break
+  fi
+  [ "$i" -lt 6 ] && echo "Check $i/6 — no feedback yet, waiting 60s..." && sleep 60
+done
+```
+
+For each finding:
+- Correctness/bug/type safety → fix, commit, push
+- Style/naming/docs → apply if trivial, skip if out of scope
+- False positive → note and ignore
+
+If fixes applied from bot feedback, re-run `cr 2>&1` to confirm clean.
+
+**Required: emit `[AI REVIEW]` block:**
+```
+[AI REVIEW] PR #<n>
+
+CodeRabbit (local):
+  - [error/warning/info] <description> → FIXED: <what changed> | SKIPPED: <reason> | N/A: <reason>
+
+Gemini / bot:
+  - [<severity>] <description> → FIXED: <what changed> | SKIPPED: <reason> | N/A: <reason>
+
+Net: <N> fix(es) committed | no changes needed
+```
+
+---
+
+## Ship Log Append
+
+Append to the issue's `## Ship Log` section:
+
+```markdown
+**PR:** #<pr-number> — <pr-url>
+**AI Review:** <N> fixes | no changes (CodeRabbit: <finding count>, Gemini: <finding count>)
+```
+
+```bash
+CURRENT_BODY=$(gh issue view <number> --json body --jq '.body')
+# Append the PR line to the most recent Ship Log entry
+gh issue edit <number> --body "<updated body>"
+```
+
+---
+
+## Rules
+
+- Never push to alpha, beta, or main directly
+- PR must always target `alpha`
+- Bundle mode: close all issues in Phase 6 of merge-pr
+- The final approver is always the user — AI reviews inform the fix pass, never gate the merge
+- If `cr` unavailable: note "cr not available" in the review block
+- No bot feedback after 10 minutes: note "No feedback received (10 min timeout)"

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -96,8 +96,9 @@ _PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesb
 
 **Skip gate:**
 ```bash
-CHANGED_LINES=$(gh pr diff $PR_NUMBER --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+')
-DELETED_LINES=$(gh pr diff $PR_NUMBER --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+')
+STAT_LINE=$(gh pr diff "$PR_NUMBER" --stat | tail -1)
+CHANGED_LINES=$(printf '%s\n' "$STAT_LINE" | grep -oE '[0-9]+ insertions?' | grep -oE '[0-9]+')
+DELETED_LINES=$(printf '%s\n' "$STAT_LINE" | grep -oE '[0-9]+ deletions?' | grep -oE '[0-9]+')
 TOTAL_CHANGED=$(( ${CHANGED_LINES:-0} + ${DELETED_LINES:-0} ))
 if [ "$TOTAL_CHANGED" -le 10 ]; then
   echo "[AI REVIEW] Skipped — diff is $TOTAL_CHANGED lines (threshold: 10)."

--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -1,12 +1,25 @@
 ---
 name: ship-issue
-description: "Full PLEXI ship cycle. Four modes: /ship-issue (auto-find next issue), /ship-issue <issue-number> (specific issue), /ship-issue <priority> (e.g. /ship-issue P1), /ship-issue <n> <m> [...] (bundle multiple issues in one PR)."
+description: "Full PLEXI ship cycle — monolithic legacy skill. Prefer the pipeline skills for new sessions: /implement-issue → /open-pr → /validate-pr → /merge-pr. Use ship-issue only when you need the full cycle in one uninterrupted session."
 risk: medium
 source: local
 date_added: "2026-05-03"
 ---
 
 # Ship
+
+> **Pipeline alternative:** The ship cycle is now split into composable skills that are independently resumable. Prefer them for new sessions:
+> - `/implement-issue [<n>]` — find issue, set up worktree, write code, push branch
+> - `/open-pr [<branch>]` — create PR, run AI review
+> - `/validate-pr <pr-number>` — install, test, handle pass/fail/modify (max 3 soft rejects, then hard reject)
+> - `/merge-pr <pr-number>` — squash merge, bump, install, close issue
+> - `/test-pr <pr-number>` — standalone: install any PR and get test instructions
+>
+> The issue body is the state store. Each skill appends a `## Ship Log` entry so any agent can resume mid-cycle cold.
+>
+> Use `/ship-issue` only when you want the full cycle without manual handoffs.
+
+
 
 The full development lifecycle for PLEXI. One skill, four entry points:
 

--- a/.claude/skills/test-pr/SKILL.md
+++ b/.claude/skills/test-pr/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: test-pr
+description: "Standalone PR testing skill. Installs a PR build, reads the issue spec, writes test instructions, and returns pass/fail. Works independently — does not require being in a ship pipeline session. Input: PR number or issue number."
+risk: low
+source: local
+date_added: "2026-05-20"
+---
+
+# Test PR
+
+Standalone testing skill. Takes any PR and produces a structured test result.
+
+**Entry:**
+- `/test-pr <pr-number>` — test by PR number
+- `/test-pr issue/<n>` — find the open PR for issue N and test it
+
+**Output:**
+```
+[TEST RESULT] PR #<n>
+Outcome: PASS | FAIL | INCONCLUSIVE
+Attempt: <N>/3 (from Ship Log)
+Next: /merge-pr <n> | /validate-pr <n> (for retry loop) | user decision needed
+```
+
+This skill is called by `/validate-pr` internally. It can also be called directly when:
+- You have a PR open and want to test it outside the pipeline
+- You want to re-test after a manual fix
+- You're resuming a ship session cold and need to verify current state
+
+---
+
+## Step 1 — Resolve PR
+
+**If given PR number directly:**
+```bash
+gh pr view <pr-number> --json title,headRefName,number,state,body
+```
+
+**If given issue number:**
+```bash
+gh pr list --search "head:feature/<issue-number>" --json number,title,state,url | head -1
+```
+Fail loudly if no open PR found.
+
+Extract:
+- `BRANCH` = `headRefName`
+- `ISSUE_NUMBER` = parse from branch or PR body `Closes #<n>`
+- `PR_NUMBER`
+
+---
+
+## Step 2 — Read Issue Spec
+
+```bash
+gh issue view $ISSUE_NUMBER --json title,body --jq '{title: .title, body: .body}'
+```
+
+Extract Done When checklist. Read current Ship Log to determine attempt count.
+
+```bash
+ATTEMPT_COUNT=$(gh issue view $ISSUE_NUMBER --json body --jq '.body' | grep -c "### Attempt")
+```
+
+---
+
+## Step 3 — Install Gate
+
+```bash
+gh pr diff $PR_NUMBER --name-only
+```
+
+Skip install if all changed files are non-Rust, test-only, or diff-verifiable. Otherwise install.
+
+**Install (run from feature worktree):**
+```bash
+cd /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH
+just pr-install $PR_NUMBER
+```
+
+Verify compile happened (look for `Compiling plexi` in output). If not: `touch src/<changed-file>.rs && just pr-install $PR_NUMBER`.
+
+Check the log:
+```bash
+tail -20 ~/.plexi-pr-$PR_NUMBER/plexi.log
+```
+
+Report any errors or warnings before proceeding.
+
+---
+
+## Step 4 — Write Testing Block
+
+**Spec gate:** Pass criteria map 1:1 to Done When checklist. No extra criteria.
+
+Check for existing POC app in `examples/`. Use it if present.
+
+**For multi-step or multi-pane tests:** write `test_pr<N>.py` at repo root.
+
+```python
+import subprocess, sys
+CLI = "/usr/local/bin/plexi-pr-<N>"
+PASS = "\033[32mPASS\033[0m"; FAIL = "\033[31mFAIL\033[0m"
+failures = []
+def check(label, ok, detail=""):
+    if ok: print(f"  {PASS}  {label}")
+    else: print(f"  {FAIL}  {label}{': ' + detail if detail else ''}"); failures.append(label)
+# ... checks ...
+subprocess.run([CLI, "notify", "--title", "Test done", "--body", "PASS" if not failures else f"FAIL: {failures}"])
+if failures: sys.exit(1)
+```
+
+**CLI-only checks (no running host needed):** run them yourself and report the result. Don't surface a testing block for checks you can run.
+
+**Surface testing block:**
+```
+[TESTING] PR #<n> — <title> (attempt <attempt+1>/3)
+PR: <pr-url>
+Binary: plexi-pr-<n>
+
+Instructions:
+1. <exact step>
+2. <exact step>
+
+Pass criteria (from Done When):
+- <concrete observable outcome>
+
+Fail criteria:
+- <concrete observable symptom>
+
+Reply: "pass" | "fail: <description>" | "modify: <bounded change within scope>"
+```
+
+**Notification:**
+```bash
+RESULT=$(plexi notify \
+  --title "PR #<n> ready to test" \
+  --body "<title>. Attempt $((ATTEMPT_COUNT+1))/3." \
+  --choice "a:Talk to Claude:pane_focus:$PLEXI_PANE_ID" \
+  --choice "b:Open PR build" \
+  --choice "c:Open PR")
+case "$RESULT" in
+  b) open -a "Plexi PR$PR_NUMBER" ;;
+  c) open "<pr-url>" ;;
+esac
+```
+
+**STOP. Wait for reply.**
+
+---
+
+## Step 5 — Return Result
+
+This skill does not handle retry loops or hard reject. It returns the result and lets the caller decide.
+
+**Pass:**
+Append to issue Ship Log:
+```markdown
+**Test attempt <N>:** PASS — <YYYY-MM-DD>
+```
+Output: `[TEST RESULT] PR #<n> — PASS`
+
+**Fail:**
+Append to issue Ship Log:
+```markdown
+**Test attempt <N>:** FAIL — <verbatim user description> (<YYYY-MM-DD>)
+```
+Output: `[TEST RESULT] PR #<n> — FAIL: <description>`
+
+**Modify:**
+Append to issue Ship Log:
+```markdown
+**Test attempt <N>:** MODIFY — <description>
+```
+Output: `[TEST RESULT] PR #<n> — MODIFY: <description>`
+
+The caller (`/validate-pr`) handles what happens next based on the attempt count.
+
+---
+
+## Rules
+
+- Never merge, close, or push in this skill — read and report only
+- Always read the PR log before reporting a fail finding
+- Never include log-reading commands in the user-facing testing block
+- `test_pr<N>.py` must use full absolute path to the PR binary
+- One command per code block in the testing instructions — never inline
+- Never run `test_pr<N>.py` yourself — it blocks on `plexi notify`
+- CLI-verifiable output: run it yourself, report the result, skip the testing block

--- a/.claude/skills/test-pr/SKILL.md
+++ b/.claude/skills/test-pr/SKILL.md
@@ -73,7 +73,8 @@ Skip install if all changed files are non-Rust, test-only, or diff-verifiable. O
 
 **Install (run from feature worktree):**
 ```bash
-cd /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/worktrees/$BRANCH"
 just pr-install $PR_NUMBER
 ```
 

--- a/.claude/skills/validate-pr/SKILL.md
+++ b/.claude/skills/validate-pr/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: validate-pr
+description: "Phase 3 of the PLEXI ship pipeline. Installs a PR build, generates test instructions, handles user pass/fail/modify responses, and manages the retry loop (max 3 soft rejects before escalating to hard reject). Input: PR number. Output: approved PR number or hard-reject."
+risk: medium
+source: local
+date_added: "2026-05-20"
+---
+
+# Validate PR
+
+Phase 3 of the ship pipeline. Manages the test loop and all rejection paths.
+
+**Entry:**
+- `/validate-pr <pr-number>` — start validation for a PR
+- `/validate-pr <pr-number> --attempt <n>` — resume at attempt N (used internally on soft-reject retry)
+
+**Outcomes:**
+- **Pass** → output `[VALIDATED] PR #<n>` → proceed to `/merge-pr <pr-number>`
+- **Soft reject** → push a fix commit, reinstall, re-run (max 3 attempts total)
+- **Hard reject** → close PR, rewrite issue body, clean up
+
+**Reads `## Ship Log` in the issue body to determine current attempt count.** Never trust an argument alone — always verify against the log.
+
+---
+
+## Step 0 — Read Context
+
+```bash
+gh pr view <pr-number> --json title,headRefName,number,baseRefName,state
+```
+
+Extract:
+- `BRANCH` = `headRefName` (e.g. `feature/1234-something`)
+- `ISSUE_NUMBER` = parse from branch name
+- `PR_NUMBER` = from arg
+
+Read current attempt count from issue body:
+```bash
+gh issue view $ISSUE_NUMBER --json body --jq '.body'
+```
+Count `### Attempt` entries in `## Ship Log`. Set `ATTEMPT_COUNT` = that number (0 if no log yet).
+
+---
+
+## Step 1 — Install Gate
+
+Check if a binary install is needed:
+```bash
+gh pr diff $PR_NUMBER --name-only
+```
+
+**Skip install if all changed files are:**
+- Non-Rust: justfile, TOML config, scripts, docs, skills, completion files, markdown
+- Rust with pure code deletion and no behavioral change
+- Rust test-only additions (`#[cfg(test)]` or `tests/` only)
+- CLI output changes verifiable without a running host
+
+If install not needed → use diff-review testing block (see below). Skip install steps.
+
+---
+
+## Step 2 — Install
+
+Run from inside the feature worktree:
+```bash
+cd /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH
+just pr-install $PR_NUMBER
+```
+
+> **CWD check:** `just pr-install` runs `cargo bundle` from CWD. Running from alpha silently builds old code.
+
+> **Compile check:** If no `Compiling plexi` line in output, the binary was cached. `touch src/<changed-file>.rs` then re-run.
+
+Wait for completion. Read the log to confirm the build landed:
+```bash
+tail -20 ~/.plexi-pr-$PR_NUMBER/plexi.log
+```
+
+---
+
+## Step 3 — Write and Surface Testing Block
+
+**Spec gate:** Re-read the issue's Done When checklist before writing. Pass criteria map 1:1 to checklist items. No extra criteria.
+
+**Check for existing POC app:** scan `examples/` in the feature worktree. If one exists, use it.
+
+**If more than one command, or copy-paste across panes is awkward:** write a `test_pr<N>.py` at the repo root instead of a markdown block.
+
+```python
+import subprocess, json, sys
+CLI = "/usr/local/bin/plexi-pr-<N>"  # full path required
+PASS = "\033[32mPASS\033[0m"; FAIL = "\033[31mFAIL\033[0m"
+failures = []
+def check(label, ok, detail=""):
+    if ok: print(f"  {PASS}  {label}")
+    else: print(f"  {FAIL}  {label}{': ' + detail if detail else ''}"); failures.append(label)
+# ... checks ...
+subprocess.run([CLI, "notify", "--title", "Test result", "--body", "PASS" if not failures else "FAIL"])
+if failures: sys.exit(1)
+```
+
+**Surface testing block format:**
+```
+[TESTING] PR #<n> — <title> (attempt <attempt+1>/3)
+PR: <pr-url>
+
+Instructions:
+1. <exact step>
+2. <exact step>
+
+Pass criteria:
+- <concrete observable outcome>
+
+Fail criteria:
+- <concrete observable symptom>
+
+Reply: "pass" | "fail: <description>" | "modify: <bounded change>"
+```
+
+**Notification:**
+```bash
+RESULT=$(plexi notify \
+  --title "PR #<n> ready to test (attempt $((ATTEMPT_COUNT+1))/3)" \
+  --body "<title>. Reply pass/fail/modify in pane." \
+  --choice "a:Talk to Claude:pane_focus:$PLEXI_PANE_ID" \
+  --choice "b:Open PR build" \
+  --choice "c:Open PR")
+case "$RESULT" in
+  b) open -a "Plexi PR$PR_NUMBER" ;;
+  c) open "<pr-url>" ;;
+esac
+```
+
+**STOP. Wait for user reply.**
+
+---
+
+## Step 4 — Handle Response
+
+### Pass
+
+Append to issue Ship Log:
+```markdown
+**Validate attempt <N>:** PASS
+**Test date:** <YYYY-MM-DD>
+```
+
+Output:
+```
+[VALIDATED] PR #<n> — <title>
+Attempt: <N>/3
+Next: /merge-pr <n>
+```
+
+### Modify
+
+Valid only if pass criteria were **not** fully met. If criteria were met and user wants extras: "Pass criteria are met. Filing that as a separate issue." Create the issue, then treat as pass.
+
+Fix the specific change on the feature branch, commit, push:
+```bash
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH add <files>
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH commit -m "fix: <description>"
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH push
+```
+
+Re-run `just pr-install $PR_NUMBER` from the feature worktree. Re-surface the testing block. Do not expand scope.
+
+Append to Ship Log:
+```markdown
+**Validate attempt <N>:** MODIFY — <description of change>
+```
+
+### Soft Reject (fail with description)
+
+"fail" without a description: ask for it before taking any action.
+
+**Check attempt count:**
+```bash
+ATTEMPT_COUNT=$(gh issue view $ISSUE_NUMBER --json body --jq '.body' | grep -c "### Attempt")
+```
+
+**If ATTEMPT_COUNT < 3 (soft reject — push a fix):**
+
+Read the PR build log first:
+```bash
+tail -100 ~/.plexi-pr-$PR_NUMBER/plexi.log
+```
+Report what the log shows.
+
+Apply the targeted fix to the feature branch, commit, push:
+```bash
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH add <files>
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH commit -m "fix: <description from failure>"
+git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH push
+```
+
+Re-run `just pr-install $PR_NUMBER` from the feature worktree.
+
+Append to Ship Log:
+```markdown
+**Validate attempt <N>:** FAIL — <verbatim user description>
+**Fix applied:** <what was pushed> (commit <hash>)
+```
+
+Re-surface the testing block (attempt N+1/3). Fire the notification again. STOP.
+
+**If ATTEMPT_COUNT >= 3 (escalate to hard reject):**
+
+Send notification:
+```bash
+RESULT=$(plexi notify \
+  --title "PR #<n> failed 3 times — hard reject?" \
+  --body "<title>. 3 attempts exhausted. Close and rewrite issue?" \
+  --choice "a:Talk to Claude:pane_focus:$PLEXI_PANE_ID" \
+  --choice "b:Hard reject — close PR" \
+  --choice "c:Keep open — I'll review")
+```
+
+If `b` or user confirms in chat → proceed to Hard Reject.
+If `c` → STOP. Leave PR open. Remove attempt limit — user owns it from here.
+
+---
+
+## Hard Reject
+
+1. **Read the PR log:**
+```bash
+tail -100 ~/.plexi-pr-$PR_NUMBER/plexi.log
+```
+
+2. **Close the PR:**
+```bash
+gh pr close $PR_NUMBER --comment "Closing after 3 failed validate attempts. Full context in issue #$ISSUE_NUMBER body."
+```
+
+3. **Rewrite the issue body:**
+
+Fetch the current body and all Ship Log entries. Rewrite the body to include:
+- Original spec (preserved)
+- `## Prior Attempts` section (required format):
+  ```markdown
+  ## Prior Attempts
+
+  **Attempt N:** What was tried (branch, files changed, approach).
+  **Why it failed:** Root cause or observable symptom (from validate log and user description).
+  **What to try next:** Specific next investigation step.
+  ```
+  One block per attempt, using the Ship Log entries as source.
+- Updated `## Ship Log` with hard-reject entry:
+  ```markdown
+  **Hard reject:** <YYYY-MM-DD> — PR #<pr-number> closed after <N> attempts.
+  ```
+
+```bash
+gh issue edit $ISSUE_NUMBER --body "<rewritten body>"
+```
+
+4. **Re-label:**
+```bash
+gh issue edit $ISSUE_NUMBER --remove-label "in progress" --add-label "ready"
+```
+
+5. **Clean up:**
+```bash
+just pr-clean $PR_NUMBER
+wtp remove feature/<branch> --force
+git push origin --delete feature/<branch>
+```
+
+6. **Output:**
+```
+[HARD REJECT] PR #<n> closed
+Issue #<issue-number> rewritten with Prior Attempts section
+Branch feature/<branch> deleted
+Issue re-labeled ready for next attempt
+```
+
+---
+
+## Diff-Review Testing Block (no install)
+
+```
+[TESTING] PR #<n> — <title> (diff review only)
+
+No binary install needed for this change.
+
+Review the diff: <pr-url>
+
+Pass criteria:
+- <observable change visible in diff>
+
+Fail criteria:
+- <what would look wrong>
+
+Reply: "pass" | "fail: <description>" | "modify: <change>"
+```
+
+---
+
+## Rules
+
+- `fail` without description: ask for it before taking any action
+- `modify` is only valid if pass criteria not yet met
+- Attempt count comes from the Ship Log, not arguments
+- Max 3 soft rejects. Hard reject requires explicit confirmation unless user already typed "fail" 3 times.
+- Never close an issue on hard reject — only the PR closes. Issue stays open.
+- PR build log must be read before any soft-reject diagnosis
+- Test script (`test_pr<N>.py`) is deleted in merge-pr Phase 5 — never committed
+- Never run `test_pr<N>.py` yourself — it blocks on `plexi notify`; use direct Bash for automated checks
+- All subprocess calls in test script must use full absolute path to PR binary
+- Never include `tail` or log-reading in user-facing testing block — read the log yourself, report findings directly
+- Cosmetic issues spotted during testing go in separate issues — not blockers or modifies

--- a/.claude/skills/validate-pr/SKILL.md
+++ b/.claude/skills/validate-pr/SKILL.md
@@ -38,7 +38,11 @@ Read current attempt count from issue body:
 ```bash
 gh issue view $ISSUE_NUMBER --json body --jq '.body'
 ```
-Count `### Attempt` entries in `## Ship Log`. Set `ATTEMPT_COUNT` = that number (0 if no log yet).
+Count `**Validate attempt` entries in `## Ship Log`. Set `ATTEMPT_COUNT` = that number (0 if no log yet).
+```bash
+ATTEMPT_COUNT=$(gh issue view $ISSUE_NUMBER --json body --jq '.body' \
+  | grep -cE '^\*\*Validate attempt [0-9]+:' || true)
+```
 
 ---
 
@@ -63,7 +67,8 @@ If install not needed → use diff-review testing block (see below). Skip instal
 
 Run from inside the feature worktree:
 ```bash
-cd /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/worktrees/$BRANCH"
 just pr-install $PR_NUMBER
 ```
 
@@ -158,9 +163,9 @@ Valid only if pass criteria were **not** fully met. If criteria were met and use
 
 Fix the specific change on the feature branch, commit, push:
 ```bash
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH add <files>
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH commit -m "fix: <description>"
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH push
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" add <files>
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" commit -m "fix: <description>"
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" push
 ```
 
 Re-run `just pr-install $PR_NUMBER` from the feature worktree. Re-surface the testing block. Do not expand scope.
@@ -189,9 +194,9 @@ Report what the log shows.
 
 Apply the targeted fix to the feature branch, commit, push:
 ```bash
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH add <files>
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH commit -m "fix: <description from failure>"
-git -C /Users/ianburke/Documents/GitHub/PLEXI/worktrees/$BRANCH push
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" add <files>
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" commit -m "fix: <description from failure>"
+git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" push
 ```
 
 Re-run `just pr-install $PR_NUMBER` from the feature worktree.


### PR DESCRIPTION
## Summary

- Splits the monolithic `ship-issue` skill into five independently-resumable pipeline skills
- The issue body becomes the state store — each skill appends a `## Ship Log` entry so any agent can resume mid-cycle cold
- Hard reject path rewrites the issue body with a `## Prior Attempts` section so the next agent starts informed, not blank

## New skills

| Skill | Input | Output |
|---|---|---|
| `/implement-issue` | issue number | pushed branch |
| `/open-pr` | branch name | PR URL |
| `/validate-pr` | PR number | approved PR / hard reject |
| `/merge-pr` | PR number | installed alpha at new version |
| `/test-pr` | PR number | pass / fail / modify |

## Retry loop (in validate-pr)

- Soft reject (up to 3): push a targeted fix commit, reinstall, re-test
- After 3 failures: escalate to hard reject with user confirmation
- Hard reject: close PR, rewrite issue body with Prior Attempts, re-label ready

## Test plan

- [ ] Verify each new skill file exists and is syntactically valid markdown
- [ ] Verify ship-issue now contains the pipeline header pointing to the new skills
- [ ] Invoke /implement-issue on a test issue and confirm it stops before PR creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced independent, resumable pipeline phases for issue automation.
  * Replaced monolithic workflows with composable, modular steps that can be executed separately.
  * Enabled mid-cycle work resumption using shared state tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->