### PR TITLE
feat(sdk): feed-quality primitives — max_lines, avatar, skeleton, measure_text_wrapped (#1607)

### DIFF
--- a/examples/bluesky/main.py
+++ b/examples/bluesky/main.py
@@ -28,9 +28,14 @@ BASE     = "https://public.api.bsky.app/xrpc"
 DISCOVER = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
 LIMIT    = 30
 
-ROW_H    = 56.0   # feed list row height
-IMG_H    = 80.0   # height increment per inline image in thread view
-THREAD_H = 88.0   # thread row base height (text + stats, no images)
+AVATAR_R  = 16.0   # avatar circle radius
+TEXT_X    = PAD + AVATAR_R * 2 + 8.0   # left edge of text column
+ROW_BASE  = 48.0   # row height with no extra text lines
+LINE_H    = CAPTION + 4.0   # height per extra wrapped line
+MAX_LINES = 3      # max post body lines in feed
+
+THREAD_H  = 88.0   # thread row base height
+IMG_H     = 80.0   # height per image in thread view
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -49,12 +54,19 @@ def _author(post: dict) -> str:
     return f"{name} @{hand}" if name and name != hand else f"@{hand}"
 
 
+def _avatar_url(post: dict) -> str:
+    return (post.get("author") or {}).get("avatar") or ""
+
+
+def _did(post: dict) -> str:
+    return (post.get("author") or {}).get("did") or ""
+
+
 def _text(post: dict) -> str:
     return (post.get("record") or {}).get("text", "")
 
 
 def _thumbs(post: dict) -> list[str]:
-    """Extract thumbnail URLs from a post's embed (images or recordWithMedia)."""
     e = post.get("embed") or {}
     t = e.get("$type", "")
     if "images#view" in t:
@@ -66,7 +78,6 @@ def _thumbs(post: dict) -> list[str]:
 
 
 def _at_web(uri: str) -> str:
-    """at://did:plc:xxx/.../yyy → https://bsky.app/profile/did:plc:xxx/post/yyy"""
     if not uri.startswith("at://"):
         return ""
     try:
@@ -92,19 +103,21 @@ class BlueskyApp(App):
         self._loading = True
         self._error   : str | None = None
 
-        # cursor-based pagination: _cursors[i] = cursor to fetch page i
         self._cursors   : list[str | None] = [None]
         self._page_idx  = 0
         self._next_cur  : str | None = None
 
-        # profile mode
         self._feed_label    = "Discover"
         self._author_handle : str | None = None
         self._show_input    = False
 
-        # thread
-        self._thread  : list[dict] = []   # [{post, depth}, ...]
+        self._thread  : list[dict] = []
         self._t_scroll = 0.0
+
+        # per-post measured row heights (pre-computed at fetch time)
+        self._row_heights: list[float] = []
+        # avatar handles keyed by author did
+        self._avatar_handles: dict[str, str] = {}
 
         self.emit.info("bluesky: init")
         ctx.status_summary("Loading Discover feed…")
@@ -135,6 +148,7 @@ class BlueskyApp(App):
             self._next_cur = data.get("cursor")
             self._sel      = 0
             self.emit.info(f"bluesky: discover loaded {len(self._feed)} posts")
+            await self._post_fetch_setup()
         except Exception as exc:
             self.emit.warn(f"bluesky: discover error: {exc}")
             self._error = str(exc)
@@ -154,16 +168,47 @@ class BlueskyApp(App):
             if data.get("error"):
                 raise RuntimeError(data["error"])
             posts = [item["post"] for item in data.get("feed", []) if "post" in item]
-            # drop replies so the profile view shows original posts only
             self._feed     = [p for p in posts if not (p.get("record") or {}).get("reply")]
             self._next_cur = data.get("cursor")
             self._sel      = 0
             self.emit.info(f"bluesky: author @{handle} loaded {len(self._feed)} posts")
+            await self._post_fetch_setup()
         except Exception as exc:
             self.emit.warn(f"bluesky: author feed error: {exc}")
             self._error = str(exc)
         self._loading = False
         self.emit.schedule_render()
+
+    async def _post_fetch_setup(self) -> None:
+        """Pre-measure row heights and load avatars after any feed fetch."""
+        pane_w = 700.0  # conservative default; real width used for render
+        text_w = pane_w - TEXT_X - PAD
+
+        heights = []
+        for post in self._feed:
+            body = _text(post)
+            if body:
+                try:
+                    h = await self.emit.measure_text_wrapped(
+                        body, CAPTION, text_w, max_lines=MAX_LINES
+                    )
+                    heights.append(ROW_BASE + max(0.0, h - CAPTION))
+                except Exception:
+                    heights.append(ROW_BASE + LINE_H * MAX_LINES)
+            else:
+                heights.append(ROW_BASE)
+        self._row_heights = heights
+
+        # Load avatars for unique authors
+        for post in self._feed:
+            did = _did(post)
+            url = _avatar_url(post)
+            if did and url and did not in self._avatar_handles:
+                try:
+                    handle = await self.emit.load_image(url)
+                    self._avatar_handles[did] = handle
+                except Exception:
+                    pass  # placeholder circle renders fine
 
     async def _fetch_thread(self, uri: str) -> None:
         self._loading = True
@@ -197,9 +242,7 @@ class BlueskyApp(App):
 
     def _page_fetch(self, cursor: str | None) -> None:
         if self._author_handle:
-            asyncio.create_task(
-                self._fetch_author(self._author_handle, cursor)
-            )
+            asyncio.create_task(self._fetch_author(self._author_handle, cursor))
         else:
             asyncio.create_task(self._fetch_discover(cursor))
 
@@ -226,7 +269,7 @@ class BlueskyApp(App):
         self._draw_header(ctx)
 
         if self._loading:
-            ctx.text(PAD, HEADER_H + PAD, "Loading…", size=BODY, color=MUTED)
+            self._draw_loading_skeleton(ctx)
             return
 
         if self._error:
@@ -242,6 +285,21 @@ class BlueskyApp(App):
             self._draw_feed(ctx)
             if self._show_input:
                 self._draw_input_overlay(ctx)
+
+    def _draw_loading_skeleton(self, ctx: RenderContext) -> None:
+        """Render animated skeleton rows instead of plain 'Loading…'."""
+        y = HEADER_H + PAD
+        for _ in range(8):
+            row_h = ROW_BASE + LINE_H * 2
+            # avatar circle placeholder
+            ctx.skeleton(PAD, y + (row_h - AVATAR_R * 2) / 2,
+                         AVATAR_R * 2, AVATAR_R * 2, radius=AVATAR_R)
+            # author line
+            ctx.skeleton(TEXT_X, y + 6, ctx.w * 0.35, HINT, radius=3.0)
+            # text lines
+            ctx.skeleton(TEXT_X, y + 6 + HINT + 6, ctx.w * 0.85 - TEXT_X, CAPTION, radius=3.0)
+            ctx.skeleton(TEXT_X, y + 6 + HINT + 6 + LINE_H, ctx.w * 0.60 - TEXT_X, CAPTION, radius=3.0)
+            y += row_h + 1
 
     def _draw_header(self, ctx: RenderContext) -> None:
         ctx.rect(0, 0, ctx.w, HEADER_H, fill=SURFACE)
@@ -268,44 +326,64 @@ class BlueskyApp(App):
         ctx.shortcuts(x=ctx.w / 3, y=mid_y - HINT / 2,
                       max_width=ctx.w * 2 / 3 - PAD, pairs=pairs)
 
+    def _row_height(self, i: int) -> float:
+        if i < len(self._row_heights):
+            return self._row_heights[i]
+        return ROW_BASE + LINE_H * 2
+
     def _draw_feed(self, ctx: RenderContext) -> None:
         if not self._feed:
             ctx.text(PAD, HEADER_H + PAD, "No posts.", size=BODY, color=MUTED)
             return
 
+        content_h = sum(self._row_height(i) for i in range(len(self._feed)))
         list_y = HEADER_H
         ctx.begin_scroll("feed-list", 0.0, list_y, ctx.w,
-                         ctx.h - list_y, ROW_H * len(self._feed))
+                         ctx.h - list_y, content_h)
 
+        y = list_y - self._scroll
         for i, post in enumerate(self._feed):
-            iy  = list_y + i * ROW_H - self._scroll
-            sel = i == self._sel
-            ctx.rect(0, iy, ctx.w, ROW_H,
+            row_h = self._row_height(i)
+            sel   = i == self._sel
+            ctx.rect(0, y, ctx.w, row_h,
                      fill=HIGHLIGHT if sel else (SURFACE if i % 2 == 0 else BG))
             if i > 0:
-                ctx.rect(0, iy, ctx.w, 1, fill=BG)
+                ctx.rect(0, y, ctx.w, 1, fill=BG)
 
+            # Avatar
+            did = _did(post)
+            av_handle = self._avatar_handles.get(did, "")
+            av_cy = y + row_h / 2
+            if av_handle:
+                ctx.avatar(av_handle, x=PAD, y_center=av_cy, radius=AVATAR_R)
+            else:
+                ctx.circle(PAD + AVATAR_R, av_cy, AVATAR_R, fill="#3a3a4a")
+
+            # Author + timestamp
             ts = _short_ts((post.get("record") or {}).get("createdAt", ""))
-            ctx.text(PAD, iy + 6, _author(post),
-                     size=HINT, color=ACCENT, max_width=ctx.w - PAD * 2 - 36)
+            ctx.text(TEXT_X, y + 6, _author(post),
+                     size=HINT, color=ACCENT,
+                     max_width=ctx.w - TEXT_X - PAD - 36)
             if ts:
-                ctx.text(ctx.w - PAD - 32, iy + 6, ts, size=HINT, color=MUTED)
+                ctx.text(ctx.w - PAD - 32, y + 6, ts, size=HINT, color=MUTED)
 
-            ctx.text(PAD, iy + 6 + HINT + 4, _text(post),
-                     size=CAPTION, color=FG, max_width=ctx.w - PAD * 2, elide=True)
+            # Post body (up to MAX_LINES lines)
+            body = _text(post)
+            if body:
+                ctx.text(TEXT_X, y + 6 + HINT + 4, body,
+                         size=CAPTION, color=FG,
+                         max_width=ctx.w - TEXT_X - PAD,
+                         max_lines=MAX_LINES)
 
+            # Stats
             likes   = post.get("likeCount", 0)
             reposts = post.get("repostCount", 0)
             replies = post.get("replyCount", 0)
-            ctx.text(PAD, iy + ROW_H - HINT - 4,
-                     f"♥ {likes}  ↺ {reposts}  \U0001f4ac {replies}",
+            ctx.text(TEXT_X, y + row_h - HINT - 4,
+                     f"♥ {likes}  ↺ {reposts}  💬 {replies}",
                      size=HINT, color=MUTED)
 
-            if _thumbs(post):
-                n = len(_thumbs(post))
-                ctx.badge(x=ctx.w - PAD - 44, y_center=iy + ROW_H / 2,
-                          label=f"img×{n}", fill=SURFACE, fg=MUTED,
-                          font_size=HINT, radius=3.0)
+            y += row_h
 
         ctx.end_scroll()
 
@@ -332,26 +410,37 @@ class BlueskyApp(App):
             if idx > 0:
                 ctx.rect(PAD + indent, y, ctx.w - PAD - indent, 1, fill=SURFACE)
 
+            # Avatar
+            did = _did(post)
+            av_handle = self._avatar_handles.get(did, "")
+            av_cy = y + HINT / 2 + 6
+            if av_handle:
+                ctx.avatar(av_handle, x=PAD + indent, y_center=av_cy, radius=AVATAR_R)
+            else:
+                ctx.circle(PAD + indent + AVATAR_R, av_cy, AVATAR_R, fill="#3a3a4a")
+
+            t_x = PAD + indent + AVATAR_R * 2 + 6
+
             ts = _short_ts((post.get("record") or {}).get("createdAt", ""))
-            ctx.text(PAD + indent, y + 6, _author(post),
+            ctx.text(t_x, y + 6, _author(post),
                      size=HINT, color=ACCENT,
-                     max_width=ctx.w - PAD * 2 - indent - 36)
+                     max_width=ctx.w - t_x - PAD - 36)
             if ts:
                 ctx.text(ctx.w - PAD - 32, y + 6, ts, size=HINT, color=MUTED)
 
-            ctx.markdown(PAD + indent, y + 6 + HINT + 4,
-                         ctx.w - PAD * 2 - indent, _text(post))
+            ctx.markdown(t_x, y + 6 + HINT + 4,
+                         ctx.w - t_x - PAD, _text(post))
 
             img_y = y + THREAD_H - 6.0
             for thumb in _thumbs(post)[:2]:
-                ctx.image(thumb, PAD + indent, img_y, 120.0, 72.0, fit="cover")
+                ctx.image(thumb, t_x, img_y, 120.0, 72.0, fit="cover")
                 img_y += IMG_H
 
             likes   = post.get("likeCount", 0)
             reposts = post.get("repostCount", 0)
             replies = post.get("replyCount", 0)
-            ctx.text(PAD + indent, y + h - HINT - 4,
-                     f"♥ {likes}  ↺ {reposts}  \U0001f4ac {replies}",
+            ctx.text(t_x, y + h - HINT - 4,
+                     f"♥ {likes}  ↺ {reposts}  💬 {replies}",
                      size=HINT, color=MUTED)
 
             y += h
@@ -435,11 +524,14 @@ class BlueskyApp(App):
         if self._view == self.VIEW_FEED and not self._loading and self._feed:
             local_y = y - HEADER_H + self._scroll
             if local_y >= 0:
-                idx = int(local_y / ROW_H)
-                if 0 <= idx < len(self._feed):
-                    self._sel = idx
-                    if button == "primary":
-                        self._open_thread()
+                acc = 0.0
+                for i, rh in enumerate(self._row_heights):
+                    if local_y < acc + rh:
+                        self._sel = i
+                        if button == "primary":
+                            self._open_thread()
+                        break
+                    acc += rh
 
     # ── actions ───────────────────────────────────────────────────────────────
 

--- a/examples/bluesky/main.py
+++ b/examples/bluesky/main.py
@@ -193,7 +193,8 @@ class BlueskyApp(App):
                         body, CAPTION, text_w, max_lines=MAX_LINES
                     )
                     heights.append(ROW_BASE + max(0.0, h - CAPTION))
-                except Exception:
+                except Exception as exc:
+                    self.emit.warn(f"bluesky: measure_text_wrapped failed: {exc}")
                     heights.append(ROW_BASE + LINE_H * MAX_LINES)
             else:
                 heights.append(ROW_BASE)
@@ -207,8 +208,9 @@ class BlueskyApp(App):
                 try:
                     handle = await self.emit.load_image(url)
                     self._avatar_handles[did] = handle
-                except Exception:
-                    pass  # placeholder circle renders fine
+                except Exception as exc:
+                    self.emit.warn(f"bluesky: avatar load failed for {did}: {exc}")
+                    # placeholder circle renders fine
 
     async def _fetch_thread(self, uri: str) -> None:
         self._loading = True

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -153,6 +153,8 @@ class App:
         self._pending_command_preview: "dict[str, asyncio.Queue]" = {}
         # RenderContext.measure_text: awaits PlexiEvent::TextMeasured keyed on request_id.
         self._pending_measure_text: "dict[str, asyncio.Queue]" = {}
+        # RenderContext.measure_text_wrapped: awaits PlexiEvent::TextWrappedMeasured.
+        self._pending_measure_text_wrapped: "dict[str, asyncio.Queue]" = {}
         self._pipes: dict[str, Pipe] = {}
         self._last_render_time: "float | None" = None
         self._consecutive_render_errors: int = 0
@@ -685,6 +687,12 @@ class App:
                             float(ev.get("width", 0.0)),
                             float(ev.get("height", 0.0)),
                         ))
+
+                elif t == "text_wrapped_measured":
+                    req_id = ev.get("request_id", "")
+                    q = self._pending_measure_text_wrapped.pop(req_id, None)
+                    if q:
+                        q.put_nowait(float(ev.get("height", 0.0)))
 
                 # ── Inline non-hook events (fast, no user code) ──────────────
 

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -947,6 +947,7 @@ class Emitter:
             raise RuntimeError(f"load_image {src!r}: {message}")
         return handle
 
+    @_blocking_emit_method
     async def measure_text_wrapped(self, text: str, font_size: float,
                                     max_width: float,
                                     max_lines: "int | None" = None) -> float:
@@ -963,7 +964,13 @@ class Emitter:
         if max_lines is not None:
             payload["max_lines"] = max_lines
         _emit(payload)
-        return await q.get()
+        try:
+            return await asyncio.wait_for(q.get(), timeout=10.0)
+        except asyncio.TimeoutError:
+            self._app._pending_measure_text_wrapped.pop(request_id, None)
+            raise RuntimeError(
+                f"measure_text_wrapped timed out after 10s (request_id={request_id!r})"
+            )
 
     @_blocking_emit_method
     async def ai_query(self, model_tier: str, system: str,

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -947,6 +947,24 @@ class Emitter:
             raise RuntimeError(f"load_image {src!r}: {message}")
         return handle
 
+    async def measure_text_wrapped(self, text: str, font_size: float,
+                                    max_width: float,
+                                    max_lines: "int | None" = None) -> float:
+        """Measure the height of text wrapped at max_width using real host font metrics.
+
+        If `max_lines` is set, clamps the result to that many rows.
+        Returns height in logical pixels. Requires a running app loop.
+        """
+        request_id = str(uuid.uuid4())
+        q: asyncio.Queue[float] = _make_async_queue()
+        self._app._pending_measure_text_wrapped[request_id] = q
+        payload: dict = {"type": "measure_text_wrapped", "request_id": request_id,
+                         "text": text, "font_size": font_size, "max_width": max_width}
+        if max_lines is not None:
+            payload["max_lines"] = max_lines
+        _emit(payload)
+        return await q.get()
+
     @_blocking_emit_method
     async def ai_query(self, model_tier: str, system: str,
                        messages: "list[dict]",

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -135,7 +135,8 @@ class RenderContext:
              align: str = "top_left",
              max_width: "float | None" = None,
              elide: bool = True,
-             selectable: bool = False) -> None:
+             selectable: bool = False,
+             max_lines: "int | None" = None) -> None:
         """Draw text. `align` controls how `(x, y)` maps to the text box:
 
           - "top_left" (default) — (x, y) is the top-left corner.
@@ -159,10 +160,13 @@ class RenderContext:
         so the host always has required fields (no serde defaults). The SDK
         fills in None / True / False when the caller omits them.
         """
-        self._queue({"type": "text", "x": x, "y": y, "text": text, "size": size,
-                     "color": color, "monospace": monospace, "bold": bold,
-                     "align": align, "max_width": max_width, "elide": elide,
-                     "selectable": selectable})
+        d: dict = {"type": "text", "x": x, "y": y, "text": text, "size": size,
+                   "color": color, "monospace": monospace, "bold": bold,
+                   "align": align, "max_width": max_width, "elide": elide,
+                   "selectable": selectable}
+        if max_lines is not None:
+            d["max_lines"] = max_lines
+        self._queue(d)
 
     def markdown(self, x: float, y: float, w: float, text: str,
                  base_size: float = 14.0, color: str = FG) -> None:
@@ -370,6 +374,54 @@ class RenderContext:
         _emit({"type": "measure_text", "request_id": request_id,
                "text": text, "font_size": font_size, "monospace": monospace})
         return await q.get()
+
+    async def measure_text_wrapped(self, text: str, font_size: float,
+                                    max_width: float,
+                                    max_lines: "int | None" = None) -> float:
+        """Measure the height of `text` wrapped at `max_width` using real host font metrics.
+
+        If `max_lines` is set, clamps the result to that many rows.
+        Returns height in logical pixels.
+
+        Call at data-load time (once per item), not inside on_render() — each call
+        is an async IPC roundtrip.
+        """
+        import uuid as _uuid
+        request_id = str(_uuid.uuid4())
+        from ._emitter import _make_async_queue
+        q: asyncio.Queue[float] = _make_async_queue()
+        self._app._pending_measure_text_wrapped[request_id] = q
+        if self._buf:
+            with _LOCK:
+                sys.stdout.write("".join(self._buf))
+                sys.stdout.flush()
+            self._buf.clear()
+        payload: dict = {"type": "measure_text_wrapped", "request_id": request_id,
+                         "text": text, "font_size": font_size, "max_width": max_width}
+        if max_lines is not None:
+            payload["max_lines"] = max_lines
+        _emit(payload)
+        return await q.get()
+
+    def avatar(self, src: str, x: float, y_center: float, radius: float) -> None:
+        """Render a circular clipped image.
+
+        `src` accepts a handle from `emit.load_image()` or a local file path.
+        `x` is the left edge of the circle's bounding box (circle centre = x + radius).
+        `y_center` is the vertical centre of the circle.
+        `radius` is the circle radius in logical pixels.
+        """
+        self._queue({"type": "avatar", "src": src,
+                     "cx": x + radius, "cy": y_center, "radius": radius})
+
+    def skeleton(self, x: float, y: float, w: float, h: float,
+                 radius: float = 4.0) -> None:
+        """Render an animated shimmer placeholder rect for loading states.
+
+        The host drives a ~20fps pulsing animation — no app-side timer needed.
+        """
+        self._queue({"type": "skeleton", "x": x, "y": y, "w": w, "h": h,
+                     "radius": radius})
 
     def push_clip(self, x: float, y: float, w: float, h: float) -> None:
         """Push a clip rect onto the host's clip stack.

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -401,7 +401,13 @@ class RenderContext:
         if max_lines is not None:
             payload["max_lines"] = max_lines
         _emit(payload)
-        return await q.get()
+        try:
+            return await asyncio.wait_for(q.get(), timeout=10.0)
+        except asyncio.TimeoutError:
+            self._app._pending_measure_text_wrapped.pop(request_id, None)
+            raise RuntimeError(
+                f"measure_text_wrapped timed out after 10s (request_id={request_id!r})"
+            )
 
     def avatar(self, src: str, x: float, y_center: float, radius: float) -> None:
         """Render a circular clipped image.

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -3017,4 +3017,154 @@ mod tests {
             "must fail without required description field"
         );
     }
+
+    // ── feed-quality primitives wire shape (#1607) ────────────────────────
+    // Pin wire contracts for TextWrappedMeasured, MeasureTextWrapped, Avatar,
+    // Skeleton, and Text::max_lines.
+
+    #[test]
+    fn text_wrapped_measured_event_round_trips_serde() {
+        let json = r#"{"type":"text_wrapped_measured","request_id":"req-wrap-1","height":48.5}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::TextWrappedMeasured { request_id, height } => {
+                assert_eq!(request_id, "req-wrap-1");
+                assert!((height - 48.5).abs() < 0.001);
+            }
+            other => panic!("expected TextWrappedMeasured, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""type":"text_wrapped_measured""#), "wire tag missing: {serialised}");
+        assert!(serialised.contains(r#""request_id":"req-wrap-1""#), "request_id missing: {serialised}");
+        assert!(serialised.contains(r#""height":"#), "height missing: {serialised}");
+    }
+
+    #[test]
+    fn text_wrapped_measured_missing_height_fails_deserialise() {
+        let json = r#"{"type":"text_wrapped_measured","request_id":"req-wrap-2"}"#;
+        let result: Result<PlexiEvent, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "must fail without required height field");
+    }
+
+    #[test]
+    fn measure_text_wrapped_command_round_trips_serde() {
+        let json = r#"{"type":"measure_text_wrapped","request_id":"req-mw-1","text":"hello world","font_size":14.0,"max_width":300.0,"max_lines":3}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Control(ControlCommand::MeasureTextWrapped {
+                request_id, text, font_size, max_width, max_lines,
+            }) => {
+                assert_eq!(request_id, "req-mw-1");
+                assert_eq!(text, "hello world");
+                assert!((font_size - 14.0).abs() < 0.001);
+                assert!((max_width - 300.0).abs() < 0.001);
+                assert_eq!(*max_lines, Some(3));
+            }
+            other => panic!("expected MeasureTextWrapped, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"measure_text_wrapped""#), "wire tag missing: {serialised}");
+    }
+
+    #[test]
+    fn measure_text_wrapped_without_max_lines_round_trips_serde() {
+        let json = r#"{"type":"measure_text_wrapped","request_id":"req-mw-2","text":"hi","font_size":12.0,"max_width":200.0}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Control(ControlCommand::MeasureTextWrapped { max_lines, .. }) => {
+                assert_eq!(*max_lines, None, "max_lines should be absent");
+            }
+            other => panic!("expected MeasureTextWrapped, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn measure_text_wrapped_missing_required_field_fails_deserialise() {
+        // No `max_width` field — required, must fail.
+        let json = r#"{"type":"measure_text_wrapped","request_id":"r","text":"hi","font_size":12.0}"#;
+        let result: Result<DrawCommand, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "must fail without required max_width field");
+    }
+
+    #[test]
+    fn avatar_render_command_round_trips_serde() {
+        let json = r#"{"type":"avatar","src":"abc-handle","cx":24.0,"cy":36.0,"radius":20.0}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::Avatar { src, cx, cy, radius }) => {
+                assert_eq!(src, "abc-handle");
+                assert!((cx - 24.0).abs() < 0.001);
+                assert!((cy - 36.0).abs() < 0.001);
+                assert!((radius - 20.0).abs() < 0.001);
+            }
+            other => panic!("expected Avatar, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"avatar""#), "wire tag missing: {serialised}");
+        assert!(serialised.contains(r#""src":"abc-handle""#), "src missing: {serialised}");
+    }
+
+    #[test]
+    fn avatar_missing_required_field_fails_deserialise() {
+        // No `radius` — required, must fail.
+        let json = r#"{"type":"avatar","src":"h","cx":0.0,"cy":0.0}"#;
+        let result: Result<DrawCommand, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "must fail without required radius field");
+    }
+
+    #[test]
+    fn skeleton_render_command_round_trips_serde() {
+        let json = r#"{"type":"skeleton","x":10.0,"y":20.0,"w":200.0,"h":16.0}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::Skeleton { x, y, w, h, radius }) => {
+                assert!((x - 10.0).abs() < 0.001);
+                assert!((y - 20.0).abs() < 0.001);
+                assert!((w - 200.0).abs() < 0.001);
+                assert!((h - 16.0).abs() < 0.001);
+                assert!((radius - 4.0).abs() < 0.001, "default radius should be 4.0");
+            }
+            other => panic!("expected Skeleton, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"skeleton""#), "wire tag missing: {serialised}");
+    }
+
+    #[test]
+    fn skeleton_with_explicit_radius_round_trips_serde() {
+        let json = r#"{"type":"skeleton","x":0.0,"y":0.0,"w":100.0,"h":8.0,"radius":8.0}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::Skeleton { radius, .. }) => {
+                assert!((radius - 8.0).abs() < 0.001);
+            }
+            other => panic!("expected Skeleton, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_max_lines_present_round_trips_serde() {
+        let json = r##"{"type":"text","x":0.0,"y":0.0,"text":"hello","size":14.0,"color":"#fff","monospace":false,"bold":false,"align":"top_left","max_width":null,"elide":false,"selectable":false,"max_lines":3}"##;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::Text { max_lines, text, .. }) => {
+                assert_eq!(*max_lines, Some(3));
+                assert_eq!(text, "hello");
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_max_lines_absent_deserialises_to_none() {
+        // max_lines is #[serde(default)] so absence → None, not an error.
+        let json = r##"{"type":"text","x":0.0,"y":0.0,"text":"hi","size":14.0,"color":"#fff","monospace":false,"bold":false,"align":"top_left","max_width":null,"elide":false,"selectable":false}"##;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::Text { max_lines, .. }) => {
+                assert_eq!(*max_lines, None, "absent max_lines should be None");
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
 }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -188,6 +188,13 @@ pub enum PlexiEvent {
         width: f32,
         height: f32,
     },
+    /// Response to a `ControlCommand::MeasureTextWrapped` request.
+    /// `height` is the pixel height of the text when wrapped at the requested width,
+    /// clamped to `max_lines` rows if specified.
+    TextWrappedMeasured {
+        request_id: String,
+        height: f32,
+    },
     /// User pressed Enter inside a `DrawCommand::TextInput` field.
     ///
     /// `id` matches the `id` the app supplied on the `TextInput` command.
@@ -585,6 +592,8 @@ pub enum RenderCommand {
         max_width: Option<f32>,
         elide: bool,
         selectable: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_lines: Option<u32>,
     },
     /// Draw a line segment.
     Line {
@@ -753,6 +762,27 @@ pub enum RenderCommand {
         /// One of: "contain" | "cover" | "fill". Default: "contain".
         #[serde(default = "default_image_fit")]
         fit: String,
+    },
+
+    /// Circular clipped image. `src` accepts a load_image handle (UUID) or local path.
+    /// `cx`, `cy` are the circle centre in pane-local coordinates.
+    /// `radius` is the circle radius in logical pixels.
+    Avatar {
+        src: String,
+        cx: f32,
+        cy: f32,
+        radius: f32,
+    },
+
+    /// Animated shimmer placeholder rect for loading states.
+    /// The host drives a subtle pulsing animation at ~20fps using request_repaint_after.
+    Skeleton {
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        #[serde(default = "default_skeleton_radius")]
+        radius: f32,
     },
 
     /// Render an amplitude meter reading from a binary pipe.
@@ -1524,6 +1554,17 @@ pub enum ControlCommand {
         #[serde(default)]
         monospace: bool,
     },
+    /// Measure the height of `text` wrapped at `max_width` using real host font metrics.
+    /// If `max_lines` is Some(n), clamps the measurement to n rows.
+    /// Replies with `PlexiEvent::TextWrappedMeasured { request_id, height }`.
+    MeasureTextWrapped {
+        request_id: String,
+        text: String,
+        font_size: f32,
+        max_width: f32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_lines: Option<u32>,
+    },
     /// Override the manifest-declared minimum size at runtime.
     /// Stored by the host and used as the live effective minimum from this
     /// point forward, superseding the manifest `[launch]` values.
@@ -1727,6 +1768,9 @@ fn default_text_input_h() -> f32 {
     24.0
 }
 
+fn default_skeleton_radius() -> f32 {
+    4.0
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1234,6 +1234,31 @@ impl ProcessApp {
                         height: sz.y,
                     });
             }
+            ControlCommand::MeasureTextWrapped {
+                request_id,
+                text,
+                font_size,
+                max_width,
+                max_lines,
+            } => {
+                let font_id = egui::FontId::proportional(font_size);
+                let galley = ui.fonts(|f| {
+                    f.layout(text.clone(), font_id, egui::Color32::WHITE, max_width)
+                });
+                let n_rows = max_lines
+                    .map(|n| (n as usize).min(galley.rows.len()))
+                    .unwrap_or(galley.rows.len());
+                let height = if n_rows == 0 {
+                    0.0
+                } else {
+                    galley.rows[n_rows - 1].rect.max.y
+                };
+                self.outbound_events
+                    .push_back(crate::app_protocol::PlexiEvent::TextWrappedMeasured {
+                        request_id: request_id.clone(),
+                        height,
+                    });
+            }
             ControlCommand::SetMinSize { width, height } => {
                 self.live_min_size = Some((width, height));
                 log::info!(

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1253,6 +1253,10 @@ impl ProcessApp {
                 } else {
                     galley.rows[n_rows - 1].rect.max.y
                 };
+                log::debug!(
+                    "ProcessApp[{}]: MeasureTextWrapped request_id={} max_width={:.1} max_lines={:?} rows={} height={:.1}",
+                    self.type_id, request_id, max_width, max_lines, n_rows, height
+                );
                 self.outbound_events
                     .push_back(crate::app_protocol::PlexiEvent::TextWrappedMeasured {
                         request_id: request_id.clone(),

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -108,6 +108,9 @@ pub(crate) fn render_draw_commands(
 
                 // max_lines: wrap text at max_width (or pane width) and clip to n rows with "…"
                 if let Some(n) = max_lines {
+                    if *n == 0 {
+                        continue;
+                    }
                     let wrap_w = max_width
                         .filter(|w| *w > 0.0)
                         .unwrap_or((pane_rect.max.x - (origin.x + x)).max(1.0));

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -100,10 +100,45 @@ pub(crate) fn render_draw_commands(
                 max_width,
                 elide,
                 selectable,
+                max_lines,
             } => {
                 let color = parse_color(color).unwrap_or(colors.text_primary);
                 let family = font_family_for_text(*monospace);
                 let font_id = egui::FontId::new(*size, family.clone());
+
+                // max_lines: wrap text at max_width (or pane width) and clip to n rows with "…"
+                if let Some(n) = max_lines {
+                    let wrap_w = max_width
+                        .filter(|w| *w > 0.0)
+                        .unwrap_or((pane_rect.max.x - (origin.x + x)).max(1.0));
+                    let galley = ui.fonts(|f| {
+                        f.layout(text.clone(), font_id.clone(), color, wrap_w)
+                    });
+                    let final_text: std::borrow::Cow<str> = if galley.rows.len() > *n as usize {
+                        let mut lo = 0usize;
+                        let mut hi = text.chars().count();
+                        while lo + 1 < hi {
+                            let mid = (lo + hi) / 2;
+                            let candidate: String = text.chars().take(mid).collect::<String>() + "…";
+                            let g = ui.fonts(|f| f.layout(candidate, font_id.clone(), color, wrap_w));
+                            if g.rows.len() <= *n as usize {
+                                lo = mid;
+                            } else {
+                                hi = mid;
+                            }
+                        }
+                        std::borrow::Cow::Owned(text.chars().take(lo).collect::<String>() + "…")
+                    } else {
+                        std::borrow::Cow::Borrowed(text.as_str())
+                    };
+                    let final_galley = ui.fonts(|f| {
+                        f.layout(final_text.to_string(), font_id.clone(), color, wrap_w)
+                    });
+                    let pos = egui::pos2(origin.x + x, origin.y + y);
+                    ui.painter().with_clip_rect(clip).galley(pos, final_galley, color);
+                    continue;
+                }
+
                 let pos = egui::pos2(origin.x + x, origin.y + y);
                 let anchor = match align.as_str() {
                     "center" => egui::Align2::CENTER_CENTER,
@@ -484,6 +519,65 @@ pub(crate) fn render_draw_commands(
                     );
                     painter.galley(text_pos, galley, colors.text_dim);
                 }
+            }
+
+            RenderCommand::Avatar { src, cx, cy, radius } => {
+                if src.starts_with("http://") || src.starts_with("https://") {
+                    image_cache.request_url(src, net_http_granted);
+                } else {
+                    image_cache.request(src, workspace_root);
+                }
+                let center = egui::pos2(origin.x + cx, origin.y + cy);
+                let painter = ui.painter().with_clip_rect(clip);
+                if let Some(handle) = image_cache.get(src) {
+                    let tex_id = handle.id();
+                    let n_segs: u32 = 48;
+                    let mut mesh = egui::Mesh::with_texture(tex_id);
+                    // Centre vertex (UV 0.5, 0.5)
+                    mesh.vertices.push(egui::epaint::Vertex {
+                        pos: center,
+                        uv: egui::pos2(0.5, 0.5),
+                        color: egui::Color32::WHITE,
+                    });
+                    // Perimeter vertices
+                    for i in 0..=n_segs {
+                        let angle = i as f32 / n_segs as f32 * std::f32::consts::TAU;
+                        let cos = angle.cos();
+                        let sin = angle.sin();
+                        mesh.vertices.push(egui::epaint::Vertex {
+                            pos: egui::pos2(center.x + cos * radius, center.y + sin * radius),
+                            uv: egui::pos2(0.5 + cos * 0.5, 0.5 + sin * 0.5),
+                            color: egui::Color32::WHITE,
+                        });
+                    }
+                    // Triangle fan: centre=0, perimeter i+1..i+2
+                    for i in 0..n_segs {
+                        mesh.indices.push(0);
+                        mesh.indices.push(i + 1);
+                        mesh.indices.push(i + 2);
+                    }
+                    painter.add(egui::Shape::Mesh(std::sync::Arc::new(mesh)));
+                } else {
+                    // Placeholder: filled circle with muted color
+                    painter.circle_filled(center, *radius, egui::Color32::from_rgb(0x3a, 0x3a, 0x4a));
+                }
+            }
+
+            RenderCommand::Skeleton { x, y, w, h, radius } => {
+                let t = ui.input(|i| i.time) as f32;
+                let alpha = 0.4 + 0.25 * (t * std::f32::consts::TAU * 0.8).sin();
+                let fill = egui::Color32::from_rgba_unmultiplied(0x45, 0x47, 0x5a, (alpha * 255.0) as u8);
+                let rect = egui::Rect::from_min_size(
+                    egui::pos2(origin.x + x, origin.y + y),
+                    egui::vec2(*w, *h),
+                );
+                ui.painter().with_clip_rect(clip).rect_filled(
+                    rect,
+                    egui::CornerRadius::same(*radius as u8),
+                    fill,
+                );
+                // Drive animation — request repaint at ~20fps while skeleton is visible
+                ui.ctx().request_repaint_after(std::time::Duration::from_millis(50));
             }
 
             // AudioMeter (#341): renders a live peak-amplitude bar driven by

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -317,6 +317,7 @@ pub(crate) fn portal_responsive_tiers(
             max_width: None,
             elide: false,
             selectable: false,
+            max_lines: None,
         }),
     };
 
@@ -332,6 +333,7 @@ pub(crate) fn portal_responsive_tiers(
             max_width: None,
             elide: false,
             selectable: false,
+            max_lines: None,
         }),
     };
 
@@ -347,6 +349,7 @@ pub(crate) fn portal_responsive_tiers(
             max_width: None,
             elide: false,
             selectable: false,
+            max_lines: None,
         }),
     };
 
@@ -369,6 +372,7 @@ pub(crate) fn portal_responsive_tiers(
                 max_width: None,
                 elide: false,
                 selectable: false,
+                max_lines: None,
             }),
         }
     }).collect();
@@ -422,6 +426,7 @@ pub(crate) fn portal_responsive_tiers(
                 max_width: None,
                 elide: false,
                 selectable: false,
+                max_lines: None,
             }),
         },
         LayoutChild::Leaf {
@@ -436,6 +441,7 @@ pub(crate) fn portal_responsive_tiers(
                 max_width: None,
                 elide: false,
                 selectable: false,
+                max_lines: None,
             }),
         },
     ];
@@ -452,6 +458,7 @@ pub(crate) fn portal_responsive_tiers(
                 max_width: None,
                 elide: false,
                 selectable: false,
+                max_lines: None,
             }),
         });
     }


### PR DESCRIPTION
Closes #1607

## Summary

- Adds `max_lines` to `ctx.text()` so feed rows can show 2–3 lines then elide, instead of always 1
- Adds `ctx.avatar()` for circular clipped images using the existing `emit.load_image()` handle system
- Adds `ctx.skeleton()` for host-driven animated shimmer placeholder rows during loading
- Adds `await ctx.measure_text_wrapped()` / `emit.measure_text_wrapped()` for pre-measuring variable row heights using real egui font metrics

## Done When

1. Bluesky feed shows 2–3 lines per post — row heights vary with content length
2. Profile picture circles render in the left gutter of each feed row
3. While loading, the feed shows animated skeleton rows instead of "Loading…" text
4. `plexi-alpha app render bluesky --state <loaded-state>` captures a visually populated feed

## Notes

- `MeasureTextWrapped` is a ControlCommand (not RenderCommand) — handled in `process_app/mod.rs` alongside `MeasureText`, requires `ui` for font metrics
- Avatar uses a triangle-fan mesh over the image texture for a true circle clip; placeholder circle renders while image loads
- Skeleton animation is host-driven via `ui.ctx().request_repaint_after(50ms)` — no app-side timer needed
- `_post_fetch_setup()` in bluesky measures all row heights and loads all avatars once after each feed fetch, never in `on_render()`
- `src/tiling.rs` needed 7 `RenderCommand::Text` struct literal updates for the new `max_lines: None` field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added circular avatar rendering for post authors
  * Introduced animated skeleton placeholders for loading states
  * Added text measurement capability for precise content layout

* **Improvements**
  * Enhanced feed rendering with variable row heights based on post content
  * Optimized avatar loading and caching for improved performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->