### PR TITLE
fix(cli): app init no-workspace fallback uses global profile dir instead of CWD (#1612)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -761,9 +761,10 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
         found
     };
 
-    let base = workspace_root.unwrap_or_else(|| cwd.clone());
+    let placement = if workspace_root.is_some() { "workspace" } else { "global" };
+    let base = workspace_root.unwrap_or_else(|| home.clone().unwrap_or_else(|| cwd.clone()));
     let app_dir = base.join(&channel_dir).join("apps").join(name);
-    log::info!("app_init: scaffold path={}", app_dir.display());
+    log::info!("app_init: placement={placement} path={}", app_dir.display());
 
     if app_dir.exists() {
         eprintln!("error: {} already exists", app_dir.display());


### PR DESCRIPTION
## Summary

When `plexi app init` finds no workspace while walking up from CWD, it was falling back to CWD as the base dir, producing `<cwd>/.plexi-alpha/apps/<name>/` — a stray workspace-in-place that the registry only discovers when the terminal happens to be in that exact directory.

**Fix:** fall back to `home_dir()` instead, producing `~/.plexi-alpha/apps/<name>/` — the global profile dir that the registry always scans.

## Changes

- `src/cli.rs:764` — change fallback from `cwd.clone()` to `home.clone().unwrap_or_else(|| cwd.clone())` (reuses `home` already resolved at line 727)
- Add `placement` label (`workspace` vs `global`) to the existing `log::info!` trace so agents can diagnose where apps land

## Done When

1. `plexi-pr-<N> app init my-app` from a dir with no `.plexi-<channel>/` ancestor creates `~/.plexi-pr-<N>/apps/my-app/`
2. `plexi-pr-<N> open my-app` works from any directory immediately after
3. No stray `.plexi-<channel>/` dir created in CWD
4. `cargo build` passes ✅

Closes #1612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app initialization fallback logic to use the home directory when a preferred workspace isn't available, instead of the current working directory.
  * Enhanced initialization logging to better display placement context and resulting file paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->