### PR TITLE
feat(cli): plexi open github:owner/repo — ephemeral launch without install (#1530)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1492,7 +1492,7 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, .. } => {
+                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, workspace_root, .. } => {
                     log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
@@ -1536,7 +1536,8 @@ impl PlexiApp {
                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, new_pane_first, cwd_override);
                         }
                     } else if let Some(path_str) = path {
-                        launch_result = self.launch_app_by_path_with_layout(path_str, layout.clone());
+                        let ws_root = workspace_root.as_deref().map(std::path::PathBuf::from);
+                        launch_result = self.launch_app_by_path_with_layout(path_str, layout.clone(), ws_root);
                     } else {
                         launch_result = self.launch_app_by_id_with_layout(type_id, layout.clone(), args, cwd_override);
                     }
@@ -1892,7 +1893,8 @@ impl PlexiApp {
                 .unwrap_or_default();
             let cwd_override: Option<std::path::PathBuf> = val["cwd"].as_str().map(std::path::PathBuf::from);
             let no_focus = val["no_focus"].as_bool().unwrap_or(false);
-            log::info!("spawn-queue: launching '{type_id}' path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd_override:?}");
+            let ws_root_override = val["workspace_root"].as_str().map(std::path::PathBuf::from);
+            log::info!("spawn-queue: launching '{type_id}' path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd_override:?} workspace_root={ws_root_override:?}");
             let active = self.active_window;
             let original_focused = self.windows[active].focused_pane;
             if type_id == "terminal" {
@@ -1902,7 +1904,7 @@ impl PlexiApp {
                 let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, new_pane_first, cwd_override);
             } else if let Some(ref path_str) = path {
-                let _ = self.launch_app_by_path_with_layout(path_str, layout);
+                let _ = self.launch_app_by_path_with_layout(path_str, layout, ws_root_override);
             } else {
                 let _ = self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1493,7 +1493,7 @@ impl PlexiApp {
                     }
                 }
                 crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, workspace_root, .. } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} workspace_root={workspace_root:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
                     // Override focused_pane for the split if from_pane_id is specified,
@@ -1904,7 +1904,9 @@ impl PlexiApp {
                 let initial_cmd = cmd_from_args(&args);
                 self.split_focused(vertical, initial_cmd.as_deref(), ephemeral, new_pane_first, cwd_override);
             } else if let Some(ref path_str) = path {
-                let _ = self.launch_app_by_path_with_layout(path_str, layout, ws_root_override);
+                if let Err(e) = self.launch_app_by_path_with_layout(path_str, layout, ws_root_override) {
+                    log::warn!("spawn-queue: launch_app_by_path_with_layout failed for path={path_str:?}: {e}");
+                }
             } else {
                 let _ = self.launch_app_by_id_with_layout(&type_id, layout, &args, cwd_override);
             }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1045,6 +1045,10 @@ pub enum AppRequest {
         /// rather than looking it up in the registry by type_id.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<String>,
+        /// When set, use this path as the workspace root for app state scoping
+        /// instead of defaulting to the app directory. Sent by `plexi open github:`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_root: Option<String>,
         /// When set, spawn the pane into this child context instead of the
         /// requesting app's own context. The target context must exist and be
         /// a descendant of the requesting app's context (#1518).

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -2762,6 +2762,38 @@ mod tests {
     }
 
     #[test]
+    fn spawn_pane_with_workspace_root_round_trips_serde() {
+        let json = r#"{"type":"spawn_pane","type_id":"terminal","workspace_root":"/tmp/github-repo"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(AppRequest::SpawnPane { workspace_root, .. }) => {
+                assert_eq!(workspace_root.as_deref(), Some("/tmp/github-repo"));
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""workspace_root":"/tmp/github-repo""#),
+            "workspace_root missing: {serialised}"
+        );
+
+        // None should be omitted from serialised output.
+        let json_absent = r#"{"type":"spawn_pane","type_id":"terminal"}"#;
+        let cmd_absent: DrawCommand = serde_json::from_str(json_absent).expect("deserialise absent");
+        match &cmd_absent {
+            DrawCommand::Host(AppRequest::SpawnPane { workspace_root, .. }) => {
+                assert!(workspace_root.is_none(), "absent workspace_root must deserialise to None");
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised_absent = serde_json::to_string(&cmd_absent).expect("serialise absent");
+        assert!(
+            !serialised_absent.contains("workspace_root"),
+            "workspace_root should be omitted when None: {serialised_absent}"
+        );
+    }
+
+    #[test]
     fn pane_spawned_with_request_id_round_trips_serde() {
         let json = r#"{"type":"pane_spawned","pane_id":99,"request_id":"req-abc"}"#;
         let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2823,11 +2823,160 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -
 /// spawn_pane command directly via the socket — channel-agnostic, works on
 /// alpha, beta, stable, and PR builds without caring which binary is on PATH.
 ///
+/// `plexi open github:owner/repo` — clone and run ephemerally, without installing.
+///
+/// Clones to a channel-scoped cache dir and sends a path-based spawn_pane,
+/// passing the user's workspace root so app state is scoped correctly.
+fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
+    let rest = source.strip_prefix("github:").unwrap_or(source);
+    let parts: Vec<&str> = rest.splitn(2, '/').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        eprintln!("error: invalid github source '{source}'; expected 'github:owner/repo'");
+        return 1;
+    }
+    let owner = parts[0];
+    let repo = parts[1].trim_end_matches(".git");
+
+    let cache_dir = crate::config::config_dir()
+        .join("github-cache")
+        .join(owner)
+        .join(repo);
+
+    if !cache_dir.exists() {
+        let url = format!("https://github.com/{owner}/{repo}.git");
+        log::info!("open_github_ephemeral: cloning {url} → {}", cache_dir.display());
+        eprintln!("Cloning github:{owner}/{repo}...");
+        match std::process::Command::new("git")
+            .args(["clone", "--depth=1", &url, &cache_dir.to_string_lossy()])
+            .status()
+        {
+            Ok(s) if s.success() => {}
+            Ok(s) => {
+                eprintln!("error: git clone failed (exit {})", s.code().unwrap_or(-1));
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("error: could not run git: {e}");
+                return 1;
+            }
+        }
+    } else {
+        log::info!("open_github_ephemeral: reusing cache at {}", cache_dir.display());
+    }
+
+    // Walk up from CWD to find a Plexi workspace root.
+    let workspace_root: Option<String> = std::env::current_dir().ok().and_then(|cwd| {
+        let mut dir: &std::path::Path = cwd.as_path();
+        loop {
+            if dir.join(".plexi").join("workspace.toml").exists() {
+                return Some(dir.to_string_lossy().into_owned());
+            }
+            dir = dir.parent()?;
+        }
+    });
+
+    let abs_path = cache_dir.to_string_lossy().into_owned();
+    log::info!(
+        "open_github_ephemeral: launching from {abs_path} workspace_root={workspace_root:?}"
+    );
+
+    if std::env::var("PLEXI_SOCKET").is_ok() {
+        let id = uuid::Uuid::new_v4();
+        let response_file = crate::config::config_dir()
+            .join(format!("spawn-pane-response-{id}.json"))
+            .to_string_lossy()
+            .into_owned();
+        let mut payload = serde_json::json!({
+            "type": "spawn_pane",
+            "type_id": "",
+            "path": abs_path,
+            "layout": layout,
+            "response_file": response_file,
+        });
+        if let Some(pid) = from_pane_id {
+            payload["from_pane_id"] = serde_json::Value::Number(pid.into());
+        }
+        if let Some(ref ws) = workspace_root {
+            payload["workspace_root"] = serde_json::Value::String(ws.clone());
+        }
+        log::info!("open_github_ephemeral: sending via socket response_file={response_file:?}");
+        let code = send_to_socket(payload);
+        if code != 0 {
+            return code;
+        }
+        let response_path = std::path::PathBuf::from(&response_file);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if response_path.exists() {
+                match std::fs::read_to_string(&response_path) {
+                    Ok(content) => {
+                        let _ = std::fs::remove_file(&response_path);
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                                eprintln!("error: {msg}");
+                                return 1;
+                            }
+                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+                                println!("{pid}");
+                                return 0;
+                            }
+                        }
+                        print!("{content}");
+                        return 0;
+                    }
+                    Err(e) => {
+                        eprintln!("error: could not read response file: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("error: timed out waiting for open response");
+                return 1;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    // Fallback: spawn-queue (outside a Plexi pane).
+    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
+        eprintln!("error: could not create spawn queue: {e}");
+        return 1;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut queue_payload = serde_json::json!({
+        "type_id": "",
+        "path": abs_path,
+        "layout": layout,
+    });
+    if let Some(ref ws) = workspace_root {
+        queue_payload["workspace_root"] = serde_json::Value::String(ws.clone());
+    }
+    let file = queue_dir.join(format!("{ts}.json"));
+    if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
+        eprintln!("error: could not write spawn request: {e}");
+        return 1;
+    }
+    log::info!("open_github_ephemeral: queued path={abs_path}");
+    println!("queued: open github:{owner}/{repo}");
+    println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
+    0
+}
+
 /// When called from outside Plexi, falls back to the spawn-queue directory
 /// which the running host drains each second.
 ///
 /// Returns 0 on success, 1 on error.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
+    // Intercept github: prefix for ephemeral open-without-install.
+    if type_id.starts_with("github:") {
+        return open_github_ephemeral(type_id, layout, from_pane_id);
+    }
+
     if type_id == "terminal" {
         log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
         eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2827,7 +2827,7 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -
 ///
 /// Clones to a channel-scoped cache dir and sends a path-based spawn_pane,
 /// passing the user's workspace root so app state is scoped correctly.
-fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
+fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     let rest = source.strip_prefix("github:").unwrap_or(source);
     let parts: Vec<&str> = rest.splitn(2, '/').collect();
     if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
@@ -2842,12 +2842,23 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
         .join(owner)
         .join(repo);
 
+    // Ensure the parent directory exists before cloning.
+    if let Some(parent) = cache_dir.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("error: could not create cache directory {}: {e}", parent.display());
+            return 1;
+        }
+    }
+
     if !cache_dir.exists() {
         let url = format!("https://github.com/{owner}/{repo}.git");
         log::info!("open_github_ephemeral: cloning {url} → {}", cache_dir.display());
         eprintln!("Cloning github:{owner}/{repo}...");
         match std::process::Command::new("git")
-            .args(["clone", "--depth=1", &url, &cache_dir.to_string_lossy()])
+            .arg("clone")
+            .arg("--depth=1")
+            .arg(&url)
+            .arg(&cache_dir)
             .status()
         {
             Ok(s) if s.success() => {}
@@ -2864,16 +2875,14 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
         log::info!("open_github_ephemeral: reusing cache at {}", cache_dir.display());
     }
 
-    // Walk up from CWD to find a Plexi workspace root.
-    let workspace_root: Option<String> = std::env::current_dir().ok().and_then(|cwd| {
-        let mut dir: &std::path::Path = cwd.as_path();
-        loop {
-            if dir.join(".plexi").join("workspace.toml").exists() {
-                return Some(dir.to_string_lossy().into_owned());
-            }
-            dir = dir.parent()?;
-        }
-    });
+    // Resolve workspace root from the provided cwd, falling back to current_dir.
+    let start_dir = cwd
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::current_dir().ok());
+    let workspace_root: Option<String> = start_dir
+        .as_deref()
+        .and_then(|d| crate::app_registry::resolve_workspace_root(d))
+        .map(|p| p.to_string_lossy().into_owned());
 
     let abs_path = cache_dir.to_string_lossy().into_owned();
     log::info!(
@@ -2898,6 +2907,9 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
         }
         if let Some(ref ws) = workspace_root {
             payload["workspace_root"] = serde_json::Value::String(ws.clone());
+        }
+        if let Some(cwd_str) = cwd {
+            payload["cwd"] = serde_json::Value::String(cwd_str.to_string());
         }
         log::info!("open_github_ephemeral: sending via socket response_file={response_file:?}");
         let code = send_to_socket(payload);
@@ -2948,6 +2960,7 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
+    let queue_id = uuid::Uuid::new_v4();
     let mut queue_payload = serde_json::json!({
         "type_id": "",
         "path": abs_path,
@@ -2956,7 +2969,10 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
     if let Some(ref ws) = workspace_root {
         queue_payload["workspace_root"] = serde_json::Value::String(ws.clone());
     }
-    let file = queue_dir.join(format!("{ts}.json"));
+    if let Some(cwd_str) = cwd {
+        queue_payload["cwd"] = serde_json::Value::String(cwd_str.to_string());
+    }
+    let file = queue_dir.join(format!("{ts}-{queue_id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
@@ -2974,7 +2990,7 @@ fn open_github_ephemeral(source: &str, layout: Option<&str>, from_pane_id: Optio
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     // Intercept github: prefix for ephemeral open-without-install.
     if type_id.starts_with("github:") {
-        return open_github_ephemeral(type_id, layout, from_pane_id);
+        return open_github_ephemeral(type_id, layout, from_pane_id, cwd);
     }
 
     if type_id == "terminal" {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -684,6 +684,7 @@ impl PlexiApp {
         &mut self,
         app_path: &str,
         layout: Option<String>,
+        workspace_root_override: Option<std::path::PathBuf>,
     ) -> Result<(), String> {
         let app_dir = PathBuf::from(app_path);
         log::info!("launch_app_by_path_with_layout: path={app_path}");
@@ -717,13 +718,18 @@ impl PlexiApp {
             .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
+        let workspace_root = workspace_root_override.unwrap_or_else(|| app_dir.clone());
+        log::info!(
+            "launch_app_by_path_with_layout: workspace_root={}",
+            workspace_root.display()
+        );
         match crate::process_app::ProcessApp::launch(
             installed.manifest.id.clone(),
             installed.manifest.name.clone(),
             &installed.bin_path,
             &cwd,
             &[],
-            app_dir.clone(),
+            workspace_root,
             caps,
             keyboard_capture,
             installed.manifest.mcp.as_ref(),
@@ -1188,6 +1194,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            workspace_root: None,
             target_context: None,
         });
         h.run_frames(2);
@@ -1227,6 +1234,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            workspace_root: None,
             target_context: None,
         });
         h.run_frames(2);
@@ -1269,6 +1277,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            workspace_root: None,
             target_context: None,
         });
         h.run_frames(2);
@@ -1310,6 +1319,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            workspace_root: None,
             target_context: None,
         });
         h.run_frames(2);
@@ -1361,6 +1371,7 @@ mod tests {
             cwd: None,
             no_focus: false,
             path: None,
+            workspace_root: None,
             target_context: None,
         });
         h.run_frames(2);
@@ -1410,6 +1421,7 @@ mod tests {
                 cwd: None,
                 no_focus: false,
                 path: None,
+                workspace_root: None,
                 target_context: None,
             });
             h.run_frames(2);
@@ -1685,6 +1697,7 @@ mod quick_note_tests {
                 cwd: None,
                 no_focus: false,
                 path: None,
+                workspace_root: None,
                 target_context: Some(999),
             },
         ));

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -773,6 +773,7 @@ impl ProcessApp {
                 cwd: _,
                 no_focus: _,
                 path: _,
+                workspace_root: _,
                 target_context,
             } => {
                 if let PermissionCheck::Denied(reason) =


### PR DESCRIPTION
## Summary

- Adds `plexi open github:owner/repo` as a new ephemeral open path — clones (shallow) to `config_dir()/github-cache/<owner>/<repo>/` and spawns the app without any registry entry
- Adds `workspace_root` to the `SpawnPane` IPC protocol so the host uses the caller's CWD-derived workspace root for app state scoping (workspace-local vs global)
- App state persists between runs under the existing `app_states/<manifest-id>.json` path, scoped correctly

## Done When

- [x] `plexi open github:owner/repo` runs the app without a prior install step
- [x] State is persisted and restored between runs, scoped correctly to workspace vs global
- [x] `plexi install github:owner/repo` remains unchanged for permanent installation

## Test plan

- [ ] `plexi open github:plexi-apps/stand-up-reminder` (or another valid Plexi app repo) launches the app pane without running `plexi install` first
- [ ] Running the same command twice reuses the cache (no second clone)
- [ ] App state written in one run is present on the next run in the same CWD
- [ ] Running from inside a workspace dir saves state to workspace `.plexi/app_states/`, not global
- [ ] `plexi install github:owner/repo` still works and registers the app normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)