### PR TITLE
fix(host): promote CapabilityModal to FocusLayer for exclusive keyboard input (#1596)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4839,7 +4839,10 @@ impl PlexiApp {
             .focus_stack
             .iter()
             .any(|l| *l == FocusLayer::CapabilityModal);
-        if should_own && !has_layer {
+        let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::CapabilityModal));
+        if should_own && !is_top {
+            // Push to top (re-promoting from buried position if already in stack).
+            self.focus_stack.retain(|l| *l != FocusLayer::CapabilityModal);
             log::info!("capability_modal: focus captured — pending prompts on focused pane");
             self.push_focus_layer(FocusLayer::CapabilityModal);
         } else if !should_own && has_layer {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -88,6 +88,11 @@ pub(crate) enum FocusLayer {
     TextInput,
     /// Close-context confirmation dialog with pane inventory and dissolve option.
     ContextCloseConfirm,
+    /// Capability / secret consent modal for a focused ProcessApp pane.
+    /// Promoted to the focus stack when the focused pane has pending prompts,
+    /// so the modal renders in step 2 of `update()` with exclusive keyboard
+    /// ownership — before `dispatch_app_key_events` can steal Escape.
+    CapabilityModal,
 }
 
 /// What a `TextInputOverlay` commit should do.
@@ -2269,6 +2274,7 @@ impl eframe::App for PlexiApp {
         self.sync_cli_setup_prompt_focus();
         self.sync_context_inspector_focus();
         self.sync_text_input_focus();
+        self.sync_capability_modal_focus();
 
         // If an overlay owns input, render it FIRST so its widgets (the
         // notification modal's TextEdit for the `input` kind, the palette's
@@ -2320,6 +2326,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::ContextCloseConfirm) => {
                     self.draw_context_close_confirm(ctx);
                 }
+                Some(FocusLayer::CapabilityModal) => {
+                    self.draw_capability_modal(ctx);
+                }
                 None => {}
             }
             self.drain_captured_keyboard_input(ctx);
@@ -2336,6 +2345,7 @@ impl eframe::App for PlexiApp {
             self.sync_cli_setup_prompt_focus();
             self.sync_context_inspector_focus();
             self.sync_text_input_focus();
+            self.sync_capability_modal_focus();
         }
 
         // Apps only receive key input if nothing is capturing above them.
@@ -4296,6 +4306,7 @@ impl PlexiApp {
                 | Some(FocusLayer::ContextInspector)
                 | Some(FocusLayer::TextInput)
                 | Some(FocusLayer::ContextCloseConfirm)
+                | Some(FocusLayer::CapabilityModal)
         )
     }
 
@@ -4815,6 +4826,68 @@ impl PlexiApp {
             self.push_focus_layer(FocusLayer::TextInput);
         } else if !should_own && has_layer {
             self.pop_focus_layer(&FocusLayer::TextInput);
+        }
+    }
+
+    /// Push/pop `FocusLayer::CapabilityModal` based on whether the focused
+    /// ProcessApp pane has pending prompts. Called every frame (both before
+    /// and after the overlay render block) so the layer tracks prompt state
+    /// without polling lag.
+    pub(crate) fn sync_capability_modal_focus(&mut self) {
+        let should_own = self.focused_pane_has_pending_prompts();
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::CapabilityModal);
+        if should_own && !has_layer {
+            log::info!("capability_modal: focus captured — pending prompts on focused pane");
+            self.push_focus_layer(FocusLayer::CapabilityModal);
+        } else if !should_own && has_layer {
+            log::info!("capability_modal: focus released — prompt queue drained");
+            self.focus_stack.retain(|l| *l != FocusLayer::CapabilityModal);
+        }
+    }
+
+    /// Returns true when the focused ProcessApp pane has at least one pending prompt.
+    ///
+    /// `win.focused_pane` holds a `TileId`. After egui_tiles renders a bare-pane
+    /// root for the first time it wraps that tile in a Container, so the stored
+    /// TileId may now refer to a Container instead of a Pane. `find_pane_in_tile`
+    /// descends through any Container layer to reach the actual pane.
+    fn focused_pane_has_pending_prompts(&self) -> bool {
+        let win = &self.windows[self.active_window];
+        let focused_tile = match win.focused_pane {
+            Some(t) => t,
+            None => return false,
+        };
+        let pane_id = match Self::find_pane_in_tile(&win.tree, focused_tile) {
+            Some(id) => id,
+            None => return false,
+        };
+        match win.panes.get(&pane_id) {
+            Some(crate::pane::Pane::App(app_pane)) => {
+                match &app_pane.runtime {
+                    crate::pane::AppRuntime::Process(proc) => !proc.pending_prompts.is_empty(),
+                    crate::pane::AppRuntime::Builtin(_) => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Walk a tile tree node and return the first `PaneId` found within it.
+    /// Handles the case where `tile_id` is a Container wrapping the actual pane
+    /// (egui_tiles normalises bare-pane roots into containers on first render).
+    pub(crate) fn find_pane_in_tile(
+        tree: &egui_tiles::Tree<crate::tiling::PaneId>,
+        tile_id: egui_tiles::TileId,
+    ) -> Option<crate::tiling::PaneId> {
+        match tree.tiles.get(tile_id)? {
+            egui_tiles::Tile::Pane(id) => Some(*id),
+            egui_tiles::Tile::Container(c) => c
+                .children()
+                .copied()
+                .find_map(|child| Self::find_pane_in_tile(tree, child)),
         }
     }
 

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2580,6 +2580,78 @@ impl PlexiApp {
         }
     }
 
+    /// Capability / secret consent modal for the focused ProcessApp pane.
+    /// Called from step 2 of `update()` so it holds exclusive keyboard
+    /// ownership before `dispatch_app_key_events` runs.
+    pub(crate) fn draw_capability_modal(&mut self, ctx: &egui::Context) {
+        let active = self.active_window;
+        let colors = self.colors;
+
+        // Resolve focused pane id — bail if it's not a ProcessApp.
+        // Use find_pane_in_tile so we traverse through any Container wrapper that
+        // egui_tiles may have inserted around a bare-pane root after first render.
+        let pane_id = {
+            let win = &self.windows[active];
+            let focused_tile = match win.focused_pane {
+                Some(t) => t,
+                None => return,
+            };
+            match crate::app::PlexiApp::find_pane_in_tile(&win.tree, focused_tile) {
+                Some(id) => id,
+                None => return,
+            }
+        };
+
+        // Take fields out of the ProcessApp, call the modal, put them back.
+        // Two separate borrows so Rust doesn't see a conflict.
+        let (mut pending_prompts, mut outbound_events, mut permissions,
+             mut secret_input_buf, mut permission_store, type_id, workspace_root) = {
+            let pane = match self.windows[active].panes.get_mut(&pane_id) {
+                Some(crate::pane::Pane::App(a)) => a,
+                _ => return,
+            };
+            let crate::pane::AppRuntime::Process(ref mut proc) = pane.runtime else { return };
+            if proc.pending_prompts.is_empty() {
+                return;
+            }
+            (
+                std::mem::take(&mut proc.pending_prompts),
+                std::mem::take(&mut proc.outbound_events),
+                std::mem::take(&mut proc.permissions),
+                std::mem::take(&mut proc.secret_input_buf),
+                std::mem::take(&mut proc.permission_store),
+                proc.type_id.clone(),
+                proc.workspace_root.clone(),
+            )
+        };
+
+        let config_dir = crate::config::config_dir();
+        crate::process_app::prompts::show_prompt_modal(
+            ctx,
+            &mut pending_prompts,
+            &mut outbound_events,
+            &mut permissions,
+            &type_id,
+            &workspace_root,
+            &mut secret_input_buf,
+            &config_dir,
+            &mut permission_store,
+            &colors,
+        );
+
+        // Put the data back.
+        let pane = match self.windows[active].panes.get_mut(&pane_id) {
+            Some(crate::pane::Pane::App(a)) => a,
+            _ => return,
+        };
+        let crate::pane::AppRuntime::Process(ref mut proc) = pane.runtime else { return };
+        proc.pending_prompts = pending_prompts;
+        proc.outbound_events = outbound_events;
+        proc.permissions = permissions;
+        proc.secret_input_buf = secret_input_buf;
+        proc.permission_store = permission_store;
+    }
+
     /// Context-close confirmation dialog. Shows pane inventory with three choices:
     /// Close All (Enter), Dissolve (D), Cancel (Escape).
     pub(crate) fn draw_context_close_confirm(&mut self, ctx: &egui::Context) {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -14,7 +14,7 @@
 pub(crate) mod image_cache;
 mod lifecycle;
 pub(crate) mod mcp_server;
-mod prompts;
+pub(crate) mod prompts;
 pub(crate) mod render;
 mod render_session;
 mod routing;
@@ -1406,34 +1406,6 @@ impl App for ProcessApp {
                 DrawCommand::Host(h) => self.route_command(h),
                 DrawCommand::Render(r) => self.pending_frame.push(r),
             }
-        }
-
-        if !self.pending_prompts.is_empty() {
-            let mut pending_prompts = std::mem::take(&mut self.pending_prompts);
-            let mut outbound_events = std::mem::take(&mut self.outbound_events);
-            let mut permissions = std::mem::take(&mut self.permissions);
-            let mut secret_input_buf = std::mem::take(&mut self.secret_input_buf);
-            let mut permission_store = std::mem::take(&mut self.permission_store);
-            let type_id = self.type_id.clone();
-            let workspace_root = self.workspace_root.clone();
-            let config_dir = crate::config::config_dir();
-            prompts::show_prompt_modal(
-                ui,
-                &mut pending_prompts,
-                &mut outbound_events,
-                &mut permissions,
-                &type_id,
-                &workspace_root,
-                &mut secret_input_buf,
-                &config_dir,
-                &mut permission_store,
-                ctx.colors,
-            );
-            self.pending_prompts = pending_prompts;
-            self.outbound_events = outbound_events;
-            self.permissions = permissions;
-            self.secret_input_buf = secret_input_buf;
-            self.permission_store = permission_store;
         }
 
         // Render the current committed frame.

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -78,9 +78,10 @@ pub fn persist_granted_secret(
 }
 
 /// Show a modal for the first pending prompt (capability or secret).
-/// Blocks user interaction with the pane until the user grants or denies.
-pub(super) fn show_prompt_modal(
-    ui: &mut egui::Ui,
+/// Called from the host's early-modal path (step 2 of `update()`) so the
+/// modal owns keyboard input before `dispatch_app_key_events` runs.
+pub(crate) fn show_prompt_modal(
+    ctx: &egui::Context,
     pending_prompts: &mut VecDeque<PendingPrompt>,
     outbound_events: &mut VecDeque<PlexiEvent>,
     permissions: &mut AppPermissions,
@@ -100,17 +101,18 @@ pub(super) fn show_prompt_modal(
     let (mut grant_once, mut grant_forever, mut deny_once, mut deny_forever) =
         match prompt {
             PendingPrompt::Capability { .. } => {
-                ui.ctx().input_mut(|i| {
+                ctx.input_mut(|i| {
                     let shift_enter = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Enter);
                     let key_a = i.consume_key(egui::Modifiers::NONE, egui::Key::A);
                     let key_d = i.consume_key(egui::Modifiers::NONE, egui::Key::D);
+                    let shift_esc = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Escape);
                     let plain_enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
-                    (plain_enter, shift_enter || key_a, false, key_d)
+                    let plain_esc = i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+                    (plain_enter, shift_enter || key_a, plain_esc, shift_esc || key_d)
                 })
             }
             PendingPrompt::Secret { .. } => {
-                let esc = ui
-                    .ctx()
+                let esc = ctx
                     .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
                 (false, false, esc, false)
             }
@@ -120,7 +122,7 @@ pub(super) fn show_prompt_modal(
         .collapsible(false)
         .resizable(false)
         .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-        .show(ui.ctx(), |ui| {
+        .show(ctx, |ui| {
             match prompt {
                 PendingPrompt::Capability { capability, .. } => {
                     ui.label(format!("App \"{}\" is requesting access to:", type_id));

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -815,4 +815,90 @@ mod tests {
         );
     }
 
+    // -- Capability modal focus layer -----------------------------------------
+
+    /// Regression guard for #1596: Escape must reach the capability consent
+    /// modal and fire deny_once. Before the fix, `dispatch_app_key_events` ran
+    /// in step 3 of `update()`, the focused app consumed any key (returning
+    /// `consumed = true`), which caused the host to steal Escape from the
+    /// input state — the modal in step 4 saw nothing. After the fix the modal
+    /// renders in step 2 with exclusive keyboard ownership.
+    ///
+    /// Observable invariants checked (all follow from a successful deny_once):
+    /// 1. `CapabilityModal` is on the focus stack while a prompt is queued.
+    /// 2. After Escape, `pending_prompts` is empty (prompt was popped).
+    /// 3. After Escape, `CapabilityModal` is removed from the focus stack
+    ///    (sync_capability_modal_focus pops it when the queue drains).
+    #[test]
+    fn capability_modal_escape_fires_deny_once() {
+        use crate::app::FocusLayer;
+        use crate::process_app::PendingPrompt;
+        use crate::pane::AppRuntime;
+
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+
+        // Set the pane as the focused pane so sync_capability_modal_focus finds it.
+        let tile_id = {
+            let win = &h.app.windows[0];
+            win.tree.tiles.iter()
+                .find_map(|(id, tile)| match tile {
+                    egui_tiles::Tile::Pane(p) if *p == pane => Some(id),
+                    _ => None,
+                })
+                .expect("test pane must have a tile")
+        };
+        h.app.windows[0].focused_pane = Some(*tile_id);
+
+        // Queue a capability prompt directly on the pane's ProcessApp.
+        {
+            let win = &mut h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(ref mut proc) = app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            proc.pending_prompts.push_back(PendingPrompt::Capability {
+                request_id: "req-cap-1".to_string(),
+                capability: "net.http".to_string(),
+            });
+        }
+
+        // One idle frame: sync_capability_modal_focus should push the layer.
+        h.run_frames(1);
+        assert!(
+            h.app.focus_stack.iter().any(|l| *l == FocusLayer::CapabilityModal),
+            "CapabilityModal must be on the focus stack when the focused pane has pending prompts"
+        );
+
+        // Send Escape. The modal must consume it and pop the prompt (deny_once).
+        h.key(egui::Key::Escape, egui::Modifiers::NONE);
+
+        // pending_prompts must be empty — Escape triggered deny_once, which pops
+        // the front of the queue. If it's still non-empty, the modal didn't see Escape.
+        let prompts_empty = {
+            let win = &h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(ref proc) = app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            proc.pending_prompts.is_empty()
+        };
+        assert!(
+            prompts_empty,
+            "pending_prompts must be empty after Escape — deny_once must have consumed the prompt. \
+             If non-empty, dispatch_app_key_events stole Escape before the modal could read it."
+        );
+
+        // CapabilityModal must have been popped from the focus stack since
+        // sync_capability_modal_focus removes it when pending_prompts drains.
+        assert!(
+            !h.app.focus_stack.iter().any(|l| *l == FocusLayer::CapabilityModal),
+            "CapabilityModal must be removed from the focus stack after deny_once drains the queue"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

- Adds `FocusLayer::CapabilityModal` to the focus stack so the capability/secret consent modal renders at step 2 (early-modal path) — before `dispatch_app_key_events` runs at step 4
- Adds `sync_capability_modal_focus()` pre-flight guard: pushes the layer when the focused pane has pending prompts, pops when the queue drains
- Fixes the `draw_capability_modal` / `focused_pane_has_pending_prompts` pane lookup via `find_pane_in_tile`, which descends through any Container wrapper egui_tiles inserts on first render
- Removes the now-redundant `show_prompt_modal` call from `ProcessApp::ui()` step 5
- Adds `capability_modal_escape_fires_deny_once` HostHarness regression test

## Root cause

`show_prompt_modal` was called in step 5 (pane render). By that point `dispatch_app_key_events` (step 4) had already consumed Escape because the focused app returned `consumed = true`. The modal never saw the keystroke.

## Test plan

- [ ] `cargo test --bin plexi capability_modal_escape_fires_deny_once` passes
- [ ] Full `cargo test --bin plexi` — 535 pass, 7 pre-existing failures unchanged (no regressions)
- [ ] Install PR build: `just pr-install <N>`
- [ ] Run an app that triggers a capability prompt (e.g. `net.http`), press Escape — modal dismisses as Deny Once
- [ ] Press Enter — Grant Once; Shift+Enter — Grant Forever; `D` / `S+Esc` — Deny Forever
- [ ] Secret prompt: type value + Enter submits; Escape cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)