### PR TITLE
fix(host): use retain in sync_*_focus to remove stale buried overlay layers (#1598)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4727,7 +4727,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ConfirmClose);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::ConfirmClose);
+            log::info!("focus: ConfirmClose layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::ConfirmClose);
         }
     }
 
@@ -4740,7 +4741,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ContextCloseConfirm);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::ContextCloseConfirm);
+            log::info!("focus: ContextCloseConfirm layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::ContextCloseConfirm);
         }
     }
 
@@ -4807,7 +4809,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::NotificationModal);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::NotificationModal);
+            log::info!("focus: NotificationModal layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::NotificationModal);
         }
     }
 
@@ -4854,7 +4857,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::CommandPalette);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::CommandPalette);
+            log::info!("focus: CommandPalette layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::CommandPalette);
             // Explicitly surrender egui focus from palette_search so AccessKit
             // doesn't hold a stale focused node ID after the widget is gone.
             self.ctx.memory_mut(|m| {
@@ -4911,7 +4915,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::RenamePane);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::RenamePane);
+            log::info!("focus: RenamePane layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::RenamePane);
         }
     }
 
@@ -4927,7 +4932,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ContextRename);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::ContextRename);
+            log::info!("focus: ContextRename layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::ContextRename);
         }
     }
 
@@ -4941,7 +4947,8 @@ impl PlexiApp {
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::TextInput);
         } else if !should_own && has_layer {
-            self.pop_focus_layer(&FocusLayer::TextInput);
+            log::info!("focus: TextInput layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::TextInput);
         }
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -901,4 +901,53 @@ mod tests {
         );
     }
 
+    /// A buried sync-managed layer must be removed even when another layer sits on top.
+    ///
+    /// Regression guard for the `pop_focus_layer` → `retain` fix: `pop_focus_layer` only
+    /// removes the top entry, so a buried entry would survive until it accidentally
+    /// became top again — causing a closed overlay to regain keyboard ownership.
+    #[test]
+    fn buried_stale_focus_layer_is_removed_by_sync() {
+        use crate::app::FocusLayer;
+
+        let mut h = HostHarness::new();
+
+        // Push ConfirmClose by activating its source state and running sync.
+        h.app.pending_close = true;
+        h.app.sync_confirm_close_focus();
+        assert!(
+            h.app.focus_stack.iter().any(|l| *l == FocusLayer::ConfirmClose),
+            "ConfirmClose must be pushed when pending_close is true"
+        );
+
+        // Push CommandPalette on top — now ConfirmClose is buried.
+        h.app.show_command_palette = true;
+        h.app.sync_command_palette_focus();
+        assert_eq!(
+            h.app.focus_stack.last(),
+            Some(&FocusLayer::CommandPalette),
+            "CommandPalette must be at the top after its source state becomes true"
+        );
+        assert!(
+            h.app.focus_stack.iter().any(|l| *l == FocusLayer::ConfirmClose),
+            "ConfirmClose must still be in the stack (buried beneath CommandPalette)"
+        );
+
+        // Clear ConfirmClose source state — sync must remove the buried entry.
+        h.app.pending_close = false;
+        h.app.sync_confirm_close_focus();
+
+        assert!(
+            !h.app.focus_stack.iter().any(|l| *l == FocusLayer::ConfirmClose),
+            "ConfirmClose must be removed from the stack even though CommandPalette was on top. \
+             If this fails, sync_confirm_close_focus used pop_focus_layer (top-only) instead of retain."
+        );
+
+        // The layer that was on top must still be present — we only removed ConfirmClose.
+        assert!(
+            h.app.focus_stack.iter().any(|l| *l == FocusLayer::CommandPalette),
+            "CommandPalette must remain in the stack after removing the buried ConfirmClose layer"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

`pop_focus_layer` only removes the **top** stack entry. When a sync-managed layer is buried beneath another (e.g. `ConfirmClose` pushed, then `CommandPalette` pushed on top), clearing the lower layer's source state was a no-op — the buried entry survived and could later regain keyboard ownership after the top layer was dismissed.

**Fix:** Replace 7 `pop_focus_layer` calls in sync methods with `focus_stack.retain(|l| *l != <layer>)`, matching the pattern already established by `sync_cli_setup_prompt_focus`, `sync_context_inspector_focus`, and `sync_capability_modal_focus`.

**Affected methods:**
- `sync_confirm_close_focus`
- `sync_context_close_focus`
- `sync_notification_modal_focus`
- `sync_command_palette_focus` (egui focus-surrender block preserved)
- `sync_rename_pane_focus`
- `sync_context_rename_focus`
- `sync_text_input_focus`

**Test:** New `buried_stale_focus_layer_is_removed_by_sync` HostHarness test proves that a buried `ConfirmClose` entry is removed by `sync_confirm_close_focus` even when `CommandPalette` sits above it. Test was written first and confirmed failing before the fix.

## Done When

- [x] A HostHarness test proves a buried stale layer is removed when its source state turns false.
- [x] `input_captured_by_overlay()` cannot return true for a closed overlay after the top layer is popped.
- [x] Adding `CapabilityModal` from #1596 does not introduce another bespoke stale-layer path (already uses `retain`).
- [x] `cargo test --bin plexi` passes (excluding pre-existing failures unrelated to this change).

Closes #1598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where modal dialogs and confirmation windows would not properly close when hidden beneath other active UI layers, ensuring interface elements clean up correctly in all scenarios.

* **Tests**
  * Added regression test to verify modal layer cleanup behavior in complex UI states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->