### PR TITLE
fix(cli): print launch notice when plexi is run with no arguments (#1515)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -533,6 +533,12 @@ fn main() -> eframe::Result {
         std::process::exit(0);
     }
 
+    // When invoked with no arguments outside Plexi, print a brief launch
+    // notice so the terminal isn't silent for first-time users (#1515).
+    if !cli_mode && adopted_root.is_none() {
+        println!("Starting Plexi — run 'plexi --help' to see available commands.");
+    }
+
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/app-icon.png"))
         .expect("failed to load app icon");
 


### PR DESCRIPTION
## Summary

- Running `plexi` with no arguments outside a Plexi pane produced zero stdout output — the GUI launched silently
- First-time users had no feedback that anything was happening, and no pointer to `--help`
- Added a single `println!` guarded by `!cli_mode && adopted_root.is_none()` that fires only on a bare `plexi` invocation (not when a subcommand or workspace path is given)

## Test plan

- [ ] Run `plexi` (or `plexi-alpha`) with no args from a terminal outside Plexi — verify "Starting Plexi — run 'plexi --help' to see available commands." appears on stdout before the GUI opens
- [ ] Run `plexi --help` — verify no double output (help only, no launch notice)
- [ ] Run `plexi list` — verify no launch notice (cli_mode skips it)
- [ ] Run `plexi /path/to/workspace` — verify no launch notice (adopted_root is Some)
- [ ] Run `plexi` from inside a Plexi terminal pane — verify existing "already running inside Plexi" behavior unchanged

Closes #1515