### PR TITLE
fix(host/terminal): QuickNote paste falls through to terminal behind (#1637)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -1254,6 +1254,54 @@ impl PlexiApp {
             return;
         }
 
+        // Explicitly consume paste events before the TextEdit renders.
+        // egui::TextEdit processes Paste via filtered_events(), which requires
+        // settled egui focus. When the zoom overlay is active it calls
+        // set_focus(true) unconditionally, stealing focus from the TextEdit and
+        // leaving paste unhandled — the event then falls through to the terminal
+        // backend. Consuming here is consistent with how Esc and Enter are
+        // handled above and guarantees paste lands in QuickNote every frame.
+        let pasted: String = ctx.input_mut(|i| {
+            let mut text = String::new();
+            i.events.retain(|e| {
+                if let egui::Event::Paste(t) = e {
+                    text.push_str(t);
+                    false
+                } else {
+                    true
+                }
+            });
+            text
+        });
+        if !pasted.is_empty() {
+            let te_id = egui::Id::new("quick_note_text");
+            let inserted = if let Some(mut state) = egui::TextEdit::load_state(ctx, te_id) {
+                if let Some(range) = state.cursor.char_range() {
+                    let lo = range.primary.index.min(range.secondary.index);
+                    let hi = range.primary.index.max(range.secondary.index);
+                    let chars: Vec<char> = self.quick_note_text.chars().collect();
+                    let mut new_chars: Vec<char> = chars[..lo].to_vec();
+                    new_chars.extend(pasted.chars());
+                    new_chars.extend(chars[hi..].iter().copied());
+                    self.quick_note_text = new_chars.into_iter().collect();
+                    let new_pos = lo + pasted.chars().count();
+                    state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
+                        egui::text::CCursor::new(new_pos),
+                    )));
+                    state.store(ctx, te_id);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !inserted {
+                self.quick_note_text.push_str(&pasted);
+            }
+            log::info!("QuickNote: pasted {} chars", pasted.len());
+        }
+
         // Plain Enter (no shift) → advance to destination picker.
         let advance = ctx.input_mut(|i| {
             if !i.modifiers.shift && !i.modifiers.command {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -950,4 +950,76 @@ mod tests {
         );
     }
 
+    // -- QuickNote paste (#1637) -----------------------------------------------
+
+    /// Regression guard for #1637: Cmd+V (paste) while QuickNote is open must
+    /// land in `quick_note_text`, not fall through to the terminal pane behind
+    /// the overlay.
+    ///
+    /// The fix: `draw_quick_note_modal` explicitly consumes `egui::Event::Paste`
+    /// via `ctx.input_mut` and inserts the text at the cursor position, rather
+    /// than relying on the TextEdit's internal event processing (which depends on
+    /// focus being fully settled by the time the TextEdit renders).
+    #[test]
+    fn quick_note_paste_inserts_into_note_text() {
+        let mut h = HostHarness::new();
+
+        // Open QuickNote.
+        h.app.push_focus_layer(crate::app::FocusLayer::QuickNote);
+
+        // Run two idle frames so the overlay and focus fully settle.
+        h.run_frames(2);
+
+        // Inject a paste event in the next frame.
+        h.frame(egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 800.0),
+            )),
+            events: vec![egui::Event::Paste("hello world".into())],
+            ..Default::default()
+        });
+
+        assert_eq!(
+            h.app.quick_note_text,
+            "hello world",
+            "Pasted text must appear in quick_note_text after a Paste event with QuickNote open"
+        );
+    }
+
+    /// After a paste event with QuickNote open, `quick_note_text` must be
+    /// updated AND the `Paste` event must not be present in the queue for
+    /// downstream readers (terminal backends, poll_actions).
+    #[test]
+    fn quick_note_paste_consumed_from_queue() {
+        let mut h = HostHarness::new();
+
+        h.app.push_focus_layer(crate::app::FocusLayer::QuickNote);
+        h.run_frames(2);
+
+        // Inject paste + a non-input event that must survive.
+        h.app.ctx.input_mut(|i| {
+            i.events.push(egui::Event::Paste("test".into()));
+            i.events.push(egui::Event::PointerMoved(egui::pos2(50.0, 50.0)));
+        });
+
+        // Run the overlay draw + drain directly (same path as a full frame).
+        let ctx = h.app.ctx.clone();
+        h.app.draw_quick_note_modal(&ctx);
+        h.app.drain_captured_keyboard_input(&ctx);
+
+        // Paste event must be gone.
+        h.app.ctx.input(|i| {
+            assert!(
+                !i.events.iter().any(|e| matches!(e, egui::Event::Paste(_))),
+                "Paste event must be consumed before terminal backends see it"
+            );
+            // Non-input event must survive.
+            assert!(
+                i.events.iter().any(|e| matches!(e, egui::Event::PointerMoved(_))),
+                "Non-input events must not be drained"
+            );
+        });
+    }
+
 }


### PR DESCRIPTION
Closes #1637

## Root cause

When QuickNote is open and the zoom overlay is also active, `TerminalView::set_focus(true)` is called unconditionally inside the CentralPanel render pass (`app/mod.rs:3999`). This `request_focus()` call runs before the re-focus block at line 4312 wins focus back to `quick_note_text`. On those frames, egui's `TextEdit` skips paste processing because `mem.has_focus(id)` is false — so `egui::Event::Paste` falls through to the terminal behind.

## Fix

Added an explicit paste handler in `draw_quick_note_modal` that consumes `egui::Event::Paste` from `ctx.input_mut` regardless of egui focus state — same pattern used for Esc and Enter. Uses `TextEdit::load_state` + `CCursorRange` for cursor-aware insertion, with a `push_str` fallback when no TextEdit state exists yet.

## Done when
- Cmd+V while QuickNote is open inserts text into the note, not the terminal behind
- `cargo test` green (551 passing, 7 pre-existing failures unchanged)

## Tests added
- `quick_note_paste_inserts_into_note_text` — Paste event with QuickNote open lands in `quick_note_text`
- `quick_note_paste_consumed_from_queue` — Paste event is removed from the egui event queue after modal processing