### PR TITLE
fix(ui/sidebar): show dot when context has exactly one pane (#1661)

### DIFF
--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -140,7 +140,7 @@ impl ContextItem {
 
             // --- Section 3: Pane dots ---
             if let Some(ref dots) = pane_dots {
-                if dots.count > 1 {
+                if dots.count > 0 {
                     ui.horizontal(|ui| {
                         ui.add_space(indent);
                         let capped = dots.count.min(PANE_DOT_MAX);


### PR DESCRIPTION
## Summary

Sidebar pane-dot row was hidden when a context had exactly one pane open. The guard `dots.count > 1` prevented rendering for single-pane contexts.

## Change

`src/sidebar_row.rs:143` — change `dots.count > 1` → `dots.count > 0`

## Done When
- One dim dot (unfocused) or accent dot (focused) appears under each context name when that context has exactly one pane.
- Two panes show two dots.
- Zero panes show no dots.

Closes #1661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the display logic for context item indicators to appear when a single item is present, instead of requiring multiple items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->