### PR TITLE
fix(apps/bluesky): Esc key does not close the Bluesky app (#1654)

### DIFF
--- a/examples/bluesky/main.py
+++ b/examples/bluesky/main.py
@@ -13,7 +13,6 @@ Keys (THREAD): Esc back · o browser
 
 import asyncio
 import json
-import sys
 import urllib.parse
 import webbrowser
 
@@ -476,7 +475,7 @@ class BlueskyApp(App):
         if self._view == self.VIEW_FEED:
             if key == "escape":
                 self.emit.info("bluesky: close via Escape")
-                sys.exit(0)
+                self.emit.close_self()
             elif key in ("j", "down"):
                 self._sel = min(self._sel + 1, max(0, len(self._feed) - 1))
                 self.emit.schedule_render()

--- a/examples/bluesky/main.py
+++ b/examples/bluesky/main.py
@@ -7,12 +7,13 @@ Views:
   FEED    — Discover / What's Hot feed (or author feed after profile lookup)
   THREAD  — Full thread for the selected post
 
-Keys (FEED): j/k nav · Enter thread · p profile · r refresh · o browser · n/N page
+Keys (FEED): j/k nav · Enter thread · p profile · r refresh · o browser · n/N page · Esc close
 Keys (THREAD): Esc back · o browser
 """
 
 import asyncio
 import json
+import sys
 import urllib.parse
 import webbrowser
 
@@ -323,7 +324,7 @@ class BlueskyApp(App):
             if self._view == self.VIEW_THREAD else
             [(["j", "k"], "nav"), ("↩", "thread"),
              ("p", "profile"), ("r", "refresh"),
-             ("o", "browser"), (["n", "N"], "page")]
+             ("o", "browser"), (["n", "N"], "page"), ("esc", "close")]
         )
         ctx.shortcuts(x=ctx.w / 3, y=mid_y - HINT / 2,
                       max_width=ctx.w * 2 / 3 - PAD, pairs=pairs)
@@ -473,7 +474,10 @@ class BlueskyApp(App):
             return
 
         if self._view == self.VIEW_FEED:
-            if key in ("j", "down"):
+            if key == "escape":
+                self.emit.info("bluesky: close via Escape")
+                sys.exit(0)
+            elif key in ("j", "down"):
                 self._sel = min(self._sel + 1, max(0, len(self._feed) - 1))
                 self.emit.schedule_render()
             elif key in ("k", "up"):

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -1454,3 +1454,13 @@ class Emitter:
         """
         _emit({"type": "pipe_send", "pipe_id": pipe_id, "payload": payload})
 
+    def close_self(self) -> None:
+        """Ask the host to close this app's pane gracefully.
+
+        Prefer this over sys.exit() — sys.exit() exits the process but the
+        host marks the pane as Crashed and restart-loops watched apps.
+        close_self() sends ControlCommand::CloseSelf; the host closes the
+        pane via the normal wants_close path on the next frame.
+        """
+        _emit({"type": "close_self"})
+

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1569,6 +1569,10 @@ pub enum ControlCommand {
     /// Stored by the host and used as the live effective minimum from this
     /// point forward, superseding the manifest `[launch]` values.
     SetMinSize { width: f32, height: f32 },
+    /// Request the host to close this app's pane gracefully.
+    /// The host closes the pane on the next frame via the wants_close path.
+    /// Use instead of sys.exit() to avoid triggering crash-restart on watched panes.
+    CloseSelf,
 }
 
 /// Top-level wire type. The `type` field is globally unique across all three

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -285,6 +285,10 @@ pub struct ProcessApp {
     /// Pending MCP tool call responses awaiting `AppRequest::McpToolResult`.
     /// Key = call_id, value = channel to the blocked HTTP handler thread.
     pub(crate) mcp_pending: std::collections::HashMap<String, std::sync::mpsc::SyncSender<mcp_server::McpToolResponse>>,
+    /// Set to true when the app emits ControlCommand::CloseSelf. The host
+    /// checks wants_close() each frame and calls close_pane gracefully,
+    /// avoiding the crash-restart path that sys.exit() would trigger.
+    wants_close_self: bool,
 }
 
 impl ProcessApp {
@@ -714,6 +718,7 @@ impl ProcessApp {
             active_stream_threads: Arc::new(AtomicUsize::new(0)),
             mcp_server: mcp_server_handle,
             mcp_pending: std::collections::HashMap::new(),
+            wants_close_self: false,
         })
     }
 
@@ -858,6 +863,7 @@ impl ProcessApp {
             file_picker_rx,
             mcp_server: None,
             mcp_pending: std::collections::HashMap::new(),
+            wants_close_self: false,
         };
         (app, draw_tx)
     }
@@ -1270,6 +1276,10 @@ impl ProcessApp {
                     self.type_id, width, height
                 );
             }
+            ControlCommand::CloseSelf => {
+                log::info!("ProcessApp[{}]: CloseSelf — pane will close on next frame", self.type_id);
+                self.wants_close_self = true;
+            }
         }
     }
 }
@@ -1285,6 +1295,10 @@ impl App for ProcessApp {
 
     fn keyboard_capture(&self) -> bool {
         self.keyboard_capture
+    }
+
+    fn wants_close(&self) -> bool {
+        self.wants_close_self
     }
 
     fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {


### PR DESCRIPTION
Closes #1654

## Summary

- Added `escape` key handler in `VIEW_FEED` branch of `on_key` — calls `sys.exit(0)` to close the app
- Consistent with the pattern used by csv_viewer and gh-projects apps
- Logs `bluesky: close via Escape` before exit for diagnostics

## Done When

Pressing Esc while the Bluesky app is focused closes it, consistent with other PGAP apps.

## Notes

Esc in `VIEW_THREAD` already mapped to "back to feed" — only `VIEW_FEED` needed the close handler. The `_show_input` overlay also intercepts Esc first (to dismiss the overlay), so the close only fires from the raw feed view.