### PR TITLE
P0: `plexi open config.toml` does nothing on machines without VS Code (#1545)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4251,17 +4251,18 @@ pub fn config_edit() -> i32 {
             log::warn!("config_edit: EDITOR is set but empty, falling through to system default");
         } else {
             let mut parts = editor_env.split_whitespace();
-            let editor_bin = parts.next().unwrap_or("open");
-            let args: Vec<&str> = parts.collect();
-            match std::process::Command::new(editor_bin).args(&args).arg(&path).status() {
-                Ok(status) if status.success() => return 0,
-                Ok(status) => {
-                    eprintln!("error: editor {editor_bin:?} exited with status {}", status.code().unwrap_or(1));
-                    return status.code().unwrap_or(1);
-                }
-                Err(e) => {
-                    eprintln!("error: could not launch editor {editor_bin:?}: {e}");
-                    return 1;
+            if let Some(editor_bin) = parts.next() {
+                let args: Vec<&str> = parts.collect();
+                match std::process::Command::new(editor_bin).args(&args).arg(&path).status() {
+                    Ok(status) if status.success() => return 0,
+                    Ok(status) => {
+                        eprintln!("error: editor {editor_bin:?} exited with status {}", status.code().unwrap_or(1));
+                        return status.code().unwrap_or(1);
+                    }
+                    Err(e) => {
+                        eprintln!("error: could not launch editor {editor_bin:?}: {e}");
+                        return 1;
+                    }
                 }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4247,18 +4247,22 @@ pub fn config_edit() -> i32 {
     log::info!("config_edit: opening {} in editor", path.display());
 
     if let Ok(editor_env) = std::env::var("EDITOR") {
-        let mut parts = editor_env.split_whitespace();
-        let editor_bin = parts.next().unwrap_or("open");
-        let args: Vec<&str> = parts.collect();
-        match std::process::Command::new(editor_bin).args(&args).arg(&path).status() {
-            Ok(status) if status.success() => return 0,
-            Ok(status) => {
-                eprintln!("error: editor {editor_bin:?} exited with status {}", status.code().unwrap_or(1));
-                return status.code().unwrap_or(1);
-            }
-            Err(e) => {
-                eprintln!("error: could not launch editor {editor_bin:?}: {e}");
-                return 1;
+        if editor_env.trim().is_empty() {
+            log::warn!("config_edit: EDITOR is set but empty, falling through to system default");
+        } else {
+            let mut parts = editor_env.split_whitespace();
+            let editor_bin = parts.next().unwrap_or("open");
+            let args: Vec<&str> = parts.collect();
+            match std::process::Command::new(editor_bin).args(&args).arg(&path).status() {
+                Ok(status) if status.success() => return 0,
+                Ok(status) => {
+                    eprintln!("error: editor {editor_bin:?} exited with status {}", status.code().unwrap_or(1));
+                    return status.code().unwrap_or(1);
+                }
+                Err(e) => {
+                    eprintln!("error: could not launch editor {editor_bin:?}: {e}");
+                    return 1;
+                }
             }
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4246,17 +4246,29 @@ pub fn config_edit() -> i32 {
     let path = crate::config::ensure_config_exists();
     log::info!("config_edit: opening {} in editor", path.display());
 
-    let editor_env = std::env::var("EDITOR").unwrap_or_else(|_| "open".to_string());
-    let mut parts = editor_env.split_whitespace();
-    let editor_bin = parts.next().unwrap_or("open");
-    match std::process::Command::new(editor_bin).args(parts).arg(&path).status() {
-        Ok(status) => {
-            if status.success() { 0 } else { status.code().unwrap_or(1) }
+    if let Ok(editor_env) = std::env::var("EDITOR") {
+        let mut parts = editor_env.split_whitespace();
+        let editor_bin = parts.next().unwrap_or("open");
+        let args: Vec<&str> = parts.collect();
+        match std::process::Command::new(editor_bin).args(&args).arg(&path).status() {
+            Ok(status) if status.success() => return 0,
+            Ok(status) => {
+                eprintln!("error: editor {editor_bin:?} exited with status {}", status.code().unwrap_or(1));
+                return status.code().unwrap_or(1);
+            }
+            Err(e) => {
+                eprintln!("error: could not launch editor {editor_bin:?}: {e}");
+                return 1;
+            }
         }
-        Err(e) => {
-            eprintln!("error: could not launch editor {editor_bin:?}: {e}");
-            1
-        }
+    }
+
+    // No $EDITOR set — use the fallback chain: VS Code → system default → TextEdit
+    if crate::config::open_file_with_fallback(&path) {
+        0
+    } else {
+        eprintln!("error: could not open {:?} — install VS Code, set $EDITOR, or ensure a default text editor is configured", path);
+        1
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,9 +691,8 @@ pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
             log::info!("open_file_with_fallback: opened {} (args: {:?})", path.display(), args);
             return true;
         }
-        if !args.is_empty() {
-            log::warn!("open_file_with_fallback: opener {:?} failed for {}, trying next", args, path.display());
-        }
+        let opener_desc = if args.is_empty() { "system default".to_string() } else { format!("{:?}", args) };
+        log::warn!("open_file_with_fallback: opener {} failed for {}, trying next", opener_desc, path.display());
     }
     false
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -678,7 +678,7 @@ pub fn open_config_file() {
 pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
     let candidates: &[&[&str]] = &[
         &["-a", "Visual Studio Code"],
-        &[],
+        &["-t"],
         &["-a", "TextEdit"],
     ];
     for args in candidates {

--- a/src/config.rs
+++ b/src/config.rs
@@ -667,9 +667,35 @@ pub fn open_config_file() {
         let _ = std::fs::write(&path, CONFIG_TEMPLATE);
     }
 
-    if let Err(e) = std::process::Command::new("open").arg(&path).status() {
-        log::error!("open_config_file: failed to open {}: {e}", path.display());
+    if !open_file_with_fallback(&path) {
+        log::error!("open_config_file: could not open {} with any available editor", path.display());
     }
+}
+
+/// Opens `path` with a fallback chain: VS Code → system default → TextEdit.
+/// Returns `true` if any opener succeeded.
+pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
+    let candidates: &[&[&str]] = &[
+        &["-a", "Visual Studio Code"],
+        &[],
+        &["-a", "TextEdit"],
+    ];
+    for args in candidates {
+        let ok = std::process::Command::new("open")
+            .args(*args)
+            .arg(path)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            log::info!("open_file_with_fallback: opened {} (args: {:?})", path.display(), args);
+            return true;
+        }
+        if !args.is_empty() {
+            log::warn!("open_file_with_fallback: opener {:?} failed for {}, trying next", args, path.display());
+        }
+    }
+    false
 }
 
 impl PlexiConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -674,6 +674,7 @@ pub fn open_config_file() {
 
 /// Opens `path` with a fallback chain: VS Code → system default → TextEdit.
 /// Returns `true` if any opener succeeded.
+#[cfg(target_os = "macos")]
 pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
     let candidates: &[&[&str]] = &[
         &["-a", "Visual Studio Code"],
@@ -694,6 +695,12 @@ pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
         let opener_desc = if args.is_empty() { "system default".to_string() } else { format!("{:?}", args) };
         log::warn!("open_file_with_fallback: opener {} failed for {}, trying next", opener_desc, path.display());
     }
+    false
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
+    log::warn!("open_file_with_fallback: no platform implementation for {}", path.display());
     false
 }
 


### PR DESCRIPTION
Closes #1545

## Summary

- Adds a fallback chain to `open_config_file()`: VS Code → system default text editor (`open -t`) → TextEdit
- Updates `config_edit()` in `cli.rs` to surface a user-visible error if all fallbacks fail
- Removes hardcoded VS Code assumption; config file now opens on machines without VS Code installed

## Done When

- `plexi open config.toml` (or equivalent config-open command) opens the file on a machine without VS Code
- Falls back to TextEdit if no system default is set
- A clear error message is shown if all fallbacks fail (no silent failure)

## Notes

Fallback chain uses `open -a "Visual Studio Code"` first, catches failure, then `open -t` (system default text editor), then `open -a TextEdit` as last resort. This matches macOS idiom without requiring additional dependencies.