### PR TITLE
P0: `plexi -h` crashes; no-args spawns app with no escape hatch; need `plexi kill` (#1546)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5066,14 +5066,26 @@ mod secret_set_tests {
 /// Sends SIGTERM to all processes matching the current binary name, excluding
 /// the calling process. Works without `PLEXI_SOCKET` so it's usable from SSH
 /// sessions where the user got trapped in the GUI.
+#[cfg(unix)]
 pub fn kill_cli() -> i32 {
-    let binary_name = std::env::args()
-        .next()
-        .as_deref()
-        .and_then(|p| std::path::Path::new(p).file_name())
-        .and_then(|n| n.to_str())
-        .unwrap_or("plexi")
-        .to_string();
+    // Use current_exe() — not args[0] — so an alias or symlink can't cause
+    // the binary name to match a system utility like `sh` or `ls`.
+    let binary_name = match std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+    {
+        Some(name) if name.starts_with("plexi") => name,
+        Some(name) => {
+            log::error!("kill:cli: refusing to kill non-plexi binary name={name:?}");
+            eprintln!("error: binary name {name:?} does not start with 'plexi' — refusing to kill");
+            return 1;
+        }
+        None => {
+            log::error!("kill:cli: could not determine binary name from current_exe");
+            eprintln!("error: could not determine binary name");
+            return 1;
+        }
+    };
 
     log::info!("kill:cli: sending SIGTERM to {binary_name}");
 
@@ -5151,6 +5163,12 @@ pub fn kill_cli() -> i32 {
         println!("Plexi stopped.");
         0
     }
+}
+
+#[cfg(not(unix))]
+pub fn kill_cli() -> i32 {
+    eprintln!("error: plexi kill is not supported on this platform");
+    1
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5061,6 +5061,75 @@ mod secret_set_tests {
     }
 }
 
+/// `plexi kill` — terminate the running Plexi GUI for this channel.
+///
+/// Sends SIGTERM to all processes matching the current binary name, excluding
+/// the calling process. Works without `PLEXI_SOCKET` so it's usable from SSH
+/// sessions where the user got trapped in the GUI.
+pub fn kill_cli() -> i32 {
+    let binary_name = std::env::args()
+        .next()
+        .as_deref()
+        .and_then(|p| std::path::Path::new(p).file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("plexi")
+        .to_string();
+
+    log::info!("kill:cli: sending SIGTERM to {binary_name}");
+
+    let my_pid = std::process::id();
+
+    // Collect PIDs matching the binary name, excluding this CLI process.
+    let output = match std::process::Command::new("pgrep")
+        .args(["-x", &binary_name])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("error: could not run pgrep: {e}");
+            return 1;
+        }
+    };
+
+    let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|l| l.trim().parse::<u32>().ok())
+        .filter(|&pid| pid != my_pid)
+        .collect();
+
+    if pids.is_empty() {
+        eprintln!("error: no running {binary_name} instance found");
+        return 1;
+    }
+
+    let mut any_failed = false;
+    for pid in &pids {
+        let status = std::process::Command::new("kill")
+            .args([pid.to_string()])
+            .status();
+        match status {
+            Ok(s) if s.success() => {
+                log::info!("kill:cli: sent SIGTERM to pid={pid}");
+            }
+            Ok(s) => {
+                eprintln!("error: kill {pid} exited with {:?}", s.code());
+                any_failed = true;
+            }
+            Err(e) => {
+                eprintln!("error: could not kill pid {pid}: {e}");
+                any_failed = true;
+            }
+        }
+    }
+
+    if any_failed {
+        1
+    } else {
+        println!("Plexi stopped.");
+        0
+    }
+}
+
 #[cfg(test)]
 mod app_run_tests {
     use tempfile::TempDir;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5080,16 +5080,37 @@ pub fn kill_cli() -> i32 {
     let my_pid = std::process::id();
 
     // Collect PIDs matching the binary name, excluding this CLI process.
+    // pgrep exits 0 when matches found, 1 when no matches, 2+ on error.
     let output = match std::process::Command::new("pgrep")
         .args(["-x", &binary_name])
         .output()
     {
         Ok(o) => o,
         Err(e) => {
+            log::error!("kill:cli: pgrep failed to spawn: {e}");
             eprintln!("error: could not run pgrep: {e}");
             return 1;
         }
     };
+
+    match output.status.code() {
+        Some(0) => {} // matches found — proceed
+        Some(1) => {
+            eprintln!("error: no running {binary_name} instance found");
+            return 1;
+        }
+        Some(code) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            log::error!("kill:cli: pgrep exited with code {code}: {stderr}");
+            eprintln!("error: pgrep failed (exit {code}): {stderr}");
+            return 1;
+        }
+        None => {
+            log::error!("kill:cli: pgrep terminated by signal");
+            eprintln!("error: pgrep terminated unexpectedly");
+            return 1;
+        }
+    }
 
     let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
         .lines()
@@ -5112,10 +5133,12 @@ pub fn kill_cli() -> i32 {
                 log::info!("kill:cli: sent SIGTERM to pid={pid}");
             }
             Ok(s) => {
+                log::error!("kill:cli: kill pid={pid} exited with {:?}", s.code());
                 eprintln!("error: kill {pid} exited with {:?}", s.code());
                 any_failed = true;
             }
             Err(e) => {
+                log::error!("kill:cli: could not kill pid={pid}: {e}");
                 eprintln!("error: could not kill pid {pid}: {e}");
                 any_failed = true;
             }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -243,6 +243,13 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: Option<NotesCmd>,
     },
+    /// Terminate the running Plexi instance for this channel.
+    ///
+    /// Sends SIGTERM to the running GUI process for this build channel.
+    /// Use this when Plexi is unreachable (e.g. after an SSH session where it launched).
+    ///
+    /// Example: plexi kill
+    Kill,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,7 @@ fn main() -> eframe::Result {
             "run", "secret", "app", "workspace", "notify", "pane", "terminal",
             "open", "install", "uninstall", "update", "list", "pack",
             "descriptor", "registry", "validate", "context", "completions", "config",
+            "kill",
         ];
         !a.starts_with('-') && CLI_SUBCOMMANDS.contains(&a.as_str())
     });
@@ -498,6 +499,7 @@ fn main() -> eframe::Result {
                         Some(NotesCmd::List) | None => std::process::exit(cli::notes_list_cli()),
                         Some(NotesCmd::Open) => std::process::exit(cli::notes_open_cli()),
                     },
+                    Commands::Kill => std::process::exit(cli::kill_cli()),
                 }
             }
             // No subcommand — fall through to workspace path check, then GUI
@@ -533,10 +535,14 @@ fn main() -> eframe::Result {
         std::process::exit(0);
     }
 
-    // When invoked with no arguments outside Plexi, print a brief launch
-    // notice so the terminal isn't silent for first-time users (#1515).
+    // Bare `plexi` with no subcommand and no workspace path: show help and
+    // exit. Prevents trapping SSH users in the TUI with no escape hatch.
+    // `plexi <path>` still launches the GUI (adopted_root is Some).
     if !cli_mode && adopted_root.is_none() {
-        println!("Starting Plexi — run 'plexi --help' to see available commands.");
+        use clap::CommandFactory;
+        let _ = Cli::command().print_help();
+        println!();
+        std::process::exit(0);
     }
 
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/app-icon.png"))
@@ -612,6 +618,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "config",
         "routine",
         "notes",
+        "kill",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).
@@ -622,7 +629,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
             let _ = iter.next();
             continue;
         }
-        if a.starts_with("--") {
+        if a.starts_with('-') {
             continue;
         }
         if SUBCOMMANDS.contains(&a.as_str()) {
@@ -784,6 +791,21 @@ mod cli_tests {
         // `plexi --profile alpha` must not treat "alpha" as a path.
         let resolved = parse_workspace_path_arg(&argv(&["--profile", "alpha"]))
             .expect("flag-only argv should resolve");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn plexi_dash_h_does_not_error_as_path() {
+        // `plexi -h` must be skipped as a flag, not treated as a workspace path.
+        let resolved = parse_workspace_path_arg(&argv(&["-h"]))
+            .expect("-h should be skipped as a flag, not error as a missing path");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn plexi_kill_subcommand_skipped_as_path() {
+        let resolved = parse_workspace_path_arg(&argv(&["kill"]))
+            .expect("kill subcommand should be recognized and skipped");
         assert!(resolved.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,10 +535,10 @@ fn main() -> eframe::Result {
         std::process::exit(0);
     }
 
-    // Bare `plexi` with no subcommand and no workspace path: show help and
-    // exit. Prevents trapping SSH users in the TUI with no escape hatch.
-    // `plexi <path>` still launches the GUI (adopted_root is Some).
-    if !cli_mode && adopted_root.is_none() {
+    // Bare `plexi` with no args: show help and exit. Prevents trapping SSH
+    // users in the TUI with no escape hatch. Guard on args.len() == 1 so
+    // `plexi --profile alpha` (global flag, no path) still launches the GUI.
+    if !cli_mode && adopted_root.is_none() && args.len() == 1 {
         use clap::CommandFactory;
         let _ = Cli::command().print_help();
         println!();


### PR DESCRIPTION
Closes #1546

## Summary

- **`plexi -h` crash fixed:** `parse_workspace_path_arg` was only skipping `--` flags; now skips any arg starting with `-`, so `-h`, `-v`, etc. are never mistaken for workspace paths
- **Bare `plexi` shows help and exits:** when invoked with no subcommand and no workspace path, Plexi prints clap help and exits instead of launching the GUI, preventing SSH trap scenarios
- **`plexi kill` added:** new subcommand sends SIGTERM to the running GUI instance for this channel using `pgrep -x <binary-name>` (channel-aware: `plexi`, `plexi-alpha`, `plexi-pr-N`), excluding the CLI's own PID

## Done When

- `plexi -h` shows help text instead of `error: workspace path does not exist: -h`
- `plexi` with no args shows help and exits (does not launch GUI)
- `plexi kill` terminates the running Plexi instance for this channel

## Notes

- `plexi <path>` still launches the GUI — the `adopted_root.is_some()` guard preserves that path
- `plexi kill` uses `pgrep` not `pkill` to exclude the calling CLI process by PID before sending signals
- Two new `cli_tests` cover the `-h` fix and the `kill` subcommand skip