### PR TITLE
fix(cli): gui launch from Finder/Dock broken by bare-args exit path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,11 @@ fn main() -> eframe::Result {
     // Bare `plexi` with no args: show help and exit. Prevents trapping SSH
     // users in the TUI with no escape hatch. Guard on args.len() == 1 so
     // `plexi --profile alpha` (global flag, no path) still launches the GUI.
-    if !cli_mode && adopted_root.is_none() && args.len() == 1 {
+    // Only trigger when stdin is a TTY — when macOS launches the app bundle
+    // from Finder/Spotlight/Dock, stdin is /dev/null (not a TTY), so we skip
+    // this branch and let the GUI start normally.
+    use std::io::IsTerminal;
+    if !cli_mode && adopted_root.is_none() && args.len() == 1 && std::io::stdin().is_terminal() {
         use clap::CommandFactory;
         let _ = Cli::command().print_help();
         println!();


### PR DESCRIPTION
## Summary
- `plexi` bare-args SSH escape hatch introduced in #1674 exits with help text when `args.len() == 1 && adopted_root.is_none()`
- macOS app bundle launches (Finder, Spotlight, Dock) also satisfy this condition — so the GUI silently exited without opening
- Fix: gate the early-exit on `stdin.is_terminal()`. SSH/terminal invocations have a real TTY; bundle launches have `/dev/null` as stdin

## Root cause
PR #1674 introduced the guard to prevent SSH trap scenarios. The guard was too broad — it didn't distinguish "CLI user with no path" from "Finder double-click with no path". Both have `args = [binary]`.

## Fix
`std::io::IsTerminal` (stable since Rust 1.70): `stdin.is_terminal()` is `true` in a terminal/SSH session, `false` when macOS launches the app bundle.

## Test plan
- [ ] `open -a "Plexi Alpha"` launches the GUI (not a CLI — stdin is not a TTY)
- [ ] `plexi-alpha` in a terminal still shows help and exits
- [ ] `plexi-alpha kill` still works (CLI subcommand path, unaffected)
- [ ] Diff-review only — no install needed to verify logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)