### PR TITLE
feat(cli): plexi pane list --context <id> to filter panes by context (#1664)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1385,11 +1385,16 @@ impl PlexiApp {
                         log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::AppRequest::ListPanes { response_file } => {
-                    log::info!("pane_ipc: kind=list_panes response_file={:?}", response_file);
+                crate::app_protocol::AppRequest::ListPanes { response_file, context_id: filter_context_id } => {
+                    log::info!("pane_ipc: kind=list_panes context_id={:?} response_file={:?}", filter_context_id, response_file);
                     let active_win = self.active_window;
                     let mut entries: Vec<serde_json::Value> = Vec::new();
                     for (win_idx, win) in self.windows.iter().enumerate() {
+                        if let Some(cid) = filter_context_id {
+                            if win.context_id != *cid {
+                                continue;
+                            }
+                        }
                         let focused_pane_id = win.focused_pane
                             .and_then(|t| win.tree.tiles.get(t))
                             .and_then(|tile| {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -211,6 +211,7 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
     let resp_file = std::env::temp_dir().join("plexi_test_pane_list_996.json");
     h.inject_ipc(crate::app_protocol::AppRequest::ListPanes {
         response_file: resp_file.to_string_lossy().to_string(),
+        context_id: None,
     });
     h.app.drain_pane_cmd_channel();
 

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1096,6 +1096,9 @@ pub enum AppRequest {
     /// List all open panes. Host writes a JSON array to `response_file`. Sent by `plexi pane list`.
     ListPanes {
         response_file: String,
+        /// When Some, only panes in this context are returned.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_id: Option<u64>,
     },
 
     /// Query info for a specific pane by ID. Host writes JSON object to `response_file`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2458,19 +2458,41 @@ fn print_json_output(json_str: &str) -> i32 {
 /// Sends a `list_panes` command to PLEXI_SOCKET. The host writes a JSON array
 /// to a response file; this function polls for it and prints it to stdout.
 /// Returns 0 on success, 1 on error.
-pub fn pane_list_cli() -> i32 {
+pub fn pane_list_cli(context: Option<u64>, current: bool) -> i32 {
+    let context_id: Option<u64> = if current {
+        let raw = match std::env::var("PLEXI_CONTEXT_ID") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("error: PLEXI_CONTEXT_ID is not set — run this inside a Plexi terminal pane");
+                return 1;
+            }
+        };
+        match raw.parse::<u64>() {
+            Ok(n) => Some(n),
+            Err(_) => {
+                eprintln!("error: PLEXI_CONTEXT_ID is not a valid number: {raw}");
+                return 1;
+            }
+        }
+    } else {
+        context
+    };
+
     let id = uuid::Uuid::new_v4();
     let response_file = crate::config::config_dir()
         .join(format!("pane-list-response-{id}.json"))
         .to_string_lossy()
         .into_owned();
 
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "type": "list_panes",
         "response_file": response_file,
     });
+    if let Some(cid) = context_id {
+        payload["context_id"] = serde_json::json!(cid);
+    }
 
-    log::info!("pane_list:cli: sending via socket response_file={:?}", response_file);
+    log::info!("pane_list:cli: sending via socket context_id={:?} response_file={:?}", context_id, response_file);
 
     let code = send_to_socket(payload);
     if code != 0 {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -407,7 +407,7 @@ pub enum PaneCmd {
     /// Filter by context with --context <id> or --current (reads PLEXI_CONTEXT_ID).
     List {
         /// Only return panes belonging to this context ID.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "current")]
         context: Option<u64>,
         /// Only return panes in the caller's context (reads PLEXI_CONTEXT_ID from env).
         #[arg(long)]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -403,7 +403,16 @@ pub enum PaneCmd {
         second: Option<String>,
     },
     /// List all open panes as a JSON array.
-    List,
+    ///
+    /// Filter by context with --context <id> or --current (reads PLEXI_CONTEXT_ID).
+    List {
+        /// Only return panes belonging to this context ID.
+        #[arg(long)]
+        context: Option<u64>,
+        /// Only return panes in the caller's context (reads PLEXI_CONTEXT_ID from env).
+        #[arg(long)]
+        current: bool,
+    },
     /// Move the visible focus to a specific pane.
     ///
     /// This moves what the user sees on screen — it does not change which pane an agent is running in.

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,7 @@ fn main() -> eframe::Result {
                             };
                             std::process::exit(cli::pane_set_title_cli(pane_id, &name))
                         }
-                        PaneCmd::List => std::process::exit(cli::pane_list_cli()),
+                        PaneCmd::List { context, current } => std::process::exit(cli::pane_list_cli(context, current)),
                         PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
                         PaneCmd::Close { pane_id } => {
                             let id = match pane_id {


### PR DESCRIPTION
Closes #1664

## Summary

- Adds `--context <id>` flag to `plexi pane list` to return only panes in a specific context
- Adds `--current` flag that auto-reads `PLEXI_CONTEXT_ID` from the caller's environment — intended for agents running inside a Plexi pane
- No flags preserves existing behavior (all panes returned)

## Done When

- `plexi pane list --current` run from inside a Plexi pane returns only panes whose `context_id` matches the caller's context
- `plexi pane list --context <id>` run outside a pane returns only panes for that context
- `plexi pane list` (no flags) still returns all panes, unchanged
- `cargo test --bin plexi` passes

## Notes

- `context_id` field in `ListPanes` protocol message uses `#[serde(default)]` so existing clients sending no filter field continue to work without changes
- Host-side filter is a window-level skip (each window maps 1:1 to a context), so no pane-level iteration waste

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context filtering to `plexi pane list` command: use `--context <ID>` to display panes from a specific context, or `--current` to show panes from your current context.
  * Backward compatible; existing commands without filters work unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->