### PR TITLE
refactor(skills): collapse ship pipeline to 2-phase with hand-off

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -255,19 +255,11 @@ gh issue edit <number> --body "$NEW_BODY"
 
 ---
 
-## Pipeline Labels
+## Chain to open-pr
 
-After pushing and writing the Ship Log, set pipeline state:
+After pushing and writing the Ship Log, invoke `/open-pr` inline — read and follow the open-pr skill now, in this same session. Pass the branch name explicitly.
 
-```bash
-gh issue edit <number> \
-  --add-label "pipeline:open-pr" \
-  --add-label "ready" \
-  --remove-label "pipeline:implement" \
-  --remove-label "in progress"
-```
-
-This is the only handoff mechanism. Never spawn a new pane or output "Next: /open-pr" as an instruction — PM reads the label and dispatches.
+Do not set pipeline labels. Do not stop. The chain continues: implement → open-pr → hand-off to validate-pr.
 
 ---
 

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -213,6 +213,18 @@ gh issue edit <number> --body "<updated body>"
 
 ---
 
+## Exit — Hand Off to Validate
+
+After the Ship Log entry is written, immediately hand off to validate-pr in a new pane and close self:
+
+```
+/hand-off /validate-pr <pr-number>
+```
+
+The new pane starts fresh — clean context for reviewing the PR without implementation baggage. Do not hand off on error or hard-reject paths — those stop here.
+
+---
+
 ## Rules
 
 - Never push to alpha, beta, or main directly

--- a/.claude/skills/ship-issue/scripts/run.sh
+++ b/.claude/skills/ship-issue/scripts/run.sh
@@ -1,188 +1,30 @@
 #!/usr/bin/env bash
-# Orchestrates the full ship pipeline for a single issue.
-# Spawns each phase in a new Plexi pane, waits for exit, reads the Ship Log,
-# then dispatches the next phase. Resumes mid-pipeline if called on an issue
-# that's already in flight.
+# Starts the ship pipeline for a single issue.
+#
+# The pipeline is self-orchestrating:
+#   implement-issue → open-pr (inline) → hand-off → validate-pr → merge-pr (inline)
+#
+# This script just spawns implement-issue. Everything else chains automatically.
 #
 # Usage: run.sh <issue-number>
 
 set -euo pipefail
 
 ISSUE=$1
-POLL_INTERVAL=60   # seconds between pane-alive checks
-LOG_POLL_INTERVAL=300  # seconds between Ship Log checks when pane is still alive
-
-# ── helpers ──────────────────────────────────────────────────────────────────
+REPO_DIR=$(git rev-parse --show-toplevel)
+PLEXI=plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL}
 
 log() { echo "[ship-issue #$ISSUE] $*"; }
 
-issue_body() {
-  gh issue view "$ISSUE" --json body --jq '.body'
-}
-
-ship_log() {
-  issue_body | awk '/^## Ship Log/,0'
-}
-
-last_marker() {
-  # Returns the last [MARKER] line found in the Ship Log section
-  ship_log | grep -oE '\[(IMPLEMENTED|PR OPENED|VALIDATED|HARD REJECT|COMPLETE)\]' | tail -1
-}
-
-pane_alive() {
-  local pane_id=$1
-  plexi pane list --json | jq -e ".[] | select(.id == $pane_id)" > /dev/null 2>&1
-}
-
-wait_for_pane_exit() {
-  local pane_id=$1
-  local phase=$2
-  log "Waiting for $phase pane ($pane_id) to exit..."
-  while pane_alive "$pane_id"; do
-    sleep "$POLL_INTERVAL"
-  done
-  log "$phase pane exited."
-}
-
-spawn() {
-  local cmd=$1
-  local pane_id
-  pane_id=$(plexi terminal -- bash -c "c '$cmd'; echo '[dispatch] pane done'; sleep 2" 2>/dev/null)
-  echo "$pane_id"
-}
-
-notify_orch() {
-  local title=$1
-  local body=$2
-  plexi notify \
-    --title "$title" \
-    --body "$body" \
-    --choice "ok:Dismiss" \
-    2>/dev/null || true
-}
-
-fail() {
-  local reason=$1
-  log "FAILED: $reason"
-  notify_orch "ship-issue #$ISSUE failed" "$reason"
+if [ -z "${PLEXI_PANE_ID:-}" ]; then
+  echo "ERROR: PLEXI_PANE_ID not set — must run inside a Plexi pane." >&2
   exit 1
-}
-
-# ── determine resume point ────────────────────────────────────────────────────
-
-MARKER=$(last_marker || true)
-log "Current Ship Log marker: ${MARKER:-none}"
-
-case "$MARKER" in
-  "")
-    START_PHASE="implement"
-    ;;
-  "[IMPLEMENTED]")
-    START_PHASE="open-pr"
-    ;;
-  "[PR OPENED]")
-    START_PHASE="validate"
-    ;;
-  "[VALIDATED]")
-    START_PHASE="merge"
-    ;;
-  "[COMPLETE]")
-    log "Issue #$ISSUE is already complete."
-    notify_orch "ship-issue #$ISSUE" "Already complete — nothing to do."
-    exit 0
-    ;;
-  "[HARD REJECT]")
-    log "Issue #$ISSUE was hard-rejected. Review the issue body before re-dispatching."
-    notify_orch "ship-issue #$ISSUE — hard reject" "Previous attempt hard-rejected. Issue body has Prior Attempts section. Review before re-dispatching."
-    exit 1
-    ;;
-  *)
-    fail "Unknown Ship Log marker: $MARKER"
-    ;;
-esac
-
-log "Resuming at phase: $START_PHASE"
-
-# ── phase: implement ──────────────────────────────────────────────────────────
-
-if [[ "$START_PHASE" == "implement" ]]; then
-  log "Spawning /implement-issue $ISSUE..."
-  PANE=$(spawn "/implement-issue $ISSUE")
-  wait_for_pane_exit "$PANE" "implement-issue"
-
-  MARKER=$(last_marker || true)
-  if [[ "$MARKER" != "[IMPLEMENTED]" ]]; then
-    fail "implement-issue exited but Ship Log shows '$MARKER' — expected [IMPLEMENTED]. Check pane output."
-  fi
-  log "implement-issue completed."
 fi
 
-# ── phase: open-pr ────────────────────────────────────────────────────────────
+log "Spawning /implement-issue $ISSUE..."
+$PLEXI terminal "c '/implement-issue $ISSUE'" \
+  --cwd "$REPO_DIR" \
+  --no-focus
 
-if [[ "$START_PHASE" == "implement" || "$START_PHASE" == "open-pr" ]]; then
-  # Extract branch from Ship Log
-  BRANCH=$(ship_log | grep "^\*\*Branch:\*\*" | tail -1 | awk '{print $2}')
-  if [[ -z "$BRANCH" ]]; then
-    fail "Could not extract branch name from Ship Log. Check issue #$ISSUE body."
-  fi
-  log "Spawning /open-pr $BRANCH..."
-  PANE=$(spawn "/open-pr $BRANCH")
-  wait_for_pane_exit "$PANE" "open-pr"
-
-  MARKER=$(last_marker || true)
-  if [[ "$MARKER" != "[PR OPENED]" ]]; then
-    fail "open-pr exited but Ship Log shows '$MARKER' — expected [PR OPENED]."
-  fi
-  log "open-pr completed."
-fi
-
-# ── phase: validate ───────────────────────────────────────────────────────────
-
-if [[ "$START_PHASE" == "implement" || "$START_PHASE" == "open-pr" || "$START_PHASE" == "validate" ]]; then
-  # Extract PR number from Ship Log
-  PR_NUMBER=$(ship_log | grep -oE 'PR #([0-9]+)' | tail -1 | grep -oE '[0-9]+')
-  if [[ -z "$PR_NUMBER" ]]; then
-    fail "Could not extract PR number from Ship Log. Check issue #$ISSUE body."
-  fi
-  log "Spawning /validate-pr $PR_NUMBER..."
-  PANE=$(spawn "/validate-pr $PR_NUMBER")
-
-  # validate-pr requires human interaction — we wait for pane exit but also
-  # poll the Ship Log to surface status updates to the orchestrator output.
-  log "validate-pr requires human testing. Polling every ${LOG_POLL_INTERVAL}s for updates..."
-  while pane_alive "$PANE"; do
-    CURRENT=$(last_marker || true)
-    log "  Ship Log: ${CURRENT:-in progress}"
-    sleep "$LOG_POLL_INTERVAL"
-  done
-
-  MARKER=$(last_marker || true)
-  if [[ "$MARKER" == "[HARD REJECT]" ]]; then
-    log "validate-pr hard-rejected PR #$PR_NUMBER. Issue #$ISSUE updated. Stopping."
-    notify_orch "ship-issue #$ISSUE — hard reject" "PR #$PR_NUMBER hard-rejected after 3 attempts. Issue body updated with Prior Attempts."
-    exit 1
-  fi
-  if [[ "$MARKER" != "[VALIDATED]" ]]; then
-    fail "validate-pr exited but Ship Log shows '$MARKER' — expected [VALIDATED] or [HARD REJECT]."
-  fi
-  log "validate-pr: PR approved."
-fi
-
-# ── phase: merge ──────────────────────────────────────────────────────────────
-
-PR_NUMBER=$(ship_log | grep -oE 'PR #([0-9]+)' | tail -1 | grep -oE '[0-9]+')
-if [[ -z "$PR_NUMBER" ]]; then
-  fail "Could not extract PR number from Ship Log before merge."
-fi
-log "Spawning /merge-pr $PR_NUMBER..."
-PANE=$(spawn "/merge-pr $PR_NUMBER")
-wait_for_pane_exit "$PANE" "merge-pr"
-
-MARKER=$(last_marker || true)
-if [[ "$MARKER" != "[COMPLETE]" ]]; then
-  fail "merge-pr exited but Ship Log shows '$MARKER' — expected [COMPLETE]."
-fi
-
-VERSION=$(ship_log | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
-log "Done. Issue #$ISSUE shipped as $VERSION."
-notify_orch "Shipped #$ISSUE" "Issue #$ISSUE closed — $VERSION"
+log "Pipeline is self-orchestrating:"
+log "  implement-issue → open-pr (inline) → /hand-off → validate-pr → merge-pr (inline)"


### PR DESCRIPTION
## Summary

- **implement-issue** now chains `/open-pr` inline (same Claude session) instead of setting a pipeline label and waiting for PM to dispatch
- **open-pr** hands off to `/validate-pr <pr-number>` at exit via `/hand-off`, closing itself and opening a fresh validate pane
- **validate-pr** already chained merge-pr inline — no change needed
- **ship-issue/run.sh** collapsed from 185-line 4-phase polling orchestrator to a single spawn
- **foreman** updated to track by issue labels instead of pane IDs (pane ID changes at the hand-off boundary)

## Result

Before: 3+ panes per issue (foreman → ship-issue watcher → implement-issue → open-pr → validate-pr → merge-pr)
After: 1 pane spawned per issue, 1 hand-off at the implement+open-pr → validate boundary

## Done When

- [ ] `/ship-issue <N>` spawns implement-issue pane which chains open-pr inline then hands off to validate-pr
- [ ] validate-pr pane chains merge-pr inline on pass
- [ ] No intermediate ship-issue watcher pane visible