### PR TITLE
fix(skills/dispatch): dispatch implement-issue directly, not ship-issue

### DIFF
--- a/.claude/skills/dispatch/scripts/open-lanes.sh
+++ b/.claude/skills/dispatch/scripts/open-lanes.sh
@@ -25,7 +25,7 @@ PREV_ID=$MY_PANE_ID
 LAYOUT=split_h
 
 for ISSUE in "$@"; do
-  PANE_ID=$($PLEXI terminal "c '/ship-issue $ISSUE'" \
+  PANE_ID=$($PLEXI terminal "c '/implement-issue $ISSUE'" \
     --layout $LAYOUT \
     --from-pane-id $PREV_ID \
     --cwd "$REPO_DIR" \


### PR DESCRIPTION
## Summary

- `open-lanes.sh` was sending `c '/ship-issue $ISSUE'` to each lane pane
- ship-issue's Claude then read the skill and ran `run.sh`, which spawned a NEW pane with `c '/implement-issue $ISSUE'`
- Result: 2 panes per issue (ship-issue watcher + implement-issue worker), same layering problem as before

One-line fix: dispatch `implement-issue` directly. Since implement-issue now chains open-pr inline then hands off to validate-pr, it owns the full pipeline. ship-issue as a dispatch target is redundant.

## Done When

- [ ] Dispatching an issue via foreman/project-manager creates exactly 1 pane per issue (the implement-issue pane)
- [ ] That pane chains open-pr inline, then hands off to a validate-pr pane
- [ ] No intermediate ship-issue watcher pane appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated issue processing in dispatch lanes to use the correct workflow command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->