### PR TITLE
fix(apps/logs): copy-to-clipboard does nothing — text never reaches macOS pasteboard (#1679)

### DIFF
--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -193,8 +193,12 @@ class RenderContext:
                      "fit": fit})
 
     def copy_to_clipboard(self, text: str) -> None:
-        """Convenience shortcut for `emit.copy_to_clipboard(text)` (#146)."""
-        self._queue({"type": "copy_to_clipboard", "text": text})
+        """Write `text` to the OS clipboard via the host.
+
+        Uses _emit (immediate write) rather than _queue so this works from
+        on_key and other hook handlers where frame_done() is never called.
+        """
+        _emit({"type": "copy_to_clipboard", "text": text})
 
     def badge(self, x: float, y_center: float, label: str,
               fill: str = ACCENT, fg: str = BG,

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1213,6 +1213,8 @@ impl ProcessApp {
             // owns the clipboard backend selection (pasteboard / X11 /
             // Wayland / Win32) — we just hand egui the string.
             ControlCommand::CopyToClipboard { text } => {
+                let preview = text.chars().take(80).collect::<String>();
+                log::info!(target: &format!("app::{}", self.type_id), "copy_to_clipboard: {} chars: {:?}", text.len(), preview);
                 ui.ctx().copy_text(text);
             }
             // MeasureText is handled here (not in routing.rs) because it


### PR DESCRIPTION
Closes #1679

## Summary

- `ctx.copy_to_clipboard()` was buffering the command via `_queue`, but `on_key` hooks never call `frame_done()`, so the command was silently dropped before reaching the host
- Fixed by switching `RenderContext.copy_to_clipboard` to use `_emit` (immediate stdout write) instead of `_queue`, matching `emit.copy_to_clipboard` and making the docstring accurate
- Added `log::info!` in the Rust `CopyToClipboard` handler so clipboard ops appear in `plexi.log` for diagnostics

## Done When

`y` in copy mode puts the selected log lines on the macOS clipboard; Cmd+V in Terminal pastes the text.

## Notes

Root cause: `_dispatch_hook_task` fires `on_key` as a fire-and-forget background task with no `frame_done()` call. Any `_queue`-buffered control commands from these hooks were lost. `copy_to_clipboard` has no render-frame dependency, so emitting immediately is correct. Other control commands (`ScheduleRender`, `MeasureText`) are handled inline during render and are unaffected.