### PR TITLE
feat(host/pane-ops): send pane in direction — Ctrl+Opt+Cmd+HJKL moves pane without following focus (#1710)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3342,6 +3342,44 @@ impl eframe::App for PlexiApp {
                         crate::pane_ops::SwapResult::NoFocus => {}
                     }
                 }
+                Action::SendPane(dir) => {
+                    match self.send_pane(dir) {
+                        crate::pane_ops::SwapResult::Swapped {
+                            rect_a, rect_b, ..
+                        } => {
+                            let now = std::time::Instant::now();
+                            self.pane_anims = vec![
+                                PaneSwapAnim { from: rect_a, to: rect_b, started_at: now },
+                                PaneSwapAnim { from: rect_b, to: rect_a, started_at: now },
+                            ];
+                            self.ctx.request_repaint();
+                        }
+                        crate::pane_ops::SwapResult::AtBoundary => {
+                            let moved = match dir {
+                                crate::keys::Direction::Down => {
+                                    self.move_focused_pane_to_row_boundary(true)
+                                }
+                                crate::keys::Direction::Up => {
+                                    self.move_focused_pane_to_row_boundary(false)
+                                }
+                                _ => self.move_focused_pane_to_adjacent_window(dir),
+                            };
+                            if moved {
+                                self.ctx.request_repaint();
+                            } else if let Some(focused) =
+                                self.windows[self.active_window].focused_pane
+                            {
+                                self.edge_pulse = Some(EdgePulse {
+                                    tile: focused,
+                                    dir,
+                                    started_at: std::time::Instant::now(),
+                                });
+                                self.ctx.request_repaint();
+                            }
+                        }
+                        crate::pane_ops::SwapResult::NoFocus => {}
+                    }
+                }
                 Action::ClosePane => {
                     // If the focused app pane has a non-empty nav stack
                     // (via PushNav), Escape routes NavBack to the app

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3356,23 +3356,14 @@ impl eframe::App for PlexiApp {
                             ];
                             self.ctx.request_repaint();
                         }
-                        crate::pane_ops::SwapResult::AtBoundary => {
-                            log::info!("action: send_pane at_boundary dir={dir:?}");
-                            let moved = match dir {
-                                crate::keys::Direction::Down => {
-                                    self.move_focused_pane_to_row_boundary(true)
-                                }
-                                crate::keys::Direction::Up => {
-                                    self.move_focused_pane_to_row_boundary(false)
-                                }
-                                _ => self.move_focused_pane_to_adjacent_window(dir),
-                            };
-                            if moved {
-                                self.ctx.request_repaint();
-                            } else if let Some(focused) =
+                        crate::pane_ops::SwapResult::AtBoundary
+                        | crate::pane_ops::SwapResult::NoFocus => {
+                            // Send never moves to a new window — focus can't stay at an empty
+                            // slot. Edge-pulse the boundary instead.
+                            log::info!("action: send_pane at_boundary or no_focus dir={dir:?}");
+                            if let Some(focused) =
                                 self.windows[self.active_window].focused_pane
                             {
-                                log::info!("action: send_pane blocked edge_pulse dir={dir:?} tile={focused:?}");
                                 self.edge_pulse = Some(EdgePulse {
                                     tile: focused,
                                     dir,
@@ -3380,9 +3371,6 @@ impl eframe::App for PlexiApp {
                                 });
                                 self.ctx.request_repaint();
                             }
-                        }
-                        crate::pane_ops::SwapResult::NoFocus => {
-                            log::info!("action: send_pane ignored: no focused pane");
                         }
                     }
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3343,10 +3343,12 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SendPane(dir) => {
+                    log::info!("action: send_pane dir={dir:?}");
                     match self.send_pane(dir) {
                         crate::pane_ops::SwapResult::Swapped {
                             rect_a, rect_b, ..
                         } => {
+                            log::info!("action: send_pane swapped dir={dir:?}");
                             let now = std::time::Instant::now();
                             self.pane_anims = vec![
                                 PaneSwapAnim { from: rect_a, to: rect_b, started_at: now },
@@ -3355,6 +3357,7 @@ impl eframe::App for PlexiApp {
                             self.ctx.request_repaint();
                         }
                         crate::pane_ops::SwapResult::AtBoundary => {
+                            log::info!("action: send_pane at_boundary dir={dir:?}");
                             let moved = match dir {
                                 crate::keys::Direction::Down => {
                                     self.move_focused_pane_to_row_boundary(true)
@@ -3369,6 +3372,7 @@ impl eframe::App for PlexiApp {
                             } else if let Some(focused) =
                                 self.windows[self.active_window].focused_pane
                             {
+                                log::info!("action: send_pane blocked edge_pulse dir={dir:?} tile={focused:?}");
                                 self.edge_pulse = Some(EdgePulse {
                                     tile: focused,
                                     dir,
@@ -3377,7 +3381,9 @@ impl eframe::App for PlexiApp {
                                 self.ctx.request_repaint();
                             }
                         }
-                        crate::pane_ops::SwapResult::NoFocus => {}
+                        crate::pane_ops::SwapResult::NoFocus => {
+                            log::info!("action: send_pane ignored: no focused pane");
+                        }
                     }
                 }
                 Action::ClosePane => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,9 @@ const KNOWN_AI_OLLAMA: &[&str] = &["host", "model_low", "model_medium", "model_h
 const KNOWN_KEYBINDINGS: &[&str] = &[
     "quit", "close_pane", "toggle_command_palette", "split_horizontal",
     "split_vertical", "split_right", "split_down", "swap_pane_left",
-    "swap_pane_down", "swap_pane_up", "swap_pane_right", "navigate_left",
+    "swap_pane_down", "swap_pane_up", "swap_pane_right",
+    "send_pane_left", "send_pane_down", "send_pane_up", "send_pane_right",
+    "navigate_left",
     "navigate_down", "navigate_up", "navigate_right", "new_tab", "next_tab",
     "prev_tab", "first_tab", "last_tab", "nav_back", "focus_history_forward",
     "toggle_sidebar", "toggle_zoom", "toggle_shortcuts", "rename_context",
@@ -180,6 +182,10 @@ pub struct KeybindingsConfig {
     pub swap_pane_down: Option<String>,
     pub swap_pane_up: Option<String>,
     pub swap_pane_right: Option<String>,
+    pub send_pane_left: Option<String>,
+    pub send_pane_down: Option<String>,
+    pub send_pane_up: Option<String>,
+    pub send_pane_right: Option<String>,
     pub navigate_left: Option<String>,
     pub navigate_down: Option<String>,
     pub navigate_up: Option<String>,
@@ -234,6 +240,10 @@ impl KeybindingsConfig {
         overlay_field!(swap_pane_down);
         overlay_field!(swap_pane_up);
         overlay_field!(swap_pane_right);
+        overlay_field!(send_pane_left);
+        overlay_field!(send_pane_down);
+        overlay_field!(send_pane_up);
+        overlay_field!(send_pane_right);
         overlay_field!(navigate_left);
         overlay_field!(navigate_down);
         overlay_field!(navigate_up);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,6 +10,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+W                       — close pane
 // Cmd+H/J/K/L                 — navigate panes (falls through to adjacent window at boundary)
 // Cmd+Ctrl+H/J/K/L            — swap focused pane with neighbor in direction
+// Ctrl+Opt+Cmd+H/J/K/L        — send pane in direction (focus stays at vacated slot)
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
 // Cmd+Shift+L/H               — next/prev tab
@@ -121,6 +122,9 @@ pub enum Action {
     /// Swap the focused pane with its neighbor in the given direction.
     /// Bound to Cmd+Ctrl+H/J/K/L.
     SwapPane(Direction),
+    /// Send the focused pane in the given direction; focus stays at the vacated slot.
+    /// Bound to Ctrl+Opt+Cmd+H/J/K/L.
+    SendPane(Direction),
     /// Open the scratchpad overlay. Bound to Cmd+Shift+Space.
     OpenScratchpad,
     /// Zoom into the sub-context tile that has focus. Bound to Cmd+Shift+Enter.
@@ -144,6 +148,10 @@ pub struct KeyBindings {
     pub swap_pane_down: (egui::Modifiers, egui::Key),
     pub swap_pane_up: (egui::Modifiers, egui::Key),
     pub swap_pane_right: (egui::Modifiers, egui::Key),
+    pub send_pane_left: (egui::Modifiers, egui::Key),
+    pub send_pane_down: (egui::Modifiers, egui::Key),
+    pub send_pane_up: (egui::Modifiers, egui::Key),
+    pub send_pane_right: (egui::Modifiers, egui::Key),
     pub navigate_left: (egui::Modifiers, egui::Key),
     pub navigate_down: (egui::Modifiers, egui::Key),
     pub navigate_up: (egui::Modifiers, egui::Key),
@@ -190,6 +198,9 @@ fn cmd_ctrl() -> egui::Modifiers {
 fn cmd_alt() -> egui::Modifiers {
     egui::Modifiers { alt: true, ..egui::Modifiers::COMMAND }
 }
+fn cmd_ctrl_alt() -> egui::Modifiers {
+    egui::Modifiers { ctrl: true, alt: true, ..egui::Modifiers::COMMAND }
+}
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {
@@ -200,10 +211,14 @@ impl Default for KeyBindings {
             split_vertical:            (cmd_shift(), egui::Key::D),
             split_right:               (cmd(),       egui::Key::Backslash),
             split_down:                (cmd_shift(), egui::Key::Backslash),
-            swap_pane_left:            (cmd_ctrl(),  egui::Key::H),
-            swap_pane_down:            (cmd_ctrl(),  egui::Key::J),
-            swap_pane_up:              (cmd_ctrl(),  egui::Key::K),
-            swap_pane_right:           (cmd_ctrl(),  egui::Key::L),
+            swap_pane_left:            (cmd_ctrl(),     egui::Key::H),
+            swap_pane_down:            (cmd_ctrl(),     egui::Key::J),
+            swap_pane_up:              (cmd_ctrl(),     egui::Key::K),
+            swap_pane_right:           (cmd_ctrl(),     egui::Key::L),
+            send_pane_left:            (cmd_ctrl_alt(), egui::Key::H),
+            send_pane_down:            (cmd_ctrl_alt(), egui::Key::J),
+            send_pane_up:              (cmd_ctrl_alt(), egui::Key::K),
+            send_pane_right:           (cmd_ctrl_alt(), egui::Key::L),
             navigate_left:             (cmd(),       egui::Key::H),
             navigate_down:             (cmd(),       egui::Key::J),
             navigate_up:               (cmd(),       egui::Key::K),
@@ -355,6 +370,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(swap_pane_down, "swap_pane_down");
     apply_override!(swap_pane_up, "swap_pane_up");
     apply_override!(swap_pane_right, "swap_pane_right");
+    apply_override!(send_pane_left, "send_pane_left");
+    apply_override!(send_pane_down, "send_pane_down");
+    apply_override!(send_pane_up, "send_pane_up");
+    apply_override!(send_pane_right, "send_pane_right");
     apply_override!(navigate_left, "navigate_left");
     apply_override!(navigate_down, "navigate_down");
     apply_override!(navigate_up, "navigate_up");
@@ -401,6 +420,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("swap_pane_down",            bindings.swap_pane_down),
         ("swap_pane_up",              bindings.swap_pane_up),
         ("swap_pane_right",           bindings.swap_pane_right),
+        ("send_pane_left",            bindings.send_pane_left),
+        ("send_pane_down",            bindings.send_pane_down),
+        ("send_pane_up",              bindings.send_pane_up),
+        ("send_pane_right",           bindings.send_pane_right),
         ("navigate_left",             bindings.navigate_left),
         ("navigate_down",             bindings.navigate_down),
         ("navigate_up",               bindings.navigate_up),
@@ -487,6 +510,20 @@ pub fn poll_actions(
             actions.push(Action::SplitVertical);
         } else if input.consume_key(bindings.split_horizontal.0, bindings.split_horizontal.1) {
             actions.push(Action::SplitHorizontal);
+        }
+
+        // Pane send (Ctrl+Opt+Cmd) — check before swap (more specific modifier set).
+        if input.consume_key(bindings.send_pane_left.0, bindings.send_pane_left.1) {
+            actions.push(Action::SendPane(Direction::Left));
+        }
+        if input.consume_key(bindings.send_pane_down.0, bindings.send_pane_down.1) {
+            actions.push(Action::SendPane(Direction::Down));
+        }
+        if input.consume_key(bindings.send_pane_up.0, bindings.send_pane_up.1) {
+            actions.push(Action::SendPane(Direction::Up));
+        }
+        if input.consume_key(bindings.send_pane_right.0, bindings.send_pane_right.1) {
+            actions.push(Action::SendPane(Direction::Right));
         }
 
         // Pane swap — check before plain pane navigation.

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -823,6 +823,50 @@ impl PlexiApp {
         SwapResult::Swapped { rect_a, rect_b }
     }
 
+    pub(crate) fn send_pane(&mut self, dir: Direction) -> SwapResult {
+        use egui_tiles::Tile;
+        let active = self.active_window;
+        let ctx = &mut self.windows[active];
+
+        let Some(focused) = ctx.focused_pane else {
+            return SwapResult::NoFocus;
+        };
+
+        let Some(neighbor) = ctx.find_pane_in_direction_from(focused, dir) else {
+            log::info!("send_pane({:?}): at boundary, no neighbor", dir);
+            return SwapResult::AtBoundary;
+        };
+
+        let rect_a = ctx.tree.tiles.rect(focused).unwrap_or(egui::Rect::ZERO);
+        let rect_b = ctx.tree.tiles.rect(neighbor).unwrap_or(egui::Rect::ZERO);
+
+        let pane_a = match ctx.tree.tiles.get(focused) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+        let pane_b = match ctx.tree.tiles.get(neighbor) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(focused) {
+            *id = pane_b;
+        }
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(neighbor) {
+            *id = pane_a;
+        }
+
+        // Focus stays at the vacated slot (now containing pane_b).
+        ctx.focused_pane = Some(focused);
+
+        log::info!(
+            "send_pane({:?}): pane {} ↔ pane {} (tiles {:?} ↔ {:?}) — focus stays at {:?}",
+            dir, pane_a, pane_b, focused, neighbor, focused
+        );
+
+        SwapResult::Swapped { rect_a, rect_b }
+    }
+
     /// Move the focused pane to the first (`end=false`, Cmd+Ctrl+K) or last
     /// (`end=true`, Cmd+Ctrl+J) column position in the current context row by
     /// creating a new window at that boundary. Returns `true` if the move
@@ -1442,6 +1486,45 @@ mod swap_tests {
         app.windows[0].focused_pane = Some(tile);
         // No neighbors (rects unset = Rect::ZERO, geometric search returns None)
         assert!(matches!(app.swap_pane(Direction::Right), SwapResult::AtBoundary));
+    }
+}
+
+#[cfg(test)]
+mod send_pane_tests {
+    use super::*;
+
+    fn test_app() -> PlexiApp {
+        let ctx = egui::Context::default();
+        let ft = crate::logging::new_frame_tick();
+        PlexiApp::new_for_test(ctx, ft).0
+    }
+
+    #[test]
+    fn send_pane_no_focus_returns_no_focus() {
+        let mut app = test_app();
+        assert!(matches!(app.send_pane(Direction::Right), SwapResult::NoFocus));
+    }
+
+    #[test]
+    fn send_pane_at_boundary_with_single_pane() {
+        let mut app = test_app();
+        let tile = app.windows[0].tree.tiles.insert_pane(1u64);
+        app.windows[0].focused_pane = Some(tile);
+        assert!(matches!(app.send_pane(Direction::Right), SwapResult::AtBoundary));
+    }
+
+    #[test]
+    fn send_pane_with_focused_pane_and_no_neighbor_is_at_boundary() {
+        // Verifies: focused pane + no geometric neighbor → AtBoundary (not NoFocus).
+        // The focus-stays-at-source-tile invariant is verified in layout code:
+        // `ctx.focused_pane = Some(focused)` on Swapped (unit-testable only after
+        // a rendered frame sets tile rects, which isn't available in headless tests).
+        let mut app = test_app();
+        let tile = app.windows[0].tree.tiles.insert_pane(10u64);
+        app.windows[0].focused_pane = Some(tile);
+        assert!(matches!(app.send_pane(Direction::Right), SwapResult::AtBoundary));
+        // Focus is unchanged when at boundary.
+        assert_eq!(app.windows[0].focused_pane, Some(tile));
     }
 }
 


### PR DESCRIPTION
Closes #1710

## Summary

- Adds `SendPane(Direction)` action bound to `Ctrl+Opt+Cmd+HJKL` — the complement to `SwapPane(Cmd+Ctrl+HJKL)`. Both swap adjacent panes, but `SendPane` keeps focus at the vacated slot (you stay; the pane moves away) while `SwapPane` follows the content
- Wires up the full keybinding stack: `cmd_ctrl_alt()` modifier helper, 4 new `send_pane_*` fields in `KeyBindings` and `KeybindingsConfig`, `apply_override!` entries, conflict-detection array, and input-loop detection (checked before swap block, as it has a more specific modifier set)
- `send_pane()` in `layout.rs` mirrors `swap_pane()` except `ctx.focused_pane = Some(focused)` instead of `Some(neighbor)`; 3 unit tests cover no-focus, at-boundary, and focus-preserved-at-boundary cases

## Done When

- Pressing Ctrl+Opt+Cmd+L while focused on pane 2 of 3 moves pane 2 to slot 3; the pane that was in slot 3 is now in slot 2 and is focused.
- Swap (Cmd+Ctrl+L) behavior is unchanged.
- `cargo test --bin plexi` green.

## Notes

- `egui_tiles::Tiles` has no `set_rect` — tile rects only exist after a render frame, so the Swapped case for `send_pane` can't be exercised in headless unit tests. The focus invariant (`focused_pane = Some(focused)`) is directly visible in the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pane-send functionality, enabling users to move the focused pane in a specified direction while keeping focus in the original location.
  * Extended keybindings configuration system to support new customizable shortcuts for sending panes in all directions (left, down, up, right).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->