### PR TITLE
bug(host): command palette app list is stale — registry not re-scanned after app init or filesystem changes (#1712)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -393,6 +393,11 @@ pub struct PlexiApp {
     /// a signal so `reload_config()` runs automatically.
     pub(crate) _config_watcher: Option<crate::config_watcher::ConfigWatcher>,
     pub(crate) config_reload_rx: Option<std::sync::mpsc::Receiver<()>>,
+    /// App registry filesystem watcher (#1712). Watches the global and workspace-local
+    /// apps dirs; signals `registry_reload_rx` on any directory change so the registry
+    /// is rescanned without a host restart.
+    pub(crate) _registry_watcher: Option<crate::app_registry_watcher::AppRegistryWatcher>,
+    pub(crate) registry_reload_rx: Option<std::sync::mpsc::Receiver<()>>,
     /// Watched panes scheduled for crash-restart. Value is the earliest `Instant` at
     /// which the restart fires — giving the developer ~2s to read the crash overlay.
     pub(crate) pending_crash_restarts: HashMap<PaneId, std::time::Instant>,
@@ -676,6 +681,13 @@ impl PlexiApp {
         let cwd = std::env::current_dir().unwrap_or_default();
         let registry = AppRegistry::load(&cwd);
 
+        let (mut reg_watcher, mut reg_reload_rx) = match crate::app_registry_watcher::start(
+            crate::app_registry::registry_watch_dirs(&cwd),
+        ) {
+            Some((w, rx)) => (Some(w), Some(rx)),
+            None => (None, None),
+        };
+
         // Initialize the event log. Global log goes to ~/.plexi-*/events.jsonl;
         // workspace log goes to .plexi/events.jsonl if we're inside a workspace.
         {
@@ -938,6 +950,8 @@ impl PlexiApp {
                     hot_reload_rx: hr_rx,
                     _config_watcher: cfg_watcher.take(),
                     config_reload_rx: cfg_reload_rx.take(),
+                    _registry_watcher: reg_watcher.take(),
+                    registry_reload_rx: reg_reload_rx.take(),
                     pending_crash_restarts: HashMap::new(),
                     minimap: crate::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
@@ -995,6 +1009,16 @@ impl PlexiApp {
             }
             None => ("Default".to_string(), None, None),
         };
+
+        let default_cwd = std::env::current_dir().unwrap_or_default();
+        let default_registry = AppRegistry::load(&default_cwd);
+        let (mut default_reg_watcher, mut default_reg_reload_rx) =
+            match crate::app_registry_watcher::start(
+                crate::app_registry::registry_watch_dirs(&default_cwd),
+            ) {
+                Some((w, rx)) => (Some(w), Some(rx)),
+                None => (None, None),
+            };
 
         Self {
             pty_event_rx: rx,
@@ -1064,7 +1088,7 @@ impl PlexiApp {
             rename_pane_focus_requested: false,
             text_overlay: None,
             text_overlay_browse_rx: None,
-            registry: AppRegistry::load(&std::env::current_dir().unwrap_or_default()),
+            registry: default_registry,
             features,
             pending_notifications: load_pending_notifications_from(&crate::config::config_dir().join("notifications.json")),
             show_notification_modal: false,
@@ -1097,6 +1121,8 @@ impl PlexiApp {
             hot_reload_rx: hr_rx2,
             _config_watcher: cfg_watcher.take(),
             config_reload_rx: cfg_reload_rx.take(),
+            _registry_watcher: default_reg_watcher.take(),
+            registry_reload_rx: default_reg_reload_rx.take(),
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -1256,6 +1282,8 @@ impl PlexiApp {
             hot_reload_rx: hr_rx,
             _config_watcher: None,
             config_reload_rx: None,
+            _registry_watcher: None,
+            registry_reload_rx: None,
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -3655,6 +3683,23 @@ impl eframe::App for PlexiApp {
             });
         if config_changed {
             self.reload_config();
+        }
+
+        // App registry hot-reload (#1712): drain filesystem watcher signals.
+        let registry_changed = self
+            .registry_reload_rx
+            .as_ref()
+            .map_or(false, |rx| {
+                let hit = rx.try_recv().is_ok();
+                if hit {
+                    while rx.try_recv().is_ok() {}
+                }
+                hit
+            });
+        if registry_changed {
+            log::info!("app_registry_watcher: rescanning registry");
+            let cwd = std::env::current_dir().unwrap_or_default();
+            self.registry = crate::app_registry::AppRegistry::load(&cwd);
         }
 
         // Handle window close request (X button or macOS Cmd+Q OS event).

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -792,8 +792,11 @@ pub fn registry_watch_dirs(cwd: &Path) -> Vec<PathBuf> {
     let mut dirs = vec![apps_dir()];
     let channel_dir = registry_config_dir();
     if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
-        dirs.push(root.join(&channel_dir).join("apps"));
-        dirs.push(root.join(&channel_dir).join("agents"));
+        let channel_root = root.join(&channel_dir);
+        // Watch the channel dir itself (catches links.toml changes from `app link`).
+        dirs.push(channel_root.clone());
+        dirs.push(channel_root.join("apps"));
+        dirs.push(channel_root.join("agents"));
     }
     dirs
 }

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -785,6 +785,19 @@ pub fn resolve_workspace_root(start: &Path) -> Option<PathBuf> {
     resolve_workspace_root_with_channel(start, &registry_config_dir())
 }
 
+/// Returns the directories that [`load`] would scan for the given `cwd`.
+/// Passed to `app_registry_watcher::start()` so the watcher covers exactly the
+/// same paths the registry uses — no independent workspace detection.
+pub fn registry_watch_dirs(cwd: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![apps_dir()];
+    let channel_dir = registry_config_dir();
+    if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
+        dirs.push(root.join(&channel_dir).join("apps"));
+        dirs.push(root.join(&channel_dir).join("agents"));
+    }
+    dirs
+}
+
 fn resolve_workspace_root_with_channel(start: &Path, channel_dir: &str) -> Option<PathBuf> {
     let home = dirs::home_dir();
     let mut current = start.to_path_buf();

--- a/src/app_registry_watcher.rs
+++ b/src/app_registry_watcher.rs
@@ -27,7 +27,9 @@ impl Drop for AppRegistryWatcher {
             *c = true;
         }
         if let Some(h) = self.thread.take() {
-            let _ = h.join();
+            if let Err(e) = h.join() {
+                log::warn!("app_registry_watcher: debounce thread panicked: {e:?}");
+            }
         }
     }
 }

--- a/src/app_registry_watcher.rs
+++ b/src/app_registry_watcher.rs
@@ -1,0 +1,114 @@
+//! Watches the global and workspace-local app directories for filesystem changes
+//! and emits debounced reload signals so the host can rescan the `AppRegistry`
+//! without a restart. (#1712)
+//!
+//! Mirrors `config_watcher.rs` but watches a list of directories (not a single
+//! file) with a 500 ms debounce — scaffolding creates many files in rapid
+//! succession, so a longer window avoids redundant rescans.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const DEBOUNCE_MS: u64 = 500;
+
+pub struct AppRegistryWatcher {
+    _watcher: RecommendedWatcher,
+    cancel: Arc<Mutex<bool>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for AppRegistryWatcher {
+    fn drop(&mut self) {
+        if let Ok(mut c) = self.cancel.lock() {
+            *c = true;
+        }
+        if let Some(h) = self.thread.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Start watching `dirs`, filtering to those that currently exist.
+///
+/// Returns `None` if no directories could be watched (e.g. the global apps dir
+/// has never been created). Any `Create`, `Modify`, or `Remove` event in any
+/// watched directory fires a signal on the returned `Receiver<()>`.
+pub fn start(dirs: Vec<PathBuf>) -> Option<(AppRegistryWatcher, Receiver<()>)> {
+    let existing: Vec<PathBuf> = dirs.into_iter().filter(|d| d.is_dir()).collect();
+    if existing.is_empty() {
+        log::info!("app_registry_watcher: no existing dirs to watch; watcher not started");
+        return None;
+    }
+
+    let (reload_tx, reload_rx) = mpsc::channel::<()>();
+    let (raw_tx, raw_rx) = mpsc::channel::<()>();
+
+    let mut watcher = match notify::recommended_watcher(move |res: notify::Result<Event>| {
+        match res {
+            Ok(ev) => {
+                if matches!(
+                    ev.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                ) {
+                    let _ = raw_tx.send(());
+                }
+            }
+            Err(e) => log::warn!("app_registry_watcher: watcher error: {e}"),
+        }
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            log::warn!("app_registry_watcher: failed to create watcher: {e}");
+            return None;
+        }
+    };
+
+    for dir in &existing {
+        if let Err(e) = watcher.watch(dir, RecursiveMode::NonRecursive) {
+            log::warn!("app_registry_watcher: failed to watch {dir:?}: {e}");
+        } else {
+            log::info!("app_registry_watcher: watching {dir:?}");
+        }
+    }
+
+    let cancel = Arc::new(Mutex::new(false));
+    let cancel_thread = Arc::clone(&cancel);
+    let thread = thread::spawn(move || {
+        debounce_loop(raw_rx, reload_tx, cancel_thread);
+    });
+
+    Some((AppRegistryWatcher { _watcher: watcher, cancel, thread: Some(thread) }, reload_rx))
+}
+
+fn debounce_loop(rx: Receiver<()>, sender: Sender<()>, cancel: Arc<Mutex<bool>>) {
+    let mut last_event: Option<Instant> = None;
+    let debounce = Duration::from_millis(DEBOUNCE_MS);
+    let poll = Duration::from_millis(50);
+    loop {
+        if cancel.lock().map(|g| *g).unwrap_or(true) {
+            return;
+        }
+        match rx.try_recv() {
+            Ok(()) => {
+                last_event = Some(Instant::now());
+            }
+            Err(TryRecvError::Disconnected) => return,
+            Err(TryRecvError::Empty) => {
+                if let Some(t) = last_event {
+                    if t.elapsed() >= debounce {
+                        log::info!("app_registry_watcher: apps dir changed, rescanning registry");
+                        if sender.send(()).is_err() {
+                            return;
+                        }
+                        last_event = None;
+                    }
+                }
+                thread::sleep(poll);
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod app_permissions;
 mod app_protocol;
 mod app_render;
 mod app_registry;
+mod app_registry_watcher;
 mod app_trait;
 mod audio;
 mod cli;


### PR DESCRIPTION
Closes #1712

## Summary

- Added `app_registry_watcher` module (mirrors `config_watcher` pattern) that watches the global and workspace-local apps dirs using the `notify` crate with a 500ms debounce
- Added `registry_watch_dirs(cwd)` to `app_registry.rs` so the watcher covers exactly the same paths `AppRegistry::load()` uses — no independent workspace detection
- In `update()`, drains `registry_reload_rx` each frame and calls `AppRegistry::load(&cwd)` when signaled; both `new()` branches wire up the watcher, test constructor gets `None`

## Done When

1. `plexi app init myapp` from a workspace dir — `myapp` appears in ⌘P within ~1 second without restarting.
2. Deleting an app directory from disk — the app disappears from ⌘P within ~1 second.
3. `cargo test --bin plexi` is green.

## Notes

- Debounce is 500ms (vs 200ms for config_watcher) because `app init` scaffolds create many files rapidly; the longer window collapses all of them into one reload signal
- `registry_watch_dirs` uses `RecursiveMode::NonRecursive` on each dir — detects app creation/deletion at the directory level without firing on every file write inside an app
- 7 pre-existing test failures on alpha (canvas_bindings, ai_tests, install, cli_registry) — unchanged by this PR