### PR TITLE
fix(cli): workspace init does not create channel dir — resolve_workspace_root fails on non-stable channels (#1720)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -371,15 +371,19 @@ pub fn workspace_init() -> i32 {
             log::info!("workspace_init:cli: initialized workspace_id={} at {}", cfg.id, cwd.display());
             let channel_dir = app_init_config_dir();
             let channel_path = cwd.join(&channel_dir);
-            if let Err(e) = std::fs::create_dir_all(&channel_path) {
+            let channel_created = if let Err(e) = std::fs::create_dir_all(&channel_path) {
                 log::warn!("workspace_init:cli: could not create channel dir {}: {e}", channel_path.display());
+                false
             } else {
                 log::info!("workspace_init:cli: created channel dir {}", channel_path.display());
-            }
+                true
+            };
             println!("Initialized workspace at {}", cwd.display());
             println!("  workspace id: {}", cfg.id);
             println!("  router:       .plexi/secrets.toml (fallback = true)");
-            println!("  channel dir:  {channel_dir}/");
+            if channel_created {
+                println!("  channel dir:  {channel_dir}/");
+            }
             print_tip("define runnable commands in .plexi/commands.toml, then run them with `plexi run <name>`.");
             0
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -369,9 +369,17 @@ pub fn workspace_init() -> i32 {
     match crate::workspace_secrets::init_workspace(&cwd) {
         Ok(cfg) => {
             log::info!("workspace_init:cli: initialized workspace_id={} at {}", cfg.id, cwd.display());
+            let channel_dir = app_init_config_dir();
+            let channel_path = cwd.join(&channel_dir);
+            if let Err(e) = std::fs::create_dir_all(&channel_path) {
+                log::warn!("workspace_init:cli: could not create channel dir {}: {e}", channel_path.display());
+            } else {
+                log::info!("workspace_init:cli: created channel dir {}", channel_path.display());
+            }
             println!("Initialized workspace at {}", cwd.display());
             println!("  workspace id: {}", cfg.id);
             println!("  router:       .plexi/secrets.toml (fallback = true)");
+            println!("  channel dir:  {channel_dir}/");
             print_tip("define runnable commands in .plexi/commands.toml, then run them with `plexi run <name>`.");
             0
         }
@@ -5122,5 +5130,55 @@ mod app_run_tests {
         let path = dir.path().to_string_lossy().to_string();
         let code = super::app_run(&path);
         assert_eq!(code, 1);
+    }
+}
+
+#[cfg(test)]
+mod workspace_init_tests {
+    use std::fs;
+
+    /// Calls the internal init_workspace logic and then the channel-dir creation
+    /// on a temp dir, asserting both `.plexi/` and the channel dir are present.
+    #[test]
+    fn workspace_init_creates_channel_dir_alongside_plexi_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().to_path_buf();
+
+        // Run init_workspace (creates .plexi/)
+        crate::workspace_secrets::init_workspace(&cwd)
+            .expect("init_workspace should succeed in a temp dir");
+
+        // Replicate the channel dir creation from workspace_init()
+        let channel_dir = super::app_init_config_dir();
+        let channel_path = cwd.join(&channel_dir);
+        fs::create_dir_all(&channel_path).expect("create_dir_all should succeed");
+
+        assert!(
+            cwd.join(".plexi").is_dir(),
+            ".plexi/ dir must exist after workspace init"
+        );
+        assert!(
+            channel_path.is_dir(),
+            "{channel_dir}/ dir must exist after workspace init"
+        );
+    }
+
+    /// After init, resolve_workspace_root must find the workspace via the channel dir.
+    #[test]
+    fn workspace_init_makes_workspace_visible_to_resolver() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().to_path_buf();
+
+        crate::workspace_secrets::init_workspace(&cwd)
+            .expect("init_workspace should succeed");
+
+        let channel_dir = super::app_init_config_dir();
+        std::fs::create_dir_all(cwd.join(&channel_dir)).unwrap();
+
+        let found = crate::app_registry::resolve_workspace_root(&cwd);
+        assert!(
+            found.is_some(),
+            "resolve_workspace_root should find the workspace after workspace_init creates the channel dir"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5167,9 +5167,9 @@ mod workspace_init_tests {
         );
     }
 
-    /// After init, resolve_workspace_root must find the workspace via the channel dir.
+    /// After init, resolve_workspace_root must still find the workspace and the channel dir must exist.
     #[test]
-    fn workspace_init_makes_workspace_visible_to_resolver() {
+    fn workspace_remains_resolvable_after_channel_dir_creation() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path().to_path_buf();
 
@@ -5182,7 +5182,11 @@ mod workspace_init_tests {
         let found = crate::app_registry::resolve_workspace_root(&cwd);
         assert!(
             found.is_some(),
-            "resolve_workspace_root should find the workspace after workspace_init creates the channel dir"
+            "resolve_workspace_root should still find the workspace (via .plexi/) after channel dir creation"
+        );
+        assert!(
+            cwd.join(&channel_dir).is_dir(),
+            "channel directory should exist alongside .plexi/"
         );
     }
 }


### PR DESCRIPTION
Closes #1720

## Summary

- `workspace_init()` now calls `create_dir_all` on the channel-specific dir (e.g. `.plexi-alpha/`) immediately after `init_workspace` creates `.plexi/`
- `resolve_workspace_root_with_channel` can now find the workspace without requiring `plexi app init` as a prerequisite
- Success output prints the channel dir (e.g. `channel dir: .plexi-alpha/`) so users can confirm the right dir was created
- Two unit tests added: one asserting both dirs exist post-init, one asserting `resolve_workspace_root` returns `Some` immediately after init

## Done When

- `plexi-alpha workspace init` in a clean dir creates both `.plexi/` and `.plexi-alpha/`
- `plexi-alpha secret set MY_KEY` succeeds immediately after `workspace init` (no `app init` required)
- `plexi install` (no-args, #1719) resolves the workspace via `resolve_workspace_root` immediately after `workspace init`
- `cargo test --bin plexi` passes

## Notes

`app_init_config_dir()` returns `.plexi` in tests (binary isn't `plexi-alpha`) — both new tests see the same channel dir as stable, which is correct and expected per the issue's Known Gotchas.