### PR TITLE
feat(cli/terminal): cursor-based incremental pane capture (#1723)

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -438,6 +438,44 @@ impl TerminalBackend {
         Self::capture_lines_from_grid(term.grid(), n)
     }
 
+    /// Read the last `n` lines and the current cursor in one atomic snapshot.
+    ///
+    /// Avoids the TOCTOU between calling `capture_lines` and reading
+    /// `lines_written` separately — both values are derived from the same
+    /// term lock.
+    pub fn capture_lines_with_cursor(&self, n: usize) -> (Vec<String>, u64) {
+        use alacritty_terminal::index::{Column, Line};
+        let term = self.term.lock();
+        let grid = term.grid();
+        let screen_lines = grid.screen_lines();
+        let history_size = grid.history_size();
+        let total = screen_lines + history_size;
+
+        {
+            let mut prev = self.prev_total.lock().unwrap();
+            let delta = total.saturating_sub(*prev);
+            if delta > 0 {
+                self.lines_written.fetch_add(delta as u64, Ordering::Relaxed);
+                *prev = total;
+            }
+            if history_size > 0 && history_size == self.max_scroll_limit {
+                let oldest: String = {
+                    let row = &grid[Line(-(history_size as i32))];
+                    (0..grid.columns()).map(|c| row[Column(c)].c).collect()
+                };
+                let mut snapshot = self.oldest_row_snapshot.lock().unwrap();
+                if *snapshot != oldest {
+                    self.lines_written.fetch_add(1, Ordering::Relaxed);
+                    *snapshot = oldest;
+                }
+            }
+        }
+
+        let lw = self.lines_written.load(Ordering::Relaxed);
+        let captured = Self::capture_lines_from_grid(grid, n);
+        (captured, lw)
+    }
+
     /// Read lines written after `cursor` from the PTY scrollback buffer.
     ///
     /// Returns `(lines, new_cursor, missed)`:

--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -148,9 +148,9 @@ pub struct TerminalBackend {
     notifier: Notifier,
     last_content: RenderableContent,
     child_pid: u32,
-    pub lines_written: Arc<AtomicU64>,
-    prev_total: Arc<Mutex<usize>>,
-    oldest_row_snapshot: Arc<Mutex<String>>,
+    pub lines_written: AtomicU64,
+    /// (prev_total, oldest_row_snapshot) — grouped to avoid nested lock acquisitions.
+    capture_state: Mutex<(usize, String)>,
     max_scroll_limit: usize,
 }
 
@@ -233,10 +233,6 @@ impl TerminalBackend {
                 }
             })?;
 
-        let lines_written = Arc::new(AtomicU64::new(0));
-        let prev_total = Arc::new(Mutex::new(0usize));
-        let oldest_row_snapshot = Arc::new(Mutex::new(String::new()));
-
         Ok(Self {
             id,
             url_regex,
@@ -246,9 +242,8 @@ impl TerminalBackend {
             notifier,
             last_content: initial_content,
             child_pid,
-            lines_written,
-            prev_total,
-            oldest_row_snapshot,
+            lines_written: AtomicU64::new(0),
+            capture_state: Mutex::new((0usize, String::new())),
             max_scroll_limit: 10_000,
         })
     }
@@ -399,6 +394,39 @@ impl TerminalBackend {
         self.child_pid
     }
 
+    /// Advance `lines_written` to account for newly written terminal lines.
+    ///
+    /// Always updates `prev_total` — including on terminal resize-down — so
+    /// the next call correctly counts lines written after the resize.
+    fn advance_cursor(
+        &self,
+        grid: &alacritty_terminal::Grid<alacritty_terminal::term::cell::Cell>,
+        total: usize,
+        _screen_lines: usize,
+        history_size: usize,
+    ) {
+        use alacritty_terminal::index::{Column, Line};
+        let mut state = self.capture_state.lock().unwrap();
+        if total > state.0 {
+            let delta = total - state.0;
+            self.lines_written.fetch_add(delta as u64, Ordering::Relaxed);
+        }
+        // Always update prev_total — handles terminal resize-down correctly.
+        state.0 = total;
+        // Saturation: history at max means oldest rows may scroll off without
+        // changing `total`. Detect one scrolled line per call via row comparison.
+        if history_size > 0 && history_size == self.max_scroll_limit {
+            let oldest: String = {
+                let row = &grid[Line(-(history_size as i32))];
+                (0..grid.columns()).map(|c| row[Column(c)].c).collect()
+            };
+            if state.1 != oldest {
+                self.lines_written.fetch_add(1, Ordering::Relaxed);
+                state.1 = oldest;
+            }
+        }
+    }
+
     fn capture_lines_from_grid(
         grid: &alacritty_terminal::Grid<alacritty_terminal::term::cell::Cell>,
         n: usize,
@@ -444,33 +472,12 @@ impl TerminalBackend {
     /// `lines_written` separately — both values are derived from the same
     /// term lock.
     pub fn capture_lines_with_cursor(&self, n: usize) -> (Vec<String>, u64) {
-        use alacritty_terminal::index::{Column, Line};
         let term = self.term.lock();
         let grid = term.grid();
         let screen_lines = grid.screen_lines();
         let history_size = grid.history_size();
         let total = screen_lines + history_size;
-
-        {
-            let mut prev = self.prev_total.lock().unwrap();
-            let delta = total.saturating_sub(*prev);
-            if delta > 0 {
-                self.lines_written.fetch_add(delta as u64, Ordering::Relaxed);
-                *prev = total;
-            }
-            if history_size > 0 && history_size == self.max_scroll_limit {
-                let oldest: String = {
-                    let row = &grid[Line(-(history_size as i32))];
-                    (0..grid.columns()).map(|c| row[Column(c)].c).collect()
-                };
-                let mut snapshot = self.oldest_row_snapshot.lock().unwrap();
-                if *snapshot != oldest {
-                    self.lines_written.fetch_add(1, Ordering::Relaxed);
-                    *snapshot = oldest;
-                }
-            }
-        }
-
+        self.advance_cursor(&grid, total, screen_lines, history_size);
         let lw = self.lines_written.load(Ordering::Relaxed);
         let captured = Self::capture_lines_from_grid(grid, n);
         (captured, lw)
@@ -485,35 +492,12 @@ impl TerminalBackend {
     ///
     /// When `cursor == 0`, returns all available buffer content.
     pub fn capture_lines_since(&self, cursor: u64) -> (Vec<String>, u64, bool) {
-        use alacritty_terminal::index::{Column, Line};
         let term = self.term.lock();
         let grid = term.grid();
         let screen_lines = grid.screen_lines();
         let history_size = grid.history_size();
         let total = screen_lines + history_size;
-
-        {
-            let mut prev = self.prev_total.lock().unwrap();
-            let delta = total.saturating_sub(*prev);
-            if delta > 0 {
-                self.lines_written.fetch_add(delta as u64, Ordering::Relaxed);
-                *prev = total;
-            }
-            // Saturation: history at max means oldest rows may scroll off without
-            // changing `total`. Detect by comparing the oldest scrollback row content.
-            if history_size > 0 && history_size == self.max_scroll_limit {
-                let oldest: String = {
-                    let row = &grid[Line(-(history_size as i32))];
-                    (0..grid.columns()).map(|c| row[Column(c)].c).collect()
-                };
-                let mut snapshot = self.oldest_row_snapshot.lock().unwrap();
-                if *snapshot != oldest {
-                    self.lines_written.fetch_add(1, Ordering::Relaxed);
-                    *snapshot = oldest;
-                }
-            }
-        }
-
+        self.advance_cursor(&grid, total, screen_lines, history_size);
         let lines_written = self.lines_written.load(Ordering::Relaxed);
         if lines_written == 0 {
             return (Vec::new(), 0, false);

--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use std::io::Result;
 use std::ops::{Index, RangeInclusive};
 use std::sync::mpsc::Sender;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 
 pub type TerminalMode = TermMode;
@@ -147,6 +148,10 @@ pub struct TerminalBackend {
     notifier: Notifier,
     last_content: RenderableContent,
     child_pid: u32,
+    pub lines_written: Arc<AtomicU64>,
+    prev_total: Arc<Mutex<usize>>,
+    oldest_row_snapshot: Arc<Mutex<String>>,
+    max_scroll_limit: usize,
 }
 
 impl TerminalBackend {
@@ -228,6 +233,10 @@ impl TerminalBackend {
                 }
             })?;
 
+        let lines_written = Arc::new(AtomicU64::new(0));
+        let prev_total = Arc::new(Mutex::new(0usize));
+        let oldest_row_snapshot = Arc::new(Mutex::new(String::new()));
+
         Ok(Self {
             id,
             url_regex,
@@ -237,6 +246,10 @@ impl TerminalBackend {
             notifier,
             last_content: initial_content,
             child_pid,
+            lines_written,
+            prev_total,
+            oldest_row_snapshot,
+            max_scroll_limit: 10_000,
         })
     }
 
@@ -386,43 +399,104 @@ impl TerminalBackend {
         self.child_pid
     }
 
+    fn capture_lines_from_grid(
+        grid: &alacritty_terminal::Grid<alacritty_terminal::term::cell::Cell>,
+        n: usize,
+    ) -> Vec<String> {
+        use alacritty_terminal::index::{Column, Line};
+        if n == 0 {
+            return Vec::new();
+        }
+        let screen_lines = grid.screen_lines();
+        let history_size = grid.history_size();
+        let total = screen_lines + history_size;
+        let take = n.min(total);
+        let columns = grid.columns();
+        let first = screen_lines as i32 - take as i32;
+        let last = screen_lines as i32 - 1;
+        let mut result = Vec::with_capacity(take);
+        for line_idx in first..=last {
+            let row = &grid[Line(line_idx)];
+            let mut s: String = (0..columns).map(|col_idx| row[Column(col_idx)].c).collect();
+            let trimmed_len = s.trim_end().len();
+            s.truncate(trimmed_len);
+            result.push(s);
+        }
+        result
+    }
+
     /// Read the last `n` lines from the PTY scrollback buffer.
     ///
     /// Returns a `Vec<String>` of at most `n` entries, ordered oldest → newest.
     /// Each string has trailing whitespace stripped. Read-only — does not affect
     /// PTY state or scrollback position.
     pub fn capture_lines(&self, n: usize) -> Vec<String> {
-        use alacritty_terminal::index::{Column, Line};
-
         if n == 0 {
             return Vec::new();
         }
+        let term = self.term.lock();
+        Self::capture_lines_from_grid(term.grid(), n)
+    }
 
+    /// Read lines written after `cursor` from the PTY scrollback buffer.
+    ///
+    /// Returns `(lines, new_cursor, missed)`:
+    /// - `lines`: content since cursor, ordered oldest → newest
+    /// - `new_cursor`: opaque value — pass back as `cursor` on next call
+    /// - `missed`: true if lines scrolled off between reads (cursor too old)
+    ///
+    /// When `cursor == 0`, returns all available buffer content.
+    pub fn capture_lines_since(&self, cursor: u64) -> (Vec<String>, u64, bool) {
+        use alacritty_terminal::index::{Column, Line};
         let term = self.term.lock();
         let grid = term.grid();
         let screen_lines = grid.screen_lines();
         let history_size = grid.history_size();
         let total = screen_lines + history_size;
-        let take = n.min(total);
-        let columns = grid.columns();
 
-        // Line(0)..Line(screen_lines-1) are the visible rows (bottommost = screen_lines-1).
-        // Line(-1)..Line(-(history_size)) are scrollback (most recent = -1).
-        // We want the last `take` lines in order, ending at Line(screen_lines-1).
-        let first = screen_lines as i32 - take as i32;
-        let last = screen_lines as i32 - 1;
-
-        let mut result = Vec::with_capacity(take);
-        for line_idx in first..=last {
-            let row = &grid[Line(line_idx)];
-            let mut s: String = (0..columns)
-                .map(|col_idx| row[Column(col_idx)].c)
-                .collect();
-            let trimmed_len = s.trim_end().len();
-            s.truncate(trimmed_len);
-            result.push(s);
+        {
+            let mut prev = self.prev_total.lock().unwrap();
+            let delta = total.saturating_sub(*prev);
+            if delta > 0 {
+                self.lines_written.fetch_add(delta as u64, Ordering::Relaxed);
+                *prev = total;
+            }
+            // Saturation: history at max means oldest rows may scroll off without
+            // changing `total`. Detect by comparing the oldest scrollback row content.
+            if history_size > 0 && history_size == self.max_scroll_limit {
+                let oldest: String = {
+                    let row = &grid[Line(-(history_size as i32))];
+                    (0..grid.columns()).map(|c| row[Column(c)].c).collect()
+                };
+                let mut snapshot = self.oldest_row_snapshot.lock().unwrap();
+                if *snapshot != oldest {
+                    self.lines_written.fetch_add(1, Ordering::Relaxed);
+                    *snapshot = oldest;
+                }
+            }
         }
-        result
+
+        let lines_written = self.lines_written.load(Ordering::Relaxed);
+        if lines_written == 0 {
+            return (Vec::new(), 0, false);
+        }
+
+        let oldest_available = lines_written.saturating_sub(total as u64);
+        let missed = cursor > 0 && cursor < oldest_available;
+        let start = if missed || cursor == 0 {
+            0
+        } else {
+            (cursor.saturating_sub(oldest_available)) as usize
+        };
+        let lines_to_take = total.saturating_sub(start);
+
+        let captured = if lines_to_take == 0 {
+            Vec::new()
+        } else {
+            Self::capture_lines_from_grid(grid, lines_to_take)
+        };
+
+        (captured, lines_written, missed)
     }
 
     fn process_link_action(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1789,9 +1789,9 @@ impl PlexiApp {
                         }
                     }
                 }
-                crate::app_protocol::AppRequest::CapturePane { pane_id, lines, response_file, full_output } => {
-                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} full_output={full_output} response_file={:?}", response_file);
-                    let result = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
+                crate::app_protocol::AppRequest::CapturePane { pane_id, lines, response_file, full_output, from_cursor } => {
+                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} full_output={full_output} from_cursor={from_cursor:?} response_file={:?}", response_file);
+                    let result: Result<serde_json::Value, String> = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
                         None => {
                             log::warn!("pane_ipc: capture_pane: pane_id={pane_id} not found");
                             Err(format!("pane {pane_id} not found"))
@@ -1802,24 +1802,52 @@ impl PlexiApp {
                                 Err(format!("pane {pane_id} is not a terminal pane"))
                             }
                             Some(term) => {
-                                let mut captured = term.backend.capture_lines(*lines);
-                                if !full_output {
-                                    let trimmed = captured.iter().rposition(|l| !l.trim().is_empty())
-                                        .map(|pos| pos + 1)
-                                        .unwrap_or(0);
-                                    captured.truncate(trimmed);
-                                    log::info!("pane_ipc: capture_pane: stripped trailing empty lines, result len={}", captured.len());
+                                if let Some(cursor) = from_cursor {
+                                    let (captured_lines, new_cursor, missed) =
+                                        term.backend.capture_lines_since(*cursor);
+                                    log::info!(
+                                        "pane_ipc: capture_pane: cursor={cursor} new_cursor={new_cursor} missed={missed} lines={}",
+                                        captured_lines.len()
+                                    );
+                                    Ok(serde_json::json!({
+                                        "lines": captured_lines,
+                                        "cursor": new_cursor,
+                                        "missed": missed,
+                                    }))
+                                } else {
+                                    let mut captured = term.backend.capture_lines(*lines);
+                                    if !full_output {
+                                        let trimmed = captured
+                                            .iter()
+                                            .rposition(|l| !l.trim().is_empty())
+                                            .map(|pos| pos + 1)
+                                            .unwrap_or(0);
+                                        captured.truncate(trimmed);
+                                        log::info!(
+                                            "pane_ipc: capture_pane: stripped trailing empty lines, result len={}",
+                                            captured.len()
+                                        );
+                                    }
+                                    let lw = term.backend.lines_written.load(std::sync::atomic::Ordering::Relaxed);
+                                    log::info!("pane_ipc: capture_pane: lines={} cursor={lw}", captured.len());
+                                    Ok(serde_json::json!({
+                                        "lines": captured,
+                                        "cursor": lw,
+                                        "missed": false,
+                                    }))
                                 }
-                                Ok(captured)
                             }
                         },
                     };
                     let json_str = match result {
-                        Ok(captured) => serde_json::to_string(&captured).unwrap_or_else(|_| "[]".to_string()),
+                        Ok(v) => serde_json::to_string(&v)
+                            .unwrap_or_else(|_| r#"{"lines":[],"cursor":0,"missed":false}"#.to_string()),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
                     if let Err(e) = std::fs::write(response_file, &json_str) {
-                        log::error!("pane_ipc: capture_pane: could not write response file {response_file:?}: {e}");
+                        log::error!(
+                            "pane_ipc: capture_pane: could not write response file {response_file:?}: {e}"
+                        );
                     }
                 }
                 crate::app_protocol::AppRequest::Notify {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1803,8 +1803,16 @@ impl PlexiApp {
                             }
                             Some(term) => {
                                 if let Some(cursor) = from_cursor {
-                                    let (captured_lines, new_cursor, missed) =
+                                    let (mut captured_lines, new_cursor, missed) =
                                         term.backend.capture_lines_since(*cursor);
+                                    if !full_output {
+                                        let trimmed = captured_lines
+                                            .iter()
+                                            .rposition(|l| !l.trim().is_empty())
+                                            .map(|pos| pos + 1)
+                                            .unwrap_or(0);
+                                        captured_lines.truncate(trimmed);
+                                    }
                                     log::info!(
                                         "pane_ipc: capture_pane: cursor={cursor} new_cursor={new_cursor} missed={missed} lines={}",
                                         captured_lines.len()
@@ -1815,7 +1823,8 @@ impl PlexiApp {
                                         "missed": missed,
                                     }))
                                 } else {
-                                    let mut captured = term.backend.capture_lines(*lines);
+                                    let (mut captured, lw) =
+                                        term.backend.capture_lines_with_cursor(*lines);
                                     if !full_output {
                                         let trimmed = captured
                                             .iter()
@@ -1828,7 +1837,6 @@ impl PlexiApp {
                                             captured.len()
                                         );
                                     }
-                                    let lw = term.backend.lines_written.load(std::sync::atomic::Ordering::Relaxed);
                                     log::info!("pane_ipc: capture_pane: lines={} cursor={lw}", captured.len());
                                     Ok(serde_json::json!({
                                         "lines": captured,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1151,6 +1151,8 @@ pub enum AppRequest {
         /// When true, preserve trailing empty lines. Defaults to false (strip them).
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         full_output: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from_cursor: Option<u64>,
     },
 
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
@@ -2941,11 +2943,12 @@ mod tests {
         let json = r#"{"type":"capture_pane","pane_id":7,"lines":20,"response_file":"capture.json"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Host(AppRequest::CapturePane { pane_id, lines, response_file, full_output }) => {
+            DrawCommand::Host(AppRequest::CapturePane { pane_id, lines, response_file, full_output, from_cursor }) => {
                 assert_eq!(*pane_id, 7);
                 assert_eq!(*lines, 20);
                 assert_eq!(response_file, "capture.json");
                 assert!(!full_output, "full_output should default to false");
+                assert!(from_cursor.is_none(), "from_cursor should default to None");
             }
             other => panic!("expected CapturePane, got {other:?}"),
         }
@@ -2962,6 +2965,28 @@ mod tests {
             }
             other => panic!("expected CapturePane, got {other:?}"),
         }
+
+        // from_cursor should round-trip
+        let json_cursor = r#"{"type":"capture_pane","pane_id":7,"lines":20,"response_file":"capture.json","from_cursor":42}"#;
+        let cmd_cursor: DrawCommand = serde_json::from_str(json_cursor).expect("deserialise from_cursor");
+        match &cmd_cursor {
+            DrawCommand::Host(AppRequest::CapturePane { from_cursor, .. }) => {
+                assert_eq!(*from_cursor, Some(42), "from_cursor should be Some(42)");
+            }
+            other => panic!("expected CapturePane, got {other:?}"),
+        }
+        // from_cursor absent → None
+        let cmd_no_cursor: DrawCommand = serde_json::from_str(json).expect("deserialise no cursor");
+        match &cmd_no_cursor {
+            DrawCommand::Host(AppRequest::CapturePane { from_cursor, .. }) => {
+                assert!(from_cursor.is_none(), "from_cursor should default to None");
+            }
+            other => panic!("expected CapturePane, got {other:?}"),
+        }
+        // from_cursor=0 should be omitted from wire format
+        let cmd_zero: DrawCommand = serde_json::from_str(r#"{"type":"capture_pane","pane_id":7,"lines":5,"response_file":"f.json"}"#).unwrap();
+        let s = serde_json::to_string(&cmd_zero).unwrap();
+        assert!(!s.contains("from_cursor"), "absent from_cursor must not appear on wire: {s}");
 
         // Missing required fields must fail
         let bad = r#"{"type":"capture_pane","pane_id":1}"#;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4596,7 +4596,7 @@ _plexi() {
         pane)
           case $line[2] in
             capture)
-              _arguments '--lines[Number of lines to read]:lines:' '--full-output[Preserve trailing empty lines]' '--from[Read only lines after this cursor]:cursor:'
+              _arguments '--lines[Number of lines to read]:lines:' '--full-output[Preserve trailing empty lines]' '--from-cursor[Read only lines after this cursor]:cursor:'
               ;;
             *)
               local subcmds
@@ -4889,7 +4889,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a s
 # pane capture flags
 complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l lines -d "Number of lines to read"
 complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l full-output -d "Preserve trailing empty lines"
-complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l from -d "Read only lines written after this cursor" -r
+complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l from-cursor -d "Read only lines written after this cursor" -r
 
 # descriptor subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from descriptor" -a probe -d "Probe a CLI for its Plexi descriptor"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2795,7 +2795,7 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
 /// Reads the last N lines from a pane's PTY scrollback buffer and prints a JSON array
 /// of strings to stdout. If `pane_id` is omitted, defaults to PLEXI_PANE_ID.
 /// Returns 0 on success, 1 on error.
-pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -> i32 {
+pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool, from_cursor: Option<u64>) -> i32 {
     let resolved_pane_id = match pane_id {
         Some(id) => id,
         None => match std::env::var("PLEXI_PANE_ID") {
@@ -2819,15 +2819,19 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -
         .to_string_lossy()
         .into_owned();
 
-    log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} full_output={full_output} response_file={response_file:?}");
+    log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} full_output={full_output} from_cursor={from_cursor:?} response_file={response_file:?}");
 
-    let code = send_to_socket(serde_json::json!({
+    let mut req = serde_json::json!({
         "type": "capture_pane",
         "pane_id": resolved_pane_id,
         "lines": lines,
         "full_output": full_output,
         "response_file": response_file,
-    }));
+    });
+    if let Some(cursor) = from_cursor {
+        req["from_cursor"] = serde_json::Value::Number(serde_json::Number::from(cursor));
+    }
+    let code = send_to_socket(req);
     if code != 0 {
         return code;
     }
@@ -2839,13 +2843,21 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool) -
             match std::fs::read_to_string(&response_path) {
                 Ok(content) => {
                     let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
-                            eprintln!("error: {err}");
-                            return 1;
+                    match serde_json::from_str::<serde_json::Value>(&content) {
+                        Ok(v) => {
+                            if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                                eprintln!("error: {err}");
+                                return 1;
+                            }
+                            // Print cursor to stderr so callers can capture it without
+                            // polluting the line stream.
+                            if let Some(cursor) = v.get("cursor").and_then(|c| c.as_u64()) {
+                                eprintln!("cursor={cursor}");
+                            }
+                            return print_json_output(&content);
                         }
+                        Err(_) => return print_json_output(&content),
                     }
-                    return print_json_output(&content);
                 }
                 Err(e) => {
                     log::warn!("pane_capture:cli: could not read response file: {e}");
@@ -4584,7 +4596,7 @@ _plexi() {
         pane)
           case $line[2] in
             capture)
-              _arguments '--lines[Number of lines to read]:lines:' '--full-output[Preserve trailing empty lines]'
+              _arguments '--lines[Number of lines to read]:lines:' '--full-output[Preserve trailing empty lines]' '--from[Read only lines after this cursor]:cursor:'
               ;;
             *)
               local subcmds
@@ -4729,7 +4741,7 @@ const BASH_COMPLETION: &str = r#"_plexi_completions() {
       else
         case "${words[2]}" in
           capture)
-            COMPREPLY=($(compgen -W "--lines --full-output" -- "$cur"))
+            COMPREPLY=($(compgen -W "--lines --full-output --from" -- "$cur"))
             ;;
         esac
       fi
@@ -4877,6 +4889,7 @@ complete -c plexi -f -n "__fish_seen_subcommand_from pane" -a key -d "Inject a s
 # pane capture flags
 complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l lines -d "Number of lines to read"
 complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l full-output -d "Preserve trailing empty lines"
+complete -c plexi -n "__fish_seen_subcommand_from pane; and __fish_seen_subcommand_from capture" -l from -d "Read only lines written after this cursor" -r
 
 # descriptor subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from descriptor" -a probe -d "Probe a CLI for its Plexi descriptor"

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -458,6 +458,10 @@ pub enum PaneCmd {
         /// Preserve trailing empty lines (by default they are stripped)
         #[arg(long)]
         full_output: bool,
+        /// Read only lines written after this cursor value. Get the cursor from a
+        /// previous capture response. When set, the response is always JSON object format.
+        #[arg(long, value_name = "CURSOR")]
+        from_cursor: Option<u64>,
     },
     /// Send a key press to a pane. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
-                        PaneCmd::Capture { pane_id, lines, full_output } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output)),
+                        PaneCmd::Capture { pane_id, lines, full_output, from_cursor } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output, from_cursor)),
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));


### PR DESCRIPTION
Closes #1723

## Summary

- All `plexi pane capture` responses now return a JSON object `{"lines":[...],"cursor":N,"missed":false}` instead of a bare array, enabling callers to track position across reads
- New `--from <cursor>` flag reads only lines written since the given cursor value; cursor is echoed to stderr as `cursor=N` so it can be captured without polluting the line stream
- Added `capture_lines_since()` to `TerminalBackend` with lazy `lines_written` tracking via `AtomicU64` and saturation detection via oldest-row comparison when scrollback is at max capacity

## Done When

- `plexi pane capture` with no flags returns `{"lines": [...], "cursor": N, "missed": false}` on stdout
- `plexi pane capture --from <N>` returns only lines written after cursor N
- `missed: true` appears when the caller's cursor has fallen behind the oldest available scrollback line
- Two agent scripts can exchange output via repeated `--from` calls without re-reading stale content
- Behavior is identical across alpha, beta, main, and PR builds

## Notes

- Saturation detection (>10000 lines of scrollback between reads) uses oldest-row content comparison — detects 1 scrolled line per call. For the agent IPC use case (polling every ~1s), the 10000-line buffer makes full saturation between reads extremely unlikely in practice.
- Response shape change is breaking for callers expecting a bare array — acceptable on alpha per issue spec.