### PR TITLE
fix(apps/gh-issues): label badges overlap title text (#1724)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -208,19 +208,23 @@ class GhIssues(App):
                 font_size=HINT, radius=3.0,
             )
 
+            # compute label reserve before drawing title so max_width is accurate
+            row_labels   = issue.get("labels", [])[:2]
+            label_reserve = sum(len(lbl["name"]) * 8 + 20 + 4 for lbl in row_labels) if row_labels else 0
+
             # title
             ctx.text(
                 PAD + 52, row_mid - CAPTION / 2,
                 issue["title"],
                 size=CAPTION, color=FG,
-                max_width=ctx.w - PAD - 52 - PAD - 130,
+                max_width=ctx.w - PAD - 52 - PAD - label_reserve - PAD,
             )
 
             # labels (up to 2, right-aligned)
             lx = ctx.w - PAD
-            for lbl in reversed(issue.get("labels", [])[:2]):
+            for lbl in reversed(row_labels):
                 name    = lbl["name"]
-                badge_w = len(name) * 6 + 14
+                badge_w = len(name) * 8 + 20
                 lx     -= badge_w + 4
                 ctx.badge(
                     x=lx, y_center=row_mid,

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -209,13 +209,13 @@ class GhIssues(App):
             )
 
             # compute label reserve before drawing title so max_width is accurate
-            row_labels   = issue.get("labels", [])[:2]
-            label_reserve = sum(len(lbl["name"]) * 8 + 20 + 4 for lbl in row_labels) if row_labels else 0
+            row_labels    = (issue.get("labels") or [])[:2]
+            label_reserve = sum(len(lbl.get("name", "")) * 8 + 20 + 4 for lbl in row_labels) if row_labels else 0
 
             # title
             ctx.text(
                 PAD + 52, row_mid - CAPTION / 2,
-                issue["title"],
+                issue.get("title", ""),
                 size=CAPTION, color=FG,
                 max_width=ctx.w - PAD - 52 - PAD - label_reserve - PAD,
             )
@@ -223,7 +223,7 @@ class GhIssues(App):
             # labels (up to 2, right-aligned)
             lx = ctx.w - PAD
             for lbl in reversed(row_labels):
-                name    = lbl["name"]
+                name    = lbl.get("name", "")
                 badge_w = len(name) * 8 + 20
                 lx     -= badge_w + 4
                 ctx.badge(


### PR DESCRIPTION
Closes #1724

## Summary

- Replace fixed 130px title `max_width` reserve with a per-row `label_reserve` computed from actual label name widths
- Upgrade badge width estimate from 6px/char + 14px to 8px/char + 20px (matches rendered HINT 12pt character width)
- Refactor label loop to reuse the pre-computed `row_labels` slice

## Done When

- Open gh-issues in a pane at ~800px wide
- Rows with two labels (`enhancement` + any other) show a clean gap between the rightmost title character and the leftmost badge
- No title text overlaps any badge
- All badges are fully visible with their text intact (no truncation inside badges)

## Notes

The 8px/char estimate is still an approximation — the host renders at the actual font metrics — but it's conservative enough to prevent overlap without over-truncating titles. The `+ 4` inter-badge gap in `label_reserve` mirrors the `lx -= badge_w + 4` draw loop, keeping reserve and draw positions in sync.