### PR TITLE
feat(sdk/pgap): List + Row — host-native scrollable list container with generic slotted row (#1727)

### DIFF
--- a/apps/dev/bluesky/main.py
+++ b/apps/dev/bluesky/main.py
@@ -254,11 +254,11 @@ class BlueskyApp(App):
             reposts = post.get("repostCount", 0)
             rows.append(ListRow(
                 id=f"post-{i}",
-                leading=LeadingAvatar(av_handle) if av_handle else LeadingIcon("���"),
+                leading=LeadingAvatar(av_handle) if av_handle else LeadingIcon("👤"),
                 primary=_author(post),
                 secondary=_text(post) or None,
                 chips=[
-                    RowChip(f"��� {likes}", "muted"),
+                    RowChip(f"♥ {likes}", "muted"),
                     RowChip(f"↺ {reposts}", "muted"),
                 ],
                 trailing=ts or None,

--- a/apps/dev/bluesky/main.py
+++ b/apps/dev/bluesky/main.py
@@ -18,11 +18,12 @@ import webbrowser
 
 from plexi_sdk import (
     App, RenderContext, CapabilityDeniedError,
-    BG, SURFACE, FG, ACCENT, MUTED, HIGHLIGHT,
+    BG, SURFACE, ACCENT, MUTED,
     BODY, CAPTION, HEADING, HINT, HEADER_H,
     RED,
     PAD, PAD_TIGHT,
 )
+from plexi_sdk.ui import ListRow, RowChip, LeadingAvatar, LeadingIcon
 
 BASE     = "https://public.api.bsky.app/xrpc"
 DISCOVER = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
@@ -99,7 +100,6 @@ class BlueskyApp(App):
         self._view   = self.VIEW_FEED
         self._feed   : list[dict] = []
         self._sel    = 0
-        self._scroll  = 0.0
         self._loading = True
         self._error   : str | None = None
 
@@ -114,8 +114,6 @@ class BlueskyApp(App):
         self._thread  : list[dict] = []
         self._t_scroll = 0.0
 
-        # per-post measured row heights (pre-computed at fetch time)
-        self._row_heights: list[float] = []
         # avatar handles keyed by author did
         self._avatar_handles: dict[str, str] = {}
 
@@ -180,27 +178,7 @@ class BlueskyApp(App):
         self.emit.schedule_render()
 
     async def _post_fetch_setup(self) -> None:
-        """Pre-measure row heights and load avatars after any feed fetch."""
-        pane_w = 700.0  # conservative default; real width used for render
-        text_w = pane_w - TEXT_X - PAD
-
-        heights = []
-        for post in self._feed:
-            body = _text(post)
-            if body:
-                try:
-                    h = await self.emit.measure_text_wrapped(
-                        body, CAPTION, text_w, max_lines=MAX_LINES
-                    )
-                    heights.append(ROW_BASE + max(0.0, h - CAPTION))
-                except Exception as exc:
-                    self.emit.warn(f"bluesky: measure_text_wrapped failed: {exc}")
-                    heights.append(ROW_BASE + LINE_H * MAX_LINES)
-            else:
-                heights.append(ROW_BASE)
-        self._row_heights = heights
-
-        # Load avatars for unique authors
+        """Load avatars after any feed fetch."""
         for post in self._feed:
             did = _did(post)
             url = _avatar_url(post)
@@ -266,15 +244,32 @@ class BlueskyApp(App):
 
     # ── render ────────────────────────────────────────────────────────────────
 
+    def _feed_rows(self) -> "list[dict]":
+        rows = []
+        for i, post in enumerate(self._feed):
+            did = _did(post)
+            av_handle = self._avatar_handles.get(did, "")
+            ts = _short_ts((post.get("record") or {}).get("createdAt", ""))
+            likes = post.get("likeCount", 0)
+            reposts = post.get("repostCount", 0)
+            rows.append(ListRow(
+                id=f"post-{i}",
+                leading=LeadingAvatar(av_handle) if av_handle else LeadingIcon("���"),
+                primary=_author(post),
+                secondary=_text(post) or None,
+                chips=[
+                    RowChip(f"��� {likes}", "muted"),
+                    RowChip(f"↺ {reposts}", "muted"),
+                ],
+                trailing=ts or None,
+            ).to_dict())
+        return rows
+
     def on_render(self, ctx: RenderContext) -> None:
         ctx.clear(BG)
         self._draw_header(ctx)
 
-        if self._loading:
-            self._draw_loading_skeleton(ctx)
-            return
-
-        if self._error:
+        if self._error and not self._loading:
             ctx.text(PAD, HEADER_H + PAD, f"Error: {self._error}",
                      size=CAPTION, color=RED, max_width=ctx.w - PAD * 2)
             ctx.text(PAD, HEADER_H + PAD + BODY + PAD_TIGHT, "r — retry",
@@ -283,25 +278,19 @@ class BlueskyApp(App):
 
         if self._view == self.VIEW_THREAD:
             self._draw_thread(ctx)
-        else:
-            self._draw_feed(ctx)
-            if self._show_input:
-                self._draw_input_overlay(ctx)
+            return
 
-    def _draw_loading_skeleton(self, ctx: RenderContext) -> None:
-        """Render animated skeleton rows instead of plain 'Loading…'."""
-        y = HEADER_H + PAD
-        for _ in range(8):
-            row_h = ROW_BASE + LINE_H * 2
-            # avatar circle placeholder
-            ctx.skeleton(PAD, y + (row_h - AVATAR_R * 2) / 2,
-                         AVATAR_R * 2, AVATAR_R * 2, radius=AVATAR_R)
-            # author line
-            ctx.skeleton(TEXT_X, y + 6, ctx.w * 0.35, HINT, radius=3.0)
-            # text lines
-            ctx.skeleton(TEXT_X, y + 6 + HINT + 6, ctx.w * 0.85 - TEXT_X, CAPTION, radius=3.0)
-            ctx.skeleton(TEXT_X, y + 6 + HINT + 6 + LINE_H, ctx.w * 0.60 - TEXT_X, CAPTION, radius=3.0)
-            y += row_h + 1
+        if self._show_input:
+            self._draw_input_overlay(ctx)
+
+        ctx.list_view(
+            "feed",
+            self._feed_rows(),
+            selected=self._sel,
+            loading=self._loading,
+            error=self._error,
+            y=float(HEADER_H),
+        )
 
     def _draw_header(self, ctx: RenderContext) -> None:
         ctx.rect(0, 0, ctx.w, HEADER_H, fill=SURFACE)
@@ -327,67 +316,6 @@ class BlueskyApp(App):
         )
         ctx.shortcuts(x=ctx.w / 3, y=mid_y - HINT / 2,
                       max_width=ctx.w * 2 / 3 - PAD, pairs=pairs)
-
-    def _row_height(self, i: int) -> float:
-        if i < len(self._row_heights):
-            return self._row_heights[i]
-        return ROW_BASE + LINE_H * 2
-
-    def _draw_feed(self, ctx: RenderContext) -> None:
-        if not self._feed:
-            ctx.text(PAD, HEADER_H + PAD, "No posts.", size=BODY, color=MUTED)
-            return
-
-        content_h = sum(self._row_height(i) for i in range(len(self._feed)))
-        list_y = HEADER_H
-        ctx.begin_scroll("feed-list", 0.0, list_y, ctx.w,
-                         ctx.h - list_y, content_h)
-
-        y = list_y - self._scroll
-        for i, post in enumerate(self._feed):
-            row_h = self._row_height(i)
-            sel   = i == self._sel
-            ctx.rect(0, y, ctx.w, row_h,
-                     fill=HIGHLIGHT if sel else (SURFACE if i % 2 == 0 else BG))
-            if i > 0:
-                ctx.rect(0, y, ctx.w, 1, fill=BG)
-
-            # Avatar
-            did = _did(post)
-            av_handle = self._avatar_handles.get(did, "")
-            av_cy = y + row_h / 2
-            if av_handle:
-                ctx.avatar(av_handle, x=PAD, y_center=av_cy, radius=AVATAR_R)
-            else:
-                ctx.circle(PAD + AVATAR_R, av_cy, AVATAR_R, fill="#3a3a4a")
-
-            # Author + timestamp
-            ts = _short_ts((post.get("record") or {}).get("createdAt", ""))
-            ctx.text(TEXT_X, y + 6, _author(post),
-                     size=HINT, color=ACCENT,
-                     max_width=ctx.w - TEXT_X - PAD - 36)
-            if ts:
-                ctx.text(ctx.w - PAD - 32, y + 6, ts, size=HINT, color=MUTED)
-
-            # Post body (up to MAX_LINES lines)
-            body = _text(post)
-            if body:
-                ctx.text(TEXT_X, y + 6 + HINT + 4, body,
-                         size=CAPTION, color=FG,
-                         max_width=ctx.w - TEXT_X - PAD,
-                         max_lines=MAX_LINES)
-
-            # Stats
-            likes   = post.get("likeCount", 0)
-            reposts = post.get("repostCount", 0)
-            replies = post.get("replyCount", 0)
-            ctx.text(TEXT_X, y + row_h - HINT - 4,
-                     f"♥ {likes}  ↺ {reposts}  💬 {replies}",
-                     size=HINT, color=MUTED)
-
-            y += row_h
-
-        ctx.end_scroll()
 
     def _draw_thread(self, ctx: RenderContext) -> None:
         if not self._thread:
@@ -476,14 +404,6 @@ class BlueskyApp(App):
             if key == "escape":
                 self.emit.info("bluesky: close via Escape")
                 self.emit.close_self()
-            elif key in ("j", "down"):
-                self._sel = min(self._sel + 1, max(0, len(self._feed) - 1))
-                self.emit.schedule_render()
-            elif key in ("k", "up"):
-                self._sel = max(self._sel - 1, 0)
-                self.emit.schedule_render()
-            elif key == "return":
-                self._open_thread()
             elif key == "p":
                 self._show_input = True
                 self.emit.schedule_render()
@@ -519,24 +439,19 @@ class BlueskyApp(App):
         self.emit.info(f"bluesky: profile lookup @{handle}")
         asyncio.create_task(self._fetch_author(handle, None))
 
+    def on_list_select(self, _ctx: RenderContext, _id: str, index: int) -> None:
+        self._sel = index
+        self.emit.schedule_render()
+
+    def on_list_activate(self, _ctx: RenderContext, _id: str, _index: int) -> None:
+        self._open_thread()
+
     def on_scroll(self, _ctx: RenderContext, id: str, offset_y: float) -> None:
-        if id == "feed-list":
-            self._scroll = offset_y
-        elif id == "thread-list":
+        if id == "thread-list":
             self._t_scroll = offset_y
 
-    def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
-        if self._view == self.VIEW_FEED and not self._loading and self._feed:
-            local_y = y - HEADER_H + self._scroll
-            if local_y >= 0:
-                acc = 0.0
-                for i, rh in enumerate(self._row_heights):
-                    if local_y < acc + rh:
-                        self._sel = i
-                        if button == "primary":
-                            self._open_thread()
-                        break
-                    acc += rh
+    def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> None:
+        pass
 
     # ── actions ───────────────────────────────────────────────────────────────
 

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -19,6 +19,7 @@ from plexi_sdk import (
     GREEN, RED, YELLOW,
     PAD, PAD_TIGHT,
 )
+from plexi_sdk.ui import ListRow, RowChip, LeadingBadge
 
 # ── Layout ────────────────────────────────────────────────────────────────────
 
@@ -63,7 +64,6 @@ class GhIssues(App):
         self._view           = self.VIEW_LIST
         self._issues         : list[dict] = []
         self._sel            = 0
-        self._scroll_y       = 0.0
         self._loading        = True
         self._detail_loading = False
         self._error          : str | None = None
@@ -177,63 +177,25 @@ class GhIssues(App):
         )
 
     def _draw_list(self, ctx: RenderContext) -> None:
-        if not self._issues:
-            ctx.text(PAD, HEADER_H + PAD, "No open issues.", size=BODY, color=MUTED)
-            return
-
-        list_y = float(HEADER_H)
-        list_h = ctx.h - list_y
-        content_h = ROW_H * len(self._issues)
-
-        ctx.begin_scroll("issues-list", 0.0, list_y, ctx.w, list_h, content_h)
-
-        for i, issue in enumerate(self._issues):
-            iy      = list_y + i * ROW_H - self._scroll_y
-            focused = (i == self._sel)
-            bg      = HIGHLIGHT if focused else (SURFACE if i % 2 == 0 else BG)
-            ctx.rect(0, iy, ctx.w, ROW_H, fill=bg)
-
-            # row divider
-            if i > 0:
-                ctx.rect(0, iy, ctx.w, 1, fill=BG)
-
-            row_mid = iy + ROW_H / 2
-
-            # issue number badge
-            ctx.badge(
-                x=PAD, y_center=row_mid,
-                label=f"#{issue['number']}",
-                fill=ACCENT if focused else SURFACE,
-                fg=BG if focused else ACCENT,
-                font_size=HINT, radius=3.0,
-            )
-
-            # compute label reserve before drawing title so max_width is accurate
-            row_labels    = (issue.get("labels") or [])[:2]
-            label_reserve = sum(len(lbl.get("name", "")) * 8 + 20 + 4 for lbl in row_labels) if row_labels else 0
-
-            # title
-            ctx.text(
-                PAD + 52, row_mid - CAPTION / 2,
-                issue.get("title", ""),
-                size=CAPTION, color=FG,
-                max_width=ctx.w - PAD - 52 - PAD - label_reserve - PAD,
-            )
-
-            # labels (up to 2, right-aligned)
-            lx = ctx.w - PAD
-            for lbl in reversed(row_labels):
-                name    = lbl.get("name", "")
-                badge_w = len(name) * 8 + 20
-                lx     -= badge_w + 4
-                ctx.badge(
-                    x=lx, y_center=row_mid,
-                    label=name,
-                    fill=_label_color(name), fg=BG,
-                    font_size=HINT, radius=3.0,
-                )
-
-        ctx.end_scroll()
+        rows = [
+            ListRow(
+                id=f"issue-{issue['number']}",
+                leading=LeadingBadge(f"#{issue['number']}", color="accent"),
+                primary=issue.get("title", ""),
+                chips=[
+                    RowChip(lbl.get("name", ""), _label_color(lbl.get("name", "")))
+                    for lbl in (issue.get("labels") or [])[:2]
+                ],
+            ).to_dict()
+            for issue in self._issues
+        ]
+        ctx.list_view(
+            "issues",
+            rows,
+            selected=self._sel,
+            loading=False,
+            y=float(HEADER_H),
+        )
 
     def _draw_detail(self, ctx: RenderContext) -> None:
         if self._detail is None:
@@ -293,15 +255,7 @@ class GhIssues(App):
             return
 
         if self._view == self.VIEW_LIST:
-            if key in ("j", "down"):
-                self._sel = min(self._sel + 1, max(0, len(self._issues) - 1))
-                ctx.status_summary(self._issues[self._sel]["title"] if self._issues else "")
-            elif key in ("k", "up"):
-                self._sel = max(self._sel - 1, 0)
-                ctx.status_summary(self._issues[self._sel]["title"] if self._issues else "")
-            elif key == "return":
-                self._open_detail()
-            elif key == "o":
+            if key == "o":
                 self._open_browser()
             elif key == "r":
                 self.emit.info("gh-issues: refresh")
@@ -322,20 +276,17 @@ class GhIssues(App):
                                    cwd=self._root or None)
                     self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
 
-    def on_scroll(self, _ctx: RenderContext, id: str, offset_y: float) -> None:
-        if id == "issues-list":
-            self._scroll_y = offset_y
+    def on_list_select(self, ctx: RenderContext, _id: str, index: int) -> None:
+        self._sel = index
+        if self._issues:
+            ctx.status_summary(self._issues[self._sel]["title"])
+        self.emit.schedule_render()
 
-    def on_click(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:
-        if self._view == self.VIEW_LIST and not self._loading and self._issues:
-            list_y = float(HEADER_H)
-            local_y = y - list_y + self._scroll_y
-            if local_y >= 0:
-                idx = int(local_y / ROW_H)
-                if 0 <= idx < len(self._issues):
-                    self._sel = idx
-                    if button == "primary":
-                        self._open_detail()
+    def on_list_activate(self, _ctx: RenderContext, _id: str, _index: int) -> None:
+        self._open_detail()
+
+    def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> None:
+        pass
 
     # ── actions ───────────────────────────────────────────────────────────────
 

--- a/apps/quick-note/quick_note.py
+++ b/apps/quick-note/quick_note.py
@@ -154,7 +154,7 @@ class QuickNoteApp(App):
             # Browse mode — list on the left, optional preview on the right.
             items = [{"label": p.stem, "secondary": None} for p in self._notes]
             if items:
-                ctx.list_view(items, selected=self._selected, item_height=40.0,
+                ctx.simple_list(items, selected=self._selected, item_height=40.0,
                          x=x, y=y, w=w, h=h)
             else:
                 ctx.text(x, y + 16, "No notes yet.", size=BODY, color=MUTED)

--- a/apps/todo/todo.py
+++ b/apps/todo/todo.py
@@ -112,7 +112,7 @@ class TodoApp(App):
                 bar_h = 56.0
                 list_h = max(0.0, h - bar_h - 8.0)
                 if items:
-                    ctx.list_view(items, selected=app._selected, item_height=40.0,
+                    ctx.simple_list(items, selected=app._selected, item_height=40.0,
                              x=x, y=y, w=w, h=list_h)
                 bar_y = y + h - bar_h
                 ctx.rect(x, bar_y, w, bar_h, fill=SURFACE, radius=4.0)
@@ -121,7 +121,7 @@ class TodoApp(App):
                          size=BODY, color=FG, monospace=True)
                 return
             if items:
-                ctx.list_view(items, selected=app._selected, item_height=40.0,
+                ctx.simple_list(items, selected=app._selected, item_height=40.0,
                          x=x, y=y, w=w, h=h)
             else:
                 ctx.text(x, y + 12, "No items. Press 'a' to add.",

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -144,7 +144,7 @@ class WikiApp(App):
             elif app._mode == "results":
                 ctx.text(x, y, f'Results for "{app._query}":', size=BODY, color=FG)
                 items = [{"label": r, "secondary": None} for r in app._results]
-                ctx.list_view(items, selected=app._selected, item_height=40.0,
+                ctx.simple_list(items, selected=app._selected, item_height=40.0,
                          x=x, y=y + 28, w=w, h=max(0.0, h - 28))
             elif app._mode == "article":
                 title = app._results[app._selected] if app._results else ""

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -912,12 +912,22 @@ class App:
                         sys.stderr.write(f"on_scroll handler raised: {e}\n")
 
                 elif t == "list_select":
-                    ctx = self._make_ctx()
-                    self._dispatch_hook_task(self.on_list_select, ctx, ev.get("id", ""), ev.get("index", 0))
+                    _lid = ev.get("id")
+                    _lidx = ev.get("index")
+                    if _lid is None or _lidx is None:
+                        sys.stderr.write(f"list_select event missing required fields: {ev}\n")
+                    else:
+                        ctx = self._make_ctx()
+                        self._dispatch_hook_task(self.on_list_select, ctx, _lid, _lidx)
 
                 elif t == "list_activate":
-                    ctx = self._make_ctx()
-                    self._dispatch_hook_task(self.on_list_activate, ctx, ev.get("id", ""), ev.get("index", 0))
+                    _lid = ev.get("id")
+                    _lidx = ev.get("index")
+                    if _lid is None or _lidx is None:
+                        sys.stderr.write(f"list_activate event missing required fields: {ev}\n")
+                    else:
+                        ctx = self._make_ctx()
+                        self._dispatch_hook_task(self.on_list_activate, ctx, _lid, _lidx)
 
                 elif t == "app_spawned":
                     # Confirmation that a SpawnApp request succeeded. Apps that

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -238,6 +238,12 @@ class App:
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
+    def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
+        """Called when a list_view selection changes via j/k/up/down."""
+        return None
+    def on_list_activate(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
+        """Called when Enter is pressed on a selected list_view item."""
+        return None
     def on_text_submitted(self, _ctx: RenderContext, _id: str, _text: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_file_picked(self, _ctx: RenderContext, _request_id: str, _paths: "list[str]") -> "Coroutine[Any, Any, None] | None":
         """Called when the user selected one or more files in the picker.
@@ -904,6 +910,14 @@ class App:
                         await self._dispatch_hook(self.on_scroll, ctx, scroll_id, offset_y)
                     except Exception as e:
                         sys.stderr.write(f"on_scroll handler raised: {e}\n")
+
+                elif t == "list_select":
+                    ctx = self._make_ctx()
+                    self._dispatch_hook_task(self.on_list_select, ctx, ev.get("id", ""), ev.get("index", 0))
+
+                elif t == "list_activate":
+                    ctx = self._make_ctx()
+                    self._dispatch_hook_task(self.on_list_activate, ctx, ev.get("id", ""), ev.get("index", 0))
 
                 elif t == "app_spawned":
                     # Confirmation that a SpawnApp request succeeded. Apps that

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -480,7 +480,7 @@ class RenderContext:
         from plexi_sdk.ui import render_tree
         render_tree(self, tree, fill=fill)
 
-    def list_view(self, items: "list[dict]", selected: int = 0,
+    def simple_list(self, items: "list[dict]", selected: int = 0,
              item_height: float = 40.0, x: float = 0.0, y: float = 0.0,
              w: "float | None" = None, h: "float | None" = None) -> None:
         """Draw a scrollable list of items with optional selection highlight.
@@ -499,6 +499,52 @@ class RenderContext:
                      "h": self.h - y if h is None else h,
                      "items": items, "selected": selected,
                      "item_height": item_height})
+
+    def list_view(
+        self,
+        id: str,
+        items: "list[dict]",
+        selected: int = 0,
+        loading: bool = False,
+        error: "str | None" = None,
+        x: float = 0.0,
+        y: float = 0.0,
+        w: float = 0.0,
+        h: float = 0.0,
+    ) -> None:
+        """Host-native scrollable list with j/k navigation and typed row slots.
+
+        Items must be dicts with ``"type": "row"`` or ``"type": "custom_cell"``.
+        Use :class:`plexi_sdk.ui.ListRow` to build row descriptors.
+
+        The host handles: j/k selection, scroll-to-selected, skeleton loading
+        rows (when ``loading=True``), error text, and empty state.
+        The app receives :meth:`on_list_select` / :meth:`on_list_activate`
+        callbacks instead of managing scroll state.
+
+        Args:
+            id: Stable identifier for this list (must not change across frames).
+            items: List of row/custom_cell dicts. Use ``ListRow(...).to_dict()``.
+            selected: Index of the currently highlighted item.
+            loading: When True, renders skeleton rows instead of items.
+            error: When set, renders an error message instead of items.
+            x: Left edge in pane-local coordinates (0 = left edge).
+            y: Top edge in pane-local coordinates (0 = top of pane).
+            w: Width (0 = full pane width).
+            h: Height (0 = remaining height below y).
+        """
+        self._queue({
+            "type": "list_view",
+            "id": id,
+            "x": x,
+            "y": y,
+            "w": w,
+            "h": h,
+            "items": items,
+            "selected": selected,
+            "loading": loading,
+            "error": error,
+        })
 
     def begin_scroll(self, id: str, x: float, y: float, w: float, h: float,
                      content_height: float) -> None:

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -502,7 +502,7 @@ class RenderContext:
 
     def list_view(
         self,
-        id: str,
+        list_id: str,
         items: "list[dict]",
         selected: int = 0,
         loading: bool = False,
@@ -523,7 +523,7 @@ class RenderContext:
         callbacks instead of managing scroll state.
 
         Args:
-            id: Stable identifier for this list (must not change across frames).
+            list_id: Stable identifier for this list (must not change across frames).
             items: List of row/custom_cell dicts. Use ``ListRow(...).to_dict()``.
             selected: Index of the currently highlighted item.
             loading: When True, renders skeleton rows instead of items.
@@ -535,7 +535,7 @@ class RenderContext:
         """
         self._queue({
             "type": "list_view",
-            "id": id,
+            "id": list_id,
             "x": x,
             "y": y,
             "w": w,

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1427,6 +1427,88 @@ class ButtonRow(Component):
         )
 
 
+# ── ListView row helpers ───────────────────────────────────────────────────────
+
+@dataclass
+class LeadingBadge:
+    """Badge leading slot for :class:`ListRow`.
+
+    Renders a pill badge with ``label`` text and the given ``color``.
+    """
+    label: str
+    color: str = "accent"
+
+    def to_dict(self) -> dict:
+        return {"variant": "badge", "label": self.label, "color": self.color}
+
+
+@dataclass
+class LeadingAvatar:
+    """Circular avatar leading slot for :class:`ListRow`.
+
+    ``handle`` must be a UUID returned by ``emit.load_image(url)``.
+    """
+    handle: str
+
+    def to_dict(self) -> dict:
+        return {"variant": "avatar", "handle": self.handle}
+
+
+@dataclass
+class LeadingIcon:
+    """Text/emoji icon leading slot for :class:`ListRow`."""
+    name: str
+
+    def to_dict(self) -> dict:
+        return {"variant": "icon", "name": self.name}
+
+
+@dataclass
+class RowChip:
+    """A small colored chip label on a :class:`ListRow`."""
+    label: str
+    color: str = "accent"
+
+    def to_dict(self) -> dict:
+        return {"label": self.label, "color": self.color}
+
+
+@dataclass
+class ListRow:
+    """Typed row descriptor for :meth:`RenderContext.list_view`.
+
+    Example::
+
+        rows = [
+            ListRow(
+                id=f"issue-{issue['number']}",
+                leading=LeadingBadge(f"#{issue['number']}", color="accent"),
+                primary=issue["title"],
+                chips=[RowChip(lbl["name"], _label_color(lbl["name"])) for lbl in issue["labels"][:2]],
+            ).to_dict()
+            for issue in self._issues
+        ]
+        ctx.list_view("issues", rows, selected=self._sel, y=float(HEADER_H))
+    """
+    id: str
+    primary: str
+    leading: "LeadingBadge | LeadingAvatar | LeadingIcon | None" = None
+    secondary: "str | None" = None
+    chips: "list[RowChip]" = field(default_factory=list)
+    trailing: "str | None" = None
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "row",
+            "id": self.id,
+            "leading": self.leading.to_dict() if self.leading else {"variant": "none"},
+            "primary": self.primary,
+            "secondary": self.secondary,
+            "chips": [c.to_dict() for c in self.chips],
+            "trailing": self.trailing,
+        }
+
+
 __all__ = [
     # tokens
     "SPACE_XS", "SPACE_SM", "SPACE_MD", "SPACE_LG", "SPACE_XL",
@@ -1448,4 +1530,6 @@ __all__ = [
     "ensure_visible",
     # entry
     "render_tree",
+    # ListView row helpers
+    "ListRow", "RowChip", "LeadingBadge", "LeadingAvatar", "LeadingIcon",
 ]

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -3277,4 +3277,105 @@ mod tests {
             other => panic!("expected Text, got {other:?}"),
         }
     }
+
+    #[test]
+    fn list_view_command_round_trips_serde() {
+        let json = r#"{"type":"list_view","id":"feed","x":0.0,"y":48.0,"w":0.0,"h":0.0,"items":[{"type":"row","id":"r1","primary":"Hello","secondary":null,"leading":{"variant":"none"},"chips":[],"trailing":null}],"selected":0,"loading":false,"error":null}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::ListView { id, selected, loading, error, items, .. }) => {
+                assert_eq!(id, "feed");
+                assert_eq!(*selected, 0);
+                assert!(!loading);
+                assert!(error.is_none());
+                assert_eq!(items.len(), 1);
+            }
+            other => panic!("expected ListView, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""type":"list_view""#), "wire tag missing: {serialised}");
+        assert!(serialised.contains(r#""id":"feed""#), "id missing: {serialised}");
+    }
+
+    #[test]
+    fn list_view_loading_state_round_trips_serde() {
+        let json = r#"{"type":"list_view","id":"issues","x":0.0,"y":0.0,"w":0.0,"h":0.0,"items":[],"selected":0,"loading":true,"error":null}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::ListView { loading, error, .. }) => {
+                assert!(loading, "loading should be true");
+                assert!(error.is_none());
+            }
+            other => panic!("expected ListView, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_view_error_state_round_trips_serde() {
+        let json = r#"{"type":"list_view","id":"issues","x":0.0,"y":0.0,"w":0.0,"h":0.0,"items":[],"selected":0,"loading":false,"error":"network timeout"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::ListView { error, .. }) => {
+                assert_eq!(error.as_deref(), Some("network timeout"));
+            }
+            other => panic!("expected ListView, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_view_row_badge_leading_round_trips_serde() {
+        let json = r##"{"type":"list_view","id":"issues","x":0.0,"y":0.0,"w":0.0,"h":0.0,"items":[{"type":"row","id":"r1","primary":"Fix bug","secondary":"subtitle","leading":{"variant":"badge","label":"#42","color":"accent"},"chips":[{"label":"P1","color":"red"}],"trailing":"3m ago"}],"selected":0,"loading":false,"error":null}"##;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Render(RenderCommand::ListView { items, .. }) => {
+                assert_eq!(items.len(), 1);
+                match &items[0] {
+                    crate::app_protocol::ListViewItem::Row(row) => {
+                        assert_eq!(row.primary, "Fix bug");
+                        assert_eq!(row.secondary.as_deref(), Some("subtitle"));
+                        assert_eq!(row.chips.len(), 1);
+                        assert_eq!(row.trailing.as_deref(), Some("3m ago"));
+                        match &row.leading {
+                            Some(crate::app_protocol::ListViewLeading::Badge { label, color }) => {
+                                assert_eq!(label, "#42");
+                                assert_eq!(color, "accent");
+                            }
+                            other => panic!("expected Badge leading, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Row item, got {other:?}"),
+                }
+            }
+            other => panic!("expected ListView, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_select_event_round_trips_serde() {
+        let json = r#"{"type":"list_select","id":"feed","index":3}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::ListSelect { id, index } => {
+                assert_eq!(id, "feed");
+                assert_eq!(*index, 3);
+            }
+            other => panic!("expected ListSelect, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&event).expect("serialise");
+        assert!(serialised.contains(r#""type":"list_select""#), "wire tag missing: {serialised}");
+        assert!(serialised.contains(r#""index":3"#), "index missing: {serialised}");
+    }
+
+    #[test]
+    fn list_activate_event_round_trips_serde() {
+        let json = r#"{"type":"list_activate","id":"issues","index":0}"#;
+        let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");
+        match &event {
+            PlexiEvent::ListActivate { id, index } => {
+                assert_eq!(id, "issues");
+                assert_eq!(*index, 0);
+            }
+            other => panic!("expected ListActivate, got {other:?}"),
+        }
+    }
 }

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1822,6 +1822,20 @@ pub enum ListViewItem {
     },
 }
 
+impl ListViewItem {
+    pub const ROW_H_BASE: f32 = 40.0;
+    pub const ROW_H_WITH_SEC: f32 = 56.0;
+
+    pub fn height(&self) -> f32 {
+        match self {
+            ListViewItem::Row(r) => {
+                if r.secondary.is_some() { Self::ROW_H_WITH_SEC } else { Self::ROW_H_BASE }
+            }
+            ListViewItem::CustomCell { height_hint, .. } => *height_hint,
+        }
+    }
+}
+
 fn default_custom_cell_height() -> f32 { 40.0 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -381,6 +381,14 @@ pub enum PlexiEvent {
     /// the region. `offset_y` is always >= 0 and clamped to
     /// `max(0, content_height - viewport_height)`.
     ScrollOffset { id: String, offset_y: f32 },
+
+    /// Emitted when j/k/up/down changes the list selection.
+    /// `id` matches the `list_view` id field; `index` is the new selected index.
+    ListSelect { id: String, index: usize },
+
+    /// Emitted when Enter is pressed on the selected item.
+    /// `id` matches the `list_view` id field; `index` is the activated item index.
+    ListActivate { id: String, index: usize },
 }
 
 /// On-the-wire shape of one MIDI port. Mirrors `midi::MidiPortInfo` but lives
@@ -639,6 +647,30 @@ pub enum RenderCommand {
         selected: usize,
         #[serde(default)]
         item_height: f32,
+    },
+
+    /// Host-native scrollable list with j/k navigation, typed row slots,
+    /// and built-in loading/error/empty states.
+    /// Host emits `PlexiEvent::ListSelect` / `PlexiEvent::ListActivate` for callbacks.
+    ListView {
+        id: String,
+        #[serde(default)]
+        x: f32,
+        #[serde(default)]
+        y: f32,
+        /// 0.0 = full pane width
+        #[serde(default)]
+        w: f32,
+        /// 0.0 = remaining pane height below y
+        #[serde(default)]
+        h: f32,
+        items: Vec<ListViewItem>,
+        #[serde(default)]
+        selected: usize,
+        #[serde(default)]
+        loading: bool,
+        #[serde(default)]
+        error: Option<String>,
     },
 
     // ── Host-measured layout primitives ──────────────────────────────────
@@ -1745,6 +1777,52 @@ pub struct ListItem {
     #[serde(default)]
     pub is_dir: bool,
 }
+
+/// Leading slot for a ListView row.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(tag = "variant", rename_all = "snake_case")]
+pub enum ListViewLeading {
+    Badge { label: String, color: String },
+    Avatar { handle: String },
+    Icon { name: String },
+    None,
+}
+
+/// One chip label on a ListView row.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+pub struct ListViewChip {
+    pub label: String,
+    pub color: String,
+}
+
+/// A generic typed row for a ListView.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+pub struct ListViewRowDescriptor {
+    pub id: String,
+    #[serde(default)]
+    pub leading: Option<ListViewLeading>,
+    pub primary: String,
+    #[serde(default)]
+    pub secondary: Option<String>,
+    #[serde(default)]
+    pub chips: Vec<ListViewChip>,
+    #[serde(default)]
+    pub trailing: Option<String>,
+}
+
+/// An item inside a ListView — either a typed row or a custom cell.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ListViewItem {
+    Row(ListViewRowDescriptor),
+    CustomCell {
+        id: String,
+        #[serde(default = "default_custom_cell_height")]
+        height_hint: f32,
+    },
+}
+
+fn default_custom_cell_height() -> f32 { 40.0 }
 
 fn is_false(b: &bool) -> bool {
     !*b

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -183,9 +183,11 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
         egui::CentralPanel::default()
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
+                let mut lv_offsets = std::collections::HashMap::new();
                 crate::process_app::render::render_draw_commands(
                     ui, rect, commands, &colors, &mut cm_cache, &peaks,
                     &mut img_cache, &std::env::temp_dir(), false,
+                    &mut lv_offsets,
                 );
             });
     });

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1892,7 +1892,7 @@ impl App for ProcessApp {
                         }
                         // Suppress j/k text events when a ListView is active
                         if self.render_session.list_view_intercepts_nav
-                            && matches!(ch, 'j' | 'k')
+                            && matches!(ch, 'j' | 'k' | 'J' | 'K')
                         {
                             continue;
                         }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1848,6 +1848,26 @@ impl App for ProcessApp {
                             | egui::Key::Space
                             | egui::Key::Plus
                     );
+                    // When a ListView is active, suppress bare j/k/up/down/enter
+                    // forwarding — the list_view pass already handled these host-side.
+                    if self.render_session.list_view_intercepts_nav
+                        && !modifiers.ctrl
+                        && !modifiers.command
+                    {
+                        let is_nav = matches!(
+                            key,
+                            egui::Key::J
+                                | egui::Key::K
+                                | egui::Key::ArrowDown
+                                | egui::Key::ArrowUp
+                                | egui::Key::Enter
+                        );
+                        if is_nav {
+                            consumed = true;
+                            continue;
+                        }
+                    }
+
                     // Cmd-modified chords are reserved for host shortcuts
                     // (Cmd+Enter zoom, Cmd+P palette, Cmd+Shift+A notifications,
                     // etc.). Apps can't shadow a host keybind; they use bare
@@ -1868,6 +1888,12 @@ impl App for ProcessApp {
                 egui::Event::Text(text) => {
                     for ch in text.chars() {
                         if ch.is_control() {
+                            continue;
+                        }
+                        // Suppress j/k text events when a ListView is active
+                        if self.render_session.list_view_intercepts_nav
+                            && matches!(ch, 'j' | 'k')
+                        {
                             continue;
                         }
                         self.send_event(&PlexiEvent::Key {

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -391,7 +391,7 @@ pub(crate) fn render_draw_commands(
             } => {
                 use crate::app_protocol::{ListViewItem, ListViewLeading};
 
-                log::info!("ListView: id={id:?} items={} selected={selected} loading={loading}", items.len());
+                log::debug!("ListView: id={id:?} items={} selected={selected} loading={loading}", items.len());
 
                 let list_w = if *w > 0.0 { *w } else { pane_rect.width() };
                 let list_h = if *h > 0.0 { *h } else { pane_rect.height() - y };

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -389,7 +389,7 @@ pub(crate) fn render_draw_commands(
                 loading,
                 error,
             } => {
-                use crate::app_protocol::{ListViewItem, ListViewLeading};
+                use crate::app_protocol::ListViewLeading;
 
                 log::debug!("ListView: id={id:?} items={} selected={selected} loading={loading}", items.len());
 
@@ -401,8 +401,7 @@ pub(crate) fn render_draw_commands(
                 );
                 let list_clip = clip.intersect(list_rect);
 
-                const ROW_H_BASE: f32 = 40.0;
-                const ROW_H_WITH_SEC: f32 = 56.0;
+                use crate::app_protocol::ListViewItem as LVI;
                 const LEADING_W: f32 = 48.0;
                 const PAD_X: f32 = 12.0;
                 const CHIP_GAP: f32 = 4.0;
@@ -412,16 +411,7 @@ pub(crate) fn render_draw_commands(
                 const FONT_CAPTION: f32 = 13.0;
                 const FONT_HINT: f32 = 12.0;
 
-                let item_height = |item: &ListViewItem| -> f32 {
-                    match item {
-                        ListViewItem::Row(r) => {
-                            if r.secondary.is_some() { ROW_H_WITH_SEC } else { ROW_H_BASE }
-                        }
-                        ListViewItem::CustomCell { height_hint, .. } => *height_hint,
-                    }
-                };
-
-                let heights: Vec<f32> = items.iter().map(|i| item_height(i)).collect();
+                let heights: Vec<f32> = items.iter().map(|i| i.height()).collect();
                 let total_h = if heights.is_empty() {
                     0.0
                 } else {
@@ -436,10 +426,11 @@ pub(crate) fn render_draw_commands(
                     for (i, h_item) in heights.iter().enumerate() {
                         if i == sel {
                             let item_bot = item_top + h_item;
-                            if item_top < *scroll_y_ref {
+                            if *h_item > list_h {
                                 *scroll_y_ref = item_top;
-                            }
-                            if item_bot > *scroll_y_ref + list_h {
+                            } else if item_top < *scroll_y_ref {
+                                *scroll_y_ref = item_top;
+                            } else if item_bot > *scroll_y_ref + list_h {
                                 *scroll_y_ref = (item_bot - list_h).max(0.0);
                             }
                             break;
@@ -460,20 +451,20 @@ pub(crate) fn render_draw_commands(
                         if sy > list_rect.max.y { break; }
                         let row_rect = egui::Rect::from_min_size(
                             egui::pos2(list_rect.min.x, sy),
-                            egui::vec2(list_w, ROW_H_BASE),
+                            egui::vec2(list_w, LVI::ROW_H_BASE),
                         );
                         painter.rect_filled(row_rect, 0.0, colors.terminal_bg);
                         let lead_rect = egui::Rect::from_min_size(
-                            egui::pos2(list_rect.min.x + PAD_X, sy + (ROW_H_BASE - 20.0) / 2.0),
+                            egui::pos2(list_rect.min.x + PAD_X, sy + (LVI::ROW_H_BASE - 20.0) / 2.0),
                             egui::vec2(20.0, 20.0),
                         );
                         painter.rect_filled(lead_rect, 10.0, colors.border);
                         let txt_rect = egui::Rect::from_min_size(
-                            egui::pos2(list_rect.min.x + LEADING_W, sy + (ROW_H_BASE - FONT_CAPTION) / 2.0),
+                            egui::pos2(list_rect.min.x + LEADING_W, sy + (LVI::ROW_H_BASE - FONT_CAPTION) / 2.0),
                             egui::vec2(list_w * 0.6, FONT_CAPTION),
                         );
                         painter.rect_filled(txt_rect, 3.0, colors.border);
-                        sy += ROW_H_BASE + SPACE_XS;
+                        sy += LVI::ROW_H_BASE + SPACE_XS;
                     }
                     // return is inside the match arm — use continue instead
                 }
@@ -541,10 +532,10 @@ pub(crate) fn render_draw_commands(
                         painter.rect_filled(row_rect, 0.0, bg);
 
                         match item {
-                            ListViewItem::CustomCell { .. } => {
+                            LVI::CustomCell { .. } => {
                                 // Custom cell: host only renders background. App draws over it.
                             }
-                            ListViewItem::Row(row) => {
+                            LVI::Row(row) => {
                                 let mid_y = row_rect.center().y;
                                 let primary_y = if row.secondary.is_some() {
                                     row_rect.min.y + 8.0
@@ -636,16 +627,16 @@ pub(crate) fn render_draw_commands(
                                         egui::FontId::proportional(FONT_HINT),
                                         colors.text_dim,
                                     );
-                                    trailing_reserve = trailing.len() as f32 * 6.0 + 16.0;
+                                    trailing_reserve = trailing.chars().count() as f32 * 6.0 + 16.0;
                                 }
 
                                 // Chips (right-aligned)
                                 let chips_reserve: f32 = row.chips.iter()
-                                    .map(|c| c.label.len() as f32 * 7.0 + CHIP_PAD_X * 2.0 + CHIP_GAP)
+                                    .map(|c| c.label.chars().count() as f32 * 7.0 + CHIP_PAD_X * 2.0 + CHIP_GAP)
                                     .sum();
                                 let mut cx = list_rect.max.x - PAD_X - trailing_reserve - chips_reserve;
                                 for chip in &row.chips {
-                                    let chip_w = chip.label.len() as f32 * 7.0 + CHIP_PAD_X * 2.0;
+                                    let chip_w = chip.label.chars().count() as f32 * 7.0 + CHIP_PAD_X * 2.0;
                                     let chip_color = parse_color(&chip.color)
                                         .unwrap_or(colors.accent);
                                     let chip_rect = egui::Rect::from_min_size(

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -42,6 +42,7 @@ pub(crate) fn render_draw_commands(
     image_cache: &mut super::image_cache::ImageCache,
     workspace_root: &std::path::Path,
     net_http_granted: bool,
+    list_view_scroll_offsets: &mut HashMap<String, f32>,
 ) {
     let origin = pane_rect.min;
 
@@ -373,6 +374,316 @@ pub(crate) fn render_draw_commands(
                             egui::FontId::proportional(10.0),
                             colors.text_dim,
                         );
+                    }
+                }
+            }
+
+            RenderCommand::ListView {
+                id,
+                x,
+                y,
+                w,
+                h,
+                items,
+                selected,
+                loading,
+                error,
+            } => {
+                use crate::app_protocol::{ListViewItem, ListViewLeading};
+
+                log::info!("ListView: id={id:?} items={} selected={selected} loading={loading}", items.len());
+
+                let list_w = if *w > 0.0 { *w } else { pane_rect.width() };
+                let list_h = if *h > 0.0 { *h } else { pane_rect.height() - y };
+                let list_rect = egui::Rect::from_min_size(
+                    egui::pos2(pane_rect.min.x + x, pane_rect.min.y + y),
+                    egui::vec2(list_w, list_h),
+                );
+                let list_clip = clip.intersect(list_rect);
+
+                const ROW_H_BASE: f32 = 40.0;
+                const ROW_H_WITH_SEC: f32 = 56.0;
+                const LEADING_W: f32 = 48.0;
+                const PAD_X: f32 = 12.0;
+                const CHIP_GAP: f32 = 4.0;
+                const CHIP_PAD_X: f32 = 8.0;
+                const SPACE_XS: f32 = 4.0;
+                const SCROLLBAR_W: f32 = 3.0;
+                const FONT_CAPTION: f32 = 13.0;
+                const FONT_HINT: f32 = 12.0;
+
+                let item_height = |item: &ListViewItem| -> f32 {
+                    match item {
+                        ListViewItem::Row(r) => {
+                            if r.secondary.is_some() { ROW_H_WITH_SEC } else { ROW_H_BASE }
+                        }
+                        ListViewItem::CustomCell { height_hint, .. } => *height_hint,
+                    }
+                };
+
+                let heights: Vec<f32> = items.iter().map(|i| item_height(i)).collect();
+                let total_h = if heights.is_empty() {
+                    0.0
+                } else {
+                    heights.iter().sum::<f32>() + SPACE_XS * (heights.len().saturating_sub(1)) as f32
+                };
+
+                // Scroll-to-selected: ensure selected row is visible
+                let scroll_y_ref = list_view_scroll_offsets.entry(id.clone()).or_insert(0.0);
+                if !items.is_empty() {
+                    let sel = (*selected).min(items.len().saturating_sub(1));
+                    let mut item_top = 0.0f32;
+                    for (i, h_item) in heights.iter().enumerate() {
+                        if i == sel {
+                            let item_bot = item_top + h_item;
+                            if item_top < *scroll_y_ref {
+                                *scroll_y_ref = item_top;
+                            }
+                            if item_bot > *scroll_y_ref + list_h {
+                                *scroll_y_ref = (item_bot - list_h).max(0.0);
+                            }
+                            break;
+                        }
+                        item_top += h_item + SPACE_XS;
+                    }
+                    let max_scroll = (total_h - list_h).max(0.0);
+                    *scroll_y_ref = scroll_y_ref.clamp(0.0, max_scroll);
+                }
+                let scroll_y = *scroll_y_ref;
+
+                let painter = ui.painter().with_clip_rect(list_clip);
+
+                // Loading state: 8 skeleton rows
+                if *loading {
+                    let mut sy = list_rect.min.y;
+                    for _ in 0..8 {
+                        if sy > list_rect.max.y { break; }
+                        let row_rect = egui::Rect::from_min_size(
+                            egui::pos2(list_rect.min.x, sy),
+                            egui::vec2(list_w, ROW_H_BASE),
+                        );
+                        painter.rect_filled(row_rect, 0.0, colors.terminal_bg);
+                        let lead_rect = egui::Rect::from_min_size(
+                            egui::pos2(list_rect.min.x + PAD_X, sy + (ROW_H_BASE - 20.0) / 2.0),
+                            egui::vec2(20.0, 20.0),
+                        );
+                        painter.rect_filled(lead_rect, 10.0, colors.border);
+                        let txt_rect = egui::Rect::from_min_size(
+                            egui::pos2(list_rect.min.x + LEADING_W, sy + (ROW_H_BASE - FONT_CAPTION) / 2.0),
+                            egui::vec2(list_w * 0.6, FONT_CAPTION),
+                        );
+                        painter.rect_filled(txt_rect, 3.0, colors.border);
+                        sy += ROW_H_BASE + SPACE_XS;
+                    }
+                    // return is inside the match arm — use continue instead
+                }
+                // Error state
+                else if let Some(err_msg) = error {
+                    painter.text(
+                        egui::pos2(list_rect.min.x + PAD_X, list_rect.min.y + PAD_X),
+                        egui::Align2::LEFT_TOP,
+                        err_msg.as_str(),
+                        egui::FontId::proportional(FONT_CAPTION),
+                        colors.text_dim,
+                    );
+                }
+                // Empty state
+                else if items.is_empty() {
+                    painter.text(
+                        egui::pos2(list_rect.min.x + PAD_X, list_rect.min.y + PAD_X),
+                        egui::Align2::LEFT_TOP,
+                        "No items.",
+                        egui::FontId::proportional(FONT_CAPTION),
+                        colors.text_dim,
+                    );
+                } else {
+                    // Scrollbar (only when content overflows)
+                    if total_h > list_h {
+                        let track_x = list_rect.max.x - SCROLLBAR_W;
+                        let thumb_ratio = list_h / total_h;
+                        let thumb_h = (thumb_ratio * list_h).max(20.0);
+                        let scroll_ratio = scroll_y / (total_h - list_h).max(1.0);
+                        let thumb_y = list_rect.min.y + scroll_ratio * (list_h - thumb_h);
+                        painter.rect_filled(
+                            egui::Rect::from_min_size(
+                                egui::pos2(track_x, thumb_y),
+                                egui::vec2(SCROLLBAR_W, thumb_h),
+                            ),
+                            1.5,
+                            colors.border,
+                        );
+                    }
+
+                    // Render visible rows
+                    let mut item_top = 0.0f32;
+                    for (i, item) in items.iter().enumerate() {
+                        let h_item = heights[i];
+                        let row_abs_y = list_rect.min.y + item_top - scroll_y;
+                        item_top += h_item + SPACE_XS;
+
+                        if row_abs_y + h_item < list_rect.min.y || row_abs_y > list_rect.max.y {
+                            continue;
+                        }
+
+                        let row_rect = egui::Rect::from_min_size(
+                            egui::pos2(list_rect.min.x, row_abs_y),
+                            egui::vec2(list_w, h_item),
+                        );
+                        let is_sel = i == (*selected).min(items.len().saturating_sub(1));
+
+                        let bg = if is_sel {
+                            colors.bg_active
+                        } else if i % 2 == 0 {
+                            colors.terminal_bg
+                        } else {
+                            colors.bg_darkest
+                        };
+                        painter.rect_filled(row_rect, 0.0, bg);
+
+                        match item {
+                            ListViewItem::CustomCell { .. } => {
+                                // Custom cell: host only renders background. App draws over it.
+                            }
+                            ListViewItem::Row(row) => {
+                                let mid_y = row_rect.center().y;
+                                let primary_y = if row.secondary.is_some() {
+                                    row_rect.min.y + 8.0
+                                } else {
+                                    mid_y - FONT_CAPTION / 2.0
+                                };
+
+                                let text_start_x = match &row.leading {
+                                    Some(ListViewLeading::Badge { label, color }) => {
+                                        // render_badge takes origin + pane-local coords
+                                        let badge_x = list_rect.min.x - pane_rect.min.x + PAD_X;
+                                        let badge_y = row_abs_y - pane_rect.min.y + h_item / 2.0;
+                                        render_badge(
+                                            ui,
+                                            pane_rect.min,
+                                            list_clip,
+                                            badge_x,
+                                            badge_y,
+                                            label,
+                                            color,
+                                            "#1e1e2e",
+                                            FONT_HINT,
+                                            3.0,
+                                        );
+                                        list_rect.min.x + LEADING_W
+                                    }
+                                    Some(ListViewLeading::Avatar { handle }) => {
+                                        let avatar_r = 14.0;
+                                        let av_cx = list_rect.min.x + PAD_X + avatar_r;
+                                        let av_cy = mid_y;
+                                        if let Some(img_handle) = image_cache.get(handle) {
+                                            let tex_id = img_handle.id();
+                                            let n_segs: u32 = 32;
+                                            let center = egui::pos2(av_cx, av_cy);
+                                            let mut mesh = egui::Mesh::with_texture(tex_id);
+                                            mesh.vertices.push(egui::epaint::Vertex {
+                                                pos: center,
+                                                uv: egui::pos2(0.5, 0.5),
+                                                color: egui::Color32::WHITE,
+                                            });
+                                            for seg_i in 0..=n_segs {
+                                                let angle = seg_i as f32 / n_segs as f32 * std::f32::consts::TAU;
+                                                let cos = angle.cos();
+                                                let sin = angle.sin();
+                                                mesh.vertices.push(egui::epaint::Vertex {
+                                                    pos: egui::pos2(center.x + cos * avatar_r, center.y + sin * avatar_r),
+                                                    uv: egui::pos2(0.5 + cos * 0.5, 0.5 + sin * 0.5),
+                                                    color: egui::Color32::WHITE,
+                                                });
+                                            }
+                                            for seg_i in 0..n_segs {
+                                                mesh.indices.push(0);
+                                                mesh.indices.push(seg_i + 1);
+                                                mesh.indices.push(seg_i + 2);
+                                            }
+                                            painter.add(egui::Shape::Mesh(std::sync::Arc::new(mesh)));
+                                        } else {
+                                            painter.circle_filled(
+                                                egui::pos2(av_cx, av_cy),
+                                                avatar_r,
+                                                egui::Color32::from_rgb(0x3a, 0x3a, 0x4a),
+                                            );
+                                        }
+                                        list_rect.min.x + LEADING_W
+                                    }
+                                    Some(ListViewLeading::Icon { name }) => {
+                                        painter.text(
+                                            egui::pos2(list_rect.min.x + PAD_X, mid_y),
+                                            egui::Align2::LEFT_CENTER,
+                                            name.as_str(),
+                                            egui::FontId::proportional(FONT_CAPTION),
+                                            colors.text_dim,
+                                        );
+                                        list_rect.min.x + LEADING_W
+                                    }
+                                    Some(ListViewLeading::None) | None => {
+                                        list_rect.min.x + PAD_X
+                                    }
+                                };
+
+                                // Trailing text (right-aligned)
+                                let mut trailing_reserve = 0.0f32;
+                                if let Some(trailing) = &row.trailing {
+                                    let t_x = list_rect.max.x - PAD_X;
+                                    painter.text(
+                                        egui::pos2(t_x, primary_y),
+                                        egui::Align2::RIGHT_TOP,
+                                        trailing.as_str(),
+                                        egui::FontId::proportional(FONT_HINT),
+                                        colors.text_dim,
+                                    );
+                                    trailing_reserve = trailing.len() as f32 * 6.0 + 16.0;
+                                }
+
+                                // Chips (right-aligned)
+                                let chips_reserve: f32 = row.chips.iter()
+                                    .map(|c| c.label.len() as f32 * 7.0 + CHIP_PAD_X * 2.0 + CHIP_GAP)
+                                    .sum();
+                                let mut cx = list_rect.max.x - PAD_X - trailing_reserve - chips_reserve;
+                                for chip in &row.chips {
+                                    let chip_w = chip.label.len() as f32 * 7.0 + CHIP_PAD_X * 2.0;
+                                    let chip_color = parse_color(&chip.color)
+                                        .unwrap_or(colors.accent);
+                                    let chip_rect = egui::Rect::from_min_size(
+                                        egui::pos2(cx, row_rect.min.y + (h_item - FONT_HINT - 4.0) / 2.0),
+                                        egui::vec2(chip_w, FONT_HINT + 4.0),
+                                    );
+                                    painter.rect_filled(chip_rect, 3.0, chip_color.linear_multiply(0.2));
+                                    painter.text(
+                                        chip_rect.center(),
+                                        egui::Align2::CENTER_CENTER,
+                                        chip.label.as_str(),
+                                        egui::FontId::proportional(FONT_HINT),
+                                        chip_color,
+                                    );
+                                    cx += chip_w + CHIP_GAP;
+                                }
+
+                                // Primary text
+                                painter.text(
+                                    egui::pos2(text_start_x, primary_y),
+                                    egui::Align2::LEFT_TOP,
+                                    row.primary.as_str(),
+                                    egui::FontId::proportional(FONT_CAPTION),
+                                    colors.text_primary,
+                                );
+
+                                // Secondary text
+                                if let Some(sec) = &row.secondary {
+                                    painter.text(
+                                        egui::pos2(text_start_x, primary_y + FONT_CAPTION + 4.0),
+                                        egui::Align2::LEFT_TOP,
+                                        sec.as_str(),
+                                        egui::FontId::proportional(FONT_HINT),
+                                        colors.text_dim,
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -19,12 +19,17 @@ pub(crate) struct RenderSession {
     /// Per-region scroll offsets for `DrawCommand::BeginScroll` / `EndScroll`.
     /// Key = scroll region id; value = current vertical offset in logical pixels.
     scroll_offsets: HashMap<String, f32>,
+    /// Per-ListView scroll offsets. Key = list_view id; value = current vertical offset.
+    list_view_scroll_offsets: HashMap<String, f32>,
+    /// True when the current frame contains a ListView command.
+    /// When true, `handle_key` in mod.rs suppresses j/k/up/down/enter forwarding.
+    pub(crate) list_view_intercepts_nav: bool,
     /// Set externally by `src/pane_ops/layout.rs` when a pane gains keyboard focus.
     /// Read during render to auto-focus the first TextInput.
     pub(crate) pane_just_focused: bool,
     /// Events accumulated during one render pass. Drained after render into
     /// `ProcessApp::outbound_events` by `drain_events`.
-    outbound_events: Vec<PlexiEvent>,
+    pub(crate) outbound_events: Vec<PlexiEvent>,
 }
 
 impl RenderSession {
@@ -34,6 +39,8 @@ impl RenderSession {
             text_input_visible_prev: HashSet::new(),
             text_input_has_focus: false,
             scroll_offsets: HashMap::new(),
+            list_view_scroll_offsets: HashMap::new(),
+            list_view_intercepts_nav: false,
             pane_just_focused: false,
             outbound_events: Vec::new(),
         }
@@ -70,6 +77,7 @@ impl RenderSession {
             image_cache,
             app_dir,
             net_http_granted,
+            &mut self.list_view_scroll_offsets,
         );
 
         // ── Pass 2: TextInput widgets ────────────────────────────────────────
@@ -77,6 +85,9 @@ impl RenderSession {
 
         // ── Pass 3: scroll region scan ───────────────────────────────────────
         self.render_scroll_regions(ui, pane_rect, frame);
+
+        // ── Pass 4: ListView interaction (j/k/enter, scroll gesture) ─────────
+        self.render_list_views(ui, pane_rect, frame);
     }
 
     /// Pass 2: render every `RenderCommand::TextInput` as a real egui `TextEdit`.
@@ -296,6 +307,102 @@ impl RenderSession {
         PlexiEvent::TextSubmitted {
             id: id.to_string(),
             value,
+        }
+    }
+
+    /// Pass 4: handle ListView pointer scroll, j/k/enter key events.
+    fn render_list_views(
+        &mut self,
+        ui: &mut egui::Ui,
+        pane_rect: egui::Rect,
+        frame: &[RenderCommand],
+    ) {
+        use crate::app_protocol::{ListViewItem, PlexiEvent};
+
+        // Reset intercept flag — recalculate from current frame
+        self.list_view_intercepts_nav = false;
+
+        for cmd in frame {
+            let RenderCommand::ListView {
+                id, x, y, w, h, items, selected, loading, ..
+            } = cmd else { continue };
+
+            // This frame has a list_view — host intercepts j/k/enter
+            self.list_view_intercepts_nav = true;
+
+            let list_w = if *w > 0.0 { *w } else { pane_rect.width() };
+            let list_h = if *h > 0.0 { *h } else { pane_rect.height() - y };
+            let list_rect = egui::Rect::from_min_size(
+                egui::pos2(pane_rect.min.x + x, pane_rect.min.y + y),
+                egui::vec2(list_w, list_h),
+            );
+
+            if *loading || items.is_empty() {
+                continue;
+            }
+
+            let n = items.len();
+            let sel = (*selected).min(n.saturating_sub(1));
+
+            // Scroll gesture (pointer inside list_rect)
+            let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
+            if scroll_delta.y != 0.0 {
+                if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
+                    if list_rect.contains(pos) {
+                        const SPACE_XS: f32 = 4.0;
+                        let total_h: f32 = items.iter().map(|item| match item {
+                            ListViewItem::Row(r) => if r.secondary.is_some() { 56.0 } else { 40.0 },
+                            ListViewItem::CustomCell { height_hint, .. } => *height_hint,
+                        }).sum::<f32>() + SPACE_XS * (n.saturating_sub(1)) as f32;
+                        let max_scroll = (total_h - list_h).max(0.0);
+                        let prev = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
+                        let next = (prev - scroll_delta.y).clamp(0.0, max_scroll);
+                        if (next - prev).abs() > 0.01 {
+                            self.list_view_scroll_offsets.insert(id.clone(), next);
+                            ui.ctx().request_repaint();
+                        }
+                    }
+                }
+            }
+
+            // j / down
+            let j_pressed = ui.input(|i|
+                i.key_pressed(egui::Key::J) || i.key_pressed(egui::Key::ArrowDown)
+            );
+            if j_pressed && sel + 1 < n {
+                let new_sel = sel + 1;
+                log::info!("ListView[{id}]: j → select {new_sel}");
+                self.outbound_events.push(PlexiEvent::ListSelect {
+                    id: id.clone(),
+                    index: new_sel,
+                });
+                ui.ctx().request_repaint();
+            }
+
+            // k / up
+            let k_pressed = ui.input(|i|
+                i.key_pressed(egui::Key::K) || i.key_pressed(egui::Key::ArrowUp)
+            );
+            if k_pressed && sel > 0 {
+                let new_sel = sel - 1;
+                log::info!("ListView[{id}]: k → select {new_sel}");
+                self.outbound_events.push(PlexiEvent::ListSelect {
+                    id: id.clone(),
+                    index: new_sel,
+                });
+                ui.ctx().request_repaint();
+            }
+
+            // Enter
+            let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+            if enter_pressed {
+                log::info!("ListView[{id}]: enter → activate {sel}");
+                self.outbound_events.push(PlexiEvent::ListActivate {
+                    id: id.clone(),
+                    index: sel,
+                });
+                ui.ctx().request_repaint();
+            }
         }
     }
 }

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -317,11 +317,21 @@ impl RenderSession {
         pane_rect: egui::Rect,
         frame: &[RenderCommand],
     ) {
-        use crate::app_protocol::{ListViewItem, PlexiEvent};
+        use crate::app_protocol::PlexiEvent;
 
         // Reset intercept flag — recalculate from current frame
         self.list_view_intercepts_nav = false;
 
+        // Prune scroll state for lists no longer in the frame
+        let live_ids: std::collections::HashSet<String> = frame
+            .iter()
+            .filter_map(|cmd| {
+                if let RenderCommand::ListView { id, .. } = cmd { Some(id.clone()) } else { None }
+            })
+            .collect();
+        self.list_view_scroll_offsets.retain(|id, _| live_ids.contains(id));
+
+        let mut handled_nav = false;
         for cmd in frame {
             let RenderCommand::ListView {
                 id, x, y, w, h, items, selected, loading, ..
@@ -337,7 +347,7 @@ impl RenderSession {
                 egui::vec2(list_w, list_h),
             );
 
-            if *loading || items.is_empty() {
+            if handled_nav || *loading || items.is_empty() {
                 continue;
             }
 
@@ -350,10 +360,8 @@ impl RenderSession {
                 if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
                     if list_rect.contains(pos) {
                         const SPACE_XS: f32 = 4.0;
-                        let total_h: f32 = items.iter().map(|item| match item {
-                            ListViewItem::Row(r) => if r.secondary.is_some() { 56.0 } else { 40.0 },
-                            ListViewItem::CustomCell { height_hint, .. } => *height_hint,
-                        }).sum::<f32>() + SPACE_XS * (n.saturating_sub(1)) as f32;
+                        let total_h: f32 = items.iter().map(|item| item.height()).sum::<f32>()
+                            + SPACE_XS * (n.saturating_sub(1)) as f32;
                         let max_scroll = (total_h - list_h).max(0.0);
                         let prev = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
                         let next = (prev - scroll_delta.y).clamp(0.0, max_scroll);
@@ -377,6 +385,7 @@ impl RenderSession {
                     index: new_sel,
                 });
                 ui.ctx().request_repaint();
+                handled_nav = true;
             }
 
             // k / up
@@ -391,6 +400,7 @@ impl RenderSession {
                     index: new_sel,
                 });
                 ui.ctx().request_repaint();
+                handled_nav = true;
             }
 
             // Enter
@@ -402,6 +412,7 @@ impl RenderSession {
                     index: sel,
                 });
                 ui.ctx().request_repaint();
+                handled_nav = true;
             }
         }
     }


### PR DESCRIPTION
Closes #1727

## Summary

- Add `ListView` as a new `RenderCommand` — host owns j/k navigation, scroll-to-selected, virtual scroll, skeleton loading, error, and empty states. App just emits a list of `ListRow` descriptors once per frame.
- Add `ListRow` / `RowChip` / `LeadingBadge` / `LeadingAvatar` / `LeadingIcon` Python dataclasses in `sdk/python/plexi_sdk/ui.py`; new `ctx.list_view()` method in `_render_context.py`; `on_list_select` / `on_list_activate` dispatch in `_app.py`.
- Migrate `apps/dev/bluesky` and `apps/dev/gh-issues` to `ctx.list_view()`, removing all per-app scroll math, skeleton code, and j/k handlers. Rename the existing `ctx.list_view()` to `ctx.simple_list()` (unchanged wire format `{"type":"list"}`) to preserve backward compat for wikipedia, quick-note, and todo.

## Done When

- `ctx.list_view()` is callable from any PGAP app with Row descriptors and loading/error state
- Bluesky `on_render` uses `ctx.list_view()` with no manual scroll math, no j/k handler, no skeleton code
- gh-issues `_draw_list` replaced by `ctx.list_view()`; `_scroll_y` and `on_scroll` removed
- j/k with scroll-to-selected works in both apps with zero app-side code
- Loading shows skeleton rows; error shows error text; empty shows empty message
- Pane resize at 300px–1200px produces correct layout with no clipping
- `cargo test --bin plexi` passes

## Notes

- `list_view_scroll_offsets: HashMap<String, f32>` is carried on `RenderSession` (not per-frame) so scroll position survives re-renders; passed by `&mut` into `render_draw_commands`.
- j/k suppression uses both `egui::Event::Key` (arrows/Enter) and `egui::Event::Text` ('j'/'k' chars) because egui fires Text events for printable keys even when Key is handled.
- `custom_cell` escape hatch is wired in the protocol but renders as a plain fixed-height rect for now — full custom routing deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced list navigation with keyboard shortcuts (j/k or arrow keys to move between items, Enter to open/activate).
  * Improved visual feedback for lists, including loading indicators, error messages, and empty states.
  * Consistent list behavior across all apps.

* **Refactor**
  * Modernized list UI implementation for better performance and user experience consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->