### PR TITLE
refactor(examples/typing-tutor): migrate to SDK v2 component API (#1280)

### DIFF
--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -92,7 +92,8 @@ class _LevelGrid(Component):
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         app = self._app
-        cols, rows = 5, 2
+        cols = 5
+        rows = (len(LEVELS) + cols - 1) // cols
         gap = 12.0
         card_w = (w - (cols - 1) * gap) / cols
         card_h = (h - (rows - 1) * gap) / rows
@@ -130,8 +131,9 @@ class _LevelGrid(Component):
 
             if not unlocked:
                 ctx.rect(cx, cy, card_w, card_h, fill="#00000066", radius=RADIUS_MD)
-                ctx.text(cx + card_w / 2 - 18, cy + card_h / 2 - 8,
-                         f"🔒 Need {level.stars_needed}★", size=TEXT_HINT, color=MUTED)
+                ctx.text(cx + card_w / 2, cy + card_h / 2,
+                         f"🔒 Need {level.stars_needed}★", size=TEXT_HINT, color=MUTED,
+                         align="center")
 
 
 class _CharGrid(Component):
@@ -174,8 +176,6 @@ class _CharGrid(Component):
             else:
                 ctx.text(cx, cy, ch, size=char_size, color=MUTED, monospace=True)
 
-        ctx.emit.schedule_render(16)
-
 
 class _TimerBar(Component):
     """Progress bar + countdown timer pinned above the footer."""
@@ -203,6 +203,7 @@ class _TimerBar(Component):
         ctx.rect(x + SPACE_SM, bar_y, bar_w, 8.0, fill=SURFACE, radius=4.0)
         progress = app._typed / max(len(level.text), 1)
         ctx.rect(x + SPACE_SM, bar_y, bar_w * progress, 8.0, fill=GREEN, radius=4.0)
+        ctx.schedule_render(100)
 
 
 # ── App ──────────────────────────────────────────────────────────────────────
@@ -298,7 +299,7 @@ class TypingTutorApp(App):
             self._selected = max(0, self._selected - 5)
         elif key in ("j", "down"):
             self._selected = min(n - 1, self._selected + 5)
-        elif key in (" ", "Enter"):
+        elif key in ("space", "return"):
             if _is_unlocked(self._selected, self._level_stars):
                 self._start_level(self._selected)
 
@@ -306,12 +307,12 @@ class TypingTutorApp(App):
         level = LEVELS[self._play_level]
         text = level.text
 
-        if key == "Escape":
+        if key == "escape":
             self.emit.info(f"typing-tutor: aborted level={self._play_level + 1}")
             self._screen = Screen.LEVEL_SELECT
             return
 
-        if key == "Backspace":
+        if key == "backspace":
             if self._typed > 0:
                 self._typed -= 1
                 self._errors.discard(self._typed)
@@ -333,7 +334,7 @@ class TypingTutorApp(App):
             self._go_result(ctx, timed_out=False)
 
     def _key_result(self, key: str) -> None:
-        if key in (" ", "Enter"):
+        if key in ("space", "return"):
             self._screen = Screen.LEVEL_SELECT
         elif key == "r":
             self._start_level(self._play_level)

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -172,8 +172,8 @@ class _CharGrid(Component):
                 else:
                     ctx.text(cx, cy, ch, size=char_size, color=GREEN, monospace=True)
             elif i == app._typed:
-                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ACCENT + "55", radius=2.0)
-                ctx.text(cx, cy, ch, size=char_size, color=FG, monospace=True)
+                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ACCENT, radius=2.0)
+                ctx.text(cx, cy, ch, size=char_size, color=BG, monospace=True)
             else:
                 ctx.text(cx, cy, ch, size=char_size, color=MUTED, monospace=True)
 

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -109,7 +109,7 @@ class _LevelGrid(Component):
             stars = app._level_stars[i]
 
             if selected:
-                bg, border, bw = ACCENT + "33", ACCENT, 2.0
+                bg, border, bw = SURFACE, ACCENT, 2.0
             elif unlocked:
                 bg, border, bw = SURFACE, HIGHLIGHT, 1.0
             else:
@@ -122,8 +122,9 @@ class _LevelGrid(Component):
             ctx.rect(cx + card_w - bw, cy, bw, card_h, fill=border)
 
             text_color = FG if unlocked else MUTED
+            num_color = ACCENT if selected else (ACCENT if unlocked else MUTED)
             ctx.text(cx + 10, cy + 10, f"{i + 1}", size=TEXT_BODY,
-                     color=ACCENT if selected else text_color, bold=True)
+                     color=num_color, bold=True)
             ctx.text(cx + 10, cy + 28, level.name, size=TEXT_HINT, color=text_color)
             ctx.text(cx + 10, cy + card_h - 20,
                      "★" * stars + "☆" * (5 - stars),

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -4,8 +4,14 @@
 import time
 from enum import Enum
 
-from plexi_sdk import App, RenderContext, BG, FG, ACCENT, RED, GREEN, MUTED, SURFACE, HIGHLIGHT
-from plexi_sdk import BODY, CAPTION, HINT, TITLE, HEADING
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    Column, AppBar, Card, Label, Spacer, FooterKeys, Component,
+    SPACE_SM, SPACE_XS,
+    TEXT_HINT, TEXT_CAPTION, TEXT_BODY,
+    RADIUS_MD,
+    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN,
+)
 
 from levels import LEVELS
 
@@ -50,7 +56,6 @@ def _is_unlocked(level_idx: int, level_stars: list[int]) -> bool:
     return _total_stars(level_stars) >= needed
 
 
-# Map shift+key to the typed character
 _SHIFT_MAP: dict[str, str] = {
     "1": "!", "2": "@", "3": "#", "4": "$", "5": "%",
     "6": "^", "7": "&", "8": "*", "9": "(", "0": ")",
@@ -61,7 +66,6 @@ _SHIFT_MAP: dict[str, str] = {
 
 
 def _key_to_char(key: str, shift: bool) -> str | None:
-    """Convert a key event to the character it types, or None if not typeable."""
     if len(key) == 1:
         if shift:
             return _SHIFT_MAP.get(key, key.upper())
@@ -71,10 +75,143 @@ def _key_to_char(key: str, shift: bool) -> str | None:
     return None
 
 
+# ── Custom components ────────────────────────────────────────────────────────
+
+
+class _LevelGrid(Component):
+    """2×5 grid of level cards with selection highlight and lock overlays."""
+
+    def __init__(self, app: "TypingTutorApp") -> None:
+        self._app = app
+
+    def measure(self, avail_w: float) -> float:
+        return 0.0
+
+    def is_grow(self) -> bool:
+        return True
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        app = self._app
+        cols, rows = 5, 2
+        gap = 12.0
+        card_w = (w - (cols - 1) * gap) / cols
+        card_h = (h - (rows - 1) * gap) / rows
+
+        for i, level in enumerate(LEVELS):
+            col = i % cols
+            row = i // cols
+            cx = x + col * (card_w + gap)
+            cy = y + row * (card_h + gap)
+
+            unlocked = _is_unlocked(i, app._level_stars)
+            selected = i == app._selected
+            stars = app._level_stars[i]
+
+            if selected:
+                bg, border, bw = ACCENT + "33", ACCENT, 2.0
+            elif unlocked:
+                bg, border, bw = SURFACE, HIGHLIGHT, 1.0
+            else:
+                bg, border, bw = BG, MUTED + "55", 1.0
+
+            ctx.rect(cx, cy, card_w, card_h, fill=bg, radius=RADIUS_MD)
+            ctx.rect(cx, cy, card_w, bw, fill=border)
+            ctx.rect(cx, cy + card_h - bw, card_w, bw, fill=border)
+            ctx.rect(cx, cy, bw, card_h, fill=border)
+            ctx.rect(cx + card_w - bw, cy, bw, card_h, fill=border)
+
+            text_color = FG if unlocked else MUTED
+            ctx.text(cx + 10, cy + 10, f"{i + 1}", size=TEXT_BODY,
+                     color=ACCENT if selected else text_color, bold=True)
+            ctx.text(cx + 10, cy + 28, level.name, size=TEXT_HINT, color=text_color)
+            ctx.text(cx + 10, cy + card_h - 20,
+                     "★" * stars + "☆" * (5 - stars),
+                     size=TEXT_HINT, color=ACCENT if stars > 0 else MUTED)
+
+            if not unlocked:
+                ctx.rect(cx, cy, card_w, card_h, fill="#00000066", radius=RADIUS_MD)
+                ctx.text(cx + card_w / 2 - 18, cy + card_h / 2 - 8,
+                         f"🔒 Need {level.stars_needed}★", size=TEXT_HINT, color=MUTED)
+
+
+class _CharGrid(Component):
+    """Character-by-character typing feedback with per-char color coding."""
+
+    def __init__(self, app: "TypingTutorApp") -> None:
+        self._app = app
+
+    def measure(self, avail_w: float) -> float:
+        return 0.0
+
+    def is_grow(self) -> bool:
+        return True
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        app = self._app
+        text = LEVELS[app._play_level].text
+        char_size = 16.0
+        cell_w = char_size * 0.72
+        cell_h = char_size + 6
+        chars_per_row = max(1, int((w - SPACE_SM * 2) / cell_w))
+        ox = x + SPACE_SM
+        oy = y + SPACE_SM
+
+        for i, ch in enumerate(text):
+            row = i // chars_per_row
+            col = i % chars_per_row
+            cx = ox + col * cell_w
+            cy = oy + row * cell_h
+
+            if i < app._typed:
+                if i in app._errors:
+                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=RED + "44", radius=2.0)
+                    ctx.text(cx, cy, ch, size=char_size, color=RED, monospace=True)
+                else:
+                    ctx.text(cx, cy, ch, size=char_size, color=GREEN, monospace=True)
+            elif i == app._typed:
+                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ACCENT + "55", radius=2.0)
+                ctx.text(cx, cy, ch, size=char_size, color=FG, monospace=True)
+            else:
+                ctx.text(cx, cy, ch, size=char_size, color=MUTED, monospace=True)
+
+        ctx.emit.schedule_render(16)
+
+
+class _TimerBar(Component):
+    """Progress bar + countdown timer pinned above the footer."""
+
+    HEIGHT = 36.0
+
+    def __init__(self, app: "TypingTutorApp") -> None:
+        self._app = app
+
+    def measure(self, avail_w: float) -> float:
+        return self.HEIGHT
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        app = self._app
+        level = LEVELS[app._play_level]
+        elapsed = time.time() - app._start_time
+        time_remaining = max(0.0, level.time_sec - elapsed)
+
+        timer_color = RED if time_remaining < 10 else FG
+        ctx.text(x + SPACE_SM, y + SPACE_XS,
+                 f"Time: {time_remaining:.0f}s", size=TEXT_CAPTION, color=timer_color)
+
+        bar_y = y + TEXT_CAPTION + SPACE_XS * 2
+        bar_w = w - SPACE_SM * 2
+        ctx.rect(x + SPACE_SM, bar_y, bar_w, 8.0, fill=SURFACE, radius=4.0)
+        progress = app._typed / max(len(level.text), 1)
+        ctx.rect(x + SPACE_SM, bar_y, bar_w * progress, 8.0, fill=GREEN, radius=4.0)
+
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+
 class TypingTutorApp(App):
     def on_init(self, ctx: RenderContext) -> None:
         self._screen = Screen.LEVEL_SELECT
-        self._selected = 0  # level selector index (0-based)
+        self._selected = 0
         self._level_stars: list[int] = [0] * len(LEVELS)
 
         state = ctx.load_state()
@@ -90,19 +227,17 @@ class TypingTutorApp(App):
 
         self.emit.info(f"typing-tutor: ready levels={len(LEVELS)}")
 
-        # Play state (initialised in _start_level)
         self._play_level: int = 0
-        self._typed: int = 0          # current cursor position
-        self._errors: set[int] = set()  # positions that had an error
+        self._typed: int = 0
+        self._errors: set[int] = set()
         self._start_time: float = 0.0
         self._finished: bool = False
 
-        # Result state
         self._result_stars: int = 0
         self._result_accuracy: float = 0.0
         self._result_time_taken: float = 0.0
 
-    # ── Level selector ──────────────────────────────────────────────────────
+    # ── Level management ──────────────────────────────────────────────────
 
     def _start_level(self, idx: int) -> None:
         level = LEVELS[idx]
@@ -130,7 +265,6 @@ class TypingTutorApp(App):
         self._finished = True
         self._screen = Screen.RESULT
 
-        # Save best-of
         if stars > self._level_stars[self._play_level]:
             self._level_stars[self._play_level] = stars
             ctx.save_state({"level_stars": self._level_stars})
@@ -143,11 +277,10 @@ class TypingTutorApp(App):
             f"accuracy={accuracy:.1f}% elapsed={elapsed:.1f}s timed_out={timed_out}"
         )
 
-    # ── Key handling ────────────────────────────────────────────────────────
+    # ── Key handling ───────────────────────────────────────────────────────
 
     def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
         shift = bool(mods.get("shift"))
-
         if self._screen == Screen.LEVEL_SELECT:
             self._key_select(key)
         elif self._screen == Screen.PLAYING:
@@ -205,11 +338,9 @@ class TypingTutorApp(App):
         elif key == "r":
             self._start_level(self._play_level)
 
-    # ── Rendering ───────────────────────────────────────────────────────────
+    # ── Rendering ──────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
-
         if self._screen == Screen.LEVEL_SELECT:
             self._render_select(ctx)
         elif self._screen == Screen.PLAYING:
@@ -218,144 +349,45 @@ class TypingTutorApp(App):
             self._render_result(ctx)
 
     def _render_select(self, ctx: RenderContext) -> None:
-        pad = 20.0
-        title_h = 52.0
-
-        ctx.text(pad, pad, "Typing Tutor", size=TITLE, color=FG, bold=True)
         total = _total_stars(self._level_stars)
-        ctx.text(pad, pad + 28, f"Total stars: {total}/50",
-                 size=CAPTION, color=MUTED)
-
-        # 2×5 grid
-        cols = 5
-        rows = 2
-        grid_pad = pad
-        card_w = (ctx.w - grid_pad * 2 - (cols - 1) * 12) / cols
-        card_h = (ctx.h - title_h - grid_pad * 2 - (rows - 1) * 12) / rows
-
-        for i, level in enumerate(LEVELS):
-            col = i % cols
-            row = i // cols
-            x = grid_pad + col * (card_w + 12)
-            y = title_h + grid_pad + row * (card_h + 12)
-
-            unlocked = _is_unlocked(i, self._level_stars)
-            selected = i == self._selected
-            stars = self._level_stars[i]
-
-            # Card background
-            if selected:
-                bg = ACCENT + "33"
-                border = ACCENT
-            elif unlocked:
-                bg = SURFACE
-                border = HIGHLIGHT
-            else:
-                bg = BG
-                border = MUTED + "55"
-
-            ctx.rect(x, y, card_w, card_h, fill=bg, radius=8.0)
-            # Border
-            bw = 2.0 if selected else 1.0
-            ctx.rect(x, y, card_w, bw, fill=border)
-            ctx.rect(x, y + card_h - bw, card_w, bw, fill=border)
-            ctx.rect(x, y, bw, card_h, fill=border)
-            ctx.rect(x + card_w - bw, y, bw, card_h, fill=border)
-
-            text_color = FG if unlocked else MUTED
-            ctx.text(x + 10, y + 10, f"{i + 1}", size=BODY, color=ACCENT if selected else text_color, bold=True)
-            ctx.text(x + 10, y + 30, level.name, size=HINT, color=text_color)
-
-            # Stars
-            star_str = "★" * stars + "☆" * (5 - stars)
-            ctx.text(x + 10, y + card_h - 22, star_str, size=HINT,
-                     color=ACCENT if stars > 0 else MUTED)
-
-            # Lock overlay
-            if not unlocked:
-                ctx.rect(x, y, card_w, card_h, fill="#00000066", radius=8.0)
-                needed = level.stars_needed
-                ctx.text(x + card_w / 2 - 18, y + card_h / 2 - 10,
-                         f"🔒 Need {needed}★", size=HINT, color=MUTED)
-
-        # Footer hints
-        ctx.text(pad, ctx.h - 18,
-                 "h/← l/→ k/↑ j/↓   Enter/Space launch",
-                 size=HINT, color=MUTED)
+        ctx.render(Column([
+            AppBar(title="Typing Tutor", subtitle=f"Total stars: {total}/50"),
+            _LevelGrid(self),
+            FooterKeys([
+                (["h", "←"], "prev"),
+                (["l", "→"], "next"),
+                (["k", "↑"], "back"),
+                (["j", "↓"], "fwd"),
+                ("Enter", "launch"),
+            ]),
+        ]))
 
     def _render_play(self, ctx: RenderContext) -> None:
         level = LEVELS[self._play_level]
-        text = level.text
         now = time.time()
         elapsed = now - self._start_time
         time_remaining = max(0.0, level.time_sec - elapsed)
 
-        # Check timer
         if time_remaining <= 0 and not self._finished:
             self._go_result(ctx, timed_out=True)
             return
 
-        # --- Stats bar ---
-        pad = 16.0
-        bar_h = 40.0
-
-        # Live star preview
-        live_stars = _calc_stars(
-            len(self._errors), self._typed, time_remaining, level.time_sec
-        ) if self._typed > 0 else 0
+        live_stars = (
+            _calc_stars(len(self._errors), self._typed, time_remaining, level.time_sec)
+            if self._typed > 0 else 0
+        )
         star_str = "★" * live_stars + "☆" * (5 - live_stars)
+        errors_str = f"Errors: {len(self._errors)}/{self._typed}"
 
-        ctx.rect(0, 0, ctx.w, bar_h, fill=SURFACE)
-        ctx.text(pad, 12, f"Level {level.id} — {level.name}", size=CAPTION, color=FG)
-        ctx.text(ctx.w / 2 - 30, 12, star_str, size=CAPTION, color=ACCENT)
-        ctx.text(ctx.w - 120, 12, f"Errors: {len(self._errors)}/{self._typed}",
-                 size=CAPTION, color=RED if self._errors else MUTED)
-
-        # --- Character grid ---
-        char_size = 16.0
-        cell_w = char_size * 0.72
-        cell_h = char_size + 6
-
-        chars_per_row = max(1, int((ctx.w - pad * 2) / cell_w))
-        grid_top = bar_h + 20.0
-
-        for i, ch in enumerate(text):
-            row = i // chars_per_row
-            col = i % chars_per_row
-            cx = pad + col * cell_w
-            cy = grid_top + row * cell_h
-
-            if i < self._typed:
-                if i in self._errors:
-                    # Error: red fill, original char
-                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=RED + "44", radius=2.0)
-                    ctx.text(cx, cy, ch, size=char_size, color=RED, monospace=True)
-                else:
-                    # Correct: green text
-                    ctx.text(cx, cy, ch, size=char_size, color=GREEN, monospace=True)
-            elif i == self._typed:
-                # Cursor
-                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ACCENT + "55", radius=2.0)
-                ctx.text(cx, cy, ch, size=char_size, color=FG, monospace=True)
-            else:
-                # Remaining
-                ctx.text(cx, cy, ch, size=char_size, color=MUTED, monospace=True)
-
-        # --- Progress + timer bar ---
-        prog_y = ctx.h - 30
-        prog_w = ctx.w - pad * 2
-        prog_h = 8.0
-
-        ctx.rect(pad, prog_y, prog_w, prog_h, fill=SURFACE, radius=4.0)
-        progress = self._typed / max(len(text), 1)
-        ctx.rect(pad, prog_y, prog_w * progress, prog_h, fill=GREEN, radius=4.0)
-
-        timer_color = RED if time_remaining < 10 else FG
-        ctx.text(pad, prog_y - 18, f"Time: {time_remaining:.0f}s", size=CAPTION, color=timer_color)
-        ctx.text(ctx.w - 80, prog_y - 18, "ESC=quit", size=HINT, color=MUTED)
-
-        # Drive timer updates
-        ctx.emit.schedule_render(16)
+        ctx.render(Column([
+            AppBar(
+                title=f"Level {level.id} — {level.name}",
+                subtitle=f"{star_str}  {errors_str}",
+            ),
+            _CharGrid(self),
+            _TimerBar(self),
+            FooterKeys([("Esc", "quit")]),
+        ]))
 
     def _render_result(self, ctx: RenderContext) -> None:
         level = LEVELS[self._play_level]
@@ -363,35 +395,33 @@ class TypingTutorApp(App):
         accuracy = self._result_accuracy
         elapsed = self._result_time_taken
 
-        # Card
-        cw, ch = 340.0, 220.0
-        cx = (ctx.w - cw) / 2
-        cy = (ctx.h - ch) / 2
-
-        ctx.rect(cx, cy, cw, ch, fill=SURFACE, radius=12.0)
-        ctx.rect(cx, cy, cw, 2.0, fill=ACCENT)  # top accent bar
-
-        ctx.text(cx + 20, cy + 20, f"Level {level.id} — {level.name}", size=CAPTION, color=MUTED)
-        ctx.text(cx + 20, cy + 44, "★" * stars + "☆" * (5 - stars),
-                 size=HEADING, color=ACCENT if stars > 0 else MUTED)
-
-        ctx.text(cx + 20, cy + 90, f"Accuracy:  {accuracy:.1f}%", size=BODY, color=FG)
-        ctx.text(cx + 20, cy + 118, f"Time:      {elapsed:.1f}s / {level.time_sec}s",
-                 size=BODY, color=FG)
-
-        timed_out = self._result_time_taken >= LEVELS[self._play_level].time_sec
+        timed_out = elapsed >= level.time_sec
         if stars == 0:
             msg = "Time's up!" if timed_out else "Keep practicing — error rate too high"
-            color = RED
+            msg_color = RED
         elif stars == 5:
             msg = "Perfect run!"
-            color = GREEN
+            msg_color = GREEN
         else:
             msg = "Nice work!"
-            color = ACCENT
+            msg_color = ACCENT
 
-        ctx.text(cx + 20, cy + 152, msg, size=CAPTION, color=color)
-        ctx.text(cx + 20, cy + 182, "Enter/Space → menu   r → retry", size=HINT, color=MUTED)
+        ctx.render(Column([
+            AppBar(title=f"Level {level.id} — {level.name}"),
+            Spacer(grow=True),
+            Card([
+                Label("★" * stars + "☆" * (5 - stars),
+                      color=ACCENT if stars > 0 else MUTED, bold=True),
+                Label(f"Accuracy:  {accuracy:.1f}%"),
+                Label(f"Time:      {elapsed:.1f}s / {level.time_sec}s"),
+                Label(msg, color=msg_color),
+            ]),
+            Spacer(grow=True),
+            FooterKeys([
+                ("Enter", "menu"),
+                ("r", "retry"),
+            ]),
+        ]))
 
 
 if __name__ == "__main__":

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -308,7 +308,7 @@ class TypingTutorApp(App):
         text = level.text
 
         if key == "escape":
-            self.emit.info(f"typing-tutor: aborted level={self._play_level + 1}")
+            ctx.info(f"typing-tutor: aborted level={self._play_level + 1}")
             self._screen = Screen.LEVEL_SELECT
             return
 


### PR DESCRIPTION
Closes #1280

## Summary

- Replace all low-level `ctx.rect`/`ctx.text` coordinate rendering with SDK v2 component tree (`Column`, `AppBar`, `Card`, `Label`, `FooterKeys`)
- Introduce three custom `Component` subclasses (`_LevelGrid`, `_CharGrid`, `_TimerBar`) for the grid layout and per-character color feedback that require primitive draws
- All game logic, key handling, star gating, scoring, and state persistence unchanged — rendering only

## Done When

1. App opens to level selector with modern UI appearance
2. Levels 3–10 show locked overlays with star requirements
3. Level cards respond to hjkl/arrow key navigation
4. Playing a level shows clean character-by-character feedback
5. Star counts persist across restarts
6. Result screen displays results with modern styling
7. All original behaviors preserved (star gating, best-of scoring, etc.)

## Notes

- Per-character inline feedback (GREEN/RED/ACCENT) requires custom rendering — `_CharGrid` uses the SDK v2 escape hatch pattern, calling `ctx.emit.schedule_render(16)` from within the component to drive timer updates
- Level card grid (`_LevelGrid`) uses primitive draws internally for selection highlight, lock overlay, and star badges — no SDK grid component exists yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * UI rendering system modernized to use standard components instead of custom drawing code, improving overall code maintainability and consistency across the typing tutor interface.

* **Updates**
  * Keyboard controls updated: Space/Return to select levels and continue, Escape to quit, Backspace to delete, and R to retry on the results screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->