### PR TITLE
chore(cli): remove deprecated app link / app unlink commands and links.toml infrastructure (#1704)

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -698,7 +698,6 @@ pub fn registry_watch_dirs(cwd: &Path) -> Vec<PathBuf> {
     let channel_dir = registry_config_dir();
     if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
         let channel_root = root.join(&channel_dir);
-        dirs.push(channel_root.clone());
         dirs.push(channel_root.join("apps"));
         dirs.push(channel_root.join("agents"));
     }

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -5,7 +5,6 @@
 //! 1. `~/.plexi-<channel>/apps/<id>/manifest.toml` — global apps (lowest priority)
 //! 2. `<workspace_root>/.plexi/apps/<id>/manifest.toml` — local app (overrides global)
 //! 3. `<workspace_root>/.plexi/agents/<id>/manifest.toml` — local agent (overrides above)
-//! 4. `<linked_path>/manifest.toml` — linked apps (`.plexi/links.toml`)
 //!
 //! `workspace_root` is the nearest ancestor of the current working directory that
 //! contains a `.plexi/` directory; if none is found, only global apps are loaded.
@@ -262,8 +261,6 @@ pub enum RegistrySource {
     LocalApp,
     /// `<workspace_root>/.plexi/agents/<id>/`
     LocalAgent,
-    /// Linked via `.plexi/links.toml` — absolute path registered by `plexi app link`
-    Linked,
 }
 
 impl RegistrySource {
@@ -272,7 +269,6 @@ impl RegistrySource {
             RegistrySource::Global => "global",
             RegistrySource::LocalApp => "local-app",
             RegistrySource::LocalAgent => "local-agent",
-            RegistrySource::Linked => "linked",
         }
     }
 }
@@ -341,12 +337,6 @@ impl AppRegistry {
             if local_agents.is_dir() {
                 registry.scan_dir(&local_agents, RegistrySource::LocalAgent);
             }
-            // Linked apps — registered via `plexi app link`, stored as absolute paths in
-            // `<channel_dir>/links.toml`. Scanned last — linked entries shadow all other sources.
-            let links_path = root.join(&channel_dir).join("links.toml");
-            if links_path.exists() {
-                registry.scan_links(&links_path);
-            }
         }
 
         registry
@@ -414,91 +404,6 @@ impl AppRegistry {
                 }
                 Err(e) => {
                     log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());
-                }
-            }
-        }
-    }
-
-    /// Parse `.plexi/links.toml` and load each listed absolute path as a linked app.
-    /// links.toml format:
-    /// ```toml
-    /// links = ["/abs/path/to/app1", "/abs/path/to/app2"]
-    /// ```
-    fn scan_links(&mut self, links_path: &Path) {
-        let content = match std::fs::read_to_string(links_path) {
-            Ok(s) => s,
-            Err(e) => {
-                log::warn!("AppRegistry: failed to read {:?}: {e}", links_path);
-                return;
-            }
-        };
-        #[derive(serde::Deserialize)]
-        struct LinksFile {
-            #[serde(default)]
-            links: Vec<String>,
-        }
-        let parsed: LinksFile = match toml::from_str(&content) {
-            Ok(p) => p,
-            Err(e) => {
-                log::warn!("AppRegistry: failed to parse {:?}: {e}", links_path);
-                return;
-            }
-        };
-        // Profile dir — linked paths must not point inside it. A path inside
-        // the global config dir would silently override a managed install with
-        // arbitrary code from a local workspace's links.toml.
-        // Canonicalize so symlinks (e.g. macOS /var → /private/var) don't
-        // allow a bypass via the real resolved path.
-        let raw_profile = crate::config::config_dir();
-        let profile_dir = raw_profile.canonicalize().unwrap_or(raw_profile);
-
-        for raw_path in &parsed.links {
-            let app_dir = PathBuf::from(raw_path);
-            if !app_dir.is_absolute() {
-                log::warn!("AppRegistry: skipping relative path in links.toml: {:?} (must be absolute)", raw_path);
-                continue;
-            }
-            // Canonicalize to resolve symlinks before the profile-dir check.
-            let canonical = match app_dir.canonicalize() {
-                Ok(p) => p,
-                Err(e) => {
-                    log::warn!("AppRegistry: skipping linked path {:?}: cannot canonicalize: {e}", raw_path);
-                    continue;
-                }
-            };
-            if canonical.starts_with(&profile_dir) {
-                log::warn!(
-                    "AppRegistry: skipping linked path {:?}: resolves inside profile dir {:?} — use global install instead",
-                    raw_path,
-                    profile_dir,
-                );
-                continue;
-            }
-            match self.load_app(&canonical) {
-                Ok(installed) => {
-                    let id = installed.manifest.id.clone();
-                    if let Some(existing) = self.apps.get(&id) {
-                        log::warn!(
-                            "AppRegistry: '{}' — linked entry (from {:?}) shadows {} entry (from {:?})",
-                            id,
-                            canonical,
-                            existing.source.label(),
-                            existing.bin_path.parent().unwrap_or(&existing.bin_path),
-                        );
-                    } else {
-                        log::info!(
-                            "AppRegistry: loaded linked entry '{}' from {:?}",
-                            id,
-                            canonical,
-                        );
-                    }
-                    for ext in &installed.manifest.capabilities.file_types {
-                        self.extension_map.insert(ext.to_lowercase(), id.clone());
-                    }
-                    self.apps.insert(id, InstalledApp { source: RegistrySource::Linked, ..installed });
-                }
-                Err(e) => {
-                    log::warn!("AppRegistry: skipping linked path {:?}: {e}", canonical);
                 }
             }
         }
@@ -793,7 +698,6 @@ pub fn registry_watch_dirs(cwd: &Path) -> Vec<PathBuf> {
     let channel_dir = registry_config_dir();
     if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
         let channel_root = root.join(&channel_dir);
-        // Watch the channel dir itself (catches links.toml changes from `app link`).
         dirs.push(channel_root.clone());
         dirs.push(channel_root.join("apps"));
         dirs.push(channel_root.join("agents"));
@@ -1224,48 +1128,6 @@ notification_scope = \"global\"
     }
 
     #[test]
-    fn linked_app_appears_in_registry() {
-        let global = tempfile::tempdir().unwrap();
-        let workspace = tempfile::tempdir().unwrap();
-        // Create workspace .plexi dir
-        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
-        // Create app directory outside .plexi/ — write_app creates <parent>/<id>/ subdir
-        let apps_parent = workspace.path().join("apps");
-        fs::create_dir_all(&apps_parent).unwrap();
-        write_app(&apps_parent, "linked-app", "Linked App");
-        let app_dir = apps_parent.join("linked-app");
-        // Write links.toml
-        let links_toml = format!("links = [{:?}]\n", app_dir.to_string_lossy());
-        fs::write(workspace.path().join(".plexi").join("links.toml"), links_toml).unwrap();
-
-        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
-        let app = registry.get("linked-app").expect("linked app must appear in registry");
-        assert_eq!(app.source, RegistrySource::Linked);
-    }
-
-    #[test]
-    fn linked_app_shadows_global_with_same_id() {
-        let global = tempfile::tempdir().unwrap();
-        let workspace = tempfile::tempdir().unwrap();
-        // Global install of "my-app"
-        write_app(global.path(), "my-app", "Global My App");
-        // Workspace .plexi dir
-        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
-        // Linked version of same id — write_app creates <parent>/<id>/ subdir
-        let apps_parent = workspace.path().join("apps");
-        fs::create_dir_all(&apps_parent).unwrap();
-        write_app(&apps_parent, "my-app", "Linked My App");
-        let linked_app = apps_parent.join("my-app");
-        let links_toml = format!("links = [{:?}]\n", linked_app.to_string_lossy());
-        fs::write(workspace.path().join(".plexi").join("links.toml"), links_toml).unwrap();
-
-        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
-        let app = registry.get("my-app").expect("my-app must be in registry");
-        assert_eq!(app.source, RegistrySource::Linked, "linked must shadow global");
-        assert_eq!(app.manifest.name, "Linked My App");
-    }
-
-    #[test]
     fn local_agent_shadows_local_app_with_same_id() {
         let global = tempfile::tempdir().unwrap();
         let workspace = tempfile::tempdir().unwrap();
@@ -1281,34 +1143,6 @@ notification_scope = \"global\"
         let entry = registry.get("tool").expect("tool must be discovered");
         assert_eq!(entry.source, RegistrySource::LocalAgent, "agent must shadow local app");
         assert_eq!(entry.manifest.name, "Tool (agent)");
-    }
-
-    #[test]
-    fn linked_app_relative_path_rejected() {
-        let global = tempfile::tempdir().unwrap();
-        let workspace = tempfile::tempdir().unwrap();
-        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
-
-        // A relative path in links.toml must be skipped — only absolute paths allowed.
-        let bad_links = "links = [\"relative/path/to/app\"]\n";
-        fs::write(workspace.path().join(".plexi").join("links.toml"), bad_links).unwrap();
-
-        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
-        assert!(registry.get("anything").is_none(), "relative linked path must be rejected");
-    }
-
-    #[test]
-    fn linked_app_with_nonexistent_path_skipped() {
-        let global = tempfile::tempdir().unwrap();
-        let workspace = tempfile::tempdir().unwrap();
-        fs::create_dir_all(workspace.path().join(".plexi")).unwrap();
-
-        let bad_links = "links = [\"/nonexistent/path/to/app\"]\n";
-        fs::write(workspace.path().join(".plexi").join("links.toml"), bad_links).unwrap();
-
-        // Must not panic — skips with a warn
-        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
-        assert!(registry.get("anything").is_none());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -985,172 +985,6 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> 
     Ok(())
 }
 
-/// `plexi app link <path>` — register a local app directory with the nearest workspace.
-pub fn app_link(path: &str) -> i32 {
-    eprintln!("deprecated: `plexi app link` is deprecated — use `plexi app run <path>` instead");
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => { eprintln!("error: {e}"); return 1; }
-    };
-    let app_dir = if std::path::Path::new(path).is_absolute() {
-        std::path::PathBuf::from(path)
-    } else {
-        cwd.join(path)
-    };
-    let app_dir = match app_dir.canonicalize() {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("error: could not resolve {path}: {e}");
-            return 1;
-        }
-    };
-    // Validate manifest.toml exists and is parseable
-    let manifest_path = app_dir.join("manifest.toml");
-    if !manifest_path.exists() {
-        eprintln!("error: no manifest.toml found in {}", app_dir.display());
-        eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
-        return 1;
-    }
-    let manifest_str = match std::fs::read_to_string(&manifest_path) {
-        Ok(s) => s,
-        Err(e) => { eprintln!("error: could not read manifest.toml: {e}"); return 1; }
-    };
-    let manifest: toml::Value = match toml::from_str(&manifest_str) {
-        Ok(v) => v,
-        Err(e) => { eprintln!("error: manifest.toml parse failed: {e}"); return 1; }
-    };
-    let app_id = match manifest.get("app").and_then(|a| a.get("id")).and_then(|v| v.as_str()) {
-        Some(id) if !id.is_empty() => id.to_string(),
-        _ => {
-            eprintln!("error: manifest.toml is missing a valid [app].id");
-            return 1;
-        }
-    };
-
-    let workspace_root = match crate::app_registry::resolve_workspace_root(&cwd) {
-        Some(r) => r,
-        None => {
-            eprintln!("error: no .plexi/ workspace found at or above {}.", cwd.display());
-            eprintln!("  Run `plexi workspace init` first.");
-            return 1;
-        }
-    };
-
-    log::info!(
-        "app_link:cli: linking {} as app '{}' in workspace {}",
-        app_dir.display(), app_id, workspace_root.display()
-    );
-
-    let links_path = workspace_root.join(".plexi").join("links.toml");
-    let abs_path = app_dir.to_string_lossy().to_string();
-
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct LinksFile { #[serde(default)] links: Vec<String> }
-
-    // Read existing links (or start fresh)
-    let mut links: Vec<String> = if links_path.exists() {
-        let content = match std::fs::read_to_string(&links_path) {
-            Ok(s) => s,
-            Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
-        };
-        match toml::from_str::<LinksFile>(&content) {
-            Ok(f) => f.links,
-            Err(e) => { eprintln!("error: could not parse links.toml: {e}"); return 1; }
-        }
-    } else {
-        Vec::new()
-    };
-
-    if links.contains(&abs_path) {
-        println!("Already linked: {}", app_dir.display());
-        return 0;
-    }
-
-    links.push(abs_path);
-
-    let new_content = match toml::to_string_pretty(&LinksFile { links }) {
-        Ok(s) => s,
-        Err(e) => { eprintln!("error: could not serialize links.toml: {e}"); return 1; }
-    };
-
-    if let Err(e) = std::fs::write(&links_path, new_content) {
-        eprintln!("error: could not write links.toml: {e}");
-        return 1;
-    }
-
-    println!("Linked '{}' from {}", app_id, app_dir.display());
-    println!("  App will appear in the run palette on next launch or reload.");
-    0
-}
-
-/// `plexi app unlink <path>` — remove a linked app directory from the workspace registry.
-pub fn app_unlink(path: &str) -> i32 {
-    eprintln!("deprecated: `plexi app unlink` is deprecated — use `plexi app run <path>` instead");
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => { eprintln!("error: {e}"); return 1; }
-    };
-    let app_dir = if std::path::Path::new(path).is_absolute() {
-        std::path::PathBuf::from(path)
-    } else {
-        cwd.join(path)
-    };
-    // Try to canonicalize; fall back to the raw path if it doesn't exist
-    let app_dir = app_dir.canonicalize().unwrap_or(app_dir);
-    let abs_path = app_dir.to_string_lossy().to_string();
-
-    let workspace_root = match crate::app_registry::resolve_workspace_root(&cwd) {
-        Some(r) => r,
-        None => {
-            eprintln!("error: no .plexi/ workspace found at or above {}.", cwd.display());
-            eprintln!("  Run `plexi workspace init` first.");
-            return 1;
-        }
-    };
-
-    log::info!(
-        "app_unlink:cli: unlinking {} from workspace {}",
-        app_dir.display(), workspace_root.display()
-    );
-
-    let links_path = workspace_root.join(".plexi").join("links.toml");
-    if !links_path.exists() {
-        println!("Not linked (no links.toml found).");
-        return 0;
-    }
-
-    let content = match std::fs::read_to_string(&links_path) {
-        Ok(s) => s,
-        Err(e) => { eprintln!("error: could not read links.toml: {e}"); return 1; }
-    };
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct LinksFile { #[serde(default)] links: Vec<String> }
-    let mut links: Vec<String> = match toml::from_str::<LinksFile>(&content) {
-        Ok(f) => f.links,
-        Err(e) => { eprintln!("error: could not parse links.toml: {e}"); return 1; }
-    };
-
-    let before = links.len();
-    links.retain(|p| p != &abs_path);
-    if links.len() == before {
-        println!("Not found in links.toml: {}", app_dir.display());
-        return 0;
-    }
-
-    let new_content = match toml::to_string_pretty(&LinksFile { links }) {
-        Ok(s) => s,
-        Err(e) => { eprintln!("error: could not serialize links.toml: {e}"); return 1; }
-    };
-
-    if let Err(e) = std::fs::write(&links_path, new_content) {
-        eprintln!("error: could not write links.toml: {e}");
-        return 1;
-    }
-
-    println!("Unlinked: {}", app_dir.display());
-    0
-}
-
 /// `plexi app run <path>` — open any directory with a valid manifest.toml as an app pane.
 ///
 /// No install, no link required. Edits take effect on next launch.
@@ -2134,8 +1968,7 @@ pub fn list_cli() -> i32 {
         match app.source {
             crate::app_registry::RegistrySource::Global => globals.push(row),
             crate::app_registry::RegistrySource::LocalApp
-            | crate::app_registry::RegistrySource::LocalAgent
-            | crate::app_registry::RegistrySource::Linked => workspace.push(row),
+            | crate::app_registry::RegistrySource::LocalAgent => workspace.push(row),
         }
     }
     if !globals.is_empty() {
@@ -4573,7 +4406,7 @@ _plexi() {
               ;;
             *)
               local subcmds
-              subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Remove an installed app by id' 'list:List installed apps' 'render:Render an app to PNG headlessly' 'info:Show app info' 'link:Register a local app directory' 'unlink:Remove a linked app directory')
+              subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Remove an installed app by id' 'list:List installed apps' 'render:Render an app to PNG headlessly' 'info:Show app info')
               _describe 'subcommand' subcmds
               ;;
           esac
@@ -4854,9 +4687,6 @@ complete -c plexi -f -n "__fish_seen_subcommand_from app" -a uninstall -d "Unins
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a list -d "List installed apps"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a render -d "Render an app to PNG headlessly"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a info -d "Show app info"
-complete -c plexi -f -n "__fish_seen_subcommand_from app" -a link -d "Register a local app directory with the workspace"
-complete -c plexi -f -n "__fish_seen_subcommand_from app" -a unlink -d "Remove a linked app directory from the workspace"
-
 # app init flags
 complete -c plexi -n "__fish_seen_subcommand_from app; and __fish_seen_subcommand_from init" -l lang -d "Language template" -a "python"
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -341,18 +341,6 @@ pub enum AppCmd {
         /// Path to the app folder containing manifest.toml
         path: String,
     },
-    /// Link a local app directory so Plexi can see it without copying files.
-    ///
-    /// Useful during development — edits to your app folder take effect immediately without reinstalling.
-    Link {
-        /// Path to the app folder containing manifest.toml
-        path: String,
-    },
-    /// Unlink a previously linked app directory.
-    Unlink {
-        /// Path to the app folder (the same path you passed to `link`)
-        path: String,
-    },
     /// Run an app directly from a local directory without installing or linking.
     ///
     /// Opens the app in a pane immediately. Edits to the app take effect on next launch.

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,8 +256,6 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
                         }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
-                        AppCmd::Link { path } => std::process::exit(cli::app_link(&path)),
-                        AppCmd::Unlink { path } => std::process::exit(cli::app_unlink(&path)),
                         AppCmd::Run { path } => std::process::exit(cli::app_run(&path)),
                     },
                     Commands::Install { spec, pack } => {


### PR DESCRIPTION
Closes #1704

## Summary

- Removes `AppCmd::Link` and `AppCmd::Unlink` clap variants, the `app_link()` and `app_unlink()` CLI functions, and their `main.rs` dispatch arms
- Deletes `RegistrySource::Linked`, `scan_links()`, and the `links.toml` scan block from `AppRegistry::load_with_global()`
- Cleans up zsh and fish completions; removes 4 now-dead registry tests

## Done When

- `plexi app link` and `plexi app unlink` are unrecognised subcommands (clap error)
- `cargo test --bin plexi` is green
- No reference to `links.toml` or `scan_links` in `src/`

## Notes

One stray `RegistrySource::Linked` arm in `app_list()` in cli.rs was missed by the issue's file list — caught during build and fixed in the same commit.