### PR TITLE
feat(text-editor): built-in text editor pane with syntax highlighting (#1737)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1125,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -2861,6 +2887,7 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "syntect",
  "taffy",
  "tempfile",
  "thiserror 2.0.18",
@@ -3802,6 +3829,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.18",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ wgpu = { version = "24", default-features = false, features = ["wgsl", "metal"] 
 egui-wgpu = "0.31"
 png = "0.17"
 taffy = "0.5"
+# Built-in text editor syntax highlighting (#1737).
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Keychain access via Security.framework C API — no subprocess, distinct error

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -9,6 +9,7 @@ use std::time::SystemTime;
 pub(crate) enum MediaKind {
     Video,
     Audio,
+    Text,
     Other,
 }
 
@@ -34,6 +35,10 @@ impl MediaKind {
             // via `RunInLinkedTerminal`. All recognised extensions route
             // identically.
             "mp3" | "wav" | "flac" | "m4a" | "aac" | "ogg" | "opus" => Self::Audio,
+            "txt" | "md" | "rs" | "py" | "js" | "ts" | "tsx" | "jsx" | "toml" | "yaml" | "yml"
+            | "json" | "sh" | "bash" | "zsh" | "fish" | "html" | "css" | "go" | "rb" | "java"
+            | "c" | "cpp" | "h" | "hpp" | "sql" | "log" | "gitignore" | "lock" | "ron" | "kdl"
+            | "swift" | "kt" | "lua" | "r" => Self::Text,
             _ => Self::Other,
         }
     }
@@ -44,6 +49,7 @@ impl MediaKind {
         match self {
             Self::Video => Some("video-player"),
             Self::Audio => Some("audio-player"),
+            Self::Text => Some("text_editor"),
             Self::Other => None,
         }
     }
@@ -153,7 +159,6 @@ mod media_bridge_tests {
     #[test]
     fn unrecognized_extension_falls_back_to_system_open() {
         for path in &[
-            "/tmp/notes.txt",
             "/tmp/photo.tiff",
             "/tmp/archive.zip",
             "/tmp/Makefile",
@@ -171,6 +176,36 @@ mod media_bridge_tests {
                 None,
                 "{path} should not route to an in-app player"
             );
+        }
+    }
+
+    #[test]
+    fn open_text_file_routes_to_text_editor_app() {
+        for ext in &["rs", "md", "py", "js", "toml", "json", "sh", "txt"] {
+            let p = PathBuf::from(format!("/tmp/file.{ext}"));
+            assert_eq!(
+                MediaKind::for_path(&p),
+                MediaKind::Text,
+                "extension {ext} should classify as Text"
+            );
+            assert_eq!(
+                MediaKind::for_path(&p).player_app_id(),
+                Some("text_editor"),
+                "{ext} routes to text_editor app"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecognized_extension_still_falls_back_to_system_open() {
+        for path in &[
+            "/tmp/photo.tiff",
+            "/tmp/archive.zip",
+            "/tmp/.dotfile",
+            "/tmp/no-extension",
+        ] {
+            let p = PathBuf::from(path);
+            assert_eq!(MediaKind::for_path(&p).player_app_id(), None);
         }
     }
 }

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1172,6 +1172,19 @@ mod tests {
         (app, dir)
     }
 
+    fn takes_one_text_editor_spawn(app: &mut FileBrowserApp, filename: &str) {
+        use crate::app_trait::AppCommand;
+        let cmds = app.take_pending_commands();
+        assert_eq!(cmds.len(), 1, "expected one pending SpawnApp command");
+        match &cmds[0] {
+            AppCommand::SpawnApp { type_id, args, .. } => {
+                assert_eq!(type_id, "text_editor", "file must route to text_editor app");
+                assert!(args[0].ends_with(filename), "args[0] must be the file path");
+            }
+            _ => panic!("expected SpawnApp"),
+        }
+    }
+
     #[test]
     fn enter_on_file_opens_file_and_browser_stays_open() {
         let (mut app, _dir) = make_file_only_dir_app();
@@ -1179,8 +1192,7 @@ mod tests {
         assert!(!app.entries[0].is_dir, "first entry must be a file (no dirs in fixture)");
         let consumed = run_handle_key(&mut app, vec![key_event(Key::Enter, Modifiers::default())]);
         assert!(consumed, "Enter on a file must be consumed");
-        assert_eq!(app.opened_files.len(), 1, "Enter on a file must call open_file");
-        assert!(app.opened_files[0].ends_with("readme.txt"), "must open the selected file");
+        takes_one_text_editor_spawn(&mut app, "readme.txt");
         assert!(!app.should_close, "browser must stay open after opening a file");
     }
 
@@ -1189,7 +1201,7 @@ mod tests {
         let (mut app, _dir) = make_file_only_dir_app();
         let consumed = run_handle_key(&mut app, vec![key_event(Key::L, Modifiers::default())]);
         assert!(consumed);
-        assert_eq!(app.opened_files.len(), 1, "l on a file must call open_file");
+        takes_one_text_editor_spawn(&mut app, "readme.txt");
     }
 
     #[test]
@@ -1197,7 +1209,7 @@ mod tests {
         let (mut app, _dir) = make_file_only_dir_app();
         let consumed = run_handle_key(&mut app, vec![key_event(Key::ArrowRight, Modifiers::default())]);
         assert!(consumed);
-        assert_eq!(app.opened_files.len(), 1, "→ on a file must call open_file");
+        takes_one_text_editor_spawn(&mut app, "readme.txt");
     }
 
     #[test]
@@ -1219,7 +1231,7 @@ mod tests {
         // press Enter to open the (only) filtered result
         let consumed = run_handle_key(&mut app, vec![key_event(Key::Enter, Modifiers::default())]);
         assert!(consumed);
-        assert_eq!(app.opened_files.len(), 1, "Enter in search mode on a file must call open_file");
+        takes_one_text_editor_spawn(&mut app, "readme.txt");
         assert!(!app.in_search, "search mode must exit after opening a file");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ mod sidebar;
 mod sidebar_row;
 mod spatial;
 mod style;
+mod text_editor;
 mod theme;
 mod tiling;
 mod typed_pipes;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -708,6 +708,20 @@ impl PlexiApp {
             return Ok(());
         }
 
+        if id == "text_editor" {
+            let path_arg = args.first().cloned();
+            let app: Box<dyn crate::app_trait::App> = Box::new(
+                crate::text_editor::TextEditorApp::from_args(args)
+            );
+            let hint = layout.or_else(|| Some("split_h".to_string()));
+            let te_cwd = cwd_override
+                .or_else(|| self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane))
+                .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+            log::info!("launch_app_by_id: text_editor path={path_arg:?} hint={hint:?}");
+            self.open_builtin_app_pane(app, crate::app_permissions::AppPermissions::default(), te_cwd, None, hint.as_deref(), None);
+            return Ok(());
+        }
+
         let cwd_explicit = cwd_override.is_some();
         let cwd = cwd_override
             .or_else(|| self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane))
@@ -959,47 +973,18 @@ impl PlexiApp {
         self.open_builtin_app_pane(app, perms, cwd, None, Some("overlay"), None);
     }
 
-    /// Open a terminal editor in the focused pane for scratchpad editing.
+    /// Open the text editor as a scratchpad overlay on the current pane.
     ///
-    /// Injects `micro <path>` (or `nano` fallback) into the focused terminal's PTY.
-    /// The scratchpad file persists at `<config_dir>/scratchpad.md` across sessions.
+    /// Opens a new timestamped note in the built-in text editor as an overlay,
+    /// replacing the old PTY-injection pattern.
     pub(crate) fn open_scratchpad(&mut self) {
-        let active = self.active_window;
-
-        let focused_tile = match self.windows[active].focused_pane {
-            Some(t) => t,
-            None => {
-                log::warn!("scratchpad: no focused pane — ignored");
-                return;
-            }
-        };
-        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
-            Some(egui_tiles::Tile::Pane(id)) => *id,
-            _ => {
-                log::warn!("scratchpad: focused tile is not a pane — ignored");
-                return;
-            }
-        };
-        let Some(term) = self.windows[active].panes.get_mut(&pane_id).and_then(Pane::as_terminal_mut) else {
-            log::warn!("scratchpad: focused pane {pane_id} is not a terminal — ignored");
-            return;
-        };
-
-        let path = scratchpad_file();
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                log::warn!("scratchpad: could not create notes dir {:?}: {e}", parent);
-            } else {
-                log::info!("scratchpad: notes dir {:?} ready", parent);
-            }
-        }
-        let path_str = path.display().to_string();
-        let escaped = crate::shell::shell_quote(&path_str);
-        let editor = preferred_editor();
-
-        let cmd = format!("{editor} {escaped}\r");
-        log::info!("scratchpad: injecting '{editor} {escaped}' into terminal pane {pane_id}");
-        term.backend.process_command(BackendCommand::Write(cmd.into_bytes()));
+        let path = crate::text_editor::scratchpad_file();
+        log::info!("text_editor: opening scratchpad overlay at '{}'", path.display());
+        let app: Box<dyn crate::app_trait::App> = Box::new(
+            crate::text_editor::TextEditorApp::new(path)
+        );
+        let cwd = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"));
+        self.open_builtin_app_pane(app, crate::app_permissions::AppPermissions::default(), cwd, None, Some("overlay"), None);
     }
 
     /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
@@ -1955,19 +1940,3 @@ mod quick_note_tests {
     }
 }
 
-/// Timestamped scratchpad file path: `<config_dir>/notes/YYYY-MM-DD_HHMMSS.md`.
-fn scratchpad_file() -> PathBuf {
-    use chrono::Local;
-    let timestamp = Local::now().format("%Y-%m-%d_%H%M%S").to_string();
-    crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
-}
-
-/// Resolve the preferred terminal editor: `micro` if available, else `nano`, then `vim`.
-fn preferred_editor() -> &'static str {
-    for editor in ["micro", "nano", "vim"] {
-        if cli_binary_in_path(editor) {
-            return editor;
-        }
-    }
-    "nano"
-}

--- a/src/text_editor/mod.rs
+++ b/src/text_editor/mod.rs
@@ -1,0 +1,354 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme, ThemeSet};
+use syntect::parsing::SyntaxSet;
+use syntect::util::LinesWithEndings;
+use egui::text::{LayoutJob, TextFormat};
+use egui::{Color32, FontId};
+use crate::app_trait::{App, AppCommand, AppRenderContext};
+
+pub(crate) struct TextEditorApp {
+    path: PathBuf,
+    content: String,
+    original_content: String,
+    syntax_set: SyntaxSet,
+    theme: Theme,
+    dirty: bool,
+    should_close: bool,
+    dirty_escape_warned: bool,
+    focus_requested: bool,
+    // Cache: rebuild layout only when content changes
+    content_version: u64,
+    cached_version: u64,
+    cached_layout: Option<LayoutJob>,
+}
+
+impl TextEditorApp {
+    /// Create from args: args[0] is the file path. If absent, opens a new scratchpad note.
+    pub(crate) fn from_args(args: &[String]) -> Self {
+        let path = if let Some(p) = args.first() {
+            PathBuf::from(p)
+        } else {
+            scratchpad_file()
+        };
+        Self::new(path)
+    }
+
+    pub(crate) fn new(path: PathBuf) -> Self {
+        // Ensure parent directory exists (important for scratchpad notes/).
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::warn!("text_editor: could not create dir {:?}: {e}", parent);
+            }
+        }
+
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        log::info!("text_editor: opening '{}' ({} bytes)", path.display(), content.len());
+
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let theme_set = ThemeSet::load_defaults();
+        let theme = theme_set.themes["base16-ocean.dark"].clone();
+
+        let original_content = content.clone();
+        Self {
+            path,
+            content,
+            original_content,
+            syntax_set,
+            theme,
+            dirty: false,
+            should_close: false,
+            dirty_escape_warned: false,
+            focus_requested: false,
+            content_version: 0,
+            cached_version: u64::MAX,
+            cached_layout: None,
+        }
+    }
+
+    fn build_layout(&mut self, font_size: f32) -> LayoutJob {
+        let ext = self.path.extension().and_then(|e| e.to_str()).unwrap_or("txt");
+        let syntax = self.syntax_set
+            .find_syntax_by_extension(ext)
+            .or_else(|| self.syntax_set.find_syntax_by_name("Plain Text"))
+            .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
+
+        let mut highlighter = HighlightLines::new(syntax, &self.theme);
+        let mut job = LayoutJob::default();
+        let font_id = FontId::monospace(font_size);
+
+        for line in LinesWithEndings::from(&self.content) {
+            let ranges = highlighter.highlight_line(line, &self.syntax_set)
+                .unwrap_or_default();
+            for (style, text) in ranges {
+                let fg = style.foreground;
+                let color = Color32::from_rgb(fg.r, fg.g, fg.b);
+                job.append(text, 0.0, TextFormat {
+                    font_id: font_id.clone(),
+                    color,
+                    ..Default::default()
+                });
+            }
+        }
+
+        // Empty file fallback: at least one section so TextEdit has something to measure.
+        if job.sections.is_empty() {
+            job.append("", 0.0, TextFormat {
+                font_id,
+                color: Color32::GRAY,
+                ..Default::default()
+            });
+        }
+
+        self.cached_version = self.content_version;
+        self.cached_layout = Some(job.clone());
+        job
+    }
+}
+
+impl App for TextEditorApp {
+    fn type_id(&self) -> &'static str {
+        "text_editor"
+    }
+
+    fn display_name(&self) -> String {
+        let filename = self.path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "untitled".to_string());
+        if self.dirty {
+            format!("● {filename}")
+        } else {
+            filename
+        }
+    }
+
+    fn keyboard_capture(&self) -> bool {
+        true
+    }
+
+    fn wants_close(&self) -> bool {
+        self.should_close
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<AppCommand> {
+        vec![]
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+        let content_before = self.content.clone();
+
+        // Handle Cmd+S to save
+        let cmd_s = ui.input(|i| {
+            i.key_pressed(egui::Key::S) && i.modifiers.command
+        });
+        if cmd_s {
+            match std::fs::write(&self.path, &self.content) {
+                Ok(()) => {
+                    log::info!("text_editor: saved '{}' ({} bytes)", self.path.display(), self.content.len());
+                    self.original_content = self.content.clone();
+                    self.dirty = false;
+                    self.dirty_escape_warned = false;
+                }
+                Err(e) => {
+                    log::error!("text_editor: failed to save '{}': {e}", self.path.display());
+                }
+            }
+        }
+
+        // Handle Escape
+        let escape = ui.input(|i| {
+            i.key_pressed(egui::Key::Escape)
+        });
+        if escape {
+            if !self.dirty {
+                log::info!("text_editor: clean close of '{}'", self.path.display());
+                self.should_close = true;
+            } else if !self.dirty_escape_warned {
+                log::info!("text_editor: dirty escape warning for '{}'", self.path.display());
+                self.dirty_escape_warned = true;
+            } else {
+                log::info!("text_editor: discarding changes to '{}' and closing", self.path.display());
+                self.should_close = true;
+            }
+        }
+
+        egui::Frame::new()
+            .fill(colors.terminal_bg)
+            .show(ui, |ui| {
+                // Footer hint bar
+                ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        ui.colored_label(
+                            colors.text_dim,
+                            egui::RichText::new("⌘S save").size(11.0),
+                        );
+                        ui.colored_label(colors.text_dim, egui::RichText::new("  ").size(11.0));
+                        if self.dirty && self.dirty_escape_warned {
+                            ui.colored_label(
+                                egui::Color32::YELLOW,
+                                egui::RichText::new("Unsaved — Esc again to discard").size(11.0),
+                            );
+                        } else {
+                            ui.colored_label(
+                                colors.text_dim,
+                                egui::RichText::new("Esc close").size(11.0),
+                            );
+                        }
+                        if self.dirty {
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                ui.colored_label(
+                                    egui::Color32::YELLOW,
+                                    egui::RichText::new("●").size(11.0),
+                                );
+                            });
+                        }
+                    });
+                    ui.separator();
+
+                    // Main editor area
+                    let available = ui.available_size();
+                    let font_size = 13.0_f32;
+
+                    // Build/cache syntax-highlighted layout job
+                    let cached_job = if self.content_version == self.cached_version {
+                        self.cached_layout.clone().unwrap_or_else(|| self.build_layout(font_size))
+                    } else {
+                        self.build_layout(font_size)
+                    };
+
+                    let mut layouter = |ui: &egui::Ui, _string: &str, wrap_width: f32| -> Arc<egui::Galley> {
+                        let mut job = cached_job.clone();
+                        job.wrap.max_width = wrap_width;
+                        ui.fonts(|f| f.layout_job(job))
+                    };
+
+                    let te_id = egui::Id::new("text_editor_main");
+                    let te_response = ui.add_sized(
+                        available,
+                        egui::TextEdit::multiline(&mut self.content)
+                            .id(te_id)
+                            .font(egui::TextStyle::Monospace)
+                            .desired_width(f32::INFINITY)
+                            .frame(false)
+                            .layouter(&mut layouter),
+                    );
+
+                    // One-shot focus request (after all widgets render)
+                    if !self.focus_requested {
+                        te_response.request_focus();
+                        self.focus_requested = true;
+                    }
+                });
+            });
+
+        // Track dirty state
+        if self.content != content_before {
+            self.content_version += 1;
+            self.dirty = self.content != self.original_content;
+            if !self.dirty {
+                self.dirty_escape_warned = false;
+            }
+        }
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "path": self.path.to_string_lossy(),
+        }))
+    }
+
+    fn restore_state(&mut self, state: &serde_json::Value) {
+        if let Some(path) = state.get("path").and_then(|v| v.as_str()) {
+            let new_path = PathBuf::from(path);
+            if new_path != self.path {
+                let content = std::fs::read_to_string(&new_path).unwrap_or_default();
+                log::info!("text_editor: restoring state for '{}'", new_path.display());
+                self.original_content = content.clone();
+                self.content = content;
+                self.path = new_path;
+                self.dirty = false;
+                self.content_version += 1;
+            }
+        }
+    }
+}
+
+/// Timestamped scratchpad file: `<config_dir>/notes/YYYY-MM-DD_HHMMSS.md`.
+pub(crate) fn scratchpad_file() -> PathBuf {
+    use chrono::Local;
+    let timestamp = Local::now().format("%Y-%m-%d_%H%M%S").to_string();
+    crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_temp_file(content: &str, ext: &str) -> (tempfile::NamedTempFile, PathBuf) {
+        let mut f = tempfile::Builder::new().suffix(&format!(".{ext}")).tempfile().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        let path = f.path().to_path_buf();
+        (f, path)
+    }
+
+    #[test]
+    fn display_name_clean() {
+        let (_f, path) = make_temp_file("hello", "rs");
+        let app = TextEditorApp::new(path.clone());
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        assert_eq!(app.display_name(), name);
+    }
+
+    #[test]
+    fn display_name_dirty() {
+        let (_f, path) = make_temp_file("hello", "rs");
+        let mut app = TextEditorApp::new(path.clone());
+        app.content = "changed".to_string();
+        app.dirty = true;
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        assert_eq!(app.display_name(), format!("● {name}"));
+    }
+
+    #[test]
+    fn dirty_flag_follows_content() {
+        let (_f, path) = make_temp_file("original", "txt");
+        let mut app = TextEditorApp::new(path);
+        assert!(!app.dirty);
+        app.content = "changed".to_string();
+        app.dirty = app.content != app.original_content;
+        assert!(app.dirty);
+        app.content = "original".to_string();
+        app.dirty = app.content != app.original_content;
+        assert!(!app.dirty);
+    }
+
+    #[test]
+    fn wants_close_false_by_default() {
+        let (_f, path) = make_temp_file("", "txt");
+        let app = TextEditorApp::new(path);
+        assert!(!app.wants_close());
+    }
+
+    #[test]
+    fn keyboard_capture_true() {
+        let (_f, path) = make_temp_file("", "txt");
+        let app = TextEditorApp::new(path);
+        assert!(app.keyboard_capture());
+    }
+
+    #[test]
+    fn serialize_restore_roundtrip() {
+        let (_f, path) = make_temp_file("data", "md");
+        let app = TextEditorApp::new(path.clone());
+        let state = app.serialize_state().unwrap();
+        assert_eq!(
+            state.get("path").and_then(|v| v.as_str()),
+            Some(path.to_str().unwrap())
+        );
+    }
+}

--- a/src/text_editor/mod.rs
+++ b/src/text_editor/mod.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::SyntaxSet;
@@ -8,12 +8,24 @@ use egui::text::{LayoutJob, TextFormat};
 use egui::{Color32, FontId};
 use crate::app_trait::{App, AppCommand, AppRenderContext};
 
+static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+fn syntax_set() -> &'static SyntaxSet {
+    SYNTAX_SET.get_or_init(SyntaxSet::load_defaults_newlines)
+}
+
+fn theme() -> &'static Theme {
+    THEME.get_or_init(|| {
+        let theme_set = ThemeSet::load_defaults();
+        theme_set.themes["base16-ocean.dark"].clone()
+    })
+}
+
 pub(crate) struct TextEditorApp {
     path: PathBuf,
     content: String,
     original_content: String,
-    syntax_set: SyntaxSet,
-    theme: Theme,
     dirty: bool,
     should_close: bool,
     dirty_escape_warned: bool,
@@ -46,17 +58,11 @@ impl TextEditorApp {
         let content = std::fs::read_to_string(&path).unwrap_or_default();
         log::info!("text_editor: opening '{}' ({} bytes)", path.display(), content.len());
 
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let theme_set = ThemeSet::load_defaults();
-        let theme = theme_set.themes["base16-ocean.dark"].clone();
-
         let original_content = content.clone();
         Self {
             path,
             content,
             original_content,
-            syntax_set,
-            theme,
             dirty: false,
             should_close: false,
             dirty_escape_warned: false,
@@ -69,18 +75,18 @@ impl TextEditorApp {
 
     fn build_layout(&mut self, font_size: f32) -> LayoutJob {
         let ext = self.path.extension().and_then(|e| e.to_str()).unwrap_or("txt");
-        let syntax = self.syntax_set
+        let ss = syntax_set();
+        let syntax = ss
             .find_syntax_by_extension(ext)
-            .or_else(|| self.syntax_set.find_syntax_by_name("Plain Text"))
-            .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
+            .or_else(|| ss.find_syntax_by_name("Plain Text"))
+            .unwrap_or_else(|| ss.find_syntax_plain_text());
 
-        let mut highlighter = HighlightLines::new(syntax, &self.theme);
+        let mut highlighter = HighlightLines::new(syntax, theme());
         let mut job = LayoutJob::default();
         let font_id = FontId::monospace(font_size);
 
         for line in LinesWithEndings::from(&self.content) {
-            let ranges = highlighter.highlight_line(line, &self.syntax_set)
-                .unwrap_or_default();
+            let ranges = highlighter.highlight_line(line, ss).unwrap_or_default();
             for (style, text) in ranges {
                 let fg = style.foreground;
                 let color = Color32::from_rgb(fg.r, fg.g, fg.b);
@@ -140,10 +146,14 @@ impl App for TextEditorApp {
         let colors = ctx.colors;
         let content_before = self.content.clone();
 
-        // Handle Cmd+S to save
-        let cmd_s = ui.input(|i| {
-            i.key_pressed(egui::Key::S) && i.modifiers.command
-        });
+        // Derive a per-pane unique ID from the enclosing ui region.
+        // Using ui.id() avoids static-ID conflicts when multiple editors are open.
+        let te_id = ui.id().with("text_editor_main");
+        let has_focus = ui.memory(|mem| mem.has_focus(te_id));
+
+        // Guard input behind has_focus so unfocused editors don't react to
+        // Escape/Cmd+S pressed in another pane (global input state is shared).
+        let cmd_s = has_focus && ui.input(|i| i.key_pressed(egui::Key::S) && i.modifiers.command);
         if cmd_s {
             match std::fs::write(&self.path, &self.content) {
                 Ok(()) => {
@@ -158,10 +168,7 @@ impl App for TextEditorApp {
             }
         }
 
-        // Handle Escape
-        let escape = ui.input(|i| {
-            i.key_pressed(egui::Key::Escape)
-        });
+        let escape = has_focus && ui.input(|i| i.key_pressed(egui::Key::Escape));
         if escape {
             if !self.dirty {
                 log::info!("text_editor: clean close of '{}'", self.path.display());
@@ -178,14 +185,10 @@ impl App for TextEditorApp {
         egui::Frame::new()
             .fill(colors.terminal_bg)
             .show(ui, |ui| {
-                // Footer hint bar
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
                     ui.add_space(4.0);
                     ui.horizontal(|ui| {
-                        ui.colored_label(
-                            colors.text_dim,
-                            egui::RichText::new("⌘S save").size(11.0),
-                        );
+                        ui.colored_label(colors.text_dim, egui::RichText::new("⌘S save").size(11.0));
                         ui.colored_label(colors.text_dim, egui::RichText::new("  ").size(11.0));
                         if self.dirty && self.dirty_escape_warned {
                             ui.colored_label(
@@ -193,27 +196,19 @@ impl App for TextEditorApp {
                                 egui::RichText::new("Unsaved — Esc again to discard").size(11.0),
                             );
                         } else {
-                            ui.colored_label(
-                                colors.text_dim,
-                                egui::RichText::new("Esc close").size(11.0),
-                            );
+                            ui.colored_label(colors.text_dim, egui::RichText::new("Esc close").size(11.0));
                         }
                         if self.dirty {
                             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                ui.colored_label(
-                                    egui::Color32::YELLOW,
-                                    egui::RichText::new("●").size(11.0),
-                                );
+                                ui.colored_label(egui::Color32::YELLOW, egui::RichText::new("●").size(11.0));
                             });
                         }
                     });
                     ui.separator();
 
-                    // Main editor area
                     let available = ui.available_size();
                     let font_size = 13.0_f32;
 
-                    // Build/cache syntax-highlighted layout job
                     let cached_job = if self.content_version == self.cached_version {
                         self.cached_layout.clone().unwrap_or_else(|| self.build_layout(font_size))
                     } else {
@@ -226,7 +221,6 @@ impl App for TextEditorApp {
                         ui.fonts(|f| f.layout_job(job))
                     };
 
-                    let te_id = egui::Id::new("text_editor_main");
                     let te_response = ui.add_sized(
                         available,
                         egui::TextEdit::multiline(&mut self.content)
@@ -237,7 +231,7 @@ impl App for TextEditorApp {
                             .layouter(&mut layouter),
                     );
 
-                    // One-shot focus request (after all widgets render)
+                    // One-shot focus request after all widgets render (GOTCHAS.md Fix 1).
                     if !self.focus_requested {
                         te_response.request_focus();
                         self.focus_requested = true;
@@ -245,7 +239,6 @@ impl App for TextEditorApp {
                 });
             });
 
-        // Track dirty state
         if self.content != content_before {
             self.content_version += 1;
             self.dirty = self.content != self.original_content;


### PR DESCRIPTION
Closes #1737

## Summary

- Adds `TextEditorApp` — a native Rust builtin with syntect syntax highlighting via `TextEdit::layouter()`, dirty indicator (`●` in pane title), `Cmd+S` save, and two-press Escape guard before discarding changes
- Replaces the old Cmd+Shift+Space scratchpad (which injected `micro`/`nano` into the terminal PTY) with a `TextEditorApp` opening as a pane overlay — Escape restores the pane underneath
- File browser now routes 37 text/code extensions (`.rs`, `.md`, `.py`, `.js`, `.toml`, etc.) to `text_editor` via `AppCommand::SpawnApp` with `split_h` layout (opens to the right)

## Done When

- Opening a `.rs` or `.md` file from the file browser spawns a text editor pane to the right with syntax-colored content
- Editing any character marks the pane title with `●`
- `Cmd+S` saves the file, removes `●`, and the file on disk reflects the change
- Pressing Escape when dirty shows a warning in the footer; second Escape discards and closes
- `Cmd+Shift+Space` opens a new timestamped note in the text editor as an overlay over the current pane; Escape restores the previous pane
- `cargo test --bin plexi` passes

## Notes

- `SyntaxSet` and `ThemeSet` are constructed once in `TextEditorApp::new()` — expensive to build, so they live on the struct
- `keyboard_capture() = true` disables host shortcuts (Cmd+H/J/K/L, Cmd+Enter) while the editor is focused; only Cmd+Q/W remain active
- Layout cache: `LayoutJob` is rebuilt from syntect tokens only when `content_version != cached_version`; the `Arc<Galley>` is always freshly computed by egui's font system from the cached job
- Focus fix: one-shot `focus_requested` bool gates `te_response.request_focus()` to the first frame only (GOTCHAS.md two-layer focus pattern)
- `preferred_editor()` and old `scratchpad_file()` in `pane_ops/create.rs` removed; `scratchpad_file()` moved to `src/text_editor/mod.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in text editor with syntax highlighting for viewing and editing text and code files.
  * Text files (`.txt`, `.md`, `.rs`, `.py`, `.js`, `.ts`, `.json`, `.yaml`, etc.) now open in the editor by default instead of external applications.
  * Scratchpad now uses the built-in editor.
  * Save functionality (Cmd+S) with dirty state tracking and unsaved changes warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->