### PR TITLE
feat(cli): plexi demo — live keybinding tutorial that watches events.jsonl (#1740)

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [cli] New top-level subcommands must be added to SUBCOMMANDS in parse_workspace_path_arg
+
+`parse_workspace_path_arg` in `src/main.rs` runs on raw args before clap parses anything. It has a hardcoded `SUBCOMMANDS: &[&str]` allowlist. Any first positional arg not in that list is treated as a workspace path, giving `error: workspace path does not exist: <name>` even when the subcommand is defined in the `Commands` enum.
+
+**Fix:** add the lowercase subcommand name to `SUBCOMMANDS` in `parse_workspace_path_arg` (line ~601 in `src/main.rs`) for every new `Commands` variant.
+
+---
+
 ## [git · ship] Unpushed alpha commits are silently lost when ship-issue agents rebase
 
 `ship-issue` runs `git pull --rebase origin alpha` at Phase 1. If there are commits on the local alpha branch that haven't been pushed to origin, the rebase replays them on top of origin's HEAD — but if those commits touch files that were also changed by merged PRs (e.g. skill files, CLAUDE.md), they will conflict and be silently dropped or overwritten.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4317,15 +4317,18 @@ pub fn demo_cli() -> i32 {
         }
     };
 
+    log::info!("demo_cli: starting interactive tutorial for pane_id={my_pane_id}");
+
     let events_path = crate::config::config_dir().join("events.jsonl");
 
     // Seek to end — only watch events that occur after demo starts.
-    let start_offset = if events_path.exists() {
-        std::fs::metadata(&events_path)
-            .map(|m| m.len())
-            .unwrap_or(0)
-    } else {
-        0
+    let start_offset = match std::fs::metadata(&events_path) {
+        Ok(m) => m.len(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(e) => {
+            log::warn!("demo_cli: could not read events file metadata: {e}");
+            0
+        }
     };
 
     // Welcome banner
@@ -4341,17 +4344,15 @@ pub fn demo_cli() -> i32 {
     eprintln!("  Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
     eprintln!();
 
-    if let Err(e) = poll_event(&events_path, start_offset, |kind, _obj| kind == "pane_split") {
-        eprintln!("error watching {}: {e}", events_path.display());
-        return 1;
-    }
+    let after_split_offset = match poll_event(&events_path, start_offset, |kind, _obj| kind == "pane_split") {
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
     eprintln!("  \x1b[1;32m\u{2713} 1/2\x1b[0m");
     eprintln!();
-
-    // Remember offset after step 1 so focus events from the split itself are skipped.
-    let after_split_offset = std::fs::metadata(&events_path)
-        .map(|m| m.len())
-        .unwrap_or(start_offset);
 
     // Step 2 — navigate
     eprintln!("  Step 2 of 2   Navigate panes");
@@ -4364,19 +4365,17 @@ pub fn demo_cli() -> i32 {
     eprintln!("  Press  \x1b[1m[ \u{2318}L ]\x1b[0m  to move focus right, then  \x1b[1m[ \u{2318}H ]\x1b[0m  to come back.");
     eprintln!();
 
-    // Wait for focus to LEAVE this pane (user pressed ⌘L).
-    let mut focus_offset = after_split_offset;
-    if let Err(e) = poll_event(&events_path, focus_offset, |kind, obj| {
+    // Wait for focus to LEAVE this pane (user pressed ⌘L); returned offset is exact position after match.
+    let focus_offset = match poll_event(&events_path, after_split_offset, |kind, obj| {
         kind == "focus_changed"
             && obj.get("pane_id").and_then(|v| v.as_u64()) == Some(my_pane_id)
     }) {
-        eprintln!("error watching {}: {e}", events_path.display());
-        return 1;
-    }
-    // Advance offset so the next poll starts after the first focus event.
-    focus_offset = std::fs::metadata(&events_path)
-        .map(|m| m.len())
-        .unwrap_or(focus_offset);
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
 
     // Wait for any focus_changed (user pressed ⌘H, focus leaves the other pane).
     if let Err(e) = poll_event(&events_path, focus_offset, |kind, _obj| kind == "focus_changed") {
@@ -4390,35 +4389,51 @@ pub fn demo_cli() -> i32 {
     0
 }
 
-/// Tail `path` from `offset`, calling `predicate(kind, json_object)` on each new event.
-/// Returns when the predicate matches, polling at 100ms intervals.
-fn poll_event<F>(path: &std::path::Path, offset: u64, predicate: F) -> std::io::Result<()>
+/// Tails `path` from `offset`, advancing the cursor as lines are consumed.
+/// Returns the byte offset immediately after the matched line when the predicate fires.
+/// Handles missing files gracefully; only processes complete newline-terminated lines.
+fn poll_event<F>(path: &std::path::Path, mut offset: u64, predicate: F) -> std::io::Result<u64>
 where
     F: Fn(&str, &serde_json::Value) -> bool,
 {
     use std::io::{Read, Seek, SeekFrom};
     loop {
-        if path.exists() {
-            let mut f = std::fs::File::open(path)?;
-            let file_len = f.seek(SeekFrom::End(0))?;
-            if file_len > offset {
-                f.seek(SeekFrom::Start(offset))?;
-                let mut buf = String::new();
-                f.read_to_string(&mut buf)?;
-                for line in buf.lines() {
-                    let line = line.trim();
-                    if line.is_empty() {
-                        continue;
-                    }
-                    if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) {
-                        if let Some(kind) = obj.get("kind").and_then(|v| v.as_str()) {
-                            if predicate(kind, &obj) {
-                                return Ok(());
+        match std::fs::File::open(path) {
+            Ok(mut f) => {
+                let file_len = f.seek(SeekFrom::End(0))?;
+                if file_len > offset {
+                    f.seek(SeekFrom::Start(offset))?;
+                    let mut buf = String::new();
+                    f.read_to_string(&mut buf)?;
+                    // Only process lines up to the last newline to avoid partial writes.
+                    let process_len = match buf.rfind('\n') {
+                        Some(pos) => pos + 1,
+                        None => {
+                            std::thread::sleep(std::time::Duration::from_millis(100));
+                            continue;
+                        }
+                    };
+                    let complete = &buf[..process_len];
+                    let mut byte_pos: u64 = 0;
+                    for line in complete.split_inclusive('\n') {
+                        let line_bytes = line.len() as u64;
+                        let trimmed = line.trim();
+                        if !trimmed.is_empty() {
+                            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                                if let Some(kind) = obj.get("kind").and_then(|v| v.as_str()) {
+                                    if predicate(kind, &obj) {
+                                        return Ok(offset + byte_pos + line_bytes);
+                                    }
+                                }
                             }
                         }
+                        byte_pos += line_bytes;
                     }
+                    offset += process_len as u64;
                 }
             }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4300,6 +4300,130 @@ pub fn notes_open_cli() -> i32 {
     pane_send_cli(pane_id, &cmd)
 }
 
+pub fn demo_cli() -> i32 {
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: run `plexi demo` inside a Plexi terminal pane");
+            eprintln!("hint: open Plexi, then run this command from a pane");
+            return 1;
+        }
+    };
+    let my_pane_id: u64 = match pane_id_str.parse() {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+            return 1;
+        }
+    };
+
+    let events_path = crate::config::config_dir().join("events.jsonl");
+
+    // Seek to end — only watch events that occur after demo starts.
+    let start_offset = if events_path.exists() {
+        std::fs::metadata(&events_path)
+            .map(|m| m.len())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Welcome banner
+    eprintln!("\x1b[1;36m");
+    eprintln!("  Plexi — Quick Tutorial");
+    eprintln!("\x1b[0m");
+    eprintln!("  Two moves. That's all you need to know.");
+    eprintln!();
+
+    // Step 1 — split
+    eprintln!("  Step 1 of 2   Split a pane");
+    eprintln!();
+    eprintln!("  Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
+    eprintln!();
+
+    if let Err(e) = poll_event(&events_path, start_offset, |kind, _obj| kind == "pane_split") {
+        eprintln!("error watching {}: {e}", events_path.display());
+        return 1;
+    }
+    eprintln!("  \x1b[1;32m\u{2713} 1/2\x1b[0m");
+    eprintln!();
+
+    // Remember offset after step 1 so focus events from the split itself are skipped.
+    let after_split_offset = std::fs::metadata(&events_path)
+        .map(|m| m.len())
+        .unwrap_or(start_offset);
+
+    // Step 2 — navigate
+    eprintln!("  Step 2 of 2   Navigate panes");
+    eprintln!();
+    eprintln!("     \x1b[2m^\x1b[0m");
+    eprintln!("     K");
+    eprintln!("  H     L");
+    eprintln!("     J");
+    eprintln!();
+    eprintln!("  Press  \x1b[1m[ \u{2318}L ]\x1b[0m  to move focus right, then  \x1b[1m[ \u{2318}H ]\x1b[0m  to come back.");
+    eprintln!();
+
+    // Wait for focus to LEAVE this pane (user pressed ⌘L).
+    let mut focus_offset = after_split_offset;
+    if let Err(e) = poll_event(&events_path, focus_offset, |kind, obj| {
+        kind == "focus_changed"
+            && obj.get("pane_id").and_then(|v| v.as_u64()) == Some(my_pane_id)
+    }) {
+        eprintln!("error watching {}: {e}", events_path.display());
+        return 1;
+    }
+    // Advance offset so the next poll starts after the first focus event.
+    focus_offset = std::fs::metadata(&events_path)
+        .map(|m| m.len())
+        .unwrap_or(focus_offset);
+
+    // Wait for any focus_changed (user pressed ⌘H, focus leaves the other pane).
+    if let Err(e) = poll_event(&events_path, focus_offset, |kind, _obj| kind == "focus_changed") {
+        eprintln!("error watching {}: {e}", events_path.display());
+        return 1;
+    }
+
+    eprintln!("  \x1b[1;32m\u{2713} 2/2   You know Plexi.\x1b[0m");
+    eprintln!();
+    log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");
+    0
+}
+
+/// Tail `path` from `offset`, calling `predicate(kind, json_object)` on each new event.
+/// Returns when the predicate matches, polling at 100ms intervals.
+fn poll_event<F>(path: &std::path::Path, offset: u64, predicate: F) -> std::io::Result<()>
+where
+    F: Fn(&str, &serde_json::Value) -> bool,
+{
+    use std::io::{Read, Seek, SeekFrom};
+    loop {
+        if path.exists() {
+            let mut f = std::fs::File::open(path)?;
+            let file_len = f.seek(SeekFrom::End(0))?;
+            if file_len > offset {
+                f.seek(SeekFrom::Start(offset))?;
+                let mut buf = String::new();
+                f.read_to_string(&mut buf)?;
+                for line in buf.lines() {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) {
+                        if let Some(kind) = obj.get("kind").and_then(|v| v.as_str()) {
+                            if predicate(kind, &obj) {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     match shell {
         "zsh" => { print!("{}", zsh_completion(binary_name)); 0 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -243,6 +243,12 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: Option<NotesCmd>,
     },
+    /// Interactive keybinding tutorial — learn split and navigate in real time.
+    ///
+    /// Walk through two fundamental Plexi interactions inside a live pane:
+    /// split a pane (⌘D) and navigate between panes (⌘L / ⌘H).
+    /// Must be run inside a Plexi pane (PLEXI_PANE_ID must be set).
+    Demo,
 }
 
 #[derive(Subcommand)]

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -136,6 +136,12 @@ pub enum HostEvent {
         duration_secs: u64,
         timestamp: String,
     },
+    /// A pane was created via a split action.
+    PaneSplit {
+        pane_id: u64,
+        direction: String,
+        timestamp: String,
+    },
 }
 
 // ── Wire envelope ─────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,6 +627,7 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "config",
         "routine",
         "notes",
+        "demo",
     ];
     let mut iter = args.iter().enumerate();
     // Skip argv[0] (binary name).

--- a/src/main.rs
+++ b/src/main.rs
@@ -512,6 +512,7 @@ fn main() -> eframe::Result {
                         Some(NotesCmd::List) | None => std::process::exit(cli::notes_list_cli()),
                         Some(NotesCmd::Open) => std::process::exit(cli::notes_open_cli()),
                     },
+                    Commands::Demo => std::process::exit(cli::demo_cli()),
                 }
             }
             // No subcommand — fall through to workspace path check, then GUI

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -248,6 +248,7 @@ impl PlexiApp {
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
         let direction = if vertical { "vertical" } else { "horizontal" }.to_string();
+        log::info!("split_focused: emitting PaneSplit pane_id={new_id} direction={direction}");
         crate::event_log::emit(crate::event_log::HostEvent::PaneSplit {
             pane_id: new_id,
             direction,

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -247,6 +247,13 @@ impl PlexiApp {
             })
             .unwrap_or_else(|| (self.host.alloc_pane_id(), vertical));
 
+        let direction = if vertical { "vertical" } else { "horizontal" }.to_string();
+        crate::event_log::emit(crate::event_log::HostEvent::PaneSplit {
+            pane_id: new_id,
+            direction,
+            timestamp: crate::event_log::now_timestamp(),
+        });
+
         let cwd = self.resolve_new_pane_cwd(cwd_override, Some(focused));
         log::info!("split_focused: cwd={cwd:?} context_root={:?}", self.router.active().root);
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);


### PR DESCRIPTION
Closes #1740

## Summary

- Adds `plexi demo` command — a 2-step interactive keybinding tutorial that runs inside a Plexi pane
- Adds `PaneSplit` to `HostEvent` enum and emits it from `split_focused` in `pane_ops/layout.rs`
- Polls `events.jsonl` from the current byte offset at 100ms intervals, detecting `pane_split` (step 1) and two sequential `focus_changed` events (step 2)

## Done When

Running `plexi-alpha demo` inside a Plexi pane:
- Displays the welcome banner and step 1 prompt
- After pressing ⌘D, prints `✓ 1/2` without any manual action
- After pressing `⌘L` then `⌘H`, prints `✓ 2/2 — You know Plexi.`
- Running `plexi-alpha demo` outside a Plexi pane prints a usage hint and exits 1

## Notes

- `poll_event` tails from a byte offset to avoid replaying historical events; offset is re-snapped after step 1 to skip any focus events triggered by the split itself
- No extra crates — uses only std + `serde_json` (already a dep)
- `PaneSplit` is emitted from `split_focused` only; `split_focused_mirror` delegates to `split_focused` for terminals so it naturally inherits the emission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced interactive `demo` CLI command providing step-by-step tutorials and guidance designed to run within Plexi panes, enabling hands-on learning and feature exploration
- Pane split operations now generate and emit events captured in the event logging system, enhancing the ability to monitor and review pane layout changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->