### PR TITLE
feat(cli): workspace app manifest — .plexi/apps.toml declares per-project app dependencies (#1719)

### DIFF
--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -659,6 +659,12 @@ pub fn apps_dir() -> PathBuf {
     crate::config::config_dir().join("apps")
 }
 
+/// Return the apps dir scoped to `workspace_root` for the current channel.
+/// Workspace apps live at `<workspace_root>/<channel_dir>/apps/`.
+pub fn workspace_apps_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(registry_config_dir()).join("apps")
+}
+
 /// Detect the channel config dir name from the running binary name.
 /// Mirrors the logic in `config_dir_name()` (config.rs) but without the
 /// PROFILE_OVERRIDE global, which is private to that module.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -384,7 +384,34 @@ pub fn workspace_init() -> i32 {
             if channel_created {
                 println!("  channel dir:  {channel_dir}/");
             }
-            print_tip("define runnable commands in .plexi/commands.toml, then run them with `plexi run <name>`.");
+            // Write stub apps.toml if not already present.
+            let apps_toml = cwd.join(".plexi").join("apps.toml");
+            if !apps_toml.exists() {
+                let stub = concat!(
+                    "schema_version = 1\n\n",
+                    "# Declare workspace app dependencies here.\n",
+                    "# Run `plexi install` in this directory to install them.\n",
+                    "#\n",
+                    "# Example:\n",
+                    "#\n",
+                    "# [[app]]\n",
+                    "# id      = \"gh-issues\"\n",
+                    "# source  = \"local:gh-issues\"\n",
+                    "# version = \"bundled\"\n",
+                    "#\n",
+                    "# [[app]]\n",
+                    "# id      = \"my-tool\"\n",
+                    "# source  = \"github:org/my-tool\"\n",
+                    "# version = \"v1.0.0\"\n",
+                );
+                if let Err(e) = std::fs::write(&apps_toml, stub) {
+                    log::warn!("workspace_init:cli: could not write apps.toml: {e}");
+                } else {
+                    println!("  apps:         .plexi/apps.toml (declare app dependencies here)");
+                    log::info!("workspace_init:cli: wrote stub .plexi/apps.toml");
+                }
+            }
+            print_tip("declare app dependencies in .plexi/apps.toml, then run `plexi install`.");
             0
         }
         Err(e) => {
@@ -1446,6 +1473,92 @@ pub fn install_pack_cli(spec: &str) -> i32 {
     }
 }
 
+/// `plexi install` with no args — detect `.plexi/apps.toml` and apply it.
+///
+/// Walks up from CWD looking for `.plexi/` (the workspace marker), reads
+/// `apps.toml` from it, and installs declared apps into the workspace-scoped
+/// channel apps dir (`<workspace_root>/<channel_dir>/apps/`).
+pub fn install_workspace_pack_cli() -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => { eprintln!("error: {e}"); return 1; }
+    };
+
+    // Walk up from CWD looking for `.plexi/` (workspace marker).
+    let workspace_root = {
+        let home = dirs::home_dir();
+        let mut current = cwd.clone();
+        let mut found: Option<std::path::PathBuf> = None;
+        loop {
+            if let Some(ref h) = home {
+                if current == *h {
+                    break;
+                }
+            }
+            if current == std::path::Path::new("/") {
+                break;
+            }
+            if current.join(".plexi").is_dir() {
+                found = Some(current);
+                break;
+            }
+            if !current.pop() {
+                break;
+            }
+        }
+        found
+    };
+
+    let Some(root) = workspace_root else {
+        eprintln!("Usage: plexi install <source-spec>[@ref] | plexi install --pack <path|core>");
+        eprintln!("  In a workspace (directory with .plexi/apps.toml), `plexi install` applies the manifest.");
+        eprintln!("  Run `plexi workspace init` to initialize a workspace here.");
+        return 1;
+    };
+
+    let apps_toml = root.join(".plexi").join("apps.toml");
+    if !apps_toml.exists() {
+        eprintln!("no .plexi/apps.toml found in workspace at {}", root.display());
+        eprintln!("  Declare app dependencies there, then re-run `plexi install`.");
+        eprintln!("  Usage: plexi install <source-spec>[@ref] | plexi install --pack <path|core>");
+        return 1;
+    }
+
+    log::info!("install_workspace_pack:cli: applying {}", apps_toml.display());
+    println!("Applying workspace manifest {}...", apps_toml.display());
+
+    let cloner = crate::install::GitCloner;
+    let outcomes = match crate::install::apply_workspace_pack(&root, &cloner) {
+        Ok(o) => o,
+        Err(e) => { eprintln!("error: {e}"); return 1; }
+    };
+
+    if outcomes.is_empty() {
+        println!("No apps declared in .plexi/apps.toml.");
+        return 0;
+    }
+
+    let mut any_failed = false;
+    for o in &outcomes {
+        match &o.status {
+            crate::install::InstallStatus::Installed(p) => {
+                println!("  installed  {:30} → {}", o.id, p.display());
+            }
+            crate::install::InstallStatus::AlreadyAtVersion => {
+                println!("  up-to-date {:30}", o.id);
+            }
+            crate::install::InstallStatus::SkippedOtherVersion { installed, requested } => {
+                println!("  skipped    {:30} (installed {installed}, requested {requested})", o.id);
+            }
+            crate::install::InstallStatus::Failed(msg) => {
+                eprintln!("  FAILED     {:30} {msg}", o.id);
+                any_failed = true;
+            }
+        }
+    }
+    if any_failed { 1 } else { 0 }
+}
+
 /// `plexi uninstall [--keep-data] [--yes]` — remove Plexi itself from the Mac.
 pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
     // Detect channel suffix from binary name (e.g. "plexi-alpha" → "-alpha", "plexi" → "")
@@ -1950,6 +2063,10 @@ pub fn list_cli() -> i32 {
     let workspace_root = crate::app_registry::resolve_workspace_root(&cwd);
     let core_ids = crate::install::core_pack_ids();
     let example_ids = crate::install::examples_pack_ids();
+    let workspace_ids = workspace_root
+        .as_ref()
+        .map(|r| crate::install::workspace_manifest_ids(r))
+        .unwrap_or_default();
     let mut globals: Vec<(String, String, String, &'static str)> = Vec::new();
     let mut workspace: Vec<(String, String, String, &'static str)> = Vec::new();
     for app in installed {
@@ -1961,6 +2078,8 @@ pub fn list_cli() -> i32 {
             "[core]"
         } else if example_ids.contains(app.manifest.id.as_str()) {
             "[example]"
+        } else if workspace_ids.contains(app.manifest.id.as_str()) {
+            "[workspace]"
         } else {
             ""
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -406,6 +406,7 @@ pub fn workspace_init() -> i32 {
                 );
                 if let Err(e) = std::fs::write(&apps_toml, stub) {
                     log::warn!("workspace_init:cli: could not write apps.toml: {e}");
+                    eprintln!("warning: could not create .plexi/apps.toml: {e}");
                 } else {
                     println!("  apps:         .plexi/apps.toml (declare app dependencies here)");
                     log::info!("workspace_init:cli: wrote stub .plexi/apps.toml");
@@ -1479,6 +1480,7 @@ pub fn install_pack_cli(spec: &str) -> i32 {
 /// `apps.toml` from it, and installs declared apps into the workspace-scoped
 /// channel apps dir (`<workspace_root>/<channel_dir>/apps/`).
 pub fn install_workspace_pack_cli() -> i32 {
+    log::info!("cli: install_workspace_pack (no-args flow)");
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => { eprintln!("error: {e}"); return 1; }

--- a/src/install.rs
+++ b/src/install.rs
@@ -711,6 +711,40 @@ pub fn examples_pack_ids() -> std::collections::HashSet<String> {
         .unwrap_or_default()
 }
 
+/// Read `<workspace_root>/.plexi/apps.toml` and install declared apps into the
+/// workspace-scoped apps dir (`<workspace_root>/<channel_dir>/apps/`).
+pub fn apply_workspace_pack(
+    workspace_root: &Path,
+    cloner: &dyn Cloner,
+) -> Result<Vec<InstallOutcome>, String> {
+    let apps_toml = workspace_root.join(".plexi").join("apps.toml");
+    if !apps_toml.exists() {
+        return Err(
+            "no .plexi/apps.toml found — run 'plexi app add <id>' to declare dependencies"
+                .to_string(),
+        );
+    }
+    let pack = Pack::from_path(&apps_toml)?;
+    let workspace_apps = crate::app_registry::workspace_apps_dir(workspace_root);
+    std::fs::create_dir_all(&workspace_apps)
+        .map_err(|e| format!("create workspace apps dir {}: {e}", workspace_apps.display()))?;
+    log::info!(
+        "install: workspace pack {} → {} ({} apps)",
+        apps_toml.display(),
+        workspace_apps.display(),
+        pack.apps.len()
+    );
+    Ok(apply_pack(cloner, &pack, &workspace_apps))
+}
+
+/// Return the set of app IDs declared in `<workspace_root>/.plexi/apps.toml`.
+/// Returns an empty set if the file is absent or unparseable.
+pub fn workspace_manifest_ids(workspace_root: &Path) -> std::collections::HashSet<String> {
+    Pack::from_path(&workspace_root.join(".plexi").join("apps.toml"))
+        .map(|p| p.apps.into_iter().map(|a| a.id).collect())
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::*;
@@ -1166,5 +1200,107 @@ mod core_pack_tests {
         let (s, r) = split_source_and_ref("git+ssh://user@host.example.com/repo.git");
         assert_eq!(s, "git+ssh://user@host.example.com/repo.git");
         assert_eq!(r, None);
+    }
+}
+
+#[cfg(test)]
+mod workspace_pack_tests {
+    use super::test_support::MockCloner;
+    use super::*;
+
+    #[test]
+    fn apply_workspace_pack_installs_into_channel_apps_dir() {
+        let ws = tempfile::tempdir().unwrap();
+        let plexi_dir = ws.path().join(".plexi");
+        std::fs::create_dir_all(&plexi_dir).unwrap();
+        std::fs::write(
+            plexi_dir.join("apps.toml"),
+            "schema_version = 1\n\n\
+             [[app]]\n\
+             id = \"my-tool\"\n\
+             source = \"github:org/my-tool\"\n\
+             version = \"v1.0.0\"\n",
+        )
+        .unwrap();
+
+        let cloner = MockCloner::new();
+        let outcomes = apply_workspace_pack(ws.path(), &cloner).expect("should succeed");
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].id, "my-tool");
+        assert!(
+            matches!(outcomes[0].status, InstallStatus::Installed(_)),
+            "expected Installed, got {:?}",
+            outcomes[0].status
+        );
+
+        let workspace_apps = crate::app_registry::workspace_apps_dir(ws.path());
+        assert!(
+            workspace_apps.join("my-tool").join("manifest.toml").exists(),
+            "app should be present in workspace apps dir at {}",
+            workspace_apps.display()
+        );
+    }
+
+    #[test]
+    fn apply_workspace_pack_errors_when_no_apps_toml() {
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(ws.path().join(".plexi")).unwrap();
+
+        let cloner = MockCloner::new();
+        let err = apply_workspace_pack(ws.path(), &cloner).expect_err("should error");
+        assert!(
+            err.contains("no .plexi/apps.toml found"),
+            "expected no-manifest error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn workspace_manifest_ids_returns_declared_ids() {
+        let ws = tempfile::tempdir().unwrap();
+        let plexi_dir = ws.path().join(".plexi");
+        std::fs::create_dir_all(&plexi_dir).unwrap();
+        std::fs::write(
+            plexi_dir.join("apps.toml"),
+            "schema_version = 1\n\n\
+             [[app]]\nid = \"foo\"\nsource = \"github:a/b\"\nversion = \"v1\"\n\n\
+             [[app]]\nid = \"bar\"\nsource = \"github:a/c\"\nversion = \"v2\"\n",
+        )
+        .unwrap();
+
+        let ids = workspace_manifest_ids(ws.path());
+        assert!(ids.contains("foo"));
+        assert!(ids.contains("bar"));
+        assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn workspace_manifest_ids_empty_when_no_file() {
+        let ws = tempfile::tempdir().unwrap();
+        let ids = workspace_manifest_ids(ws.path());
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn apply_workspace_pack_idempotent_on_second_run() {
+        let ws = tempfile::tempdir().unwrap();
+        let plexi_dir = ws.path().join(".plexi");
+        std::fs::create_dir_all(&plexi_dir).unwrap();
+        // MockCloner writes version "0.0.1" by default — pack must match for AlreadyAtVersion.
+        std::fs::write(
+            plexi_dir.join("apps.toml"),
+            "schema_version = 1\n\n\
+             [[app]]\nid = \"my-tool\"\nsource = \"github:org/my-tool\"\nversion = \"0.0.1\"\n",
+        )
+        .unwrap();
+
+        let cloner = MockCloner::new();
+        apply_workspace_pack(ws.path(), &cloner).unwrap();
+        let second = apply_workspace_pack(ws.path(), &cloner).unwrap();
+        assert_eq!(second.len(), 1);
+        assert!(
+            matches!(second[0].status, InstallStatus::AlreadyAtVersion),
+            "second apply should be no-op, got {:?}",
+            second[0].status
+        );
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -720,7 +720,7 @@ pub fn apply_workspace_pack(
     let apps_toml = workspace_root.join(".plexi").join("apps.toml");
     if !apps_toml.exists() {
         return Err(
-            "no .plexi/apps.toml found — run 'plexi app add <id>' to declare dependencies"
+            "no .plexi/apps.toml found — run 'plexi workspace init' to initialize a workspace with a stub apps.toml"
                 .to_string(),
         );
     }
@@ -740,9 +740,16 @@ pub fn apply_workspace_pack(
 /// Return the set of app IDs declared in `<workspace_root>/.plexi/apps.toml`.
 /// Returns an empty set if the file is absent or unparseable.
 pub fn workspace_manifest_ids(workspace_root: &Path) -> std::collections::HashSet<String> {
-    Pack::from_path(&workspace_root.join(".plexi").join("apps.toml"))
-        .map(|p| p.apps.into_iter().map(|a| a.id).collect())
-        .unwrap_or_default()
+    let path = workspace_root.join(".plexi").join("apps.toml");
+    match Pack::from_path(&path) {
+        Ok(p) => p.apps.into_iter().map(|a| a.id).collect(),
+        Err(e) => {
+            if path.exists() {
+                log::warn!("failed to parse workspace apps.toml: {e}");
+            }
+            std::collections::HashSet::new()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,10 +264,7 @@ fn main() -> eframe::Result {
                         }
                         match spec {
                             Some(s) => std::process::exit(cli::install_cli(&s)),
-                            None => {
-                                eprintln!("Usage: plexi install <source-spec>[@ref] | plexi install --pack <path|core>");
-                                std::process::exit(1);
-                            }
+                            None => std::process::exit(cli::install_workspace_pack_cli()),
                         }
                     }
                     Commands::Uninstall { keep_data, yes } => std::process::exit(cli::plexi_uninstall_cli(keep_data, yes)),


### PR DESCRIPTION
Closes #1719

## Summary

- Adds `.plexi/apps.toml` workspace manifest (reuses existing `Pack` struct — no new types)
- `plexi install` with no args inside a workspace dir reads `.plexi/apps.toml` and installs declared apps via `apply_workspace_pack()`
- `plexi app list` shows workspace-scoped apps with a `[workspace]` badge
- `plexi workspace init` generates a stub `.plexi/apps.toml` with commented examples

## Done When

- `plexi install` run in a directory with `.plexi/apps.toml` installs the declared apps
- `plexi app list` shows workspace apps with a `[workspace]` badge distinct from global apps
- `plexi workspace init` generates a stub `.plexi/apps.toml`
- `cargo test --bin plexi` passes including the new harness test

## Notes

- `workspace_apps_dir()` added to `app_registry.rs` — returns `<workspace_root>/.plexi/apps/`
- `workspace_manifest_ids()` in `install.rs` returns app IDs from the manifest for list badging
- Clear error surface when `.plexi/apps.toml` is absent: `no .plexi/apps.toml found — run 'plexi app add <id>' to declare dependencies`