### PR TITLE
ux(welcome): add Cmd+E hint, demo callout, docs link, and clean up repetition (#1741)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -4096,10 +4096,11 @@ impl PlexiApp {
                         .color(colors.text_dim),
                     );
                     ui.add_space(style::SPACE_SM);
-                    ui.label(
+                    ui.hyperlink_to(
                         RichText::new("Read the docs at plexi.dev/docs")
                             .size(style::TEXT_CAPTION)
                             .color(colors.text_dim),
+                        "https://plexi.dev/docs",
                     );
 
                     ui.add_space(style::SPACE_MD);

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -4067,6 +4067,7 @@ impl PlexiApp {
                     // Each entry: (chip groups for one combo, description).
                     // Every modifier/key is a separate chip — no combined strings.
                     let shortcuts: &[(&[&str], &str)] = &[
+                        (&["⌘", "E"], "file browser"),
                         (&["⌘", "P"], "command palette"),
                         (&["⌘", "N"], "new terminal"),
                         (&["⌘", "⇧", "N"], "new context"),
@@ -4088,33 +4089,18 @@ impl PlexiApp {
 
                     ui.add_space(style::SPACE_XL);
                     ui.label(
-                        RichText::new("Things to try")
-                            .size(style::TEXT_CAPTION)
-                            .color(colors.text_dim)
-                            .strong(),
+                        RichText::new(
+                            "New to Plexi? Run plexi demo in any terminal to get started.",
+                        )
+                        .size(style::TEXT_CAPTION)
+                        .color(colors.text_dim),
                     );
                     ui.add_space(style::SPACE_SM);
-
-                    let tips: &[&str] = &[
-                        "⌘P opens the command palette — jump to any pane or launch an installed app",
-                        "⌘⇧N opens a fresh context — use it like a virtual desktop",
-                    ];
-                    for tip in tips {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new("·")
-                                    .size(style::TEXT_BODY)
-                                    .color(colors.text_dim),
-                            );
-                            ui.add_space(style::SPACE_SM / 2.0);
-                            ui.label(
-                                RichText::new(*tip)
-                                    .size(style::TEXT_CAPTION)
-                                    .color(colors.text_dim),
-                            );
-                        });
-                        ui.add_space(style::SPACE_SM / 2.0);
-                    }
+                    ui.label(
+                        RichText::new("Read the docs at plexi.dev/docs")
+                            .size(style::TEXT_CAPTION)
+                            .color(colors.text_dim),
+                    );
 
                     ui.add_space(style::SPACE_MD);
                     ui.separator();

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -4067,9 +4067,9 @@ impl PlexiApp {
                     // Each entry: (chip groups for one combo, description).
                     // Every modifier/key is a separate chip — no combined strings.
                     let shortcuts: &[(&[&str], &str)] = &[
+                        (&["⌘", "N"], "new terminal"),
                         (&["⌘", "E"], "file browser"),
                         (&["⌘", "P"], "command palette"),
-                        (&["⌘", "N"], "new terminal"),
                         (&["⌘", "⇧", "N"], "new context"),
                         (&["⌘", "/"], "keyboard shortcuts"),
                     ];
@@ -4088,13 +4088,25 @@ impl PlexiApp {
                     }
 
                     ui.add_space(style::SPACE_XL);
-                    ui.label(
-                        RichText::new(
-                            "New to Plexi? Run plexi demo in any terminal to get started.",
-                        )
-                        .size(style::TEXT_CAPTION)
-                        .color(colors.text_dim),
-                    );
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            RichText::new("New to Plexi? Run ")
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_dim),
+                        );
+                        ui.label(
+                            RichText::new("plexi demo")
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_dim)
+                                .monospace()
+                                .background_color(colors.bg_active),
+                        );
+                        ui.label(
+                            RichText::new(" in any terminal to get started.")
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_dim),
+                        );
+                    });
                     ui.add_space(style::SPACE_SM);
                     ui.hyperlink_to(
                         RichText::new("Read the docs at plexi.dev/docs")


### PR DESCRIPTION
Closes #1741

## Summary

- Add ⌘E (file browser) as the first shortcut hint — most immediately useful action for a new user
- Remove redundant "Things to try" section (duplicated ⌘P and ⌘⇧N already in shortcuts list)
- Add `plexi demo` callout and docs link at plexi.dev/docs before the footer

## Done When

1. Welcome screen shows Cmd+E as the first shortcut hint
2. `plexi demo` callout is visible for new users
3. Docs link is present
4. No repetition between shortcuts and tips — one clean section
5. `cargo build` passes

## Notes

#1740 (`plexi demo` CLI command) is still open — the callout is static display text so it works independently of whether `plexi demo` exists yet.