### PR TITLE
feat(sdk): publish plexi-sdk to PyPI for pip/uv install (#1746)

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,29 @@
+name: Publish SDK to PyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/plexi-sdk
+    permissions:
+      id-token: write  # Required for PyPI OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build SDK
+        working-directory: sdk/python
+        run: uv build
+
+      - name: Publish to PyPI
+        working-directory: sdk/python
+        run: uv publish --skip-existing

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -19,6 +19,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 
+[project.urls]
+Homepage = "https://github.com/ianjamesburke/PLEXI"
+Repository = "https://github.com/ianjamesburke/PLEXI"
+Documentation = "https://github.com/ianjamesburke/PLEXI/tree/main/sdk/python"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Closes #1746

## Summary

- Adds `.github/workflows/publish-sdk.yml` that publishes the Python SDK to PyPI on every `v*` tag using OIDC trusted publishing — no API token secret needed
- Uses `uv build` + `uv publish --skip-existing` so repeated tags (when SDK version is unchanged between releases) are safe
- Adds `[project.urls]` to `sdk/python/pyproject.toml` for proper PyPI display

## Done When

1. `pip install plexi-sdk` (or `uv add plexi-sdk`) works from PyPI
2. `from plexi_sdk import App` resolves in any Python environment with the package installed
3. New apps scaffolded by `app init` don't include `sys.path.insert` hacks

## Notes

- **One manual setup step required before first publish:** Register `plexi-sdk` on PyPI and configure a trusted publisher: repo `ianjamesburke/PLEXI`, workflow `publish-sdk.yml`, environment `release`. No token needed after that — OIDC handles auth.
- SDK versions independently from the Plexi host (SDK is `0.4.0`, host is `0.0.505`). Publishing fires on every `v*` tag; `--skip-existing` is a no-op when the SDK version hasn't changed.
- The `app init` template (`sdk/python/plexi_sdk/templates/app_init.py`) already has clean `from plexi_sdk import ...` imports — no `sys.path.insert` present. Removing hacks from existing `apps/` is a follow-up per the issue.