### PR TITLE
fix(cli): consolidate app lifecycle commands under plexi app namespace (#1644)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -390,7 +390,7 @@ pub fn workspace_init() -> i32 {
                 let stub = concat!(
                     "schema_version = 1\n\n",
                     "# Declare workspace app dependencies here.\n",
-                    "# Run `plexi install` in this directory to install them.\n",
+                    "# Run `plexi app install` in this directory to install them.\n",
                     "#\n",
                     "# Example:\n",
                     "#\n",
@@ -412,7 +412,7 @@ pub fn workspace_init() -> i32 {
                     log::info!("workspace_init:cli: wrote stub .plexi/apps.toml");
                 }
             }
-            print_tip("declare app dependencies in .plexi/apps.toml, then run `plexi install`.");
+            print_tip("declare app dependencies in .plexi/apps.toml, then run `plexi app install`.");
             0
         }
         Err(e) => {
@@ -994,7 +994,7 @@ pub fn app_install(path: &str) -> i32 {
 
     log::info!("app::install: installed {app_id} v{app_version} from {}", src.display());
     println!("Installed '{app_id}' v{app_version} from {}.", src.display());
-    println!("Run `plexi open {app_id}` to launch it.");
+    println!("Run `plexi app open {app_id}` to launch it.");
     0
 }
 
@@ -1387,7 +1387,7 @@ pub fn install_cli(spec: &str) -> i32 {
         Ok(outcome) => match outcome.status {
             crate::install::InstallStatus::Installed(path) => {
                 println!("installed '{}' at {}", outcome.id, path.display());
-                print_tip(&format!("open your app with `plexi open {}`.", outcome.id));
+                print_tip(&format!("open your app with `plexi app open {}`.", outcome.id));
                 0
             }
             crate::install::InstallStatus::AlreadyAtVersion => {
@@ -1512,8 +1512,8 @@ pub fn install_workspace_pack_cli() -> i32 {
     };
 
     let Some(root) = workspace_root else {
-        eprintln!("Usage: plexi install <source-spec>[@ref] | plexi install --pack <path|core>");
-        eprintln!("  In a workspace (directory with .plexi/apps.toml), `plexi install` applies the manifest.");
+        eprintln!("Usage: plexi app install <source-spec>[@ref] | plexi app install --pack <path|core>");
+        eprintln!("  In a workspace (directory with .plexi/apps.toml), `plexi app install` applies the manifest.");
         eprintln!("  Run `plexi workspace init` to initialize a workspace here.");
         return 1;
     };
@@ -1521,8 +1521,8 @@ pub fn install_workspace_pack_cli() -> i32 {
     let apps_toml = root.join(".plexi").join("apps.toml");
     if !apps_toml.exists() {
         eprintln!("no .plexi/apps.toml found in workspace at {}", root.display());
-        eprintln!("  Declare app dependencies there, then re-run `plexi install`.");
-        eprintln!("  Usage: plexi install <source-spec>[@ref] | plexi install --pack <path|core>");
+        eprintln!("  Declare app dependencies there, then re-run `plexi app install`.");
+        eprintln!("  Usage: plexi app install <source-spec>[@ref] | plexi app install --pack <path|core>");
         return 1;
     }
 
@@ -2056,7 +2056,7 @@ pub fn list_cli() -> i32 {
     let installed = registry.list();
     if installed.is_empty() {
         println!("no apps installed");
-        println!("install one with: plexi install <source>[@ref]");
+        println!("install one with: plexi app install <source>[@ref]");
         return 0;
     }
     // Read versions directly from the global apps dir for the source-of-truth
@@ -3005,8 +3005,8 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
     }
 
     if type_id == "terminal" {
-        log::warn!("open:cli: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
-        eprintln!("warning: 'plexi open terminal' is deprecated — use 'plexi terminal' instead");
+        log::warn!("open:cli: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
+        eprintln!("warning: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
     }
 
     let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());
@@ -4611,16 +4611,13 @@ _plexi() {
         'workspace:Workspace management'
         'secret:Secret management'
         'app:App management'
-        'install:Install an app'
         'uninstall:Uninstall an app'
         'update:Update apps or self'
-        'list:List installed apps'
         'validate:Validate a Plexi app directory'
         'pack:Pack management'
         'notify:Send a notification'
         'pane:Pane management'
         'terminal:Open a terminal pane'
-        'open:Open an app pane'
         'descriptor:Descriptor probe'
         'registry:CLI registry'
         'context:Context management'
@@ -4666,7 +4663,7 @@ _plexi() {
               ;;
             *)
               local subcmds
-              subcmds=('init:Scaffold a new app' 'install:Install a local app directory' 'uninstall:Remove an installed app by id' 'list:List installed apps' 'render:Render an app to PNG headlessly' 'info:Show app info')
+              subcmds=('open:Open an app in a new pane' 'install:Install an app' 'uninstall:Remove an installed app by id' 'remove:Remove an installed app by id' 'list:List installed apps' 'init:Scaffold a new app' 'render:Render an app to PNG headlessly' 'info:Show app info' 'run:Run a local app dir in a pane')
               _describe 'subcommand' subcmds
               ;;
           esac
@@ -4901,25 +4898,22 @@ complete -F _plexi_completions plexi
 
 const FISH_COMPLETION: &str = r#"# Plexi shell completions for fish
 
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a run -d "Run a named command"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a workspace -d "Workspace management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a secret -d "Secret management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a app -d "App management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a install -d "Install an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a uninstall -d "Uninstall an app"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a update -d "Update apps or self"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a list -d "List installed apps"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a validate -d "Validate a Plexi app directory"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a pack -d "Pack management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a notify -d "Send a notification"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a pane -d "Pane management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a terminal -d "Open a terminal pane"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a open -d "Open an app pane"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a descriptor -d "Descriptor probe"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a registry -d "CLI registry"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a context -d "Context management"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a completions -d "Print shell completion script"
-complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app install uninstall update list validate pack notify pane terminal open descriptor registry context completions config" -a config -d "Configuration management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a run -d "Run a named command"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a workspace -d "Workspace management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a secret -d "Secret management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a app -d "App management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a uninstall -d "Uninstall Plexi itself"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a update -d "Update apps or self"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a validate -d "Validate a Plexi app directory"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a pack -d "Pack management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a notify -d "Send a notification"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a pane -d "Pane management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a terminal -d "Open a terminal pane"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a descriptor -d "Descriptor probe"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a registry -d "CLI registry"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a context -d "Context management"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a completions -d "Print shell completion script"
+complete -c plexi -f -n "not __fish_seen_subcommand_from run workspace secret app uninstall update validate pack notify pane terminal descriptor registry context completions config" -a config -d "Configuration management"
 
 # config subcommands
 complete -c plexi -f -n "__fish_seen_subcommand_from config" -a check -d "Validate config.toml and report errors"
@@ -4941,12 +4935,18 @@ complete -c plexi -n "__fish_seen_subcommand_from secret; and __fish_seen_subcom
 complete -c plexi -n "__fish_seen_subcommand_from secret; and __fish_seen_subcommand_from get" -l global -d "Read from global store only"
 
 # app subcommands
-complete -c plexi -f -n "__fish_seen_subcommand_from app" -a init -d "Scaffold a new app"
-complete -c plexi -f -n "__fish_seen_subcommand_from app" -a install -d "Install a local app directory"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a open -d "Open an app in a new pane"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a install -d "Install an app (local path, remote source, or pack)"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a uninstall -d "Uninstall an app"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a remove -d "Remove an installed app (alias for uninstall)"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a list -d "List installed apps"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a init -d "Scaffold a new app"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a render -d "Render an app to PNG headlessly"
 complete -c plexi -f -n "__fish_seen_subcommand_from app" -a info -d "Show app info"
+complete -c plexi -f -n "__fish_seen_subcommand_from app" -a run -d "Run a local app dir in a pane"
+# app install flags
+complete -c plexi -n "__fish_seen_subcommand_from app; and __fish_seen_subcommand_from install" -l pack -d "Install from a pack file or 'core'"
+
 # app init flags
 complete -c plexi -n "__fish_seen_subcommand_from app; and __fish_seen_subcommand_from init" -l lang -d "Language template" -a "python"
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -46,25 +46,10 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: SecretCmd,
     },
-    /// Manage your Plexi apps — scaffold, install, list, and inspect.
+    /// Manage your Plexi apps — open, install, list, scaffold, and inspect.
     App {
         #[command(subcommand)]
         cmd: AppCmd,
-    },
-    /// Install an app from a remote source or a pack file.
-    ///
-    /// Pass a GitHub source like `github:owner/repo`, or use `--pack` to install from a local pack file or the built-in core pack.
-    ///
-    /// Example: plexi install github:owner/repo
-    /// Example: plexi install --pack core
-    ///
-    /// To install a local app directory you are developing, use `plexi app install <path>` instead.
-    Install {
-        /// Source to install from (e.g. github:owner/repo or a bare app id)
-        spec: Option<String>,
-        /// Install from a pack file or 'core'
-        #[arg(long)]
-        pack: Option<String>,
     },
     /// Remove Plexi from your Mac — uninstalls the app, CLI, and optionally your profile data.
     ///
@@ -89,8 +74,6 @@ pub enum Commands {
         #[command(subcommand)]
         subcommand: Option<UpdateCmd>,
     },
-    /// Show all installed apps with their versions.
-    List,
     /// Check a Plexi app directory for errors before publishing or installing.
     Validate {
         /// Path to check (default: current directory)
@@ -153,34 +136,6 @@ pub enum Commands {
         /// Keep focus on the current pane instead of jumping to the new one
         #[arg(long)]
         no_focus: bool,
-    },
-    /// Open an app or tool in a new pane.
-    ///
-    /// Pass an app id (e.g. `plexi open snake`) to open an installed app.
-    /// Use `--mcp` to wrap an MCP server, or `--cli` to open any CLI tool with a Plexi UI.
-    Open {
-        /// App id to open (mutually exclusive with --mcp and --cli)
-        #[arg(conflicts_with_all = ["mcp", "cli"])]
-        type_id: Option<String>,
-        /// Wrap a stdio MCP server in a Plexi pane.
-        ///
-        /// Example: plexi open --mcp npx @modelcontextprotocol/server-filesystem /tmp
-        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true, conflicts_with = "cli")]
-        mcp: Vec<String>,
-        /// Wrap a CLI tool in a Plexi pane with a visual UI.
-        ///
-        /// Example: plexi open --cli git
-        #[arg(long, value_name = "BINARY", conflicts_with = "mcp")]
-        cli: Option<String>,
-        /// Where to place the new pane: split_h (right), split_left (left), split_v (below), split_right, split_below, split_above, tab, or new_window
-        #[arg(long)]
-        layout: Option<String>,
-        /// Open the new pane relative to this pane ID instead of the focused pane
-        #[arg(long)]
-        from_pane_id: Option<u64>,
-        /// Extra arguments passed through to the app (only valid with an app id)
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true, conflicts_with_all = ["mcp", "cli"])]
-        extra_args: Vec<String>,
     },
     /// Descriptor probe
     #[command(hide = true)]
@@ -283,18 +238,52 @@ pub enum SecretCmd {
 
 #[derive(Subcommand)]
 pub enum AppCmd {
-    /// Create a new app from a template.
+    /// Open an app or tool in a new pane.
     ///
-    /// Scaffolds the folder structure and files you need to build a Plexi app.
-    /// Use --lang to pick the language (default: python).
-    Init {
-        name: String,
-        #[arg(long, default_value = "python")]
-        lang: String,
+    /// Pass an app id (e.g. `plexi app open snake`) to open an installed app.
+    /// Use `--mcp` to wrap an MCP server, or `--cli` to open any CLI tool with a Plexi UI.
+    Open {
+        /// App id to open (mutually exclusive with --mcp and --cli)
+        #[arg(conflicts_with_all = ["mcp", "cli"])]
+        type_id: Option<String>,
+        /// Wrap a stdio MCP server in a Plexi pane.
+        ///
+        /// Example: plexi app open --mcp npx @modelcontextprotocol/server-filesystem /tmp
+        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true, conflicts_with = "cli")]
+        mcp: Vec<String>,
+        /// Wrap a CLI tool in a Plexi pane with a visual UI.
+        ///
+        /// Example: plexi app open --cli git
+        #[arg(long, value_name = "BINARY", conflicts_with = "mcp")]
+        cli: Option<String>,
+        /// Where to place the new pane: split_h (right), split_left (left), split_v (below), split_right, split_below, split_above, tab, or new_window
+        #[arg(long)]
+        layout: Option<String>,
+        /// Open the new pane relative to this pane ID instead of the focused pane
+        #[arg(long)]
+        from_pane_id: Option<u64>,
+        /// Extra arguments passed through to the app (only valid with an app id)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, conflicts_with_all = ["mcp", "cli"])]
+        extra_args: Vec<String>,
+    },
+    /// Install an app from a local path, a remote source, or a pack file.
+    ///
+    /// Local path: `plexi app install ./my-app` — copies the app dir into Plexi's store.
+    /// Remote source: `plexi app install github:owner/repo` — fetches and installs from GitHub.
+    /// Pack file: `plexi app install --pack core` — installs from a pack file or the built-in core pack.
+    /// Workspace pack: `plexi app install` (no args) — installs from .plexi/apps.toml.
+    Install {
+        /// Source to install: a local path, GitHub spec (github:owner/repo), or bare app id.
+        /// Omit to install from the workspace pack (.plexi/apps.toml).
+        spec_or_path: Option<String>,
+        /// Install from a pack file or 'core'
+        #[arg(long)]
+        pack: Option<String>,
     },
     /// Remove an installed app by id.
     ///
     /// Example: plexi app uninstall github-tree
+    #[command(aliases = ["remove", "delete"])]
     Uninstall {
         /// App id to remove (use `plexi app list` to see installed ids)
         id: String,
@@ -302,7 +291,7 @@ pub enum AppCmd {
         #[arg(long = "yes", short = 'y')]
         yes: bool,
     },
-    /// Show all installed apps (alias for `plexi list`).
+    /// Show all installed apps with their versions.
     List,
     /// Render an app to a PNG image without opening the UI (useful for screenshots and testing).
     Render {
@@ -322,13 +311,14 @@ pub enum AppCmd {
     Info {
         id: String,
     },
-    /// Install a local app directory you are developing into Plexi.
+    /// Create a new app from a template.
     ///
-    /// Copies your app folder into Plexi's app store so it shows up and runs like any other app.
-    /// To install apps from GitHub or a pack file, use `plexi install` instead.
-    Install {
-        /// Path to the app folder containing manifest.toml
-        path: String,
+    /// Scaffolds the folder structure and files you need to build a Plexi app.
+    /// Use --lang to pick the language (default: python).
+    Init {
+        name: String,
+        #[arg(long, default_value = "python")]
+        lang: String,
     },
     /// Run an app directly from a local directory without installing or linking.
     ///
@@ -381,14 +371,13 @@ pub enum PaneCmd {
     },
     /// List all open panes as a JSON array.
     ///
-    /// Filter by context with --context <id> or --current (reads PLEXI_CONTEXT_ID).
+    /// Filter by context: `--context` (no value) returns panes in the caller's context
+    /// (reads PLEXI_CONTEXT_ID from env). `--context <id>` filters to a specific context ID.
     List {
-        /// Only return panes belonging to this context ID.
-        #[arg(long, conflicts_with = "current")]
-        context: Option<u64>,
-        /// Only return panes in the caller's context (reads PLEXI_CONTEXT_ID from env).
-        #[arg(long)]
-        current: bool,
+        /// Filter by context. With no argument, reads PLEXI_CONTEXT_ID from env (caller's context).
+        /// With a numeric argument, returns panes in that specific context.
+        #[arg(long, value_name = "ID", num_args = 0..=1, default_missing_value = "current")]
+        context: Option<String>,
     },
     /// Move the visible focus to a specific pane.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn main() -> eframe::Result {
     let cli_mode = raw_args.iter().skip(1).any(|a| {
         const CLI_SUBCOMMANDS: &[&str] = &[
             "run", "secret", "app", "workspace", "notify", "pane", "terminal",
-            "open", "install", "uninstall", "update", "list", "pack",
+            "uninstall", "update", "pack",
             "descriptor", "registry", "validate", "context", "completions", "config",
         ];
         !a.starts_with('-') && CLI_SUBCOMMANDS.contains(&a.as_str())
@@ -248,8 +248,77 @@ fn main() -> eframe::Result {
                         SecretCmd::Delete { friendly_name } => std::process::exit(cli::workspace_secret_delete(&friendly_name)),
                     },
                     Commands::App { cmd } => match cmd {
+                        AppCmd::Open { type_id, mcp, cli: cli_flag, layout, from_pane_id, extra_args } => {
+                            let mode_count = type_id.is_some() as u8
+                                + (!mcp.is_empty()) as u8
+                                + cli_flag.is_some() as u8;
+                            if mode_count == 0 {
+                                eprintln!("error: one of TYPE_ID, --mcp, or --cli is required");
+                                std::process::exit(2);
+                            }
+                            if mode_count > 1 {
+                                eprintln!("error: TYPE_ID, --mcp, and --cli are mutually exclusive");
+                                std::process::exit(2);
+                            }
+                            if let Some(tid) = type_id {
+                                log::info!("app_open:cli: opening app type_id={tid}");
+                                std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id, None));
+                            } else if !mcp.is_empty() {
+                                log::info!("app_open:cli: launching mcp-renderer with command {:?}", mcp);
+                                std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id, None));
+                            } else {
+                                let binary = cli_flag.unwrap();
+                                log::info!("app_open:cli: running --help parser for `{binary}`");
+                                match cli_help_parser::parse_help_to_descriptor(&binary) {
+                                    Ok(json) => {
+                                        let id = uuid::Uuid::new_v4();
+                                        let tmp = std::env::temp_dir()
+                                            .join(format!("plexi-descriptor-{id}.json"));
+                                        if let Err(e) = std::fs::write(&tmp, &json) {
+                                            eprintln!("error: could not write descriptor temp file: {e}");
+                                            std::process::exit(1);
+                                        }
+                                        let path = tmp.to_string_lossy().into_owned();
+                                        log::info!("app_open:cli: launching descriptor-renderer with descriptor at {path}");
+                                        std::process::exit(cli::open_cli(
+                                            "descriptor-renderer",
+                                            &[path],
+                                            layout.as_deref(),
+                                            from_pane_id,
+                                            None,
+                                        ));
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: could not parse --help output: {e}");
+                                        std::process::exit(1);
+                                    }
+                                }
+                            }
+                        }
+                        AppCmd::Install { spec_or_path, pack } => {
+                            if let Some(p) = pack {
+                                log::info!("app_install:cli: pack={p}");
+                                std::process::exit(cli::install_pack_cli(&p));
+                            }
+                            match spec_or_path {
+                                None => {
+                                    log::info!("app_install:cli: workspace pack (no args)");
+                                    std::process::exit(cli::install_workspace_pack_cli());
+                                }
+                                Some(s) => {
+                                    // Local path: contains a path separator, starts with . or /, or the path exists on disk.
+                                    let is_local = s.contains('/') || s.starts_with('.') || std::path::Path::new(&s).exists();
+                                    if is_local {
+                                        log::info!("app_install:cli: local path={s}");
+                                        std::process::exit(cli::app_install(&s));
+                                    } else {
+                                        log::info!("app_install:cli: remote spec={s}");
+                                        std::process::exit(cli::install_cli(&s));
+                                    }
+                                }
+                            }
+                        }
                         AppCmd::Init { name, lang } => std::process::exit(cli::app_init(&name, &lang)),
-                        AppCmd::Install { path } => std::process::exit(cli::app_install(&path)),
                         AppCmd::Uninstall { id, yes } => std::process::exit(cli::app_uninstall(&id, yes)),
                         AppCmd::List => std::process::exit(cli::app_list()),
                         AppCmd::Render { id, size, state, output } => {
@@ -258,21 +327,11 @@ fn main() -> eframe::Result {
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                         AppCmd::Run { path } => std::process::exit(cli::app_run(&path)),
                     },
-                    Commands::Install { spec, pack } => {
-                        if let Some(p) = pack {
-                            std::process::exit(cli::install_pack_cli(&p));
-                        }
-                        match spec {
-                            Some(s) => std::process::exit(cli::install_cli(&s)),
-                            None => std::process::exit(cli::install_workspace_pack_cli()),
-                        }
-                    }
                     Commands::Uninstall { keep_data, yes } => std::process::exit(cli::plexi_uninstall_cli(keep_data, yes)),
                     Commands::Update { subcommand } => match subcommand {
                         Some(UpdateCmd::Apps { id }) => std::process::exit(cli::update_cli(id.as_deref())),
                         None => std::process::exit(cli::self_update_cli()),
                     },
-                    Commands::List => std::process::exit(cli::list_cli()),
                     Commands::Validate { path } => std::process::exit(cli::validate_cli(&path)),
                     Commands::Pack { cmd } => match cmd {
                         PackCmd::Export { path } => std::process::exit(cli::pack_export_cli(&path)),
@@ -378,7 +437,20 @@ fn main() -> eframe::Result {
                             };
                             std::process::exit(cli::pane_set_title_cli(pane_id, &name))
                         }
-                        PaneCmd::List { context, current } => std::process::exit(cli::pane_list_cli(context, current)),
+                        PaneCmd::List { context } => {
+                            let (context_id, current) = match context.as_deref() {
+                                None => (None, false),
+                                Some("current") => (None, true),
+                                Some(s) => match s.parse::<u64>() {
+                                    Ok(id) => (Some(id), false),
+                                    Err(_) => {
+                                        eprintln!("error: --context value must be a numeric context ID or omitted for current context");
+                                        std::process::exit(1);
+                                    }
+                                },
+                            };
+                            std::process::exit(cli::pane_list_cli(context_id, current))
+                        }
                         PaneCmd::Focus { pane_id } => std::process::exit(cli::pane_focus_cli(pane_id)),
                         PaneCmd::Close { pane_id } => {
                             let id = match pane_id {
@@ -411,46 +483,6 @@ fn main() -> eframe::Result {
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));
-                    }
-                    Commands::Open { type_id, mcp, cli: cli_flag, layout, from_pane_id, extra_args } => {
-                        let mode_count = type_id.is_some() as u8
-                            + (!mcp.is_empty()) as u8
-                            + cli_flag.is_some() as u8;
-                        if mode_count == 0 {
-                            eprintln!("error: one of TYPE_ID, --mcp, or --cli is required");
-                            std::process::exit(2);
-                        }
-                        if mode_count > 1 {
-                            eprintln!("error: TYPE_ID, --mcp, and --cli are mutually exclusive");
-                            std::process::exit(2);
-                        }
-                        if let Some(tid) = type_id {
-                            std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id, None));
-                        } else if !mcp.is_empty() {
-                            log::info!("open:mcp: launching mcp-renderer with command {:?}", mcp);
-                            std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id, None));
-                        } else {
-                            let binary = cli_flag.unwrap();
-                            log::info!("open:cli-flag: running --help parser for `{binary}`");
-                            match cli_help_parser::parse_help_to_descriptor(&binary) {
-                                Ok(json) => {
-                                    let id = uuid::Uuid::new_v4();
-                                    let tmp = std::env::temp_dir()
-                                        .join(format!("plexi-descriptor-{id}.json"));
-                                    if let Err(e) = std::fs::write(&tmp, &json) {
-                                        eprintln!("error: could not write descriptor temp file: {e}");
-                                        std::process::exit(1);
-                                    }
-                                    let path = tmp.to_string_lossy().into_owned();
-                                    log::info!("open:cli-flag: launching descriptor-renderer with descriptor at {path}");
-                                    std::process::exit(cli::open_cli("descriptor-renderer", &[path], layout.as_deref(), from_pane_id, None));
-                                }
-                                Err(e) => {
-                                    eprintln!("error: could not parse --help output for `{binary}`: {e}");
-                                    std::process::exit(1);
-                                }
-                            }
-                        }
                     }
                     Commands::Descriptor { cmd } => match cmd {
                         DescriptorCmd::Probe { command, no_registry, no_crawl, json, extra_args } => {
@@ -589,13 +621,9 @@ fn parse_workspace_path_arg(args: &[String]) -> Result<Option<std::path::PathBuf
         "notify",
         "pane",
         "terminal",
-        "open",
         "--render",
-        // #308 Phase 2 — top-level package manager subcommands
-        "install",
         "uninstall",
         "update",
-        "list",
         "pack",
         // #188 — `plexi descriptor probe <cmd>` for the --plexi standard.
         "descriptor",

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,8 +306,10 @@ fn main() -> eframe::Result {
                                     std::process::exit(cli::install_workspace_pack_cli());
                                 }
                                 Some(s) => {
-                                    // Local path: contains a path separator, starts with . or /, or the path exists on disk.
-                                    let is_local = s.contains('/') || s.starts_with('.') || std::path::Path::new(&s).exists();
+                                    // Local path: contains a path separator, starts with . or /, or is an existing directory.
+                                    // Using is_dir() (not exists()) avoids misrouting bare app IDs that happen
+                                    // to match a file in the current directory.
+                                    let is_local = s.contains('/') || s.starts_with('.') || std::path::Path::new(&s).is_dir();
                                     if is_local {
                                         log::info!("app_install:cli: local path={s}");
                                         std::process::exit(cli::app_install(&s));


### PR DESCRIPTION
Closes #1644

## Summary

- Moved `plexi open`, `plexi install`, and `plexi list` under `plexi app {open,install,list}` — all app lifecycle operations now live under one noun
- Merged local-path and remote-source install into a unified `plexi app install` that routes by detecting whether the argument looks like a local path (contains `/`, starts with `.`, or exists on disk) vs a remote spec
- Added `remove`/`delete` as aliases for `plexi app uninstall`
- Replaced `pane list --current` with an optional-value `--context` flag: `--context` (no arg) reads `PLEXI_CONTEXT_ID` from env; `--context 42` filters to a specific context ID

## Done When

1. `plexi app open <app>` opens an app (old `plexi open` removed)
2. `plexi app install <source>` installs an app (old `plexi install` removed)
3. `plexi app list` is the only way to list apps (old `plexi list` removed)
4. `plexi app remove` works as an alias for `plexi app uninstall`
5. `plexi pane list --context` (no arg) returns panes in the caller's context
6. `plexi pane list --context 42` returns panes in context 42
7. `--current` flag is removed
8. `cargo build` passes
9. Shell completions reflect the new structure

## Notes

- Local vs remote routing in `app install`: checks `contains('/')`, `starts_with('.')`, or `Path::exists()` — bare app IDs like `snake` without `/` go to `install_cli` (remote), local paths with `/` or `.` go to `app_install` (local copy)
- Both SUBCOMMANDS lists in `main.rs` (`parse_workspace_path_arg` and `cli_mode` detection) had `"open"`, `"install"`, `"list"` removed per GOTCHAS.md requirement
- Hardcoded zsh and fish completion blocks in `cli.rs` updated to match new namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `remove` and `delete` as aliases for the uninstall command.

* **Chores**
  * Reorganized CLI commands—top-level app commands are now under `plexi app` namespace.
  * Updated command help text and descriptions.
  * Updated shell completions for zsh and fish.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->