### PR TITLE
ux(cli): trim help output — remove Quick Start, Inside Pane, and Workspace sections (#1742)

### DIFF
--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -5,24 +5,7 @@ use clap::{Parser, Subcommand};
     name = "plexi",
     about = "Plexi — the last app you'll ever need",
     version = env!("CARGO_PKG_VERSION"),
-    after_help = "\x1b[1mQuick start:\x1b[0m
-  plexi                     Launch the Plexi GUI
-  plexi list                Show installed apps
-  plexi open <app>          Open an app in a new pane
-  plexi install <source>    Install an app (e.g. github:owner/repo)
-  plexi app init <name>     Scaffold a new app
-
-\x1b[1mInside a Plexi pane:\x1b[0m
-  plexi terminal            Open a terminal pane
-  plexi pane list           List all open panes
-  plexi notify --title ...  Send a notification
-
-\x1b[1mWorkspace (per-project):\x1b[0m
-  plexi workspace init      Set up a .plexi/ workspace
-  plexi secret set <name>   Store a secret in your keychain
-  plexi run                 List available workspace commands
-  plexi run <command>       Run a command from .plexi/commands.toml
-"
+    after_help = "Get started: plexi demo | Docs: https://plexi.dev"
 )]
 pub struct Cli {
     /// Profile name (e.g. alpha, beta)

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -102,7 +102,7 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PackCmd,
     },
-    /// Send a notification to the Plexi UI. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Send a notification to the Plexi UI.
     Notify {
         /// Notification title (required)
         #[arg(long)]
@@ -129,7 +129,7 @@ pub enum Commands {
         #[arg(long, value_name = "SCOPE")]
         scope: Option<String>,
     },
-    /// Control panes — list, focus, send input, capture output, and more. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Control panes — list, focus, send input, capture output, and more.
     Pane {
         #[command(subcommand)]
         cmd: PaneCmd,
@@ -193,7 +193,7 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: RegistryCmd,
     },
-    /// Manage the active context (the folder and project scope tied to the current pane). Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Manage the active context (the folder and project scope tied to the current pane).
     Context {
         #[command(subcommand)]
         cmd: ContextCmd,
@@ -403,7 +403,7 @@ pub enum PaneCmd {
         /// Pane id to close (from `plexi pane list`). Defaults to the current pane if not given.
         pane_id: Option<u64>,
     },
-    /// Type text into another pane as if it came from the keyboard. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Type text into another pane as if it came from the keyboard.
     ///
     /// Use `\n` in the text to press Enter (which submits a command).
     ///
@@ -421,7 +421,7 @@ pub enum PaneCmd {
     Self_,
     /// Print details about the current pane as JSON.
     Info,
-    /// Capture the last N lines of a pane's output as a JSON array. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Capture the last N lines of a pane's output as a JSON array.
     ///
     /// Defaults to the current pane when no pane id is given.
     ///
@@ -440,7 +440,7 @@ pub enum PaneCmd {
         #[arg(long, value_name = "CURSOR")]
         from_cursor: Option<u64>,
     },
-    /// Send a key press to a pane. Run this from inside a Plexi pane (open one first with `plexi open terminal`).
+    /// Send a key press to a pane.
     ///
     /// For terminal panes, injects the keystroke into the terminal.
     /// For app panes, delivers a structured key event.


### PR DESCRIPTION
Closes #1742

## Summary

- Removes the three-section `after_help` block (Quick Start, Inside a Pane, Workspace) that duplicated clap's auto-generated subcommand list
- Replaces it with a single `Get started: plexi demo | Docs: https://plexi.dev` line
- Result: `plexi --help` is noticeably shorter and non-redundant

## Done When

1. `plexi --help` output is noticeably shorter with no repeated command listings
2. `cargo build` passes

## Notes

Kept a minimal after_help rather than removing entirely — the `plexi demo` entry point is worth surfacing since it's not a subcommand that clap would list.