### PR TITLE
feat(cli): ship default workspace commands, scripts, and hi game on install (#1743)

### DIFF
--- a/scripts/default-scripts/guess
+++ b/scripts/default-scripts/guess
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# hi — a number-guessing game bundled with Plexi
-# Try: plexi run hi
+# guess — a number-guessing game bundled with Plexi
+# Try: plexi run guess
 echo "Hi! I'm thinking of a number between 1 and 10."
 secret=$((RANDOM % 10 + 1))
 attempts=0

--- a/scripts/default-scripts/hi
+++ b/scripts/default-scripts/hi
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# hi — a number-guessing game bundled with Plexi
+# Try: plexi run hi
+echo "Hi! I'm thinking of a number between 1 and 10."
+secret=$((RANDOM % 10 + 1))
+attempts=0
+while true; do
+  printf "Your guess: "
+  read -r guess
+  if ! [[ "$guess" =~ ^[0-9]+$ ]]; then
+    echo "Please enter a number."
+    continue
+  fi
+  attempts=$((attempts + 1))
+  if [[ "$guess" -eq "$secret" ]]; then
+    echo "Correct! You got it in $attempts guess(es)."
+    break
+  elif [[ "$guess" -lt "$secret" ]]; then
+    echo "Too low!"
+  else
+    echo "Too high!"
+  fi
+done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -118,6 +118,20 @@ if [[ "$channel" == "main" || "$channel" == "alpha" || "$channel" == "beta" ]]; 
 fi
 
 mkdir -p "$profile_dir/sdk" "$profile_dir/apps" "$profile_dir/scripts"
+
+# Seed default scripts (skip files already present to preserve user customizations).
+DEFAULT_SCRIPTS_DIR="$REPO_ROOT/scripts/default-scripts"
+if [[ -d "$DEFAULT_SCRIPTS_DIR" ]]; then
+  for script in "$DEFAULT_SCRIPTS_DIR"/*; do
+    [[ -f "$script" ]] || continue
+    name="$(basename "$script")"
+    dest="$profile_dir/scripts/$name"
+    if [[ ! -f "$dest" ]]; then
+      cp "$script" "$dest"
+      chmod +x "$dest"
+    fi
+  done
+fi
 apps_was_empty=true
 if find "$profile_dir/apps" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .; then
   apps_was_empty=false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -483,8 +483,8 @@ pub fn workspace_init() -> i32 {
                     "# [commands.build]\n",
                     "# run = \"cargo build\"\n",
                     "\n",
-                    "[commands.hi]\n",
-                    "run = \"$PLEXI_CONFIG_DIR/scripts/hi\"\n",
+                    "[commands.guess]\n",
+                    "run = \"$PLEXI_CONFIG_DIR/scripts/guess\"\n",
                 );
                 if let Err(e) = std::fs::write(&commands_toml, stub) {
                     log::warn!("workspace_init:cli: could not write commands.toml: {e}");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,13 +157,12 @@ pub fn run_command(command_name: &str) -> i32 {
     let config_path = cwd.join(COMMANDS_FILE);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // No workspace commands.toml — try global script from config_dir()/scripts/.
             let script_path = crate::config::config_dir().join("scripts").join(command_name);
             if script_path.is_file() && is_executable(&script_path) {
                 log::info!("cli: running global script {:?}", script_path);
-                let mut child_cmd = Command::new("sh");
-                child_cmd.arg(&script_path);
+                let mut child_cmd = Command::new(&script_path);
                 child_cmd.env("PLEXI_CONFIG_DIR", crate::config::config_dir());
                 return match child_cmd.status() {
                     Ok(status) => status.code().unwrap_or(1),
@@ -175,6 +174,10 @@ pub fn run_command(command_name: &str) -> i32 {
             }
             eprintln!("error: no {COMMANDS_FILE} found in {}", cwd.display());
             eprintln!("Create a .plexi/commands.toml to define runnable commands.");
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("error: could not read {}: {e}", config_path.display());
             return 1;
         }
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,37 @@ pub struct CommandDef {
     pub secrets: Vec<String>,
 }
 
+/// List executable files in a scripts directory.
+fn list_global_scripts(scripts_dir: &std::path::Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(scripts_dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let path = e.path();
+            path.is_file() && is_executable(&path)
+        })
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    names.sort();
+    names
+}
+
+fn is_executable(path: &std::path::Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.exists()
+    }
+}
+
 fn print_tip(msg: &str) {
     let config = crate::config::PlexiConfig::load_with_workspace(
         crate::config::active_workspace_root().as_deref(),
@@ -61,14 +92,22 @@ pub fn run_list_commands() -> i32 {
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::info!("cli: no workspace commands.toml, falling back to global scripts");
+            let scripts_dir = crate::config::config_dir().join("scripts");
+            let global_scripts = list_global_scripts(&scripts_dir);
+            if !global_scripts.is_empty() {
+                println!("Built-in scripts:");
+                for name in &global_scripts {
+                    println!("  {name}");
+                }
+                println!();
+                println!("Run one with: plexi run <script>");
+                println!();
+            }
             println!("No workspace commands configured.");
             println!();
-            println!("To set up commands, create {COMMANDS_FILE} in your project:");
+            println!("To add project commands:");
             println!("  plexi workspace init");
-            println!();
-            println!("Then define commands in .plexi/commands.toml:");
-            println!("  [commands.dev]");
-            println!("  run = \"npm run dev\"");
             return 0;
         }
         Err(e) => {
@@ -119,6 +158,21 @@ pub fn run_command(command_name: &str) -> i32 {
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(_) => {
+            // No workspace commands.toml — try global script from config_dir()/scripts/.
+            let script_path = crate::config::config_dir().join("scripts").join(command_name);
+            if script_path.is_file() && is_executable(&script_path) {
+                log::info!("cli: running global script {:?}", script_path);
+                let mut child_cmd = Command::new("sh");
+                child_cmd.arg(&script_path);
+                child_cmd.env("PLEXI_CONFIG_DIR", crate::config::config_dir());
+                return match child_cmd.status() {
+                    Ok(status) => status.code().unwrap_or(1),
+                    Err(e) => {
+                        eprintln!("error: failed to spawn script: {e}");
+                        1
+                    }
+                };
+            }
             eprintln!("error: no {COMMANDS_FILE} found in {}", cwd.display());
             eprintln!("Create a .plexi/commands.toml to define runnable commands.");
             return 1;
@@ -410,6 +464,31 @@ pub fn workspace_init() -> i32 {
                 } else {
                     println!("  apps:         .plexi/apps.toml (declare app dependencies here)");
                     log::info!("workspace_init:cli: wrote stub .plexi/apps.toml");
+                }
+            }
+            // Write stub commands.toml if not already present.
+            let commands_toml = cwd.join(".plexi").join("commands.toml");
+            if !commands_toml.exists() {
+                let stub = concat!(
+                    "# Workspace commands — run with: plexi run <name>\n",
+                    "#\n",
+                    "# Examples:\n",
+                    "#\n",
+                    "# [commands.dev]\n",
+                    "# run = \"npm run dev\"\n",
+                    "#\n",
+                    "# [commands.build]\n",
+                    "# run = \"cargo build\"\n",
+                    "\n",
+                    "[commands.hi]\n",
+                    "run = \"$PLEXI_CONFIG_DIR/scripts/hi\"\n",
+                );
+                if let Err(e) = std::fs::write(&commands_toml, stub) {
+                    log::warn!("workspace_init:cli: could not write commands.toml: {e}");
+                    eprintln!("warning: could not create .plexi/commands.toml: {e}");
+                } else {
+                    println!("  commands:     .plexi/commands.toml (run commands with: plexi run)");
+                    log::info!("workspace_init:cli: wrote stub .plexi/commands.toml");
                 }
             }
             print_tip("declare app dependencies in .plexi/apps.toml, then run `plexi app install`.");


### PR DESCRIPTION
Closes #1743

## Summary

- `plexi run` with no workspace now falls back to listing executable scripts from `~/.plexi/scripts/`, so fresh installs have something to discover immediately
- `plexi run hi` (and any other global script) works without a workspace via the same fallback in `run_command()`
- `plexi workspace init` now scaffolds `.plexi/commands.toml` with a working `hi` example command
- `scripts/default-scripts/hi` ships a number-guessing game; `install.sh` seeds it into `~/.plexi/scripts/` on first install (skips if already present to preserve user customizations)

## Done When

1. Fresh install: `plexi run` shows at least one available command
2. `plexi workspace init` creates a `commands.toml` with a working example
3. `hi` game is discoverable and runnable
4. `cargo build` passes

## Notes

- Global script fallback in `run_command()` runs `sh <script-path>` directly — no secrets injection, no commands.toml parsing needed
- `is_executable()` uses `PermissionsExt` on unix, falls back to `exists()` on non-unix
- Install seeding is additive-only (skips existing files) so user-created scripts in `~/.plexi/scripts/` are never overwritten