### PR TITLE
fix(ui/overlays): Enter/Space does not dismiss tombstoned notifications (source pane dead) (#1771)

### DIFF
--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -3608,7 +3608,6 @@ impl PlexiApp {
 
         // ── Resolve keyboard input into an action_cmd (only if not already
         //    produced by a mouse click). Mouse wins; keyboard is a fallback.
-        // Tombstoned notifications have no keyboard actions — only the mouse Dismiss.
         if action_cmd.is_none() && !notif.tombstoned {
             match notif.kind {
                 NotifyKind::Message => {
@@ -3682,6 +3681,21 @@ impl PlexiApp {
                 }
                 _ => {}
             }
+        }
+
+        if action_cmd.is_none() && notif.tombstoned && (enter_pressed || space_pressed) {
+            action_cmd = Some(AppCommand::DeliverNotifyAction {
+                pane_id: notif.sender_pane_id,
+                notify_id: notif.notify_id.clone(),
+                action_label: "tombstone_dismiss".to_string(),
+                value: Some("tombstone_dismiss".to_string()),
+                response_file: notif.response_file.clone(),
+                host_action: None,
+            });
+            log::info!(
+                "notify:tombstone_dismiss:keyboard notify_id={}",
+                notif.notify_id
+            );
         }
 
         // Esc defers (not cancels) unless the notification is required.

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -3107,7 +3107,8 @@ impl PlexiApp {
 
         // For NotifyKind::Input, bare Enter must reach the TextEdit (newline).
         // For all other kinds, consume it so it cannot bleed into panes behind.
-        let consume_bare_enter = !matches!(notif.kind, NotifyKind::Input);
+        // Tombstoned notifications never render a TextEdit, so always consume.
+        let consume_bare_enter = notif.tombstoned || !matches!(notif.kind, NotifyKind::Input);
 
         let (
             enter_pressed,


### PR DESCRIPTION
Closes #1771

## Summary

- Added keyboard handler for tombstoned notifications in `draw_notification_modal` — pressing Enter or Space now dismisses identically to clicking the Dismiss button
- Handler sets `action_cmd = DeliverNotifyAction { action_label: "tombstone_dismiss" }` and lets the existing action_cmd resolution block handle queue removal and modal close (same pattern as non-tombstoned handlers)
- Added `log::info!` trace so dismissals appear in the log

## Done When

- Pressing Enter or Space on a tombstoned notification closes the modal and removes the notification from the queue (same visible outcome as clicking "Dismiss")
- `cargo test --bin plexi` passes

## Notes

The issue Action Plan included manual `retain`/`save_notifications`/`current_notify_id = None` inline, but the existing `if let Some(cmd) = action_cmd` block already does all of that. Using the standard action_cmd path keeps the code consistent and avoids double-removal.