### PR TITLE
fix(infra/build): remove invalid xattr -r flag from install script (#1775)

### DIFF
--- a/scripts/user-install.sh
+++ b/scripts/user-install.sh
@@ -97,7 +97,7 @@ rm -rf "$APP_DEST"
 cp -R "$APP_SRC" "$APP_DEST"
 
 # clear Gatekeeper quarantine flag so the app opens without "unidentified developer" block
-xattr -cr "$APP_DEST" 2>/dev/null || true
+xattr -c "$APP_DEST" 2>/dev/null || true
 ok "Installed $APP_DEST"
 
 # ── CLI symlink ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1775

## Summary

- Removes the invalid `-r` flag from `xattr -cr "$APP_DEST"` in `scripts/user-install.sh` (line 100)
- `xattr -r` is not a recognized flag; only `-c` is needed to clear the Gatekeeper quarantine attribute on the app bundle itself
- The error was suppressed by `2>/dev/null || true` so install succeeded, but the `option -r not recognized` message was noisy and alarming

## Done When

Running the install script produces no xattr error message. The install output is clean.

## Notes

No behavior change — the quarantine attribute was already being cleared correctly by the underlying `xattr -c`; the `-r` flag was simply invalid and producing stderr noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the app installation process on macOS systems by adjusting how system attributes are handled during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->