### PR TITLE
ux(cli): move 'plexi validate' under 'app' namespace and rename 'plexi pack export' to 'plexi app freeze' (#1779)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2251,10 +2251,9 @@ pub fn list_cli() -> i32 {
     0
 }
 
-/// `plexi pack export <path>` — write a `pack.toml` for the current set of
-/// installed apps under the channel apps dir to `path`. See
-/// `crate::install::export_pack` for the source-spec inference rules.
-pub fn pack_export_cli(dest_path: &str) -> i32 {
+/// `plexi app freeze <path>` — write a `pack.toml` snapshot of installed apps to `path`.
+/// See `crate::install::export_pack` for the source-spec inference rules.
+pub fn freeze_cli(dest_path: &str) -> i32 {
     let target_root = crate::app_registry::apps_dir();
     let dest = std::path::PathBuf::from(dest_path);
     match crate::install::export_pack(&target_root, &dest) {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -74,17 +74,6 @@ pub enum Commands {
         #[command(subcommand)]
         subcommand: Option<UpdateCmd>,
     },
-    /// Check a Plexi app directory for errors before publishing or installing.
-    Validate {
-        /// Path to check (default: current directory)
-        #[arg(default_value = ".")]
-        path: String,
-    },
-    /// Package your apps for sharing or bulk installation.
-    Pack {
-        #[command(subcommand)]
-        cmd: PackCmd,
-    },
     /// Send a notification to the Plexi UI.
     Notify {
         /// Notification title (required)
@@ -328,6 +317,19 @@ pub enum AppCmd {
         /// Path to the app folder containing manifest.toml
         path: String,
     },
+    /// Check a Plexi app directory for errors before publishing or installing.
+    Validate {
+        /// Path to check (default: current directory)
+        #[arg(default_value = ".")]
+        path: String,
+    },
+    /// Export your currently installed apps as a single TOML snapshot for sharing or backup.
+    ///
+    /// Like `pip freeze` — captures exactly what's installed so you can replay it later with `plexi app install`.
+    Freeze {
+        /// Destination path for the TOML snapshot file
+        path: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -338,14 +340,6 @@ pub enum UpdateCmd {
     Apps {
         /// App id to update (omit to update all installed apps)
         id: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-pub enum PackCmd {
-    /// Export your currently installed apps as a single pack file for sharing or backup.
-    Export {
-        path: String,
     },
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -320,7 +320,7 @@ pub enum AppCmd {
     /// Check a Plexi app directory for errors before publishing or installing.
     Validate {
         /// Path to check (default: current directory)
-        #[arg(default_value = ".")]
+        #[arg(default_value = ".", value_hint = ValueHint::DirPath)]
         path: String,
     },
     /// Export your currently installed apps as a single TOML snapshot for sharing or backup.
@@ -328,6 +328,7 @@ pub enum AppCmd {
     /// Like `pip freeze` — captures exactly what's installed so you can replay it later with `plexi app install`.
     Freeze {
         /// Destination path for the TOML snapshot file
+        #[arg(value_hint = ValueHint::FilePath)]
         path: String,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PackCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd, NotesCmd};
+    use crate::cli_args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd, NotesCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -322,15 +322,19 @@ fn main() -> eframe::Result {
                         }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                         AppCmd::Run { path } => std::process::exit(cli::app_run(&path)),
+                        AppCmd::Validate { path } => {
+                            log::info!("app_validate:cli: path={path}");
+                            std::process::exit(cli::validate_cli(&path));
+                        }
+                        AppCmd::Freeze { path } => {
+                            log::info!("app_freeze:cli: path={path}");
+                            std::process::exit(cli::freeze_cli(&path));
+                        }
                     },
                     Commands::Uninstall { keep_data, yes } => std::process::exit(cli::plexi_uninstall_cli(keep_data, yes)),
                     Commands::Update { subcommand } => match subcommand {
                         Some(UpdateCmd::Apps { id }) => std::process::exit(cli::update_cli(id.as_deref())),
                         None => std::process::exit(cli::self_update_cli()),
-                    },
-                    Commands::Validate { path } => std::process::exit(cli::validate_cli(&path)),
-                    Commands::Pack { cmd } => match cmd {
-                        PackCmd::Export { path } => std::process::exit(cli::pack_export_cli(&path)),
                     },
                     Commands::Notify { title, body, level, choices, host_actions, timeout, scope } => {
                         // Parse --host-action flags into a key → "action_type:action_arg" map.

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -114,6 +114,8 @@ Manage your Plexi apps — open, install, list, scaffold, and inspect
 | `info` | Show details about an installed app: id, name, version, and available tools |
 | `init` | Create a new app from a template |
 | `run` | Run an app directly from a local directory without installing or linking |
+| `validate` | Check a Plexi app directory for errors before publishing or installing |
+| `freeze` | Export installed apps as a TOML snapshot for sharing or backup |
 
 ### `plexi app open`
 
@@ -196,6 +198,24 @@ Opens the app in a pane immediately. Edits to the app take effect on next launch
 |---|---|---|---|
 | `<path>` | string | yes | Path to the app folder containing manifest.toml |
 
+### `plexi app validate`
+
+Check a Plexi app directory for errors before publishing or installing
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no | Path to check (default: current directory) Default: `.`. |
+
+### `plexi app freeze`
+
+Export your currently installed apps as a single TOML snapshot for sharing or backup.
+
+Like `pip freeze` — captures exactly what's installed so you can replay it later with `plexi app install`.
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes | Destination path for the TOML snapshot file |
+
 ## `plexi uninstall`
 
 Remove Plexi from your Mac — uninstalls the app, CLI, and optionally your profile data.
@@ -228,30 +248,6 @@ Omit the app id to update all installed apps at once.
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<id>` | string | no | App id to update (omit to update all installed apps) |
-
-## `plexi validate`
-
-Check a Plexi app directory for errors before publishing or installing
-
-| Flag / Arg | Type | Required | Description |
-|---|---|---|---|
-| `<path>` | string | no | Path to check (default: current directory) Default: `.`. |
-
-## `plexi pack`
-
-Package your apps for sharing or bulk installation
-
-| Subcommand | Description |
-|---|---|
-| `export` | Export your currently installed apps as a single pack file for sharing or backup |
-
-### `plexi pack export`
-
-Export your currently installed apps as a single pack file for sharing or backup
-
-| Flag / Arg | Type | Required | Description |
-|---|---|---|---|
-| `<path>` | string | yes |  |
 
 ## `plexi notify`
 


### PR DESCRIPTION
Closes #1779

## Summary

- Removes `plexi validate` and `plexi pack` / `plexi pack export` from the top-level CLI namespace
- Adds `plexi app validate <path>` and `plexi app freeze <path>` as subcommands of `plexi app`
- Renames `pack_export_cli` → `freeze_cli` in `src/cli.rs`; updates docs in `website/src/content/docs/cli.md`

## Done When

- `plexi validate` returns an error (unknown command)
- `plexi app validate .` preflight-checks the current directory correctly
- `plexi pack export` returns an error (unknown command)
- `plexi app freeze <path>` writes a TOML snapshot of all installed apps
- Shell completions reflect the new paths

## Notes

`freeze_cli` is a direct rename of `pack_export_cli` — same logic, same underlying `export_pack` call. No behavior changes.