### PR TITLE
feat(host/notifications): surface window-scoped notifications on window navigation (#1774)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -133,6 +133,9 @@ pub(crate) struct PendingNotification {
     pub sender_pane_id: u64,
     /// Stable context identity the notification originated from (stamped at drain time).
     pub source_context_id: u64,
+    /// Stable window identity the notification originated from. Used by
+    /// `NotifyScope::Window` to restrict visibility to the originating window.
+    pub source_window_id: u64,
     pub level: String,
     pub title: String,
     pub body: String,
@@ -182,6 +185,8 @@ struct PersistedNotification {
     notify_id: String,
     sender_pane_id: u64,
     source_context_id: u64,
+    #[serde(default)]
+    source_window_id: u64,
     level: String,
     title: String,
     body: String,
@@ -517,6 +522,7 @@ pub(crate) fn save_pending_notifications_to(
                 notify_id: n.notify_id.clone(),
                 sender_pane_id: n.sender_pane_id,
                 source_context_id: n.source_context_id,
+                source_window_id: n.source_window_id,
                 level: n.level.clone(),
                 title: n.title.clone(),
                 body: n.body.clone(),
@@ -580,6 +586,7 @@ pub(crate) fn load_pending_notifications_from(
                 notify_id: p.notify_id,
                 sender_pane_id: p.sender_pane_id,
                 source_context_id: p.source_context_id,
+                source_window_id: p.source_window_id,
                 level: p.level,
                 title: p.title,
                 body: p.body,
@@ -1882,6 +1889,7 @@ impl PlexiApp {
                         notify_id: internal_id.clone(),
                         sender_pane_id: 0,
                         source_context_id: self.router.active().context_id,
+                        source_window_id: self.windows[self.active_window].window_id,
                         scope: scope.unwrap_or(crate::app_protocol::NotifyScope::Global),
                         level: level.clone(),
                         title: title.clone(),
@@ -2229,8 +2237,10 @@ impl PlexiApp {
         }
         match n.scope {
             crate::app_protocol::NotifyScope::Global => true,
-            crate::app_protocol::NotifyScope::Window
-            | crate::app_protocol::NotifyScope::Context => {
+            crate::app_protocol::NotifyScope::Window => {
+                n.source_window_id == self.windows[self.active_window].window_id
+            }
+            crate::app_protocol::NotifyScope::Context => {
                 n.source_context_id == self.router.active().context_id
             }
         }
@@ -2901,9 +2911,16 @@ impl eframe::App for PlexiApp {
                         continue;
                     }
                     let new_id = notify_id.clone();
-                    // Capture scope/source_context_id before they move into the struct.
+                    // Capture scope/source_context_id/source_window_id before they move into the struct.
                     let notif_scope = scope;
                     let notif_source_ctx = source_context_id;
+                    let notif_source_win_id: u64 = if sender_pane_id != 0 {
+                        self.find_pane_in_any_window(sender_pane_id)
+                            .map(|(idx, _)| self.windows[idx].window_id)
+                            .unwrap_or_else(|| self.windows[self.active_window].window_id)
+                    } else {
+                        self.windows[self.active_window].window_id
+                    };
                     // Strip any per-option shortcut that conflicts with navigation keys.
                     let options: Vec<crate::app_protocol::NotifyOption> = options.into_iter().map(|mut opt| {
                         if let Some(ref sc) = opt.shortcut.clone() {
@@ -2921,6 +2938,7 @@ impl eframe::App for PlexiApp {
                         notify_id,
                         sender_pane_id,
                         source_context_id,
+                        source_window_id: notif_source_win_id,
                         level,
                         title,
                         body,
@@ -2951,8 +2969,10 @@ impl eframe::App for PlexiApp {
                     // (badge ticks) but the modal doesn't pop.
                     let is_visible = match notif_scope {
                         crate::app_protocol::NotifyScope::Global => true,
-                        crate::app_protocol::NotifyScope::Window
-                        | crate::app_protocol::NotifyScope::Context => {
+                        crate::app_protocol::NotifyScope::Window => {
+                            notif_source_win_id == self.windows[self.active_window].window_id
+                        }
+                        crate::app_protocol::NotifyScope::Context => {
                             notif_source_ctx == self.router.active().context_id
                         }
                     };
@@ -3880,12 +3900,15 @@ impl eframe::App for PlexiApp {
                 // avoid a borrow conflict with the mutable ctx reference below.
                 let notify_counts: std::collections::HashMap<u64, usize> = {
                     let active_context_id = self.router.active().context_id;
+                    let active_window_id = self.windows[self.active_window].window_id;
                     let mut counts = std::collections::HashMap::new();
                     for n in &self.pending_notifications {
                         let visible = match n.scope {
                             crate::app_protocol::NotifyScope::Global => true,
-                            crate::app_protocol::NotifyScope::Window
-                            | crate::app_protocol::NotifyScope::Context => {
+                            crate::app_protocol::NotifyScope::Window => {
+                                n.source_window_id == active_window_id
+                            }
+                            crate::app_protocol::NotifyScope::Context => {
                                 n.source_context_id == active_context_id
                             }
                         };
@@ -4790,6 +4813,7 @@ impl PlexiApp {
                 notify_id: notify_id.clone(),
                 sender_pane_id: 0,
                 source_context_id: 0,
+                source_window_id: 0,
                 level: "error".to_string(),
                 title: "Config Error".to_string(),
                 body: error_msg,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -244,6 +244,7 @@ fn snoozed_notification_invisible_then_visible() {
         notify_id: "snoozed-woken".into(),
         sender_pane_id: 0,
         source_context_id: h.app.router.active().context_id,
+        source_window_id: h.app.windows[h.app.active_window].window_id,
         level: "info".into(),
         title: "Snoozed".into(),
         body: "body".into(),
@@ -283,6 +284,7 @@ fn snoozed_notification_exempt_from_timeout() {
         notify_id: "snoozed-no-timeout".into(),
         sender_pane_id: sender_id,
         source_context_id: h.app.router.active().context_id,
+        source_window_id: h.app.windows[h.app.active_window].window_id,
         level: "info".into(),
         title: "ShouldNotTimeout".into(),
         body: "body".into(),
@@ -971,6 +973,7 @@ fn persist_roundtrip() {
         notify_id: "test-id".into(),
         sender_pane_id: 0,
         source_context_id: 1,
+        source_window_id: 1,
         level: "info".into(),
         title: "Test".into(),
         body: "body".into(),
@@ -1062,4 +1065,57 @@ fn test_spawn_pane_targets_correct_window_with_from_pane_id() {
     let (found_win_idx, found_tile) = loc.unwrap();
     assert_eq!(found_win_idx, 0, "pane should be in window 0");
     assert_eq!(found_tile, tile_in_w0);
+}
+
+/// #1774: A Window-scoped notification from a pane on window 0 must be visible
+/// only when window 0 is active; navigating to window 1 hides it; returning
+/// makes it visible again.
+#[test]
+fn window_scoped_notification_visible_only_on_source_window() {
+    let mut h = HostHarness::new();
+    let _pane_w0 = h.add_test_pane();
+
+    // Add a second window in the same workspace so we can switch active_window.
+    let win1_id = 2u64;
+    h.app.windows.push(same_workspace_window_below(win1_id, 9920));
+
+    let win0_id = h.app.windows[0].window_id;
+    assert_eq!(h.app.active_window, 0);
+
+    // Push a Window-scoped notification originating from window 0.
+    h.app.pending_notifications.push(PendingNotification {
+        notify_id: "win-scoped-1774".into(),
+        sender_pane_id: 0,
+        source_context_id: h.app.router.active().context_id,
+        source_window_id: win0_id,
+        level: "info".into(),
+        title: "Window Notification".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        priority: 100,
+        scope: crate::app_protocol::NotifyScope::Window,
+        image_inline: None,
+        image_pipe_id: None,
+        response_file: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        enqueued_at: std::time::Instant::now(),
+        tombstoned: false,
+        deliver_after: None,
+    });
+
+    // Visible on window 0.
+    assert_eq!(h.app.active_window, 0);
+    assert_eq!(h.app.visible_notification_count(), 1, "notification must be visible on source window");
+
+    // Navigate to window 1 — notification must disappear.
+    h.app.active_window = 1;
+    assert_eq!(h.app.visible_notification_count(), 0, "notification must be invisible on a different window");
+
+    // Return to window 0 — notification reappears.
+    h.app.active_window = 0;
+    assert_eq!(h.app.visible_notification_count(), 1, "notification must reappear when returning to source window");
 }


### PR DESCRIPTION
Closes #1774

## Summary

- Add `source_window_id: u64` to `PendingNotification` (and its `PersistedNotification` mirror with `#[serde(default)]` for backward compat)
- Stamp `source_window_id` at all three push sites: CLI/pane-IPC path uses active window; app `ShowNotification` path resolves via `find_pane_in_any_window`
- Fix `notification_is_visible` and two inline visibility checks to gate `NotifyScope::Window` on `source_window_id == active window id` (previously treated identically to `Context`)

## Done When

1. A Window-scoped notification from a pane on Window A is visible only when Window A is the active window within its context.
2. Navigating away from Window A hides the notification; returning shows it again.
3. The notification persists across window switches until the user dismisses it.
4. Global- and Context-scoped notifications are unaffected.
5. `cargo test --bin plexi` passes.

## Notes

`PersistedNotification::source_window_id` uses `#[serde(default)]` so existing persisted notifications (which lack the field) deserialize to `0`. Window-scoped notifications with `source_window_id == 0` will be invisible on any real window since window IDs start at 1 — they'll persist in the queue until dismissed or expired, which is the safest degradation.