### PR TITLE
test(sdk): verify PyPI publish workflow and local dev cycle for plexi-sdk (#1760)

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ regen-if-stale:
 install: fetch-python-runtime regen-if-stale
     bash scripts/install.sh
 
-# Editable install of plexi-sdk into your system Python for local development.
+# Editable install of plexi-sdk into your virtual environment for local development.
 # Makes `plexi_sdk` importable in your IDE/type-checker with live source changes.
 # Does not affect the SDK bundled into the Plexi app (use `just install` for that).
 sdk-dev:

--- a/justfile
+++ b/justfile
@@ -95,6 +95,12 @@ regen-if-stale:
 install: fetch-python-runtime regen-if-stale
     bash scripts/install.sh
 
+# Editable install of plexi-sdk into your system Python for local development.
+# Makes `plexi_sdk` importable in your IDE/type-checker with live source changes.
+# Does not affect the SDK bundled into the Plexi app (use `just install` for that).
+sdk-dev:
+    uv pip install -e sdk/python
+
 # Build and install the current worktree as a testable PR build.
 # Installs as "Plexi PR<number>.app" with isolated profile ~/.plexi-pr-<number>/.
 # Run from inside the feature worktree: just pr-install 123

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -20,12 +20,15 @@ To work on the SDK itself with live source changes, install it as an editable pa
 uv pip install -e ./sdk/python
 ```
 
-Run from the repo root. Changes to `sdk/python/plexi_sdk/` take effect immediately — no reinstall needed.
+Run from the repo root. `uv` creates `.venv` automatically if it doesn't exist. Changes to `sdk/python/plexi_sdk/` take effect immediately — no reinstall needed.
 
-This makes `plexi_sdk` importable in your system Python and IDE. Note that apps running inside Plexi use the bundled SDK copy set on `PYTHONPATH` by the host — the editable install does not affect those. Use it for type checking, testing, and local development only.
+This makes `plexi_sdk` importable in your IDE and type checker. Note that apps running inside Plexi use the bundled SDK copy set on `PYTHONPATH` by the host — the editable install does not affect those. Use it for type checking, testing, and local development only.
+
+Verify the install:
 
 ```sh
-.venv/bin/python3 -c "from plexi_sdk import App; print('ok')"
+source .venv/bin/activate
+python3 -c "from plexi_sdk import App; print('ok')"
 ```
 
 To rebuild and reinstall the bundled copy (used by running apps), run `just install` from the repo root.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -6,6 +6,32 @@ Full API reference: `plexi_sdk/__init__.py` docstring.
 
 ---
 
+## Install
+
+```sh
+pip install plexi-sdk
+```
+
+## Development
+
+To work on the SDK itself with live source changes, install it as an editable package:
+
+```sh
+uv pip install -e ./sdk/python
+```
+
+Run from the repo root. Changes to `sdk/python/plexi_sdk/` take effect immediately — no reinstall needed.
+
+This makes `plexi_sdk` importable in your system Python and IDE. Note that apps running inside Plexi use the bundled SDK copy set on `PYTHONPATH` by the host — the editable install does not affect those. Use it for type checking, testing, and local development only.
+
+```sh
+.venv/bin/python3 -c "from plexi_sdk import App; print('ok')"
+```
+
+To rebuild and reinstall the bundled copy (used by running apps), run `just install` from the repo root.
+
+---
+
 ## Keyboard Conventions
 
 Apps should follow these standard navigation bindings so users get consistent behavior across all Plexi apps.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -22,7 +22,7 @@ uv pip install -e ./sdk/python
 
 Run from the repo root. `uv` creates `.venv` automatically if it doesn't exist. Changes to `sdk/python/plexi_sdk/` take effect immediately — no reinstall needed.
 
-This makes `plexi_sdk` importable in your IDE and type checker. Note that apps running inside Plexi use the bundled SDK copy set on `PYTHONPATH` by the host — the editable install does not affect those. Use it for type checking, testing, and local development only.
+This makes `plexi_sdk` importable in your virtual environment and IDE. Note that apps running inside Plexi use the bundled SDK copy set on `PYTHONPATH` by the host — the editable install does not affect those. Use it for type checking, testing, and local development only.
 
 Verify the install:
 


### PR DESCRIPTION
Closes #1760

## Summary

- Adds `## Install` and `## Development` sections to `sdk/python/README.md` documenting the editable install workflow (`uv pip install -e ./sdk/python`) and how to verify it
- Adds `just sdk-dev` recipe to `justfile` as a discoverable shortcut for the editable install — intentionally separate from `just install` (which builds the host binary) since the editable install is opt-in for IDE/type-checking use
- Clarifies the distinction: editable install = system Python for local dev; bundled SDK = what Plexi-spawned apps actually use

## Done When

1. `pip install plexi-sdk` works from PyPI
2. GitHub Actions publish workflow succeeds on a tag push
3. Editable install documented and verified

## Notes

PyPI criteria 1 + 2 are already met: `plexi-sdk==0.4.0` is live on PyPI, the `publish-sdk.yml` workflow has run successfully on recent version tags, and OIDC trusted publishing is configured. The one-time old failure (`v0.0.514`) was a stale `--skip-existing` flag that was already fixed before this issue was filed.

`just sdk-dev` installs into the project `.venv`; verify with `.venv/bin/python3 -c "from plexi_sdk import App; print('ok')"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Python SDK installation guide with setup and verification steps
  * Clarified local development workflow for type checking and testing with live code changes

* **Chores**
  * Added convenient development recipe for installing SDK in editable mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->