### PR TITLE
fix(palette): workspace-scoped apps show in palette outside their context (#1770)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -403,6 +403,10 @@ pub struct PlexiApp {
     /// is rescanned without a host restart.
     pub(crate) _registry_watcher: Option<crate::app_registry_watcher::AppRegistryWatcher>,
     pub(crate) registry_reload_rx: Option<std::sync::mpsc::Receiver<()>>,
+    /// Last workspace root the registry was loaded from (#1770). Compared each
+    /// frame against the active context's root — mismatch triggers a rescan and
+    /// watcher restart so switching contexts immediately reflects their local apps.
+    pub(crate) last_registry_root: Option<std::path::PathBuf>,
     /// Watched panes scheduled for crash-restart. Value is the earliest `Instant` at
     /// which the restart fires — giving the developer ~2s to read the crash overlay.
     pub(crate) pending_crash_restarts: HashMap<PaneId, std::time::Instant>,
@@ -959,6 +963,7 @@ impl PlexiApp {
                     config_reload_rx: cfg_reload_rx.take(),
                     _registry_watcher: reg_watcher.take(),
                     registry_reload_rx: reg_reload_rx.take(),
+                    last_registry_root: None,
                     pending_crash_restarts: HashMap::new(),
                     minimap: crate::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
@@ -1130,6 +1135,7 @@ impl PlexiApp {
             config_reload_rx: cfg_reload_rx.take(),
             _registry_watcher: default_reg_watcher.take(),
             registry_reload_rx: default_reg_reload_rx.take(),
+            last_registry_root: None,
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -1291,6 +1297,7 @@ impl PlexiApp {
             config_reload_rx: None,
             _registry_watcher: None,
             registry_reload_rx: None,
+            last_registry_root: None,
             pending_crash_restarts: HashMap::new(),
             minimap: crate::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
@@ -3768,11 +3775,33 @@ impl eframe::App for PlexiApp {
                 }
                 hit
             });
-        if registry_changed {
-            let root = self.router.active().root.clone()
+        // Active context root change (#1770): rescan registry and restart
+        // watcher whenever the active context's root differs from the last
+        // loaded root. Covers switch_workspace, set_active_context_root, and
+        // any other path that changes which context is active.
+        let active_root = self.router.active().root.clone();
+        let root_changed = active_root.as_deref() != self.last_registry_root.as_deref();
+        if registry_changed || root_changed {
+            let root = active_root.clone()
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-            log::info!("app_registry_watcher: rescanning registry from {}", root.display());
+            log::info!(
+                "app_registry: rescanning for {} (fs_event={registry_changed} root_changed={root_changed})",
+                root.display()
+            );
             self.registry = crate::app_registry::AppRegistry::load(&root);
+            self.last_registry_root = active_root;
+            // Restart the watcher so it tracks the new workspace directories.
+            let watch_dirs = crate::app_registry::registry_watch_dirs(&root);
+            match crate::app_registry_watcher::start(watch_dirs) {
+                Some((watcher, rx)) => {
+                    self._registry_watcher = Some(watcher);
+                    self.registry_reload_rx = Some(rx);
+                }
+                None => {
+                    self._registry_watcher = None;
+                    self.registry_reload_rx = None;
+                }
+            }
         }
 
         // Handle window close request (X button or macOS Cmd+Q OS event).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3769,9 +3769,10 @@ impl eframe::App for PlexiApp {
                 hit
             });
         if registry_changed {
-            log::info!("app_registry_watcher: rescanning registry");
-            let cwd = std::env::current_dir().unwrap_or_default();
-            self.registry = crate::app_registry::AppRegistry::load(&cwd);
+            let root = self.router.active().root.clone()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+            log::info!("app_registry_watcher: rescanning registry from {}", root.display());
+            self.registry = crate::app_registry::AppRegistry::load(&root);
         }
 
         // Handle window close request (X button or macOS Cmd+Q OS event).

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -403,7 +403,7 @@ impl AppRegistry {
                         // Plain insert — local entries override global for extension map too.
                         self.extension_map.insert(ext.to_lowercase(), id.clone());
                     }
-                    self.apps.insert(id, InstalledApp { source, workspace_root: workspace_root.map(ToOwned::to_owned), ..installed });
+                    self.apps.insert(id, InstalledApp { source, workspace_root: workspace_root.map(Path::to_path_buf), ..installed });
                 }
                 Err(e) => {
                     log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -287,6 +287,9 @@ pub struct InstalledApp {
     /// value returned by `load_app` is a placeholder and is overwritten at
     /// insert time.
     pub source: RegistrySource,
+    /// The workspace root this app was discovered under. `Some` for
+    /// `LocalApp`/`LocalAgent` entries; `None` for `Global` entries.
+    pub workspace_root: Option<PathBuf>,
 }
 
 pub struct AppRegistry {
@@ -321,7 +324,7 @@ impl AppRegistry {
         };
 
         if global_dir.is_dir() {
-            registry.scan_dir(global_dir, RegistrySource::Global);
+            registry.scan_dir(global_dir, RegistrySource::Global, None);
         }
 
         // Local apps + agents — only scanned when a workspace root exists.
@@ -331,11 +334,11 @@ impl AppRegistry {
         if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
             let local_apps = root.join(&channel_dir).join("apps");
             if local_apps.is_dir() {
-                registry.scan_dir(&local_apps, RegistrySource::LocalApp);
+                registry.scan_dir(&local_apps, RegistrySource::LocalApp, Some(&root));
             }
             let local_agents = root.join(&channel_dir).join("agents");
             if local_agents.is_dir() {
-                registry.scan_dir(&local_agents, RegistrySource::LocalAgent);
+                registry.scan_dir(&local_agents, RegistrySource::LocalAgent, Some(&root));
             }
         }
 
@@ -350,7 +353,7 @@ impl AppRegistry {
     /// Scan one directory of manifest-bearing subdirs, inserting discovered
     /// entries. Calls made later in `load()` shadow earlier ones; on shadow
     /// the displaced entry's source is logged so users can debug discovery.
-    fn scan_dir(&mut self, dir: &Path, source: RegistrySource) {
+    fn scan_dir(&mut self, dir: &Path, source: RegistrySource, workspace_root: Option<&Path>) {
         let read_dir = match std::fs::read_dir(dir) {
             Ok(d) => d,
             Err(e) => {
@@ -400,7 +403,7 @@ impl AppRegistry {
                         // Plain insert — local entries override global for extension map too.
                         self.extension_map.insert(ext.to_lowercase(), id.clone());
                     }
-                    self.apps.insert(id, InstalledApp { source, ..installed });
+                    self.apps.insert(id, InstalledApp { source, workspace_root: workspace_root.map(ToOwned::to_owned), ..installed });
                 }
                 Err(e) => {
                     log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());
@@ -472,8 +475,9 @@ impl AppRegistry {
             launch: manifest.launch,
             secrets: manifest.secrets,
             bin_path,
-            // Placeholder — `scan_dir` overwrites this with the real source.
+            // Placeholder — `scan_dir` overwrites source and workspace_root.
             source: RegistrySource::Global,
+            workspace_root: None,
         })
     }
 

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -189,11 +189,20 @@ impl PlexiApp {
         };
 
         // ── App entries ────────────────────────────────────────────────────
+        let active_ctx_root = self.router.active().root.clone();
         let app_entries: Vec<(String, String, String)> = self
             .registry
             .list()
             .into_iter()
             .filter(|app| {
+                // Workspace-local apps are only visible when the active context
+                // root matches the workspace they were installed into (#1770).
+                use crate::app_registry::RegistrySource;
+                if app.source != RegistrySource::Global
+                    && app.workspace_root.as_deref() != active_ctx_root.as_deref()
+                {
+                    return false;
+                }
                 query.is_empty()
                     || app.manifest.name.to_lowercase().contains(&query)
                     || app.manifest.id.to_lowercase().contains(&query)

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -562,11 +562,9 @@ impl PlexiApp {
             self.router.active().context_id,
             root.display()
         );
-        self.router.get_mut(idx).root = Some(root.clone());
-        // Rescan the registry immediately so the command palette reflects the
-        // new workspace's local apps without waiting for a filesystem event (#1770).
-        log::info!("set_active_context_root: rescanning app registry for {}", root.display());
-        self.registry = crate::app_registry::AppRegistry::load(&root);
+        self.router.get_mut(idx).root = Some(root);
+        // Registry rescan is handled by the update() loop via last_registry_root
+        // comparison (#1770) — covers both this path and switch_workspace.
     }
 
     /// Dissolve a portal: reparent all its panes into the parent window (the active

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -562,7 +562,11 @@ impl PlexiApp {
             self.router.active().context_id,
             root.display()
         );
-        self.router.get_mut(idx).root = Some(root);
+        self.router.get_mut(idx).root = Some(root.clone());
+        // Rescan the registry immediately so the command palette reflects the
+        // new workspace's local apps without waiting for a filesystem event (#1770).
+        log::info!("set_active_context_root: rescanning app registry for {}", root.display());
+        self.registry = crate::app_registry::AppRegistry::load(&root);
     }
 
     /// Dissolve a portal: reparent all its panes into the parent window (the active


### PR DESCRIPTION
Closes #1770

## Summary

- Added `workspace_root: Option<PathBuf>` to `InstalledApp` — set to the resolved workspace root for `LocalApp`/`LocalAgent` entries, `None` for `Global` entries
- Command palette now filters out non-Global apps whose `workspace_root` doesn't match the active context's root, so switching contexts immediately hides the previous workspace's local apps
- `set_active_context_root` triggers an immediate registry rescan so the new context's workspace apps appear in the palette without waiting for a filesystem event; watcher rescan also uses the active context root instead of `std::env::current_dir()`

## Done When

- Switching to a context with a different root removes the previous context's workspace-local apps from the palette immediately.
- Workspace-local apps for the newly active context appear in the palette.
- Global apps remain visible in all contexts.

## Notes

- `scan_dir` signature changed from `(dir, source)` to `(dir, source, workspace_root: Option<&Path>)` — all three call sites updated in `load_with_global`
- The palette filter uses `as_deref()` comparison so `Option<PathBuf>` vs `Option<PathBuf>` works cleanly without cloning
- Pre-existing test failures (6) are on alpha before this PR and are unrelated to these changes