### PR TITLE
feat(sdk): declarative Arg class for app launch arguments (#1788)

### DIFF
--- a/apps/backlog/backlog.py
+++ b/apps/backlog/backlog.py
@@ -11,7 +11,6 @@ Items from the channel backlog are prefixed with [ch] in the list.
 Pass -g/--global to show only channel-level items: plexi open backlog -g
 """
 
-import argparse
 import os
 import shutil
 import subprocess
@@ -19,7 +18,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
-from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN
+from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN, Arg
 from plexi_sdk.ui import SelectList
 
 def _detect_channel_backlog_dir() -> "Path | None":
@@ -51,13 +50,9 @@ BOTTOM_BAR_H = 26.0
 
 
 class BacklogApp(App):
+    global_only: Arg[bool] = Arg("-g", "--global", dest="global_only", type=bool, default=False)
 
     def on_init(self, ctx: RenderContext) -> None:
-        parser = argparse.ArgumentParser(add_help=False)
-        parser.add_argument("-g", "--global", dest="global_only", action="store_true")
-        parsed, _ = parser.parse_known_args(self.args)
-        self.global_only: bool = parsed.global_only
-
         self.backlog_dir = Path(ctx.workspace_root) / ".plexi" / "backlog"
         self.channel_dir = _detect_channel_backlog_dir()
         self.items: list = []         # list[Path]

--- a/apps/balls/balls.py
+++ b/apps/balls/balls.py
@@ -15,7 +15,7 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
 
-from plexi_sdk import App, RenderContext, dim
+from plexi_sdk import App, RenderContext, dim, Arg
 
 GRAVITY = 300.0      # px/s²
 DAMPING = 0.78       # energy retained on wall bounce
@@ -56,12 +56,11 @@ def _new_ball(x: float, y: float, idx: int,
 
 
 class BallsApp(App):
-    # Override the default dark background with the physics demo's deep-space color.
     default_background = "#0d0d1a"
+    count: Arg[int] = Arg(positional=True, type=int, default=10)
 
     def on_init(self, ctx: RenderContext) -> None:
-        count = int(self.args[0]) if self.args else 10
-        count = max(1, min(count, MAX_BALLS))
+        count = max(1, min(self.count, MAX_BALLS))
         self.balls: list[Ball] = []
         w, h = ctx.w, ctx.h
         for i in range(count):

--- a/apps/dev/descriptor-renderer/descriptor_renderer.py
+++ b/apps/dev/descriptor-renderer/descriptor_renderer.py
@@ -13,11 +13,10 @@ Form view:   host-managed text_input per arg/flag; first field auto-focused;
 """
 
 import json
-import sys
 import threading
 from pathlib import Path
 
-from plexi_sdk import App, RenderContext, CapabilityDeniedError
+from plexi_sdk import App, RenderContext, CapabilityDeniedError, Arg
 from plexi_sdk.ui import (
     Column, AppBar, FormField, FooterKeys,
     ListItem, Label, Spacer, Card,
@@ -30,21 +29,6 @@ from plexi_sdk.widgets import ListView
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
-
-def _parse_descriptor_path(argv: list[str]) -> str | None:
-    i = 0
-    while i < len(argv):
-        if argv[i] == "--descriptor" and i + 1 < len(argv):
-            return argv[i + 1]
-        i += 1
-    for arg in argv:
-        if not arg.startswith("-"):
-            return arg
-    sample = Path(__file__).parent / "sample.json"
-    if sample.exists():
-        return str(sample)
-    return None
-
 
 def _load_descriptor(path: str) -> dict:
     p = Path(path).expanduser().resolve()
@@ -90,6 +74,8 @@ def _build_command(cli: str, path: list[str], field_values: dict[str, str],
 # ── App ────────────────────────────────────────────────────────────────────────
 
 class DescriptorRendererApp(App):
+    descriptor: Arg[str | None] = Arg("--descriptor", default=None)
+    descriptor_pos: Arg[str | None] = Arg(positional=True, nargs="?", default=None)
 
     def on_init(self, ctx: RenderContext) -> None:
         self._descriptor: dict | None = None
@@ -109,7 +95,8 @@ class DescriptorRendererApp(App):
         # UI components
         self._list = ListView(item_height=ListItem.HEIGHT_DOUBLE)
 
-        path = _parse_descriptor_path(sys.argv[1:])
+        sample = Path(__file__).parent / "sample.json"
+        path = self.descriptor or self.descriptor_pos or (str(sample) if sample.exists() else None)
         if not path:
             self._error = "No descriptor path. Usage: descriptor-renderer --descriptor <path.json>"
             self._view = "error"

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -13,7 +13,7 @@ import json
 import subprocess
 
 from plexi_sdk import (
-    App, RenderContext,
+    App, RenderContext, Arg,
     BG, SURFACE, FG, ACCENT, MUTED, HIGHLIGHT,
     BODY, CAPTION, HEADING, HINT,
     GREEN, RED, YELLOW,
@@ -60,6 +60,8 @@ class GhIssues(App):
     VIEW_LIST   = "list"
     VIEW_DETAIL = "detail"
 
+    repo_dir: Arg[str | None] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
+
     async def on_init(self, ctx: RenderContext) -> None:
         self._view           = self.VIEW_LIST
         self._issues         : list[dict] = []
@@ -68,7 +70,7 @@ class GhIssues(App):
         self._detail_loading = False
         self._error          : str | None = None
         self._detail         : dict | None = None
-        self._root           = ctx.workspace_root or ""
+        self._root           = self.repo_dir or ""
         ctx.status_summary("Loading…")
         self.emit.info(f"gh-issues init workspace={self._root!r}")
         self._fetch()

--- a/apps/dev/mcp-renderer/mcp_renderer.py
+++ b/apps/dev/mcp-renderer/mcp_renderer.py
@@ -12,16 +12,16 @@ Form view:   host-managed text_input per field; first field auto-focused;
 Result view: Shows tool call output inline. Escape or Back returns to list.
 """
 
+import argparse
 import asyncio
 import json
 import os
 import select
 import subprocess
-import sys
 import threading
 from typing import IO
 
-from plexi_sdk import App, RenderContext
+from plexi_sdk import App, RenderContext, Arg
 from plexi_sdk.ui import (
     Column, AppBar, FormField, Scrollable, FooterKeys,
     ListItem, Label, Spacer, Card,
@@ -130,6 +130,7 @@ class McpClient:
 # ── App ────────────────────────────────────────────────────────────────────────
 
 class McpRendererApp(App):
+    cmd: Arg[list] = Arg(positional=True, nargs=argparse.REMAINDER, default=[])
 
     def on_init(self, ctx: RenderContext) -> None:
         self._view: str = "loading"   # loading | error | list | form | result
@@ -153,17 +154,16 @@ class McpRendererApp(App):
         self._client: McpClient | None = None
         self._tools_ready = threading.Event()
 
-        argv = sys.argv[1:]
-        if not argv:
+        if not self.cmd:
             self._error = "Usage: plexi open mcp-renderer <command> [args...]\nExample: plexi open mcp-renderer npx -y @modelcontextprotocol/server-filesystem /tmp"
             self._view = "error"
             ctx.status_summary("mcp-renderer: no command")
             return
 
         ctx.status_summary("mcp-renderer: connecting…")
-        self.emit.info(f"mcp-renderer: spawning {argv!r}")
+        self.emit.info(f"mcp-renderer: spawning {self.cmd!r}")
         try:
-            threading.Thread(target=self._connect, args=(argv,), daemon=True).start()
+            threading.Thread(target=self._connect, args=(self.cmd,), daemon=True).start()
         except RuntimeError as e:
             self._error = f"Failed to start connection thread: {e}"
             self._view = "error"
@@ -211,7 +211,7 @@ class McpRendererApp(App):
     # ── Render ────────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        cmd_name = sys.argv[1] if len(sys.argv) > 1 else "mcp"
+        cmd_name = self.cmd[0] if self.cmd else "mcp"
         tool_count = len(self._tools)
         subtitle = f"{tool_count} tool{'s' if tool_count != 1 else ''}" if tool_count else None
 

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -6,12 +6,9 @@ separate Rust sub-project. The spec allows either; Python is 80 lines vs a
 new cargo crate + cross-compile setup. This is the intentional choice.
 """
 
-import sys
-import os
-
 import threading
 import time
-from plexi_sdk import App, RenderContext, BG, ACCENT, FG, RED, GREEN, MUTED
+from plexi_sdk import App, RenderContext, BG, ACCENT, FG, RED, GREEN, MUTED, Arg
 from plexi_sdk._pipe import Pipe
 
 CELL = 18.0          # cell size in logical px
@@ -31,20 +28,14 @@ DIR_MAP = {
 }
 
 
-def _parse_pipe_id() -> "str | None":
-    for arg in sys.argv[1:]:
-        if arg.startswith("--pipe="):
-            return arg[len("--pipe="):]
-    return None
-
-
 class SnakeApp(App):
+    pipe_id: Arg[str | None] = Arg("--pipe", default=None)
+
     def on_init(self, ctx: RenderContext) -> None:
         self._pipe: "Pipe | None" = None
-        pipe_id = _parse_pipe_id()
-        if pipe_id:
-            self._pipe = self.emit.pipe_open(pipe_id, mode="json", direction="out")
-            self.emit.info(f"snake: pipe open pipe_id={pipe_id}")
+        if self.pipe_id:
+            self._pipe = self.emit.pipe_open(self.pipe_id, mode="json", direction="out")
+            self.emit.info(f"snake: pipe open pipe_id={self.pipe_id}")
         self._reset()
         self._timer_thread = threading.Thread(
             target=self._tick_loop, daemon=True

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -474,4 +474,4 @@ from ._protocol import AiResponse, MidiPortInfo, MidiDeviceList, AudioDeviceInfo
 from ._emitter import Emitter, _emit, _make_async_queue, _LOCK
 from ._pipe import Pipe
 from ._render_context import RenderContext, COMPACT_DEFAULT, REGULAR_DEFAULT
-from ._app import App
+from ._app import App, Arg

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -13,6 +13,48 @@ from ._pipe import Pipe
 from ._render_context import RenderContext
 
 
+# ── Arg descriptor ────────────────────────────────────────────────────────────
+
+_MISSING: Any = object()
+
+
+class Arg:
+    """Declare a typed launch argument on an App subclass.
+
+    The SDK parses sys.argv before on_init runs and sets the resolved value as
+    an instance attribute with the same name as the class-level declaration.
+
+    Usage::
+
+        class MyApp(App):
+            repo_dir: Arg[str | None] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
+            limit: Arg[int] = Arg("--limit", type=int, default=100)
+            count: Arg[int] = Arg(positional=True, type=int, default=10)
+
+            async def on_init(self, ctx):
+                print(self.repo_dir)  # already resolved
+    """
+
+    def __init__(
+        self,
+        *flags: str,
+        positional: bool = False,
+        type: Any = None,
+        default: Any = _MISSING,
+        dest: "str | None" = None,
+        nargs: Any = None,
+    ) -> None:
+        self.flags = flags
+        self.positional = positional
+        self.arg_type = type
+        self.default = default
+        self.dest = dest
+        self.nargs = nargs
+
+    def __class_getitem__(cls, _item: Any) -> "type[Arg]":
+        return cls
+
+
 def _log_task_exception(task: asyncio.Task) -> None:
     """Done callback for background tasks — logs unhandled exceptions."""
     try:
@@ -108,7 +150,6 @@ class App:
     def __init__(self) -> None:
         self._sdk_initialized: bool = True
         self.app_id: str = ""
-        self.args: list[str] = sys.argv[1:]
         self.workspace_root: str = ""
         self.capabilities: list[str] = []
         self.feature_flags: list[str] = []
@@ -186,6 +227,21 @@ class App:
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
+
+        # Collect Arg descriptors declared directly on this class
+        own_specs: "list[tuple[str, Arg]]" = [
+            (name, value)
+            for name, value in cls.__dict__.items()
+            if isinstance(value, Arg)
+        ]
+        # Merge with parent's specs (own overrides parent entries with the same name)
+        parent_specs: "list[tuple[str, Arg]]" = list(getattr(cls, "_arg_specs", []))
+        if own_specs:
+            own_names = {n for n, _ in own_specs}
+            cls._arg_specs = [(n, s) for n, s in parent_specs if n not in own_names] + own_specs
+        else:
+            cls._arg_specs = parent_specs
+
         orig_init = cls.__dict__.get("__init__")
         if orig_init is not None:
             def wrapped(self_inner: "App", *args: Any, _orig: Any = orig_init, **kw: Any) -> None:
@@ -450,6 +506,78 @@ class App:
         ctx._compact_threshold = self._compact_threshold
         ctx._regular_threshold = self._regular_threshold
         return ctx
+
+    def _parse_launch_args(self, ctx: RenderContext) -> None:
+        """Parse sys.argv against declared Arg specs and set resolved instance attributes.
+
+        Called automatically before on_init when the class declares Arg fields.
+        Lambda defaults receive ctx and are resolved here.
+        """
+        import argparse as _argparse
+        specs: "list[tuple[str, Arg]]" = type(self)._arg_specs
+        if not specs:
+            return
+
+        parser = _argparse.ArgumentParser(add_help=False)
+        lambda_defaults: "dict[str, Any]" = {}
+
+        for attr_name, arg_spec in specs:
+            dest = arg_spec.dest or attr_name
+            is_lambda = callable(arg_spec.default) and not isinstance(arg_spec.default, type)
+            if is_lambda:
+                raw_default: Any = None
+                lambda_defaults[attr_name] = arg_spec.default
+            elif arg_spec.default is _MISSING:
+                raw_default = None
+            else:
+                raw_default = arg_spec.default
+
+            if arg_spec.positional:
+                pkw: "dict[str, Any]" = {}
+                if arg_spec.nargs is not None:
+                    pkw["nargs"] = arg_spec.nargs
+                    pkw["default"] = raw_default if raw_default is not None else []
+                else:
+                    pkw["nargs"] = "?"
+                    pkw["default"] = raw_default
+                if arg_spec.arg_type is not None and arg_spec.arg_type is not bool:
+                    pkw["type"] = arg_spec.arg_type
+                parser.add_argument(dest, **pkw)
+            else:
+                if not arg_spec.flags:
+                    continue
+                okw: "dict[str, Any]" = {"dest": dest, "default": raw_default}
+                if arg_spec.arg_type is bool:
+                    okw["action"] = "store_true"
+                elif arg_spec.arg_type is not None:
+                    okw["type"] = arg_spec.arg_type
+                if arg_spec.nargs is not None:
+                    okw["nargs"] = arg_spec.nargs
+                parser.add_argument(*arg_spec.flags, **okw)
+
+        argv = [a for a in sys.argv[1:] if a != "--plexi-introspect"]
+        try:
+            ns, _ = parser.parse_known_args(argv)
+        except SystemExit as e:
+            sys.exit(e.code)
+
+        for attr_name, arg_spec in specs:
+            dest = arg_spec.dest or attr_name
+            value = getattr(ns, dest, None)
+
+            if value is None and arg_spec.default is _MISSING and not arg_spec.positional:
+                flag = arg_spec.flags[0] if arg_spec.flags else attr_name
+                sys.stderr.write(f"{flag}: required argument missing\n")
+                sys.exit(1)
+
+            if value is None and attr_name in lambda_defaults:
+                value = lambda_defaults[attr_name](ctx)
+
+            setattr(self, attr_name, value)
+        self.emit.info(
+            f"args: parsed {len(specs)} arg(s): "
+            + ", ".join(f"{n}={getattr(self, n)!r}" for n, _ in specs)
+        )
 
     def run(self) -> None:
         """Start the PGAP v3 asyncio event loop. Blocks until Shutdown.
@@ -779,6 +907,8 @@ class App:
                                       if f in ("pane_groups_v1",)]
                     _emit({"type": "ready", "sdk": SDK_ID, "features_used": features_used})
                     self.emit.info(f"sdk: default_background={self.default_background!r}")
+                    if getattr(type(self), "_arg_specs", None):
+                        self._parse_launch_args(self._make_ctx())
                     await self._dispatch_hook(self.on_init, self._make_ctx())
 
                 elif t == "render":

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -143,6 +143,9 @@ class App:
     dispatched outside a render frame.
     """
 
+    # Populated by __init_subclass__ when Arg fields are declared on a subclass.
+    _arg_specs: "list[tuple[str, Arg]]" = []
+
     # Background color applied automatically before each on_render call.
     # Set to None to disable the default background and manage clearing manually.
     default_background: "str | None" = _DEFAULT_BG
@@ -537,9 +540,11 @@ class App:
                 if arg_spec.nargs is not None:
                     pkw["nargs"] = arg_spec.nargs
                     pkw["default"] = raw_default if raw_default is not None else []
-                else:
+                elif arg_spec.default is not _MISSING:
+                    # Explicit default → optional positional
                     pkw["nargs"] = "?"
                     pkw["default"] = raw_default
+                # else: no nargs, no default → required positional (argparse enforces)
                 if arg_spec.arg_type is not None and arg_spec.arg_type is not bool:
                     pkw["type"] = arg_spec.arg_type
                 parser.add_argument(dest, **pkw)


### PR DESCRIPTION
Closes #1788

## Summary

- Adds `Arg` descriptor class to `plexi_sdk`; app authors declare launch arguments as typed class-level fields instead of parsing `sys.argv` manually
- SDK collects `Arg` specs via `__init_subclass__`, parses `sys.argv` before `on_init` runs, and sets resolved values as instance attributes; lambda defaults receive `ctx` and are resolved at init time
- Removes `self.args` from `App.__init__` (no backwards compat); migrates all 6 affected apps (balls, backlog, gh-issues, snake, mcp-renderer, descriptor-renderer)

## Done When

- `from plexi_sdk import Arg` works
- All 6 files migrated; no remaining `self.args` or direct `sys.argv[1:]` in app code
- `plexi app open gh-issues -- --repo-dir /some/path` resolves `self.repo_dir` correctly
- `cargo test --bin plexi` green

## Notes

- `type=bool` on an option flag is treated as `action="store_true"` (boolean flags like `--global`)
- `nargs=argparse.REMAINDER` used for mcp-renderer's `cmd` arg so it captures the full subprocess command including any flags the MCP server expects
- descriptor-renderer uses two `Arg` fields (`--descriptor` flag + positional `nargs='?'`) to preserve both invocation forms; falls back to `sample.json` if neither provided
- Pre-existing 6 Rust test failures exist on `origin/alpha` — not introduced by this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--repo-dir` configuration option to the gh-issues app to specify a custom repository directory.

* **Refactor**
  * Modernized argument parsing across multiple applications to use a unified, declarative approach for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->