### PR TITLE
Cleaner state injection primitive for headless render / app testing (#1790)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -71,12 +71,14 @@ class GhIssues(App):
         self._error          : str | None = None
         self._detail         : dict | None = None
         self._root           = self.repo_dir or ""
+        self._render_seeded  = False
         ctx.status_summary("Loading…")
         self.emit.info(f"gh-issues init workspace={self._root!r}")
         self._fetch()
 
     async def on_render_seed(self, _ctx: RenderContext, payload: dict) -> None:
         if "_issues" in payload:
+            self._render_seeded  = True
             self._issues         = payload["_issues"]
             self._loading        = payload.get("_loading", False)
             self._sel            = payload.get("_sel", 0)
@@ -99,6 +101,8 @@ class GhIssues(App):
         asyncio.get_event_loop().create_task(asyncio.to_thread(self._load_list))
 
     def _load_list(self) -> None:
+        if getattr(self, "_render_seeded", False):
+            return
         rc, out, err = _gh(
             "issue", "list", "--state", "open",
             "--json", "number,title,state,labels,assignees,createdAt",

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -75,6 +75,15 @@ class GhIssues(App):
         self.emit.info(f"gh-issues init workspace={self._root!r}")
         self._fetch()
 
+    async def on_render_seed(self, _ctx: RenderContext, payload: dict) -> None:
+        if "_issues" in payload:
+            self._issues  = payload["_issues"]
+            self._loading = payload.get("_loading", False)
+            self._sel     = payload.get("_sel", 0)
+            self._error   = payload.get("_error")
+            self._view    = payload.get("_view", self.VIEW_LIST)
+            self.emit.info(f"gh-issues: seeded {len(self._issues)} issues for headless render")
+
     # ── data ──────────────────────────────────────────────────────────────────
 
     def _fetch(self) -> None:

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -77,11 +77,18 @@ class GhIssues(App):
 
     async def on_render_seed(self, _ctx: RenderContext, payload: dict) -> None:
         if "_issues" in payload:
-            self._issues  = payload["_issues"]
-            self._loading = payload.get("_loading", False)
-            self._sel     = payload.get("_sel", 0)
-            self._error   = payload.get("_error")
-            self._view    = payload.get("_view", self.VIEW_LIST)
+            self._issues         = payload["_issues"]
+            self._loading        = payload.get("_loading", False)
+            self._sel            = payload.get("_sel", 0)
+            self._error          = payload.get("_error")
+            self._detail         = payload.get("_detail")
+            self._detail_loading = bool(payload.get("_detail_loading", False))
+            requested_view       = payload.get("_view", self.VIEW_LIST)
+            self._view = (
+                requested_view
+                if requested_view != self.VIEW_DETAIL or self._detail or self._detail_loading
+                else self.VIEW_LIST
+            )
             self.emit.info(f"gh-issues: seeded {len(self._issues)} issues for headless render")
 
     # ── data ──────────────────────────────────────────────────────────────────

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -100,6 +100,7 @@ class App:
     Awaited (block the event loop until they return):
         on_init(ctx)                                — after Init handshake
         on_render(ctx)                              — on each Render event
+        on_render_seed(ctx, payload)                — on RenderSeed (headless only, before first Render)
         on_suspend()                                — on Suspend
         on_resume()                                 — on Resume
         on_shutdown()                               — on Shutdown
@@ -116,7 +117,6 @@ class App:
         on_pipe_message(ctx, pipe_id, payload)       — on PipeMessage
         on_path_changed(ctx, cwd)                    — on PathChanged
         on_inject(ctx, payload)                      — on Inject event
-        on_render_seed(ctx, payload)                 — on RenderSeed (headless render only)
         on_nav_back(ctx, view_id)                    — on NavBack event
         on_timer(ctx, timer_id)                      — on Timer event
         on_scroll(ctx, id, offset_y)                 — on Scroll event

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -116,6 +116,7 @@ class App:
         on_pipe_message(ctx, pipe_id, payload)       — on PipeMessage
         on_path_changed(ctx, cwd)                    — on PathChanged
         on_inject(ctx, payload)                      — on Inject event
+        on_render_seed(ctx, payload)                 — on RenderSeed (headless render only)
         on_nav_back(ctx, view_id)                    — on NavBack event
         on_timer(ctx, timer_id)                      — on Timer event
         on_scroll(ctx, id, offset_y)                 — on Scroll event
@@ -271,6 +272,7 @@ class App:
     def on_pipe_message(self, _ctx: RenderContext, _pipe_id: str, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
     def on_path_changed(self, _ctx: RenderContext, _cwd: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_inject(self, _ctx: RenderContext, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
+    def on_render_seed(self, _ctx: RenderContext, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
     def on_nav_back(self, _ctx: RenderContext, _view_id: str) -> "Coroutine[Any, Any, None] | None":
         """Called when the host emits ``NavBack`` — user pressed Cmd+[ or the
         back arrow in the pane chrome. ``view_id`` is the view being navigated
@@ -1016,6 +1018,13 @@ class App:
                     self._app_state = ev.get("payload") or {}
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_inject, ctx, ev.get("payload", {}))
+
+                elif t == "render_seed":
+                    # Headless-only: sent by `plexi app render --state` before the first
+                    # Render event. Awaited so state is applied before on_render fires.
+                    # Does not affect live inject behavior.
+                    ctx = self._make_ctx()
+                    await self._dispatch_hook(self.on_render_seed, ctx, ev.get("payload", {}))
 
                 elif t == "midi_input_opened":
                     # Confirms an OpenMidiInput call landed a CoreMIDI source.

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -1023,6 +1023,7 @@ class App:
                     # Headless-only: sent by `plexi app render --state` before the first
                     # Render event. Awaited so state is applied before on_render fires.
                     # Does not affect live inject behavior.
+                    sys.stderr.write("plexi_sdk: render_seed received — applying headless seed state\n")
                     ctx = self._make_ctx()
                     await self._dispatch_hook(self.on_render_seed, ctx, ev.get("payload", {}))
 

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -149,6 +149,11 @@ pub enum PlexiEvent {
     /// Sent at startup with persisted app state (workspace if available, else global).
     /// Also usable from `pgap_test_harness` to seed deterministic state.
     InjectState { payload: serde_json::Value },
+    /// Sent by the headless renderer to seed app state before the first render.
+    /// Unlike InjectState (which fires on_inject as a background task and is a live
+    /// protocol event), RenderSeed fires on_render_seed awaited, so state is applied
+    /// before the Render event arrives. Live app behavior is completely unaffected.
+    RenderSeed { payload: serde_json::Value },
     /// Host broker response to a `DrawCommand::HttpRequest`. `error` is present
     /// when the request failed; `body` may still carry a partial response.
     HttpResponse {

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -16,8 +16,14 @@ const FRAME_TIMEOUT: Duration = Duration::from_secs(10);
 const PROTOCOL: &str = "pgap/3";
 
 /// Spawn the app at `bin_path`, collect one frame at `width`×`height`, render to PNG bytes.
-pub fn render_app_to_png(app_id: &str, bin_path: &Path, width: u32, height: u32) -> Result<Vec<u8>, String> {
-    let commands = spawn_and_collect_frame(app_id, bin_path, width, height)?;
+pub fn render_app_to_png(
+    app_id: &str,
+    bin_path: &Path,
+    width: u32,
+    height: u32,
+    seed_state: Option<serde_json::Value>,
+) -> Result<Vec<u8>, String> {
+    let commands = spawn_and_collect_frame(app_id, bin_path, width, height, seed_state)?;
     render_commands_to_png(&commands, width, height)
 }
 
@@ -27,6 +33,7 @@ fn spawn_and_collect_frame(
     bin_path: &Path,
     width: u32,
     height: u32,
+    seed_state: Option<serde_json::Value>,
 ) -> Result<Vec<RenderCommand>, String> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
@@ -108,6 +115,15 @@ fn spawn_and_collect_frame(
                 log::warn!("app_render[{app_id}]: parse error before Ready: {e} (line: {line})");
             }
         }
+    }
+
+    // Send RenderSeed if caller provided seed data
+    if let Some(payload) = seed_state {
+        let seed = PlexiEvent::RenderSeed { payload };
+        let seed_json = serde_json::to_string(&seed)
+            .map_err(|e| format!("failed to serialize RenderSeed: {e}"))?;
+        writeln!(stdin, "{seed_json}").map_err(|e| format!("failed to write RenderSeed: {e}"))?;
+        log::info!("app_render[{app_id}]: sent RenderSeed");
     }
 
     // Send Render

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1322,13 +1322,15 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
         }
     };
 
-    // Optional: parse seed state JSON to inject via protocol
-    let seed_state: Option<serde_json::Value> = state.and_then(|s| {
+    // Optional: parse seed state JSON to inject via protocol.
+    // Either path (read or parse failure) is a hard error — the caller explicitly
+    // requested seeded state, so silently falling back would produce a misleading render.
+    let seed_state: Option<serde_json::Value> = if let Some(s) = state {
         let json = match std::fs::read_to_string(s) {
             Ok(j) => j,
             Err(e) => {
                 eprintln!("error: could not read state file '{s}': {e}");
-                return None;
+                return 1;
             }
         };
         match serde_json::from_str(&json) {
@@ -1338,10 +1340,12 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
             }
             Err(e) => {
                 eprintln!("error: invalid JSON in state file '{s}': {e}");
-                None
+                return 1;
             }
         }
-    });
+    } else {
+        None
+    };
 
     // Resolve the app binary
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1322,8 +1322,8 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
         }
     };
 
-    // Optional: pre-seed app state
-    let seeded_path = state.and_then(|s| {
+    // Optional: parse seed state JSON to inject via protocol
+    let seed_state: Option<serde_json::Value> = state.and_then(|s| {
         let json = match std::fs::read_to_string(s) {
             Ok(j) => j,
             Err(e) => {
@@ -1331,16 +1331,16 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
                 return None;
             }
         };
-        let dest = crate::config::config_dir().join("app_states").join(format!("{id}.json"));
-        if let Some(parent) = dest.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        match serde_json::from_str(&json) {
+            Ok(v) => {
+                log::info!("app_render[{id}]: loaded seed state from '{s}'");
+                Some(v)
+            }
+            Err(e) => {
+                eprintln!("error: invalid JSON in state file '{s}': {e}");
+                None
+            }
         }
-        if let Err(e) = std::fs::write(&dest, &json) {
-            eprintln!("error: could not write state to {}: {e}", dest.display());
-            return None;
-        }
-        log::info!("app_render[{id}]: pre-seeded state from '{s}' → {}", dest.display());
-        Some(dest)
     });
 
     // Resolve the app binary
@@ -1350,29 +1350,17 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
         Some(a) => a.bin_path.clone(),
         None => {
             eprintln!("error: app '{id}' not found — run `plexi app list` to see installed apps");
-            if let Some(path) = seeded_path {
-                let _ = std::fs::remove_file(path);
-            }
             return 1;
         }
     };
 
-    let png_bytes = match crate::app_render::render_app_to_png(id, &app_bin, width, height) {
+    let png_bytes = match crate::app_render::render_app_to_png(id, &app_bin, width, height, seed_state) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("error: render failed: {e}");
-            if let Some(path) = seeded_path {
-                let _ = std::fs::remove_file(path);
-            }
             return 1;
         }
     };
-
-    // Clean up seeded state if we wrote it
-    if let Some(ref path) = seeded_path {
-        let _ = std::fs::remove_file(path);
-        log::info!("app_render[{id}]: cleaned up seeded state at {}", path.display());
-    }
 
     // Write output
     match output {


### PR DESCRIPTION
Closes #1790

## Summary

- Adds `RenderSeed` protocol event sent only by `plexi app render --state` — completely separate from the live `InjectState` / `on_inject` path, so live app behavior is untouched
- Adds `on_render_seed(ctx, payload)` hook to the SDK `App` base class, awaited before the first `Render` event so state is applied synchronously in headless renders
- Refactors `cli.rs` to parse `--state` JSON directly instead of writing/cleaning up a temp file on disk; `app_render.rs` now passes the parsed value through the protocol pipe

## Done When

No explicit Done When in issue — implementation delivers Option 2 from the issue's "Better direction" section (separate `on_render_seed` hook, headless-only semantics).

## Notes

`on_inject` dispatch is unchanged (stays `_dispatch_hook_task`, background task). The old alpha workaround wrote state to `config_dir/app_states/<id>.json` at render time and relied on `process_app` to pick it up at startup — the new approach sends `RenderSeed` directly through the protocol pipe, which is simpler and doesn't require filesystem side-effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Headless rendering now supports seeding app state before the first render, enabling applications to initialize with pre-populated data without additional setup steps.
  * Application rendering via CLI can accept and inject initial state, simplifying state management in automated rendering workflows and batch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->