### PR TITLE
fix(apps/gh-issues): refactor to SDK ui.py components + iterate with --state render until no overlaps (#1792)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -192,24 +192,24 @@ class GhIssues(App):
                 self._draw_detail(ctx)
             return
 
-        # Header: AppBar (title + count) + FooterKeys (shortcuts)
+        # Header: AppBar (title + count). Shortcuts live in a bottom footer.
         appbar = AppBar(
             "Issues",
             subtitle=f"{len(self._issues)} open" if not self._loading else None,
             accent=theme.accent,
         )
-        shortcuts = FooterKeys([
+        footer = FooterKeys([
             (["j", "k"], "navigate"),
             ("↩", "detail"),
             ("o", "browser"),
             ("r", "refresh"),
             ("n", "new"),
-        ], divider=False)
-        appbar_h    = appbar.measure(ctx.w)
-        shortcuts_h = shortcuts.measure(ctx.w)
+        ])
+        appbar_h  = appbar.measure(ctx.w)
+        footer_h  = footer.measure(ctx.w)
+        list_top  = appbar_h
         appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)
-        shortcuts.render(ctx, 0.0, appbar_h, ctx.w, shortcuts_h)
-        list_top = appbar_h + shortcuts_h
+        footer.render(ctx, 0.0, ctx.h - footer_h, ctx.w, footer_h)
 
         if self._loading:
             ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=theme.muted)
@@ -221,9 +221,9 @@ class GhIssues(App):
                      "r — retry", size=HINT, color=theme.muted)
             return
 
-        self._draw_list(ctx, list_top)
+        self._draw_list(ctx, list_top, footer_h)
 
-    def _draw_list(self, ctx: RenderContext, list_top: float) -> None:
+    def _draw_list(self, ctx: RenderContext, list_top: float, footer_h: float) -> None:
         rows = [
             ListRow(
                 id=f"issue-{issue['number']}",
@@ -236,7 +236,9 @@ class GhIssues(App):
             ).to_dict()
             for issue in self._issues
         ]
-        ctx.list_view("issues", rows, selected=self._sel, y=float(list_top))
+        list_h = max(0.0, ctx.h - list_top - footer_h)
+        ctx.list_view("issues", rows, selected=self._sel,
+                      y=float(list_top), h=float(list_h))
 
     def _draw_detail(self, ctx: RenderContext) -> None:
         if self._detail is None:

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -204,7 +204,7 @@ class GhIssues(App):
             ("o", "browser"),
             ("r", "refresh"),
             ("n", "new"),
-        ])
+        ], divider=False)
         appbar_h    = appbar.measure(ctx.w)
         shortcuts_h = shortcuts.measure(ctx.w)
         appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -14,9 +14,8 @@ import subprocess
 
 from plexi_sdk import (
     App, RenderContext, Arg,
-    BG, ACCENT, MUTED,
+    theme,
     BODY, CAPTION, HINT,
-    GREEN, RED, YELLOW,
     PAD, PAD_TIGHT,
 )
 from plexi_sdk.ui import (
@@ -67,12 +66,12 @@ def _gh(*args: str, cwd: str | None = None, timeout: float = 15.0) -> tuple[int,
 def _label_color(name: str) -> str:
     n = name.lower()
     if any(w in n for w in ("bug", "error", "p0", "p1")):
-        return RED
+        return theme.danger
     if any(w in n for w in ("p2", "enhancement", "feat")):
-        return YELLOW
+        return theme.warning
     if any(w in n for w in ("ready", "done", "p3", "p4")):
-        return GREEN
-    return ACCENT
+        return theme.success
+    return theme.accent
 
 
 # ── App ───────────────────────────────────────────────────────────────────────
@@ -172,20 +171,20 @@ class GhIssues(App):
     # ── render ────────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.clear(BG)
+        ctx.clear(theme.bg)
 
         if self._view == self.VIEW_DETAIL:
             if self._detail_loading:
                 ctx.render(Column([
-                    AppBar("Issues", accent=ACCENT),
+                    AppBar("Issues", accent=theme.accent),
                     Spacer(size=SPACE_MD),
-                    Label("Loading issue…", tone="body", color=MUTED),
+                    Label("Loading issue…", tone="body", color=theme.muted),
                 ], padding_top=0))
             elif self._error:
                 ctx.render(Column([
-                    AppBar("Error", accent=ACCENT),
+                    AppBar("Error", accent=theme.accent),
                     Spacer(size=SPACE_MD),
-                    Label(f"Error: {self._error}", tone="body", color=RED),
+                    Label(f"Error: {self._error}", tone="body", color=theme.danger),
                     Spacer(grow=True),
                     FooterKeys([("escape", "back")]),
                 ], padding_top=0))
@@ -197,7 +196,7 @@ class GhIssues(App):
         appbar = AppBar(
             "Issues",
             subtitle=f"{len(self._issues)} open" if not self._loading else None,
-            accent=ACCENT,
+            accent=theme.accent,
         )
         shortcuts = FooterKeys([
             (["j", "k"], "navigate"),
@@ -213,13 +212,13 @@ class GhIssues(App):
         list_top = appbar_h + shortcuts_h
 
         if self._loading:
-            ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=MUTED)
+            ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=theme.muted)
             return
         if self._error:
             ctx.text(PAD, list_top + PAD, f"Error: {self._error}",
-                     size=CAPTION, color=RED, max_width=ctx.w - PAD * 2)
+                     size=CAPTION, color=theme.danger, max_width=ctx.w - PAD * 2)
             ctx.text(PAD, list_top + PAD + BODY + PAD_TIGHT,
-                     "r — retry", size=HINT, color=MUTED)
+                     "r — retry", size=HINT, color=theme.muted)
             return
 
         self._draw_list(ctx, list_top)
@@ -228,7 +227,7 @@ class GhIssues(App):
         rows = [
             ListRow(
                 id=f"issue-{issue['number']}",
-                leading=LeadingBadge(f"#{issue['number']}", color="accent"),
+                leading=LeadingBadge(f"#{issue['number']}", color=theme.accent),
                 primary=issue.get("title", ""),
                 chips=[
                     RowChip(lbl.get("name", ""), _label_color(lbl.get("name", "")))
@@ -251,11 +250,11 @@ class GhIssues(App):
 
         self._body_scroll.child = (
             _MarkdownBlock(body_text) if body_text
-            else Label("No body.", tone="caption", color=MUTED)
+            else Label("No body.", tone="caption", color=theme.muted)
         )
 
         ctx.render(Column([
-            AppBar(f"← #{number}  {title}", accent=ACCENT),
+            AppBar(f"← #{number}  {title}", accent=theme.accent),
             InfoTable([
                 ("number",    f"#{number}"),
                 ("state",     d.get("state", "open")),

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -3,7 +3,7 @@
 
 Two views:
   - LIST: scrollable issue rows with number badge, title, labels
-  - DETAIL: terminal-style metadata table + markdown body
+  - DETAIL: metadata card + scrollable markdown body
 
 Keys: j/k navigate · Enter open detail · Esc back · o open in browser
       r refresh · n new issue in terminal
@@ -14,18 +14,39 @@ import subprocess
 
 from plexi_sdk import (
     App, RenderContext, Arg,
-    BG, SURFACE, FG, ACCENT, MUTED, HIGHLIGHT,
-    BODY, CAPTION, HEADING, HINT,
+    BG, ACCENT, MUTED,
+    BODY, CAPTION, HINT,
     GREEN, RED, YELLOW,
     PAD, PAD_TIGHT,
 )
-from plexi_sdk.ui import ListRow, RowChip, LeadingBadge
+from plexi_sdk.ui import (
+    AppBar, FooterKeys, InfoTable, Section,
+    Scrollable, Column, Label, Spacer,
+    ListRow, RowChip, LeadingBadge,
+    Component,
+    TEXT_BODY,
+    SPACE_MD,
+    _markdown_measure_lines,
+)
 
-# ── Layout ────────────────────────────────────────────────────────────────────
 
-HEADER_H = 52
-ROW_H    = 38
-KEY_COL  = 90
+# ── Private markdown component ────────────────────────────────────────────────
+
+class _MarkdownBlock(Component):
+    """Embeds ctx.markdown() in the declarative component tree."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def measure(self, avail_w: float) -> float:
+        if not self.text:
+            return 0.0
+        lines = _markdown_measure_lines(self.text, avail_w, TEXT_BODY, max_lines=400)
+        return max(1, lines) * (TEXT_BODY + 5.0)
+
+    def render(self, ctx, x: float, y: float, w: float, _h: float) -> None:
+        if self.text:
+            ctx.markdown(x, y, w, self.text)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -72,6 +93,8 @@ class GhIssues(App):
         self._detail         : dict | None = None
         self._root           = self.repo_dir or ""
         self._render_seeded  = False
+        # Stable Scrollable instance — scroll offset persists across renders.
+        self._body_scroll    = Scrollable(Label(""))
         ctx.status_summary("Loading…")
         self.emit.info(f"gh-issues init workspace={self._root!r}")
         self._fetch()
@@ -117,7 +140,6 @@ class GhIssues(App):
             return
         try:
             self._issues = json.loads(out)
-            # clamp selection to new list bounds
             self._sel = max(0, min(self._sel, len(self._issues) - 1)) if self._issues else 0
         except Exception as exc:
             self.emit.warn(f"gh issue list json parse error: {exc}")
@@ -151,54 +173,50 @@ class GhIssues(App):
 
     def on_render(self, ctx: RenderContext) -> None:
         ctx.clear(BG)
-        self._draw_header(ctx)
-
-        if self._loading:
-            ctx.text(PAD, HEADER_H + PAD, "Loading…", size=BODY, color=MUTED)
-            return
-        if self._error:
-            ctx.text(PAD, HEADER_H + PAD, f"Error: {self._error}",
-                     size=CAPTION, color=RED, max_width=ctx.w - PAD * 2)
-            ctx.text(PAD, HEADER_H + PAD + BODY + PAD_TIGHT,
-                     "r — retry", size=HINT, color=MUTED)
-            return
 
         if self._view == self.VIEW_DETAIL:
             if self._detail_loading:
-                ctx.text(PAD, HEADER_H + PAD, "Loading issue…", size=BODY, color=MUTED)
-                return
-            self._draw_detail(ctx)
-        else:
-            self._draw_list(ctx)
+                ctx.render(Column([
+                    AppBar("Issues", accent=ACCENT),
+                    Spacer(size=SPACE_MD),
+                    Label("Loading issue…", tone="body", color=MUTED),
+                ], padding_top=0))
+            else:
+                self._draw_detail(ctx)
+            return
 
-    def _draw_header(self, ctx: RenderContext) -> None:
-        ctx.rect(0, 0, ctx.w, HEADER_H, fill=SURFACE)
-        ctx.rect(0, HEADER_H - 1, ctx.w, 1, fill=BG)
-
-        mid_y = HEADER_H / 2
-        ctx.text(PAD, mid_y - HEADING / 2, "Issues", size=HEADING, color=ACCENT,
-                 bold=True, monospace=True)
-
-        if not self._loading:
-            ctx.badge(
-                x=PAD + 76, y_center=mid_y,
-                label=f"{len(self._issues)} open",
-                fill=SURFACE, fg=MUTED, font_size=HINT, radius=3.0,
-            )
-
-        ctx.shortcuts(
-            x=ctx.w / 2, y=mid_y - HINT / 2,
-            max_width=ctx.w / 2 - PAD,
-            pairs=[
-                (["j", "k"], "navigate"),
-                ("↩", "detail"),
-                ("o", "browser"),
-                ("r", "refresh"),
-                ("n", "new"),
-            ],
+        # Header: AppBar (title + count) + FooterKeys (shortcuts)
+        appbar = AppBar(
+            "Issues",
+            subtitle=f"{len(self._issues)} open" if not self._loading else None,
+            accent=ACCENT,
         )
+        shortcuts = FooterKeys([
+            (["j", "k"], "navigate"),
+            ("↩", "detail"),
+            ("o", "browser"),
+            ("r", "refresh"),
+            ("n", "new"),
+        ])
+        appbar_h    = appbar.measure(ctx.w)
+        shortcuts_h = shortcuts.measure(ctx.w)
+        appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)
+        shortcuts.render(ctx, 0.0, appbar_h, ctx.w, shortcuts_h)
+        list_top = appbar_h + shortcuts_h
 
-    def _draw_list(self, ctx: RenderContext) -> None:
+        if self._loading:
+            ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=MUTED)
+            return
+        if self._error:
+            ctx.text(PAD, list_top + PAD, f"Error: {self._error}",
+                     size=CAPTION, color=RED, max_width=ctx.w - PAD * 2)
+            ctx.text(PAD, list_top + PAD + BODY + PAD_TIGHT,
+                     "r — retry", size=HINT, color=MUTED)
+            return
+
+        self._draw_list(ctx, list_top)
+
+    def _draw_list(self, ctx: RenderContext, list_top: float) -> None:
         rows = [
             ListRow(
                 id=f"issue-{issue['number']}",
@@ -211,64 +229,34 @@ class GhIssues(App):
             ).to_dict()
             for issue in self._issues
         ]
-        ctx.list_view(
-            "issues",
-            rows,
-            selected=self._sel,
-            loading=False,
-            y=float(HEADER_H),
-        )
+        ctx.list_view("issues", rows, selected=self._sel, y=float(list_top))
 
     def _draw_detail(self, ctx: RenderContext) -> None:
         if self._detail is None:
             return
-        d  = self._detail
-        y  = float(HEADER_H + PAD)
-
-        ctx.text(PAD, y, "← esc", size=HINT, color=MUTED)
-        y += HINT + PAD
-
-        # title
-        ctx.text(PAD, y, d["title"], size=HEADING, color=FG,
-                 bold=True, max_width=ctx.w - PAD * 2)
-        y += HEADING + PAD
-
-        # metadata table (1073 style: SURFACE bg, GREEN keys, FG values)
+        d             = self._detail
         labels_str    = ", ".join(lb["name"] for lb in d.get("labels", [])) or "none"
         assignees_str = ", ".join(a["login"] for a in d.get("assignees", [])) or "unassigned"
-        rows = [
-            ("number",    f"#{d['number']}"),
-            ("state",     d.get("state", "open")),
-            ("labels",    labels_str),
-            ("assignees", assignees_str),
-            ("opened",    (d.get("createdAt") or "")[:10]),
-        ]
-        T_ROW_H = 28
-        table_h = T_ROW_H * len(rows)
-        ctx.rect(PAD, y, ctx.w - PAD * 2, table_h, fill=SURFACE, radius=6.0)
-        for i, (key, value) in enumerate(rows):
-            ry = y + i * T_ROW_H
-            if i > 0:
-                ctx.rect(PAD, ry, ctx.w - PAD * 2, 1, fill=BG)
-            ty = ry + (T_ROW_H - CAPTION) / 2
-            ctx.text(PAD + 10, ty, key,   size=CAPTION, color=GREEN, monospace=True)
-            ctx.text(PAD + 10 + KEY_COL, ty, value, size=CAPTION, color=FG,
-                     monospace=True, max_width=ctx.w - PAD - 10 - KEY_COL - PAD)
-        y += table_h + PAD
+        body_text     = (d.get("body") or "").strip()
 
-        # body (markdown)
-        body = (d.get("body") or "").strip()
-        if body:
-            ctx.text(PAD, y, "body", size=CAPTION, color=MUTED, monospace=True)
-            y += CAPTION + PAD_TIGHT
-            ctx.markdown(PAD, y, ctx.w - PAD * 2, body)
-
-        # footer shortcuts
-        ctx.shortcuts(
-            x=PAD, y=ctx.h - PAD - HINT,
-            max_width=ctx.w - PAD * 2,
-            pairs=[("o", "open in browser"), ("esc", "back")],
+        self._body_scroll.child = (
+            _MarkdownBlock(body_text) if body_text
+            else Label("No body.", tone="caption", color=MUTED)
         )
+
+        ctx.render(Column([
+            AppBar(f"← #{d['number']}  {d['title']}", accent=ACCENT),
+            InfoTable([
+                ("number",    f"#{d['number']}"),
+                ("state",     d.get("state", "open")),
+                ("labels",    labels_str),
+                ("assignees", assignees_str),
+                ("opened",    (d.get("createdAt") or "")[:10]),
+            ]),
+            Section("Body"),
+            self._body_scroll,
+            FooterKeys([("o", "open in browser"), ("escape", "back")]),
+        ], padding_top=0))
 
     # ── input ─────────────────────────────────────────────────────────────────
 
@@ -297,6 +285,9 @@ class GhIssues(App):
                     rc, _, _ = _gh("issue", "view", str(num), "--web",
                                    cwd=self._root or None)
                     self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
+            else:
+                if self._body_scroll.handle_key(key):
+                    self.emit.schedule_render()
 
     def on_list_select(self, ctx: RenderContext, _id: str, index: int) -> None:
         self._sel = index
@@ -317,9 +308,10 @@ class GhIssues(App):
             return
         issue = self._issues[self._sel]
         self.emit.info(f"gh-issues: open detail #{issue['number']}")
-        self._view           = self.VIEW_DETAIL
-        self._detail         = None
-        self._detail_loading = True
+        self._view                      = self.VIEW_DETAIL
+        self._detail                    = None
+        self._detail_loading            = True
+        self._body_scroll.scroll_offset = 0.0
         asyncio.get_event_loop().create_task(
             asyncio.to_thread(self._load_detail, issue["number"])
         )

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -181,6 +181,14 @@ class GhIssues(App):
                     Spacer(size=SPACE_MD),
                     Label("Loading issue…", tone="body", color=MUTED),
                 ], padding_top=0))
+            elif self._error:
+                ctx.render(Column([
+                    AppBar("Error", accent=ACCENT),
+                    Spacer(size=SPACE_MD),
+                    Label(f"Error: {self._error}", tone="body", color=RED),
+                    Spacer(grow=True),
+                    FooterKeys([("escape", "back")]),
+                ], padding_top=0))
             else:
                 self._draw_detail(ctx)
             return
@@ -235,9 +243,11 @@ class GhIssues(App):
         if self._detail is None:
             return
         d             = self._detail
-        labels_str    = ", ".join(lb["name"] for lb in d.get("labels", [])) or "none"
-        assignees_str = ", ".join(a["login"] for a in d.get("assignees", [])) or "unassigned"
+        labels_str    = ", ".join(lb.get("name", "") for lb in d.get("labels", []) if lb) or "none"
+        assignees_str = ", ".join(a.get("login", "") for a in d.get("assignees", []) if a) or "unassigned"
         body_text     = (d.get("body") or "").strip()
+        number        = d.get("number", "")
+        title         = d.get("title", "")
 
         self._body_scroll.child = (
             _MarkdownBlock(body_text) if body_text
@@ -245,9 +255,9 @@ class GhIssues(App):
         )
 
         ctx.render(Column([
-            AppBar(f"← #{d['number']}  {d['title']}", accent=ACCENT),
+            AppBar(f"← #{number}  {title}", accent=ACCENT),
             InfoTable([
-                ("number",    f"#{d['number']}"),
+                ("number",    f"#{number}"),
                 ("state",     d.get("state", "open")),
                 ("labels",    labels_str),
                 ("assignees", assignees_str),
@@ -311,6 +321,7 @@ class GhIssues(App):
         self._view                      = self.VIEW_DETAIL
         self._detail                    = None
         self._detail_loading            = True
+        self._error                     = None
         self._body_scroll.scroll_offset = 0.0
         asyncio.get_event_loop().create_task(
             asyncio.to_thread(self._load_detail, issue["number"])

--- a/apps/dev/gh-issues/state.json
+++ b/apps/dev/gh-issues/state.json
@@ -1,0 +1,71 @@
+{
+  "_issues": [
+    {
+      "number": 1792,
+      "title": "fix(apps/gh-issues): refactor to SDK ui.py components + iterate with --state render until no overlaps",
+      "state": "OPEN",
+      "labels": [
+        {"name": "bug"},
+        {"name": "P2"},
+        {"name": "ready"},
+        {"name": "area:sdk/python"},
+        {"name": "area:apps/github-issues"}
+      ],
+      "assignees": [],
+      "createdAt": "2026-05-28T10:00:00Z"
+    },
+    {
+      "number": 1791,
+      "title": "feat(cli): add workspace status command",
+      "state": "OPEN",
+      "labels": [
+        {"name": "enhancement"},
+        {"name": "P2"},
+        {"name": "ready"}
+      ],
+      "assignees": [{"login": "ianjamesburke"}],
+      "createdAt": "2026-05-27T09:30:00Z"
+    },
+    {
+      "number": 1785,
+      "title": "bug: pane title truncates on narrow widths",
+      "state": "OPEN",
+      "labels": [
+        {"name": "bug"},
+        {"name": "P3"}
+      ],
+      "assignees": [],
+      "createdAt": "2026-05-25T14:22:00Z"
+    },
+    {
+      "number": 1780,
+      "title": "docs: update SDK reference for ui.py InfoTable and FooterKeys",
+      "state": "OPEN",
+      "labels": [
+        {"name": "P4"},
+        {"name": "ready"}
+      ],
+      "assignees": [],
+      "createdAt": "2026-05-24T11:00:00Z"
+    },
+    {
+      "number": 1770,
+      "title": "P0: host crash when app emits DrawCommand::Markdown with empty string body",
+      "state": "OPEN",
+      "labels": [
+        {"name": "bug"},
+        {"name": "P0"},
+        {"name": "area:apps/github-issues"},
+        {"name": "load:S"}
+      ],
+      "assignees": [{"login": "ianjamesburke"}],
+      "createdAt": "2026-05-20T08:00:00Z"
+    }
+  ],
+  "_sel": 0,
+  "_view": "list",
+  "_loading": false,
+  "_error": null,
+  "_detail": null,
+  "_detail_loading": false
+}

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -475,3 +475,6 @@ from ._emitter import Emitter, _emit, _make_async_queue, _LOCK
 from ._pipe import Pipe
 from ._render_context import RenderContext, COMPACT_DEFAULT, REGULAR_DEFAULT
 from ._app import App, Arg
+# Live host theme (light/dark + user overrides), populated from Init. Also on
+# ctx.theme. Read colors via theme.<role>: theme.bg, theme.accent, theme.danger…
+from ._theme import theme, Theme

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -909,6 +909,10 @@ class App:
                     self.feature_flags = ev.get("feature_flags", [])
                     self._compact_threshold = ev.get("compact_threshold", 280.0)
                     self._regular_threshold = ev.get("regular_threshold", 480.0)
+                    # Apply host theme (light/dark + user overrides) so app-drawn
+                    # chrome matches the host. Mutates the shared singleton in place.
+                    from ._theme import theme as _theme
+                    _theme.update_from(ev.get("theme"))
                     # Send Ready
                     features_used = [f for f in self.feature_flags
                                       if f in ("pane_groups_v1",)]

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -33,6 +33,10 @@ class RenderContext:
         self.workspace_root = workspace_root
         self.capabilities = capabilities
         self.feature_flags = feature_flags
+        # Active host theme (light/dark + user overrides). Read colors via
+        # ctx.theme.<role>, e.g. ctx.theme.accent / ctx.theme.bg / ctx.theme.danger.
+        from ._theme import theme as _theme
+        self.theme = _theme
         self._app = app
         self.emit: "Emitter" = app.emit
         # Seconds elapsed since the previous on_render call. 0.0 on first frame.
@@ -169,17 +173,17 @@ class RenderContext:
         self._queue(d)
 
     def markdown(self, x: float, y: float, w: float, text: str,
-                 base_size: float = 14.0, color: str = FG) -> None:
+                 base_size: float = 14.0, color: "str | None" = None) -> None:
         """Render markdown text via the host's egui_commonmark renderer.
 
         The host creates a child Ui at (x, y) with width w and renders the
         markdown with proper formatting (bold, italic, code blocks, lists, etc.).
 
         `base_size` — body font size in pt (headers scale relative to this).
-        `color`     — default text colour (hex).
+        `color`     — body text colour (hex); defaults to the active theme fg.
         """
         self._queue({"type": "markdown", "x": x, "y": y, "w": w, "text": text,
-                     "base_size": base_size, "color": color})
+                     "base_size": base_size, "color": color or self.theme.fg})
 
     def image(self, src: str, x: float, y: float, w: float, h: float,
               fit: str = "contain") -> None:
@@ -463,9 +467,11 @@ class RenderContext:
                      "color": color, "width": width})
 
     # ── SDK v2 declarative UI entry point ──
-    def render(self, tree: Any, fill: str = "#1e1e2e") -> None:
+    def render(self, tree: Any, fill: "str | None" = None) -> None:
         """Render a declarative UI tree (see `plexi_sdk.ui`). Clears the pane
         to `fill` first, then lays out `tree` into the full pane rect.
+
+        `fill` defaults to the active host theme background (`ctx.theme.bg`).
 
         Example:
             from plexi_sdk.ui import Column, Header, Footer, Spacer

--- a/sdk/python/plexi_sdk/_theme.py
+++ b/sdk/python/plexi_sdk/_theme.py
@@ -1,0 +1,84 @@
+"""Live theme singleton.
+
+Populated from the host ``Init`` payload so app-drawn chrome tracks the host
+theme (light/dark + user ``[theme]`` overrides in ``config.toml``). Until ``Init``
+arrives the attributes hold the built-in Catppuccin Mocha dark defaults, so apps
+and ``ui.py`` components still render correctly pre-handshake.
+
+The module exposes a single process-wide instance, ``theme``, which is mutated
+**in place** on ``Init``. Every module that did ``from ._theme import theme`` sees
+the update — so never rebind the name, only set attributes.
+
+Apps read colors via ``ctx.theme.<role>`` (e.g. ``ctx.theme.accent``). Both the
+SDK-semantic names (``bg``/``surface``/``muted``/...) and ANSI aliases
+(``red``/``green``/``yellow``) are available; pick whichever reads best.
+"""
+
+from __future__ import annotations
+
+
+# Catppuccin Mocha dark defaults — used before Init and as fallback when the
+# host sends an empty/partial theme map.
+_DEFAULTS = {
+    "bg": "#1e1e2e",
+    "bg_darkest": "#11111b",
+    "surface": "#313244",
+    "highlight": "#45475a",
+    "border": "#2a2a3c",
+    "fg": "#cdd6f4",
+    "muted": "#6c7086",
+    "text_section": "#585b70",
+    "accent": "#89b4fa",
+    "danger": "#f38ba8",
+    "red": "#f38ba8",
+    "success": "#a6e3a1",
+    "green": "#a6e3a1",
+    "warning": "#f9e2af",
+    "yellow": "#f9e2af",
+}
+
+ROLES = tuple(_DEFAULTS.keys())
+
+
+class Theme:
+    """Mutable bag of semantic color roles, each a ``#rrggbb`` string."""
+
+    # Explicit annotations (not computed) so type checkers resolve ctx.theme.<role>.
+    bg: str
+    bg_darkest: str
+    surface: str
+    highlight: str
+    border: str
+    fg: str
+    muted: str
+    text_section: str
+    accent: str
+    danger: str
+    red: str
+    success: str
+    green: str
+    warning: str
+    yellow: str
+
+    __slots__ = ROLES
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        for role, value in _DEFAULTS.items():
+            setattr(self, role, value)
+
+    def update_from(self, payload: "dict | None") -> None:
+        """Overlay host-provided roles. Unknown keys and non-string/empty
+        values are ignored so a partial payload never blanks a color."""
+        if not payload:
+            return
+        for role in ROLES:
+            value = payload.get(role)
+            if isinstance(value, str) and value:
+                setattr(self, role, value)
+
+
+# Process-wide singleton. Mutated in place on Init — do not rebind.
+theme = Theme()

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -80,6 +80,11 @@ RED = "#f38ba8"
 GREEN = "#a6e3a1"
 YELLOW = "#f9e2af"
 
+# Live host theme — populated from the Init payload (light/dark + user
+# overrides). Components read `theme.<role>` at render time so they track the
+# active theme; the constants above remain as pre-Init / fallback defaults.
+from ._theme import theme
+
 # ── Utilities ──────────────────────────────────────────────────────────────
 
 
@@ -268,10 +273,10 @@ class Label(Component):
         if self.color:
             return self.color
         return {
-            "body": FG,
-            "caption": FG,
-            "hint": MUTED,
-        }.get(self.tone, FG)
+            "body": theme.fg,
+            "caption": theme.fg,
+            "hint": theme.muted,
+        }.get(self.tone, theme.fg)
 
     def _lines(self, avail_w: float) -> List[str]:
         return _wrap_to_width(self.text, avail_w, self._font_size(),
@@ -337,7 +342,7 @@ class AppBar(Component):
     """
     title: str
     subtitle: Optional[str] = None
-    accent: str = FG
+    accent: Optional[str] = None  # default: theme.fg (resolved at render time)
 
     TITLE_SIZE = 16.0
     SUBTITLE_SIZE = TEXT_HINT
@@ -352,7 +357,8 @@ class AppBar(Component):
         return self._band() + self.DIVIDER_H
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.rect(x, y, w, h, BG)
+        ctx.rect(x, y, w, h, theme.bg)
+        accent = self.accent or theme.fg
         band = self._band()
         text_x = x + SPACE_MD
         text_w = w - 2 * SPACE_MD
@@ -361,17 +367,17 @@ class AppBar(Component):
             title_y = y + (band - block_h) / 2.0
             sub_y = title_y + self.TITLE_SIZE + SPACE_XS
             ctx.text(text_x, title_y, self.title,
-                     size=self.TITLE_SIZE, color=self.accent, bold=True,
+                     size=self.TITLE_SIZE, color=accent, bold=True,
                      max_width=text_w, elide=True)
             ctx.text(text_x, sub_y, self.subtitle,
-                     size=self.SUBTITLE_SIZE, color=MUTED,
+                     size=self.SUBTITLE_SIZE, color=theme.muted,
                      max_width=text_w, elide=True)
         else:
             text_y = y + (band - self.TITLE_SIZE) / 2.0
             ctx.text(text_x, text_y, self.title,
-                     size=self.TITLE_SIZE, color=self.accent, bold=True,
+                     size=self.TITLE_SIZE, color=accent, bold=True,
                      max_width=text_w, elide=True)
-        ctx.rect(x, y + band, w, self.DIVIDER_H, HIGHLIGHT)
+        ctx.rect(x, y + band, w, self.DIVIDER_H, theme.highlight)
 
 
 @dataclass
@@ -389,10 +395,10 @@ class Section(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         label_y = y + SPACE_SM
         ctx.text(x, label_y, self.title.upper(),
-                 size=TEXT_HINT, color=MUTED, bold=True,
+                 size=TEXT_HINT, color=theme.muted, bold=True,
                  max_width=w, elide=True)
         line_y = label_y + TEXT_HINT + SPACE_XS
-        ctx.rect(x, line_y, w, 1.0, HIGHLIGHT)
+        ctx.rect(x, line_y, w, 1.0, theme.highlight)
 
 
 @dataclass
@@ -574,8 +580,8 @@ class Scrollable(Component):
             # Clamp thumb to track
             thumb_y = min(thumb_y, y + track_h - thumb_h)
             bar_x = x + w - self._SCROLLBAR_W
-            ctx.rect(bar_x, y, self._SCROLLBAR_W, track_h, HIGHLIGHT)
-            ctx.rect(bar_x, thumb_y, self._SCROLLBAR_W, thumb_h, MUTED)
+            ctx.rect(bar_x, y, self._SCROLLBAR_W, track_h, theme.highlight)
+            ctx.rect(bar_x, thumb_y, self._SCROLLBAR_W, thumb_h, theme.muted)
 
 
 def ensure_visible(scroll_offset: float, viewport_h: float,
@@ -690,9 +696,9 @@ class FooterKeys(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         # Opaque BG backdrop so any content scrolled behind the footer doesn't
         # bleed through the divider line.
-        ctx.rect(x, y, w, h, BG)
+        ctx.rect(x, y, w, h, theme.bg)
         line_y = y + self.TOP_GAP
-        ctx.rect(x, line_y, w, 1.0, HIGHLIGHT)
+        ctx.rect(x, line_y, w, 1.0, theme.highlight)
 
         chip_row_y = line_y + 1.0 + self.TOP_GAP
 
@@ -1314,12 +1320,13 @@ class Column(Component):
 # ── Public render entry point ──────────────────────────────────────────────
 
 
-def render_tree(ctx, root: Component, fill: str = BG) -> None:
+def render_tree(ctx, root: Component, fill: Optional[str] = None) -> None:
     """Clear the pane to `fill`, then render `root` into the full pane rect.
 
+    `fill` defaults to the active host theme background (`theme.bg`).
     Apps normally call `ctx.render(root)` instead, which calls this.
     """
-    ctx.clear(fill)
+    ctx.clear(fill or theme.bg)
     root.render(ctx, 0.0, 0.0, ctx.w, ctx.h)
 
 
@@ -1339,8 +1346,8 @@ class InfoTable(Component):
     """
     rows: List[tuple]  # list of (key_label, value_text)
     key_width: float = 100.0
-    background: str = SURFACE
-    border: str = HIGHLIGHT
+    background: Optional[str] = None  # default: theme.surface
+    border: Optional[str] = None      # default: theme.highlight
     radius: float = RADIUS_MD
 
     ROW_H = 30.0
@@ -1353,11 +1360,13 @@ class InfoTable(Component):
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         # Background + border
-        ctx.rect(x, y, w, h, self.background, radius=self.radius)
-        ctx.rect(x, y, w, 1.0, self.border)
-        ctx.rect(x, y + h - 1.0, w, 1.0, self.border)
-        ctx.rect(x, y, 1.0, h, self.border)
-        ctx.rect(x + w - 1.0, y, 1.0, h, self.border)
+        background = self.background or theme.surface
+        border = self.border or theme.highlight
+        ctx.rect(x, y, w, h, background, radius=self.radius)
+        ctx.rect(x, y, w, 1.0, border)
+        ctx.rect(x, y + h - 1.0, w, 1.0, border)
+        ctx.rect(x, y, 1.0, h, border)
+        ctx.rect(x + w - 1.0, y, 1.0, h, border)
 
         val_x = x + self.PAD_H + self.key_width + self.PAD_H
         val_w = w - self.PAD_H - self.key_width - self.PAD_H * 2
@@ -1368,18 +1377,18 @@ class InfoTable(Component):
 
             # Key (green, monospace)
             ctx.text(x + self.PAD_H, cy, str(key),
-                     size=TEXT_CAPTION, color=GREEN, monospace=True,
+                     size=TEXT_CAPTION, color=theme.success, monospace=True,
                      align="left_center", max_width=self.key_width, elide=True)
 
             # Value (FG, monospace)
             ctx.text(val_x, cy, str(value),
-                     size=TEXT_CAPTION, color=FG, monospace=True,
+                     size=TEXT_CAPTION, color=theme.fg, monospace=True,
                      align="left_center", max_width=val_w, elide=True)
 
             # Row divider (skip last row)
             if i < len(self.rows) - 1:
                 div_y = row_y + self.ROW_H
-                ctx.rect(x + 1.0, div_y, w - 2.0, 1.0, BG)
+                ctx.rect(x + 1.0, div_y, w - 2.0, 1.0, theme.bg)
 
 
 @dataclass

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -680,6 +680,11 @@ class FooterKeys(Component):
     in the footer context.
     """
     shortcuts: List[tuple]  # list of (key_or_keys, description)
+    # Draw the separating rule above the chip row. True for true footers
+    # (bottom of a pane). Set False when this row sits directly under an
+    # AppBar, whose own bottom divider already separates it — otherwise the
+    # two rules stack with dead space between them.
+    divider: bool = True
 
     # TOP_GAP reduced from SPACE_MD (12px) to SPACE_SM (8px) — trimmer chrome.
     TOP_GAP = SPACE_SM
@@ -691,16 +696,20 @@ class FooterKeys(Component):
     ROW_H = CHIP_H + 2.0  # reduced from +4.0 — tighter without cramping chips
 
     def measure(self, avail_w: float) -> float:
+        if not self.divider:
+            return self.TOP_GAP + self.ROW_H
         return self.TOP_GAP + 1.0 + self.TOP_GAP + self.ROW_H
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         # Opaque BG backdrop so any content scrolled behind the footer doesn't
         # bleed through the divider line.
         ctx.rect(x, y, w, h, theme.bg)
-        line_y = y + self.TOP_GAP
-        ctx.rect(x, line_y, w, 1.0, theme.highlight)
-
-        chip_row_y = line_y + 1.0 + self.TOP_GAP
+        if self.divider:
+            line_y = y + self.TOP_GAP
+            ctx.rect(x, line_y, w, 1.0, theme.highlight)
+            chip_row_y = line_y + 1.0 + self.TOP_GAP
+        else:
+            chip_row_y = y + self.TOP_GAP
 
         # Single host-measured shortcuts row — host owns ALL geometry:
         # chip widths from real font metrics, inter-group flow, and

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -346,8 +346,10 @@ class AppBar(Component):
 
     TITLE_SIZE = 16.0
     SUBTITLE_SIZE = TEXT_HINT
-    BAND_H = 36.0
-    BAND_H_DOUBLE = 52.0
+    BAND_H = 34.0
+    # Two-line band = SPACE_SM top + title + SPACE_XS + subtitle + SPACE_SM
+    # bottom = 8 + 16 + 4 + 12 + 8 = 48. Snug, symmetric padding.
+    BAND_H_DOUBLE = 48.0
     DIVIDER_H = 1.0
 
     def _band(self) -> float:
@@ -697,7 +699,8 @@ class FooterKeys(Component):
 
     def measure(self, avail_w: float) -> float:
         if not self.divider:
-            return self.TOP_GAP + self.ROW_H
+            # Symmetric padding above and below the chip row.
+            return self.TOP_GAP + self.ROW_H + self.TOP_GAP
         return self.TOP_GAP + 1.0 + self.TOP_GAP + self.ROW_H
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
@@ -709,7 +712,8 @@ class FooterKeys(Component):
             ctx.rect(x, line_y, w, 1.0, theme.highlight)
             chip_row_y = line_y + 1.0 + self.TOP_GAP
         else:
-            chip_row_y = y + self.TOP_GAP
+            # Center the chip row vertically within its symmetric band.
+            chip_row_y = y + self.TOP_GAP + (self.ROW_H - self.CHIP_H) / 2.0
 
         # Single host-measured shortcuts row — host owns ALL geometry:
         # chip widths from real font metrics, inter-group flow, and

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -721,9 +721,9 @@ class FooterKeys(Component):
         # width math, no truncation, no overlap. This is the whole
         # point of the host-measured layout primitives (#312).
         ctx.shortcuts(
-            x=x,
+            x=x + SPACE_MD,
             y=chip_row_y,
-            max_width=w,
+            max_width=w - 2 * SPACE_MD,
             pairs=list(self.shortcuts),
             font_size=TEXT_HINT,
         )

--- a/sdk/python/tests/test_appbar.py
+++ b/sdk/python/tests/test_appbar.py
@@ -1,13 +1,15 @@
 """Tests for AppBar component layout."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
-from plexi_sdk.ui import AppBar
+from plexi_sdk import theme
+from plexi_sdk.ui import AppBar, SPACE_MD
 
 
 def test_appbar_text_y_centered() -> None:
     """AppBar.render places the title text at exactly (BAND_H - TITLE_SIZE) / 2
-    below the component's y origin — no empirical nudge."""
+    below the component's y origin, inset by SPACE_MD on the left. With no
+    explicit accent, the title color resolves to the active theme foreground."""
     bar = AppBar("test")
 
     # measure() must return BAND_H + DIVIDER_H = 36 + 1 = 37.0
@@ -16,14 +18,14 @@ def test_appbar_text_y_centered() -> None:
     ctx = MagicMock()
     bar.render(ctx, x=0, y=0, w=200, h=37)
 
-    # Expected text_y: 0 + (36 - 16) / 2 = 10.0
+    # Expected text_y: 0 + (36 - 16) / 2 = 10.0; text_x: x + SPACE_MD.
     ctx.text.assert_called_once_with(
-        0,
+        SPACE_MD,
         10.0,
         "test",
         size=AppBar.TITLE_SIZE,
-        color=bar.accent,
+        color=theme.fg,
         bold=True,
-        max_width=200,
+        max_width=200 - 2 * SPACE_MD,
         elide=True,
     )

--- a/sdk/python/tests/test_appbar.py
+++ b/sdk/python/tests/test_appbar.py
@@ -12,16 +12,16 @@ def test_appbar_text_y_centered() -> None:
     explicit accent, the title color resolves to the active theme foreground."""
     bar = AppBar("test")
 
-    # measure() must return BAND_H + DIVIDER_H = 36 + 1 = 37.0
-    assert bar.measure(200) == 37.0
+    # measure() must return BAND_H + DIVIDER_H = 34 + 1 = 35.0
+    assert bar.measure(200) == 35.0
 
     ctx = MagicMock()
-    bar.render(ctx, x=0, y=0, w=200, h=37)
+    bar.render(ctx, x=0, y=0, w=200, h=35)
 
-    # Expected text_y: 0 + (36 - 16) / 2 = 10.0; text_x: x + SPACE_MD.
+    # Expected text_y: 0 + (34 - 16) / 2 = 9.0; text_x: x + SPACE_MD.
     ctx.text.assert_called_once_with(
         SPACE_MD,
-        10.0,
+        9.0,
         "test",
         size=AppBar.TITLE_SIZE,
         color=theme.fg,

--- a/skills/create-plexi-app/SKILL.md
+++ b/skills/create-plexi-app/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-plexi-app
 description: Use when building, scaffolding, or modifying a Plexi Python app. Covers manifest, SDK surface, key-handling, the dev loop, render verification, and logging requirements.
-skill_version: "0.0.470"
+skill_version: "0.0.471"
 ---
 
 # Build a Plexi App
@@ -113,6 +113,9 @@ MyApp().run()
 | `ctx.info/warn/error/debug(msg)` | Log from render |
 | `ctx.notify(title, body)` | Fire-and-forget notification |
 | `ctx.schedule_render(after_ms)` | Request re-render after delay |
+| `ctx.theme` | Live host theme — read colors via `ctx.theme.<role>` |
+
+**Theme (`ctx.theme`):** populated from the `Init` payload; reflects light/dark mode AND the user's custom `[theme]` overrides in `config.toml`. Roles (all `#rrggbb` strings): `bg`, `bg_darkest`, `surface`, `highlight`, `border`, `fg`, `muted`, `text_section`, `accent`, `danger` (alias `red`), `success` (alias `green`), `warning` (alias `yellow`). Also a module-level singleton: `from plexi_sdk import theme` — same object, useful in module-level helpers that lack a `ctx`. Prefer `ctx.theme.<role>` over the frozen `BG`/`FG`/... constants so the app tracks the host theme.
 
 **Prefer `ctx.render(tree)` from `plexi_sdk.ui`** for standard layouts — use raw draw calls only for custom visuals.
 
@@ -157,7 +160,7 @@ ctx.render(Column([
 
 ### Constants (`from plexi_sdk import ...`)
 
-**Colors (Catppuccin Mocha):** `BG`, `SURFACE`, `HIGHLIGHT`, `ACCENT`, `MUTED`, `FG`, `RED`, `GREEN`, `YELLOW`  
+**Colors (dark-mode fallbacks only):** `BG`, `SURFACE`, `HIGHLIGHT`, `ACCENT`, `MUTED`, `FG`, `RED`, `GREEN`, `YELLOW` — frozen Catppuccin Mocha. Theme-aware apps should prefer `ctx.theme.<role>` (or the imported `theme` singleton) so they respect light/dark + user `[theme]` overrides.  
 **Font sizes:** `TITLE=22`, `HEADING=18`, `BODY=15`, `CAPTION=13`, `HINT=12`, `MONO_BODY=14`, `MONO_SMALL=12`  
 **Layout:** `PAD=16`, `PAD_TIGHT=8`, `HEADER_H=48`, `STATUS_H=44`  
 **Notification priorities:** `PRIORITY_LOW=0`, `PRIORITY_NORMAL=50`, `PRIORITY_HIGH=100`, `PRIORITY_CRITICAL=200`  
@@ -255,6 +258,16 @@ Tell the user: "Open this in your terminal pane — do NOT run it from Claude Co
 
 **Never surface an app to the user without passing render verify first.**
 
+### Editing the SDK itself — `PLEXI_SDK_PATH`
+
+The SDK is embedded into the binary at build time and re-extracted to the profile dir on every launch. Editing `sdk/python/plexi_sdk/*.py` in a worktree does **nothing** until you rebuild + reinstall the binary — unless you set `PLEXI_SDK_PATH`. It prepends your worktree SDK to `PYTHONPATH`, loading it live. Honored by both `app render` (headless) and live pane launches.
+
+```bash
+PLEXI_SDK_PATH="$PWD/sdk/python" <plexi-binary> app render <app-id> --state state.json --output /tmp/<app-id>.png
+```
+
+Without it, you must rebuild + reinstall the binary to test SDK changes.
+
 ---
 
 ## Logging requirements (not optional)
@@ -334,4 +347,5 @@ Any alpha below 160 is effectively invisible on Catppuccin Mocha dark background
 | Using `ctrl` for primary shortcuts | Prefer `meta` (⌘) on macOS |
 | `ctx.text(w - N, y, hint, CAPTION, MUTED)` near right edge | Use `ctx.text(max(w/2, w - N), y, hint, CAPTION, MUTED, align="right")` — prevents left-clip in narrow panes |
 | `dim(FG, 80)` or `dim(FG, 120)` for labels | Minimum readable alpha is 160 — use `dim(FG, 160)` for de-emphasized text |
+| Frozen `BG`/`FG`/`MUTED` constants for app-drawn chrome | Use `ctx.theme.bg` / `ctx.theme.fg` / `ctx.theme.muted` so the app tracks the host theme (light/dark + user overrides) |
 | Pyright variance warnings on `list[Label]` in `Card([...])` | Benign — `List[Component]` invariance is a type stub issue, not a runtime error. Do not restructure correct code to silence it. |

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -65,6 +65,11 @@ pub enum PlexiEvent {
         compact_threshold: f32,
         #[serde(default = "default_regular_threshold")]
         regular_threshold: f32,
+        /// Active host theme as a `role -> #rrggbb` map (see `Colors::to_theme_map`).
+        /// Lets app-drawn chrome track the host theme (light/dark + user overrides).
+        /// Empty map ⇒ app falls back to its built-in dark constants.
+        #[serde(default)]
+        theme: std::collections::HashMap<String, String>,
     },
     /// Request a new frame. App replies with DrawCommands terminated by FrameDone.
     Render {

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -4,7 +4,6 @@
 
 use crate::app_protocol::{ControlCommand, DrawCommand, PlexiEvent, Rect as ProtoRect, RenderCommand};
 use crate::theme::Colors;
-use egui::Color32;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write as IoWrite};
 use std::path::Path;
@@ -55,9 +54,14 @@ fn spawn_and_collect_frame(
             cmd.env(k, v);
         }
     }
-    // PYTHONPATH: config-dir SDK first, then bundle SDK if present.
+    // PYTHONPATH: dev override (PLEXI_SDK_PATH) first, then config-dir SDK,
+    // then bundle SDK if present.
     let sdk_dir = crate::config::config_dir().join("sdk");
     let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
+    if let Some(dev_sdk) = crate::config::sdk_path_override() {
+        pythonpath = format!("{}:{}", dev_sdk.to_string_lossy(), pythonpath);
+        log::info!("app_render[{app_id}]: PLEXI_SDK_PATH override active -> {}", dev_sdk.display());
+    }
     let bundle_sdk = std::env::current_exe()
         .ok()
         .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
@@ -86,6 +90,7 @@ fn spawn_and_collect_frame(
         feature_flags: vec![],
         compact_threshold: 280.0,
         regular_threshold: 480.0,
+        theme: render_colors().to_theme_map(),
     };
     let init_json = serde_json::to_string(&init)
         .map_err(|e| format!("failed to serialize Init: {e}"))?;
@@ -190,7 +195,7 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
         ..Default::default()
     };
 
-    let colors = default_colors();
+    let colors = render_colors();
     let mut cm_cache = egui_commonmark::CommonMarkCache::default();
     let peaks: HashMap<String, f32> = HashMap::new();
     let mut img_cache = crate::process_app::image_cache::ImageCache::new();
@@ -345,22 +350,10 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
     Ok(png_data)
 }
 
-fn default_colors() -> Colors {
-    Colors {
-        bg_darkest: Color32::from_rgb(0x11, 0x11, 0x1b),
-        bg_sidebar: Color32::from_rgb(0x18, 0x18, 0x25),
-        bg_toolbar: Color32::from_rgb(0x18, 0x18, 0x25),
-        terminal_bg: Color32::from_rgb(0x29, 0x2a, 0x44),
-        bg_hover: Color32::from_rgb(0x2a, 0x2a, 0x3c),
-        bg_sidebar_hover: Color32::from_rgb(0x2e, 0x2e, 0x48),
-        bg_active: Color32::from_rgb(0x31, 0x31, 0x44),
-        text_primary: Color32::from_rgb(0xcd, 0xd6, 0xf4),
-        text_dim: Color32::from_rgb(0x6c, 0x70, 0x86),
-        text_section: Color32::from_rgb(0x58, 0x5b, 0x70),
-        accent: Color32::from_rgb(0x89, 0xb4, 0xfa),
-        border: Color32::from_rgb(0x2a, 0x2a, 0x3c),
-        danger: Color32::from_rgb(0xff, 0x55, 0x55),
-        terminal_fg_bytes: [0xe8, 0xe6, 0xed],
-        terminal_bg_bytes: [0x29, 0x2a, 0x44],
-    }
+/// Resolve the colors used for headless render: the user's actual configured
+/// theme when a config exists, falling back to the built-in dark defaults.
+/// This makes `app render` output match what the GUI shows (light/dark + overrides).
+fn render_colors() -> Colors {
+    let config = crate::config::PlexiConfig::load_with_workspace(None);
+    crate::theme::colors_from_config(&config)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -612,6 +612,27 @@ pub fn config_dir() -> PathBuf {
         .join(config_dir_name())
 }
 
+/// Dev override: when `PLEXI_SDK_PATH` is set, Python apps import the SDK from
+/// that directory (which must contain the `plexi_sdk` package) instead of the
+/// binary-embedded copy. This enables live SDK iteration — edit
+/// `sdk/python/plexi_sdk/*.py`, re-render, no rebuild. Returns the path only if
+/// it exists and actually contains a `plexi_sdk` package; otherwise `None` so a
+/// stale/typo'd value fails loudly via the missing-import rather than silently.
+pub fn sdk_path_override() -> Option<PathBuf> {
+    let raw = std::env::var_os("PLEXI_SDK_PATH")?;
+    let path = PathBuf::from(raw);
+    if path.join("plexi_sdk").join("__init__.py").is_file() {
+        Some(path)
+    } else {
+        eprintln!(
+            "PLEXI_SDK_PATH={} does not contain a plexi_sdk package (expected {}/plexi_sdk/__init__.py) — ignoring",
+            path.display(),
+            path.display()
+        );
+        None
+    }
+}
+
 pub const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");
 
 /// Ensures the config file exists, creating it from the default template if not.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -442,6 +442,12 @@ impl ProcessApp {
             pythonpath.push(':');
             pythonpath.push_str(&bundle_sdk.to_string_lossy());
         }
+        // Dev override: PLEXI_SDK_PATH wins over the embedded/bundled SDK so the
+        // worktree SDK can be iterated live without a rebuild (see config::sdk_path_override).
+        if let Some(dev_sdk) = crate::config::sdk_path_override() {
+            pythonpath = format!("{}:{}", dev_sdk.to_string_lossy(), pythonpath);
+            log::info!("process_app[{type_id}]: PLEXI_SDK_PATH override active -> {}", dev_sdk.display());
+        }
 
         // Static capability validation — runs before the real spawn.
         // For Python apps only; non-Python apps skip. Subprocess failures log warn and proceed.
@@ -1347,6 +1353,7 @@ impl App for ProcessApp {
                 feature_flags: vec!["pane_groups_v1".into()],
                 compact_threshold: self.compact_threshold,
                 regular_threshold: self.regular_threshold,
+                theme: ctx.colors.to_theme_map(),
             });
             // Inject persisted state before first render so on_inject runs with data.
             let state = load_app_state(&self.type_id, &self.workspace_root);

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -557,7 +557,7 @@ pub(crate) fn render_draw_commands(
                                             badge_y,
                                             label,
                                             color,
-                                            "#1e1e2e",
+                                            contrast_text_hex(color),
                                             FONT_HINT,
                                             3.0,
                                         );
@@ -1013,6 +1013,19 @@ pub(crate) fn render_draw_commands(
 /// Renders a pill badge at (`origin.x + x`, vertically centred on `origin.y + y_center`).
 /// Returns the pill width so callers can flow following content past the badge
 /// instead of assuming a fixed slot (which clips wide labels like `#1792`).
+/// Pick a legible text color for a filled chip/badge based on the fill's
+/// perceptual luminance. Dark fills get light text, light fills get dark text.
+/// Returns a hex string so it can be threaded through the `&str` fg params.
+pub(crate) fn contrast_text_hex(fill: &str) -> &'static str {
+    match parse_color(fill) {
+        Some(c) => {
+            let lum = 0.299 * c.r() as f32 + 0.587 * c.g() as f32 + 0.114 * c.b() as f32;
+            if lum > 140.0 { "#1e1e2e" } else { "#ffffff" }
+        }
+        None => "#1e1e2e",
+    }
+}
+
 pub(crate) fn render_badge(
     ui: &mut egui::Ui,
     origin: egui::Pos2,

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -406,6 +406,7 @@ pub(crate) fn render_draw_commands(
                 const PAD_X: f32 = 12.0;
                 const CHIP_GAP: f32 = 4.0;
                 const CHIP_PAD_X: f32 = 8.0;
+                const BADGE_TEXT_GAP: f32 = 8.0;
                 const SPACE_XS: f32 = 4.0;
                 const SCROLLBAR_W: f32 = 3.0;
                 const FONT_CAPTION: f32 = 13.0;
@@ -563,7 +564,6 @@ pub(crate) fn render_draw_commands(
                                         // Flow the title past the badge's real width so wide
                                         // labels (e.g. "#1792") never clip the title; keep at
                                         // least the old fixed slot so short badges stay aligned.
-                                        const BADGE_TEXT_GAP: f32 = 8.0;
                                         (list_rect.min.x + PAD_X + badge_w + BADGE_TEXT_GAP)
                                             .max(list_rect.min.x + LEADING_W)
                                     }
@@ -659,12 +659,48 @@ pub(crate) fn render_draw_commands(
                                     cx += chip_w + CHIP_GAP;
                                 }
 
-                                // Primary text
+                                // Primary text — elide so the title never runs
+                                // under the right-aligned chips / trailing text.
+                                let primary_font = egui::FontId::proportional(FONT_CAPTION);
+                                let has_right = !row.chips.is_empty() || row.trailing.is_some();
+                                let text_right = if has_right {
+                                    list_rect.max.x - PAD_X - trailing_reserve - chips_reserve - BADGE_TEXT_GAP
+                                } else {
+                                    list_rect.max.x - PAD_X
+                                };
+                                let avail_w = (text_right - text_start_x).max(0.0);
+                                let display_primary: std::borrow::Cow<'_, str> = {
+                                    let galley = ui.fonts(|f| {
+                                        f.layout_no_wrap(
+                                            row.primary.clone(),
+                                            primary_font.clone(),
+                                            colors.text_primary,
+                                        )
+                                    });
+                                    if galley.size().x > avail_w {
+                                        let mut lo = 0usize;
+                                        let mut hi = row.primary.chars().count();
+                                        while lo + 1 < hi {
+                                            let mid = (lo + hi) / 2;
+                                            let candidate: String =
+                                                row.primary.chars().take(mid).collect::<String>() + "…";
+                                            let g = ui.fonts(|f| {
+                                                f.layout_no_wrap(candidate, primary_font.clone(), colors.text_primary)
+                                            });
+                                            if g.size().x <= avail_w { lo = mid; } else { hi = mid; }
+                                        }
+                                        std::borrow::Cow::Owned(
+                                            row.primary.chars().take(lo).collect::<String>() + "…",
+                                        )
+                                    } else {
+                                        std::borrow::Cow::Borrowed(row.primary.as_str())
+                                    }
+                                };
                                 painter.text(
                                     egui::pos2(text_start_x, primary_y),
                                     egui::Align2::LEFT_TOP,
-                                    row.primary.as_str(),
-                                    egui::FontId::proportional(FONT_CAPTION),
+                                    display_primary.as_ref(),
+                                    primary_font,
                                     colors.text_primary,
                                 );
 

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -785,9 +785,15 @@ pub(crate) fn render_draw_commands(
                 if !md_rect.is_positive() {
                     continue;
                 }
+                // Lay the markdown out at the full requested rect (whose top may
+                // sit above the clip when a Scrollable has offset it upward), and
+                // clip to the visible intersection. Using md_rect as the layout
+                // rect would re-anchor content to the top of the visible area
+                // every frame, so a scroll offset would move the scrollbar but
+                // never the text.
                 let mut child = ui.new_child(
                     egui::UiBuilder::new()
-                        .max_rect(md_rect)
+                        .max_rect(requested_rect)
                         .layout(egui::Layout::top_down(egui::Align::LEFT)),
                 );
                 child.set_clip_rect(md_rect);

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -548,7 +548,7 @@ pub(crate) fn render_draw_commands(
                                         // render_badge takes origin + pane-local coords
                                         let badge_x = list_rect.min.x - pane_rect.min.x + PAD_X;
                                         let badge_y = row_abs_y - pane_rect.min.y + h_item / 2.0;
-                                        render_badge(
+                                        let badge_w = render_badge(
                                             ui,
                                             pane_rect.min,
                                             list_clip,
@@ -560,7 +560,12 @@ pub(crate) fn render_draw_commands(
                                             FONT_HINT,
                                             3.0,
                                         );
-                                        list_rect.min.x + LEADING_W
+                                        // Flow the title past the badge's real width so wide
+                                        // labels (e.g. "#1792") never clip the title; keep at
+                                        // least the old fixed slot so short badges stay aligned.
+                                        const BADGE_TEXT_GAP: f32 = 8.0;
+                                        (list_rect.min.x + PAD_X + badge_w + BADGE_TEXT_GAP)
+                                            .max(list_rect.min.x + LEADING_W)
                                     }
                                     Some(ListViewLeading::Avatar { handle }) => {
                                         let avatar_r = 14.0;
@@ -969,6 +974,9 @@ pub(crate) fn render_draw_commands(
 // overlays that reuse these helpers always match.
 
 /// Render a Badge pill. `x` is the left edge; `y` is the vertical centre.
+/// Renders a pill badge at (`origin.x + x`, vertically centred on `origin.y + y_center`).
+/// Returns the pill width so callers can flow following content past the badge
+/// instead of assuming a fixed slot (which clips wide labels like `#1792`).
 pub(crate) fn render_badge(
     ui: &mut egui::Ui,
     origin: egui::Pos2,
@@ -980,7 +988,7 @@ pub(crate) fn render_badge(
     fg: &str,
     font_size: f32,
     radius: f32,
-) {
+) -> f32 {
     let fill_color = parse_color(fill).unwrap_or(egui::Color32::from_rgb(0x89, 0xb4, 0xfa));
     let fg_color = parse_color(fg).unwrap_or(egui::Color32::from_rgb(0x1e, 0x1e, 0x2e));
     let font_id = egui::FontId::proportional(font_size);
@@ -1001,6 +1009,7 @@ pub(crate) fn render_badge(
     let text_x = pill_rect.center().x - text_w / 2.0;
     let text_y = pill_rect.center().y - text_h / 2.0;
     painter.galley(egui::pos2(text_x, text_y), galley, fg_color);
+    pill_w
 }
 
 /// Render a single KeyChip at absolute position (`origin.x + x`, `origin.y + y`).

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,6 +33,8 @@ pub struct Colors {
     pub border: Color32,
     // Semantic state colors
     pub danger: Color32,
+    pub success: Color32,
+    pub warning: Color32,
     // Terminal fg/bg as bytes for dynamic colors
     pub terminal_fg_bytes: [u8; 3],
     pub terminal_bg_bytes: [u8; 3],
@@ -55,10 +57,60 @@ impl Colors {
             border: parse_hex_or(&cfg.border, Color32::from_rgb(0x2a, 0x2a, 0x3c)),
             // Derive from the theme's ANSI red; fallback matches the Dracula red used in event_log.rs.
             danger: parse_hex_or(&cfg.red, Color32::from_rgb(0xff, 0x55, 0x55)),
+            success: parse_hex_or(&cfg.green, Color32::from_rgb(0xa6, 0xe3, 0xa1)),
+            warning: parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
             terminal_fg_bytes: hex_to_bytes(cfg.foreground.as_deref(), [0xe8, 0xe6, 0xed]),
             terminal_bg_bytes: hex_to_bytes(cfg.background.as_deref(), [0x29, 0x2a, 0x44]),
         }
     }
+
+    /// Serialize the semantic color roles to a `role -> #rrggbb` map for the
+    /// SDK `Init` payload. Apps read these via `ctx.theme.<role>` so app-drawn
+    /// chrome tracks the host theme (light/dark + user `[theme]` overrides).
+    /// Both the SDK-semantic names (bg/surface/muted/...) and ANSI aliases
+    /// (red/green/yellow) are emitted so apps can pull whichever they need.
+    pub fn to_theme_map(&self) -> std::collections::HashMap<String, String> {
+        fn hex(c: Color32) -> String {
+            format!("#{:02x}{:02x}{:02x}", c.r(), c.g(), c.b())
+        }
+        // `bg` is the color the host paints behind the app pane (terminal_bg),
+        // so an app that clears to theme.bg matches its container in any theme.
+        [
+            ("bg", self.terminal_bg),
+            ("bg_darkest", self.bg_darkest),
+            ("surface", self.bg_active),
+            ("highlight", self.bg_hover),
+            ("border", self.border),
+            ("fg", self.text_primary),
+            ("muted", self.text_dim),
+            ("text_section", self.text_section),
+            ("accent", self.accent),
+            ("danger", self.danger),
+            ("red", self.danger),
+            ("success", self.success),
+            ("green", self.success),
+            ("warning", self.warning),
+            ("yellow", self.warning),
+        ]
+        .into_iter()
+        .map(|(k, c)| (k.to_string(), hex(c)))
+        .collect()
+    }
+}
+
+/// Resolve the active `Colors` from a loaded config: merges the user's
+/// `[theme]` overrides over the named preset (or pure user config if no
+/// preset). Shared by the GUI and the headless `app render` path.
+pub fn colors_from_config(config: &crate::config::PlexiConfig) -> Colors {
+    let user_theme = config.theme.clone().unwrap_or_default();
+    let cfg = match &config.theme_preset {
+        Some(preset_name) => match preset_colors(preset_name) {
+            Some(preset) => apply_preset(&preset, &user_theme),
+            None => user_theme,
+        },
+        None => user_theme,
+    };
+    Colors::from_config(&cfg)
 }
 
 fn hex_to_bytes(s: Option<&str>, default: [u8; 3]) -> [u8; 3] {


### PR DESCRIPTION
Closes #1792

## Summary

- Remove hardcoded pixel constants (`HEADER_H = 52`, `ROW_H = 38`, `KEY_COL = 90`) from gh-issues app; all layout now delegated to `plexi_sdk.ui` components
- List view header replaced with `AppBar` (title + count subtitle) + `FooterKeys` (shortcuts) — heights computed via `.measure()` so `ctx.list_view` gets the correct `y` offset dynamically
- Detail view `_draw_detail` replaced with `ctx.render(Column([AppBar, InfoTable, Section, Scrollable, FooterKeys]))` — no manual `y +=` cursor; body scrollable with j/k via stable `Scrollable` instance; `state.json` fixture committed for headless render iteration

## Done When

- `plexi app render gh-issues --state state.json` produces a PNG with no overlapping elements in list view (titles clear of badges, header clear of shortcuts)
- Same command with `_view: "detail"` produces a readable detail card with no element overlap
- The app opens on the alpha build and visually matches the PNG
- `apps/dev/gh-issues/main.py` contains no manual pixel-offset constants (`HEADER_H`, `KEY_COL`, etc.) — all layout delegated to `plexi_sdk.ui`
- `state.json` fixture committed alongside the app for future iteration

## Notes

- `_MarkdownBlock` is a private `Component` subclass in `main.py` (not added to `ui.py`) — wraps `ctx.markdown()` so markdown body fits inside the `Column` tree without an escape hatch
- `Scrollable` instance created once in `on_init`; scroll offset reset to `0.0` in `_open_detail()` on each new issue open; child swapped each render frame
- `_markdown_measure_lines` is a private SDK function (underscore prefix) but it's the right tool here — same technique used in `ChatBubble`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned issue detail view: metadata card plus scrollable markdown body with preserved scroll position and keyboard scrolling.
  * Live theming: runtime theme exposed in the SDK so apps adapt to host-provided colors.
* **UI Improvements**
  * Improved list item layout and title truncation; labels and chrome now follow the active theme.
* **Documentation**
  * SDK docs updated with theme guidance and live-editing via PLEXI_SDK_PATH.
* **Chores**
  * Init payload now carries theme data; dev SDK override support added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->