### PR TITLE
fix(sdk/pgap): mouse-wheel scroll has no effect in SDK Scrollable containers (#1794)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -312,6 +312,11 @@ class GhIssues(App):
     def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> None:
         pass
 
+    def on_scroll_delta(self, ctx: RenderContext, delta_y: float) -> None:
+        if self._view == self.VIEW_DETAIL:
+            self._body_scroll.handle_scroll(delta_y)
+            self.emit.schedule_render()
+
     # ── actions ───────────────────────────────────────────────────────────────
 
     def _open_detail(self) -> None:

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -312,7 +312,7 @@ class GhIssues(App):
     def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> None:
         pass
 
-    def on_scroll_delta(self, ctx: RenderContext, delta_y: float) -> None:
+    def on_scroll_delta(self, _ctx: RenderContext, delta_y: float) -> None:
         if self._view == self.VIEW_DETAIL:
             self._body_scroll.handle_scroll(delta_y)
             self.emit.schedule_render()

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -299,6 +299,7 @@ class App:
 
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
+    def on_scroll_delta(self, _ctx: RenderContext, _delta_y: float) -> "Coroutine[Any, Any, None] | None": return None
     def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when a list_view selection changes via j/k/up/down."""
         return None
@@ -1059,6 +1060,17 @@ class App:
                         await self._dispatch_hook(self.on_scroll, ctx, scroll_id, offset_y)
                     except Exception as e:
                         sys.stderr.write(f"on_scroll handler raised: {e}\n")
+
+                elif t == "scroll":
+                    # Raw wheel delta for SDK Scrollable containers (#1794).
+                    # Fires when the cursor is over the app pane but not over a
+                    # host-managed BeginScroll region or ListView.
+                    delta_y = float(ev.get("delta_y", 0.0))
+                    ctx = self._make_ctx()
+                    try:
+                        await self._dispatch_hook(self.on_scroll_delta, ctx, delta_y)
+                    except Exception as e:
+                        sys.stderr.write(f"on_scroll_delta handler raised: {e}\n")
 
                 elif t == "list_select":
                     _lid = ev.get("id")

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -544,9 +544,9 @@ class Scrollable(Component):
         Returns True (always consumes the event). Call from the app's
         on_scroll_delta handler:
 
-            def on_scroll_delta(self, ctx, delta_y):
+            def on_scroll_delta(self, _ctx, delta_y):
                 self._scrollable.handle_scroll(delta_y)
-                ctx.request_render()
+                self.emit.schedule_render()
 
         `delta_y` is positive when scrolling up (matches egui's
         smooth_scroll_delta convention). The offset is clamped to

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -488,12 +488,8 @@ class Scrollable(Component):
     Keyboard scroll: j/k or arrow-down/up keys update `scroll_offset`.
     Apps drive this by calling `handle_key(key)` from their `on_key` handler.
 
-    # IMPL-NOTE: Wheel/touch event plumbing is deferred. The PGAP protocol
-    # doesn't yet carry scroll-wheel events from the host to the app. Once
-    # PlexiEvent::Scroll is wired through (a follow-up to #314), Scrollable
-    # can subscribe to it here with no breaking changes. For now, keyboard
-    # scroll (j/k) is the v1 input source. Apps that need wheel scroll today
-    # should use the host-managed DrawCommand::List primitive instead.
+    Mouse-wheel scroll: call `handle_scroll(delta_y)` from the app's
+    `on_scroll_delta` handler (receives `PlexiEvent::Scroll` from the host).
     """
     child: Component
     scroll_offset: float = field(default=0.0, repr=False)
@@ -541,6 +537,24 @@ class Scrollable(Component):
             self.scroll_offset = max(0.0, self.scroll_offset - self.key_step)
             return True
         return False
+
+    def handle_scroll(self, delta_y: float) -> bool:
+        """Update scroll_offset from a mouse-wheel delta.
+
+        Returns True (always consumes the event). Call from the app's
+        on_scroll_delta handler:
+
+            def on_scroll_delta(self, ctx, delta_y):
+                self._scrollable.handle_scroll(delta_y)
+                ctx.request_render()
+
+        `delta_y` is positive when scrolling up (matches egui's
+        smooth_scroll_delta convention). The offset is clamped to
+        [0, content_height - viewport_height].
+        """
+        self.scroll_offset = max(0.0, self.scroll_offset - delta_y)
+        self._clamp_offset(self._avail_h)
+        return True
 
     def ensure_visible(self, top: float, bottom: float, margin: float = 0.0) -> None:
         """See `ensure_visible(...)` free function. Wrapper for Scrollable's

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -392,6 +392,13 @@ pub enum PlexiEvent {
     /// `max(0, content_height - viewport_height)`.
     ScrollOffset { id: String, offset_y: f32 },
 
+    /// Emitted when the mouse wheel moves over an app pane that has no
+    /// host-managed scroll region or list_view under the cursor.
+    /// `delta_y` is the raw `smooth_scroll_delta.y` value from egui (positive =
+    /// scroll up). SDK `Scrollable` components call `handle_scroll(delta_y)` from
+    /// the app's `on_scroll_delta` handler.
+    Scroll { delta_y: f32 },
+
     /// Emitted when j/k/up/down changes the list selection.
     /// `id` matches the `list_view` id field; `index` is the new selected index.
     ListSelect { id: String, index: usize },

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -330,7 +330,7 @@ impl RenderSession {
             }
         }
 
-        log::debug!("render_session: forwarding wheel delta_y={} to app", scroll_delta.y);
+        log::info!("render_session: forwarding wheel delta_y={} to app", scroll_delta.y);
         self.outbound_events.push(PlexiEvent::Scroll { delta_y: scroll_delta.y });
     }
 

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -46,11 +46,14 @@ impl RenderSession {
         }
     }
 
-    /// Execute all three rendering passes for one frame.
+    /// Execute all rendering passes for one frame.
     ///
     /// Pass 1 — draw commands (painter-only, no egui allocation)
     /// Pass 2 — TextInput widgets (real egui widgets with buffer state)
     /// Pass 3 — scroll region scan (pointer interaction, emits ScrollOffset events)
+    /// Pass 4 — ListView interaction (j/k/enter, scroll gesture)
+    /// Pass 5 — app scroll delta (emits Scroll for SDK Scrollable when wheel
+    ///           moves over the pane but no host-managed region consumed it)
     pub(crate) fn render(
         &mut self,
         ui: &mut egui::Ui,
@@ -84,10 +87,15 @@ impl RenderSession {
         self.render_text_inputs(ui, pane_rect, frame, pane_id, colors);
 
         // ── Pass 3: scroll region scan ───────────────────────────────────────
-        self.render_scroll_regions(ui, pane_rect, frame);
+        let scroll_consumed = self.render_scroll_regions(ui, pane_rect, frame);
 
         // ── Pass 4: ListView interaction (j/k/enter, scroll gesture) ─────────
         self.render_list_views(ui, pane_rect, frame);
+
+        // ── Pass 5: app scroll delta for SDK Scrollable ───────────────────────
+        if !scroll_consumed {
+            self.render_app_scroll(ui, pane_rect, frame);
+        }
     }
 
     /// Pass 2: render every `RenderCommand::TextInput` as a real egui `TextEdit`.
@@ -238,18 +246,20 @@ impl RenderSession {
     }
 
     /// Pass 3: scan for scroll regions and emit `ScrollOffset` events.
+    /// Returns true if a `BeginScroll` region consumed the wheel input so that
+    /// Pass 5 knows not to emit a fallback `PlexiEvent::Scroll`.
     fn render_scroll_regions(
         &mut self,
         ui: &mut egui::Ui,
         pane_rect: egui::Rect,
         frame: &[RenderCommand],
-    ) {
+    ) -> bool {
         let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
         if scroll_delta.y == 0.0 {
-            return;
+            return false;
         }
         let Some(pointer_pos) = ui.input(|i| i.pointer.hover_pos()) else {
-            return;
+            return false;
         };
 
         let mut scroll_regions: Vec<(&String, egui::Rect, f32)> = Vec::new();
@@ -277,9 +287,51 @@ impl RenderSession {
                         offset_y: next,
                     });
                 }
-                break;
+                return true;
             }
         }
+        false
+    }
+
+    /// Pass 5: forward raw wheel delta to the app as `PlexiEvent::Scroll` so
+    /// SDK `Scrollable` components can update their offset. Only fires when no
+    /// `BeginScroll` region consumed the event (Pass 3 returns false) and the
+    /// cursor is over the pane but not over a `ListView` rect (Pass 4 handles
+    /// those).
+    fn render_app_scroll(
+        &mut self,
+        ui: &mut egui::Ui,
+        pane_rect: egui::Rect,
+        frame: &[RenderCommand],
+    ) {
+        let scroll_delta = ui.input(|i| i.smooth_scroll_delta);
+        if scroll_delta.y == 0.0 {
+            return;
+        }
+        let Some(pointer_pos) = ui.input(|i| i.pointer.hover_pos()) else {
+            return;
+        };
+        if !pane_rect.contains(pointer_pos) {
+            return;
+        }
+
+        // Skip if the cursor is inside a ListView (Pass 4 already handled it).
+        for cmd in frame {
+            if let RenderCommand::ListView { x, y, w, h, .. } = cmd {
+                let list_w = if *w > 0.0 { *w } else { pane_rect.width() };
+                let list_h = if *h > 0.0 { *h } else { pane_rect.height() - y };
+                let list_rect = egui::Rect::from_min_size(
+                    egui::pos2(pane_rect.min.x + x, pane_rect.min.y + y),
+                    egui::vec2(list_w, list_h),
+                );
+                if list_rect.contains(pointer_pos) {
+                    return;
+                }
+            }
+        }
+
+        log::debug!("render_session: forwarding wheel delta_y={} to app", scroll_delta.y);
+        self.outbound_events.push(PlexiEvent::Scroll { delta_y: scroll_delta.y });
     }
 
     /// Private helper: drain the buffer for `id` and push a `TextSubmitted` event


### PR DESCRIPTION
Closes #1794

## Summary

- Adds `PlexiEvent::Scroll { delta_y }` emitted by a new render Pass 5 in `render_session.rs` when the mouse wheel moves over an app pane but no `BeginScroll` region or `ListView` rect consumed it
- Adds `Scrollable.handle_scroll(delta_y)` to the SDK mirroring `handle_key()`, and routes the new host event through `App.on_scroll_delta(ctx, delta_y)`
- Wires `on_scroll_delta` in the gh-issues app so wheel scroll over the detail body advances `_body_scroll`

## Done When

Wheel-scrolling over the gh-issues detail body (or any `Scrollable`) moves the content, and the scrollbar tracks it, on the alpha build.

## Notes

Pass 5 fires only when neither a `BeginScroll` region (Pass 3) nor a `ListView` rect (Pass 4) is under the cursor — the existing scroll handling for those surfaces is unchanged. `delta_y` sign matches egui's `smooth_scroll_delta` convention (positive = up).