### PR TITLE
fix(host/navigation): app key dispatch ignores OS window focus (#1795)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -8,7 +8,7 @@ use super::PlexiApp;
 mod tests {
     use super::*;
     use crate::app_permissions::AppPermissions;
-    use crate::app_protocol::{NotifyKind, NotifyScope};
+    use crate::app_protocol::{NotifyKind, NotifyScope, PlexiEvent};
     use crate::process_app::ProcessApp;
     use crate::testing::HostHarness;
     /// Regression guard for issue #879: parked background app notifications
@@ -62,6 +62,75 @@ mod tests {
             "source_context_id should be the park-time context_id ({park_context_id}), not hardcoded 0"
         );
     }
+
+    /// Regression guard for issue #1795: key events must not reach an app pane
+    /// when the egui viewport reports `focused = Some(false)` (window out of OS focus).
+    ///
+    /// Strategy: call `dispatch_app_key_events` directly with a hand-crafted context
+    /// that holds a `Paste` event (Paste queues to `outbound_events` directly, so it
+    /// is readable via `effects_drain` before any `flush_outbound_events` call drains
+    /// the queue). With the guard in place, `dispatch_app_key_events` returns before
+    /// `handle_key` is reached, so `outbound_events` stays empty.
+    #[test]
+    fn no_key_dispatch_when_viewport_unfocused() {
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+
+        // Stabilise egui tile structure (bare-pane root rewrites itself on first render).
+        h.run_frames(1);
+
+        // Point window focus at the app pane tile.
+        let tile_id = {
+            let win = &h.app.windows[0];
+            win.tree
+                .tiles
+                .iter()
+                .find_map(|(id, tile)| match tile {
+                    egui_tiles::Tile::Pane(p) if *p == pane => Some(*id),
+                    _ => None,
+                })
+                .expect("test pane must have a tile")
+        };
+        h.app.windows[0].focused_pane = Some(tile_id);
+
+        // Build a fresh egui context with viewport focused = Some(false) and a Paste
+        // event. We call dispatch_app_key_events directly rather than through a full
+        // frame so flush_outbound_events (called inside ui()) cannot drain the queue
+        // before we inspect it.
+        let test_ctx = egui::Context::default();
+        let viewports: egui::ViewportIdMap<egui::ViewportInfo> =
+            std::iter::once((egui::ViewportId::ROOT, {
+                let mut info = egui::ViewportInfo::default();
+                info.focused = Some(false);
+                info
+            }))
+            .collect();
+
+        let _ = test_ctx.run(
+            egui::RawInput {
+                viewports,
+                events: vec![egui::Event::Paste("should-not-arrive".into())],
+                ..Default::default()
+            },
+            |ctx| {
+                h.app.dispatch_app_key_events(ctx);
+            },
+        );
+
+        // outbound_events must be empty: the viewport-focus guard must have returned
+        // before handle_key was reached. Paste queues to outbound_events directly
+        // (unlike Key/Text which go through send_event), so it would be visible here
+        // if the guard were absent.
+        let events = h.effects_drain(pane);
+        let paste_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, PlexiEvent::Paste { .. }))
+            .collect();
+        assert!(
+            paste_events.is_empty(),
+            "Paste must not reach the app when the viewport is unfocused; got {paste_events:?}"
+        );
+    }
 }
 
 impl PlexiApp {
@@ -71,6 +140,12 @@ impl PlexiApp {
     /// apps can surface notifications and other commands while the
     /// focused pane is something else (or while a modal holds focus).
     pub(super) fn dispatch_app_key_events(&mut self, ctx: &egui::Context) {
+        // Block key delivery when the OS has focus elsewhere. `active_window` is not
+        // cleared on blur, so without this guard keys route to the last-active pane
+        // even while a different app (or Plexi window) owns the keyboard.
+        if !ctx.input(|i| i.viewport().focused.unwrap_or(true)) {
+            return;
+        }
         let active = self.active_window;
         let Some(focused_tile) = self.windows[active].focused_pane else {
             return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4367,6 +4367,7 @@ impl eframe::App for PlexiApp {
                                     } else if let Some(a) = pane.as_app_mut() {
                                         let app_ctx = crate::app_trait::AppRenderContext {
                                             colors: &self.colors,
+                                            is_focused: true, // zoomed pane is always focused
                                         };
                                         a.runtime.ui(ui, &app_ctx);
                                     }

--- a/src/app_trait.rs
+++ b/src/app_trait.rs
@@ -12,6 +12,8 @@ pub(crate) enum KeyDisposition {
 /// Context passed to an app during rendering.
 pub struct AppRenderContext<'a> {
     pub colors: &'a Colors,
+    /// Whether this pane is the currently focused pane in its window.
+    pub is_focused: bool,
 }
 
 /// Commands an app can issue back to the system.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1490,7 +1490,7 @@ impl App for ProcessApp {
         }
         let net_http_granted = self.permissions.is_builtin
             || self.permissions.capabilities.contains(&Capability::NetHttp);
-        self.render_session.render(ui, pane_rect, &self.frame, ctx.colors, &mut self.commonmark_cache, &audio_peaks, self.pane_id, &mut self.image_cache, &self.app_dir, net_http_granted);
+        self.render_session.render(ui, pane_rect, &self.frame, ctx.colors, &mut self.commonmark_cache, &audio_peaks, self.pane_id, &mut self.image_cache, &self.app_dir, net_http_granted, ctx.is_focused);
         self.outbound_events.extend(self.render_session.drain_events());
 
         // ── Error fallback ──────────────────────────────────────────────────

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -66,6 +66,7 @@ impl RenderSession {
         image_cache: &mut super::image_cache::ImageCache,
         app_dir: &std::path::Path,
         net_http_granted: bool,
+        is_focused: bool,
     ) {
         log::debug!("render_session: render pane_id={} cmds={}", pane_id, frame.len());
 
@@ -90,7 +91,7 @@ impl RenderSession {
         let scroll_consumed = self.render_scroll_regions(ui, pane_rect, frame);
 
         // ── Pass 4: ListView interaction (j/k/enter, scroll gesture) ─────────
-        self.render_list_views(ui, pane_rect, frame);
+        self.render_list_views(ui, pane_rect, frame, is_focused);
 
         // ── Pass 5: app scroll delta for SDK Scrollable ───────────────────────
         if !scroll_consumed {
@@ -368,6 +369,7 @@ impl RenderSession {
         ui: &mut egui::Ui,
         pane_rect: egui::Rect,
         frame: &[RenderCommand],
+        is_focused: bool,
     ) {
         use crate::app_protocol::PlexiEvent;
 
@@ -425,8 +427,9 @@ impl RenderSession {
                 }
             }
 
-            // j / down
-            let j_pressed = ui.input(|i|
+            // j / down — only when this pane has focus; prevents routing to
+            // background app while a terminal pane is focused (#1795)
+            let j_pressed = is_focused && ui.input(|i|
                 i.key_pressed(egui::Key::J) || i.key_pressed(egui::Key::ArrowDown)
             );
             if j_pressed && sel + 1 < n {
@@ -441,7 +444,7 @@ impl RenderSession {
             }
 
             // k / up
-            let k_pressed = ui.input(|i|
+            let k_pressed = is_focused && ui.input(|i|
                 i.key_pressed(egui::Key::K) || i.key_pressed(egui::Key::ArrowUp)
             );
             if k_pressed && sel > 0 {
@@ -456,7 +459,7 @@ impl RenderSession {
             }
 
             // Enter
-            let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+            let enter_pressed = is_focused && ui.input(|i| i.key_pressed(egui::Key::Enter));
             if enter_pressed {
                 log::info!("ListView[{id}]: enter → activate {sel}");
                 self.outbound_events.push(PlexiEvent::ListActivate {

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -17,7 +17,7 @@ const NAV_BAR_HEIGHT: f32 = 32.0;
 /// Horizontal padding inside the nav bar.
 const NAV_BAR_PAD: f32 = style::SPACE_SM;
 
-pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, _is_focused: bool) {
+pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_focused: bool) {
     // Check if we need a nav bar (non-empty stack).
     let nav_title: Option<String> = app_pane
         .runtime
@@ -68,12 +68,12 @@ pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, _is_fo
             });
 
             // App content fills remaining space.
-            let ctx = AppRenderContext { colors };
+            let ctx = AppRenderContext { colors, is_focused };
             app_pane.runtime.ui(ui, &ctx);
         });
     } else {
         // No nav stack — render app content directly (hot path, no allocation).
-        let ctx = AppRenderContext { colors };
+        let ctx = AppRenderContext { colors, is_focused };
         app_pane.runtime.ui(ui, &ctx);
     }
 }


### PR DESCRIPTION
Closes #1795

## Summary

- `dispatch_app_key_events` now returns early when `ctx.input(|i| i.viewport().focused)` is `Some(false)`, preventing key delivery to app panes while the OS focus is elsewhere
- `unwrap_or(true)` is used so that viewports that don't report a focused state (e.g. tests without explicit viewport info) are unaffected
- HostHarness regression test added: injects a `Paste` event via a direct `dispatch_app_key_events` call with `focused = Some(false)` and asserts `outbound_events` stays empty

## Done When

With an app pane focused, defocusing the window (switch app/window) and pressing j/k produces no scroll/no `PlexiEvent::Key`, verified by the HostHarness test and on alpha.

## Notes

`active_window` is intentionally left as-is (not cleared on blur). The viewport-focus guard is the correct fix — clearing `active_window` would break routing for commands that legitimately arrive while the window is backgrounded (notifications, background ticks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard and paste events are now blocked for unfocused app panes; navigation keys in list views only affect a pane when it is focused.
  * Zoomed panes consistently render with a focused context so interactions behave predictably.

* **Tests**
  * Added a regression test ensuring unfocused panes do not receive paste events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->