### PR TITLE
refactor(secrets): collapse v1/v2 + v3 into one resolver (#1798)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,15 +253,57 @@ pub fn run_command(command_name: &str) -> i32 {
         }
     }
 
-    // Resolve secrets from Keychain
-    let dir_str = cwd.to_string_lossy();
+    // Resolve secrets via workspace-routed v3 resolver.
     let mut resolved: Vec<(String, zeroize::Zeroizing<String>)> = Vec::new();
     let mut missing: Vec<&str> = Vec::new();
 
-    for key in &secret_keys {
-        match crate::secrets::resolve_secret(key, APP_ID, &dir_str) {
-            Some(value) => resolved.push((key.to_string(), value)),
-            None => missing.push(key),
+    if !secret_keys.is_empty() {
+        #[cfg(target_os = "macos")]
+        {
+            use crate::workspace_secrets::{
+                resolve, MacKeychain, ResolveOutcome, WorkspaceConfig, WorkspaceSecrets,
+            };
+            let store = MacKeychain::new();
+            // Load workspace context once — fail early if secrets are required but workspace
+            // is not initialised (missing workspace.toml or secrets.toml).
+            let ws_root = crate::app_registry::resolve_workspace_root(&cwd);
+            let ws_context: Option<(String, WorkspaceSecrets)> =
+                ws_root.as_ref().and_then(|root| {
+                    let cfg = WorkspaceConfig::load(root).ok().flatten()?;
+                    let router = WorkspaceSecrets::load(root).ok().flatten()?;
+                    Some((cfg.id, router))
+                });
+            match ws_context {
+                None => {
+                    log::warn!("run_command: secrets required but no initialized workspace found in {}", cwd.display());
+                    eprintln!("error: command requires secrets but no initialized workspace found.");
+                    eprintln!("  → plexi workspace init   (then: plexi secret set <NAME>)");
+                    return 1;
+                }
+                Some((ws_id, router)) => {
+                    for key in &secret_keys {
+                        match resolve(&ws_id, APP_ID, key, &router, &store) {
+                            ResolveOutcome::Found(value) => {
+                                resolved.push((key.to_string(), value));
+                            }
+                            ResolveOutcome::HardMissing { reason } => {
+                                log::warn!("run_command: secret '{key}' hard-missing: {reason}");
+                                missing.push(key);
+                            }
+                            ResolveOutcome::PromptUser => {
+                                log::info!("run_command: secret '{key}' not in workspace Keychain");
+                                missing.push(key);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            for key in &secret_keys {
+                missing.push(key);
+            }
         }
     }
 
@@ -582,9 +624,12 @@ fn require_workspace(
 /// Scope:
 ///   --global     store under `plexi:user:<name>` (cross-workspace)
 ///   default      walk up to nearest .plexi/ workspace, store workspace-scoped
-pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32 {
+pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool, alias: Option<&str>) -> i32 {
+    // `friendly` is the canonical name (env var name used in app code).
+    // `alias` overrides the Keychain entry name when the user wants a different friendly name.
+    let effective_friendly = alias.unwrap_or(friendly);
     log::info!(
-        "secret_set:cli: friendly={friendly} from_env={from_env} global={global}"
+        "secret_set:cli: canonical={friendly} effective_friendly={effective_friendly} from_env={from_env} global={global}"
     );
     // Resolve value
     let value: String = if from_env {
@@ -622,12 +667,14 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
         let store = MacKeychain::new();
 
         if global {
-            let account = keychain_user_name(friendly);
+            let account = keychain_user_name(effective_friendly);
             return match store.set(&account, &value) {
                 Ok(()) => {
                     log::info!("secret_set:cli: stored globally account={account}");
-                    eprintln!("Stored '{friendly}' globally (plexi:user:{friendly})");
-                    print_tip("reference secrets in commands.toml under `[secrets] required = [\"...\"]`.");
+                    eprintln!("Stored '{friendly}' globally (plexi:user:{effective_friendly})");
+                    print_tip(&format!(
+                        "reference '{friendly}' in commands.toml under `[secrets] required = [\"{friendly}\"]`."
+                    ));
                     0
                 }
                 Err(e) => {
@@ -649,7 +696,7 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
                 return 1;
             }
         };
-        let account = keychain_workspace_name(&cfg.id, friendly);
+        let account = keychain_workspace_name(&cfg.id, effective_friendly);
         match store.set(&account, &value) {
             Ok(()) => {
                 log::info!(
@@ -662,7 +709,24 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
                     root.display(),
                     cfg.id
                 );
-                print_tip("reference secrets in commands.toml under `[secrets] required = [\"...\"]`.");
+                // Auto-write the canonical→friendly route to secrets.toml.
+                match crate::workspace_secrets::write_default_route(&root, friendly, effective_friendly) {
+                    Ok(()) => {
+                        log::info!(
+                            "secret_set:cli: wrote default route {friendly} → {effective_friendly} in secrets.toml"
+                        );
+                        print_tip(&format!(
+                            "Route written to .plexi/secrets.toml — use in commands.toml: [secrets] required = [\"{friendly}\"]"
+                        ));
+                    }
+                    Err(e) => {
+                        log::warn!("secret_set:cli: write_default_route failed: {e}");
+                        // Non-fatal — Keychain write succeeded.
+                        print_tip(&format!(
+                            "reference '{friendly}' in commands.toml under `[secrets] required = [\"{friendly}\"]`."
+                        ));
+                    }
+                }
                 0
             }
             Err(e) => {
@@ -674,7 +738,7 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool) -> i32
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (friendly, value, global);
+        let _ = (friendly, effective_friendly, value, global);
         eprintln!("error: keychain not available on this platform");
         1
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -267,17 +267,37 @@ pub fn run_command(command_name: &str) -> i32 {
             // Load workspace context once — fail early if secrets are required but workspace
             // is not initialised (missing workspace.toml or secrets.toml).
             let ws_root = crate::app_registry::resolve_workspace_root(&cwd);
-            let ws_context: Option<(String, WorkspaceSecrets)> =
-                ws_root.as_ref().and_then(|root| {
-                    let cfg = WorkspaceConfig::load(root).ok().flatten()?;
-                    let router = WorkspaceSecrets::load(root).ok().flatten()?;
-                    Some((cfg.id, router))
-                });
+            let ws_context: Option<(String, WorkspaceSecrets)> = ws_root.as_ref().and_then(|root| {
+                let cfg = match WorkspaceConfig::load(root) {
+                    Ok(Some(c)) => c,
+                    Ok(None) => {
+                        log::warn!("run_command: workspace.toml missing at {}", root.display());
+                        return None;
+                    }
+                    Err(e) => {
+                        log::warn!("run_command: failed to load workspace.toml at {}: {e}", root.display());
+                        return None;
+                    }
+                };
+                let router = match WorkspaceSecrets::load(root) {
+                    Ok(Some(r)) => r,
+                    Ok(None) => {
+                        log::warn!("run_command: secrets.toml missing at {}", root.display());
+                        return None;
+                    }
+                    Err(e) => {
+                        log::warn!("run_command: failed to load secrets.toml at {}: {e}", root.display());
+                        return None;
+                    }
+                };
+                Some((cfg.id, router))
+            });
             match ws_context {
                 None => {
-                    log::warn!("run_command: secrets required but no initialized workspace found in {}", cwd.display());
-                    eprintln!("error: command requires secrets but no initialized workspace found.");
-                    eprintln!("  → plexi workspace init   (then: plexi secret set <NAME>)");
+                    log::warn!("run_command: secrets required but workspace context unavailable in {}", cwd.display());
+                    eprintln!("error: command requires secrets but workspace is not fully initialized.");
+                    eprintln!("  → plexi workspace init   (creates workspace.toml + secrets.toml)");
+                    eprintln!("  → plexi secret set <NAME>  (then store the required secrets)");
                     return 1;
                 }
                 Some((ws_id, router)) => {
@@ -625,6 +645,13 @@ fn require_workspace(
 ///   --global     store under `plexi:user:<name>` (cross-workspace)
 ///   default      walk up to nearest .plexi/ workspace, store workspace-scoped
 pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool, alias: Option<&str>) -> i32 {
+    // `--alias` is incompatible with `--global`: global secrets are resolved via
+    // `plexi:user:<canonical>` and there is no secrets.toml to hold an alias route.
+    if global && alias.is_some() {
+        eprintln!("error: --alias cannot be combined with --global.");
+        eprintln!("  Global secrets are always stored under their canonical name.");
+        return 1;
+    }
     // `friendly` is the canonical name (env var name used in app code).
     // `alias` overrides the Keychain entry name when the user wants a different friendly name.
     let effective_friendly = alias.unwrap_or(friendly);

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -205,6 +205,12 @@ pub enum SecretCmd {
         /// Store this secret globally so it's available in all projects, not just this one
         #[arg(long)]
         global: bool,
+        /// Use a different name for the Keychain entry than the canonical env var name.
+        ///
+        /// Useful when the Keychain entry already exists under a different name.
+        /// Example: plexi secret set OPENAI_API_KEY --alias openai_personal
+        #[arg(long)]
+        alias: Option<String>,
     },
     /// Print a stored secret's value to stdout.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ fn main() -> eframe::Result {
                         RoutineCmd::Run { name } => std::process::exit(cli::routine_run(&name)),
                     },
                     Commands::Secret { cmd } => match cmd {
-                        SecretCmd::Set { friendly_name, from_env, global } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global)),
+                        SecretCmd::Set { friendly_name, from_env, global, alias } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global, alias.as_deref())),
                         SecretCmd::Get { friendly_name, global } => std::process::exit(cli::workspace_secret_get(&friendly_name, global)),
                         SecretCmd::List => std::process::exit(cli::workspace_secret_list()),
                         SecretCmd::Delete { friendly_name } => std::process::exit(cli::workspace_secret_delete(&friendly_name)),

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -248,40 +248,6 @@ pub fn toggle_inject_secret(key: &str, app_id: &str, directory: &str) -> Option<
     Some(new_value)
 }
 
-/// Walk up from `launch_dir` to the user's home directory, returning the first
-/// matching secret. Returns `None` if no match is found at any level.
-#[cfg(target_os = "macos")]
-pub fn resolve_secret(key: &str, app_id: &str, launch_dir: &str) -> Option<Zeroizing<String>> {
-    use std::path::PathBuf;
-
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => {
-            warn!("secrets::resolve_secret: could not determine home directory");
-            return None;
-        }
-    };
-
-    let mut current = PathBuf::from(launch_dir);
-    loop {
-        let dir_str = current.to_string_lossy();
-        if let Some(value) = retrieve_secret(key, app_id, &dir_str) {
-            return Some(value);
-        }
-
-        if current == home {
-            break;
-        }
-
-        match current.parent() {
-            Some(parent) if parent != current => current = parent.to_path_buf(),
-            _ => break,
-        }
-    }
-
-    None
-}
-
 // ── Non-macOS stubs ────────────────────────────────────────────────────
 
 #[cfg(not(target_os = "macos"))]
@@ -300,10 +266,4 @@ pub fn retrieve_secret(key: &str, app_id: &str, directory: &str) -> Option<Zeroi
 pub fn delete_secret(key: &str, app_id: &str, directory: &str) -> bool {
     warn!("secrets::delete_secret({key}, {app_id}, {directory}): Keychain not available on this platform");
     false
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn resolve_secret(key: &str, app_id: &str, launch_dir: &str) -> Option<Zeroizing<String>> {
-    warn!("secrets::resolve_secret({key}, {app_id}, {launch_dir}): Keychain not available on this platform");
-    None
 }

--- a/src/workspace_secrets.rs
+++ b/src/workspace_secrets.rs
@@ -530,6 +530,81 @@ fn write_gitignore_if_absent(workspace_root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+// ── Route auto-write ─────────────────────────────────────────────────────────
+
+/// After a `plexi secret set` Keychain write, record the canonical→friendly
+/// route in `<workspace_root>/.plexi/secrets.toml` under `[default]`.
+///
+/// - File absent: creates it with `fallback = true` + the route.
+/// - Canonical key already in `[default]`: no-op (idempotent).
+/// - Otherwise: injects `canonical = "friendly"`, preserving existing content.
+pub fn write_default_route(
+    workspace_root: &Path,
+    canonical: &str,
+    friendly: &str,
+) -> Result<(), String> {
+    let secrets_path = workspace_root.join(".plexi").join("secrets.toml");
+
+    if !secrets_path.exists() {
+        let dir = workspace_root.join(".plexi");
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("create {}: {e}", dir.display()))?;
+        let content = format!("fallback = true\n\n[default]\n{canonical} = \"{friendly}\"\n");
+        return std::fs::write(&secrets_path, content)
+            .map_err(|e| format!("write {}: {e}", secrets_path.display()));
+    }
+
+    let raw = std::fs::read_to_string(&secrets_path)
+        .map_err(|e| format!("read {}: {e}", secrets_path.display()))?;
+
+    // Idempotency: bail out if the route is already declared.
+    if let Ok(Some(router)) = WorkspaceSecrets::load(workspace_root) {
+        if router.default.contains_key(canonical) {
+            return Ok(());
+        }
+    }
+
+    let updated = inject_default_route_line(&raw, canonical, friendly);
+    std::fs::write(&secrets_path, updated)
+        .map_err(|e| format!("write {}: {e}", secrets_path.display()))
+}
+
+/// Inject `canonical = "friendly"` into the `[default]` section of a raw
+/// `secrets.toml` string, creating the section if absent.
+/// All existing content and comments are preserved.
+fn inject_default_route_line(raw: &str, canonical: &str, friendly: &str) -> String {
+    let entry_line = format!("{canonical} = \"{friendly}\"");
+    let lines: Vec<&str> = raw.lines().collect();
+    let trailing_newline = raw.ends_with('\n');
+
+    if let Some(start) = lines.iter().position(|l| l.trim() == "[default]") {
+        // End of section: next uncommented table header, or EOF.
+        let end = lines[start + 1..]
+            .iter()
+            .position(|l| {
+                let t = l.trim();
+                t.starts_with('[') && !t.starts_with('#')
+            })
+            .map(|p| start + 1 + p)
+            .unwrap_or(lines.len());
+
+        let mut parts: Vec<&str> = Vec::with_capacity(lines.len() + 1);
+        parts.extend_from_slice(&lines[..end]);
+        parts.push(&entry_line);
+        parts.extend_from_slice(&lines[end..]);
+        let joined = parts.join("\n");
+        if trailing_newline {
+            format!("{joined}\n")
+        } else {
+            joined
+        }
+    } else {
+        // No [default] section — append one.
+        let base = raw.trim_end_matches('\n');
+        format!("{base}\n\n[default]\n{entry_line}\n")
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -736,5 +811,88 @@ mod tests {
             raw, custom,
             "init must NOT overwrite an existing .gitignore"
         );
+    }
+
+    // ── write_default_route tests ──────────────────────────────────────────────
+
+    #[test]
+    fn write_default_route_creates_file_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        write_default_route(tmp.path(), "AGE", "AGE").expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        assert!(raw.contains("fallback = true"), "missing fallback: {raw}");
+        assert!(raw.contains("[default]"), "missing section: {raw}");
+        assert!(raw.contains("AGE = \"AGE\""), "missing route: {raw}");
+        WorkspaceSecrets::parse(&raw).expect("created file must parse");
+    }
+
+    #[test]
+    fn write_default_route_idempotent_when_route_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        let initial = "fallback = true\n\n[default]\nAGE = \"AGE\"\n";
+        std::fs::write(tmp.path().join(".plexi").join("secrets.toml"), initial).unwrap();
+        write_default_route(tmp.path(), "AGE", "AGE").expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        // Content must not grow — no duplicate entries.
+        assert_eq!(raw.matches("AGE = \"AGE\"").count(), 1, "duplicate entry: {raw}");
+    }
+
+    #[test]
+    fn write_default_route_appends_to_existing_default_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        let initial = "fallback = true\n\n[default]\nGITHUB_TOKEN = \"gh_personal\"\n";
+        std::fs::write(tmp.path().join(".plexi").join("secrets.toml"), initial).unwrap();
+        write_default_route(tmp.path(), "AGE", "AGE").expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        assert!(raw.contains("GITHUB_TOKEN = \"gh_personal\""), "existing entry lost: {raw}");
+        assert!(raw.contains("AGE = \"AGE\""), "new entry missing: {raw}");
+        WorkspaceSecrets::parse(&raw).expect("file must still parse");
+    }
+
+    #[test]
+    fn write_default_route_appends_new_section_when_none_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        let initial = "fallback = true\n\n# [default]\n# GITHUB_TOKEN = \"gh\"\n";
+        std::fs::write(tmp.path().join(".plexi").join("secrets.toml"), initial).unwrap();
+        write_default_route(tmp.path(), "AGE", "AGE").expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        assert!(raw.contains("[default]"), "section missing: {raw}");
+        assert!(raw.contains("AGE = \"AGE\""), "entry missing: {raw}");
+        WorkspaceSecrets::parse(&raw).expect("file must parse");
+    }
+
+    #[test]
+    fn write_default_route_with_alias_writes_friendly_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        write_default_route(tmp.path(), "OPENAI_API_KEY", "openai_personal")
+            .expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        assert!(raw.contains("OPENAI_API_KEY = \"openai_personal\""), "route wrong: {raw}");
+    }
+
+    #[test]
+    fn inject_default_route_line_appends_when_no_section() {
+        let raw = "fallback = true\n";
+        let out = inject_default_route_line(raw, "X", "x_alias");
+        assert!(out.contains("[default]"), "{out}");
+        assert!(out.contains("X = \"x_alias\""), "{out}");
+        WorkspaceSecrets::parse(&out).expect("must parse: {out}");
+    }
+
+    #[test]
+    fn inject_default_route_line_inserts_before_next_section() {
+        let raw = "fallback = true\n\n[default]\nA = \"a\"\n\n[apps.foo]\nB = \"b\"\n";
+        let out = inject_default_route_line(raw, "C", "c");
+        // C must appear inside [default], before [apps.foo]
+        let default_pos = out.find("[default]").unwrap();
+        let apps_pos = out.find("[apps.foo]").unwrap();
+        let c_pos = out.find("C = \"c\"").unwrap();
+        assert!(c_pos > default_pos && c_pos < apps_pos, "C not in [default]: {out}");
+        WorkspaceSecrets::parse(&out).expect("must parse");
     }
 }

--- a/src/workspace_secrets.rs
+++ b/src/workspace_secrets.rs
@@ -580,7 +580,11 @@ fn upsert_default_route_line(raw: &str, canonical: &str, friendly: &str) -> Stri
     let lines: Vec<&str> = raw.lines().collect();
     let trailing_newline = raw.ends_with('\n');
 
-    if let Some(start) = lines.iter().position(|l| l.trim() == "[default]") {
+    if let Some(start) = lines.iter().position(|l| {
+        let t = l.trim();
+        t == "[default]"
+            || (t.starts_with("[default]") && t[9..].trim_start().starts_with('#'))
+    }) {
         // End of section: next uncommented table header, or EOF.
         let end = lines[start + 1..]
             .iter()
@@ -927,6 +931,15 @@ mod tests {
         let apps_pos = out.find("[apps.foo]").unwrap();
         let c_pos = out.find("C = \"c\"").unwrap();
         assert!(c_pos > default_pos && c_pos < apps_pos, "C not in [default]: {out}");
+        WorkspaceSecrets::parse(&out).expect("must parse");
+    }
+
+    #[test]
+    fn upsert_default_route_line_handles_inline_comment_on_section_header() {
+        let raw = "fallback = true\n\n[default] # route table\nA = \"a\"\n";
+        let out = upsert_default_route_line(raw, "B", "b_alias");
+        assert!(out.contains("B = \"b_alias\""), "entry missing: {out}");
+        assert!(out.contains("[default] # route table"), "header modified: {out}");
         WorkspaceSecrets::parse(&out).expect("must parse");
     }
 

--- a/src/workspace_secrets.rs
+++ b/src/workspace_secrets.rs
@@ -536,8 +536,9 @@ fn write_gitignore_if_absent(workspace_root: &Path) -> Result<(), String> {
 /// route in `<workspace_root>/.plexi/secrets.toml` under `[default]`.
 ///
 /// - File absent: creates it with `fallback = true` + the route.
-/// - Canonical key already in `[default]`: no-op (idempotent).
-/// - Otherwise: injects `canonical = "friendly"`, preserving existing content.
+/// - Canonical already maps to the same friendly: no-op (idempotent).
+/// - Canonical maps to a different friendly: updates the existing entry in-place.
+/// - Canonical not present: injects a new entry, preserving existing content.
 pub fn write_default_route(
     workspace_root: &Path,
     canonical: &str,
@@ -557,22 +558,24 @@ pub fn write_default_route(
     let raw = std::fs::read_to_string(&secrets_path)
         .map_err(|e| format!("read {}: {e}", secrets_path.display()))?;
 
-    // Idempotency: bail out if the route is already declared.
+    // Idempotency: bail out only when the mapping already points at the same friendly name.
     if let Ok(Some(router)) = WorkspaceSecrets::load(workspace_root) {
-        if router.default.contains_key(canonical) {
+        if router.default.get(canonical).map(|s| s.as_str()) == Some(friendly) {
             return Ok(());
         }
     }
 
-    let updated = inject_default_route_line(&raw, canonical, friendly);
+    // Insert or update the canonical→friendly mapping.
+    let updated = upsert_default_route_line(&raw, canonical, friendly);
     std::fs::write(&secrets_path, updated)
         .map_err(|e| format!("write {}: {e}", secrets_path.display()))
 }
 
-/// Inject `canonical = "friendly"` into the `[default]` section of a raw
-/// `secrets.toml` string, creating the section if absent.
-/// All existing content and comments are preserved.
-fn inject_default_route_line(raw: &str, canonical: &str, friendly: &str) -> String {
+/// Insert or update `canonical = "friendly"` in the `[default]` section of a
+/// raw `secrets.toml` string, creating the section if absent.
+/// If an existing `canonical = "..."` line is found, it is replaced in-place.
+/// All other content and comments are preserved.
+fn upsert_default_route_line(raw: &str, canonical: &str, friendly: &str) -> String {
     let entry_line = format!("{canonical} = \"{friendly}\"");
     let lines: Vec<&str> = raw.lines().collect();
     let trailing_newline = raw.ends_with('\n');
@@ -588,11 +591,29 @@ fn inject_default_route_line(raw: &str, canonical: &str, friendly: &str) -> Stri
             .map(|p| start + 1 + p)
             .unwrap_or(lines.len());
 
-        let mut parts: Vec<&str> = Vec::with_capacity(lines.len() + 1);
-        parts.extend_from_slice(&lines[..end]);
-        parts.push(&entry_line);
-        parts.extend_from_slice(&lines[end..]);
-        let joined = parts.join("\n");
+        // Check for an existing entry for this canonical key and replace it if found.
+        let canonical_prefix = format!("{canonical} = ");
+        let existing = lines[start + 1..end]
+            .iter()
+            .position(|l| l.trim().starts_with(&canonical_prefix))
+            .map(|p| start + 1 + p);
+
+        let result = if let Some(idx) = existing {
+            let mut parts: Vec<&str> = Vec::with_capacity(lines.len());
+            parts.extend_from_slice(&lines[..idx]);
+            parts.push(&entry_line);
+            parts.extend_from_slice(&lines[idx + 1..]);
+            parts
+        } else {
+            // No existing entry — append inside section before next section header.
+            let mut parts: Vec<&str> = Vec::with_capacity(lines.len() + 1);
+            parts.extend_from_slice(&lines[..end]);
+            parts.push(&entry_line);
+            parts.extend_from_slice(&lines[end..]);
+            parts
+        };
+
+        let joined = result.join("\n");
         if trailing_newline {
             format!("{joined}\n")
         } else {
@@ -876,23 +897,46 @@ mod tests {
     }
 
     #[test]
-    fn inject_default_route_line_appends_when_no_section() {
+    fn write_default_route_updates_existing_entry_when_alias_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".plexi")).unwrap();
+        let initial = "fallback = true\n\n[default]\nOPENAI_API_KEY = \"old_alias\"\n";
+        std::fs::write(tmp.path().join(".plexi").join("secrets.toml"), initial).unwrap();
+        write_default_route(tmp.path(), "OPENAI_API_KEY", "new_alias").expect("should succeed");
+        let raw = std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+        assert!(raw.contains("OPENAI_API_KEY = \"new_alias\""), "updated entry missing: {raw}");
+        assert!(!raw.contains("old_alias"), "stale entry not removed: {raw}");
+        WorkspaceSecrets::parse(&raw).expect("must parse");
+    }
+
+    #[test]
+    fn upsert_default_route_line_appends_when_no_section() {
         let raw = "fallback = true\n";
-        let out = inject_default_route_line(raw, "X", "x_alias");
+        let out = upsert_default_route_line(raw, "X", "x_alias");
         assert!(out.contains("[default]"), "{out}");
         assert!(out.contains("X = \"x_alias\""), "{out}");
         WorkspaceSecrets::parse(&out).expect("must parse: {out}");
     }
 
     #[test]
-    fn inject_default_route_line_inserts_before_next_section() {
+    fn upsert_default_route_line_inserts_before_next_section() {
         let raw = "fallback = true\n\n[default]\nA = \"a\"\n\n[apps.foo]\nB = \"b\"\n";
-        let out = inject_default_route_line(raw, "C", "c");
+        let out = upsert_default_route_line(raw, "C", "c");
         // C must appear inside [default], before [apps.foo]
         let default_pos = out.find("[default]").unwrap();
         let apps_pos = out.find("[apps.foo]").unwrap();
         let c_pos = out.find("C = \"c\"").unwrap();
         assert!(c_pos > default_pos && c_pos < apps_pos, "C not in [default]: {out}");
+        WorkspaceSecrets::parse(&out).expect("must parse");
+    }
+
+    #[test]
+    fn upsert_default_route_line_replaces_existing_entry() {
+        let raw = "fallback = true\n\n[default]\nFOO = \"old\"\nBAR = \"bar\"\n";
+        let out = upsert_default_route_line(raw, "FOO", "new");
+        assert!(out.contains("FOO = \"new\""), "replacement missing: {out}");
+        assert!(!out.contains("FOO = \"old\""), "old entry not removed: {out}");
+        assert!(out.contains("BAR = \"bar\""), "sibling entry lost: {out}");
         WorkspaceSecrets::parse(&out).expect("must parse");
     }
 }


### PR DESCRIPTION
Closes #1798

## Summary

- Add `workspace_secrets::write_default_route` — after `plexi secret set`, auto-writes `canonical = "friendly"` to `.plexi/secrets.toml [default]` (idempotent, preserves existing content)
- Port `run_command` secret injection to `workspace_secrets::resolve` — the `commands.toml` runner now reads from the same `plexi:<ws_id>:<friendly>` Keychain namespace as `ctx.secret()`, eliminating the split-brain state
- Delete `secrets::resolve_secret` (v1/v2 directory-walk resolver); add `--alias` flag to `plexi secret set` for canonical→friendly routing

## Done When

1. `plexi secret set AGE && cat .plexi/secrets.toml` shows `AGE = "AGE"` under `[default]`
2. A Plexi app calling `ctx.secret("AGE")` in the same workspace returns the value with no prompt modal
3. A `commands.toml` command declaring `secrets = ["AGE"]` runs with `AGE` injected from the same Keychain entry
4. `grep -rn "resolve_secret\|account_key" src/` returns no production call sites
5. `cargo test --bin plexi` passes

## Notes

- `get_secret_scoped` (legacy path-based fallback in `routing.rs`) is retained — issue says "until that path is also replaced"
- `store_secret`/`retrieve_secret`/`delete_secret` are retained as they're still used by `secrets_app.rs` and `shell.rs`
- `run_command` fails early with a clear message when secrets are required but no initialized workspace is found (no `workspace.toml` or `secrets.toml`)
- Global secrets (`--global`) do not write a route entry — they resolve via `fallback = true` in the workspace's `secrets.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--alias` flag to `plexi secret set` for custom Keychain entry names.
  * Workspace secrets now auto-generate default route mappings in configuration.
  * Commands requiring uninitialized workspace secrets now provide setup instructions.

* **Changes**
  * Secret resolution for commands updated to use workspace-routed mechanism on macOS.
  * Non-macOS platforms treat required secrets as unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->