### PR TITLE
refactor(sdk): one SDK delivery path — single sdk_path() resolver, PLEXI_SDK_PATH override, no clobber-on-launch (#1800)

### DIFF
--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -54,23 +54,11 @@ fn spawn_and_collect_frame(
             cmd.env(k, v);
         }
     }
-    // PYTHONPATH: dev override (PLEXI_SDK_PATH) first, then config-dir SDK,
-    // then bundle SDK if present.
-    let sdk_dir = crate::config::config_dir().join("sdk");
-    let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
-    if let Some(dev_sdk) = crate::config::sdk_path_override() {
-        pythonpath = format!("{}:{}", dev_sdk.to_string_lossy(), pythonpath);
-        log::info!("app_render[{app_id}]: PLEXI_SDK_PATH override active -> {}", dev_sdk.display());
-    }
     let bundle_sdk = std::env::current_exe()
         .ok()
         .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
-        .map(|p| p.join("Resources").join("sdk").join("python"))
-        .filter(|p| p.exists());
-    if let Some(bsdk) = bundle_sdk {
-        pythonpath.push(':');
-        pythonpath.push_str(&bsdk.to_string_lossy());
-    }
+        .map(|p| p.join("Resources").join("sdk").join("python"));
+    let pythonpath = crate::config::build_pythonpath(bundle_sdk.as_deref());
     cmd.env("PYTHONPATH", &pythonpath);
     log::info!("app_render[{app_id}]: PYTHONPATH={pythonpath}");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,8 +525,11 @@ pub fn set_profile(name: Option<String>) {
 
 /// Ensure the profile directory exists and the Python SDK is up to date.
 /// Returns `true` if the profile directory was newly created (first launch),
-/// `false` if it already existed. The SDK is always overwritten so upgrades
-/// land the correct version without a fresh profile wipe.
+/// `false` if it already existed.
+///
+/// The embedded SDK is extracted only when missing or when the binary version
+/// changed since the last extract, so manual edits and symlinks in the profile
+/// SDK dir survive normal app launches.
 pub fn ensure_profile_initialized() -> bool {
     let dir = config_dir();
     let is_new = if !dir.exists() {
@@ -545,20 +548,37 @@ pub fn ensure_profile_initialized() -> bool {
         false
     };
 
-    // Always overwrite the SDK on every launch so upgrades always get the
-    // version embedded in the current binary, not a stale copy from a prior install.
-    let sdk_dest = dir.join("sdk").join("plexi_sdk");
-    let _ = std::fs::remove_dir_all(&sdk_dest);
-    if let Err(e) = std::fs::create_dir_all(&sdk_dest) {
-        eprintln!("profile init: failed to create sdk dir: {e}");
-    } else {
-        let embedded_sdk =
-            include_dir::include_dir!("$CARGO_MANIFEST_DIR/sdk/python/plexi_sdk");
-        if let Err(e) = embedded_sdk.extract(&sdk_dest) {
-            eprintln!("profile init: failed to seed SDK: {e}");
+    // Only re-extract when the embedded SDK version differs from what was last written.
+    // This preserves manual edits and symlinks placed in the profile SDK dir during
+    // normal launches while still ensuring upgrades land the correct version.
+    let sdk_dir = dir.join("sdk");
+    let stamp_path = sdk_dir.join(".sdk_version");
+    let current_version = env!("CARGO_PKG_VERSION");
+    let needs_extract = std::fs::read_to_string(&stamp_path)
+        .map(|v| v.trim() != current_version)
+        .unwrap_or(true);
+
+    if needs_extract {
+        let sdk_dest = sdk_dir.join("plexi_sdk");
+        let _ = std::fs::remove_dir_all(&sdk_dest);
+        if let Err(e) = std::fs::create_dir_all(&sdk_dest) {
+            eprintln!("profile init: failed to create sdk dir: {e}");
         } else {
-            log::info!("profile init: seeded SDK to {}", sdk_dest.display());
+            let embedded_sdk =
+                include_dir::include_dir!("$CARGO_MANIFEST_DIR/sdk/python/plexi_sdk");
+            if let Err(e) = embedded_sdk.extract(&sdk_dest) {
+                eprintln!("profile init: failed to seed SDK: {e}");
+            } else {
+                let _ = std::fs::create_dir_all(&sdk_dir);
+                let _ = std::fs::write(&stamp_path, current_version);
+                log::info!(
+                    "profile init: seeded SDK v{current_version} to {}",
+                    sdk_dest.display()
+                );
+            }
         }
+    } else {
+        log::info!("profile init: SDK v{current_version} up to date, skipping extract");
     }
 
     is_new
@@ -631,6 +651,25 @@ pub fn sdk_path_override() -> Option<PathBuf> {
         );
         None
     }
+}
+
+/// Builds the `PYTHONPATH` value for Python app subprocesses.
+///
+/// This is the single source for how PYTHONPATH is constructed. Both
+/// `ProcessApp::launch` and the static render path must call this so the
+/// priority is defined in exactly one place:
+///   `PLEXI_SDK_PATH` override → config-dir SDK → bundle SDK (when present)
+pub fn build_pythonpath(bundle_sdk: Option<&std::path::Path>) -> String {
+    let sdk_dir = config_dir().join("sdk");
+    let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
+    if let Some(bsdk) = bundle_sdk.filter(|p| p.exists()) {
+        pythonpath.push(':');
+        pythonpath.push_str(&bsdk.to_string_lossy());
+    }
+    if let Some(dev_sdk) = sdk_path_override() {
+        pythonpath = format!("{}:{}", dev_sdk.to_string_lossy(), pythonpath);
+    }
+    pythonpath
 }
 
 pub const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,14 +552,15 @@ pub fn ensure_profile_initialized() -> bool {
     // This preserves manual edits and symlinks placed in the profile SDK dir during
     // normal launches while still ensuring upgrades land the correct version.
     let sdk_dir = dir.join("sdk");
+    let sdk_dest = sdk_dir.join("plexi_sdk");
     let stamp_path = sdk_dir.join(".sdk_version");
     let current_version = env!("CARGO_PKG_VERSION");
-    let needs_extract = std::fs::read_to_string(&stamp_path)
-        .map(|v| v.trim() != current_version)
-        .unwrap_or(true);
+    let needs_extract = !sdk_dest.exists()
+        || std::fs::read_to_string(&stamp_path)
+            .map(|v| v.trim() != current_version)
+            .unwrap_or(true);
 
     if needs_extract {
-        let sdk_dest = sdk_dir.join("plexi_sdk");
         let _ = std::fs::remove_dir_all(&sdk_dest);
         if let Err(e) = std::fs::create_dir_all(&sdk_dest) {
             eprintln!("profile init: failed to create sdk dir: {e}");

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -429,25 +429,11 @@ impl ProcessApp {
             }
         }
 
-        // Make the shared Plexi SDK importable by Python apps without per-app copies.
-        // Priority: user's local SDK (~/.plexi-alpha/sdk/) first, then the copy
-        // bundled inside the .app bundle (Contents/Resources/sdk/python/). The bundle path
-        // ensures apps work on a fresh install where just install-alpha was never run.
-        let sdk_dir = crate::config::config_dir().join("sdk");
-        let mut pythonpath = sdk_dir.to_string_lossy().into_owned();
-        if let Some(bundle_sdk) = bundle_contents
-            .map(|p| p.join("Resources").join("sdk").join("python"))
-            .filter(|p| p.exists())
-        {
-            pythonpath.push(':');
-            pythonpath.push_str(&bundle_sdk.to_string_lossy());
-        }
-        // Dev override: PLEXI_SDK_PATH wins over the embedded/bundled SDK so the
-        // worktree SDK can be iterated live without a rebuild (see config::sdk_path_override).
-        if let Some(dev_sdk) = crate::config::sdk_path_override() {
-            pythonpath = format!("{}:{}", dev_sdk.to_string_lossy(), pythonpath);
-            log::info!("process_app[{type_id}]: PLEXI_SDK_PATH override active -> {}", dev_sdk.display());
-        }
+        let bundle_sdk = bundle_contents
+            .as_ref()
+            .map(|p| p.join("Resources").join("sdk").join("python"));
+        let pythonpath = crate::config::build_pythonpath(bundle_sdk.as_deref());
+        log::info!("process_app[{type_id}]: PYTHONPATH={pythonpath}");
 
         // Static capability validation — runs before the real spawn.
         // For Python apps only; non-Python apps skip. Subprocess failures log warn and proceed.


### PR DESCRIPTION
Closes #1800

## Summary

- Add `config::build_pythonpath(bundle_sdk)` as the single source for PYTHONPATH construction — both `ProcessApp::launch` and the static render path call it, removing the duplicated inline construction
- Replace blind `remove_dir_all` + re-extract in `ensure_profile_initialized` with a version-stamped check: the embedded SDK is only re-extracted when the binary version changes, so manual edits and symlinks placed in the profile SDK dir survive normal app launches
- `PLEXI_SDK_PATH` override flows through the shared helper (already existed, now guaranteed to be picked up by all spawn paths)

## Done When

1. `PLEXI_SDK_PATH=/path/to/sdk/python` makes an app import that working copy; editing it and reopening the app reflects the change with no `cargo build`.
2. A symlink or edit in the profile-dir SDK survives a normal app launch (no clobber) unless the embedded version stamp changed.
3. `grep -rn "PYTHONPATH" src/` shows PYTHONPATH built in exactly one helper.
4. `cargo test --bin plexi` passes.

## Notes

- `build_pythonpath` is a pure value function; callers log the result with their own context tag (`app_render[id]` / `process_app[id]`)
- Version stamp written to `config_dir/sdk/.sdk_version` — re-extract triggers when stamp is missing or version differs
- `bundle_contents` in process_app is now borrowed (`.as_ref()`) rather than moved, since it's no longer the last use site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * SDK initialization is now more efficient. The embedded Python SDK is only extracted when the version changes, rather than on every launch, resulting in faster application startup times.

* **Refactor**
  * Internal Python environment configuration has been refactored for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->