### PR TITLE
refactor(context): single context-transition seam — one choke point owns registry rescan + watcher restart + palette scope (#1801)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3783,9 +3783,14 @@ impl eframe::App for PlexiApp {
                 hit
             });
         if registry_changed {
-            log::info!("app_registry_watcher: rescanning registry");
-            let cwd = std::env::current_dir().unwrap_or_default();
-            self.registry = crate::app_registry::AppRegistry::load(&cwd);
+            let root = self
+                .router
+                .active()
+                .root
+                .clone()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+            log::info!("app_registry_watcher: rescanning registry for root={}", root.display());
+            self.registry = crate::app_registry::AppRegistry::load(&root);
         }
 
         // Handle window close request (X button or macOS Cmd+Q OS event).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -880,7 +880,7 @@ impl PlexiApp {
                 let window_count = windows.iter().filter(|w| w.context_id == active_ctx_id).count();
                 let mut host = crate::host::model::HostModel::new();
                 host.seed_next_pane_id(ws.next_pane_id);
-                return Self {
+                let mut app = Self {
                     pty_event_rx: rx,
                     pty_event_tx: tx,
                     theme: theme::terminal_theme(&theme_cfg),
@@ -978,6 +978,8 @@ impl PlexiApp {
                     last_system_theme: None,
 
                 };
+                app.apply_context_transition_effects();
+                return app;
             }
         }
 
@@ -1030,7 +1032,7 @@ impl PlexiApp {
                 None => (None, None),
             };
 
-        Self {
+        let mut app = Self {
             pty_event_rx: rx,
             pty_event_tx: tx,
             theme: theme::terminal_theme(&theme_cfg),
@@ -1148,7 +1150,9 @@ impl PlexiApp {
             last_logged_focus: None,
             focus_started_at: None,
             last_system_theme: None,
-        }
+        };
+        app.apply_context_transition_effects();
+        app
     }
 
     /// Search ALL windows (not just the active one) for a pane by ID.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3792,7 +3792,10 @@ impl eframe::App for PlexiApp {
                 .active()
                 .root
                 .clone()
-                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+                .unwrap_or_else(|| {
+                    std::env::current_dir()
+                        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+                });
             log::info!("app_registry_watcher: rescanning registry for root={}", root.display());
             self.registry = crate::app_registry::AppRegistry::load(&root);
         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1119,3 +1119,95 @@ fn window_scoped_notification_visible_only_on_source_window() {
     h.app.active_window = 0;
     assert_eq!(h.app.visible_notification_count(), 1, "notification must reappear when returning to source window");
 }
+
+/// Issue #1801: context transition must rescan the registry and restart the watcher.
+///
+/// Creates two temp roots each with a distinct workspace-local app, switches the
+/// active context between them, and asserts that the registry always reflects the
+/// current root — no stale apps from the previous root survive the switch.
+#[test]
+fn context_transition_rescans_registry() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    // Two isolated temp roots with different workspace-local apps.
+    let dir_a = std::env::temp_dir().join("plexi_test_1801_ctx_a");
+    let dir_b = std::env::temp_dir().join("plexi_test_1801_ctx_b");
+
+    let manifest_a = concat!(
+        "schema_version = 1\n",
+        "[app]\n",
+        "id = \"test-1801-app-a\"\n",
+        "name = \"Test App A\"\n",
+        "entry = \"app.py\"\n",
+        "type = \"app\"\n",
+    );
+    let manifest_b = concat!(
+        "schema_version = 1\n",
+        "[app]\n",
+        "id = \"test-1801-app-b\"\n",
+        "name = \"Test App B\"\n",
+        "entry = \"app.py\"\n",
+        "type = \"app\"\n",
+    );
+
+    let apps_a = crate::app_registry::workspace_apps_dir(&dir_a);
+    std::fs::create_dir_all(apps_a.join("test-1801-app-a")).unwrap();
+    std::fs::write(apps_a.join("test-1801-app-a").join("manifest.toml"), manifest_a).unwrap();
+    std::fs::write(apps_a.join("test-1801-app-a").join("app.py"), b"").unwrap();
+
+    let apps_b = crate::app_registry::workspace_apps_dir(&dir_b);
+    std::fs::create_dir_all(apps_b.join("test-1801-app-b")).unwrap();
+    std::fs::write(apps_b.join("test-1801-app-b").join("manifest.toml"), manifest_b).unwrap();
+    std::fs::write(apps_b.join("test-1801-app-b").join("app.py"), b"").unwrap();
+
+    // Switch context 0 to root A and verify registry picks up app-a.
+    let idx0 = app.router.active_idx();
+    app.router.get_mut(idx0).root = Some(dir_a.clone());
+    app.apply_context_transition_effects();
+
+    let ids: Vec<String> = app.registry.list().into_iter().map(|a| a.manifest.id.clone()).collect();
+    assert!(ids.contains(&"test-1801-app-a".to_string()),
+        "registry should contain test-1801-app-a after setting root A, got: {ids:?}");
+    assert!(!ids.contains(&"test-1801-app-b".to_string()),
+        "registry should not contain test-1801-app-b while on root A, got: {ids:?}");
+
+    // Add a second context pointing at root B and switch to it.
+    let ctx_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    let win_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    app.router.push(crate::context::Context {
+        name: "Context B".into(),
+        path: dir_b.clone(),
+        root: Some(dir_b.clone()),
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+    });
+    app.windows.push(Window {
+        name: "Context B".into(),
+        path: dir_b.clone(),
+        tree: egui_tiles::Tree::empty("test_tree_b"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+    let ctx_b_idx = app.router.len() - 1;
+    app.switch_workspace(ctx_b_idx);
+
+    let ids: Vec<String> = app.registry.list().into_iter().map(|a| a.manifest.id.clone()).collect();
+    assert!(ids.contains(&"test-1801-app-b".to_string()),
+        "registry should contain test-1801-app-b after switching to root B, got: {ids:?}");
+    assert!(!ids.contains(&"test-1801-app-a".to_string()),
+        "registry should not contain test-1801-app-a while on root B, got: {ids:?}");
+
+    let _ = std::fs::remove_dir_all(&dir_a);
+    let _ = std::fs::remove_dir_all(&dir_b);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1134,6 +1134,9 @@ fn context_transition_rescans_registry() {
     // Two isolated temp roots with different workspace-local apps.
     let dir_a = std::env::temp_dir().join("plexi_test_1801_ctx_a");
     let dir_b = std::env::temp_dir().join("plexi_test_1801_ctx_b");
+    // Clean up from any prior failed run before creating fixtures.
+    let _ = std::fs::remove_dir_all(&dir_a);
+    let _ = std::fs::remove_dir_all(&dir_b);
 
     let manifest_a = concat!(
         "schema_version = 1\n",

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -160,6 +160,7 @@ impl PlexiApp {
         self.active_window = self.windows.len() - 1;
         self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = false;
+        self.apply_context_transition_effects();
 
         // Auto-open inline rename so the user can name the context immediately.
         let new_ctx_idx = self.router.len() - 1;
@@ -233,6 +234,7 @@ impl PlexiApp {
         self.active_window = self.windows.len() - 1;
         self.context_active_window.insert(ctx_id, win_id);
         self.minimap.visible = false;
+        self.apply_context_transition_effects();
     }
 
     /// Create a new page immediately to the right of the active page on the

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -534,6 +534,8 @@ impl PlexiApp {
             .get(&new_ctx_id)
             .copied()
             .unwrap_or(page_count > 1);
+
+        self.apply_context_transition_effects();
     }
 
     pub(crate) fn pick_active_context_from_workspace(&mut self) {
@@ -563,6 +565,40 @@ impl PlexiApp {
             root.display()
         );
         self.router.get_mut(idx).root = Some(root);
+        self.apply_context_transition_effects();
+    }
+
+    /// Single choke point for all context-transition side effects.
+    ///
+    /// Must be called after every operation that changes the active context (either
+    /// which context is active or what root it points at). Owns, in order:
+    ///   1. Rescan the AppRegistry for the new context root.
+    ///   2. Restart the app_registry_watcher on the new root's watch dirs.
+    ///   3. Palette scope follows implicitly — the palette reads `self.registry` directly.
+    pub(crate) fn apply_context_transition_effects(&mut self) {
+        let root = self
+            .router
+            .active()
+            .root
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        log::info!(
+            "transition_context: ctx_id={} root={} — rescanning registry + restarting watcher",
+            self.router.active().context_id,
+            root.display()
+        );
+        self.registry = crate::app_registry::AppRegistry::load(&root);
+        let watch_dirs = crate::app_registry::registry_watch_dirs(&root);
+        match crate::app_registry_watcher::start(watch_dirs) {
+            Some((watcher, rx)) => {
+                self._registry_watcher = Some(watcher);
+                self.registry_reload_rx = Some(rx);
+            }
+            None => {
+                self._registry_watcher = None;
+                self.registry_reload_rx = None;
+            }
+        }
     }
 
     /// Dissolve a portal: reparent all its panes into the parent window (the active

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -583,7 +583,10 @@ impl PlexiApp {
             .active()
             .root
             .clone()
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+            .unwrap_or_else(|| {
+                std::env::current_dir()
+                    .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+            });
         log::info!(
             "transition_context: ctx_id={} root={} — rescanning registry + restarting watcher",
             self.router.active().context_id,


### PR DESCRIPTION
Closes #1801

## Summary

- Add `apply_context_transition_effects()` as the single choke point for all downstream effects of a context change: rescans `AppRegistry` from the new active context root and restarts `app_registry_watcher` on the new root's watch dirs.
- Wire both `switch_workspace` and `set_active_context_root` to call this helper at the end — every switch path now gets registry + watcher sync unconditionally.
- Fix the frame-loop file-watcher hot-reload to use the active context root instead of `std::env::current_dir()`, so filesystem-triggered rescans are also context-aware.

## Done When

1. A HostHarness test switches between two context roots and asserts the registry + active watcher both follow, with no per-frame drift poll.
2. `grep -n "set_active_context_root\|switch_workspace" src/` shows both delegating to the one transition helper.
3. The #1770 class (palette showing workspace-scoped apps outside their context; watcher not restarting on switch) cannot recur because the effects are unconditional inside the helper.
4. `cargo test --bin plexi` passes.

## Notes

- `apply_context_transition_effects` falls back to `std::env::current_dir()` when the active context has no root set, preserving existing behavior for contexts without an explicit root.
- The palette scope update is implicit — `draw_command_palette` reads `self.registry` directly, so updating the registry is sufficient.
- Pre-existing test failures (`embedded_registry_round_trips_through_parser`, 5 canvas_bindings tests) are unrelated to this change and exist on alpha.