### PR TITLE
fix(palette): workspace-scoped apps show in palette outside their context (#1770)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -299,6 +299,10 @@ pub struct PlexiApp {
     pub(crate) show_command_palette: bool,
     pub(crate) palette_query: String,
     pub(crate) palette_selected: usize,
+    /// Cached workspace root for the focused pane at the moment the palette
+    /// was opened. Resolved once on open, not per-frame, to avoid repeated
+    /// filesystem traversal in the egui draw loop.
+    pub(crate) palette_workspace_root: Option<std::path::PathBuf>,
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
     /// One-shot guard: true after `request_focus()` fires on the rename modal's
@@ -921,6 +925,7 @@ impl PlexiApp {
                     show_command_palette: false,
                     palette_query: String::new(),
                     palette_selected: 0,
+                    palette_workspace_root: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
                     rename_pane_focus_requested: false,
@@ -1095,6 +1100,7 @@ impl PlexiApp {
             show_command_palette: false,
             palette_query: String::new(),
             palette_selected: 0,
+            palette_workspace_root: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
             rename_pane_focus_requested: false,
@@ -1258,6 +1264,7 @@ impl PlexiApp {
             show_command_palette: false,
             palette_query: String::new(),
             palette_selected: 0,
+            palette_workspace_root: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
             rename_pane_focus_requested: false,
@@ -3547,6 +3554,19 @@ impl eframe::App for PlexiApp {
                     if self.show_command_palette {
                         self.palette_query.clear();
                         self.palette_selected = 0;
+                        // Resolve focused pane workspace once at open-time — not per draw-frame —
+                        // to avoid filesystem traversal in the egui hot path.
+                        let win = &self.windows[self.active_window];
+                        self.palette_workspace_root = win
+                            .focused_pane
+                            .and_then(|tile_id| win.get_focused_pane_cwd(tile_id))
+                            .and_then(|cwd| crate::app_registry::resolve_workspace_root(&cwd));
+                        log::info!(
+                            "palette: opened, focused workspace = {:?}",
+                            self.palette_workspace_root
+                        );
+                    } else {
+                        self.palette_workspace_root = None;
                     }
                 }
                 Action::RenamePane => {

--- a/src/app_registry.rs
+++ b/src/app_registry.rs
@@ -287,6 +287,9 @@ pub struct InstalledApp {
     /// value returned by `load_app` is a placeholder and is overwritten at
     /// insert time.
     pub source: RegistrySource,
+    /// For `LocalApp`/`LocalAgent` entries: the workspace root they belong to.
+    /// `None` for global entries.
+    pub workspace_root: Option<PathBuf>,
 }
 
 pub struct AppRegistry {
@@ -294,6 +297,10 @@ pub struct AppRegistry {
     apps: HashMap<String, InstalledApp>,
     /// Extension → app id mapping (first match wins).
     extension_map: HashMap<String, String>,
+    /// The workspace root the local scan was done for. `None` when no local
+    /// apps were scanned (either no workspace or workspace has no apps dir).
+    /// Used by the palette to detect when a rescan is needed.
+    pub loaded_workspace: Option<PathBuf>,
 }
 
 impl AppRegistry {
@@ -318,10 +325,11 @@ impl AppRegistry {
         let mut registry = Self {
             apps: HashMap::new(),
             extension_map: HashMap::new(),
+            loaded_workspace: None,
         };
 
         if global_dir.is_dir() {
-            registry.scan_dir(global_dir, RegistrySource::Global);
+            registry.scan_dir(global_dir, RegistrySource::Global, None);
         }
 
         // Local apps + agents — only scanned when a workspace root exists.
@@ -329,13 +337,14 @@ impl AppRegistry {
         // both shadow global, and a colliding id between local apps and local
         // agents lets the agent win (scanned later).
         if let Some(root) = resolve_workspace_root_with_channel(cwd, &channel_dir) {
+            registry.loaded_workspace = Some(root.clone());
             let local_apps = root.join(&channel_dir).join("apps");
             if local_apps.is_dir() {
-                registry.scan_dir(&local_apps, RegistrySource::LocalApp);
+                registry.scan_dir(&local_apps, RegistrySource::LocalApp, Some(root.clone()));
             }
             let local_agents = root.join(&channel_dir).join("agents");
             if local_agents.is_dir() {
-                registry.scan_dir(&local_agents, RegistrySource::LocalAgent);
+                registry.scan_dir(&local_agents, RegistrySource::LocalAgent, Some(root.clone()));
             }
         }
 
@@ -350,7 +359,7 @@ impl AppRegistry {
     /// Scan one directory of manifest-bearing subdirs, inserting discovered
     /// entries. Calls made later in `load()` shadow earlier ones; on shadow
     /// the displaced entry's source is logged so users can debug discovery.
-    fn scan_dir(&mut self, dir: &Path, source: RegistrySource) {
+    fn scan_dir(&mut self, dir: &Path, source: RegistrySource, workspace_root: Option<PathBuf>) {
         let read_dir = match std::fs::read_dir(dir) {
             Ok(d) => d,
             Err(e) => {
@@ -400,7 +409,7 @@ impl AppRegistry {
                         // Plain insert — local entries override global for extension map too.
                         self.extension_map.insert(ext.to_lowercase(), id.clone());
                     }
-                    self.apps.insert(id, InstalledApp { source, ..installed });
+                    self.apps.insert(id, InstalledApp { source, workspace_root: workspace_root.clone(), ..installed });
                 }
                 Err(e) => {
                     log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());
@@ -472,8 +481,9 @@ impl AppRegistry {
             launch: manifest.launch,
             secrets: manifest.secrets,
             bin_path,
-            // Placeholder — `scan_dir` overwrites this with the real source.
+            // Placeholders — `scan_dir` overwrites both with real values.
             source: RegistrySource::Global,
+            workspace_root: None,
         })
     }
 
@@ -1215,5 +1225,62 @@ startup_message = \"Starting Greeter…\"
         write_app(global.path(), "silent-app", "Silent App");
         let registry = AppRegistry::load_with_global(bare.path(), global.path());
         assert_eq!(registry.startup_message_for("silent-app"), None);
+    }
+
+    #[test]
+    fn local_app_has_workspace_root_populated() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        // channel_dir in tests == ".plexi" (binary name is "plexi")
+        let channel_dir = registry_config_dir();
+        let local_apps = workspace.path().join(&channel_dir).join("apps");
+        fs::create_dir_all(&local_apps).unwrap();
+        write_app(&local_apps, "ws-app", "Workspace App");
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let app = registry.get("ws-app").expect("workspace app should be discovered");
+        assert_eq!(app.source, RegistrySource::LocalApp);
+        let ws_root = app.workspace_root.as_ref().expect("workspace_root should be Some for local app");
+        assert_eq!(
+            ws_root.canonicalize().unwrap(),
+            workspace.path().canonicalize().unwrap(),
+        );
+    }
+
+    #[test]
+    fn global_app_has_no_workspace_root() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app(global.path(), "global-app", "Global App");
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        let app = registry.get("global-app").expect("global app should be discovered");
+        assert_eq!(app.source, RegistrySource::Global);
+        assert!(app.workspace_root.is_none(), "global app must have no workspace_root");
+    }
+
+    #[test]
+    fn registry_loaded_workspace_is_set_after_local_scan() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let channel_dir = registry_config_dir();
+        // Create the channel dir so resolve_workspace_root_with_channel finds it.
+        fs::create_dir_all(workspace.path().join(&channel_dir)).unwrap();
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let loaded = registry.loaded_workspace.as_ref().expect("loaded_workspace should be Some");
+        assert_eq!(
+            loaded.canonicalize().unwrap(),
+            workspace.path().canonicalize().unwrap(),
+        );
+    }
+
+    #[test]
+    fn registry_loaded_workspace_is_none_outside_workspace() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap(); // no channel dir → not a workspace
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(registry.loaded_workspace.is_none(), "loaded_workspace should be None outside workspace");
     }
 }

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -190,22 +190,20 @@ impl PlexiApp {
         };
 
         // ── Workspace-aware app entries ────────────────────────────────────
-        // Resolve the focused pane's workspace root so we can filter local apps.
-        let focused_workspace_root = self.windows[self.active_window]
-            .focused_pane
-            .and_then(|tile_id| self.windows[self.active_window].get_focused_pane_cwd(tile_id))
-            .and_then(|cwd| crate::app_registry::resolve_workspace_root(&cwd));
+        // Use the workspace root cached at palette-open time (not re-resolved
+        // per frame) to avoid filesystem traversal in the egui draw loop.
+        let focused_workspace_root = self.palette_workspace_root.as_ref();
 
-        // If the focused pane's workspace differs from what the registry was
-        // last loaded for, rescan now so local apps for the new workspace appear.
-        if focused_workspace_root != self.registry.loaded_workspace {
+        // If the cached workspace differs from what the registry was last loaded
+        // for, rescan once now so local apps for this workspace appear.
+        if focused_workspace_root != self.registry.loaded_workspace.as_ref() {
             let home = dirs::home_dir();
             let rescan_cwd = focused_workspace_root
-                .as_deref()
+                .map(|p| p.as_path())
                 .or_else(|| home.as_deref())
                 .unwrap_or(std::path::Path::new("/"));
             log::info!(
-                "palette: workspace changed ({:?} → {:?}), rescanning registry",
+                "palette: registry workspace ({:?}) differs from palette workspace ({:?}), rescanning",
                 self.registry.loaded_workspace,
                 focused_workspace_root,
             );
@@ -223,16 +221,7 @@ impl PlexiApp {
                     crate::app_registry::RegistrySource::Global => true,
                     crate::app_registry::RegistrySource::LocalApp
                     | crate::app_registry::RegistrySource::LocalAgent => {
-                        let visible = app.workspace_root.as_ref() == focused_workspace_root.as_ref();
-                        if !visible {
-                            log::debug!(
-                                "palette: hiding local app '{}' (workspace {:?} ≠ focused {:?})",
-                                app.manifest.id,
-                                app.workspace_root,
-                                focused_workspace_root,
-                            );
-                        }
-                        visible
+                        app.workspace_root.as_ref() == focused_workspace_root
                     }
                 };
                 workspace_visible

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -218,9 +218,11 @@ impl PlexiApp {
             .into_iter()
             .filter(|app| {
                 // Local apps are visible only when the focused pane is in their workspace.
+                // Use the same explicit predicate here as in the badge below — no wildcard.
                 let workspace_visible = match app.source {
                     crate::app_registry::RegistrySource::Global => true,
-                    _ => {
+                    crate::app_registry::RegistrySource::LocalApp
+                    | crate::app_registry::RegistrySource::LocalAgent => {
                         let visible = app.workspace_root.as_ref() == focused_workspace_root.as_ref();
                         if !visible {
                             log::debug!(

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -18,6 +18,7 @@ enum PaletteEntry {
         name: String,
         description: String,
         running_in_background: bool,
+        is_workspace_local: bool,
     },
 }
 
@@ -188,33 +189,79 @@ impl PlexiApp {
             ctx_entries
         };
 
-        // ── App entries ────────────────────────────────────────────────────
-        let app_entries: Vec<(String, String, String)> = self
+        // ── Workspace-aware app entries ────────────────────────────────────
+        // Resolve the focused pane's workspace root so we can filter local apps.
+        let focused_workspace_root = self.windows[self.active_window]
+            .focused_pane
+            .and_then(|tile_id| self.windows[self.active_window].get_focused_pane_cwd(tile_id))
+            .and_then(|cwd| crate::app_registry::resolve_workspace_root(&cwd));
+
+        // If the focused pane's workspace differs from what the registry was
+        // last loaded for, rescan now so local apps for the new workspace appear.
+        if focused_workspace_root != self.registry.loaded_workspace {
+            let home = dirs::home_dir();
+            let rescan_cwd = focused_workspace_root
+                .as_deref()
+                .or_else(|| home.as_deref())
+                .unwrap_or(std::path::Path::new("/"));
+            log::info!(
+                "palette: workspace changed ({:?} → {:?}), rescanning registry",
+                self.registry.loaded_workspace,
+                focused_workspace_root,
+            );
+            self.registry = crate::app_registry::AppRegistry::load(rescan_cwd);
+        }
+
+        let app_entries: Vec<(String, String, String, bool)> = self
             .registry
             .list()
             .into_iter()
             .filter(|app| {
-                query.is_empty()
-                    || app.manifest.name.to_lowercase().contains(&query)
-                    || app.manifest.id.to_lowercase().contains(&query)
-                    || app.manifest.description.to_lowercase().contains(&query)
+                // Local apps are visible only when the focused pane is in their workspace.
+                let workspace_visible = match app.source {
+                    crate::app_registry::RegistrySource::Global => true,
+                    _ => {
+                        let visible = app.workspace_root.as_ref() == focused_workspace_root.as_ref();
+                        if !visible {
+                            log::debug!(
+                                "palette: hiding local app '{}' (workspace {:?} ≠ focused {:?})",
+                                app.manifest.id,
+                                app.workspace_root,
+                                focused_workspace_root,
+                            );
+                        }
+                        visible
+                    }
+                };
+                workspace_visible
+                    && (query.is_empty()
+                        || app.manifest.name.to_lowercase().contains(&query)
+                        || app.manifest.id.to_lowercase().contains(&query)
+                        || app.manifest.description.to_lowercase().contains(&query))
             })
             .map(|app| {
+                let is_local = matches!(
+                    app.source,
+                    crate::app_registry::RegistrySource::LocalApp
+                        | crate::app_registry::RegistrySource::LocalAgent
+                );
                 (
                     app.manifest.id.clone(),
                     app.manifest.name.clone(),
                     app.manifest.description.clone(),
+                    is_local,
                 )
             })
             .collect();
 
-        for (id, name, description) in app_entries {
+        for (id, name, description, is_workspace_local) in app_entries {
             let running_in_background = self.background_apps.contains_key(&id);
             entries.push(PaletteEntry::App {
                 id,
                 name,
                 description,
                 running_in_background,
+                is_workspace_local,
             });
         }
 
@@ -431,6 +478,7 @@ impl PlexiApp {
                                             name,
                                             description,
                                             running_in_background,
+                                            is_workspace_local,
                                         } => {
                                             if !shown_apps_header {
                                                 shown_apps_header = true;
@@ -466,6 +514,14 @@ impl PlexiApp {
                                                                 RichText::new("bg")
                                                                     .size(9.0)
                                                                     .color(colors.text_dim),
+                                                            );
+                                                        }
+                                                        if *is_workspace_local {
+                                                            ui.add_space(6.0);
+                                                            ui.label(
+                                                                RichText::new("ws")
+                                                                    .size(9.0)
+                                                                    .color(colors.accent),
                                                             );
                                                         }
                                                     });


### PR DESCRIPTION
Closes #1770

## Summary

- Add `workspace_root: Option<PathBuf>` to `InstalledApp` and `loaded_workspace: Option<PathBuf>` to `AppRegistry` so each local app carries its workspace and the registry knows what it was scanned for.
- At palette-open time, resolve the focused pane's CWD → workspace root; if it differs from `registry.loaded_workspace`, rescan lazily before building the entry list.
- Filter `LocalApp`/`LocalAgent` entries so they only appear when the focused pane is inside their workspace; global apps remain visible everywhere. Workspace-local apps show a "ws" badge.

## Done When

- `plexi app init` in a workspace directory creates the app locally (not globally)
- Opening the palette with a focused pane inside `/project-a` shows `project-a`'s workspace apps
- Switching the focused pane to `/project-b` updates the palette accordingly
- Global apps remain visible everywhere

## Notes

- Lazy rescan at palette-open time avoids tracking pane-focus changes in the frame loop. Cost is one `readdir` per workspace switch, only when the palette is actually opened.
- The registry rescan triggered by context-transition (`apply_context_transition_effects`) still fires on manual context switches; this PR adds the automatic pane-CWD path.
- `workspace_root` on `InstalledApp` is set by `scan_dir` (same pattern as `source`); `load_app` returns a placeholder `None` that `scan_dir` overwrites.