### PR TITLE
fix(skills/implement-issue): replace auto-stash with fail-fast dirty check (#1687)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -81,10 +81,13 @@ git fetch origin && git status --porcelain && git log origin/alpha..HEAD --oneli
 
 If any unpushed commits listed: STOP immediately. Tell user to push first, then re-run. Do not read the issue, do not stash, do not proceed.
 
-If dirty: auto-stash:
+If dirty: fail immediately:
 ```bash
-git stash push -m "implement-issue auto-stash before #<number>"
-IMPL_STASHED=true
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: alpha has uncommitted changes — commit or stash before running implement-issue"
+  git status --short
+  exit 1
+fi
 ```
 
 Then: `git pull --rebase origin alpha`
@@ -271,15 +274,6 @@ After setting labels, invoke `/open-pr` inline in the same pane — do not spawn
 
 ---
 
-
-## Abort / Stash Pop
-
-At every exit point (success, blocked, fail):
-```bash
-[ "$IMPL_STASHED" = "true" ] && git stash pop
-```
-
----
 
 ## Rules
 


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1687

## Summary

- Removes the silent `IMPL_STASHED` auto-stash cycle from `implement-issue` Phase 1 — if alpha is dirty, the skill now errors immediately with a clear message and `git status --short` output
- Removes the `## Abort / Stash Pop` section (the `git stash pop` cleanup at every exit point) since there's nothing to pop
- Matches the fail-fast guard already used in `open-lanes.sh`