### PR TITLE
fix(cli/completions): nested command completions don't filter by context (#1777)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4823,12 +4823,12 @@ pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
 /// already use `$line[1]`, so a global `$line[2]` → `$line[1]` substitution
 /// only affects the outer dispatch.
 fn fix_zsh_workspace_path_conflict(script: &str) -> String {
-    script
-        .replace(
-            "'::workspace_path -- Open a workspace directory (plexi <path>):_default' \\\n",
-            "",
-        )
-        .replace("$line[2]", "$line[1]")
+    let without_spec: String = script
+        .lines()
+        .filter(|line| !line.contains("::workspace_path"))
+        .flat_map(|line| [line, "\n"])
+        .collect();
+    without_spec.replace("$line[2]", "$line[1]")
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4801,8 +4801,95 @@ pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     };
     log::info!("completions: generating {:?} completions for binary {:?}", shell, binary_name);
     let mut cmd = crate::cli_args::Cli::command();
-    generate(shell_variant, &mut cmd, binary_name, &mut std::io::stdout());
+    if shell_variant == Shell::Zsh {
+        // Generate to a buffer so we can post-process the zsh script.
+        let mut buf = Vec::new();
+        generate(shell_variant, &mut cmd, binary_name, &mut buf);
+        let script = String::from_utf8(buf).unwrap_or_default();
+        print!("{}", fix_zsh_workspace_path_conflict(&script));
+    } else {
+        generate(shell_variant, &mut cmd, binary_name, &mut std::io::stdout());
+    }
     0
+}
+
+/// clap_complete emits `workspace_path` as a positional spec before the
+/// subcommand slot. When the user types `plexi workspace <Tab>`, zsh assigns
+/// "workspace" to that spec (position 1) instead of the subcommand slot
+/// (position 2), so `$line[2]` is empty and no subcommand case matches.
+///
+/// Fix: strip the conflicting workspace_path spec and reindex the outer
+/// dispatch from `$line[2]` to `$line[1]`. All nested subcommand blocks
+/// already use `$line[1]`, so a global `$line[2]` → `$line[1]` substitution
+/// only affects the outer dispatch.
+fn fix_zsh_workspace_path_conflict(script: &str) -> String {
+    script
+        .replace(
+            "'::workspace_path -- Open a workspace directory (plexi <path>):_default' \\\n",
+            "",
+        )
+        .replace("$line[2]", "$line[1]")
+}
+
+#[cfg(test)]
+mod completions_tests {
+    use super::fix_zsh_workspace_path_conflict;
+    use clap::CommandFactory;
+    use clap_complete::{generate, Shell};
+
+    fn generated_zsh() -> String {
+        let mut cmd = crate::cli_args::Cli::command();
+        let mut buf = Vec::new();
+        generate(Shell::Zsh, &mut cmd, "plexi", &mut buf);
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn zsh_fix_removes_workspace_path_spec() {
+        let raw = generated_zsh();
+        assert!(
+            raw.contains("workspace_path"),
+            "raw script should contain workspace_path spec"
+        );
+        let fixed = fix_zsh_workspace_path_conflict(&raw);
+        assert!(
+            !fixed.contains("workspace_path"),
+            "fixed script must not contain workspace_path spec"
+        );
+    }
+
+    #[test]
+    fn zsh_fix_removes_line2_references() {
+        let raw = generated_zsh();
+        assert!(raw.contains("$line[2]"), "raw script should use line[2] for outer dispatch");
+        let fixed = fix_zsh_workspace_path_conflict(&raw);
+        assert!(
+            !fixed.contains("$line[2]"),
+            "fixed script must not contain $line[2] — outer dispatch should use $line[1]"
+        );
+    }
+
+    #[test]
+    fn zsh_fix_preserves_workspace_subcommand_completions() {
+        let raw = generated_zsh();
+        let fixed = fix_zsh_workspace_path_conflict(&raw);
+        assert!(
+            fixed.contains("_plexi__subcmd__workspace_commands"),
+            "workspace subcommand completion function must still be present"
+        );
+        assert!(
+            fixed.contains("(workspace)"),
+            "workspace case branch must still be present"
+        );
+    }
+
+    #[test]
+    fn zsh_fix_is_idempotent() {
+        let raw = generated_zsh();
+        let once = fix_zsh_workspace_path_conflict(&raw);
+        let twice = fix_zsh_workspace_path_conflict(&once);
+        assert_eq!(once, twice, "fix must be idempotent");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1777

## Summary

- `workspace_path: Option<String>` in `Cli` was emitted by clap_complete as a positional spec before the subcommand slot, causing zsh to assign "workspace" to position 1 instead of recognizing it as a subcommand — `$line[2]` was always empty, so no subcommand case matched and all top-level commands were shown
- Post-process the generated zsh script in `completions_cli` to strip the conflicting `workspace_path` spec and reindex outer dispatch from `$line[2]` to `$line[1]`; bash/fish completions are unaffected
- Adds 4 regression tests covering the fix, idempotency, and preservation of workspace subcommand completions

## Done When

- `plexi workspace <Tab>` shows only `init help`
- `plexi app <Tab>` shows only app subcommands
- `plexi secret <Tab>` shows only secret subcommands
- Works in zsh and bash

## Notes

`workspace_path` must remain in the `Cli` struct so clap doesn't error on `plexi /some/path` invocations — the post-processing approach avoids touching the struct while fixing the completion script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with Zsh completion script generation where workspace path arguments could cause subcommand completion matching to fail. The generated completion scripts now properly handle workspace references and workspace subcommand completions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ianjamesburke/PLEXI/pull/1810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->