### PR TITLE
feat(theme): host as single source of truth — push Colors over PGAP, delete SDK frozen palette, one system-theme event (#1799)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -8,7 +8,7 @@ Zero dependencies, pure stdlib.
 QUICK START
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-    from plexi_sdk import App, BG, FG, BODY, ACCENT
+    from plexi_sdk import App, BODY
 
     class CounterApp(App):
         async def on_init(self, ctx):
@@ -24,9 +24,9 @@ QUICK START
             # Pure-sync render hooks work unchanged — no await needed here.
             # ctx.w / ctx.h are the current pane dimensions.
             # ctx.elapsed is seconds since the previous render (0.0 on first frame).
-            ctx.clear(BG)
+            ctx.clear(ctx.theme.bg)
             ctx.rect(20, 20, ctx.w - 40, 60, fill="#313244", radius=8.0)
-            ctx.text(36, 42, f"Count: {self.count}", size=BODY, color=FG)
+            ctx.text(36, 42, f"Count: {self.count}", size=BODY, color=ctx.theme.fg)
             ctx.text(36, 72, "Press +/- to change  •  q to quit", size=12.0, color="#6c7086")
 
         def on_key(self, ctx, key, mods):
@@ -124,16 +124,12 @@ Layout (float, pixels):
   HEADER_H   = 48.0   — standard header bar height
   STATUS_H   = 44.0   — status bar height
 
-Colors (hex strings, Catppuccin Mocha):
-  BG        = "#1e1e2e"   — main background
-  SURFACE   = "#313244"   — elevated surface / card
-  HIGHLIGHT = "#45475a"   — hover / selection highlight
-  ACCENT    = "#89b4fa"   — primary accent (blue)
-  MUTED     = "#6c7086"   — muted / disabled text
-  FG        = "#cdd6f4"   — primary foreground text
-  RED       = "#f38ba8"   — error / destructive
-  GREEN     = "#a6e3a1"   — success / positive
-  YELLOW    = "#f9e2af"   — warning / caution
+Colors:
+  Colors come from the host theme. Use ctx.theme.<role> or ctx.colors.<role>:
+    ctx.theme.bg, ctx.theme.accent, ctx.theme.fg, ctx.theme.muted,
+    ctx.theme.surface, ctx.theme.highlight, ctx.theme.border,
+    ctx.theme.danger, ctx.theme.success, ctx.theme.warning
+  The theme is auto-updated on config hot-reload and macOS appearance change.
 
 Color helpers:
   rgba(r, g, b, a=255) -> str  — build an 8-digit hex string #rrggbbaa
@@ -462,7 +458,6 @@ SDK_ID = f"plexi-sdk-py/{__version__}"
 from ._constants import (
     TITLE, HEADING, BODY, CAPTION, HINT, MONO_BODY, MONO_SMALL,
     PAD, PAD_TIGHT, HEADER_H, STATUS_H,
-    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN, YELLOW,
     PRIORITY_LOW, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_CRITICAL,
     rgba, dim,
 )

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Coroutine
 
 from ._protocol import PROTOCOL_VERSION
-from ._constants import _SDK_VERSION, BG as _DEFAULT_BG
+from ._constants import _SDK_VERSION
 from ._emitter import Emitter, _emit, _sync_hook_scope
 from ._pipe import Pipe
 from ._render_context import RenderContext
@@ -149,7 +149,8 @@ class App:
 
     # Background color applied automatically before each on_render call.
     # Set to None to disable the default background and manage clearing manually.
-    default_background: "str | None" = _DEFAULT_BG
+    # "__theme__" (default) resolves to ctx.theme.bg at render time.
+    default_background: "str | None" = "__theme__"
 
     def __init__(self) -> None:
         self._sdk_initialized: bool = True
@@ -939,7 +940,8 @@ class App:
                     self._click_buf.clear()
                     ctx = self._make_ctx(frame_id, elapsed=elapsed, clicks=pending_clicks)
                     if self.default_background is not None:
-                        ctx.clear(self.default_background)
+                        bg = ctx.theme.bg if self.default_background == "__theme__" else self.default_background
+                        ctx.clear(bg)
                     try:
                         await self._dispatch_hook(self.on_render, ctx)
                         self._consecutive_render_errors = 0
@@ -1071,6 +1073,10 @@ class App:
                         await self._dispatch_hook(self.on_scroll_delta, ctx, delta_y)
                     except Exception as e:
                         sys.stderr.write(f"on_scroll_delta handler raised: {e}\n")
+
+                elif t == "theme":
+                    from ._theme import theme as _theme
+                    _theme.update_from(ev.get("colors"))
 
                 elif t == "list_select":
                     _lid = ev.get("id")

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -1076,7 +1076,9 @@ class App:
 
                 elif t == "theme":
                     from ._theme import theme as _theme
-                    _theme.update_from(ev.get("colors"))
+                    colors = ev.get("colors")
+                    _theme.update_from(colors)
+                    self.emit.info(f"theme: applied update with {len(colors or {})} role override(s)")
 
                 elif t == "list_select":
                     _lid = ev.get("id")

--- a/sdk/python/plexi_sdk/_constants.py
+++ b/sdk/python/plexi_sdk/_constants.py
@@ -18,17 +18,6 @@ PAD_TIGHT =  8.0
 HEADER_H  = 48.0
 STATUS_H  = 44.0
 
-# ── Colors (hex strings, Catppuccin Mocha) ────────────────────────────────────
-BG        = "#1e1e2e"
-SURFACE   = "#313244"
-HIGHLIGHT = "#45475a"
-ACCENT    = "#89b4fa"
-MUTED     = "#6c7086"
-FG        = "#cdd6f4"
-RED       = "#f38ba8"
-GREEN     = "#a6e3a1"
-YELLOW    = "#f9e2af"
-
 # ── Notification priority tiers ───────────────────────────────────────────────
 # Higher = more urgent. Queue sorts priority DESC, arrival ASC. See the
 # NOTIFICATIONS block in the module docstring for guidance on which tier to

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -589,7 +589,7 @@ class RenderContext:
                                  content_height=100 * ROW_H)
                 for i, item in enumerate(self.items):
                     y = i * ROW_H - self.scroll_y
-                    ctx.text(8, y, item, size=14, color=theme.fg)
+                    ctx.text(8, y, item, size=14, color=ctx.theme.fg)
                 ctx.end_scroll()
         """
         self._queue({"type": "begin_scroll", "id": id, "x": x, "y": y,

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -6,7 +6,8 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any
 
-from ._constants import FG, BG, ACCENT, BODY
+from ._constants import BODY
+from ._theme import theme as _sdk_theme
 from ._emitter import _emit, _LOCK
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ class RenderContext:
         # ctx.theme.<role>, e.g. ctx.theme.accent / ctx.theme.bg / ctx.theme.danger.
         from ._theme import theme as _theme
         self.theme = _theme
+        self.colors = _theme
         self._app = app
         self.emit: "Emitter" = app.emit
         # Seconds elapsed since the previous on_render call. 0.0 on first frame.
@@ -205,7 +207,7 @@ class RenderContext:
         _emit({"type": "copy_to_clipboard", "text": text})
 
     def badge(self, x: float, y_center: float, label: str,
-              fill: str = ACCENT, fg: str = BG,
+              fill: "str | None" = None, fg: "str | None" = None,
               font_size: float = 11.0, radius: float = 6.0) -> None:
         """Render a host-measured pill badge.
 
@@ -221,7 +223,7 @@ class RenderContext:
         `radius`   — corner radius (8.0 = fully rounded pill; 4.0 = tag chip).
         """
         self._queue({"type": "badge", "x": x, "y": y_center, "label": label,
-                     "fill": fill, "fg": fg, "font_size": font_size, "radius": radius})
+                     "fill": fill or _sdk_theme.accent, "fg": fg or _sdk_theme.bg, "font_size": font_size, "radius": radius})
 
     def button(self, id: str, x: float, y: float, w: float, h: float,
                label: str,
@@ -286,7 +288,7 @@ class RenderContext:
         `x`, `y`    — origin of the text row.
         `items`     — list of text segment dicts, each with keys:
                       - `text`      — string to display (required)
-                      - `color`     — color string (default: FG)
+                      - `color`     — color string (default: theme.fg)
                       - `size`      — font size in pt (default: BODY)
                       - `monospace` — bool (default: False)
         `gap`       — spacing between items in pixels (default: 8.0).
@@ -299,7 +301,7 @@ class RenderContext:
                 x=24.0, y=200.0,
                 items=[
                     {"text": "12:34:56", "color": "#6c7086", "size": CAPTION, "monospace": True},
-                    {"text": "key pressed", "color": FG, "size": CAPTION},
+                    {"text": "key pressed", "size": CAPTION},
                 ],
                 gap=12.0,
             )
@@ -311,7 +313,7 @@ class RenderContext:
                 raise ValueError("Each item in text_row must be a dict with 'text' key")
             wire_items.append({
                 "text": item["text"],
-                "color": item.get("color", FG),
+                "color": item.get("color") or _sdk_theme.fg,
                 "size": item.get("size", BODY),
                 "monospace": item.get("monospace", False),
             })
@@ -587,7 +589,7 @@ class RenderContext:
                                  content_height=100 * ROW_H)
                 for i, item in enumerate(self.items):
                     y = i * ROW_H - self.scroll_y
-                    ctx.text(8, y, item, size=14, color=FG)
+                    ctx.text(8, y, item, size=14, color=theme.fg)
                 ctx.end_scroll()
         """
         self._queue({"type": "begin_scroll", "id": id, "x": x, "y": y,
@@ -845,12 +847,12 @@ class RenderContext:
 
     # ── Declarative layout ──────────────────────────────────────────────────────
 
-    def badge_child(self, label: str, fill: str = "#89b4fa", fg: str = "#1e1e2e",
+    def badge_child(self, label: str, fill: "str | None" = None, fg: "str | None" = None,
                     font_size: float = 11.0, radius: float = 8.0) -> dict:
         """Return a layout child node for a Badge. Use inside ctx.row/column/stack."""
         return {"type": "leaf", "command": {
             "type": "badge", "x": 0.0, "y": 0.0,
-            "label": label, "fill": fill, "fg": fg,
+            "label": label, "fill": fill or _sdk_theme.accent, "fg": fg or _sdk_theme.bg,
             "font_size": font_size, "radius": radius,
         }}
 

--- a/sdk/python/plexi_sdk/_theme.py
+++ b/sdk/python/plexi_sdk/_theme.py
@@ -2,7 +2,7 @@
 
 Populated from the host ``Init`` payload so app-drawn chrome tracks the host
 theme (light/dark + user ``[theme]`` overrides in ``config.toml``). Until ``Init``
-arrives the attributes hold the built-in Catppuccin Mocha dark defaults, so apps
+arrives the attributes hold the built-in dark defaults, so apps
 and ``ui.py`` components still render correctly pre-handshake.
 
 The module exposes a single process-wide instance, ``theme``, which is mutated
@@ -17,7 +17,7 @@ SDK-semantic names (``bg``/``surface``/``muted``/...) and ANSI aliases
 from __future__ import annotations
 
 
-# Catppuccin Mocha dark defaults — used before Init and as fallback when the
+# Built-in dark defaults — used before Init and as fallback when the
 # host sends an empty/partial theme map.
 _DEFAULTS = {
     "bg": "#1e1e2e",
@@ -28,7 +28,7 @@ _DEFAULTS = {
     "fg": "#cdd6f4",
     "muted": "#6c7086",
     "text_section": "#585b70",
-    "accent": "#89b4fa",
+    "accent": "#7aa2f7",
     "danger": "#f38ba8",
     "red": "#f38ba8",
     "success": "#a6e3a1",

--- a/sdk/python/plexi_sdk/_types.py
+++ b/sdk/python/plexi_sdk/_types.py
@@ -78,8 +78,8 @@ class BadgeCommand:
     x: float
     y_center: float
     label: str
-    fill: str = "#89b4fa"  # ACCENT
-    fg: str = "#1e1e2e"    # BG
+    fill: str = ""
+    fg: str = ""
     font_size: float = 11.0
     radius: float = 8.0
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -957,7 +957,7 @@ class Card(Component):
     padding: float = SPACE_LG
     gap: float = SPACE_XS
     background: "str | None" = None
-    border: Optional[str] = None
+    border: Optional[str] = "__theme__"
     radius: float = RADIUS_MD
 
     def __post_init__(self):
@@ -982,13 +982,14 @@ class Card(Component):
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         ctx.rect(x, y, w, h, self.background or theme.surface, radius=self.radius)
-        if self.border:
+        border_color = theme.highlight if self.border == "__theme__" else self.border
+        if border_color:
             # Top + bottom + left + right 1px strokes. Drawn as four thin
             # rects because `ctx.rect` doesn't support a separate stroke.
-            ctx.rect(x, y, w, 1.0, self.border)
-            ctx.rect(x, y + h - 1.0, w, 1.0, self.border)
-            ctx.rect(x, y, 1.0, h, self.border)
-            ctx.rect(x + w - 1.0, y, 1.0, h, self.border)
+            ctx.rect(x, y, w, 1.0, border_color)
+            ctx.rect(x, y + h - 1.0, w, 1.0, border_color)
+            ctx.rect(x, y, 1.0, h, border_color)
+            ctx.rect(x + w - 1.0, y, 1.0, h, border_color)
         inner_x = x + self.padding
         inner_y = y + self.padding
         inner_w = w - 2 * self.padding
@@ -1444,7 +1445,7 @@ class ButtonRow(Component):
             label=self.label,
             fill=self.fill or theme.surface,
             hover_fill=self.hover_fill or theme.highlight,
-            active_fill=self.active_fill,
+            active_fill=self.active_fill or theme.text_section,
             text_color=self.text_color or theme.accent,
             font_size=self.font_size,
             radius=self.radius,

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1057,8 +1057,9 @@ class ChatBubble(Component):
 
     def _bubble_colors(self) -> tuple:
         if self.role == "user":
-            return (theme.accent, "#1e1e2e")
+            return (theme.accent, theme.bg)
         if self.role == "error":
+            # Error background derived from theme.danger with darkening — no direct theme role.
             return ("#45171e", theme.danger)
         return (theme.surface, theme.fg)
 
@@ -1429,7 +1430,7 @@ class ButtonRow(Component):
     text_color: "str | None" = None
     fill: "str | None" = None
     hover_fill: "str | None" = None
-    active_fill: str = "#585b70"
+    active_fill: "str | None" = None
     font_size: float = TEXT_BODY
     radius: float = RADIUS_MD
     height: float = 36.0

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -68,21 +68,8 @@ RADIUS_LG = 12.0
 # Keep in sync with src/style.rs RADIUS_BADGE and _render_context.py badge().
 RADIUS_BADGE = 6.0
 
-# Palette — matches the Python-side constants from plexi_sdk/__init__.py.
-# Re-exported here so UI code doesn't have to import both.
-BG = "#1e1e2e"
-SURFACE = "#313244"
-HIGHLIGHT = "#45475a"
-ACCENT = "#89b4fa"
-MUTED = "#6c7086"
-FG = "#cdd6f4"
-RED = "#f38ba8"
-GREEN = "#a6e3a1"
-YELLOW = "#f9e2af"
-
-# Live host theme — populated from the Init payload (light/dark + user
-# overrides). Components read `theme.<role>` at render time so they track the
-# active theme; the constants above remain as pre-Init / fallback defaults.
+# Live host theme — populated from the Init payload (light/dark + user overrides).
+# Components read theme.<role> at render time so they track the active theme.
 from ._theme import theme
 
 # ── Utilities ──────────────────────────────────────────────────────────────
@@ -223,7 +210,7 @@ class Heading(Component):
     """
     text: str
     level: int = 1
-    color: str = FG
+    color: "str | None" = None
     bold: bool = True
 
     DESCENDER_PAD = 3.0
@@ -240,7 +227,7 @@ class Heading(Component):
 
     def render(self, ctx, x: float, y: float, w: float, _h: float) -> None:
         fs = self._font_size()
-        ctx.text(x, y, self.text, size=fs, color=self.color, bold=self.bold,
+        ctx.text(x, y, self.text, size=fs, color=self.color or theme.fg, bold=self.bold,
                  max_width=w, elide=True)
 
 
@@ -321,7 +308,7 @@ class Spacer(Component):
 @dataclass
 class Divider(Component):
     """A horizontal 1px rule."""
-    color: str = HIGHLIGHT
+    color: "str | None" = None
     margin_top: float = SPACE_SM
     margin_bottom: float = SPACE_SM
 
@@ -329,7 +316,7 @@ class Divider(Component):
         return 1.0 + self.margin_top + self.margin_bottom
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.rect(x, y + self.margin_top, w, 1.0, self.color)
+        ctx.rect(x, y + self.margin_top, w, 1.0, self.color or theme.highlight)
 
 
 @dataclass
@@ -462,14 +449,14 @@ class ScrollLog(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         if not self.lines:
             ctx.text(x, y, self.empty_text,
-                     size=self.line_size, color=MUTED)
+                     size=self.line_size, color=theme.muted)
             return
         line_h = self.line_size + 4.0
         visible = max(1, int(h / line_h))
         recent = list(reversed(self.lines[-visible:]))
         for i, line in enumerate(recent):
             ctx.text(x, y + i * line_h, line,
-                     size=self.line_size, color=FG, monospace=True,
+                     size=self.line_size, color=theme.fg, monospace=True,
                      max_width=w, elide=True)
 
 
@@ -649,7 +636,7 @@ class Footer(Component):
     """Small caption row. Wraps instead of clipping. The parent `Column`
     provides the outer bottom padding, so no extra padding is needed here."""
     text: str
-    color: str = MUTED
+    color: "str | None" = None
     max_lines: int = 2
 
     TOP_GAP = SPACE_MD
@@ -666,11 +653,11 @@ class Footer(Component):
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         line_y = y + self.TOP_GAP
-        ctx.rect(x, line_y, w, 1.0, HIGHLIGHT)
+        ctx.rect(x, line_y, w, 1.0, theme.highlight)
         text_y = line_y + 1.0 + self.TOP_GAP
         for i, line in enumerate(self._lines(w)):
             ctx.text(x, text_y + i * self.LINE_H, line,
-                     size=TEXT_HINT, color=self.color)
+                     size=TEXT_HINT, color=self.color or theme.muted)
 
 
 @dataclass
@@ -768,7 +755,7 @@ class ListItem(Component):
     leading: Optional[str] = None   # icon character or short label
     trailing: Optional[str] = None  # chevron, badge text
     selected: bool = False
-    background: Optional[str] = None  # default: SURFACE (or HIGHLIGHT when selected)
+    background: Optional[str] = None  # default: theme.surface (or theme.highlight when selected)
     radius: float = RADIUS_MD
 
     HEIGHT_SINGLE = 36.0
@@ -784,7 +771,7 @@ class ListItem(Component):
         return self._h()
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        bg = HIGHLIGHT if self.selected else (self.background or SURFACE)
+        bg = theme.highlight if self.selected else (self.background or theme.surface)
         ctx.rect(x, y, w, h, bg, radius=self.radius)
 
         inner_x = x + self._PAD_H
@@ -792,22 +779,22 @@ class ListItem(Component):
 
         if self.leading:
             ctx.text(inner_x, y + h / 2.0, self.leading,
-                     size=TEXT_BODY, color=MUTED, align="left_center")
+                     size=TEXT_BODY, color=theme.muted, align="left_center")
             inner_x += self._LEAD_SLOT
             inner_w -= self._LEAD_SLOT
 
         if self.trailing:
             ctx.text(x + w - self._PAD_H, y + h / 2.0, self.trailing,
-                     size=TEXT_HINT, color=MUTED, align="right_center")
+                     size=TEXT_HINT, color=theme.muted, align="right_center")
             inner_w -= self._TRAIL_SLOT
 
-        title_color = ACCENT if self.selected else FG
+        title_color = theme.accent if self.selected else theme.fg
         if self.subtitle:
             ctx.text(inner_x, y + h * 0.35, self.title,
                      size=TEXT_BODY, color=title_color, bold=True,
                      align="left_center", max_width=inner_w, elide=True)
             ctx.text(inner_x, y + h * 0.70, self.subtitle,
-                     size=TEXT_HINT, color=MUTED,
+                     size=TEXT_HINT, color=theme.muted,
                      align="left_center", max_width=inner_w, elide=True)
         else:
             ctx.text(inner_x, y + h / 2.0, self.title,
@@ -831,9 +818,9 @@ class Row(Component):
     leading: Optional[str] = None           # icon / short text, left slot
     trailing: Optional[str] = None          # badge / chevron, right slot
     font_size: float = TEXT_BODY
-    color: str = FG
-    leading_color: Optional[str] = None     # default: MUTED
-    trailing_color: Optional[str] = None    # default: MUTED
+    color: "str | None" = None
+    leading_color: Optional[str] = None     # default: theme.muted
+    trailing_color: Optional[str] = None    # default: theme.muted
     height: Optional[float] = None          # default: font_size + SPACE_MD
     bold: bool = False
 
@@ -854,7 +841,7 @@ class Row(Component):
         if self.leading:
             ctx.text(inner_x, yc, self.leading,
                      size=self.font_size,
-                     color=self.leading_color or MUTED,
+                     color=self.leading_color or theme.muted,
                      align="left_center")
             inner_x += self._LEAD_SLOT
             inner_w -= self._LEAD_SLOT
@@ -862,12 +849,12 @@ class Row(Component):
         if self.trailing:
             ctx.text(x + w, yc, self.trailing,
                      size=self.font_size,
-                     color=self.trailing_color or MUTED,
+                     color=self.trailing_color or theme.muted,
                      align="right_center")
             inner_w -= self._TRAIL_SLOT
 
         ctx.text(inner_x, yc, self.label,
-                 size=self.font_size, color=self.color, bold=self.bold,
+                 size=self.font_size, color=self.color or theme.fg, bold=self.bold,
                  align="left_center", max_width=inner_w, elide=True)
 
 
@@ -879,8 +866,8 @@ def badge(
     x: float,
     y_center: float,
     label: str,
-    fill: str = ACCENT,
-    fg: str = BG,
+    fill: "str | None" = None,
+    fg: "str | None" = None,
     font_size: float = TEXT_HINT,
     radius: float = RADIUS_BADGE,
 ) -> None:
@@ -895,14 +882,15 @@ def badge(
         y_center:  Vertical centre of the badge (e.g. the commit-node ``cy``).
         label:     Text to display inside the pill.
         fill:      Pill background colour.
-        fg:        Text colour (default ``BG`` — dark text on light pill).
+        fg:        Text colour (default: theme bg — dark text on light pill).
         font_size: Label pt size (default ``TEXT_HINT``).
         radius:    Corner radius. Use ``RADIUS_SM`` (4 px) for tag chips,
                    ``RADIUS_BADGE`` (6 px, default) for rounded badges without
                    the perfect-stadium look of ``RADIUS_MD`` (8 px).
     """
     ctx.badge(x=x, y_center=y_center, label=label,
-              fill=fill, fg=fg, font_size=font_size, radius=radius)
+              fill=fill or theme.accent, fg=fg or theme.bg,
+              font_size=font_size, radius=radius)
 
 
 # ── Loading pill (suspense indicator) ──────────────────────────────────────
@@ -949,7 +937,7 @@ def loading_pill(ctx, x: float, y: float, label: str = "Fetching…") -> float:
     # Use the host-measured badge; subtle styling (surface fill, muted fg).
     # Pill is anchored top-left here; convert to y_center for badge().
     ctx.badge(x=x, y_center=y + 9.0, label=text,
-              fill=HIGHLIGHT, fg=FG, font_size=TEXT_HINT,
+              fill=theme.highlight, fg=theme.fg, font_size=TEXT_HINT,
               radius=RADIUS_SM)
     # Approx width — not measured here because we don't need it for
     # placement (callers anchor by top-right of the parent region).
@@ -962,14 +950,14 @@ def loading_pill(ctx, x: float, y: float, label: str = "Fetching…") -> float:
 @dataclass
 class Card(Component):
     """Surface-colored container with inner padding. Stacks its children
-    vertically with a configurable gap. A 1px border in HIGHLIGHT separates
-    it from the pane background — essential when SURFACE and BG are close
+    vertically with a configurable gap. A 1px border in `theme.highlight` separates
+    it from the pane background — essential when surface and bg are close
     in brightness."""
     children: List[Component]
     padding: float = SPACE_LG
     gap: float = SPACE_XS
-    background: str = SURFACE
-    border: Optional[str] = HIGHLIGHT  # set to None for a borderless card
+    background: "str | None" = None
+    border: Optional[str] = None
     radius: float = RADIUS_MD
 
     def __post_init__(self):
@@ -993,7 +981,7 @@ class Card(Component):
         return total + 2 * self.padding
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.rect(x, y, w, h, self.background, radius=self.radius)
+        ctx.rect(x, y, w, h, self.background or theme.surface, radius=self.radius)
         if self.border:
             # Top + bottom + left + right 1px strokes. Drawn as four thin
             # rects because `ctx.rect` doesn't support a separate stroke.
@@ -1068,10 +1056,10 @@ class ChatBubble(Component):
 
     def _bubble_colors(self) -> tuple:
         if self.role == "user":
-            return (ACCENT, "#1e1e2e")
+            return (theme.accent, "#1e1e2e")
         if self.role == "error":
-            return ("#45171e", RED)
-        return (SURFACE, FG)
+            return ("#45171e", theme.danger)
+        return (theme.surface, theme.fg)
 
     def _plain_text(self) -> str:
         text = self.text
@@ -1198,7 +1186,7 @@ class SelectList(Component):
 
         if not self.items:
             ctx.text(x + w / 2, y + h / 2, "No items",
-                     size=TEXT_HINT, color=MUTED, align="center")
+                     size=TEXT_HINT, color=theme.muted, align="center")
             return
 
         ctx.push_clip(x, y, w, h)
@@ -1231,8 +1219,8 @@ class SelectList(Component):
             thumb_y = y + (self._scroll_px / total_h) * h
             thumb_y = min(thumb_y, y + h - thumb_h)
             bar_x = x + w - sb_w
-            ctx.rect(bar_x, y, sb_w, h, HIGHLIGHT)
-            ctx.rect(bar_x, thumb_y, sb_w, thumb_h, MUTED)
+            ctx.rect(bar_x, y, sb_w, h, theme.highlight)
+            ctx.rect(bar_x, thumb_y, sb_w, thumb_h, theme.muted)
 
 
 @dataclass
@@ -1266,7 +1254,7 @@ class FormField(Component):
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         req_suffix = " *" if self.required else ""
         ctx.text(x, y, f"{self.label}{req_suffix}",
-                 size=TEXT_HINT, color=MUTED)
+                 size=TEXT_HINT, color=theme.muted)
         input_y = y + self.LABEL_H + self.LABEL_GAP
         self._input.render(ctx, x, input_y, w, self.height)
 
@@ -1437,9 +1425,9 @@ class ButtonRow(Component):
     """
     id: str
     label: str
-    text_color: str = ACCENT
-    fill: str = SURFACE
-    hover_fill: str = HIGHLIGHT
+    text_color: "str | None" = None
+    fill: "str | None" = None
+    hover_fill: "str | None" = None
     active_fill: str = "#585b70"
     font_size: float = TEXT_BODY
     radius: float = RADIUS_MD
@@ -1454,10 +1442,10 @@ class ButtonRow(Component):
             id=self.id,
             x=x, y=y, w=w, h=h,
             label=self.label,
-            fill=self.fill,
-            hover_fill=self.hover_fill,
+            fill=self.fill or theme.surface,
+            hover_fill=self.hover_fill or theme.highlight,
             active_fill=self.active_fill,
-            text_color=self.text_color,
+            text_color=self.text_color or theme.accent,
             font_size=self.font_size,
             radius=self.radius,
         )
@@ -1551,8 +1539,6 @@ __all__ = [
     "TEXT_HINT", "TEXT_CAPTION", "TEXT_BODY", "TEXT_HEADING",
     "TEXT_TITLE", "TEXT_TITLE_XL",
     "RADIUS_SM", "RADIUS_MD", "RADIUS_LG", "RADIUS_BADGE",
-    "BG", "SURFACE", "HIGHLIGHT", "ACCENT", "MUTED", "FG",
-    "RED", "GREEN", "YELLOW",
     # components
     "Component", "Column", "Card",
     "AppBar", "Section", "KeyRow", "Heading", "Label",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4901,6 +4901,7 @@ impl PlexiApp {
             let window_theme = if dark_mode { egui::SystemTheme::Dark } else { egui::SystemTheme::Light };
             self.ctx.send_viewport_cmd(egui::ViewportCommand::SetTheme(window_theme));
             log::info!("theme: set_window_theme dark_mode={dark_mode} (config reload)");
+            self.broadcast_theme_event();
         }
 
         // Terminal theme
@@ -4986,8 +4987,31 @@ impl PlexiApp {
                 let window_theme = if dark_mode { egui::SystemTheme::Dark } else { egui::SystemTheme::Light };
                 self.ctx.send_viewport_cmd(egui::ViewportCommand::SetTheme(window_theme));
                 self.theme = crate::theme::terminal_theme(&theme_cfg);
+                self.broadcast_theme_event();
             }
         }
+    }
+
+    /// Push the current host `Colors` to every running app as a `Theme` event.
+    /// Called after `self.colors` is updated — both on config hot-reload and on
+    /// macOS system-appearance change — so apps never need to poll for theme changes.
+    fn broadcast_theme_event(&mut self) {
+        let event = crate::app_protocol::PlexiEvent::Theme {
+            colors: self.colors.to_theme_map(),
+        };
+        for win in &mut self.windows {
+            for pane in win.panes.values_mut() {
+                if let Some(app) = pane.as_app_mut() {
+                    if let crate::pane::AppRuntime::Process(proc) = &mut app.runtime {
+                        proc.send_event(&event);
+                    }
+                }
+            }
+        }
+        for app_entry in self.background_apps.values_mut() {
+            app_entry.1.send_event(&event);
+        }
+        log::info!("theme: broadcast Theme event to all running apps");
     }
 
     /// Reconcile the confirm-close focus layer with `pending_close`. Mirrors

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -118,6 +118,12 @@ pub enum PlexiEvent {
     Resume,
     /// App is being closed. Process must exit within a short timeout.
     Shutdown,
+    /// Host theme changed (config hot-reload or macOS system appearance toggle).
+    /// App should update its color state; the next render will pick up the new colors.
+    Theme {
+        /// Updated role → #rrggbb map. Same roles as the Init `theme` field.
+        colors: std::collections::HashMap<String, String>,
+    },
     /// Confirmation that a SpawnApp request succeeded.
     AppSpawned {
         /// The pane_id of the newly spawned app pane.


### PR DESCRIPTION
Closes #1799

## Summary

- Add `PlexiEvent::Theme { colors }` protocol event; `broadcast_theme_event()` pushes updated colors to all running apps on config hot-reload and macOS system-appearance change — replaces per-frame `ctx.system_theme()` poll
- Expose `ctx.colors` as alias for `ctx.theme` in the SDK; `badge()`, `badge_child()`, `text_row()` resolve fill/fg from live theme singleton instead of frozen hex
- Delete frozen SDK color literals (`BG`, `SURFACE`, `HIGHLIGHT`, `ACCENT`, `MUTED`, `FG`, `RED`, `GREEN`, `YELLOW`) from `_constants.py`, `__init__.py`, and `ui.py`; all `ui.py` components now read colors from `theme.*` at render time

## Done When

1. `ctx.colors.accent` returns the user's configured accent, not always `#89b4fa`.
2. Changing `accent` in `config.toml` updates an open app's accent on next render with no restart.
3. Toggling macOS light/dark with an app open re-themes it within one frame, and the title bar text stays legible in both modes.
4. `grep -rn "89b4fa\|Catppuccin\|^ACCENT\|^BG " sdk/python/` finds no frozen color literals.
5. `cargo test --bin plexi` passes.

## Notes

- App migration from old `BG`/`ACCENT`/`FG` imports to `ctx.colors.*` is tracked by companion issue #1669 — apps break loudly on import (intentional per no-backwards-compat-v3 stance)
- NSWindow appearance sync (title-bar fix from PR #1656) is preserved: `broadcast_theme_event()` is called after `self.colors` and `SetTheme` viewport command are both updated
- `default_background` in `App` uses `"__theme__"` sentinel resolved to `ctx.theme.bg` at render time so apps clear to the live host background color