### PR TITLE
fix(infra/skills): bundle mode Ship Log, Pipeline Labels, and Closes keywords for all N issues (#1815)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -161,10 +161,12 @@ Before writing code, produce a tight implementation spec.
   ```bash
   # Single issue:
   gh issue view <number> --json title,body,labels
-  # Bundle — run simultaneously:
-  gh issue view <n1> --json title,body,labels &
-  gh issue view <n2> --json title,body,labels &
+  # Bundle — run simultaneously, redirect to temp files to prevent stdout interleaving:
+  gh issue view <n1> --json title,body,labels > /tmp/issue_n1.json &
+  gh issue view <n2> --json title,body,labels > /tmp/issue_n2.json &
   wait
+  cat /tmp/issue_n1.json /tmp/issue_n2.json
+  rm /tmp/issue_n1.json /tmp/issue_n2.json
   ```
 - Source files for this change (see Implementation Map below)
 
@@ -247,16 +249,14 @@ git -C worktrees/<branch> push -u origin HEAD
 
 **Bundle mode:** branch name `feature/bundle-<n1>-<n2>`, implement and commit issues sequentially so each commit is independently bisectable:
 
-1. Implement issue N1 changes, then:
+1. For each issue (N1, N2, ...), implement changes and commit individually:
    ```bash
    git -C worktrees/<branch> add <files>
-   git -C worktrees/<branch> commit -m "fix/feat: <n1 description> (#<n1>)"
+   git -C worktrees/<branch> commit -m "fix/feat: <issue description> (#<issue_number>)"
    ```
-2. Write Ship Log entry to issue N1 body immediately after its commit (see Ship Log Format).
-3. Repeat for each remaining issue (N2, N3, ...) — one commit per issue.
-4. Push all commits: `git -C worktrees/<branch> push -u origin HEAD`
-5. After pushing, write Ship Log entries for any issues not yet logged.
-6. Set Pipeline Labels on ALL N issues (see Pipeline Labels).
+2. Push all commits: `git -C worktrees/<branch> push -u origin HEAD`
+3. After pushing, write a Ship Log entry to **each** issue body (see Ship Log Format).
+4. Set Pipeline Labels on ALL N issues (see Pipeline Labels).
 
 ---
 

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -157,7 +157,15 @@ If mismatch: delete worktree and branch, redo.
 Before writing code, produce a tight implementation spec.
 
 **Read in parallel:**
-- Full issue body: `gh issue view <number> --json title,body,labels`
+- Full issue body (or all N bodies in bundle mode):
+  ```bash
+  # Single issue:
+  gh issue view <number> --json title,body,labels
+  # Bundle — run simultaneously:
+  gh issue view <n1> --json title,body,labels &
+  gh issue view <n2> --json title,body,labels &
+  wait
+  ```
 - Source files for this change (see Implementation Map below)
 
 **Implementation Map — verify, then trust.** If the issue body has an `## Implementation Map` section, it lists the exact files to touch (written by `/create-issue` during its codebase research). Do NOT re-run the broad grep/discovery sweep. Instead:
@@ -237,13 +245,24 @@ git -C worktrees/<branch> commit -m "<message>"
 git -C worktrees/<branch> push -u origin HEAD
 ```
 
-**Bundle mode:** branch name `feature/bundle-<n1>-<n2>`, implement all issues before pushing.
+**Bundle mode:** branch name `feature/bundle-<n1>-<n2>`, implement and commit issues sequentially so each commit is independently bisectable:
+
+1. Implement issue N1 changes, then:
+   ```bash
+   git -C worktrees/<branch> add <files>
+   git -C worktrees/<branch> commit -m "fix/feat: <n1 description> (#<n1>)"
+   ```
+2. Write Ship Log entry to issue N1 body immediately after its commit (see Ship Log Format).
+3. Repeat for each remaining issue (N2, N3, ...) — one commit per issue.
+4. Push all commits: `git -C worktrees/<branch> push -u origin HEAD`
+5. After pushing, write Ship Log entries for any issues not yet logged.
+6. Set Pipeline Labels on ALL N issues (see Pipeline Labels).
 
 ---
 
 ## Ship Log Format
 
-After pushing, append this section to the issue body. If a `## Ship Log` section already exists (prior attempt), append a new entry under it. If not, add the section.
+After pushing, append this section to the issue body. In bundle mode, write a Ship Log entry to **each** issue body. If a `## Ship Log` section already exists (prior attempt), append a new entry under it. If not, add the section.
 
 ```markdown
 ## Ship Log
@@ -272,17 +291,18 @@ gh issue edit <number> --body "$NEW_BODY"
 
 ## Pipeline Labels
 
-After pushing and writing the Ship Log, set pipeline state:
+After pushing and writing the Ship Log, set pipeline state on **every** issue in the bundle (or the single issue in single-issue mode):
 
 ```bash
-gh issue edit <number> \
+# Repeat for each issue number N:
+gh issue edit <N> \
   --add-label "pipeline:open-pr" \
   --add-label "ready" \
   --remove-label "pipeline:implement" \
   --remove-label "in progress"
 ```
 
-After setting labels, invoke `/open-pr` inline in the same pane — do not spawn a new pane or wait for PM to dispatch.
+After setting labels on all issues, invoke `/open-pr` inline in the same pane — do not spawn a new pane or wait for PM to dispatch.
 
 ---
 

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -46,9 +46,14 @@ Must be a `feature/` or `fix/` branch. Fail if on `alpha`, `beta`, or `main`.
 - `feature/<number>-...` → issue number is the first segment after `feature/`
 - Bundle: `feature/bundle-<n1>-<n2>-...` → multiple issue numbers
 
-**Fetch issue for PR body:**
+**Fetch issue(s) for PR body:**
 ```bash
+# Single issue:
 gh issue view <number> --json title,body,labels --jq '{title: .title, body: .body}'
+# Bundle — fetch all N in parallel:
+gh issue view <n1> --json title,body,labels --jq '{title: .title, body: .body}' &
+gh issue view <n2> --json title,body,labels --jq '{title: .title, body: .body}' &
+wait
 ```
 
 ---
@@ -64,7 +69,9 @@ if echo "$ISSUE_LABELS" | grep -q "bundle"; then
 fi
 ```
 
-**PR body — lightweight path:** When `LIGHTWEIGHT=true`, add the CodeRabbit ignore directive and a minimal body:
+**PR body — lightweight path:** When `LIGHTWEIGHT=true`, add the CodeRabbit ignore directive and a minimal body.
+
+For a **single issue**:
 ```bash
 PR_URL=$(gh pr create \
   --base alpha \
@@ -81,7 +88,28 @@ EOF
 )")
 ```
 
-**PR body — standard path:** Full body with Done When and Notes:
+For a **bundle** (`feature/bundle-<n1>-<n2>-...`):
+```bash
+PR_URL=$(gh pr create \
+  --base alpha \
+  --head <branch> \
+  --title "<short summary> (#<n1>, #<n2>)" \
+  --body "$(cat <<'EOF'
+<!-- coderabbitai:ignore -->
+Closes #<n1>, Closes #<n2>
+
+## Summary
+
+**#<n1> — <issue-n1-title>**
+- <bullet summarizing n1 change>
+
+**#<n2> — <issue-n2-title>**
+- <bullet summarizing n2 change>
+EOF
+)")
+```
+
+**PR body — standard path:** Full body with Done When and Notes. For bundles, repeat Closes and Done When for each issue:
 ```bash
 PR_URL=$(gh pr create \
   --base alpha \
@@ -103,21 +131,27 @@ Closes #<number>
 <any non-obvious implementation decisions or gotchas>
 EOF
 )")
+# Bundle standard path — one Closes per issue, one Done When block per issue:
+# Closes #<n1>, Closes #<n2>
+# ## Done When — #<n1>
+# <checklist>
+# ## Done When — #<n2>
+# <checklist>
 PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 ```
 
-Update pipeline label:
+Update pipeline label on **each** issue in the bundle (or the single issue):
 ```bash
-gh issue edit <number> --add-label "in progress" --remove-label "pipeline:implement" --add-label "pipeline:open-pr" 2>/dev/null || true
+# Repeat for each issue number N:
+gh issue edit <N> --add-label "in progress" --remove-label "pipeline:implement" --add-label "pipeline:open-pr" 2>/dev/null || true
 ```
 
-Update project board to "In Review":
+Update project board to "In Review" for **each** issue in the bundle:
 ```bash
-_PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=<number> --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
+# Repeat for each issue number N:
+_PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=<N> --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
 [ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="f1399a59" > /dev/null
 ```
-
-**Bundle mode:** PR title `<summary> (#<n1>, #<n2>[, ...])`. Body lists each issue's Done When separately.
 
 ---
 
@@ -200,7 +234,7 @@ Net: <N> fix(es) committed | no changes needed
 
 ## Ship Log Append
 
-Append to the issue's `## Ship Log` section:
+Append to the `## Ship Log` section in **each** issue's body (all N issues in bundle mode, the single issue otherwise):
 
 ```markdown
 **PR:** #<pr-number> — <pr-url>
@@ -208,26 +242,28 @@ Append to the issue's `## Ship Log` section:
 ```
 
 ```bash
-CURRENT_BODY=$(gh issue view <number> --json body --jq '.body')
+# Repeat for each issue number N:
+CURRENT_BODY=$(gh issue view <N> --json body --jq '.body')
 # Append the PR line to the most recent Ship Log entry
-gh issue edit <number> --body "<updated body>"
+gh issue edit <N> --body "<updated body>"
 ```
 
 ---
 
 ## Pipeline Labels
 
-After writing the Ship Log, set pipeline state:
+After writing the Ship Log, set pipeline state on **every** issue in the bundle (or the single issue):
 
 ```bash
-gh issue edit <number> \
+# Repeat for each issue number N:
+gh issue edit <N> \
   --add-label "pipeline:validate" \
   --add-label "ready" \
   --remove-label "pipeline:open-pr" \
   --remove-label "in progress"
 ```
 
-After setting labels, invoke `/validate-pr <pr-number>` inline in the same pane — do not spawn a new pane or wait for PM to dispatch.
+After setting labels on all issues, invoke `/validate-pr <pr-number>` inline in the same pane — do not spawn a new pane or wait for PM to dispatch.
 
 ---
 

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -50,10 +50,12 @@ Must be a `feature/` or `fix/` branch. Fail if on `alpha`, `beta`, or `main`.
 ```bash
 # Single issue:
 gh issue view <number> --json title,body,labels --jq '{title: .title, body: .body}'
-# Bundle — fetch all N in parallel:
-gh issue view <n1> --json title,body,labels --jq '{title: .title, body: .body}' &
-gh issue view <n2> --json title,body,labels --jq '{title: .title, body: .body}' &
+# Bundle — fetch all N in parallel, redirect to temp files to prevent stdout interleaving:
+gh issue view <n1> --json title,body,labels --jq '{title: .title, body: .body}' > /tmp/issue_n1.json &
+gh issue view <n2> --json title,body,labels --jq '{title: .title, body: .body}' > /tmp/issue_n2.json &
 wait
+cat /tmp/issue_n1.json /tmp/issue_n2.json
+rm /tmp/issue_n1.json /tmp/issue_n2.json
 ```
 
 ---


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1815

## Summary

- Expands `implement-issue` Phase 3 to fetch all N issue bodies in parallel for bundle invocations
- Expands `implement-issue` Phase 4 bundle mode from a one-liner into explicit steps: one commit per issue, Ship Log written after each commit, Pipeline Labels set on all N issues after push
- Expands `open-pr` Step 1 to fetch all N issue bodies in parallel when a bundle branch is detected
- Fixes `open-pr` Step 2 PR body to generate `Closes #N1, Closes #N2` (not singular) and include each issue's summary bullet for bundle PRs
- Fixes `open-pr` Ship Log Append and Pipeline Labels sections to apply to every issue in the bundle, not just the first