### PR TITLE
fix(cli): plexi secret success confirmations write to stderr instead of stdout (#1818)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -698,7 +698,7 @@ pub fn workspace_secret_set(friendly: &str, from_env: bool, global: bool, alias:
             return match store.set(&account, &value) {
                 Ok(()) => {
                     log::info!("secret_set:cli: stored globally account={account}");
-                    eprintln!("Stored '{friendly}' globally (plexi:user:{effective_friendly})");
+                    println!("Stored '{friendly}' globally (plexi:user:{effective_friendly})");
                     print_tip(&format!(
                         "reference '{friendly}' in commands.toml under `[secrets] required = [\"{friendly}\"]`."
                     ));
@@ -909,7 +909,7 @@ pub fn workspace_secret_delete(friendly: &str) -> i32 {
         let store = MacKeychain::new();
         match store.delete(&account) {
             Ok(()) => {
-                eprintln!("Deleted '{friendly}' from workspace {}", cfg.id);
+                println!("Deleted '{friendly}' from workspace {}", cfg.id);
                 0
             }
             Err(e) => {


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1818

## Summary

- `secret set --global` success confirmation was using `eprintln!` (stderr) instead of `println!` (stdout)
- `secret delete` success confirmation had the same bug
- 2-line fix: both `eprintln!` calls changed to `println!`; error paths remain on stderr