### PR TITLE
refactor(render): render_badge returns Rect + Component.render_into + assert_no_overlap (#1803)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -205,11 +205,9 @@ class GhIssues(App):
             ("r", "refresh"),
             ("n", "new"),
         ])
-        appbar_h  = appbar.measure(ctx.w)
+        list_top  = appbar.render_into(ctx, 0.0, 0.0, ctx.w)
         footer_h  = footer.measure(ctx.w)
-        list_top  = appbar_h
-        appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)
-        footer.render(ctx, 0.0, ctx.h - footer_h, ctx.w, footer_h)
+        footer.render_into(ctx, 0.0, ctx.h - footer_h, ctx.w)
 
         if self._loading:
             ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=theme.muted)

--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -207,7 +207,7 @@ class GhIssues(App):
         ])
         list_top  = appbar.render_into(ctx, 0.0, 0.0, ctx.w)
         footer_h  = footer.measure(ctx.w)
-        footer.render_into(ctx, 0.0, ctx.h - footer_h, ctx.w)
+        footer.render(ctx, 0.0, ctx.h - footer_h, ctx.w, footer_h)
 
         if self._loading:
             ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=theme.muted)

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -431,6 +431,62 @@ class AppHarness:
         """Save the last rendered frame as a PNG file."""
         save_snapshot(self.screenshot(), path)
 
+    def assert_no_overlap(
+        self,
+        *,
+        min_area: float = 100.0,
+        allowlist: "list[tuple[int, int]] | None" = None,
+    ) -> None:
+        """Assert no two non-background rect commands overlap significantly.
+
+        Collects all ``rect`` draw commands whose area >= ``min_area`` pixels,
+        excluding full-width background clears (w >= 95 % of pane width).
+        Raises ``AssertionError`` with details on the first detected overlap.
+
+        ``allowlist`` is a list of ``(i, j)`` index pairs (0-based) to skip —
+        use for intentional overlays such as a tooltip over content.
+
+        Example::
+
+            with AppHarness("my_app.py", width=400, height=300) as h:
+                h.run(1)
+                h.assert_no_overlap()
+        """
+        allow: set = set(map(tuple, allowlist or []))
+        rects: list = []
+        for cmd in self._draw_commands:
+            if cmd.get("type") != "rect":
+                continue
+            x = float(cmd.get("x", 0.0))
+            y = float(cmd.get("y", 0.0))
+            w = float(cmd.get("w", 0.0))
+            h = float(cmd.get("h", 0.0))
+            if w * h < min_area:
+                continue
+            if w >= self._width * 0.95:
+                continue
+            rects.append((x, y, x + w, y + h))
+
+        for i, (ax1, ay1, ax2, ay2) in enumerate(rects):
+            for j, (bx1, by1, bx2, by2) in enumerate(rects):
+                if j <= i:
+                    continue
+                if (i, j) in allow:
+                    continue
+                ix1 = max(ax1, bx1)
+                iy1 = max(ay1, by1)
+                ix2 = min(ax2, bx2)
+                iy2 = min(ay2, by2)
+                if ix1 < ix2 and iy1 < iy2:
+                    overlap_area = (ix2 - ix1) * (iy2 - iy1)
+                    if overlap_area >= min_area:
+                        raise AssertionError(
+                            f"Overlapping draw rects detected: "
+                            f"rect[{i}] ({ax1:.0f},{ay1:.0f}→{ax2:.0f},{ay2:.0f}) "
+                            f"and rect[{j}] ({bx1:.0f},{by1:.0f}→{bx2:.0f},{by2:.0f}), "
+                            f"overlap={overlap_area:.0f}px²"
+                        )
+
     def close(self) -> None:
         """Shut down the app subprocess cleanly."""
         import subprocess as _subprocess

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -443,8 +443,10 @@ class AppHarness:
         excluding full-width background clears (w >= 95 % of pane width).
         Raises ``AssertionError`` with details on the first detected overlap.
 
-        ``allowlist`` is a list of ``(i, j)`` index pairs (0-based) to skip —
-        use for intentional overlays such as a tooltip over content.
+        ``allowlist`` is a list of ``(i, j)`` index pairs referencing the
+        **original draw command indices** in ``self._draw_commands`` (stable
+        across ``min_area`` / width-threshold changes). Order within each pair
+        does not matter — ``(3, 7)`` and ``(7, 3)`` are equivalent.
 
         Example::
 
@@ -452,9 +454,9 @@ class AppHarness:
                 h.run(1)
                 h.assert_no_overlap()
         """
-        allow: set = set(map(tuple, allowlist or []))
+        allow: set = {tuple(sorted(p)) for p in (allowlist or [])}
         rects: list = []
-        for cmd in self._draw_commands:
+        for idx, cmd in enumerate(self._draw_commands):
             if cmd.get("type") != "rect":
                 continue
             x = float(cmd.get("x", 0.0))
@@ -465,13 +467,13 @@ class AppHarness:
                 continue
             if w >= self._width * 0.95:
                 continue
-            rects.append((x, y, x + w, y + h))
+            rects.append((idx, (x, y, x + w, y + h)))
 
-        for i, (ax1, ay1, ax2, ay2) in enumerate(rects):
-            for j, (bx1, by1, bx2, by2) in enumerate(rects):
+        for i, (idx_a, (ax1, ay1, ax2, ay2)) in enumerate(rects):
+            for j, (idx_b, (bx1, by1, bx2, by2)) in enumerate(rects):
                 if j <= i:
                     continue
-                if (i, j) in allow:
+                if tuple(sorted((idx_a, idx_b))) in allow:
                     continue
                 ix1 = max(ax1, bx1)
                 iy1 = max(ay1, by1)
@@ -482,8 +484,8 @@ class AppHarness:
                     if overlap_area >= min_area:
                         raise AssertionError(
                             f"Overlapping draw rects detected: "
-                            f"rect[{i}] ({ax1:.0f},{ay1:.0f}→{ax2:.0f},{ay2:.0f}) "
-                            f"and rect[{j}] ({bx1:.0f},{by1:.0f}→{bx2:.0f},{by2:.0f}), "
+                            f"cmd[{idx_a}] ({ax1:.0f},{ay1:.0f}→{ax2:.0f},{ay2:.0f}) "
+                            f"and cmd[{idx_b}] ({bx1:.0f},{by1:.0f}→{bx2:.0f},{by2:.0f}), "
                             f"overlap={overlap_area:.0f}px²"
                         )
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -182,6 +182,19 @@ class Component:
         """Emit draw commands. Implementations should stay within (x, y, w, h)."""
         raise NotImplementedError
 
+    def render_into(self, ctx, x: float, y: float, w: float) -> float:
+        """Measure, render, and return the consumed height.
+
+        Enables flow layout without manual y-coordinate arithmetic::
+
+            y = 0.0
+            y += appbar.render_into(ctx, 0, y, ctx.w)
+            y += section.render_into(ctx, 0, y, ctx.w)
+        """
+        h = self.measure(w)
+        self.render(ctx, x, y, w, h)
+        return h
+
     def _render_clipped(self, ctx, x: float, y: float, w: float, h: float) -> None:
         """Render this component clipped to its allocated rect.
 

--- a/sdk/python/tests/test_no_overlap.py
+++ b/sdk/python/tests/test_no_overlap.py
@@ -103,5 +103,5 @@ def test_render_into_returns_consumed_height(render_into_app: Path) -> None:
     text_cmds = [c for c in cmds if c.get("type") == "text" and "content_y=" in c.get("text", "")]
     assert text_cmds, "Expected a text command reporting content_y"
     reported_y = float(text_cmds[0]["text"].split("=")[1])
-    # AppBar is 35px (34 band + 1 divider) and Section is ~33px — content should be > 0
-    assert reported_y > 0, f"content_y should be > 0, got {reported_y}"
+    # AppBar is 35px (34 band + 1 divider), Section is 32px (8+11+4+1+8) — total ~67px
+    assert 60 < reported_y < 80, f"content_y should be ~67px, got {reported_y}"

--- a/sdk/python/tests/test_no_overlap.py
+++ b/sdk/python/tests/test_no_overlap.py
@@ -1,0 +1,107 @@
+"""Tests for AppHarness.assert_no_overlap() and Component.render_into()."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from plexi_sdk.testing import AppHarness
+
+
+# ---------------------------------------------------------------------------
+# Fixture apps
+# ---------------------------------------------------------------------------
+
+_OVERLAPPING_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+
+    class OverlapApp(App):
+        def on_render(self, ctx: RenderContext) -> None:
+            ctx.clear("#1e1e2e")
+            # Two non-background rects that deliberately overlap.
+            ctx.rect(10, 10, 100, 50, "#3a3a4a")
+            ctx.rect(50, 30, 100, 50, "#585b70")
+
+    OverlapApp().run()
+""").lstrip()
+
+_CLEAN_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+
+    class CleanApp(App):
+        def on_render(self, ctx: RenderContext) -> None:
+            ctx.clear("#1e1e2e")
+            # Header block at top, content block below — no overlap.
+            ctx.rect(0, 0, 400, 34, "#313244")   # header band
+            ctx.rect(0, 35, 400, 200, "#1e1e2e") # content area (same fill, different y)
+
+    CleanApp().run()
+""").lstrip()
+
+_RENDER_INTO_APP = textwrap.dedent("""
+    from plexi_sdk import App, RenderContext
+    from plexi_sdk.ui import AppBar, Section
+
+    class FlowApp(App):
+        def on_render(self, ctx: RenderContext) -> None:
+            ctx.clear("#1e1e2e")
+            y = 0.0
+            y += AppBar("Title").render_into(ctx, 0, y, ctx.w)
+            y += Section("Items").render_into(ctx, 0, y, ctx.w)
+            ctx.text(0, y, f"content_y={y:.0f}", size=12, color="#cdd6f4")
+
+    FlowApp().run()
+""").lstrip()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def overlapping_app(tmp_path: Path) -> Path:
+    p = tmp_path / "overlap_app.py"
+    p.write_text(_OVERLAPPING_APP)
+    return p
+
+
+@pytest.fixture
+def clean_app(tmp_path: Path) -> Path:
+    p = tmp_path / "clean_app.py"
+    p.write_text(_CLEAN_APP)
+    return p
+
+
+@pytest.fixture
+def render_into_app(tmp_path: Path) -> Path:
+    p = tmp_path / "render_into_app.py"
+    p.write_text(_RENDER_INTO_APP)
+    return p
+
+
+def test_assert_no_overlap_raises_on_overlapping_rects(overlapping_app: Path) -> None:
+    """assert_no_overlap() raises AssertionError when two rects intersect."""
+    with AppHarness(overlapping_app, width=400, height=300) as h:
+        h.run(1)
+        with pytest.raises(AssertionError, match="Overlapping draw rects detected"):
+            h.assert_no_overlap()
+
+
+def test_assert_no_overlap_passes_on_clean_layout(clean_app: Path) -> None:
+    """assert_no_overlap() passes when no non-background rects overlap."""
+    with AppHarness(clean_app, width=400, height=300) as h:
+        h.run(1)
+        h.assert_no_overlap()
+
+
+def test_render_into_returns_consumed_height(render_into_app: Path) -> None:
+    """render_into() flows components — content_y equals sum of component heights."""
+    with AppHarness(render_into_app, width=400, height=300) as h:
+        cmds = h.run(1)
+
+    text_cmds = [c for c in cmds if c.get("type") == "text" and "content_y=" in c.get("text", "")]
+    assert text_cmds, "Expected a text command reporting content_y"
+    reported_y = float(text_cmds[0]["text"].split("=")[1])
+    # AppBar is 35px (34 band + 1 divider) and Section is ~33px — content should be > 0
+    assert reported_y > 0, f"content_y should be > 0, got {reported_y}"

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -549,7 +549,7 @@ pub(crate) fn render_draw_commands(
                                         // render_badge takes origin + pane-local coords
                                         let badge_x = list_rect.min.x - pane_rect.min.x + PAD_X;
                                         let badge_y = row_abs_y - pane_rect.min.y + h_item / 2.0;
-                                        let badge_w = render_badge(
+                                        let badge_rect = render_badge(
                                             ui,
                                             pane_rect.min,
                                             list_clip,
@@ -561,10 +561,10 @@ pub(crate) fn render_draw_commands(
                                             FONT_HINT,
                                             3.0,
                                         );
-                                        // Flow the title past the badge's real width so wide
-                                        // labels (e.g. "#1792") never clip the title; keep at
-                                        // least the old fixed slot so short badges stay aligned.
-                                        (list_rect.min.x + PAD_X + badge_w + BADGE_TEXT_GAP)
+                                        // Flow title past badge's consumed rect so wide labels
+                                        // (e.g. "#1792") never overlap the title. Keep at least
+                                        // the fixed slot so short badges stay aligned.
+                                        (list_rect.min.x + PAD_X + badge_rect.width() + BADGE_TEXT_GAP)
                                             .max(list_rect.min.x + LEADING_W)
                                     }
                                     Some(ListViewLeading::Avatar { handle }) => {
@@ -1032,6 +1032,9 @@ pub(crate) fn contrast_text_hex(fill: &str) -> &'static str {
     }
 }
 
+/// Render a badge pill centred vertically at `y_center` (pane-local).
+/// Returns the consumed `Rect` in screen coordinates so callers can flow
+/// the next element from `pill_rect.max.x`.
 pub(crate) fn render_badge(
     ui: &mut egui::Ui,
     origin: egui::Pos2,
@@ -1043,7 +1046,7 @@ pub(crate) fn render_badge(
     fg: &str,
     font_size: f32,
     radius: f32,
-) -> f32 {
+) -> egui::Rect {
     let fill_color = parse_color(fill).unwrap_or(egui::Color32::from_rgb(0x89, 0xb4, 0xfa));
     let fg_color = parse_color(fg).unwrap_or(egui::Color32::from_rgb(0x1e, 0x1e, 0x2e));
     let font_id = egui::FontId::proportional(font_size);
@@ -1064,7 +1067,7 @@ pub(crate) fn render_badge(
     let text_x = pill_rect.center().x - text_w / 2.0;
     let text_y = pill_rect.center().y - text_h / 2.0;
     painter.galley(egui::pos2(text_x, text_y), galley, fg_color);
-    pill_w
+    pill_rect
 }
 
 /// Render a single KeyChip at absolute position (`origin.x + x`, `origin.y + y`).


### PR DESCRIPTION
Closes #1803

## Summary

- `render_badge` now returns `egui::Rect` (the consumed pill rect) instead of `f32` (width only); the ListView/Badge caller derives the title's x-origin from `badge_rect.width()`, establishing the flow-layout pattern.
- `Component.render_into(ctx, x, y, w) -> float` added to the base class — measures, renders, and returns consumed height, eliminating the `measure() + render()` two-liner at manual layout sites.
- `AppHarness.assert_no_overlap()` added to `testing.py` — collects non-background `rect` draw commands and raises `AssertionError` with coordinates on the first intersection. Includes `allowlist` param for intentional overlays.
- `gh-issues/main.py` list-view `on_render` migrated: `appbar_h` variable removed, `list_top` derived from `appbar.render_into()` return value.

## Done When

1. A widened badge no longer overlaps the title — the title origin comes from the badge's returned rect.
2. `AppHarness.assert_no_overlap()` exists and fails on a deliberately overlapping fixture, passes on `gh-issues`.
3. `gh-issues/main.py` no longer hand-computes component y-offsets.
4. `cargo test --bin plexi` and SDK harness tests pass.

## Notes

- The `render_badge` return type change is safe: the two other call sites (layout node renderer, direct `RenderCommand::Badge` handler) already discarded the `f32` return with a semicolon — they continue to compile unchanged since Rust doesn't require `#[must_use]` for the discard to be silent.
- Pyright errors in the worktree for `render_into` and `assert_no_overlap` are false positives — the LSP resolves `plexi_sdk` to the installed package, not the worktree source. All 3 new tests pass under `uv run pytest`.