### PR TITLE
feat(theme): add Gruvbox Light + Tokyo Day presets, generalize OS auto-switching (#1812)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3786,12 +3786,12 @@ impl eframe::App for PlexiApp {
             self.reload_config();
         }
 
-        // Auto-switch catppuccin variant on macOS appearance change (#1776).
+        // Auto-switch paired theme variant on macOS appearance change (#1776, #1812).
         let current_system_theme = self.ctx.system_theme();
         if current_system_theme != self.last_system_theme {
             self.last_system_theme = current_system_theme;
             if let Some(sys_theme) = current_system_theme {
-                self.apply_catppuccin_auto_theme(sys_theme);
+                self.apply_auto_theme(sys_theme);
             }
         }
 
@@ -4957,23 +4957,19 @@ impl PlexiApp {
         }
         log::info!("ai_broker: config reloaded");
 
-        // Reset so the auto-switch re-evaluates against the current system theme (#1776).
-        // Without this, a config reload that restores a disk preset (e.g. mocha) would leave
-        // last_system_theme unchanged, silently suppressing the catppuccin auto-switch.
+        // Reset so the auto-switch re-evaluates against the current system theme (#1776, #1812).
+        // Without this, a config reload that restores a disk preset would leave
+        // last_system_theme unchanged, silently suppressing the auto-switch.
         self.last_system_theme = None;
         log::info!("Configuration reloaded from disk.");
     }
 
-    /// Auto-switch to the catppuccin variant that matches `system_theme`.
-    /// Only fires when the OS appearance changes and the configured preset is a catppuccin variant.
-    fn apply_catppuccin_auto_theme(&mut self, system_theme: egui::Theme) {
+    /// Auto-switch to the paired preset for `system_theme`.
+    /// No-ops if the configured preset has no paired variant (e.g. nord, dracula).
+    fn apply_auto_theme(&mut self, system_theme: egui::Theme) {
         let current_preset = self.config.theme_preset.as_deref().unwrap_or("");
-        if !crate::theme::is_catppuccin_preset(current_preset) {
+        let Some(new_preset) = crate::theme::paired_preset(current_preset, system_theme) else {
             return;
-        }
-        let new_preset = match system_theme {
-            egui::Theme::Light => "catppuccin-latte",
-            egui::Theme::Dark => "catppuccin-mocha",
         };
         log::info!("theme: auto-switch to {new_preset} (system_theme={system_theme:?})");
         if let Some(preset) = crate::theme::preset_colors(new_preset) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -157,30 +157,23 @@ pub fn is_light_preset(name: &str) -> bool {
 }
 
 /// Returns the paired preset for `name` under `system_theme`, or `None` if the preset
-/// has no paired variant (nord, dracula) or the name is unrecognized.
+/// has no paired variant (nord, dracula), the name is unrecognized, or the preset is
+/// already correct for the current system appearance.
 pub fn paired_preset(name: &str, system_theme: egui::Theme) -> Option<&'static str> {
     let canonical = canonical_preset_name(name)?;
     match system_theme {
         egui::Theme::Dark => match canonical {
             "catppuccin-latte" => Some("catppuccin-mocha"),
-            "catppuccin-mocha" => Some("catppuccin-mocha"),
             "solarized-light" => Some("solarized-dark"),
-            "solarized-dark" => Some("solarized-dark"),
             "gruvbox-light" => Some("gruvbox-dark"),
-            "gruvbox-dark" => Some("gruvbox-dark"),
             "tokyo-day" => Some("tokyo-night"),
-            "tokyo-night" => Some("tokyo-night"),
             _ => None,
         },
         egui::Theme::Light => match canonical {
             "catppuccin-mocha" => Some("catppuccin-latte"),
-            "catppuccin-latte" => Some("catppuccin-latte"),
             "solarized-dark" => Some("solarized-light"),
-            "solarized-light" => Some("solarized-light"),
             "gruvbox-dark" => Some("gruvbox-light"),
-            "gruvbox-light" => Some("gruvbox-light"),
             "tokyo-night" => Some("tokyo-day"),
-            "tokyo-day" => Some("tokyo-day"),
             _ => None,
         },
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -138,7 +138,9 @@ fn canonical_preset_name(name: &str) -> Option<&'static str> {
         "catppuccin-latte" | "latte" => Some("catppuccin-latte"),
         "dracula" => Some("dracula"),
         "tokyo-night" | "tokyonight" | "tokyo" => Some("tokyo-night"),
+        "tokyo-day" | "tokyonight-day" => Some("tokyo-day"),
         "gruvbox" | "gruvbox-dark" => Some("gruvbox-dark"),
+        "gruvbox-light" => Some("gruvbox-light"),
         "nord" => Some("nord"),
         "solarized" | "solarized-dark" => Some("solarized-dark"),
         "solarized-light" => Some("solarized-light"),
@@ -148,12 +150,40 @@ fn canonical_preset_name(name: &str) -> Option<&'static str> {
 
 /// Returns true for presets with a light background — used to flip egui's dark_mode flag.
 pub fn is_light_preset(name: &str) -> bool {
-    matches!(canonical_preset_name(name), Some("catppuccin-latte") | Some("solarized-light"))
+    matches!(
+        canonical_preset_name(name),
+        Some("catppuccin-latte") | Some("solarized-light") | Some("gruvbox-light") | Some("tokyo-day")
+    )
 }
 
-/// Returns true if the preset is any catppuccin variant (latte or mocha).
-pub fn is_catppuccin_preset(name: &str) -> bool {
-    matches!(canonical_preset_name(name), Some("catppuccin-mocha" | "catppuccin-latte"))
+/// Returns the paired preset for `name` under `system_theme`, or `None` if the preset
+/// has no paired variant (nord, dracula) or the name is unrecognized.
+pub fn paired_preset(name: &str, system_theme: egui::Theme) -> Option<&'static str> {
+    let canonical = canonical_preset_name(name)?;
+    match system_theme {
+        egui::Theme::Dark => match canonical {
+            "catppuccin-latte" => Some("catppuccin-mocha"),
+            "catppuccin-mocha" => Some("catppuccin-mocha"),
+            "solarized-light" => Some("solarized-dark"),
+            "solarized-dark" => Some("solarized-dark"),
+            "gruvbox-light" => Some("gruvbox-dark"),
+            "gruvbox-dark" => Some("gruvbox-dark"),
+            "tokyo-day" => Some("tokyo-night"),
+            "tokyo-night" => Some("tokyo-night"),
+            _ => None,
+        },
+        egui::Theme::Light => match canonical {
+            "catppuccin-mocha" => Some("catppuccin-latte"),
+            "catppuccin-latte" => Some("catppuccin-latte"),
+            "solarized-dark" => Some("solarized-light"),
+            "solarized-light" => Some("solarized-light"),
+            "gruvbox-dark" => Some("gruvbox-light"),
+            "gruvbox-light" => Some("gruvbox-light"),
+            "tokyo-night" => Some("tokyo-day"),
+            "tokyo-day" => Some("tokyo-day"),
+            _ => None,
+        },
+    }
 }
 
 /// Returns the list of available preset names.
@@ -164,7 +194,9 @@ pub fn preset_names() -> &'static [&'static str] {
         "catppuccin-latte",
         "dracula",
         "tokyo-night",
+        "tokyo-day",
         "gruvbox-dark",
+        "gruvbox-light",
         "nord",
         "solarized-dark",
         "solarized-light",
@@ -275,6 +307,39 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_white: s("#c0caf5"),
             bright_foreground: s("#c0caf5"),
         }),
+        "tokyo-day" => Some(ThemeConfig {
+            bg_darkest: s("#c4c8da"),
+            bg_sidebar: s("#d5d6db"),
+            bg_toolbar: s("#d5d6db"),
+            terminal_bg: s("#e1e2e7"),
+            bg_hover: s("#b4b5be"),
+            bg_sidebar_hover: s("#a8a9b4"),
+            bg_active: s("#9c9da8"),
+            text_primary: s("#3760bf"),
+            text_dim: s("#848cb5"),
+            text_section: s("#8990b3"),
+            accent: s("#2e7de9"),
+            border: s("#b4b5be"),
+            foreground: s("#3760bf"),
+            background: s("#e1e2e7"),
+            black: s("#e9e9ec"),
+            red: s("#f52a65"),
+            green: s("#587539"),
+            yellow: s("#8c6c3e"),
+            blue: s("#2e7de9"),
+            magenta: s("#9854f1"),
+            cyan: s("#007197"),
+            white: s("#6172b0"),
+            bright_black: s("#a1a6c5"),
+            bright_red: s("#f52a65"),
+            bright_green: s("#587539"),
+            bright_yellow: s("#8c6c3e"),
+            bright_blue: s("#2e7de9"),
+            bright_magenta: s("#9854f1"),
+            bright_cyan: s("#007197"),
+            bright_white: s("#3760bf"),
+            bright_foreground: s("#3760bf"),
+        }),
         "gruvbox-dark" => Some(ThemeConfig {
             bg_darkest: s("#1d2021"),
             bg_sidebar: s("#282828"),
@@ -307,6 +372,39 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#8ec07c"),
             bright_white: s("#fbf1c7"),
             bright_foreground: s("#fbf1c7"),
+        }),
+        "gruvbox-light" => Some(ThemeConfig {
+            bg_darkest: s("#f2e5bc"),
+            bg_sidebar: s("#fbf1c7"),
+            bg_toolbar: s("#fbf1c7"),
+            terminal_bg: s("#fbf1c7"),
+            bg_hover: s("#ebdbb2"),
+            bg_sidebar_hover: s("#d5c4a1"),
+            bg_active: s("#bdae93"),
+            text_primary: s("#3c3836"),
+            text_dim: s("#7c6f64"),
+            text_section: s("#665c54"),
+            accent: s("#d65d0e"),
+            border: s("#d5c4a1"),
+            foreground: s("#3c3836"),
+            background: s("#fbf1c7"),
+            black: s("#fbf1c7"),
+            red: s("#cc241d"),
+            green: s("#98971a"),
+            yellow: s("#d79921"),
+            blue: s("#458588"),
+            magenta: s("#b16286"),
+            cyan: s("#689d6a"),
+            white: s("#7c6f64"),
+            bright_black: s("#928374"),
+            bright_red: s("#9d0006"),
+            bright_green: s("#79740e"),
+            bright_yellow: s("#b57614"),
+            bright_blue: s("#076678"),
+            bright_magenta: s("#8f3f71"),
+            bright_cyan: s("#427b58"),
+            bright_white: s("#3c3836"),
+            bright_foreground: s("#3c3836"),
         }),
         "nord" => Some(ThemeConfig {
             bg_darkest: s("#2e3440"),


### PR DESCRIPTION
Closes #1812

## Summary

- Added `gruvbox-light` and `tokyo-day` preset `ThemeConfig` blocks with canonical upstream color values (Gruvbox morhetz palette, Tokyo Night folke/tokyonight.nvim day variant)
- Replaced `is_catppuccin_preset` with `paired_preset(name, system_theme)` — a lookup table covering all four paired families: catppuccin, solarized, gruvbox, tokyo-night; nord and dracula return `None` (no pair)
- Renamed `apply_catppuccin_auto_theme` → `apply_auto_theme`, driven by `paired_preset()` instead of the Catppuccin-only guard

## Done When

- Switch macOS to light mode with `gruvbox-dark` active → Plexi switches live to `gruvbox-light` without restart
- Same for `tokyo-night` → `tokyo-day`
- `solarized-dark` ↔ `solarized-light` still works (was implicit; now explicit in the pair table)
- Catppuccin auto-switch still works identically to before
- Nord and Dracula do not switch (no pair registered)
- Manual `config.toml` edits still override everything

## Notes

`paired_preset` is idempotent on both sides of each pair — if the user has `gruvbox-light` set and switches to light mode, it stays `gruvbox-light`. No oscillation.