### PR TITLE
fix(host/list_view): mouse-wheel scroll overridden on next frame by scroll-to-selected logic (#1827)

### DIFF
--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -193,10 +193,12 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
                 let mut lv_offsets = std::collections::HashMap::new();
+                let mut lv_last_sel = std::collections::HashMap::new();
                 crate::process_app::render::render_draw_commands(
                     ui, rect, commands, &colors, &mut cm_cache, &peaks,
                     &mut img_cache, &std::env::temp_dir(), false,
                     &mut lv_offsets,
+                    &mut lv_last_sel,
                 );
             });
     });

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -43,6 +43,7 @@ pub(crate) fn render_draw_commands(
     workspace_root: &std::path::Path,
     net_http_granted: bool,
     list_view_scroll_offsets: &mut HashMap<String, f32>,
+    list_view_last_aligned_sel: &mut HashMap<String, usize>,
 ) {
     let origin = pane_rect.min;
 
@@ -419,24 +420,31 @@ pub(crate) fn render_draw_commands(
                     heights.iter().sum::<f32>() + SPACE_XS * (heights.len().saturating_sub(1)) as f32
                 };
 
-                // Scroll-to-selected: ensure selected row is visible
+                // Scroll-to-selected: only fire when the selection index changes.
+                // Running this every frame would override mouse-wheel offsets on the
+                // next repaint (selected item snaps back into view unconditionally).
                 let scroll_y_ref = list_view_scroll_offsets.entry(id.clone()).or_insert(0.0);
                 if !items.is_empty() {
                     let sel = (*selected).min(items.len().saturating_sub(1));
-                    let mut item_top = 0.0f32;
-                    for (i, h_item) in heights.iter().enumerate() {
-                        if i == sel {
-                            let item_bot = item_top + h_item;
-                            if *h_item > list_h {
-                                *scroll_y_ref = item_top;
-                            } else if item_top < *scroll_y_ref {
-                                *scroll_y_ref = item_top;
-                            } else if item_bot > *scroll_y_ref + list_h {
-                                *scroll_y_ref = (item_bot - list_h).max(0.0);
+                    let last_sel = list_view_last_aligned_sel.get(id.as_str()).copied();
+                    if last_sel != Some(sel) {
+                        let mut item_top = 0.0f32;
+                        for (i, h_item) in heights.iter().enumerate() {
+                            if i == sel {
+                                let item_bot = item_top + h_item;
+                                if *h_item > list_h {
+                                    *scroll_y_ref = item_top;
+                                } else if item_top < *scroll_y_ref {
+                                    *scroll_y_ref = item_top;
+                                } else if item_bot > *scroll_y_ref + list_h {
+                                    *scroll_y_ref = (item_bot - list_h).max(0.0);
+                                }
+                                break;
                             }
-                            break;
+                            item_top += h_item + SPACE_XS;
                         }
-                        item_top += h_item + SPACE_XS;
+                        list_view_last_aligned_sel.insert(id.clone(), sel);
+                        log::debug!("list_view scroll-to-sel: id={id:?} sel={sel} offset={scroll_y_ref}");
                     }
                     let max_scroll = (total_h - list_h).max(0.0);
                     *scroll_y_ref = scroll_y_ref.clamp(0.0, max_scroll);

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -21,6 +21,10 @@ pub(crate) struct RenderSession {
     scroll_offsets: HashMap<String, f32>,
     /// Per-ListView scroll offsets. Key = list_view id; value = current vertical offset.
     list_view_scroll_offsets: HashMap<String, f32>,
+    /// Tracks the last selected index that triggered a scroll-to-selected alignment.
+    /// Scroll-to-selected only fires when the selection index changes, so mouse-wheel
+    /// scrolls are not overridden every frame.
+    list_view_last_aligned_sel: HashMap<String, usize>,
     /// True when the current frame contains a ListView command.
     /// When true, `handle_key` in mod.rs suppresses j/k/up/down/enter forwarding.
     pub(crate) list_view_intercepts_nav: bool,
@@ -40,6 +44,7 @@ impl RenderSession {
             text_input_has_focus: false,
             scroll_offsets: HashMap::new(),
             list_view_scroll_offsets: HashMap::new(),
+            list_view_last_aligned_sel: HashMap::new(),
             list_view_intercepts_nav: false,
             pane_just_focused: false,
             outbound_events: Vec::new(),
@@ -82,6 +87,7 @@ impl RenderSession {
             app_dir,
             net_http_granted,
             &mut self.list_view_scroll_offsets,
+            &mut self.list_view_last_aligned_sel,
         );
 
         // ── Pass 2: TextInput widgets ────────────────────────────────────────
@@ -384,6 +390,7 @@ impl RenderSession {
             })
             .collect();
         self.list_view_scroll_offsets.retain(|id, _| live_ids.contains(id));
+        self.list_view_last_aligned_sel.retain(|id, _| live_ids.contains(id));
 
         let mut handled_nav = false;
         for cmd in frame {


### PR DESCRIPTION
Closes #1827

## Summary

- `scroll-to-selected` was running unconditionally every frame, snapping the viewport back to the selected row after every mouse-wheel event
- Added `list_view_last_aligned_sel: HashMap<String, usize>` to `RenderSession` to track the last selection index that triggered an alignment
- The scroll-to-selected block now only fires when `selected != last_aligned_sel[id]`, leaving wheel-driven offsets untouched until the user navigates to a different row

## Done When

Mouse-wheel scrolling over the gh-issues list moves the viewport without snapping back. The selected item (highlighted) stays in place in the list while the view scrolls past it. j/k still snaps the viewport to keep the cursor row visible. Verified on the alpha build.

## Notes

The `last_aligned_sel` map is pruned alongside `list_view_scroll_offsets` in the same `retain` call so there's no stale state for lists that leave the frame.