### PR TITLE
feat(ui/chrome): Cmd-hold pane ID overlay — ghost numbers on every pane (#1829)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4173,6 +4173,21 @@ impl eframe::App for PlexiApp {
                     }
                 }
 
+                let cmd_held = ui.input(|i| i.modifiers.command);
+                {
+                    let overlay_log_id = egui::Id::new("pane_id_overlay_on");
+                    let was_held: bool =
+                        ui.ctx().data(|d| d.get_temp(overlay_log_id).unwrap_or(false));
+                    if was_held != cmd_held {
+                        if cmd_held {
+                            log::info!("[pane-id-overlay] on");
+                        } else {
+                            log::info!("[pane-id-overlay] off");
+                        }
+                        ui.ctx().data_mut(|d| d.insert_temp(overlay_log_id, cmd_held));
+                    }
+                }
+
                 let mut behavior = PlexiBehavior {
                     panes: &mut ctx.panes,
                     focused_tile: if suppress_focus {
@@ -4193,6 +4208,7 @@ impl eframe::App for PlexiApp {
                     unfocused_opacity,
                     portal_info,
                     modal_open,
+                    cmd_held,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4173,7 +4173,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
 
-                let cmd_held = ui.input(|i| i.modifiers.command);
+                let cmd_held = ui.input(|i| i.modifiers.command) && ctx.panes.len() > 1;
                 {
                     let overlay_log_id = egui::Id::new("pane_id_overlay_on");
                     let was_held: bool =

--- a/src/style.rs
+++ b/src/style.rs
@@ -68,6 +68,12 @@ pub const SCRIM_ALPHA: u8 = 190;
 pub const MODAL_PADDING_H: i8 = 32;
 pub const MODAL_PADDING_V: i8 = 28;
 
+// ── Pane ID overlay ────────────────────────────────────────────────────────
+/// Font size for the ⌘-hold pane ID ghost number (large, centered over pane content).
+pub const TEXT_PANE_ID_GHOST: f32 = 64.0;
+/// Alpha (0–255) of the ghost pane ID number — dim enough that content reads through.
+pub const PANE_ID_GHOST_ALPHA: u8 = 55;
+
 // ── App protocol — Badge geometry ─────────────────────────────────────────
 // Padding tokens for the host-rendered Badge DrawCommand. Shared with the
 // Python SDK constants in plexi_sdk/ui.py so both sides agree on pill size.

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -89,6 +89,8 @@ pub struct PlexiBehavior<'a> {
     /// Prevents terminal panes from calling `request_focus()` and stealing
     /// egui focus from the active overlay (egui resolves focus last-caller-wins).
     pub modal_open: bool,
+    /// True when the Command modifier is held — triggers the pane ID ghost overlay.
+    pub cmd_held: bool,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -188,6 +190,16 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                     &self.colors, &mut cache, &audio_peaks,
                 );
             }
+        }
+
+        if self.cmd_held {
+            ui.painter().text(
+                pane_rect.center(),
+                egui::Align2::CENTER_CENTER,
+                format!("{}", pane_id),
+                egui::FontId::proportional(style::TEXT_PANE_ID_GHOST),
+                egui::Color32::from_rgba_unmultiplied(255, 255, 255, style::PANE_ID_GHOST_ALPHA),
+            );
         }
 
         UiResponse::None

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -193,12 +193,13 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         }
 
         if self.cmd_held {
+            let c = self.colors.text_primary;
             ui.painter().text(
                 pane_rect.center(),
                 egui::Align2::CENTER_CENTER,
-                format!("{}", pane_id),
+                pane_id.to_string(),
                 egui::FontId::proportional(style::TEXT_PANE_ID_GHOST),
-                egui::Color32::from_rgba_unmultiplied(255, 255, 255, style::PANE_ID_GHOST_ALPHA),
+                egui::Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), style::PANE_ID_GHOST_ALPHA),
             );
         }
 


### PR DESCRIPTION
Closes #1829

## Summary

- Adds a passive ⌘-hold overlay that renders each pane's real `PaneId` (large, dim, centered) over the pane content — mirrors `tmux display-panes`
- Reads `modifiers.command` once per frame in `app/mod.rs`, passed as `cmd_held` into `PlexiBehavior`; edge-detects the toggle and logs one `info` line on/off
- Two new style tokens in `style.rs`: `TEXT_PANE_ID_GHOST = 64.0` and `PANE_ID_GHOST_ALPHA = 55`; no magic numbers in `tiling.rs`

## Done When

- Holding ⌘ with 2+ panes open shows each pane's real PaneId, centered, large, dim, content still readable underneath.
- Releasing ⌘ removes the numbers.
- `~/.plexi-alpha/plexi.log` shows one info line when the overlay turns on and one when it turns off (not per-frame).
- ⌘+digit still switches context while the numbers are visible.

## Notes

- Overlay is purely passive — no `consume_key`, so ⌘+1–9 context switching and ⌘+0 quick note are unaffected while numbers are visible.
- Ghost numbers are suppressed when a pane is zoomed (early return in `pane_ui` exits before the painter block).