### PR TITLE
fix(cli): auto-install plexi-sdk during app init and app install (#1762)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -954,9 +954,11 @@ fn ensure_plexi_sdk() -> bool {
 
     log::info!("ensure_plexi_sdk: plexi_sdk not importable, attempting install");
 
-    // Try uv pip install first.
+    // Try uv pip install first; suppress output so noisy venv warnings don't surface.
     let uv_ok = std::process::Command::new("uv")
         .args(["pip", "install", "plexi-sdk"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
@@ -967,21 +969,21 @@ fn ensure_plexi_sdk() -> bool {
         return true;
     }
 
-    // Fallback: plain pip.
-    match std::process::Command::new("pip").args(["install", "plexi-sdk"]).status() {
+    // Fallback: python3 -m pip to guarantee the same environment that python3 checked.
+    match std::process::Command::new("python3").args(["-m", "pip", "install", "plexi-sdk"]).status() {
         Ok(s) if s.success() => {
             println!("Installed plexi-sdk (via pip).");
-            log::info!("ensure_plexi_sdk: installed via pip");
+            log::info!("ensure_plexi_sdk: installed via python3 -m pip");
             true
         }
         Ok(_) => {
             eprintln!("warning: could not install plexi-sdk — install manually: pip install plexi-sdk");
-            log::warn!("ensure_plexi_sdk: pip install failed");
+            log::warn!("ensure_plexi_sdk: python3 -m pip install failed");
             false
         }
         Err(e) => {
-            eprintln!("warning: pip not found ({e}) — install manually: pip install plexi-sdk");
-            log::warn!("ensure_plexi_sdk: pip not found: {e}");
+            eprintln!("warning: pip not available ({e}) — install manually: pip install plexi-sdk");
+            log::warn!("ensure_plexi_sdk: python3 -m pip not available: {e}");
             false
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -928,6 +928,77 @@ pub fn workspace_secret_delete(friendly: &str) -> i32 {
 
 // ── plexi app subcommands ─────────────────────────────────────────────────────
 
+/// Returns true if `plexi_sdk` is importable in the current `python3` environment.
+/// If not, attempts installation via `uv pip install plexi-sdk`, falling back to
+/// `pip install plexi-sdk`. Prints a single line describing what happened.
+/// Returns false only if python3 is absent or all install attempts fail.
+fn ensure_plexi_sdk() -> bool {
+    let check = std::process::Command::new("python3")
+        .args(["-c", "import plexi_sdk"])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .status();
+
+    match check {
+        Ok(s) if s.success() => {
+            log::info!("ensure_plexi_sdk: already importable");
+            return true;
+        }
+        Err(e) => {
+            log::warn!("ensure_plexi_sdk: python3 not found: {e}");
+            eprintln!("warning: python3 not found — install plexi-sdk manually: pip install plexi-sdk");
+            return false;
+        }
+        Ok(_) => {}
+    }
+
+    log::info!("ensure_plexi_sdk: plexi_sdk not importable, attempting install");
+
+    // Try uv pip install first.
+    let uv_ok = std::process::Command::new("uv")
+        .args(["pip", "install", "plexi-sdk"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if uv_ok {
+        println!("Installed plexi-sdk (via uv).");
+        log::info!("ensure_plexi_sdk: installed via uv pip");
+        return true;
+    }
+
+    // Fallback: plain pip.
+    match std::process::Command::new("pip").args(["install", "plexi-sdk"]).status() {
+        Ok(s) if s.success() => {
+            println!("Installed plexi-sdk (via pip).");
+            log::info!("ensure_plexi_sdk: installed via pip");
+            true
+        }
+        Ok(_) => {
+            eprintln!("warning: could not install plexi-sdk — install manually: pip install plexi-sdk");
+            log::warn!("ensure_plexi_sdk: pip install failed");
+            false
+        }
+        Err(e) => {
+            eprintln!("warning: pip not found ({e}) — install manually: pip install plexi-sdk");
+            log::warn!("ensure_plexi_sdk: pip not found: {e}");
+            false
+        }
+    }
+}
+
+/// Returns true if the app at `app_dir` has a Python entry point (entry ending in `.py`).
+fn app_is_python(app_dir: &std::path::Path) -> bool {
+    let Ok(s) = std::fs::read_to_string(app_dir.join("manifest.toml")) else { return false; };
+    let Ok(manifest) = toml::from_str::<toml::Value>(&s) else { return false; };
+    let entry = manifest
+        .get("app")
+        .and_then(|a| a.get("entry"))
+        .and_then(|e| e.as_str())
+        .unwrap_or("");
+    entry.ends_with(".py")
+}
+
 /// Detect the channel config dir name from the running binary name.
 fn app_init_config_dir() -> String {
     crate::config::config_dir()
@@ -1044,6 +1115,7 @@ pub fn app_init(name: &str, lang: &str, from_pane_id: Option<u64>) -> i32 {
                 println!("  cargo build --release");
                 println!("  # then run: plexi app run {}", app_dir.display());
             } else {
+                ensure_plexi_sdk();
                 // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
                 if std::env::var("PLEXI_SOCKET").is_ok() {
                     let path_str = app_dir.to_string_lossy().to_string();
@@ -1218,6 +1290,9 @@ pub fn app_install(path: &str) -> i32 {
 
     log::info!("app::install: installed {app_id} v{app_version} from {}", src.display());
     println!("Installed '{app_id}' v{app_version} from {}.", src.display());
+    if app_is_python(&dest) {
+        ensure_plexi_sdk();
+    }
     println!("Run `plexi app open {app_id}` to launch it.");
     0
 }
@@ -1603,6 +1678,9 @@ pub fn install_cli(spec: &str) -> i32 {
         Ok(outcome) => match outcome.status {
             crate::install::InstallStatus::Installed(path) => {
                 println!("installed '{}' at {}", outcome.id, path.display());
+                if app_is_python(&path) {
+                    ensure_plexi_sdk();
+                }
                 print_tip(&format!("open your app with `plexi app open {}`.", outcome.id));
                 0
             }


### PR DESCRIPTION
Closes #1762

## Summary

- Added `ensure_plexi_sdk()` helper that checks if `plexi_sdk` is importable via `python3 -c "import plexi_sdk"` and installs it via `uv pip install plexi-sdk` (falling back to `pip install plexi-sdk`) if not
- Added `app_is_python()` helper that reads `manifest.toml` to detect Python entry points
- Called `ensure_plexi_sdk()` after `app_init` scaffolds a Python app, after `app_install` (local path) succeeds for Python apps, and after `install_cli` (remote/git) installs a Python app

## Done When

1. `plexi app init myapp` on a machine with no `plexi_sdk` installed: SDK is auto-installed, app runs without import errors
2. `plexi app install github:someone/app` with a Python app: SDK is auto-installed if missing
3. Clear terminal output showing what was installed
4. `cargo build` passes

## Notes

- `uv pip` is preferred over bare `pip` per project Python tooling conventions; falls back silently if `uv` is absent
- `ensure_plexi_sdk()` is a no-op (silent) if the SDK is already importable — no install on every `app init`
- Rust apps skip the check entirely (no `ensure_plexi_sdk()` call in the Rust scaffold path)