### PR TITLE
feat(ui/sidebar): uniform heights, inline pane list, click-child-to-zoom (#1633, #1832, #1834)

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -127,8 +127,8 @@ impl PlexiApp {
             let pane_rows: Vec<PaneRowItem> = if is_active && pane_count > 0 {
                 pane_ids.iter().enumerate().map(|(idx, &pane_id)| {
                     let label = self.windows.iter()
-                        .find(|w| w.context_id == ctx_id)
-                        .and_then(|w| w.panes.get(&pane_id))
+                        .filter(|w| w.context_id == ctx_id)
+                        .find_map(|w| w.panes.get(&pane_id))
                         .map(|p| match p {
                             crate::pane::Pane::Terminal(t) => {
                                 t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1))
@@ -419,6 +419,8 @@ impl PlexiApp {
             if let Some((win_idx, tile_id)) = self.find_pane_in_any_window(pane_id) {
                 self.active_window = win_idx;
                 self.set_window_focused_pane(win_idx, tile_id);
+            } else {
+                log::warn!("sidebar: focus_pane target not found pane_id={pane_id}");
             }
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,5 +1,5 @@
 use crate::context::WindowMenuAction;
-use crate::sidebar_row::{SidebarAction, ContextItem, PaneDots};
+use crate::sidebar_row::{SidebarAction, ContextItem, PaneRowItem};
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
@@ -83,6 +83,8 @@ impl PlexiApp {
 
         let num_contexts = self.router.len();
         let mut clicked_workspace: Option<usize> = None;
+        let mut zoom_to_context: Option<usize> = None;
+        let mut focus_pane: Option<u64> = None;
         let mut delete_context: Option<usize> = None;
         let mut menu_action: Option<(usize, WindowMenuAction)> = None;
         let mut row_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
@@ -98,7 +100,7 @@ impl PlexiApp {
             let is_dragging = self.drag_context == Some(i);
             let any_dragging = self.drag_context.is_some();
 
-            // Pane count + focused-dot index for this context
+            // Pane count + focused-pane index for this context
             let ctx_id = self.router.get(i).context_id;
             let mut pane_ids: Vec<u64> = self.windows.iter()
                 .filter(|w| w.context_id == ctx_id)
@@ -107,7 +109,7 @@ impl PlexiApp {
             pane_ids.sort_unstable();
             let pane_count = pane_ids.len();
 
-            let focused_dot_idx: Option<usize> = if is_active {
+            let focused_pane_idx: Option<usize> = if is_active {
                 self.windows.get(self.active_window)
                     .and_then(|w| w.focused_pane)
                     .and_then(|tile_id| {
@@ -119,6 +121,30 @@ impl PlexiApp {
                     })
             } else {
                 None
+            };
+
+            // Build pane rows for the active context — renders inside ContextItem scope.
+            let pane_rows: Vec<PaneRowItem> = if is_active && pane_count > 0 {
+                pane_ids.iter().enumerate().map(|(idx, &pane_id)| {
+                    let label = self.windows.iter()
+                        .find(|w| w.context_id == ctx_id)
+                        .and_then(|w| w.panes.get(&pane_id))
+                        .map(|p| match p {
+                            crate::pane::Pane::Terminal(t) => {
+                                t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1))
+                            }
+                            crate::pane::Pane::App(a) => a.name.clone(),
+                            crate::pane::Pane::Portal(_) => "portal".to_string(),
+                        })
+                        .unwrap_or_else(|| format!("pane {}", idx + 1));
+                    PaneRowItem {
+                        pane_id,
+                        label,
+                        is_focused: focused_pane_idx == Some(idx),
+                    }
+                }).collect()
+            } else {
+                vec![]
             };
 
             // --- Renaming: special-cased before ContextItem path ---
@@ -205,7 +231,9 @@ impl PlexiApp {
                 ctx_index: Some(i),
                 badge_count,
                 subtitle,
-                pane_dots: Some(PaneDots { count: pane_count, focused_idx: focused_dot_idx }),
+                pane_count,
+                pane_rows,
+                is_expanded: is_active,
             }.draw(ui, egui::Id::new(("ctx", i)), &self.colors);
 
             row_rects.push(response.rect);
@@ -270,6 +298,14 @@ impl PlexiApp {
                     SidebarAction::Activate => {
                         log::debug!("sidebar: activate ctx={i} active={}", self.router.active_idx());
                         clicked_workspace = Some(i);
+                    }
+                    SidebarAction::ZoomActivate => {
+                        log::info!("sidebar: zoom into sub-context ctx_idx={i}");
+                        zoom_to_context = Some(i);
+                    }
+                    SidebarAction::ActivatePane(pane_id) => {
+                        log::info!("sidebar: activate pane pane_id={pane_id}");
+                        focus_pane = Some(pane_id);
                     }
                     _ => {}
                 }
@@ -373,6 +409,17 @@ impl PlexiApp {
             }
         } else if let Some(i) = delete_context {
             self.delete_context(i);
+        } else if let Some(i) = zoom_to_context {
+            let current_ctx_id = self.router.active().context_id;
+            let current_win_id = self.windows[self.active_window].window_id;
+            let current_focused = self.windows[self.active_window].focused_pane;
+            self.router.push_depth(current_ctx_id, current_win_id, current_focused);
+            self.switch_workspace(i);
+        } else if let Some(pane_id) = focus_pane {
+            if let Some((win_idx, tile_id)) = self.find_pane_in_any_window(pane_id) {
+                self.active_window = win_idx;
+                self.set_window_focused_pane(win_idx, tile_id);
+            }
         } else if let Some(i) = clicked_workspace {
             self.switch_workspace(i);
         }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -3,10 +3,6 @@ use crate::theme::Colors;
 
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
 
-const PANE_DOT_RADIUS: f32 = 2.5;
-const PANE_DOT_SPACING: f32 = 8.0;
-const PANE_DOT_MAX: usize = 6;
-
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
 }
@@ -32,15 +28,20 @@ fn shorten_path(path: &str) -> String {
 pub enum SidebarAction {
     None,
     Activate,
+    /// Returned when clicking a sub-context (ctx_depth > 0) — caller pushes depth stack.
+    ZoomActivate,
     Rename,
     Delete,
     DragStart,
     DragEnd,
+    /// Returned when clicking an expanded pane row — caller focuses that pane.
+    ActivatePane(u64),
 }
 
-pub struct PaneDots {
-    pub count: usize,
-    pub focused_idx: Option<usize>,
+pub struct PaneRowItem {
+    pub pane_id: u64,
+    pub label: String,
+    pub is_focused: bool,
 }
 
 pub struct ContextItem {
@@ -52,21 +53,24 @@ pub struct ContextItem {
     pub ctx_name: String,
     pub ctx_index: Option<usize>,
     pub badge_count: usize,
+    /// Root path shown inline in the name row (truncated). Does not add height.
     pub subtitle: Option<String>,
-    pub pane_dots: Option<PaneDots>,
+    /// Total pane count shown as a dim chip in the name row.
+    pub pane_count: usize,
+    /// Expanded pane list rendered inside the scope when `is_expanded`.
+    pub pane_rows: Vec<PaneRowItem>,
+    pub is_expanded: bool,
 }
 
 impl ContextItem {
     pub fn draw(self, ui: &mut egui::Ui, id: Id, colors: &Colors) -> (SidebarAction, egui::Response) {
         let row_alpha = if self.is_dragging { 0.4_f32 } else { 1.0_f32 };
 
-        // Reserve background shape slot before rendering (same pattern as selectable_row in widgets.rs).
-        // Frame inner_margin interferes with ScrollArea height measurement — use scope + shape slot instead.
+        // Reserve background shape slot before rendering content.
         let bg_idx = ui.painter().add(egui::Shape::Noop);
 
         let indent = 20.0 + self.ctx_depth as f32 * 12.0;
 
-        // Capture fields for use inside closure
         let is_active = self.is_active;
         let is_dragging = self.is_dragging;
         let any_dragging = self.any_dragging;
@@ -75,22 +79,27 @@ impl ContextItem {
         let ctx_index = self.ctx_index;
         let badge_count = self.badge_count;
         let subtitle = self.subtitle.clone();
-        let pane_dots = self.pane_dots;
+        let pane_count = self.pane_count;
+        let pane_rows = self.pane_rows;
+        let is_expanded = self.is_expanded;
+        let ctx_depth = self.ctx_depth;
         let accent_color = colors.accent;
         let text_primary = colors.text_primary;
         let text_dim = colors.text_dim;
         let bg_active = colors.bg_active;
+        let bg_sidebar_hover = colors.bg_sidebar_hover;
 
         let text_color = with_alpha(
             if is_active { text_primary } else { text_dim },
             row_alpha,
         );
 
-        let name_row_height = ui.scope(|ui| {
+        let scope_out = ui.scope(|ui| {
             ui.set_width(ui.available_width());
+            let hover_pos = ui.input(|i| i.pointer.hover_pos());
 
-            // --- Section 1: Name row ---
-            let y_before_name = ui.cursor().min.y;
+            // --- Name row — single fixed-height row regardless of path or pane count ---
+            let y_before = ui.cursor().min.y;
             ui.horizontal(|ui| {
                 ui.add_space(indent);
                 if let Some(idx) = ctx_index {
@@ -102,99 +111,127 @@ impl ContextItem {
                         );
                     }
                 }
-                ui.add(
-                    egui::Label::new(
-                        egui::RichText::new(&ctx_name).size(12.0).color(text_color)
-                    )
-                    .selectable(false),
-                );
-                if badge_count > 0 {
-                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                        ui.add_space(8.0);
-                        let badge_text = if badge_count > 9 {
-                            "9+".to_string()
-                        } else {
-                            badge_count.to_string()
-                        };
+
+                // Reserve space on the right for: action zone, pane count chip, badge.
+                let right_reserve = if action_enabled { ACTION_ZONE_WIDTH + 4.0 } else { 8.0 };
+                let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
+                let count_w = if pane_count > 0 { 18.0 } else { 0.0 };
+                let text_max = (ui.available_width() - right_reserve - badge_w - count_w).max(0.0);
+
+                // Name + subtitle share truncation zone so neither wraps and adds height.
+                ui.scope(|ui| {
+                    ui.set_max_width(text_max);
+                    ui.add(
+                        egui::Label::new(egui::RichText::new(&ctx_name).size(12.0).color(text_color))
+                            .selectable(false)
+                            .truncate(),
+                    );
+                    if let Some(ref path) = subtitle {
+                        ui.add(
+                            egui::Label::new(
+                                egui::RichText::new(format!(" — {}", shorten_path(path)))
+                                    .size(10.0)
+                                    .color(with_alpha(text_dim, row_alpha * 0.7)),
+                            )
+                            .selectable(false)
+                            .truncate(),
+                        );
+                    }
+                });
+
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    ui.add_space(if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 });
+                    if badge_count > 0 {
+                        let badge_text = if badge_count > 9 { "9+".to_string() } else { badge_count.to_string() };
                         ui.label(
                             egui::RichText::new(badge_text)
                                 .size(10.0)
                                 .color(with_alpha(accent_color, row_alpha)),
                         );
-                    });
-                }
-            });
-            let name_row_height = ui.cursor().min.y - y_before_name;
-
-            // --- Section 2: Subtitle ---
-            if let Some(ref path) = subtitle {
-                ui.horizontal(|ui| {
-                    ui.add_space(indent);
-                    ui.label(
-                        egui::RichText::new(shorten_path(path))
-                            .size(9.5)
-                            .color(with_alpha(text_dim, row_alpha)),
-                    );
+                    }
+                    if pane_count > 0 {
+                        ui.label(
+                            egui::RichText::new(pane_count.to_string())
+                                .size(10.0)
+                                .color(with_alpha(text_dim, row_alpha * 0.5)),
+                        );
+                    }
                 });
-            }
+            });
+            let name_row_h = ui.cursor().min.y - y_before;
 
-            // --- Section 3: Pane dots ---
-            if let Some(ref dots) = pane_dots {
-                if dots.count > 0 {
-                    ui.horizontal(|ui| {
-                        ui.add_space(indent);
-                        let capped = dots.count.min(PANE_DOT_MAX);
-                        let dot_area_width = (capped as f32) * PANE_DOT_SPACING;
-                        let dot_size = Vec2::new(dot_area_width, PANE_DOT_RADIUS * 2.0 + 4.0);
-                        let (rect, _) = ui.allocate_exact_size(dot_size, Sense::hover());
-                        let painter = ui.painter();
-                        let cy = rect.center().y;
-                        for dot_i in 0..capped {
-                            let cx = rect.min.x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
-                            let color = if dots.focused_idx == Some(dot_i) {
-                                with_alpha(accent_color, row_alpha)
+            // --- Pane rows — rendered inside scope to keep bg_idx deferred shape aligned ---
+            let mut pane_row_rects: Vec<(Rect, u64)> = Vec::new();
+            if is_expanded && !pane_rows.is_empty() {
+                let pane_indent = indent + 16.0;
+                for row in &pane_rows {
+                    let hover_bg_idx = ui.painter().add(egui::Shape::Noop);
+                    let pane_label_color = if row.is_focused {
+                        with_alpha(text_primary, row_alpha)
+                    } else {
+                        with_alpha(text_dim, row_alpha * 0.75)
+                    };
+                    let row_scope = ui.scope(|ui| {
+                        ui.set_width(ui.available_width());
+                        ui.horizontal(|ui| {
+                            ui.add_space(pane_indent);
+                            if row.is_focused {
+                                ui.label(egui::RichText::new("▸").size(9.0).color(with_alpha(accent_color, row_alpha)));
                             } else {
-                                with_alpha(text_dim, if is_dragging { 0.15 } else { 0.35 })
-                            };
-                            painter.circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
-                        }
-                        if dots.count > PANE_DOT_MAX {
-                            let overflow_x = rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
-                            painter.text(
-                                egui::pos2(overflow_x, cy),
-                                egui::Align2::LEFT_CENTER,
-                                format!("+{}", dots.count - PANE_DOT_MAX),
-                                egui::FontId::proportional(8.0),
-                                with_alpha(text_dim, 0.5),
+                                ui.add_space(11.0);
+                            }
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(&row.label).size(11.0).color(pane_label_color),
+                                )
+                                .selectable(false)
+                                .truncate(),
+                            );
+                        });
+                    });
+                    let pane_rect = row_scope.response.rect;
+                    if !is_dragging {
+                        if hover_pos.map_or(false, |p| pane_rect.contains(p)) {
+                            ui.painter().set(
+                                hover_bg_idx,
+                                egui::Shape::rect_filled(pane_rect, CornerRadius::ZERO, with_alpha(bg_sidebar_hover, 0.6)),
                             );
                         }
-                    });
+                    }
+                    pane_row_rects.push((pane_rect, row.pane_id));
                 }
             }
 
-            name_row_height
+            (name_row_h, pane_row_rects)
         });
 
-        let row_rect = name_row_height.response.rect;
-        let name_row_h = name_row_height.inner;
+        let row_rect = scope_out.response.rect;
+        let (name_row_h, pane_row_rects) = scope_out.inner;
 
-        // Interact on the full row
         let response = ui.interact(row_rect, id, Sense::click_and_drag());
         let hovered = response.hovered();
 
-        // Determine background fill
+        // Check pane row clicks by pointer position — avoids egui interaction conflicts.
+        let pane_action: Option<SidebarAction> = response
+            .interact_pointer_pos()
+            .filter(|_| response.clicked())
+            .and_then(|pos| {
+                pane_row_rects
+                    .iter()
+                    .find(|(rect, _)| rect.contains(pos))
+                    .map(|(_, pane_id)| SidebarAction::ActivatePane(*pane_id))
+            });
+
         let fill = if is_active {
             with_alpha(bg_active, row_alpha)
         } else if hovered && !is_dragging {
-            with_alpha(colors.bg_sidebar_hover, row_alpha)
+            with_alpha(bg_sidebar_hover, row_alpha)
         } else {
             Color32::TRANSPARENT
         };
 
-        // Paint background behind content
         ui.painter().set(bg_idx, egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill));
 
-        // Active accent bar — full row height
         if is_active {
             ui.painter().rect_filled(
                 Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
@@ -203,7 +240,6 @@ impl ContextItem {
             );
         }
 
-        // Action zone — rightmost portion of the name row
         let action_zone = if action_enabled {
             Some(Rect::from_min_max(
                 egui::pos2(row_rect.max.x - ACTION_ZONE_WIDTH, row_rect.min.y),
@@ -215,7 +251,6 @@ impl ContextItem {
 
         let in_action = action_zone.map_or(false, |az| ui.rect_contains_pointer(az));
 
-        // Action glyph (✕) — shown on hover
         if let Some(az) = action_zone {
             if hovered && !is_dragging {
                 let glyph_color = with_alpha(
@@ -232,12 +267,10 @@ impl ContextItem {
             }
         }
 
-        // Tooltip for action zone
         if in_action {
             response.clone().on_hover_text("Delete context");
         }
 
-        // Cursor — single authority
         if in_action {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         } else {
@@ -255,8 +288,9 @@ impl ContextItem {
             }
         }
 
-        // Action priority chain
-        let action = if response.double_clicked() {
+        let action = if let Some(pa) = pane_action {
+            pa
+        } else if response.double_clicked() {
             SidebarAction::Rename
         } else if response.drag_started() {
             SidebarAction::DragStart
@@ -264,6 +298,8 @@ impl ContextItem {
             SidebarAction::DragEnd
         } else if response.clicked() && in_action && hovered {
             SidebarAction::Delete
+        } else if response.clicked() && ctx_depth > 0 {
+            SidebarAction::ZoomActivate
         } else if response.clicked() {
             SidebarAction::Activate
         } else {


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1633, Closes #1832, Closes #1834

## Summary

**#1633 — Uniform sidebar item heights**
- Subtitle (root path) now shown inline in name row (truncated) instead of a second row.
- Pane count shown as a dim number chip inline instead of a separate dots row.
- All items render a single fixed-height name row regardless of content. Removed `PaneDots`.

**#1832 — Inline pane list under active context**
- Added `PaneRowItem` struct; `ContextItem` gains `pane_rows` + `is_expanded` fields.
- Active context renders panes as a compact indented list inside `ContextItem::draw()`'s `ui.scope()` — fixing the deferred-shape overflow (black bar) that sank PR #1768 when rows were appended externally after `draw()` returned.
- Clicking a pane row focuses that pane via `find_pane_in_any_window` + `set_window_focused_pane`.

**#1834 — Relative indent for sub-contexts + click-child-to-zoom**
- Sub-contexts already indented by `ctx_depth * 12.0`; confirmed correct.
- Clicking a sub-context (depth > 0) now returns `SidebarAction::ZoomActivate`; sidebar.rs pushes depth stack and switches workspace (same path as `ZoomIntoContext` IPC handler).