### PR TITLE
fix(cli): add --from-pane-id to app init/run so agents open apps in their own pane (#1691)

### DIFF
--- a/skills/create-plexi-app/SKILL.md
+++ b/skills/create-plexi-app/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-plexi-app
 description: Use when building, scaffolding, or modifying a Plexi Python app. Covers manifest, SDK surface, key-handling, the dev loop, render verification, and logging requirements.
-skill_version: "0.0.471"
+skill_version: "0.0.549"
 ---
 
 # Build a Plexi App
@@ -30,10 +30,12 @@ Substitute the correct binary and log path everywhere in this skill. Default to 
 Never hand-write a `manifest.toml`. Always scaffold:
 
 ```bash
-<plexi-binary> app init <app-name>
+<plexi-binary> app init <app-name> ${PLEXI_PANE_ID:+--from-pane-id $PLEXI_PANE_ID}
 ```
 
-This creates `<cwd>/.plexi/apps/<app-name>/` with a valid manifest and `main.py`. The app is immediately registered in the workspace — no additional install step needed. Editing an init-generated manifest is fine; writing one from scratch produces subtle schema errors.
+This creates `<cwd>/<channel-dir>/apps/<app-name>/` (e.g. `.plexi-alpha/apps/<app-name>/` on alpha) with a valid manifest and `main.py`. The app is immediately registered in the workspace — no additional install step needed. Editing an init-generated manifest is fine; writing one from scratch produces subtle schema errors.
+
+`${PLEXI_PANE_ID:+--from-pane-id $PLEXI_PANE_ID}` passes the agent's pane ID when running inside a Plexi pane so the new app pane opens adjacent to the agent, not the focused pane. It expands to nothing when `PLEXI_PANE_ID` is unset (outside a pane).
 
 After scaffolding, prune unused imports from `main.py` before implementing. The template imports several UI components; remove any you won't use (Pyright will flag them).
 
@@ -221,7 +223,7 @@ The home/root guard blocks `plexi app init` in `~/` directly. Use a neutral stag
 
 ```bash
 mkdir -p /tmp/plexi-scaffold && cd /tmp/plexi-scaffold
-<plexi-binary> app init <app-name>
+<plexi-binary> app init <app-name> ${PLEXI_PANE_ID:+--from-pane-id $PLEXI_PANE_ID}
 # App lands in ~/.plexi-alpha/apps/<app-name>/ — global registry, always accessible
 ```
 
@@ -235,16 +237,15 @@ mkdir -p ~/Documents/GitHub/PLEXI/apps/<app-name>
 # Copy an existing app as template
 ```
 
-### After scaffolding — open immediately
+### After scaffolding — auto-open
 
-After `app init`, always open the app in a split pane so the user sees hot reload working:
+When running inside a Plexi pane (`PLEXI_SOCKET` is set, which is the normal agent case), `app init` auto-opens the app immediately after scaffolding — no additional step needed.
+
+If `PLEXI_SOCKET` is not set (running outside a Plexi pane), `app init` prints the path and exits. Open the app manually once inside a Plexi pane:
 
 ```bash
-# In a separate terminal pane (not Claude Code's pane — it blocks):
 <plexi-binary> open <app-id>
 ```
-
-Tell the user: "Open this in your terminal pane — do NOT run it from Claude Code's pane or it will block."
 
 `watch = true` in the manifest handles file-change hot reload automatically. The dev loop is: edit `main.py` → save → pane updates.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -947,7 +947,7 @@ fn app_init_config_dir() -> String {
 ///
 /// The app is immediately discoverable by the registry without any additional
 /// install step, and hot reload watches the actual source.
-pub fn app_init(name: &str, lang: &str) -> i32 {
+pub fn app_init(name: &str, lang: &str, from_pane_id: Option<u64>) -> i32 {
     if name.is_empty() {
         eprintln!("Usage: plexi app init [--lang python|rust] <name>");
         return 1;
@@ -1047,8 +1047,8 @@ pub fn app_init(name: &str, lang: &str) -> i32 {
                 // Auto-open the app if PLEXI_SOCKET is set (running inside a pane).
                 if std::env::var("PLEXI_SOCKET").is_ok() {
                     let path_str = app_dir.to_string_lossy().to_string();
-                    log::info!("app_init: auto-opening '{name}' via app_run from_path={path_str}");
-                    let exit_code = app_run(&path_str);
+                    log::info!("app_init: auto-opening '{name}' via app_run from_path={path_str} from_pane_id={from_pane_id:?}");
+                    let exit_code = app_run(&path_str, from_pane_id);
                     if exit_code != 0 {
                         eprintln!("warning: app created but could not auto-open (exit {exit_code}) — run: plexi app run {}", app_dir.display());
                     }
@@ -1240,7 +1240,7 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> 
 /// `plexi app run <path>` — open any directory with a valid manifest.toml as an app pane.
 ///
 /// No install, no link required. Edits take effect on next launch.
-pub fn app_run(path: &str) -> i32 {
+pub fn app_run(path: &str, from_pane_id: Option<u64>) -> i32 {
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => { eprintln!("error: {e}"); return 1; }
@@ -1281,9 +1281,9 @@ pub fn app_run(path: &str) -> i32 {
             .join(format!("spawn-pane-response-{id}.json"))
             .to_string_lossy()
             .into_owned();
-        let from_pane_id = std::env::var("PLEXI_PANE_ID")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok());
+        let from_pane_id = from_pane_id.or_else(|| {
+            std::env::var("PLEXI_PANE_ID").ok()?.parse::<u64>().ok()
+        });
         let mut payload = serde_json::json!({
             "type": "spawn_pane",
             "type_id": "",
@@ -1293,7 +1293,7 @@ pub fn app_run(path: &str) -> i32 {
         if let Some(pid) = from_pane_id {
             payload["from_pane_id"] = serde_json::Value::Number(pid.into());
         }
-        log::info!("app_run:cli: sending via socket path={abs_path} response_file={response_file}");
+        log::info!("app_run:cli: sending via socket path={abs_path} from_pane_id={from_pane_id:?} response_file={response_file}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
@@ -5076,7 +5076,7 @@ mod app_run_tests {
 
     #[test]
     fn app_run_nonexistent_path_returns_1() {
-        let code = super::app_run("/tmp/plexi-test-nonexistent-path-xyzzy-12345");
+        let code = super::app_run("/tmp/plexi-test-nonexistent-path-xyzzy-12345", None);
         assert_eq!(code, 1);
     }
 
@@ -5084,7 +5084,7 @@ mod app_run_tests {
     fn app_run_dir_without_manifest_returns_1() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().to_string_lossy().to_string();
-        let code = super::app_run(&path);
+        let code = super::app_run(&path, None);
         assert_eq!(code, 1);
     }
 
@@ -5093,7 +5093,7 @@ mod app_run_tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("manifest.toml"), "this is not valid toml ][[[").unwrap();
         let path = dir.path().to_string_lossy().to_string();
-        let code = super::app_run(&path);
+        let code = super::app_run(&path, None);
         assert_eq!(code, 1);
     }
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -339,6 +339,10 @@ pub enum AppCmd {
         name: String,
         #[arg(long, default_value = "python")]
         lang: String,
+        /// Open the new pane relative to this pane ID instead of the focused pane.
+        /// Defaults to PLEXI_PANE_ID if set in the environment.
+        #[arg(long)]
+        from_pane_id: Option<u64>,
     },
     /// Run an app directly from a local directory without installing or linking.
     ///
@@ -347,6 +351,10 @@ pub enum AppCmd {
     Run {
         /// Path to the app folder containing manifest.toml
         path: String,
+        /// Open the new pane relative to this pane ID instead of the focused pane.
+        /// Defaults to PLEXI_PANE_ID if set in the environment.
+        #[arg(long)]
+        from_pane_id: Option<u64>,
     },
     /// Check a Plexi app directory for errors before publishing or installing.
     Validate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,14 +314,14 @@ fn main() -> eframe::Result {
                                 }
                             }
                         }
-                        AppCmd::Init { name, lang } => std::process::exit(cli::app_init(&name, &lang)),
+                        AppCmd::Init { name, lang, from_pane_id } => std::process::exit(cli::app_init(&name, &lang, from_pane_id)),
                         AppCmd::Uninstall { id, yes } => std::process::exit(cli::app_uninstall(&id, yes)),
                         AppCmd::List => std::process::exit(cli::app_list()),
                         AppCmd::Render { id, size, state, output } => {
                             std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref()))
                         }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
-                        AppCmd::Run { path } => std::process::exit(cli::app_run(&path)),
+                        AppCmd::Run { path, from_pane_id } => std::process::exit(cli::app_run(&path, from_pane_id)),
                         AppCmd::Validate { path } => {
                             log::info!("app_validate:cli: path={path}");
                             std::process::exit(cli::validate_cli(&path));


### PR DESCRIPTION
Closes #1691

## Summary

- Added `--from-pane-id` flag to `plexi app init` and `plexi app run` CLI subcommands so callers can explicitly specify which pane the new app pane should open adjacent to
- Threaded the param through `app_init()` → `app_run()` as an explicit override; env var `PLEXI_PANE_ID` remains the automatic fallback when the flag is omitted
- Updated `create-plexi-app` skill to pass `${PLEXI_PANE_ID:+--from-pane-id $PLEXI_PANE_ID}` in scaffold commands, fixed path description (`.plexi-alpha/apps/` not `.plexi/apps/`), and clarified that auto-open is handled by `app init` when inside a pane

## Done When

Run `create-plexi-app` skill while focused on a pane in a different context — the new app pane opens next to the agent pane, in the agent's context.

## Notes

`app_run` already read `PLEXI_PANE_ID` from the environment, but the `app init` subcommand had no way to explicitly pass a pane ID. This matters when the env var isn't inherited (e.g. Claude Code launched from the desktop app rather than a terminal pane). The `${PLEXI_PANE_ID:+--from-pane-id $PLEXI_PANE_ID}` bash expansion is a no-op when `PLEXI_PANE_ID` is unset, so it's safe outside a Plexi context.