### PR TITLE
feat(dispatch): title-driven PM state to cut context burn

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -28,6 +28,12 @@ Pipeline: pipeline:open-pr + ready set — invoking /open-pr inline
 
 > **Labels are the live state.** Never read the Ship Log to determine pipeline stage — read the issue labels. Ship Log is audit trail only.
 
+> **Pane status title.** This skill runs in a dispatched pane named `#<n>` (or `#<n1>+<n2>` for a bundle). At each phase boundary, update the pane title with the current stage so the project-manager can read state from `plexi pane list` instead of capturing pane content. The call is:
+> ```bash
+> plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
+> ```
+> Use the exact issue-number prefix the pane already has (`#<n1>+<n2>` for a bundle). **The status word must never contain a digit** — the PM maps panes to issues with `grep -oE '[0-9]+'` on the title, so a PR number in the suffix would corrupt the census. States this skill sets: `impl`, `pushed`, `noop`, `blocked`.
+
 ---
 
 ## Phase 0 — Find the Issue
@@ -102,7 +108,7 @@ gh issue view <number> --json state,title,labels --jq '{state: .state, title: .t
 ISSUE #<n>: <title>
 ```
 
-If `CLOSED`: stop. "Issue #<n> is already closed — nothing to do."
+If `CLOSED`: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<number> · noop"`, then stop. "Issue #<n> is already closed — nothing to do."
 
 If labeled `in progress`: surface existing worktree + PR before proceeding. Ask for takeover confirmation — do not proceed until user confirms.
 
@@ -110,11 +116,12 @@ If labeled `in progress`: surface existing worktree + PR before proceeding. Ask 
 ```bash
 gh issue view <number> --json body --jq '.body'
 ```
-Grep `src/` on alpha and `git log --oneline -20` against Done When criteria. If all criteria met: close the issue and stop.
+Grep `src/` on alpha and `git log --oneline -20` against Done When criteria. If all criteria met: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<number> · noop"`, close the issue, and stop.
 
 **Label + pane setup:**
 ```bash
 gh issue edit <number> --add-label "in progress" --add-label "pipeline:implement"
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<number> · impl"
 IMPL_PANE=$PLEXI_PANE_ID
 _PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesburke",name:"PLEXI"){issue(number:$n){projectItems(first:5){nodes{id project{id}}}}}}' -F n=<number> --jq '.data.repository.issue.projectItems.nodes[]|select(.project.id=="PVT_kwHOAkOgys4BXaQY")|.id')
 [ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="47fc9ee4" > /dev/null
@@ -307,7 +314,10 @@ gh issue edit <N> \
   --remove-label "in progress"
 ```
 
-After setting labels on all issues, invoke `/open-pr` inline in the same pane — do not spawn a new pane or wait for PM to dispatch.
+Set the pane status to `pushed`, then invoke `/open-pr` inline in the same pane — do not spawn a new pane or wait for PM to dispatch:
+```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · pushed"   # bundle: "#<n1>+<n2> · pushed"
+```
 
 ---
 
@@ -326,4 +336,4 @@ After setting labels on all issues, invoke `/open-pr` inline in the same pane �
 - Every implementation needs a logging plan
 - CLI changes must update `~/.claude/skills/plexi-cli/SKILL.md` in same PR
 - `cargo build --manifest-path <worktree>/Cargo.toml` — never rely on CWD
-- On unrecoverable failure: close PR if open, comment on issue under `## Prior Attempts`, remove `in progress`, add `ready`, exit
+- On unrecoverable failure: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"`, close PR if open, comment on issue under `## Prior Attempts`, remove `in progress`, add `ready`, exit

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -16,6 +16,12 @@ Phase 4 of the ship pipeline. Input: approved PR number. Output: clean alpha at 
 
 On completion, appends final entry to the issue's Ship Log, fires a notify, closes the pane, and outputs `[COMPLETE]` as the last line before close — never before.
 
+> **Pane status title.** Runs in the same dispatched pane (named `#<n>`, or `#<n1>+<n2>` for a bundle). Update the title so the PM reads state from `plexi pane list` instead of capturing content:
+> ```bash
+> plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
+> ```
+> **The status word must never contain a digit** (the PM maps panes to issues via `grep -oE '[0-9]+'`). States this skill sets: `merging`, then `done` just before the pane self-closes.
+
 ---
 
 ## Step 0 — Read Context
@@ -31,9 +37,10 @@ Extract:
 
 **If already MERGED:** skip to Step 5 (close issue). Another session merged it.
 
-**CWD for all steps: the repo root. Set it now:**
+**CWD for all steps: the repo root. Set it now, and flip pane status to `merging`:**
 ```bash
 cd "$(git rev-parse --show-toplevel)"
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · merging"
 ```
 
 > Labels are already correct when invoked inline from validate-pr. No label edit needed here.
@@ -210,6 +217,7 @@ Then immediately close — no stopping after the marker:
 
 **Clean exit (no deferred threads):**
 ```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · done"
 (RESULT=$(plexi notify \
   --title "Shipped #$ISSUE_NUMBER" \
   --body "<title> — v$VERSION" \
@@ -221,6 +229,9 @@ plexi pane close
 
 **Soft exit (deferred threads / improvements proposed):**
 ```bash
+# Use needs-you, NOT done — the pane stays alive for the user, and the PM must
+# not free the slot / close it while interaction is pending.
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 plexi notify \
   --title "Shipped #$ISSUE_NUMBER — review needed" \
   --body "<title> — v$VERSION. <N> improvement(s) proposed." \
@@ -240,5 +251,5 @@ plexi notify \
 - Never pass `--delete-branch` to `gh pr merge` — git refuses to delete a branch checked out by a worktree
 - Never commit directly to alpha, beta, or main
 - Alpha must be clean when this skill exits
-- On unrecoverable failure: comment on issue, remove `in progress` and all `pipeline:*` labels, add `ready`, exit
+- On unrecoverable failure: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"`, comment on issue, remove `in progress` and all `pipeline:*` labels, add `ready`, exit
 - `git status` clean check is the final gate before notify

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -26,6 +26,12 @@ Pipeline: pipeline:validate + ready set — invoking /validate-pr inline
 
 > **Labels are the live state.** Never read the Ship Log to determine pipeline stage — read the issue labels. Ship Log is audit trail only.
 
+> **Pane status title.** Runs in the same dispatched pane as implement-issue (named `#<n>`, or `#<n1>+<n2>` for a bundle). Update the title at each stage so the PM reads state from `plexi pane list` instead of capturing content:
+> ```bash
+> plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
+> ```
+> **The status word must never contain a digit** (the PM maps panes to issues via `grep -oE '[0-9]+'`). States this skill sets: `pr-open`, `review`.
+
 ---
 
 ## Step 1 — Detect Branch and Issue
@@ -166,9 +172,19 @@ _PROJ_ITEM=$(gh api graphql -f query='query($n:Int!){repository(owner:"ianjamesb
 [ -n "$_PROJ_ITEM" ] && gh api graphql -f query='mutation($i:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:"PVT_kwHOAkOgys4BXaQY",itemId:$i,fieldId:"PVTSSF_lAHOAkOgys4BXaQYzhSnRw8",value:{singleSelectOptionId:$v}}){projectV2Item{id}}}' -f i="$_PROJ_ITEM" -f v="f1399a59" > /dev/null
 ```
 
+Update pane status:
+```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · pr-open"   # bundle: "#<n1>+<n2> · pr-open"
+```
+
 ---
 
 ## Step 3 — AI Review
+
+Set pane status (skip if the review is bypassed below — it's a fast transition either way):
+```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · review"
+```
 
 **Skip gate — lightweight PRs bypass AI review entirely:**
 ```bash

--- a/.claude/skills/project-manager/SKILL.md
+++ b/.claude/skills/project-manager/SKILL.md
@@ -83,36 +83,48 @@ Print one status line:
 
 ---
 
-## Step 2b — Pane census + health check
+## Step 2b — Pane census + state read (title-driven)
 
-Build `ACTIVE_PANE_ISSUES` from live pane titles (authoritative — GitHub labels lag):
+**One cheap call gives every lane's state.** The pipeline skills (`implement-issue`, `open-pr`, `validate-pr`, `merge-pr`) write their current stage into the pane title as `#<issue> · <state>` (bundles: `#<n1>+<n2> · <state>`). Read titles instead of capturing pane content every cycle — capturing every lane every cycle is what exhausts this skill's context. Drop to `pane capture` only for the two cases that need detail: a `blocked` lane, or a working lane that has gone stale.
 
 ```bash
 PLEXI=plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL}
-$PLEXI pane list 2>/dev/null | jq -r '.[].title // ""' | grep -oE '[0-9]+' || true
+$PLEXI pane list 2>/dev/null | jq -r '.[] | "\(.id)\t\(.title // "")"'
 ```
 
-Note: the JSON field is `title`, not `name` — `.name` returns null and breaks the census.
+The JSON field is `title`, not `name` (`.name` is null). Parse each lane row into:
+- `PANE_ID` — numeric id (first column)
+- `ISSUE_NUMS` — `grep -oE '[0-9]+'` on the part **before** ` · ` (the prefix). State words are digit-free by contract, so this only ever yields issue numbers — never a PR number.
+- `STATE` — the word after ` · ` (empty if the pane has no suffix yet)
 
-**Cursor store:** Load per-pane cursors from `.claude/agent-memory/project-manager/pane-cursors.json` (create as `{}` if missing). For each active issue pane ID:
+Build `ACTIVE_PANE_ISSUES` = union of all `ISSUE_NUMS` across lane panes.
 
+**State store:** Load `.claude/agent-memory/project-manager/pane-status.json` (create `{}` if missing), keyed by pane id → `{state, unchanged}`. For each lane pane, compare its current `STATE` to the stored one: changed → set `unchanged` to 0 and save the new state; same → increment `unchanged`. Persist after the cycle and drop entries for panes that no longer exist.
+
+**Act on each lane's state:**
+
+| State | Meaning | PM action |
+|---|---|---|
+| `impl` `pushed` `pr-open` `review` `validate` `fixing` `merging` | working | Leave alone. Counts as an active lane. |
+| _(no suffix)_ | just dispatched, pre-status | Leave alone. Counts as active. |
+| `needs-you` | waiting on the user's pass/fail/modify/approve reply | **Surface** (line below). Do NOT capture. Pane stays; counts as active. |
+| `done` | merged + closed; pane self-closes | Lane is finishing — its slot is free. Step 2d closes the issue if the pane's self-close lagged. |
+| `noop` | agent exited without real work | `$PLEXI pane close <PANE_ID>`, drop its store entry, free the slot. |
+| `blocked` | unrecoverable failure / hard reject | **Capture once** (below) for the cause, surface to user, leave the pane. Counts as active — do not refill over it. |
+
+Surface line for a `needs-you` lane:
+```
+[PM] ⏳ #<issue> awaiting your reply in pane <PANE_ID> — pass / fail / modify.
+```
+
+**Exception capture — only for `blocked` or stale lanes:**
 ```bash
-# First capture (no stored cursor):
-$PLEXI pane capture --lines 10 <PANE_ID>
-
-# Subsequent captures (cursor from prior run):
-$PLEXI pane capture --from-cursor <CURSOR> <PANE_ID>
+$PLEXI pane capture --lines 30 <PANE_ID>
 ```
+- `blocked` → surface the cause: `[PM] ⛔ #<issue> blocked in pane <PANE_ID>: <one-line cause from capture>`
+- **Stale** = a working-state pane whose `unchanged` count has reached **3** (≈12 min at the 4-min cadence). Capture once to check for a hang (idle shell prompt, panic, repeated error). If hung → surface like `blocked` and flag for the user. If it's just a genuinely long step (e.g. `just pr-install` compiling) → set `unchanged` back to 0 and leave it.
 
-Each response is `{"cursor": N, "lines": [...], "missed": bool}`. Save the new `cursor` back to the store keyed by pane ID and persist to disk after each cycle. `lines: []` + `missed: false` = no new output.
-
-**Noop exit detection:** If captured lines show the agent exited without doing real work (e.g. "Issue is already closed", "Nothing to do", "already implemented", "already merged"), close the pane immediately and free the slot:
-
-```bash
-$PLEXI pane close <PANE_ID>
-```
-
-Remove its cursor entry from the store. Any issue whose pane was NOT closed must be skipped in Step 2c and Step 4.
+**After acting:** remove every `noop` and `done` issue from `ACTIVE_PANE_ISSUES` — their slots are free for refill. Any issue still in `ACTIVE_PANE_ISSUES` (working, `needs-you`, or `blocked`) must be skipped in Step 2c and Step 4.
 
 ---
 
@@ -301,9 +313,11 @@ On each re-entry after initial dispatch, lead with:
 
 ## Notes
 
-- **Pane census uses `.title`, not `.name`.** `.name` returns null — always use `jq -r '.[].title // ""'`.
-- **Always use `--from-cursor` on repeat pane captures.** `plexi pane capture --from-cursor <N> <ID>` reads only lines written since the last check. Store cursors in `.claude/agent-memory/project-manager/pane-cursors.json`, keyed by pane ID. `lines: []` + `missed: false` = no new output.
-- **Close noop panes immediately.** If an agent exits without doing real work, `pane close` right away and free the slot.
+- **State comes from pane titles, not content.** Each lane writes its stage as `#<issue> · <state>`. One `plexi pane list` per cycle reads every lane's state — never capture pane content just to learn what stage a lane is in. Field is `.title`, not `.name`.
+- **Capture is the exception, not the routine.** Only `pane capture` a lane that is `blocked` (get the cause) or a working lane gone stale (`unchanged` ≥ 3 cycles — check for a hang). This is the whole point of the title scheme: it stops the PM burning context on per-pane captures every cycle.
+- **`needs-you` means surface, don't capture.** The validate-pr pane already printed the testing block in its own pane; the user reads it there. The PM just flags which pane awaits a reply.
+- **Close `noop` panes immediately.** A `noop` title means the agent exited without real work — `pane close` right away and free the slot.
+- **State store:** `.claude/agent-memory/project-manager/pane-status.json`, keyed by pane id → `{state, unchanged}`. Drives staleness detection and slot accounting.
 - **Bare-shell pane recovery.** If a dispatch pane shows a prompt with no agent running ("← for agents"), re-send the command: `$PLEXI pane send <ID> 'c "/ship-issue <N>"\n'` — use `\n` for Enter, never a trailing `Enter` argument.
 - **Bundle issues should be batched.** Issues labeled `bundle` are micro-changes. Group by primary area and send all same-area bundles to one lane in one PR. Never open one PR per bundle issue.
 - **Post-merge cleanup runs every cycle.** Check merged PRs for still-open linked issues and close them automatically.

--- a/.claude/skills/validate-pr/SKILL.md
+++ b/.claude/skills/validate-pr/SKILL.md
@@ -25,6 +25,12 @@ Phase 3 of the ship pipeline. Manages the test loop and all rejection paths.
 
 > **Labels are the live state.** Never read the Ship Log to determine pipeline stage — read the issue labels. Ship Log is audit trail only.
 
+> **Pane status title.** Runs in the same dispatched pane (named `#<n>`, or `#<n1>+<n2>` for a bundle). Update the title at each stage so the PM reads state from `plexi pane list` instead of capturing content:
+> ```bash
+> plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
+> ```
+> **The status word must never contain a digit** (the PM maps panes to issues via `grep -oE '[0-9]+'` — a PR number in the suffix would corrupt the census). States this skill sets: `validate`, `needs-you` (waiting on the user — the PM surfaces this), `fixing`, `blocked`.
+
 ---
 
 ## Step 0 — Read Context
@@ -48,12 +54,13 @@ ATTEMPT_COUNT=$(gh issue view $ISSUE_NUMBER --json body --jq '.body' \
   | grep -cE '^\*\*Validate attempt [0-9]+:' || true)
 ```
 
-Mark issue as actively in this phase:
+Mark issue as actively in this phase and update pane status:
 ```bash
 gh issue edit $ISSUE_NUMBER \
   --add-label "in progress" \
   --remove-label "pipeline:open-pr" \
   --add-label "pipeline:validate" 2>/dev/null || true
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · validate"
 ```
 
 ---
@@ -178,6 +185,8 @@ Reply: "pass" | "fail: <description>" | "modify: <bounded change>"
 
 **Notification:**
 ```bash
+# Flip pane status to needs-you so the PM surfaces this lane as awaiting the user
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 # Route reply to PM pane if PM dispatched this skill, otherwise this pane
 REPLY_PANE="${PM_PANE_ID:-$PLEXI_PANE_ID}"
 RESULT=$(plexi notify \
@@ -226,12 +235,13 @@ Valid only if pass criteria were **not** fully met. If criteria were met and use
 
 Fix the specific change on the feature branch, commit, push:
 ```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · fixing"
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" add <files>
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" commit -m "fix: <description>"
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" push
 ```
 
-Re-run `just pr-install $PR_NUMBER` from the feature worktree. Re-surface the testing block. Do not expand scope.
+Re-run `just pr-install $PR_NUMBER` from the feature worktree. Re-surface the testing block (which flips status back to `needs-you`). Do not expand scope.
 
 Append to Ship Log:
 ```markdown
@@ -257,6 +267,7 @@ Report what the log shows.
 
 Apply the targeted fix to the feature branch, commit, push:
 ```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · fixing"
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" add <files>
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" commit -m "fix: <description from failure>"
 git -C "$(git rev-parse --show-toplevel)/worktrees/$BRANCH" push
@@ -291,8 +302,9 @@ If `c` → STOP. Leave PR open. Remove attempt limit — user owns it from here.
 
 ## Hard Reject
 
-1. **Read the PR log:**
+1. **Mark the lane blocked and read the PR log:**
 ```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"
 tail -100 ~/.plexi-pr-$PR_NUMBER/plexi.log
 ```
 
@@ -377,6 +389,11 @@ Fail criteria:
 - <what would look wrong>
 
 Reply: "pass" | "fail: <description>" | "modify: <change>"
+```
+
+Before firing the notification and waiting, flip pane status the same as the install path:
+```bash
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 ```
 
 ---


### PR DESCRIPTION
## Problem

The project-manager ran out of context fast because it captured pane *content* for every lane every cycle (`pane capture --from-cursor` × N panes × every 4 min) just to learn what stage each lane was at.

## Change

Each pipeline skill now writes its stage into the **pane title** (`#<issue> · <state>`), and the PM reads every lane's state from a single `plexi pane list` call. Content capture becomes the exception, not the routine.

**States** (all digit-free, so the PM's `grep -oE '[0-9]+'` issue census never grabs a PR number):
`impl → pushed → pr-open → review → validate → needs-you → fixing → merging → done`, plus `blocked` (failure/hard-reject) and `noop` (exited without work).

**Per skill:**
- `implement-issue` / `open-pr` / `validate-pr` / `merge-pr`: set pane status at each phase boundary.
- `project-manager` Step 2b: rewritten to read titles for state and act per-state. Drops to `pane capture` **only** for a `blocked` lane (get the cause) or a working lane gone stale (`unchanged ≥ 3` cycles → hang check). `needs-you` lanes are surfaced to the user, not captured.
- `merge-pr` soft-exit path uses `needs-you` (not `done`) so the PM won't close a pane while user interaction is pending.
- State store moved from `pane-cursors.json` to `pane-status.json` (`{state, unchanged}` per pane id).

## Design notes

- Implemented inline (no helper script) — every skill already knows its own issue number, so there's nothing to reconstruct. The digit-free invariant is stated explicitly in each skill where the literal state strings are written.
- Skill-only change: no Rust, no build, no `cargo test`. Verified by grep that all status calls and the PM rewrite landed and no stale `pane-cursors`/`--from-cursor` refs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)