### PR TITLE
fix(ui/chrome): pane ID overlay — switch trigger from ⌘-hold to ⌃-hold (#1852)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4173,18 +4173,18 @@ impl eframe::App for PlexiApp {
                     }
                 }
 
-                let cmd_held = ui.input(|i| i.modifiers.command) && ctx.panes.len() > 1;
+                let ctrl_held = ui.input(|i| i.modifiers.ctrl) && ctx.panes.len() > 1;
                 {
                     let overlay_log_id = egui::Id::new("pane_id_overlay_on");
                     let was_held: bool =
                         ui.ctx().data(|d| d.get_temp(overlay_log_id).unwrap_or(false));
-                    if was_held != cmd_held {
-                        if cmd_held {
+                    if was_held != ctrl_held {
+                        if ctrl_held {
                             log::info!("[pane-id-overlay] on");
                         } else {
                             log::info!("[pane-id-overlay] off");
                         }
-                        ui.ctx().data_mut(|d| d.insert_temp(overlay_log_id, cmd_held));
+                        ui.ctx().data_mut(|d| d.insert_temp(overlay_log_id, ctrl_held));
                     }
                 }
 
@@ -4208,7 +4208,7 @@ impl eframe::App for PlexiApp {
                     unfocused_opacity,
                     portal_info,
                     modal_open,
-                    cmd_held,
+                    ctrl_held,
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -89,8 +89,8 @@ pub struct PlexiBehavior<'a> {
     /// Prevents terminal panes from calling `request_focus()` and stealing
     /// egui focus from the active overlay (egui resolves focus last-caller-wins).
     pub modal_open: bool,
-    /// True when the Command modifier is held — triggers the pane ID ghost overlay.
-    pub cmd_held: bool,
+    /// True when the Control modifier is held — triggers the pane ID ghost overlay.
+    pub ctrl_held: bool,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -192,7 +192,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             }
         }
 
-        if self.cmd_held {
+        if self.ctrl_held {
             let c = self.colors.text_primary;
             ui.painter().text(
                 pane_rect.center(),


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1852

## Summary

- Switches the pane ID ghost overlay trigger from ⌘ (Command) to ⌃ (Control) — Command is already used for context switching, splits, and close shortcuts
- Renames the `cmd_held` field in `PlexiBehavior` to `ctrl_held` and updates the modifier read from `i.modifiers.command` → `i.modifiers.ctrl`