### PR TITLE
fix(apps): replace removed SDK color constants with ctx.theme.* (#1851)

### DIFF
--- a/apps/backlog/backlog.py
+++ b/apps/backlog/backlog.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
-from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN, Arg
+from plexi_sdk import App, RenderContext, Arg
 from plexi_sdk.ui import SelectList
 
 def _detect_channel_backlog_dir() -> "Path | None":
@@ -209,18 +209,18 @@ class BacklogApp(App):
 
     def on_render(self, ctx: RenderContext) -> None:
         w, h = ctx.w, ctx.h
-        ctx.clear(BG)
+        ctx.clear(ctx.theme.bg)
 
         list_w = w * LIST_FRAC
         list_h = h - TOP - BOTTOM_BAR_H
 
         # Header
         title = "backlog (global)" if self.global_only else "backlog"
-        ctx.text(12, 10, title, size=12, color=ACCENT, bold=True,
+        ctx.text(12, 10, title, size=12, color=ctx.theme.accent, bold=True,
                  max_width=list_w - 100)
         item_count = len(self.filtered)
         count_label = f"{item_count} item{'s' if item_count != 1 else ''}"
-        ctx.text(list_w - 80, 10, count_label, size=11, color=MUTED,
+        ctx.text(list_w - 80, 10, count_label, size=11, color=ctx.theme.muted,
                  max_width=80)
 
         if self.global_only:
@@ -231,24 +231,24 @@ class BacklogApp(App):
             )
         if not has_any_dir:
             self.emit.info("backlog: no dirs found — showing empty-state guide")
-            ctx.text(12, TOP + 12, "No notes yet.", size=13, color=FG)
+            ctx.text(12, TOP + 12, "No notes yet.", size=13, color=ctx.theme.fg)
             if self.global_only:
                 ctx.text(12, TOP + 34,
                          "No channel-level backlog found. Press ⌘0 to create a Quick Note.",
-                         size=11, color=MUTED, max_width=w - 24)
+                         size=11, color=ctx.theme.muted, max_width=w - 24)
             else:
                 ctx.text(12, TOP + 34,
                          "Press ⌘0 to open Quick Note, then press Enter twice to send to your backlog.",
-                         size=11, color=MUTED, max_width=w - 24)
+                         size=11, color=ctx.theme.muted, max_width=w - 24)
             return
 
         # Divider
-        ctx.line(list_w, TOP - 4, list_w, h - BOTTOM_BAR_H, color=HIGHLIGHT, width=1.0)
+        ctx.line(list_w, TOP - 4, list_w, h - BOTTOM_BAR_H, color=ctx.theme.highlight, width=1.0)
 
         # ── Item list ────────────────────────────────────────────────────────────
         if not self.filtered:
             msg = "No results" if self.search_query else "Backlog is empty"
-            ctx.text(12, TOP + 12, msg, size=12, color=MUTED)
+            ctx.text(12, TOP + 12, msg, size=12, color=ctx.theme.muted)
         else:
             self._item_list.render(ctx, 0, TOP, list_w, list_h)
 
@@ -257,31 +257,31 @@ class BacklogApp(App):
         pw = w - px - 10
         if self.preview_path and self.preview_text is not None:
             ctx.text(px, TOP - 18, self.preview_path.name,
-                     size=11, color=ACCENT, bold=True, max_width=pw)
+                     size=11, color=ctx.theme.accent, bold=True, max_width=pw)
             lines = self.preview_text.splitlines()
             for li, line in enumerate(lines):
                 ly = TOP + li * 15.0
                 if ly > h - BOTTOM_BAR_H - 4:
                     break
                 # Dim markdown headings differently
-                color = FG if not line.startswith("#") else ACCENT
+                color = ctx.theme.fg if not line.startswith("#") else ctx.theme.accent
                 ctx.text(px, ly, line, size=11, color=color, monospace=True,
                          max_width=pw)
 
         # ── Bottom bar ───────────────────────────────────────────────────────────
         bar_y = h - BOTTOM_BAR_H
-        ctx.rect(0, bar_y, w, BOTTOM_BAR_H, SURFACE)
+        ctx.rect(0, bar_y, w, BOTTOM_BAR_H, ctx.theme.surface)
 
         if self.in_search:
             ctx.text(12, bar_y + 7,
                      f"/ {self.search_query}▌",   # block cursor
-                     size=12, color=ACCENT, monospace=True)
+                     size=12, color=ctx.theme.accent, monospace=True)
         elif self.status:
-            ctx.text(12, bar_y + 7, self.status, size=11, color=GREEN)
+            ctx.text(12, bar_y + 7, self.status, size=11, color=ctx.theme.success)
         else:
             ctx.text(12, bar_y + 7,
                      "j/k navigate  e open  n new  a archive  d delete  / search  r refresh",
-                     size=10, color=MUTED)
+                     size=10, color=ctx.theme.muted)
 
         # ── Add-item overlay (host-owned TextInput) ─────────────────────────────
         # Issue #283 showcase migration: a real callsite for the new
@@ -290,10 +290,10 @@ class BacklogApp(App):
         # `None` on subsequent frames.
         if self.in_add:
             ox, oy, ow, oh = w / 2 - 200, h / 2 - 36, 400, 86
-            ctx.rect(ox, oy, ow, oh, SURFACE, radius=6.0)
-            ctx.rect(ox, oy, ow, 1, HIGHLIGHT)
+            ctx.rect(ox, oy, ow, oh, ctx.theme.surface, radius=6.0)
+            ctx.rect(ox, oy, ow, 1, ctx.theme.highlight)
             ctx.text(ox + 16, oy + 12, "New backlog item",
-                     size=12, color=ACCENT, bold=True)
+                     size=12, color=ctx.theme.accent, bold=True)
             submitted = ctx.text_input(
                 "backlog-new",
                 x=ox + 16, y=oy + 36, w=ow - 32,
@@ -306,12 +306,12 @@ class BacklogApp(App):
         if self.confirm_delete and self.filtered:
             name = self.filtered[self.selected].name
             ox, oy, ow, oh = w / 2 - 170, h / 2 - 36, 340, 72
-            ctx.rect(ox, oy, ow, oh, SURFACE, radius=6.0)
-            ctx.rect(ox, oy, ow, 1, HIGHLIGHT)
-            ctx.text(ox + 16, oy + 14, f"Delete  ‘{name}’?",
-                     size=13, color=RED, bold=True)
+            ctx.rect(ox, oy, ow, oh, ctx.theme.surface, radius=6.0)
+            ctx.rect(ox, oy, ow, 1, ctx.theme.highlight)
+            ctx.text(ox + 16, oy + 14, f"Delete  '{name}'?",
+                     size=13, color=ctx.theme.danger, bold=True)
             ctx.text(ox + 16, oy + 36, "Enter → confirm    Esc → cancel",
-                     size=11, color=MUTED)
+                     size=11, color=ctx.theme.muted)
 
     # ── Keys ─────────────────────────────────────────────────────────────────────
 

--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -7,7 +7,7 @@ import os
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
 
-from plexi_sdk import App, RenderContext, BG, SURFACE, FG, ACCENT, RED, MUTED, PAD
+from plexi_sdk import App, RenderContext, PAD
 BTN_W = 64.0
 BTN_H = 48.0
 BTN_GAP = 8.0
@@ -87,20 +87,20 @@ class CalcApp(App):
 
     def on_render(self, ctx: RenderContext) -> None:
         # Display
-        ctx.rect(PAD, PAD, ctx.w - PAD * 2, 80.0, fill=SURFACE, radius=8.0)
+        ctx.rect(PAD, PAD, ctx.w - PAD * 2, 80.0, fill=ctx.theme.surface, radius=8.0)
         ctx.text(ctx.w - PAD - 8, PAD + 16, self.display,
-                 size=32.0, color=FG, align="right")
+                 size=32.0, color=ctx.theme.fg, align="right")
         if self.pending_op:
-            ctx.text(PAD + 8, PAD + 8, self.pending_op, size=12.0, color=MUTED)
+            ctx.text(PAD + 8, PAD + 8, self.pending_op, size=12.0, color=ctx.theme.muted)
 
         # Buttons
         for label, col, row in BUTTONS:
             x, y, w, h = _btn_rect(col, row)
             is_op = label in ("÷", "×", "+", "−", "=")
             is_clear = label == "C"
-            fill = ACCENT if is_op else (RED if is_clear else SURFACE)
+            fill = ctx.theme.accent if is_op else (ctx.theme.danger if is_clear else ctx.theme.surface)
             hover_fill = "#b9d0f7" if is_op else ("#f5a3b5" if is_clear else "#45475a")
-            text_color = BG if is_op else (BG if is_clear else FG)
+            text_color = ctx.theme.bg if is_op else (ctx.theme.bg if is_clear else ctx.theme.fg)
             if ctx.button(label, x, y, w, h, label,
                           fill=fill, hover_fill=hover_fill,
                           text_color=text_color, radius=6.0):
@@ -108,7 +108,7 @@ class CalcApp(App):
 
         # Keyboard hint
         ctx.text(PAD, ctx.h - 24, "0-9  + - * /  Enter: equals  Backspace: delete  Esc: clear",
-                 size=10.0, color=MUTED)
+                 size=10.0, color=ctx.theme.muted)
 
     def _backspace(self) -> None:
         if self.fresh or self.display == "0":

--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from plexi_sdk import (  # type: ignore[attr-defined]
     App, RenderContext,
-    FG, MUTED, ACCENT, BG,
     BODY, CAPTION,
 )
 from plexi_sdk.ui import SelectList
@@ -100,7 +99,7 @@ class CsvViewer(App):
             self._headers = [f"Error: {e}"]
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.clear(BG)
+        ctx.clear(ctx.theme.bg)
         if self._mode == "list":
             self._draw_list(ctx)
         else:
@@ -110,22 +109,22 @@ class CsvViewer(App):
         w, h = ctx.w, ctx.h
         y = PAD
 
-        ctx.text(PAD, y, str(self._dir), size=CAPTION, color=MUTED, monospace=True)
+        ctx.text(PAD, y, str(self._dir), size=CAPTION, color=ctx.theme.muted, monospace=True)
         y += 22.0
 
         if not self._files:
-            ctx.text(PAD, y, "No CSV files found.", size=BODY, color=MUTED)
-            ctx.text(PAD, h - 20, "esc  exit", size=CAPTION, color=MUTED)
+            ctx.text(PAD, y, "No CSV files found.", size=BODY, color=ctx.theme.muted)
+            ctx.text(PAD, h - 20, "esc  exit", size=CAPTION, color=ctx.theme.muted)
             return
 
         label = f"{len(self._files)} CSV file{'s' if len(self._files) != 1 else ''}"
-        ctx.text(PAD, y, label, size=BODY, color=FG)
+        ctx.text(PAD, y, label, size=BODY, color=ctx.theme.fg)
         y += 28.0
 
         self._file_list.selected_idx = self._selected
         self._file_list.render(ctx, 0, y, w, h - y - 30)
 
-        ctx.text(PAD, h - 20, "↑↓ / jk  navigate   ↵  open   esc  exit", size=CAPTION, color=MUTED)
+        ctx.text(PAD, h - 20, "↑↓ / jk  navigate   ↵  open   esc  exit", size=CAPTION, color=ctx.theme.muted)
 
     def _draw_detail(self, ctx: RenderContext) -> None:
         w, h = ctx.w, ctx.h
@@ -134,9 +133,9 @@ class CsvViewer(App):
         path = self._files[self._selected]
         y = PAD
 
-        ctx.text(PAD, y, path.name, size=BODY, color=FG, bold=True)
+        ctx.text(PAD, y, path.name, size=BODY, color=ctx.theme.fg, bold=True)
         y += 22.0
-        ctx.text(PAD, y, f"{len(self._rows)} rows × {len(self._headers)} columns", size=CAPTION, color=MUTED)
+        ctx.text(PAD, y, f"{len(self._rows)} rows × {len(self._headers)} columns", size=CAPTION, color=ctx.theme.muted)
         y += 22.0
 
         visible_cols = max(1, int((w - PAD) // COL_W))
@@ -148,7 +147,7 @@ class CsvViewer(App):
         for ci, col_idx in enumerate(range(col_start, col_end)):
             x = PAD + ci * COL_W
             label = self._headers[col_idx] if col_idx < len(self._headers) else ""
-            ctx.text(x + CELL_PAD, y + 4, label, size=CAPTION, color=ACCENT, bold=True,
+            ctx.text(x + CELL_PAD, y + 4, label, size=CAPTION, color=ctx.theme.accent, bold=True,
                      max_width=COL_W - CELL_PAD * 2)
         y += ROW_H + 2
 
@@ -169,7 +168,7 @@ class CsvViewer(App):
             for ci, col_idx in enumerate(range(col_start, col_end)):
                 x = PAD + ci * COL_W
                 cell = row[col_idx] if col_idx < len(row) else ""
-                ctx.text(x + CELL_PAD, row_y + 4, cell, size=CAPTION, color=FG,
+                ctx.text(x + CELL_PAD, row_y + 4, cell, size=CAPTION, color=ctx.theme.fg,
                          max_width=COL_W - CELL_PAD * 2)
 
         # Footer
@@ -178,7 +177,7 @@ class CsvViewer(App):
             info = f"row {row_start + 1}–{row_end} of {len(self._rows)}  ({pct}%)"
         else:
             info = "empty"
-        ctx.text(PAD, h - 20, f"{info}   ↑↓/jk scroll   ←→/hl columns   esc  back", size=CAPTION, color=MUTED)
+        ctx.text(PAD, h - 20, f"{info}   ↑↓/jk scroll   ←→/hl columns   esc  back", size=CAPTION, color=ctx.theme.muted)
 
 
 if __name__ == "__main__":

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -273,8 +273,8 @@ class LogsApp(App):
             "ERROR": ctx.theme.danger,
             "WARN":  ctx.theme.warning,
             "INFO":  ctx.theme.accent,
-            "DEBUG": "#585b70",
-            "TRACE": "#45475a",
+            "DEBUG": ctx.theme.text_section,
+            "TRACE": ctx.theme.highlight,
         }
 
         # ── background ──────────────────────────────────────────────────────
@@ -407,7 +407,7 @@ class LogsApp(App):
             x += time_w
 
             # level badge — solid fill, host-measured, readable at any size
-            badge_fill = level_badge_fill.get(ll.level, "#45475a")
+            badge_fill = level_badge_fill.get(ll.level, ctx.theme.highlight)
             badge_fg   = ctx.theme.bg if ll.level in ("ERROR", "WARN", "INFO") else ctx.theme.fg
             ctx.badge(x, row_y + ROW_H / 2, ll.level[:4],
                       fill=badge_fill, fg=badge_fg,

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -6,7 +6,6 @@ import re
 
 from plexi_sdk import App, RenderContext
 from plexi_sdk.ui import (
-    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, YELLOW,
     TEXT_HINT, TEXT_CAPTION,
     SPACE_SM,
 )
@@ -29,14 +28,6 @@ BADGE_ADV = 50.0
 FILTERS    = ["ALL", "ERROR", "WARN", "INFO", "DEBUG"]
 FILTER_KEY = {"a": 0, "e": 1, "w": 2, "i": 3, "d": 4}
 
-# Solid fill colours for ctx.badge() — readable on dark rows
-LEVEL_BADGE_FILL: dict[str, str] = {
-    "ERROR": RED,
-    "WARN":  YELLOW,
-    "INFO":  ACCENT,
-    "DEBUG": "#585b70",
-    "TRACE": "#45475a",
-}
 
 ROW_ALT        = "#1a1a2a"
 COPY_ROW_BG    = "#1e2d1e"   # subtle green tint for copy-mode selected rows
@@ -278,15 +269,23 @@ class LogsApp(App):
         w, h = ctx.w, ctx.h
         filtered = self._filtered()
 
+        level_badge_fill = {
+            "ERROR": ctx.theme.danger,
+            "WARN":  ctx.theme.warning,
+            "INFO":  ctx.theme.accent,
+            "DEBUG": "#585b70",
+            "TRACE": "#45475a",
+        }
+
         # ── background ──────────────────────────────────────────────────────
-        ctx.rect(0, 0, w, h, BG)
+        ctx.rect(0, 0, w, h, ctx.theme.bg)
 
         # ── top bar ─────────────────────────────────────────────────────────
-        ctx.rect(0, 0, w, BAR_H, SURFACE)
+        ctx.rect(0, 0, w, BAR_H, ctx.theme.surface)
 
         if self._search_mode:
             ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "/",
-                     size=TEXT_CAPTION, color=ACCENT, bold=True)
+                     size=TEXT_CAPTION, color=ctx.theme.accent, bold=True)
             search_x = PAD + 14.0
             submitted = ctx.text_input(
                 "search",
@@ -303,17 +302,17 @@ class LogsApp(App):
                 self._copy_anchor = None
         else:
             ctx.text(PAD, BAR_H / 2 - TEXT_CAPTION / 2, "Logs",
-                     size=TEXT_CAPTION, color=FG, bold=True)
+                     size=TEXT_CAPTION, color=ctx.theme.fg, bold=True)
 
             chip_x = 50.0
             for i, label in enumerate(FILTERS):
                 active = i == self._filter_idx
                 if ctx.button(
                     f"filter_{i}", chip_x, 5.0, CHIP_W, BAR_H - 10.0, label,
-                    fill=ACCENT if active else HIGHLIGHT,
+                    fill=ctx.theme.accent if active else ctx.theme.highlight,
                     hover_fill="#a6c5f5" if active else "#45475a",
                     active_fill="#6ea8f5" if active else "#585b70",
-                    text_color=BG if active else MUTED,
+                    text_color=ctx.theme.bg if active else ctx.theme.muted,
                     font_size=12.0,
                     radius=5.0,
                 ):
@@ -326,11 +325,11 @@ class LogsApp(App):
             if self._search_q:
                 ctx.text(w - PAD, BAR_H / 2 - TEXT_HINT / 2,
                          f"/{self._search_q}",
-                         size=TEXT_HINT, color=ACCENT, align="right")
+                         size=TEXT_HINT, color=ctx.theme.accent, align="right")
 
         # ── footer ──────────────────────────────────────────────────────────
         foot_y = h - FOOT_H
-        ctx.rect(0, foot_y, w, FOOT_H, SURFACE)
+        ctx.rect(0, foot_y, w, FOOT_H, ctx.theme.surface)
 
         if self._copy_mode:
             lo, hi = self._copy_range(len(filtered))
@@ -351,7 +350,7 @@ class LogsApp(App):
                 (["esc"], "cancel"),
             ], font_size=10.0)
             ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
-                     "SEARCH", size=TEXT_HINT, color=ACCENT,
+                     "SEARCH", size=TEXT_HINT, color=ctx.theme.accent,
                      align="right")
         else:
             ctx.shortcuts(PAD, foot_y + 5.0, w - PAD * 2, [
@@ -362,7 +361,7 @@ class LogsApp(App):
                 (["y"], "copy"),
             ], font_size=10.0)
             ctx.text(w - PAD, foot_y + FOOT_H / 2 - TEXT_HINT / 2,
-                     f"{len(filtered)} lines", size=TEXT_HINT, color=MUTED,
+                     f"{len(filtered)} lines", size=TEXT_HINT, color=ctx.theme.muted,
                      align="right")
 
         # ── log rows ────────────────────────────────────────────────────────
@@ -371,7 +370,7 @@ class LogsApp(App):
         self._viewport_h = list_h
 
         if not filtered:
-            ctx.text(PAD, list_y + 16, "no log entries", size=TEXT_CAPTION, color=MUTED)
+            ctx.text(PAD, list_y + 16, "no log entries", size=TEXT_CAPTION, color=ctx.theme.muted)
             return
 
         ctx.push_clip(0, list_y, w, list_h)
@@ -399,8 +398,8 @@ class LogsApp(App):
 
             x      = PAD
             text_y = row_y + ROW_H / 2 - TEXT_HINT / 2
-            dim_fg = COPY_ROW_FG if in_selection else MUTED
-            msg_fg = COPY_ROW_FG if in_selection else FG
+            dim_fg = COPY_ROW_FG if in_selection else ctx.theme.muted
+            msg_fg = COPY_ROW_FG if in_selection else ctx.theme.fg
 
             # timestamp
             ctx.text(x, text_y, ll.time,
@@ -408,8 +407,8 @@ class LogsApp(App):
             x += time_w
 
             # level badge — solid fill, host-measured, readable at any size
-            badge_fill = LEVEL_BADGE_FILL.get(ll.level, "#45475a")
-            badge_fg   = BG if ll.level in ("ERROR", "WARN", "INFO") else FG
+            badge_fill = level_badge_fill.get(ll.level, "#45475a")
+            badge_fg   = ctx.theme.bg if ll.level in ("ERROR", "WARN", "INFO") else ctx.theme.fg
             ctx.badge(x, row_y + ROW_H / 2, ll.level[:4],
                       fill=badge_fill, fg=badge_fg,
                       font_size=10.0, radius=4.0)
@@ -435,8 +434,8 @@ class LogsApp(App):
             thumb_h     = max(20.0, list_h * thumb_ratio)
             thumb_y     = list_y + (self._scroll / total_h) * list_h
             thumb_y     = min(thumb_y, list_y + list_h - thumb_h)
-            ctx.rect(w - 4, list_y, 4, list_h, HIGHLIGHT)
-            ctx.rect(w - 4, thumb_y, 4, thumb_h, MUTED)
+            ctx.rect(w - 4, list_y, 4, list_h, ctx.theme.highlight)
+            ctx.rect(w - 4, thumb_y, 4, thumb_h, ctx.theme.muted)
 
 
 LogsApp().run()


### PR DESCRIPTION
Closes #1851

## Summary

- Four shipped apps (logs, backlog, csv_viewer, calc) crashed on launch with `ImportError` because `BG`, `FG`, `SURFACE`, `HIGHLIGHT`, `ACCENT`, `MUTED`, `RED`, `GREEN`, `YELLOW` were removed from `plexi_sdk` and `plexi_sdk.ui` during the SDK theme migration
- Replace all usages with `ctx.theme.*` equivalents (`ctx.theme.bg`, `ctx.theme.fg`, `ctx.theme.surface`, `ctx.theme.highlight`, `ctx.theme.accent`, `ctx.theme.muted`, `ctx.theme.danger`, `ctx.theme.success`, `ctx.theme.warning`)
- Move `LEVEL_BADGE_FILL` dict from module-level into `on_render` in logs.py so it can reference theme values at render time

## Done When

`plexi open logs`, `plexi open backlog`, `plexi open csv_viewer`, and `plexi open calc` all launch without crashing on the alpha build.

## Notes

The theme object has both semantic names (`danger`, `success`, `warning`) and ANSI aliases (`red`, `green`, `yellow`) — used semantic names for correctness and consistency.