### PR TITLE
fix(cli): notes open errors, demo step 2 bypass, routine docs (#1855, #1856, #1849, #1850)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4692,7 +4692,7 @@ pub fn notes_open_cli() -> i32 {
 
     let has_notes = notes_dir.is_dir()
         && std::fs::read_dir(&notes_dir)
-            .map(|d| d.filter_map(|e| e.ok()).any(|e| e.path().extension().map_or(false, |x| x == "md")))
+            .map(|d| d.filter_map(|e| e.ok()).any(|e| std::path::Path::new(&e.file_name()).extension().map_or(false, |x| x == "md")))
             .unwrap_or(false);
     if !has_notes {
         eprintln!("No notes yet. Create one with \u{2318}+Shift+Space.");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4679,17 +4679,23 @@ pub fn notes_open_cli() -> i32 {
     let notes_dir = crate::config::config_dir().join("notes");
     let notes_dir_str = notes_dir.display().to_string();
 
-    let socket_set = std::env::var("PLEXI_SOCKET").is_ok();
-    let fzf_available = binary_in_path("fzf");
+    if !binary_in_path("fzf") {
+        eprintln!("error: fzf is not installed — run `brew install fzf` to enable the picker");
+        return 1;
+    }
 
-    if !socket_set || !fzf_available {
-        if !fzf_available {
-            eprintln!("hint: install fzf (`brew install fzf`) for an interactive picker");
-        }
-        if !socket_set {
-            eprintln!("hint: run inside a Plexi pane for interactive note picking");
-        }
-        println!("{notes_dir_str}");
+    if std::env::var("PLEXI_SOCKET").is_err() {
+        eprintln!("hint: run inside a Plexi pane for interactive note picking");
+        eprintln!("notes directory: {notes_dir_str}");
+        return 0;
+    }
+
+    let has_notes = notes_dir.is_dir()
+        && std::fs::read_dir(&notes_dir)
+            .map(|d| d.filter_map(|e| e.ok()).any(|e| e.path().extension().map_or(false, |x| x == "md")))
+            .unwrap_or(false);
+    if !has_notes {
+        eprintln!("No notes yet. Create one with \u{2318}+Shift+Space.");
         return 0;
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4795,28 +4795,30 @@ pub fn demo_cli() -> i32 {
     eprintln!("  H     L");
     eprintln!("     J");
     eprintln!();
-    eprintln!("  Press  \x1b[1m[ \u{2318}L ]\x1b[0m  to move focus right, then  \x1b[1m[ \u{2318}H ]\x1b[0m  to come back.");
+    eprintln!("  Press  \x1b[1m[ \u{2318}H ]\x1b[0m  to return to this pane, then  \x1b[1m[ \u{2318}L ]\x1b[0m  to go back.");
     eprintln!();
 
-    // Wait for focus to LEAVE this pane (user pressed ⌘L).
-    let focus_offset = match poll_event(&events_path, after_split_offset, |kind, obj| {
-        kind == "focus_changed"
-            && obj.get("pane_id").and_then(|v| v.as_u64()) == Some(my_pane_id)
-    }) {
-        Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
+    // Require a confirmed round-trip between split_pane and demo pane.
+    // After the split, focus is on split_pane_id. The valid event sequence is:
+    //   focus_changed(split_pane_id)  — user left split pane via ⌘H
+    //   focus_changed(my_pane_id)     — user left demo pane via ⌘L
+    // Any other pane ID appearing between these two resets the state so that
+    // a second ⌘D split cannot satisfy the round-trip without actual navigation.
+    let mut saw_split_depart = false;
+    if let Err(e) = poll_event(&events_path, after_split_offset, |kind, obj| {
+        if kind != "focus_changed" { return false; }
+        let Some(pid) = obj.get("pane_id").and_then(|v| v.as_u64()) else { return false };
+        if !saw_split_depart {
+            if pid == split_pane_id {
+                saw_split_depart = true;
+            }
+            false
+        } else if pid == my_pane_id {
+            true
+        } else {
+            saw_split_depart = pid == split_pane_id;
+            false
         }
-    };
-
-    // Wait for focus to leave the split pane with duration_secs > 0 (user pressed ⌘H and
-    // spent deliberate time on the new pane). The split itself generates a 0-duration
-    // bounce-back that must not satisfy this check.
-    if let Err(e) = poll_event(&events_path, focus_offset, |kind, obj| {
-        kind == "focus_changed"
-            && obj.get("pane_id").and_then(|v| v.as_u64()) == Some(split_pane_id)
-            && obj.get("duration_secs").and_then(|v| v.as_u64()).unwrap_or(0) > 0
     }) {
         eprintln!("error watching {}: {e}", events_path.display());
         return 1;

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -63,6 +63,9 @@ pub enum Commands {
     /// Manage workspace routines — scheduled shell commands.
     ///
     /// Routines are declared in `.plexi/routines.toml` and run automatically on schedule.
+    /// **Requires Plexi to be running** — there is no background daemon. Routines only fire
+    /// while the host process is open.
+    ///
     /// Use `plexi routine list` to see configured routines, or `plexi routine run <name>` to fire one manually.
     Routine {
         #[command(subcommand)]

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -47,7 +47,10 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
     println!("{heading} `{full_path}`");
     println!();
     if !about.is_empty() {
-        // Normalize multi-line about strings: blank lines become paragraph breaks
+        // Normalize multi-line about strings: blank lines become paragraph breaks.
+        // Clap joins consecutive doc comment lines with spaces, so the "about" text
+        // already has the routine's schedule bullets collapsed. Emit what clap gives us;
+        // the schedule reference block below re-emits the formatted version.
         let normalized = about
             .lines()
             .map(|l| l.trim())
@@ -55,7 +58,47 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
             .join("\n")
             .trim()
             .to_string();
-        println!("{normalized}");
+        // For `routine`, omit the collapsed bullet block — the explicit reference below
+        // replaces it with properly-formatted markdown.
+        let emit = if full_path == "plexi routine" {
+            normalized
+                .lines()
+                .take_while(|l| !l.starts_with("## "))
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim()
+                .to_string()
+        } else {
+            normalized
+        };
+        println!("{emit}");
+        println!();
+    }
+
+    // Inject a hand-authored schedule reference block for `plexi routine`.
+    if full_path == "plexi routine" {
+        println!("### Routine file format (`.plexi/routines.toml`)");
+        println!();
+        println!("```toml");
+        println!("[[routine]]");
+        println!(r#"name      = "morning-sync""#);
+        println!(r#"command   = "./scripts/sync.sh""#);
+        println!(r#"schedule  = "daily at 09:00""#);
+        println!(r#"context   = "work"   # optional: only fires when this context is active"#);
+        println!(r#"ephemeral = true     # optional: close the spawned pane when the command exits"#);
+        println!("```");
+        println!();
+        println!("### Schedule formats");
+        println!();
+        println!("| Format | Example |");
+        println!("|---|---|");
+        println!("| `every N seconds` | `every 30 seconds` |");
+        println!("| `every N minutes` | `every 5 minutes` |");
+        println!("| `every N hours`   | `every 2 hours` |");
+        println!("| `daily at HH:MM`  | `daily at 09:00` |");
+        println!("| `weekly on <day> at HH:MM` | `weekly on monday at 09:00` |");
+        println!("| `monthly on N at HH:MM`    | `monthly on 1 at 08:00` |");
+        println!("| 5-field cron `m h dom mon dow` | `0 9 * * 1-5` |");
         println!();
     }
 

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -58,20 +58,7 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
             .join("\n")
             .trim()
             .to_string();
-        // For `routine`, omit the collapsed bullet block — the explicit reference below
-        // replaces it with properly-formatted markdown.
-        let emit = if full_path == "plexi routine" {
-            normalized
-                .lines()
-                .take_while(|l| !l.starts_with("## "))
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            normalized
-        };
-        println!("{emit}");
+        println!("{normalized}");
         println!();
     }
 

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,3 @@
-   Compiling plexi v0.0.555 (/Users/ianburke/Documents/GitHub/PLEXI/worktrees/feature/bundle-1849-1850-1855-1856-cli-polish-demo-fixes)
-   Compiling gen_cli_docs v0.1.0 (/Users/ianburke/Documents/GitHub/PLEXI/worktrees/feature/bundle-1849-1850-1855-1856-cli-polish-demo-fixes/tools/gen_cli_docs)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.07s
-     Running `target/debug/gen_cli_docs`
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,3 +1,7 @@
+   Compiling plexi v0.0.555 (/Users/ianburke/Documents/GitHub/PLEXI/worktrees/feature/bundle-1849-1850-1855-1856-cli-polish-demo-fixes)
+   Compiling gen_cli_docs v0.1.0 (/Users/ianburke/Documents/GitHub/PLEXI/worktrees/feature/bundle-1849-1850-1855-1856-cli-polish-demo-fixes/tools/gen_cli_docs)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.07s
+     Running `target/debug/gen_cli_docs`
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.
@@ -92,7 +96,32 @@ Delete a stored secret
 
 Manage workspace routines — scheduled shell commands.
 
-Routines are declared in `.plexi/routines.toml` and run automatically on schedule. Use `plexi routine list` to see configured routines, or `plexi routine run <name>` to fire one manually.
+Routines are declared in `.plexi/routines.toml` and run automatically on schedule. **Requires Plexi to be running** — there is no background daemon. Routines only fire while the host process is open.
+
+Use `plexi routine list` to see configured routines, or `plexi routine run <name>` to fire one manually.
+
+### Routine file format (`.plexi/routines.toml`)
+
+```toml
+[[routine]]
+name      = "morning-sync"
+command   = "./scripts/sync.sh"
+schedule  = "daily at 09:00"
+context   = "work"   # optional: only fires when this context is active
+ephemeral = true     # optional: close the spawned pane when the command exits
+```
+
+### Schedule formats
+
+| Format | Example |
+|---|---|
+| `every N seconds` | `every 30 seconds` |
+| `every N minutes` | `every 5 minutes` |
+| `every N hours`   | `every 2 hours` |
+| `daily at HH:MM`  | `daily at 09:00` |
+| `weekly on <day> at HH:MM` | `weekly on monday at 09:00` |
+| `monthly on N at HH:MM`    | `monthly on 1 at 08:00` |
+| 5-field cron `m h dom mon dow` | `0 9 * * 1-5` |
 
 | Subcommand | Description |
 |---|---|


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1855, Closes #1856, Closes #1849, Closes #1850

## Summary

**#1855 — fix(cli/notes): plexi notes open silent failures**
- `fzf` missing: exit 1 with install hint (was exit 0, no signal)
- Outside pane: print notes dir as hint, exit 0 (was silent path print)
- Empty notes dir: print `⌘+Shift+Space` hint instead of launching blank fzf

**#1856 — docs(cli/routine): schedule format reference and no-daemon note**
- Add "Requires Plexi to be running — no daemon" to help text and docs
- Inject TOML format example and schedule format table into gen_cli_docs output

**#1850 — fix(cli/demo): step 2 instruction backwards after split**
- Split moves focus to the new right pane; instruction wrongly said "press ⌘L to move right"
- Fixed to: "Press ⌘H to return to this pane, then ⌘L to go back"

**#1849 — fix(cli/demo): second split satisfies step 2 without navigation**
- Replace two independent `focus_changed` polls with a state machine requiring `split_pane_id → my_pane_id` in sequence
- Any other pane ID between the two resets state, so a ⌘D bypass no longer works