### PR TITLE
docs(file-explorer): add website docs page and welcome screen tip (#1736)

### DIFF
--- a/website/src/content/docs/file-explorer.md
+++ b/website/src/content/docs/file-explorer.md
@@ -1,0 +1,34 @@
+---
+title: File Explorer
+description: Browse your filesystem without leaving Plexi.
+verified_version: "0.0.558"
+order: 8
+---
+
+The file explorer is a built-in overlay that lets you browse and open files from within any Plexi context. Open it with `⌘E` from a terminal pane — no shell command required.
+
+## Opening the File Explorer
+
+Press `⌘E` from any focused terminal pane. The overlay opens over your current layout. It starts at the current working directory of that pane (tracked via OSC 7).
+
+## Navigation
+
+| Action | Key |
+|--------|-----|
+| Move down | `j` or `↓` |
+| Move up | `k` or `↑` |
+| Open file / enter directory | `Enter` |
+| Go up one directory | `h` or `Backspace` |
+| Search by name | `/` |
+| Toggle sort order | `s` |
+| Close | `Escape` |
+
+Files open in the focused terminal pane. Directories are entered in place — the overlay stays open until you press `Escape`.
+
+## Search
+
+Press `/` to enter search mode. Type to filter the current directory listing by filename. Press `Escape` to exit search and return to normal navigation, or `Enter` to open the highlighted match.
+
+## Sort Order
+
+Press `s` to toggle between name-ascending and name-descending sort. The sort persists for the current session.

--- a/website/src/content/docs/file-explorer.md
+++ b/website/src/content/docs/file-explorer.md
@@ -17,10 +17,11 @@ Press `⌘E` from any focused terminal pane. The overlay opens over your current
 |--------|-----|
 | Move down | `j` or `↓` |
 | Move up | `k` or `↑` |
-| Open file / enter directory | `Enter` |
-| Go up one directory | `h` or `Backspace` |
+| Open file / enter directory | `Enter`, `l`, or `→` |
+| Go up one directory | `h`, `Backspace`, or `←` |
 | Search by name | `/` |
 | Toggle sort order | `s` |
+| Refresh listing | `r` |
 | Close | `Escape` |
 
 Files open in the focused terminal pane. Directories are entered in place — the overlay stays open until you press `Escape`.


### PR DESCRIPTION
Closes #1736

## Summary

- Adds `website/src/content/docs/file-explorer.md` — covers what the file explorer is, how to open it (`⌘E`), keyboard navigation (j/k/↑↓, Enter, h/Backspace, /search, s-sort, Escape), and that it opens at the focused terminal pane's CWD
- No `overlays.rs` change needed — `⌘E → "file browser"` was already present in `draw_welcome_screen`'s shortcuts list at line 4088

## Done When

- The website docs site renders a "File Explorer" page in the docs nav.
- The welcome screen (shown when a new context is created with no panes) includes the ⌘E tip in the "Things to try" list.
- Spot-check: ⌘E in a terminal pane actually opens the file browser and the nav keys described in the docs work.

## Notes

The welcome screen shortcut entry predates this issue. The only missing piece was the docs page.