### PR TITLE
feat(cli): plexi demo — improved terminal UI with clear sections and progress header (#1755)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4722,6 +4722,22 @@ pub fn notes_open_cli() -> i32 {
     pane_send_cli(pane_id, &cmd)
 }
 
+fn print_demo_divider() {
+    eprintln!("  \x1b[2m────────────────────\x1b[0m");
+    eprintln!();
+}
+
+fn print_step_header(step: u8, total: u8, title: &str) {
+    print_demo_divider();
+    eprintln!("  \x1b[1mStep {} of {}   {}\x1b[0m", step, total, title);
+    eprintln!();
+}
+
+fn print_step_complete(step: u8, total: u8) {
+    eprintln!("  \x1b[1;32m\u{2713} {}/{}\x1b[0m", step, total);
+    eprintln!();
+}
+
 pub fn demo_cli() -> i32 {
     let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
         Ok(v) => v,
@@ -4761,9 +4777,8 @@ pub fn demo_cli() -> i32 {
     eprintln!();
 
     // Step 1 — split
-    eprintln!("  Step 1 of 2   Split a pane");
-    eprintln!();
-    eprintln!("  Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
+    print_step_header(1, 2, "Split a pane");
+    eprintln!("    Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
     eprintln!();
 
     // Capture the new pane's ID from the split event so step 2 can verify
@@ -4784,18 +4799,16 @@ pub fn demo_cli() -> i32 {
             return 1;
         }
     };
-    eprintln!("  \x1b[1;32m\u{2713} 1/2\x1b[0m");
-    eprintln!();
+    print_step_complete(1, 2);
 
     // Step 2 — navigate
-    eprintln!("  Step 2 of 2   Navigate panes");
+    print_step_header(2, 2, "Navigate panes");
+    eprintln!("       \x1b[2m^\x1b[0m");
+    eprintln!("       K");
+    eprintln!("    H     L");
+    eprintln!("       J");
     eprintln!();
-    eprintln!("     \x1b[2m^\x1b[0m");
-    eprintln!("     K");
-    eprintln!("  H     L");
-    eprintln!("     J");
-    eprintln!();
-    eprintln!("  Press  \x1b[1m[ \u{2318}H ]\x1b[0m  to return to this pane, then  \x1b[1m[ \u{2318}L ]\x1b[0m  to go back.");
+    eprintln!("    Press  \x1b[1m[ \u{2318}H ]\x1b[0m  to return to this pane, then  \x1b[1m[ \u{2318}L ]\x1b[0m  to go back.");
     eprintln!();
 
     // Require a confirmed round-trip between split_pane and demo pane.
@@ -4824,7 +4837,7 @@ pub fn demo_cli() -> i32 {
         return 1;
     }
 
-    eprintln!("  \x1b[1;32m\u{2713} 2/2   You know Plexi.\x1b[0m");
+    eprintln!("  \x1b[1;32m\u{2713} 2/2 \u{2014} You know Plexi.\x1b[0m");
     eprintln!();
     log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");
     0


### PR DESCRIPTION
Closes #1755

## Summary

- Added `print_step_header`, `print_step_complete`, and `print_demo_divider` helper functions to structure `demo_cli()` output
- Each step now opens with a dim horizontal rule (`────────────────────`) and a bold step label; body text is indented 4 spaces
- Completion markers show green bold ✓ with step fraction on the same line; final step includes `— You know Plexi.` celebration

## Done When

Running `plexi-alpha demo` inside a pane:
- Each step opens with a clearly separated header line (bold step label + section title)
- A dim horizontal rule visually separates the banner from step 1 and each step from the next
- Completion markers are green bold ✓ followed by the step fraction on the same line
- The final step prints a brief celebration line (`✓ 2/2 — You know Plexi.` or similar)
- No regressions in step detection logic

## Notes

Only `demo_cli()` in `src/cli.rs` changed. Poll event logic is untouched — only the display output was restructured.