### PR TITLE
refactor(sdk/pgap): component-owned input routing (#1802)

### DIFF
--- a/apps/dev/gh-issues/main.py
+++ b/apps/dev/gh-issues/main.py
@@ -310,11 +310,6 @@ class GhIssues(App):
     def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> None:
         pass
 
-    def on_scroll_delta(self, _ctx: RenderContext, delta_y: float) -> None:
-        if self._view == self.VIEW_DETAIL:
-            self._body_scroll.handle_scroll(delta_y)
-            self.emit.schedule_render()
-
     # ── actions ───────────────────────────────────────────────────────────────
 
     def _open_detail(self) -> None:

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -1080,7 +1080,12 @@ class App:
                     delta_y = float(ev.get("delta_y", 0.0))
                     if self._scroll_consumers:
                         for _consumer in self._scroll_consumers:
-                            _consumer.handle_scroll(delta_y)
+                            try:
+                                _consumer.handle_scroll(delta_y)
+                            except Exception as e:
+                                sys.stderr.write(
+                                    f"scroll consumer {type(_consumer).__name__} handle_scroll raised: {e}\n"
+                                )
                         self.emit.schedule_render()
                     else:
                         ctx = self._make_ctx()

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -229,6 +229,9 @@ class App:
         # Hold timer for ctx.button() active_fill (#1083): maps button id →
         # monotonic timestamp at which the active state expires.
         self._btn_active_until: dict[str, float] = {}
+        # Scroll consumers registered by components during the last completed
+        # render frame. Populated from ctx._scroll_consumers after on_render (#1802).
+        self._scroll_consumers: list = []
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
@@ -952,6 +955,8 @@ class App:
                             import traceback as _tb
                             _tb.print_exc()
                             raise
+                    # Snapshot scroll consumers registered during this frame (#1802).
+                    self._scroll_consumers = list(ctx._scroll_consumers)
                     ctx.frame_done()
 
                 elif t == "key":
@@ -1067,12 +1072,22 @@ class App:
                     # Raw wheel delta for SDK Scrollable containers (#1794).
                     # Fires when the cursor is over the app pane but not over a
                     # host-managed BeginScroll region or ListView.
+                    #
+                    # Component routing (#1802): if any component registered scroll
+                    # interest during the last render, dispatch to each and schedule
+                    # a re-render. Falls through to on_scroll_delta only when no
+                    # components are registered, preserving backward compatibility.
                     delta_y = float(ev.get("delta_y", 0.0))
-                    ctx = self._make_ctx()
-                    try:
-                        await self._dispatch_hook(self.on_scroll_delta, ctx, delta_y)
-                    except Exception as e:
-                        sys.stderr.write(f"on_scroll_delta handler raised: {e}\n")
+                    if self._scroll_consumers:
+                        for _consumer in self._scroll_consumers:
+                            _consumer.handle_scroll(delta_y)
+                        self.emit.schedule_render()
+                    else:
+                        ctx = self._make_ctx()
+                        try:
+                            await self._dispatch_hook(self.on_scroll_delta, ctx, delta_y)
+                        except Exception as e:
+                            sys.stderr.write(f"on_scroll_delta handler raised: {e}\n")
 
                 elif t == "theme":
                     from ._theme import theme as _theme

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -60,6 +60,19 @@ class RenderContext:
         expired = [bid for bid, exp in self._btn_active_until.items() if exp <= _now]
         for bid in expired:
             del self._btn_active_until[bid]
+        # Components that declare scroll interest by calling register_scroll_consumer()
+        # during render. The App saves this list after each frame and routes
+        # PlexiEvent::Scroll to these consumers automatically (#1802).
+        self._scroll_consumers: list = []
+
+    def register_scroll_consumer(self, component: Any) -> None:
+        """Declare that `component` wants to receive scroll events this frame.
+
+        Call from a component's render() method. The SDK will automatically
+        call component.handle_scroll(delta_y) on incoming scroll events and
+        schedule a re-render — no on_scroll_delta override needed in the app.
+        """
+        self._scroll_consumers.append(component)
 
     def _queue(self, obj: dict) -> None:
         """Buffer a render command for batch flush at frame_done()."""

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -573,6 +573,7 @@ class Scrollable(Component):
         self._clamp_offset(self._avail_h)
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        ctx.register_scroll_consumer(self)
         self._avail_h = h
         # Measure child at our width (less scrollbar gutter).
         content_w = w - self._SCROLLBAR_W - 2.0


### PR DESCRIPTION
Closes #1802

## Summary

- Added `RenderContext.register_scroll_consumer(component)` — components call this during `render()` to declare scroll interest for the current frame
- `App` snapshots registered consumers after each `on_render`; the `scroll` event handler routes `delta_y` to all consumers and schedules a re-render, falling through to `on_scroll_delta` only when none are registered (backward compat)
- `Scrollable.render()` now calls `ctx.register_scroll_consumer(self)` — any app that renders a `Scrollable` gets mouse-wheel scroll with zero per-app wiring
- Removed `on_scroll_delta` from `gh-issues` (reference migration); `mcp-renderer` gains scroll for free as a side effect

## Done When

1. A new app that uses `Scrollable` scrolls with the mouse wheel without any app-level event wiring.
2. Adding a hypothetical new modality touches the router + the relevant component only — not every app.
3. `gh-issues/main.py` no longer hand-wires `handle_scroll()` and still scrolls.
4. `cargo test --bin plexi` and SDK harness tests pass.

## Notes

- The fallback to `on_scroll_delta` preserves backward compatibility for apps (e.g. `github-tree`, `input-inspector`) that use `on_scroll` (host-managed BeginScroll) or hand-roll their own scroll offset — those paths are unaffected.
- `SelectList` uses `handle_key` for j/k scroll; it is not a scroll consumer (mouse-wheel doesn't target it). That is intentional and consistent with the existing behavior.