### PR TITLE
fix(host/list_view): remove row gap and wire click events (#1871)

### DIFF
--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -408,7 +408,6 @@ pub(crate) fn render_draw_commands(
                 const CHIP_GAP: f32 = 4.0;
                 const CHIP_PAD_X: f32 = 8.0;
                 const BADGE_TEXT_GAP: f32 = 8.0;
-                const SPACE_XS: f32 = 4.0;
                 const SCROLLBAR_W: f32 = 3.0;
                 const FONT_CAPTION: f32 = 13.0;
                 const FONT_HINT: f32 = 12.0;
@@ -417,7 +416,7 @@ pub(crate) fn render_draw_commands(
                 let total_h = if heights.is_empty() {
                     0.0
                 } else {
-                    heights.iter().sum::<f32>() + SPACE_XS * (heights.len().saturating_sub(1)) as f32
+                    heights.iter().sum::<f32>()
                 };
 
                 // Scroll-to-selected: only fire when the selection index changes.
@@ -441,7 +440,7 @@ pub(crate) fn render_draw_commands(
                                 }
                                 break;
                             }
-                            item_top += h_item + SPACE_XS;
+                            item_top += h_item;
                         }
                         list_view_last_aligned_sel.insert(id.clone(), sel);
                         log::debug!("list_view scroll-to-sel: id={id:?} sel={sel} offset={scroll_y_ref}");
@@ -473,7 +472,7 @@ pub(crate) fn render_draw_commands(
                             egui::vec2(list_w * 0.6, FONT_CAPTION),
                         );
                         painter.rect_filled(txt_rect, 3.0, colors.border);
-                        sy += LVI::ROW_H_BASE + SPACE_XS;
+                        sy += LVI::ROW_H_BASE;
                     }
                     // return is inside the match arm — use continue instead
                 }
@@ -519,7 +518,7 @@ pub(crate) fn render_draw_commands(
                     for (i, item) in items.iter().enumerate() {
                         let h_item = heights[i];
                         let row_abs_y = list_rect.min.y + item_top - scroll_y;
-                        item_top += h_item + SPACE_XS;
+                        item_top += h_item;
 
                         if row_abs_y + h_item < list_rect.min.y || row_abs_y > list_rect.max.y {
                             continue;

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -418,7 +418,11 @@ impl RenderSession {
                         for (i, item) in items.iter().enumerate() {
                             let h = item.height();
                             let row_abs_y = list_rect.min.y + item_top - scroll_y;
-                            if pos.y >= row_abs_y && pos.y < row_abs_y + h {
+                            let row_rect = egui::Rect::from_min_size(
+                                egui::pos2(list_rect.min.x, row_abs_y),
+                                egui::vec2(list_w, h),
+                            );
+                            if list_rect.intersect(row_rect).contains(pos) {
                                 if response.double_clicked() {
                                     log::info!("ListView[{id}]: double-click → activate {i}");
                                     self.outbound_events.push(PlexiEvent::ListSelect {

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -408,42 +408,52 @@ impl RenderSession {
                 egui::vec2(list_w, list_h),
             );
 
-            // Click detection — independent of keyboard handled_nav state
+            // Click detection — use raw input rather than ui.interact() to avoid
+            // the pane-level Sense::click_and_drag() widget (mod.rs) claiming
+            // the event first (last-registered widget wins in egui).
             if !items.is_empty() && !*loading {
-                let response = ui.interact(list_rect, ui.id().with(id), egui::Sense::click());
-                if response.clicked() || response.double_clicked() {
-                    if let Some(pos) = response.interact_pointer_pos() {
-                        let scroll_y = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
-                        let mut item_top = 0.0f32;
-                        for (i, item) in items.iter().enumerate() {
-                            let h = item.height();
-                            let row_abs_y = list_rect.min.y + item_top - scroll_y;
-                            let row_rect = egui::Rect::from_min_size(
-                                egui::pos2(list_rect.min.x, row_abs_y),
-                                egui::vec2(list_w, h),
-                            );
-                            if list_rect.intersect(row_rect).contains(pos) {
-                                if response.double_clicked() {
-                                    log::info!("ListView[{id}]: double-click → activate {i}");
-                                    self.outbound_events.push(PlexiEvent::ListSelect {
-                                        id: id.clone(),
-                                        index: i,
-                                    });
-                                    self.outbound_events.push(PlexiEvent::ListActivate {
-                                        id: id.clone(),
-                                        index: i,
-                                    });
-                                } else {
-                                    log::info!("ListView[{id}]: click → select {i}");
-                                    self.outbound_events.push(PlexiEvent::ListSelect {
-                                        id: id.clone(),
-                                        index: i,
-                                    });
+                let is_double = ui.input(|i| {
+                    i.pointer.button_double_clicked(egui::PointerButton::Primary)
+                });
+                let is_click = ui.input(|i| {
+                    i.pointer.button_released(egui::PointerButton::Primary)
+                        && !i.pointer.is_decidedly_dragging()
+                });
+                if is_double || is_click {
+                    if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                        if list_rect.contains(pos) {
+                            let scroll_y = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
+                            let mut item_top = 0.0f32;
+                            for (i, item) in items.iter().enumerate() {
+                                let h = item.height();
+                                let row_abs_y = list_rect.min.y + item_top - scroll_y;
+                                let row_rect = egui::Rect::from_min_size(
+                                    egui::pos2(list_rect.min.x, row_abs_y),
+                                    egui::vec2(list_w, h),
+                                );
+                                if list_rect.intersect(row_rect).contains(pos) {
+                                    if is_double {
+                                        log::info!("ListView[{id}]: double-click → activate {i}");
+                                        self.outbound_events.push(PlexiEvent::ListSelect {
+                                            id: id.clone(),
+                                            index: i,
+                                        });
+                                        self.outbound_events.push(PlexiEvent::ListActivate {
+                                            id: id.clone(),
+                                            index: i,
+                                        });
+                                    } else {
+                                        log::info!("ListView[{id}]: click → select {i}");
+                                        self.outbound_events.push(PlexiEvent::ListSelect {
+                                            id: id.clone(),
+                                            index: i,
+                                        });
+                                    }
+                                    ui.ctx().request_repaint();
+                                    break;
                                 }
-                                ui.ctx().request_repaint();
-                                break;
+                                item_top += h;
                             }
-                            item_top += h;
                         }
                     }
                 }

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -408,6 +408,43 @@ impl RenderSession {
                 egui::vec2(list_w, list_h),
             );
 
+            // Click detection — independent of keyboard handled_nav state
+            if !items.is_empty() && !*loading {
+                let response = ui.interact(list_rect, ui.id().with(id), egui::Sense::click());
+                if response.clicked() || response.double_clicked() {
+                    if let Some(pos) = response.interact_pointer_pos() {
+                        let scroll_y = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
+                        let mut item_top = 0.0f32;
+                        for (i, item) in items.iter().enumerate() {
+                            let h = item.height();
+                            let row_abs_y = list_rect.min.y + item_top - scroll_y;
+                            if pos.y >= row_abs_y && pos.y < row_abs_y + h {
+                                if response.double_clicked() {
+                                    log::info!("ListView[{id}]: double-click → activate {i}");
+                                    self.outbound_events.push(PlexiEvent::ListSelect {
+                                        id: id.clone(),
+                                        index: i,
+                                    });
+                                    self.outbound_events.push(PlexiEvent::ListActivate {
+                                        id: id.clone(),
+                                        index: i,
+                                    });
+                                } else {
+                                    log::info!("ListView[{id}]: click → select {i}");
+                                    self.outbound_events.push(PlexiEvent::ListSelect {
+                                        id: id.clone(),
+                                        index: i,
+                                    });
+                                }
+                                ui.ctx().request_repaint();
+                                break;
+                            }
+                            item_top += h;
+                        }
+                    }
+                }
+            }
+
             if handled_nav || *loading || items.is_empty() {
                 continue;
             }
@@ -420,9 +457,7 @@ impl RenderSession {
             if scroll_delta.y != 0.0 {
                 if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
                     if list_rect.contains(pos) {
-                        const SPACE_XS: f32 = 4.0;
-                        let total_h: f32 = items.iter().map(|item| item.height()).sum::<f32>()
-                            + SPACE_XS * (n.saturating_sub(1)) as f32;
+                        let total_h: f32 = items.iter().map(|item| item.height()).sum::<f32>();
                         let max_scroll = (total_h - list_h).max(0.0);
                         let prev = self.list_view_scroll_offsets.get(id.as_str()).copied().unwrap_or(0.0);
                         let next = (prev - scroll_delta.y).clamp(0.0, max_scroll);


### PR DESCRIPTION
Closes #1871

## Summary

- Removes the 4px `SPACE_XS` gap between list rows in both `render.rs` and `render_session.rs` — the gap was left unpainted, causing alternating rows to appear different heights due to contrast differences with row backgrounds
- Adds single-click → `ListSelect` and double-click → `ListActivate` event emission in `render_list_views()` via `ui.interact()` with pointer-to-row hit testing
- Click detection is placed before the `handled_nav` guard so it fires independently of keyboard navigation state

## Done When

- gh-issues list: all rows render at equal visual height with no gap between them
- Clicking any row changes the selection highlight (on_list_select fires)
- Double-clicking any row opens the detail view (on_list_activate fires)
- j/k/Enter still work
- `cargo test --bin plexi` passes

## Notes

Click detection walks item heights without any gap offset (consistent with the Bug 1 fix). Double-click also emits `ListSelect` first so selection tracks the click target before activation fires.