### PR TITLE
feat(contexts): new context defaults to home dir, not active pane cwd (#1693)

### DIFF
--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -116,12 +116,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn new_context(&mut self) {
-        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let cwd = self.windows[self.active_window]
-            .focused_pane
-            .and_then(|t| self.windows[self.active_window].get_focused_pane_cwd(t))
-            .filter(|p| p != &PathBuf::from("/"))
-            .unwrap_or_else(|| home.clone());
+        let cwd = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         log::info!("new_context: cwd={}", cwd.display());
         let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), None, false)
         else {


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #1693

## Summary

- `new_context()` previously read the focused pane's cwd and used it as the new context's path and root
- Replace the focused-pane cwd lookup with `dirs::home_dir()` directly — new contexts always open at `~`
- `new_context_at_path()` is unaffected (intentionally opens at a specific directory)