### PR TITLE
feat(host/navigation): unify Cmd+Enter zoom — Portal focus enters sub-context, else pane fullscreen (#1830)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2422,12 +2422,16 @@ impl eframe::App for PlexiApp {
                         .and_then(|p| p.portal_target());
                     if let Some(child_ctx_id) = portal_target {
                         // Focused pane is a Portal tile → zoom into its sub-context.
-                        log::info!("ToggleZoom on Portal: zooming into context_id={child_ctx_id}");
-                        let current_ctx_id = self.router.active().context_id;
-                        let current_win_id = self.windows[self.active_window].window_id;
-                        self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
+                        // Verify the target context exists BEFORE pushing depth state;
+                        // push_depth must not fire if there is nothing to switch to.
                         if let Some(ctx_idx) = self.router.position(|c| c.context_id == child_ctx_id) {
+                            log::info!("ToggleZoom on Portal: zooming into context_id={child_ctx_id}");
+                            let current_ctx_id = self.router.active().context_id;
+                            let current_win_id = self.windows[self.active_window].window_id;
+                            self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
                             self.switch_workspace(ctx_idx);
+                        } else {
+                            log::warn!("ToggleZoom on Portal: target context_id={child_ctx_id} not found in router");
                         }
                     } else {
                         // Non-Portal pane → toggle fullscreen zoom.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2412,20 +2412,40 @@ impl eframe::App for PlexiApp {
                     self.save_workspace();
                 }
                 Action::ToggleZoom => {
-                    let ctx = &mut self.windows[self.active_window];
-                    if let Some(focused) = ctx.focused_pane {
-                        if ctx.zoomed_pane == Some(focused) {
-                            ctx.zoomed_pane = None;
-                            log::info!("zoom: toggle off — pane={focused:?}");
-                        } else {
-                            ctx.zoomed_pane = Some(focused);
-                            log::info!("zoom: toggle on — pane={focused:?}");
+                    let focused_tile = self.windows[self.active_window].focused_pane;
+                    let focused_pane_id = focused_tile.and_then(|tile_id| {
+                        self.windows[self.active_window].tree.tiles.get(tile_id)
+                            .and_then(|t| if let egui_tiles::Tile::Pane(p) = t { Some(*p) } else { None })
+                    });
+                    let portal_target = focused_pane_id
+                        .and_then(|pane_id| self.windows[self.active_window].panes.get(&pane_id))
+                        .and_then(|p| p.portal_target());
+                    if let Some(child_ctx_id) = portal_target {
+                        // Focused pane is a Portal tile → zoom into its sub-context.
+                        log::info!("ToggleZoom on Portal: zooming into context_id={child_ctx_id}");
+                        let current_ctx_id = self.router.active().context_id;
+                        let current_win_id = self.windows[self.active_window].window_id;
+                        self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
+                        if let Some(ctx_idx) = self.router.position(|c| c.context_id == child_ctx_id) {
+                            self.switch_workspace(ctx_idx);
                         }
-                        self.ctx.memory_mut(|m| {
-                            if let Some(id) = m.focused() {
-                                m.surrender_focus(id);
+                    } else {
+                        // Non-Portal pane → toggle fullscreen zoom.
+                        let ctx = &mut self.windows[self.active_window];
+                        if let Some(focused) = ctx.focused_pane {
+                            if ctx.zoomed_pane == Some(focused) {
+                                ctx.zoomed_pane = None;
+                                log::info!("zoom: toggle off — pane={focused:?}");
+                            } else {
+                                ctx.zoomed_pane = Some(focused);
+                                log::info!("zoom: toggle on — pane={focused:?}");
                             }
-                        });
+                            self.ctx.memory_mut(|m| {
+                                if let Some(id) = m.focused() {
+                                    m.surrender_focus(id);
+                                }
+                            });
+                        }
                     }
                 }
                 Action::Quit => {
@@ -2623,27 +2643,6 @@ impl eframe::App for PlexiApp {
                 Action::OpenScratchpad => {
                     log::info!("scratchpad: Cmd+Shift+Space — opening");
                     self.open_scratchpad();
-                }
-                Action::ContextZoomIn => {
-                    // Zoom into the sub-context tile that currently has focus.
-                    let focused_tile = self.windows[self.active_window].focused_pane;
-                    if let Some(tile_id) = focused_tile {
-                        let focused_pane_id = self.windows[self.active_window].tree.tiles.get(tile_id)
-                            .and_then(|t| if let egui_tiles::Tile::Pane(p) = t { Some(*p) } else { None });
-                        if let Some(pane_id) = focused_pane_id {
-                            if let Some(child_ctx_id) = self.windows[self.active_window].panes.get(&pane_id)
-                                .and_then(|p| p.portal_target())
-                            {
-                                log::info!("ContextZoomIn: zooming into context_id={child_ctx_id}");
-                                let current_ctx_id = self.router.active().context_id;
-                                let current_win_id = self.windows[self.active_window].window_id;
-                                self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
-                                if let Some(ctx_idx) = self.router.position(|c| c.context_id == child_ctx_id) {
-                                    self.switch_workspace(ctx_idx);
-                                }
-                            }
-                        }
-                    }
                 }
                 Action::ContextZoomOut => {
                     log::info!("ContextZoomOut: popping depth stack (depth={})", self.router.current_depth());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2412,17 +2412,19 @@ impl eframe::App for PlexiApp {
                     self.save_workspace();
                 }
                 Action::ToggleZoom => {
-                    let focused_tile = self.windows[self.active_window].focused_pane;
-                    let focused_pane_id = focused_tile.and_then(|tile_id| {
-                        self.windows[self.active_window].tree.tiles.get(tile_id)
+                    let (focused_tile, portal_target) = {
+                        let win = &self.windows[self.active_window];
+                        let tile = win.focused_pane;
+                        let target = tile
+                            .and_then(|tile_id| win.tree.tiles.get(tile_id))
                             .and_then(|t| if let egui_tiles::Tile::Pane(p) = t { Some(*p) } else { None })
-                    });
-                    let portal_target = focused_pane_id
-                        .and_then(|pane_id| self.windows[self.active_window].panes.get(&pane_id))
-                        .and_then(|p| p.portal_target());
+                            .and_then(|pane_id| win.panes.get(&pane_id))
+                            .and_then(|p| p.portal_target());
+                        (tile, target)
+                    };
                     if let Some(child_ctx_id) = portal_target {
                         // Focused pane is a Portal tile → zoom into its sub-context.
-                        // Verify the target context exists BEFORE pushing depth state;
+                        // Verify target context exists BEFORE pushing depth state;
                         // push_depth must not fire if there is nothing to switch to.
                         if let Some(ctx_idx) = self.router.position(|c| c.context_id == child_ctx_id) {
                             log::info!("ToggleZoom on Portal: zooming into context_id={child_ctx_id}");

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,7 +16,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+Shift+K/J               — first/last tab
 // Cmd+Q                       — quit
 // Cmd+B                       — toggle sidebar
-// Cmd+Enter                   — toggle zoom
+// Cmd+Enter                   — zoom into sub-context (Portal focus) or toggle pane zoom
 // Cmd+/                       — toggle shortcuts overlay
 // Cmd+P                       — command palette
 // Cmd+R                       — rename pane
@@ -121,8 +121,6 @@ pub enum Action {
     SwapPane(Direction),
     /// Open the scratchpad overlay. Bound to Cmd+Shift+Space.
     OpenScratchpad,
-    /// Zoom into the sub-context tile that has focus. Bound to Cmd+Shift+Enter.
-    ContextZoomIn,
     /// Zoom out of the current sub-context to the parent. Bound to Cmd+Escape.
     ContextZoomOut,
 }
@@ -174,7 +172,6 @@ pub struct KeyBindings {
     pub toggle_notification_modal: (egui::Modifiers, egui::Key),
     pub context_inspector: (egui::Modifiers, egui::Key),
     pub open_scratchpad: (egui::Modifiers, egui::Key),
-    pub context_zoom_in: (egui::Modifiers, egui::Key),
     pub context_zoom_out: (egui::Modifiers, egui::Key),
 }
 
@@ -234,7 +231,6 @@ impl Default for KeyBindings {
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
             context_inspector:         (cmd(),       egui::Key::I),
             open_scratchpad:           (cmd_shift(), egui::Key::Space),
-            context_zoom_in:           (cmd_shift(), egui::Key::Enter),
             context_zoom_out:          (cmd(),       egui::Key::Escape),
         }
     }
@@ -555,11 +551,7 @@ pub fn poll_actions(
         if input.consume_key(bindings.toggle_sidebar.0, bindings.toggle_sidebar.1) {
             actions.push(Action::ToggleSidebar);
         }
-        // context_zoom_in (Cmd+Shift+Enter) must be checked before toggle_zoom (Cmd+Enter)
-        // because egui consume_key uses subset modifier matching.
-        if input.consume_key(bindings.context_zoom_in.0, bindings.context_zoom_in.1) {
-            actions.push(Action::ContextZoomIn);
-        } else if input.consume_key(bindings.toggle_zoom.0, bindings.toggle_zoom.1) {
+        if input.consume_key(bindings.toggle_zoom.0, bindings.toggle_zoom.1) {
             actions.push(Action::ToggleZoom);
         }
         if input.consume_key(bindings.toggle_shortcuts.0, bindings.toggle_shortcuts.1) {

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -617,7 +617,7 @@ impl PlexiApp {
                                         colors,
                                     );
                                     ui.label(
-                                        RichText::new("Zoom pane")
+                                        RichText::new("Zoom pane / enter context")
                                             .size(style::TEXT_HINT)
                                             .color(colors.text_dim),
                                     );

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -15,7 +15,7 @@ pub enum Pane {
     App(Box<AppPane>),
     /// A tile that represents a child context nested inside this one.
     /// Renders a summary card with pane count, status, and per-pane summaries.
-    /// Cmd+Shift+Enter zooms in.
+    /// Cmd+Enter zooms into the sub-context when this tile has focus.
     Portal(Box<PortalPane>),
 }
 


### PR DESCRIPTION
Closes #1830

## Summary

- Removes `Action::ContextZoomIn` and the separate `Cmd+Shift+Enter` Portal-zoom binding
- Merges Portal-focus detection into the `Action::ToggleZoom` handler: if the focused pane is a Portal tile, zooms into its sub-context via `push_depth` + `switch_workspace`; otherwise toggles pane fullscreen zoom as before
- Updates the keyboard shortcuts overlay label from "Zoom pane" to "Zoom pane / enter context"

## Done When

- Cmd+Enter on a focused Portal tile zooms into that sub-context (breadcrumb depth increments).
- Cmd+Enter on a Terminal/App pane toggles its fullscreen zoom.
- Cmd+Escape zooms/surfaces out in both cases.
- `cargo test --bin plexi` green; #1683's behavior is preserved.

## Notes

The existing `ContextZoomOut` binding (`Cmd+Escape`) is unchanged. The Portal branch reuses the identical `push_depth` / `switch_workspace` logic from the former `ContextZoomIn` handler with no changes to `workspace_router.rs`.