### PR TITLE
fix(apps): migrate removed SDK color constants to ctx.theme in 6 core apps (#1879)

### DIFF
--- a/apps/calendar/calendar_app.py
+++ b/apps/calendar/calendar_app.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from plexi_sdk import (
     App, RenderContext,
-    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, GREEN,
     BODY, CAPTION, HINT, HEADING, PAD,
 )
 
@@ -241,14 +240,14 @@ class CalendarApp(App):
     # ── Render ────────────────────────────────────────────────────────────────
 
     def on_render(self, ctx: RenderContext) -> None:
-        ctx.clear(BG)
+        ctx.clear(ctx.theme.bg)
 
         # Header bar
         header_h = 48.0
-        ctx.rect(0, 0, ctx.w, header_h, fill=SURFACE)
+        ctx.rect(0, 0, ctx.w, header_h, fill=ctx.theme.surface)
         month_name = date(self._year, self._month, 1).strftime("%B %Y")
-        ctx.text(PAD, 10.0, "Calendar", size=HEADING, color=FG, bold=True)
-        ctx.text(PAD, 30.0, month_name, size=CAPTION, color=MUTED)
+        ctx.text(PAD, 10.0, "Calendar", size=HEADING, color=ctx.theme.fg, bold=True)
+        ctx.text(PAD, 30.0, month_name, size=CAPTION, color=ctx.theme.muted)
 
         # Day-of-week column headers
         grid_left = PAD
@@ -256,7 +255,7 @@ class CalendarApp(App):
         cell_w = grid_w / 7.0
         dow_y = header_h + 8.0
         for i, name in enumerate(DAY_NAMES):
-            ctx.text(grid_left + i * cell_w + 6.0, dow_y, name, size=CAPTION, color=MUTED)
+            ctx.text(grid_left + i * cell_w + 6.0, dow_y, name, size=CAPTION, color=ctx.theme.muted)
 
         # Month grid
         cells_top = dow_y + 20.0
@@ -273,18 +272,18 @@ class CalendarApp(App):
             is_selected = (day_num == self._day)
 
             if is_selected:
-                ctx.rect(cx + 2, cy + 2, cell_w - 4, CELL_H - 4, fill=ACCENT, radius=CELL_RADIUS)
-                text_col = BG
+                ctx.rect(cx + 2, cy + 2, cell_w - 4, CELL_H - 4, fill=ctx.theme.accent, radius=CELL_RADIUS)
+                text_col = ctx.theme.bg
             elif is_today:
-                ctx.rect(cx + 2, cy + 2, cell_w - 4, CELL_H - 4, fill=SURFACE, radius=CELL_RADIUS)
-                text_col = ACCENT
+                ctx.rect(cx + 2, cy + 2, cell_w - 4, CELL_H - 4, fill=ctx.theme.surface, radius=CELL_RADIUS)
+                text_col = ctx.theme.accent
             else:
-                text_col = FG
+                text_col = ctx.theme.fg
 
             ctx.text(cx + 6.0, cy + 8.0, str(day_num), size=BODY, color=text_col)
 
             if self._events_for(d_str):
-                dot_col = BG if is_selected else ACCENT
+                dot_col = ctx.theme.bg if is_selected else ctx.theme.accent
                 ctx.circle(cx + cell_w / 2.0, cy + CELL_H - 10.0, 3.0, fill=dot_col)
 
             col += 1
@@ -308,9 +307,9 @@ class CalendarApp(App):
 
         # Footer bar
         fy = ctx.h - footer_h
-        ctx.rect(0, fy, ctx.w, footer_h, fill=SURFACE)
+        ctx.rect(0, fy, ctx.w, footer_h, fill=ctx.theme.surface)
         if self._status:
-            ctx.text(PAD, fy + 14.0, self._status, size=CAPTION, color=GREEN)
+            ctx.text(PAD, fy + 14.0, self._status, size=CAPTION, color=ctx.theme.success)
         elif self._mode == "view":
             ctx.shortcuts(PAD, fy + 14.0, ctx.w - 2 * PAD, [
                 (["j", "k"], "day"),
@@ -328,17 +327,17 @@ class CalendarApp(App):
         date_str = self._selected_date_str()
         evs = self._events_for(date_str)
         d_label = date(self._year, self._month, self._day).strftime("%A, %B %-d")
-        ctx.text(x, y, d_label, size=CAPTION, color=MUTED)
+        ctx.text(x, y, d_label, size=CAPTION, color=ctx.theme.muted)
         ey = y + 20.0
         if not evs:
-            ctx.text(x, ey, "No events", size=BODY, color=MUTED)
+            ctx.text(x, ey, "No events", size=BODY, color=ctx.theme.muted)
             return
         for ev in evs:
             if ey + 24 > y + h:
                 break
             time_part = f"{ev['time']}  " if ev.get("time") else ""
-            ctx.rect(x, ey, w, 22.0, fill=SURFACE, radius=4.0)
-            ctx.text(x + 8.0, ey + 4.0, f"{time_part}{ev['title']}", size=CAPTION, color=FG)
+            ctx.rect(x, ey, w, 22.0, fill=ctx.theme.surface, radius=4.0)
+            ctx.text(x + 8.0, ey + 4.0, f"{time_part}{ev['title']}", size=CAPTION, color=ctx.theme.fg)
             ey += 26.0
 
     def _draw_input_modal(self, ctx: RenderContext) -> None:
@@ -346,7 +345,7 @@ class CalendarApp(App):
         mh = 120.0
         mx = (ctx.w - mw) / 2.0
         my = (ctx.h - mh) / 2.0
-        ctx.rect(mx, my, mw, mh, fill=SURFACE, radius=8.0)
+        ctx.rect(mx, my, mw, mh, fill=ctx.theme.surface, radius=8.0)
 
         title_text = "Edit Event" if self._editing_id else "Add Event"
         stage_prompt = {
@@ -355,11 +354,11 @@ class CalendarApp(App):
             "time":  "Time (HH:MM, or Enter to skip):",
         }[self._add_stage]
 
-        ctx.text(mx + 16.0, my + 12.0, title_text, size=BODY, color=FG, bold=True)
-        ctx.text(mx + 16.0, my + 36.0, stage_prompt, size=CAPTION, color=MUTED)
-        ctx.rect(mx + 16.0, my + 56.0, mw - 32.0, 30.0, fill=HIGHLIGHT, radius=4.0)
-        ctx.text(mx + 22.0, my + 64.0, self._input + "▌", size=BODY, color=FG)
-        ctx.text(mx + 16.0, my + 98.0, "↵ confirm  esc cancel", size=HINT, color=MUTED)
+        ctx.text(mx + 16.0, my + 12.0, title_text, size=BODY, color=ctx.theme.fg, bold=True)
+        ctx.text(mx + 16.0, my + 36.0, stage_prompt, size=CAPTION, color=ctx.theme.muted)
+        ctx.rect(mx + 16.0, my + 56.0, mw - 32.0, 30.0, fill=ctx.theme.highlight, radius=4.0)
+        ctx.text(mx + 22.0, my + 64.0, self._input + "▌", size=BODY, color=ctx.theme.fg)
+        ctx.text(mx + 16.0, my + 98.0, "↵ confirm  esc cancel", size=HINT, color=ctx.theme.muted)
 
     def _draw_delete_modal(self, ctx: RenderContext) -> None:
         evs = self._events_for(self._selected_date_str())
@@ -370,10 +369,10 @@ class CalendarApp(App):
         mh = 90.0
         mx = (ctx.w - mw) / 2.0
         my = (ctx.h - mh) / 2.0
-        ctx.rect(mx, my, mw, mh, fill=SURFACE, radius=8.0)
-        ctx.text(mx + 16.0, my + 12.0, "Delete event?", size=BODY, color=FG, bold=True)
-        ctx.text(mx + 16.0, my + 34.0, evs[0]["title"], size=CAPTION, color=MUTED)
-        ctx.text(mx + 16.0, my + 62.0, "y  confirm    n / esc  cancel", size=HINT, color=MUTED)
+        ctx.rect(mx, my, mw, mh, fill=ctx.theme.surface, radius=8.0)
+        ctx.text(mx + 16.0, my + 12.0, "Delete event?", size=BODY, color=ctx.theme.fg, bold=True)
+        ctx.text(mx + 16.0, my + 34.0, evs[0]["title"], size=CAPTION, color=ctx.theme.muted)
+        ctx.text(mx + 16.0, my + 62.0, "y  confirm    n / esc  cancel", size=HINT, color=ctx.theme.muted)
 
 
 if __name__ == "__main__":

--- a/apps/quick-note/quick_note.py
+++ b/apps/quick-note/quick_note.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 from plexi_sdk import (
     App, RenderContext,
-    FG, MUTED, SURFACE, GREEN, BODY, CAPTION, HINT,
+    BODY, CAPTION, HINT,
     PRIORITY_LOW,
 )
 from plexi_sdk.ui import Component
@@ -143,7 +143,7 @@ class QuickNoteApp(App):
         if self._mode == "compose":
             cy = y
             for i, line in enumerate(self._lines):
-                color = FG if i == 0 else (MUTED if i > 0 else FG)
+                color = ctx.theme.fg if i == 0 else (ctx.theme.muted if i > 0 else ctx.theme.fg)
                 size = 18.0 if i == 0 else BODY
                 cursor = "▌" if i == self._cursor_line else ""
                 ctx.text(x, cy, line + cursor, size=size, color=color)
@@ -157,14 +157,14 @@ class QuickNoteApp(App):
                 ctx.simple_list(items, selected=self._selected, item_height=40.0,
                          x=x, y=y, w=w, h=h)
             else:
-                ctx.text(x, y + 16, "No notes yet.", size=BODY, color=MUTED)
+                ctx.text(x, y + 16, "No notes yet.", size=BODY, color=ctx.theme.muted)
             # Preview panel (right side if wide enough)
             if w > 520 and self._preview:
                 px = x + w * 0.5
-                ctx.rect(px, y, w - (px - x), h, fill=SURFACE)
+                ctx.rect(px, y, w - (px - x), h, fill=ctx.theme.surface)
                 py = y + 12
                 for ln in self._preview.split("\n")[: int((h - 16) / 18)]:
-                    ctx.text(px + 12, py, ln, size=CAPTION, color=FG)
+                    ctx.text(px + 12, py, ln, size=CAPTION, color=ctx.theme.fg)
                     py += 18
 
     def _shortcut_footer(self):
@@ -190,7 +190,7 @@ class QuickNoteApp(App):
             Spacer(size=HINT),
         ]
         if self._status:
-            children.append(Footer(self._status, color=GREEN))
+            children.append(Footer(self._status, color=ctx.theme.success))
         children.append(self._shortcut_footer())
         ctx.render(Column(children))
 

--- a/apps/quick-note/quick_note.py
+++ b/apps/quick-note/quick_note.py
@@ -143,7 +143,7 @@ class QuickNoteApp(App):
         if self._mode == "compose":
             cy = y
             for i, line in enumerate(self._lines):
-                color = ctx.theme.fg if i == 0 else (ctx.theme.muted if i > 0 else ctx.theme.fg)
+                color = ctx.theme.fg if i == 0 else ctx.theme.muted
                 size = 18.0 if i == 0 else BODY
                 cursor = "▌" if i == self._cursor_line else ""
                 ctx.text(x, cy, line + cursor, size=size, color=color)

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -8,8 +8,7 @@ new cargo crate + cross-compile setup. This is the intentional choice.
 
 import threading
 import time
-from plexi_sdk import App, RenderContext, BG, ACCENT, FG, RED, GREEN, MUTED, Arg
-from plexi_sdk._pipe import Pipe
+from plexi_sdk import App, RenderContext, Arg, Pipe
 
 CELL = 18.0          # cell size in logical px
 TICK = 0.15          # seconds per game tick
@@ -97,22 +96,22 @@ class SnakeApp(App):
         ox = (ctx.w - COLS * CELL) / 2
         oy = (ctx.h - ROWS * CELL) / 2
         # Background
-        ctx.rect(0, 0, ctx.w, ctx.h, fill=BG)
+        ctx.rect(0, 0, ctx.w, ctx.h, fill=ctx.theme.bg)
         # Grid border
         ctx.rect(ox - 2, oy - 2, COLS * CELL + 4, ROWS * CELL + 4,
-                 fill=MUTED, radius=2.0)
+                 fill=ctx.theme.muted, radius=2.0)
         ctx.rect(ox, oy, COLS * CELL, ROWS * CELL, fill="#11111b")
         # Food
         fx, fy = self._food
         ctx.rect(ox + fx * CELL + 2, oy + fy * CELL + 2,
-                 CELL - 4, CELL - 4, fill=RED, radius=4.0)
+                 CELL - 4, CELL - 4, fill=ctx.theme.danger, radius=4.0)
         # Snake
         for i, (sx, sy) in enumerate(self._snake):
-            color = ACCENT if i == 0 else GREEN
+            color = ctx.theme.accent if i == 0 else ctx.theme.success
             ctx.rect(ox + sx * CELL + 1, oy + sy * CELL + 1,
                      CELL - 2, CELL - 2, fill=color, radius=2.0)
         # Score
-        ctx.text(ox, oy - 28, f"Score: {self._score}", size=14.0, color=FG)
+        ctx.text(ox, oy - 28, f"Score: {self._score}", size=14.0, color=ctx.theme.fg)
         # Game over
         if self._dead:
             msg = "GAME OVER — press R to restart"
@@ -120,7 +119,7 @@ class SnakeApp(App):
                      300, 36, fill="#1e1e2e", radius=6.0)
             ctx.text(ox + COLS * CELL / 2 - 140,
                      oy + ROWS * CELL / 2 - 8,
-                     msg, size=13.0, color=RED)
+                     msg, size=13.0, color=ctx.theme.danger)
 
     def on_shutdown(self) -> None:
         self._running = False

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../sdk/python'))
 
-from plexi_sdk import App, RenderContext, FG, MUTED, ACCENT, HINT, CAPTION, BODY, dim
+from plexi_sdk import App, RenderContext, HINT, CAPTION, BODY, dim
 
 PALETTE = [
     "#f38ba8", "#a6e3a1", "#89b4fa", "#f9e2af",
@@ -290,11 +290,11 @@ class StatsApp(App):
         w, h = ctx.w, ctx.h
 
         if not self.root or not self.view_root:
-            ctx.text(w / 2 - 80, h / 2, "No events found", size=BODY, color=MUTED)
+            ctx.text(w / 2 - 80, h / 2, "No events found", size=BODY, color=ctx.theme.muted)
             if self.events_path:
-                ctx.text(w / 2 - 120, h / 2 + 24, f"Path: {self.events_path}", size=HINT, color=MUTED)
+                ctx.text(w / 2 - 120, h / 2 + 24, f"Path: {self.events_path}", size=HINT, color=ctx.theme.muted)
             else:
-                ctx.text(w / 2 - 120, h / 2 + 24, "No events.jsonl found", size=HINT, color=MUTED)
+                ctx.text(w / 2 - 120, h / 2 + 24, "No events.jsonl found", size=HINT, color=ctx.theme.muted)
             return
 
         vr = self.view_root
@@ -302,8 +302,8 @@ class StatsApp(App):
 
         # breadcrumb bar
         ctx.rect(0, 0, w, BREADCRUMB_H, fill="#181825")
-        ctx.text(8, 5, f"{breadcrumb_path} › 24h overview", size=HINT, color=MUTED, bold=True)
-        ctx.text(w - 200, 5, "r refresh · click drill · esc back", size=HINT, color=dim(MUTED, 120))
+        ctx.text(8, 5, f"{breadcrumb_path} › 24h overview", size=HINT, color=ctx.theme.muted, bold=True)
+        ctx.text(w - 200, 5, "r refresh · click drill · esc back", size=HINT, color=dim(ctx.theme.muted, 120))
 
         # treemap region
         treemap_y = BREADCRUMB_H
@@ -324,23 +324,23 @@ class StatsApp(App):
             if cw >= MIN_CELL_W and ch >= MIN_CELL_H:
                 parent_label = _shorten(os.path.dirname(node.path))
                 if parent_label and parent_label != _shorten(vr.path):
-                    ctx.text(cx + 6, cy + ch - 14 - BODY - HINT - 2, parent_label, size=HINT, color=dim(FG, 100))
+                    ctx.text(cx + 6, cy + ch - 14 - BODY - HINT - 2, parent_label, size=HINT, color=dim(ctx.theme.fg, 100))
 
-                ctx.text(cx + 6, cy + ch - 14 - BODY, node.label, size=BODY, color=FG, bold=True)
-                ctx.text(cx + 6, cy + ch - 14, _fmt_duration(node.total_duration), size=CAPTION, color=dim(FG, 180))
+                ctx.text(cx + 6, cy + ch - 14 - BODY, node.label, size=BODY, color=ctx.theme.fg, bold=True)
+                ctx.text(cx + 6, cy + ch - 14, _fmt_duration(node.total_duration), size=CAPTION, color=dim(ctx.theme.fg, 180))
 
                 if node.visits > 0:
-                    ctx.text(cx + cw - 40, cy + 6, f"{node.visits}x", size=HINT, color=dim(FG, 100))
+                    ctx.text(cx + cw - 40, cy + 6, f"{node.visits}x", size=HINT, color=dim(ctx.theme.fg, 100))
 
         # stats bar
         stats_y = treemap_y + treemap_h
         ctx.rect(0, stats_y, w, STATS_BAR_H, fill="#181825")
-        ctx.line(0, stats_y, w, stats_y, color=dim(MUTED, 60), width=1.0)
-        ctx.line(0, stats_y + STATS_BAR_H, w, stats_y + STATS_BAR_H, color=dim(MUTED, 60), width=1.0)
+        ctx.line(0, stats_y, w, stats_y, color=dim(ctx.theme.muted, 60), width=1.0)
+        ctx.line(0, stats_y + STATS_BAR_H, w, stats_y + STATS_BAR_H, color=dim(ctx.theme.muted, 60), width=1.0)
 
         stats_text_y = stats_y + (STATS_BAR_H - CAPTION) / 2
         third = w / 3
-        ctx.text(third * 0.5, stats_text_y, f"{_fmt_duration(self.total_time)} active", size=CAPTION, color=ACCENT, bold=True, align="center")
+        ctx.text(third * 0.5, stats_text_y, f"{_fmt_duration(self.total_time)} active", size=CAPTION, color=ctx.theme.accent, bold=True, align="center")
         ctx.text(third * 1.5, stats_text_y, f"{self.total_visits} visits", size=CAPTION, color="#a6e3a1", bold=True, align="center")
         ctx.text(third * 2.5, stats_text_y, f"{self.total_projects} projects", size=CAPTION, color="#f9e2af", bold=True, align="center")
 
@@ -374,7 +374,7 @@ class StatsApp(App):
             labels.append((frac, lbl))
         for frac, lbl in labels:
             mx = frac * w
-            ctx.text(mx, marker_y, lbl, size=HINT, color=dim(MUTED, 120), align="center")
+            ctx.text(mx, marker_y, lbl, size=HINT, color=dim(ctx.theme.muted, 120), align="center")
 
         self.highlight_path = None
 

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -4,7 +4,7 @@
 import time
 from enum import Enum
 
-from plexi_sdk import App, RenderContext
+from plexi_sdk import App, RenderContext, dim
 from plexi_sdk.ui import (
     Column, AppBar, Card, Label, Spacer, FooterKeys, Component,
     SPACE_SM, SPACE_XS,
@@ -112,7 +112,7 @@ class _LevelGrid(Component):
             elif unlocked:
                 bg, border, bw = ctx.theme.surface, ctx.theme.highlight, 1.0
             else:
-                bg, border, bw = ctx.theme.bg, ctx.theme.muted + "55", 1.0
+                bg, border, bw = ctx.theme.bg, dim(ctx.theme.muted, 85), 1.0
 
             ctx.rect(cx, cy, card_w, card_h, fill=bg, radius=RADIUS_MD)
             ctx.rect(cx, cy, card_w, bw, fill=border)
@@ -166,7 +166,7 @@ class _CharGrid(Component):
 
             if i < app._typed:
                 if i in app._errors:
-                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ctx.theme.danger + "44", radius=2.0)
+                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=dim(ctx.theme.danger, 68), radius=2.0)
                     ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.danger, monospace=True)
                 else:
                     ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.success, monospace=True)

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -10,7 +10,6 @@ from plexi_sdk.ui import (
     SPACE_SM, SPACE_XS,
     TEXT_HINT, TEXT_CAPTION, TEXT_BODY,
     RADIUS_MD,
-    BG, SURFACE, HIGHLIGHT, ACCENT, MUTED, FG, RED, GREEN,
 )
 
 from levels import LEVELS
@@ -109,11 +108,11 @@ class _LevelGrid(Component):
             stars = app._level_stars[i]
 
             if selected:
-                bg, border, bw = SURFACE, ACCENT, 2.0
+                bg, border, bw = ctx.theme.surface, ctx.theme.accent, 2.0
             elif unlocked:
-                bg, border, bw = SURFACE, HIGHLIGHT, 1.0
+                bg, border, bw = ctx.theme.surface, ctx.theme.highlight, 1.0
             else:
-                bg, border, bw = BG, MUTED + "55", 1.0
+                bg, border, bw = ctx.theme.bg, ctx.theme.muted + "55", 1.0
 
             ctx.rect(cx, cy, card_w, card_h, fill=bg, radius=RADIUS_MD)
             ctx.rect(cx, cy, card_w, bw, fill=border)
@@ -121,19 +120,19 @@ class _LevelGrid(Component):
             ctx.rect(cx, cy, bw, card_h, fill=border)
             ctx.rect(cx + card_w - bw, cy, bw, card_h, fill=border)
 
-            text_color = FG if unlocked else MUTED
-            num_color = ACCENT if selected else (ACCENT if unlocked else MUTED)
+            text_color = ctx.theme.fg if unlocked else ctx.theme.muted
+            num_color = ctx.theme.accent if selected else (ctx.theme.accent if unlocked else ctx.theme.muted)
             ctx.text(cx + 10, cy + 10, f"{i + 1}", size=TEXT_BODY,
                      color=num_color, bold=True)
             ctx.text(cx + 10, cy + 28, level.name, size=TEXT_HINT, color=text_color)
             ctx.text(cx + 10, cy + card_h - 20,
                      "★" * stars + "☆" * (5 - stars),
-                     size=TEXT_HINT, color=ACCENT if stars > 0 else MUTED)
+                     size=TEXT_HINT, color=ctx.theme.accent if stars > 0 else ctx.theme.muted)
 
             if not unlocked:
                 ctx.rect(cx, cy, card_w, card_h, fill="#00000066", radius=RADIUS_MD)
                 ctx.text(cx + card_w / 2, cy + card_h / 2,
-                         f"🔒 Need {level.stars_needed}★", size=TEXT_HINT, color=MUTED,
+                         f"🔒 Need {level.stars_needed}★", size=TEXT_HINT, color=ctx.theme.muted,
                          align="center")
 
 
@@ -167,15 +166,15 @@ class _CharGrid(Component):
 
             if i < app._typed:
                 if i in app._errors:
-                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=RED + "44", radius=2.0)
-                    ctx.text(cx, cy, ch, size=char_size, color=RED, monospace=True)
+                    ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ctx.theme.danger + "44", radius=2.0)
+                    ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.danger, monospace=True)
                 else:
-                    ctx.text(cx, cy, ch, size=char_size, color=GREEN, monospace=True)
+                    ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.success, monospace=True)
             elif i == app._typed:
-                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ACCENT, radius=2.0)
-                ctx.text(cx, cy, ch, size=char_size, color=BG, monospace=True)
+                ctx.rect(cx - 1, cy - 1, cell_w, cell_h, fill=ctx.theme.accent, radius=2.0)
+                ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.bg, monospace=True)
             else:
-                ctx.text(cx, cy, ch, size=char_size, color=MUTED, monospace=True)
+                ctx.text(cx, cy, ch, size=char_size, color=ctx.theme.muted, monospace=True)
 
 
 class _TimerBar(Component):
@@ -195,15 +194,15 @@ class _TimerBar(Component):
         elapsed = time.time() - app._start_time
         time_remaining = max(0.0, level.time_sec - elapsed)
 
-        timer_color = RED if time_remaining < 10 else FG
+        timer_color = ctx.theme.danger if time_remaining < 10 else ctx.theme.fg
         ctx.text(x + SPACE_SM, y + SPACE_XS,
                  f"Time: {time_remaining:.0f}s", size=TEXT_CAPTION, color=timer_color)
 
         bar_y = y + TEXT_CAPTION + SPACE_XS * 2
         bar_w = w - SPACE_SM * 2
-        ctx.rect(x + SPACE_SM, bar_y, bar_w, 8.0, fill=SURFACE, radius=4.0)
+        ctx.rect(x + SPACE_SM, bar_y, bar_w, 8.0, fill=ctx.theme.surface, radius=4.0)
         progress = app._typed / max(len(level.text), 1)
-        ctx.rect(x + SPACE_SM, bar_y, bar_w * progress, 8.0, fill=GREEN, radius=4.0)
+        ctx.rect(x + SPACE_SM, bar_y, bar_w * progress, 8.0, fill=ctx.theme.success, radius=4.0)
         ctx.schedule_render(100)
 
 
@@ -400,20 +399,20 @@ class TypingTutorApp(App):
         timed_out = elapsed >= level.time_sec
         if stars == 0:
             msg = "Time's up!" if timed_out else "Keep practicing — error rate too high"
-            msg_color = RED
+            msg_color = ctx.theme.danger
         elif stars == 5:
             msg = "Perfect run!"
-            msg_color = GREEN
+            msg_color = ctx.theme.success
         else:
             msg = "Nice work!"
-            msg_color = ACCENT
+            msg_color = ctx.theme.accent
 
         ctx.render(Column([
             AppBar(title=f"Level {level.id} — {level.name}"),
             Spacer(grow=True),
             Card([
                 Label("★" * stars + "☆" * (5 - stars),
-                      color=ACCENT if stars > 0 else MUTED, bold=True),
+                      color=ctx.theme.accent if stars > 0 else ctx.theme.muted, bold=True),
                 Label(f"Accuracy:  {accuracy:.1f}%"),
                 Label(f"Time:      {elapsed:.1f}s / {level.time_sec}s"),
                 Label(msg, color=msg_color),

--- a/apps/typing-tutor/main.py
+++ b/apps/typing-tutor/main.py
@@ -121,7 +121,7 @@ class _LevelGrid(Component):
             ctx.rect(cx + card_w - bw, cy, bw, card_h, fill=border)
 
             text_color = ctx.theme.fg if unlocked else ctx.theme.muted
-            num_color = ctx.theme.accent if selected else (ctx.theme.accent if unlocked else ctx.theme.muted)
+            num_color = ctx.theme.accent if selected or unlocked else ctx.theme.muted
             ctx.text(cx + 10, cy + 10, f"{i + 1}", size=TEXT_BODY,
                      color=num_color, bold=True)
             ctx.text(cx + 10, cy + 28, level.name, size=TEXT_HINT, color=text_color)

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -7,7 +7,7 @@ import urllib.parse
 
 from plexi_sdk import (
     App, RenderContext, CapabilityDeniedError,
-    FG, MUTED, ACCENT, SURFACE, BODY, CAPTION, RED,
+    BODY, CAPTION,
 )
 from plexi_sdk.ui import (
     Column, AppBar, Spacer, Footer, FooterKeys, Component,
@@ -131,24 +131,24 @@ class WikiApp(App):
         def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
             app = self._app
             if app._mode == "search":
-                ctx.text(x, y, "Search:", size=BODY, color=FG)
-                ctx.rect(x, y + 24, w, 32, fill=SURFACE, radius=4.0)
+                ctx.text(x, y, "Search:", size=BODY, color=ctx.theme.fg)
+                ctx.rect(x, y + 24, w, 32, fill=ctx.theme.surface, radius=4.0)
                 ctx.text(x + 8, y + 32, app._query + "▌",
-                         size=BODY, color=FG, monospace=True)
+                         size=BODY, color=ctx.theme.fg, monospace=True)
                 if app._error_msg:
                     ctx.text(x, y + 72, f"Error: {app._error_msg}",
-                             size=12, color=RED, max_width=w)
+                             size=12, color=ctx.theme.danger, max_width=w)
                 else:
                     ctx.text(x, y + 72, "Type a query and press Enter",
-                             size=12, color=MUTED)
+                             size=12, color=ctx.theme.muted)
             elif app._mode == "results":
-                ctx.text(x, y, f'Results for "{app._query}":', size=BODY, color=FG)
+                ctx.text(x, y, f'Results for "{app._query}":', size=BODY, color=ctx.theme.fg)
                 items = [{"label": r, "secondary": None} for r in app._results]
                 ctx.simple_list(items, selected=app._selected, item_height=40.0,
                          x=x, y=y + 28, w=w, h=max(0.0, h - 28))
             elif app._mode == "article":
                 title = app._results[app._selected] if app._results else ""
-                ctx.text(x, y, title, size=18.0, color=ACCENT, bold=True)
+                ctx.text(x, y, title, size=18.0, color=ctx.theme.accent, bold=True)
                 # Word-wrap extract into lines (rough 8px/char estimate).
                 words = app._extract.split()
                 line, lines = "", []
@@ -163,7 +163,7 @@ class WikiApp(App):
                     lines.append(line)
                 ty = y + 30
                 for ln in lines[: int(max(0.0, (h - 30)) / 20)]:
-                    ctx.text(x, ty, ln, size=CAPTION, color=FG)
+                    ctx.text(x, ty, ln, size=CAPTION, color=ctx.theme.fg)
                     ty += 20
 
     def _footer_component(self):


### PR DESCRIPTION
Closes #1879

## Summary

- Replaces module-level color constants (`BG`, `FG`, `ACCENT`, `MUTED`, `SURFACE`, `HIGHLIGHT`, `RED`, `GREEN`) removed from `plexi_sdk` and `plexi_sdk.ui` with `ctx.theme.*` equivalents in all 6 affected apps: calendar, quick-note, stats, snake, wikipedia, typing-tutor
- Fixes snake's internal pipe import: `from plexi_sdk._pipe import Pipe` → `from plexi_sdk import Pipe`
- Follows the same pattern as PR #1863 which fixed the first 4 apps

## Done When

All six apps launch without ImportError: `plexi open calendar`, `plexi open quick-note`, `plexi open stats`, `plexi open snake`, `plexi open wikipedia`, `plexi open typing-tutor` on the alpha build.

## Notes

typing-tutor imports colors from `plexi_sdk.ui` (not `plexi_sdk`) — same removal, handled accordingly. All replacements are mechanical; no logic changes.