### PR TITLE
fix(sdk/template): app_init scaffold key casing bug + ctx.theme pattern (#1881)

### DIFF
--- a/sdk/python/plexi_sdk/templates/app_init.py
+++ b/sdk/python/plexi_sdk/templates/app_init.py
@@ -45,7 +45,7 @@ class __CLASS_NAME__(App):
             Section("ACTIONS"),
             Card([
                 self._btn,
-                Label(f"Clicks: {self.click_count}", tone="caption"),
+                Label(f"Clicks: {self.click_count}", color=ctx.theme.accent),
                 Label(f"state stored in app_states/{self.app_id}.json — survives hot reload", tone="muted"),
             ]),
             Section("KEYBOARD SHORTCUTS"),
@@ -61,12 +61,16 @@ class __CLASS_NAME__(App):
         ]))
 
     def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
-        if key == "Escape":
+        if key == "escape":
             self.emit.close_self()
         elif key == "i":
             self.click_count += 1
             ctx.save_state({"clicks": self.click_count})
             ctx.status_summary(f"Clicked {self.click_count} time(s)")
+
+    # For async I/O (http, AI, secrets) make the handler async:
+    # async def on_key(self, ctx: RenderContext, key: str, _mods: dict) -> None:
+    #     result = await self.emit.http_get(url)  # non-blocking I/O
 
 
 __CLASS_NAME__().run()


### PR DESCRIPTION
Closes #1881

## Summary

- Fix `key == "Escape"` → `key == "escape"` in the scaffold template — the SDK normalizes all keys to lowercase via `_KEY_ALIASES` so the Escape handler was silently dead in every generated app
- Add `color=ctx.theme.accent` on the clicks counter label so the generated file contains a visible `ctx.theme.*` usage example for agents reading it
- Add inline comment showing the `async def on_key` pattern for I/O-bound handlers

## Done When

`plexi app init test-app && plexi open test-app` — pressing Escape closes the app. The generated file contains at least one `ctx.theme.*` usage visible to a reading agent.

## Notes

The key normalization was added in PR #1060 via `_KEY_ALIASES` in `_app.py`. The scaffold was never updated. All apps generated between #1060 and this fix ship with a broken Escape key.