### PR TITLE
fix(apps/tetris): hard drop (Space/Enter) never fires (#1882)

### DIFF
--- a/apps/tetris/tetris.py
+++ b/apps/tetris/tetris.py
@@ -403,7 +403,7 @@ class TetrisApp(App):
         elif key in ("up", "k", "x"):
             self._try_rotate()
 
-        elif key in (" ", "Enter"):
+        elif key in ("space", "return"):
             self._hard_drop()
 
         elif key == "r":


### PR DESCRIPTION
Closes #1882

## Summary

- `on_key` in `tetris.py` was matching against raw egui key strings (`" "`, `"Enter"`) but the Python SDK normalizes these to `"space"` and `"return"` via `_KEY_ALIASES` before calling the handler
- Space and Enter silently did nothing; all other keys worked correctly
- Fix: change the hard drop guard to use the SDK-canonical names (`"space"`, `"return"`)

## Done When

Pressing Space or Enter while a piece is falling hard-drops it to the lowest valid row and locks it immediately.

## Notes

Same pattern as the Wikipedia bug (#1567, DEV_LOG entry 2026-05-21): SDK's `_KEY_ALIASES` normalization in `_app.py:79-84` is the authoritative source for key name strings — any `on_key` handler must use those names, not raw egui debug strings.