### PR TITLE
feat(host/context): context new wraps focused pane into new child context (#1858)

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1294,3 +1294,57 @@ fn context_transition_rescans_registry() {
     let _ = std::fs::remove_dir_all(&dir_a);
     let _ = std::fs::remove_dir_all(&dir_b);
 }
+
+/// Issue #1858: `new_context` should wrap the focused pane into a new child context
+/// rather than create an empty sibling context.
+#[test]
+fn new_context_wraps_focused_pane_into_child() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let parent_ctx_id = app.router.active().context_id;
+
+    // Add a non-portal pane and make it focused.
+    let (tile_id, pane_id) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_id);
+
+    assert_eq!(app.router.len(), 1, "setup: 1 context before new_context");
+    assert_eq!(app.windows[0].panes.len(), 1, "setup: 1 pane before new_context");
+
+    app.new_context();
+
+    // Router should now have 2 contexts.
+    assert_eq!(app.router.len(), 2, "child context registered");
+
+    // Active context is the child.
+    let child_ctx_id = app.router.active().context_id;
+    assert_ne!(child_ctx_id, parent_ctx_id, "active context switched to child");
+
+    // Depth stack has one entry (parent was pushed before zoom).
+    assert_eq!(app.router.current_depth(), 1, "depth stack grew by 1");
+
+    // The child context has 1 window with the original pane id.
+    let child_win_idx = app.windows.iter().position(|w| w.context_id == child_ctx_id)
+        .expect("child context has a window");
+    assert_eq!(app.windows[child_win_idx].panes.len(), 1, "child window has 1 pane");
+    assert!(
+        app.windows[child_win_idx].panes.contains_key(&pane_id),
+        "child window contains the extracted pane"
+    );
+
+    // Parent window has exactly 1 pane — the Portal tile pointing to the child.
+    let parent_win_idx = app.windows.iter().position(|w| w.context_id == parent_ctx_id)
+        .expect("parent context has a window");
+    assert_eq!(app.windows[parent_win_idx].panes.len(), 1, "parent window has 1 pane (the portal)");
+    let has_portal = app.windows[parent_win_idx].panes.values()
+        .any(|p| p.portal_target() == Some(child_ctx_id));
+    assert!(has_portal, "parent window has a Portal pointing to the child context");
+
+    // Inline rename was opened for the new context.
+    assert_eq!(
+        app.renaming_window,
+        Some(app.router.len() - 1),
+        "inline rename opened for child context"
+    );
+}

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -2,35 +2,36 @@ use super::{send_to_socket};
 use super::validate::resolve_path;
 
 pub fn context_new_cli(name: Option<&str>, path: Option<&str>, parent: Option<&str>) -> i32 {
-    let root = match resolve_path(path) {
-        Ok(p) => p,
-        Err(e) => { eprintln!("{e}"); return 1; }
+    // Only resolve root when the user explicitly passed a path argument.
+    // Without an explicit path, we let the host use the focused pane's cwd.
+    let explicit_root = match path {
+        Some(_) => match resolve_path(path) {
+            Ok(p) => Some(p),
+            Err(e) => { eprintln!("{e}"); return 1; }
+        },
+        None => None,
     };
-    // Default parent: current context when inside a Plexi pane and --parent omitted.
-    let resolved_parent = parent
+    // Only pass parent_name when the user explicitly provided --parent.
+    // Auto-resolving from PLEXI_CONTEXT_NAME would route to new_child_context
+    // (which always creates a fresh terminal), bypassing the wrap behavior.
+    let explicit_parent = parent
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .or_else(|| {
-            std::env::var("PLEXI_CONTEXT_NAME")
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-        });
+        .map(|s| s.to_string());
     log::info!(
-        "context_new_cli: name={:?} root={} parent={:?}",
+        "context_new_cli: name={:?} root={:?} parent={:?}",
         name,
-        root.display(),
-        resolved_parent.as_deref()
+        explicit_root.as_ref().map(|p: &std::path::PathBuf| p.display().to_string()),
+        explicit_parent.as_deref()
     );
-    let mut payload = serde_json::json!({
-        "type": "create_context",
-        "root": root,
-    });
+    let mut payload = serde_json::json!({ "type": "create_context" });
+    if let Some(r) = explicit_root {
+        payload["root"] = serde_json::Value::String(r.to_string_lossy().into_owned());
+    }
     if let Some(n) = name {
         payload["name"] = serde_json::Value::String(n.to_string());
     }
-    if let Some(p) = resolved_parent {
+    if let Some(p) = explicit_parent {
         payload["parent_name"] = serde_json::Value::String(p);
     }
     send_to_socket(payload)

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -116,11 +116,136 @@ impl PlexiApp {
     }
 
     pub(crate) fn new_context(&mut self) {
+        let active_win_idx = self.active_window;
+        let focused_tile = self.windows[active_win_idx].focused_pane;
+
+        // Wrap the focused pane into a new child context, unless it is a Portal
+        // or the tile has been restructured by egui_tiles into a Container with
+        // no resolvable leaf pane — fall back to creating an empty context.
+        let wrap_info = focused_tile.and_then(|tile_id| {
+            let win = &self.windows[active_win_idx];
+            let pane_id = Self::find_pane_in_tile(&win.tree, tile_id)?;
+            if win.panes.get(&pane_id)?.portal_target().is_some() {
+                return None;
+            }
+            let leaf_tile_id = win.tree.tiles.find_pane(&pane_id)?;
+            Some((pane_id, leaf_tile_id))
+        });
+
+        if let Some((pane_id, leaf_tile_id)) = wrap_info {
+            self.new_context_wrap_pane(pane_id, leaf_tile_id);
+        } else {
+            log::info!("new_context: no non-portal focused pane — creating empty context at home");
+            self.new_context_empty();
+        }
+    }
+
+    /// Extract the focused pane into a new child context, placing a Portal tile
+    /// in its position in the parent window, then auto-zoom into the child.
+    fn new_context_wrap_pane(
+        &mut self,
+        focused_pane_id: crate::tiling::PaneId,
+        leaf_tile_id: egui_tiles::TileId,
+    ) {
+        let active_win_idx = self.active_window;
+        let parent_ctx_id = self.router.active().context_id;
+        let parent_depth = self.router.active().depth;
+        let parent_win_id = self.windows[active_win_idx].window_id;
+        let parent_focused = self.windows[active_win_idx].focused_pane;
+
+        let cwd = self.windows[active_win_idx]
+            .get_focused_pane_cwd(leaf_tile_id)
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+
+        log::info!(
+            "new_context: wrapping pane={focused_pane_id} into child of ctx={parent_ctx_id} cwd={}",
+            cwd.display()
+        );
+
+        let child_ctx_id = self.next_window_id;
+        self.next_window_id += 1;
+        let child_win_id = self.next_window_id;
+        self.next_window_id += 1;
+
+        let extracted_pane = match self.windows[active_win_idx].panes.remove(&focused_pane_id) {
+            Some(p) => p,
+            None => {
+                log::error!("new_context: pane {focused_pane_id} not found in active window");
+                return;
+            }
+        };
+
+        // Replace the leaf tile in-place with a Portal tile. This keeps the
+        // tile's position in the tree intact and avoids any structural mutation.
+        let portal_pane_id = self.host.alloc_pane_id();
+        if let Some(egui_tiles::Tile::Pane(slot)) =
+            self.windows[active_win_idx].tree.tiles.get_mut(leaf_tile_id)
+        {
+            *slot = portal_pane_id;
+        } else {
+            log::warn!("new_context: leaf_tile_id is not a Pane tile — aborting wrap");
+            self.windows[active_win_idx].panes.insert(focused_pane_id, extracted_pane);
+            return;
+        }
+        self.windows[active_win_idx].panes.insert(
+            portal_pane_id,
+            crate::pane::Pane::Portal(Box::new(crate::pane::PortalPane {
+                pane_id: portal_pane_id,
+                target_context_id: child_ctx_id,
+                context_state: None,
+            })),
+        );
+
+        // Build the child window's tree with the extracted pane as the sole root.
+        let mut child_panes = std::collections::HashMap::new();
+        child_panes.insert(focused_pane_id, extracted_pane);
+        let mut child_tiles = egui_tiles::Tiles::default();
+        let child_root_tile = child_tiles.insert_pane(focused_pane_id);
+        let child_tree = egui_tiles::Tree::new("plexi", child_root_tile, child_tiles);
+
+        let ctx_name = format!("Context {}", self.router.len() + 1);
+        self.router.push(crate::context::Context {
+            name: ctx_name.clone(),
+            path: cwd.clone(),
+            root: None,
+            description: None,
+            context_id: child_ctx_id,
+            parent_id: Some(parent_ctx_id),
+            depth: parent_depth + 1,
+        });
+        self.windows.push(Window {
+            name: String::new(),
+            path: cwd,
+            tree: child_tree,
+            panes: child_panes,
+            focused_pane: Some(child_root_tile),
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: child_win_id,
+            context_id: child_ctx_id,
+        });
+        self.context_active_window.insert(child_ctx_id, child_win_id);
+
+        let new_ctx_idx = self.router.len() - 1;
+        self.router.push_depth(parent_ctx_id, parent_win_id, parent_focused);
+        self.switch_workspace(new_ctx_idx);
+
+        self.renaming_window = Some(new_ctx_idx);
+        self.rename_buffer = ctx_name;
+
+        self.save_workspace();
+    }
+
+    /// Fallback path for `new_context` when no non-portal pane is focused:
+    /// create a standalone empty context at the home directory.
+    fn new_context_empty(&mut self) {
         let cwd = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        log::info!("new_context: cwd={}", cwd.display());
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd.clone()), None, false)
+        log::info!("new_context_empty: cwd={}", cwd.display());
+        let Some((tree, panes, root_tile)) =
+            self.create_single_pane_tree(Some(cwd.clone()), None, false)
         else {
-            log::error!("Failed to create terminal for new context");
+            log::error!("new_context_empty: failed to create terminal");
             return;
         };
 
@@ -157,7 +282,6 @@ impl PlexiApp {
         self.minimap.visible = false;
         self.apply_context_transition_effects();
 
-        // Auto-open inline rename so the user can name the context immediately.
         let new_ctx_idx = self.router.len() - 1;
         self.renaming_window = Some(new_ctx_idx);
         self.rename_buffer = self.router.get(new_ctx_idx).name.clone();


### PR DESCRIPTION
Closes #1858

## Summary

- Rewrites `new_context` so `plexi context new` extracts the focused terminal or app pane into a new child context rather than spawning a fresh empty sibling context alongside it
- The extracted pane's tile in the parent window is replaced in-place with a Portal tile; the child context auto-zooms and opens the inline rename
- Falls back to the original empty-context-at-home behavior when a Portal tile is focused or no pane is focused

## Done When

- Running `plexi context new` while in a terminal pane:
  - The current pane disappears from the parent context and reappears inside the new child context
  - The new child context is auto-zoomed into
  - The inline rename appears
  - Zooming out shows a Portal in the parent context pointing to the new child
- Running `plexi context new` with a Portal tile focused: creates an empty new context at home (current fallback behavior)
- `cargo test --bin plexi` green with a HostHarness test covering the wrap-and-zoom path

## Notes

- In-place tile replacement (mutating `Tile::Pane(pane_id)` at the existing `TileId`) is used instead of remove+reinsert to preserve the tile's position in the parent tree without any structural mutation or simplification pass
- Uses `find_pane_in_tile` + `tiles.find_pane` to handle the egui_tiles bare-pane-root restructuring GOTCHA (focused_pane can point to a Container after first render)
- Child context gets `parent_id: Some(parent_ctx_id)` and `depth: parent_depth + 1`, matching the child context model from #1409