### PR TITLE
fix(overlays): keep every text-owning overlay focused after CentralPanel renders (#1601)

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -793,5 +793,49 @@ impl PlexiApp {
         if self.inspector_renaming {
             ctx.memory_mut(|m| m.request_focus(egui::Id::new("inspector_rename_input")));
         }
+
+        // Same pattern for all remaining text-owning overlays. Each overlay's one-shot
+        // request fires during early overlay dispatch (BEFORE CentralPanel), so pane
+        // TextInput widgets rendered in CentralPanel steal focus back. Re-requesting
+        // here wins the last-write-wins contest for the frame.
+        if self.renaming_pane.is_some() {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("rename_pane_input")));
+        }
+        if self.renaming_window.is_some() && !self.sidebar_visible {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("rename_context_input")));
+        }
+        if self.editing_description.is_some() {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("edit_description_input")));
+        }
+        if self.text_overlay.is_some() {
+            ctx.memory_mut(|m| m.request_focus(egui::Id::new("text_input_overlay_field")));
+        }
+        // Capability/secret modal: only re-request for Secret prompts — Capability prompts
+        // have no text field, so requesting a non-existent ID would leave egui holding a
+        // stale focus pointer that interferes with button interactions.
+        if matches!(self.focus_stack.last(), Some(FocusLayer::CapabilityModal)) {
+            let has_secret_prompt = {
+                let win = &self.windows[self.active_window];
+                win.focused_pane
+                    .and_then(|tile_id| Self::find_pane_in_tile(&win.tree, tile_id))
+                    .and_then(|pane_id| win.panes.get(&pane_id))
+                    .and_then(|pane| pane.as_app())
+                    .map(|app| {
+                        if let crate::pane::AppRuntime::Process(ref proc) = app.runtime {
+                            matches!(
+                                proc.pending_prompts.front(),
+                                Some(crate::process_app::PendingPrompt::Secret { .. })
+                            )
+                        } else {
+                            false
+                        }
+                    })
+                    .unwrap_or(false)
+            };
+            if has_secret_prompt {
+                log::debug!("capability_modal: re-requesting focus for capability_secret_input post-CentralPanel");
+                ctx.memory_mut(|m| m.request_focus(egui::Id::new("capability_secret_input")));
+            }
+        }
     }
 }

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -168,6 +168,7 @@ pub(crate) fn show_prompt_modal(
                             egui::Stroke::new(1.0, colors.border);
                         let response = ui.add(
                             egui::TextEdit::singleline(secret_input_buf)
+                                .id(egui::Id::new("capability_secret_input"))
                                 .password(true)
                                 .margin(egui::Margin::symmetric(8, 5)),
                         );

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -775,4 +775,163 @@ mod tests {
         });
     }
 
+    // -- Layer 2 post-CentralPanel focus guard (#1601) -------------------------
+
+    /// Helper: simulate a CentralPanel pane widget stealing egui focus between two frames.
+    /// Returns the egui Id of the "stealing" widget so callers can assert against it.
+    fn steal_focus(h: &HostHarness) -> egui::Id {
+        let steal_id = egui::Id::new("fake_pane_text_input_steal");
+        h.ctx.memory_mut(|m| m.request_focus(steal_id));
+        steal_id
+    }
+
+    /// Regression guard for #1601: rename-pane TextEdit must retain egui focus
+    /// after CentralPanel renders. The between-frame steal simulates a pane TextInput
+    /// calling request_focus during CentralPanel — the post-CentralPanel block must
+    /// re-claim focus for `rename_pane_input` before the frame ends.
+    #[test]
+    fn rename_pane_overlay_focus_wins_after_central_panel_steal() {
+        use crate::app::FocusLayer;
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+        h.app.renaming_pane = Some(pane);
+        h.app.rename_buffer = "test name".to_string();
+        h.app.push_focus_layer(FocusLayer::RenamePane);
+        // Frame 1: one-shot fires, focus = rename_pane_input.
+        h.run_frames(1);
+        // Simulate CentralPanel pane widget stealing focus.
+        steal_focus(&h);
+        // Frame 2: post-CentralPanel block must reclaim rename_pane_input.
+        h.run_frames(1);
+        assert_eq!(
+            h.ctx.memory(|m| m.focused()),
+            Some(egui::Id::new("rename_pane_input")),
+            "rename_pane_input must win focus back after a CentralPanel pane widget steals it"
+        );
+    }
+
+    /// Regression guard for #1601: context-rename TextEdit (modal path, sidebar hidden)
+    /// must retain egui focus after CentralPanel renders.
+    #[test]
+    fn context_rename_overlay_focus_wins_after_central_panel_steal() {
+        use crate::app::FocusLayer;
+        let mut h = HostHarness::new();
+        h.app.renaming_window = Some(0);
+        h.app.rename_buffer = "new context".to_string();
+        h.app.sidebar_visible = false;
+        h.app.push_focus_layer(FocusLayer::ContextRename);
+        h.run_frames(1);
+        steal_focus(&h);
+        h.run_frames(1);
+        assert_eq!(
+            h.ctx.memory(|m| m.focused()),
+            Some(egui::Id::new("rename_context_input")),
+            "rename_context_input must win focus back after a CentralPanel pane widget steals it"
+        );
+    }
+
+    /// Regression guard for #1601: edit-description TextEdit must retain egui focus
+    /// after CentralPanel renders.
+    #[test]
+    fn edit_description_overlay_focus_wins_after_central_panel_steal() {
+        use crate::app::FocusLayer;
+        let mut h = HostHarness::new();
+        h.app.editing_description = Some(0);
+        h.app.description_buffer = "my description".to_string();
+        h.app.push_focus_layer(FocusLayer::ContextDescription);
+        h.run_frames(1);
+        steal_focus(&h);
+        h.run_frames(1);
+        assert_eq!(
+            h.ctx.memory(|m| m.focused()),
+            Some(egui::Id::new("edit_description_input")),
+            "edit_description_input must win focus back after a CentralPanel pane widget steals it"
+        );
+    }
+
+    /// Regression guard for #1601: generic text-input overlay field must retain
+    /// egui focus after CentralPanel renders.
+    #[test]
+    fn text_input_overlay_focus_wins_after_central_panel_steal() {
+        use crate::app::{FocusLayer, TextInputOverlay, OverlayTarget};
+        let mut h = HostHarness::new();
+        h.app.text_overlay = Some((
+            TextInputOverlay {
+                label: "Root directory".to_string(),
+                hint: "/path/to/project".to_string(),
+                buffer: String::new(),
+                focus_requested: false,
+            },
+            OverlayTarget::ContextRoot(0),
+        ));
+        h.app.push_focus_layer(FocusLayer::TextInput);
+        h.run_frames(1);
+        steal_focus(&h);
+        h.run_frames(1);
+        assert_eq!(
+            h.ctx.memory(|m| m.focused()),
+            Some(egui::Id::new("text_input_overlay_field")),
+            "text_input_overlay_field must win focus back after a CentralPanel pane widget steals it"
+        );
+    }
+
+    /// Regression guard for #1601: capability/secret prompt TextEdit must retain
+    /// egui focus after CentralPanel renders. The secret TextEdit now carries a
+    /// stable `capability_secret_input` Id so the post-CentralPanel block can
+    /// target it by name.
+    #[test]
+    fn capability_secret_overlay_focus_wins_after_central_panel_steal() {
+        use crate::app::FocusLayer;
+        use crate::process_app::PendingPrompt;
+        use crate::pane::AppRuntime;
+
+        let mut h = HostHarness::new();
+        let pane = h.add_test_pane();
+
+        // Focus the pane so sync_capability_modal_focus can find it.
+        let tile_id = {
+            let win = &h.app.windows[0];
+            win.tree.tiles.iter()
+                .find_map(|(id, tile)| match tile {
+                    egui_tiles::Tile::Pane(p) if *p == pane => Some(id),
+                    _ => None,
+                })
+                .expect("test pane must have a tile")
+        };
+        h.app.windows[0].focused_pane = Some(*tile_id);
+
+        // Queue a Secret prompt on the pane.
+        {
+            let win = &mut h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(ref mut proc) = app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            proc.pending_prompts.push_back(PendingPrompt::Secret {
+                key: "API_KEY".to_string(),
+            });
+        }
+
+        // Frame 1: sync pushes CapabilityModal layer; modal renders; post-CentralPanel
+        // requests focus on capability_secret_input.
+        h.run_frames(1);
+        assert!(
+            h.app.focus_stack.iter().any(|l| *l == FocusLayer::CapabilityModal),
+            "CapabilityModal must be on the focus stack when the focused pane has a pending Secret prompt"
+        );
+
+        // Simulate CentralPanel pane widget stealing focus.
+        steal_focus(&h);
+
+        // Frame 2: post-CentralPanel block must reclaim capability_secret_input.
+        h.run_frames(1);
+        assert_eq!(
+            h.ctx.memory(|m| m.focused()),
+            Some(egui::Id::new("capability_secret_input")),
+            "capability_secret_input must win focus back after a CentralPanel pane widget steals it"
+        );
+    }
+
 }


### PR DESCRIPTION
Closes #1601

## Summary

- Extended the post-CentralPanel egui focus restoration block in `src/app/render.rs` to cover all 5 missing text-owning overlays: rename-pane, context-rename, edit-description, text-input overlay, and capability/secret prompt
- Added stable `egui::Id::new("capability_secret_input")` to the secret TextEdit in `prompts.rs` so the post-panel block can target it by name
- Added 5 harness tests using a between-frame focus-steal to prove the Layer 2 re-request wins the last-write-wins contest each frame

## Done When

- Rename pane, context rename, context description, shared text input, QuickNote, inspector rename, command palette, and capability/secret prompt text fields all retain focus over app pane TextInputs.
- Dismissing any text overlay surrenders or clears its owned egui focus ID.
- `cargo test --bin plexi` passes.

## Notes

The fix follows the canonical pattern already documented in GOTCHAS.md: the overlay's one-shot `request_focus` fires during early overlay dispatch (Layer 1), and the post-CentralPanel block re-requests every frame (Layer 2) to win the last-write-wins contest against any pane TextInput widget rendered during CentralPanel.

The `context_rename` overlay uses an every-frame `!te.has_focus()` guard (instead of one-shot) but still needs Layer 2 because its request fires before CentralPanel; without the post-panel re-request, pane widgets win the frame.