### PR TITLE
fix(host): auto-trigger ai.query consent modal on first AiQuery (#1594)

### DIFF
--- a/apps/dev/pixel-art-tavern/main.py
+++ b/apps/dev/pixel-art-tavern/main.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from plexi_sdk import App, RenderContext, MUTED
+from plexi_sdk import App, RenderContext
 
 # ── Design constants ──────────────────────────────────────────────────────────
 PIXEL   = 4.0    # logical px per sprite pixel
@@ -257,7 +257,7 @@ class TavernApp(App):
 
         # Title
         ctx.text(PAD, PAD, "The Rusty Flagon", size=HEADING, color=Y, bold=True, monospace=True)
-        ctx.text(PAD, PAD + HEADING + 4, "A pixel art tavern", size=CAPTION, color=MUTED, monospace=True)
+        ctx.text(PAD, PAD + HEADING + 4, "A pixel art tavern", size=CAPTION, color=ctx.theme.muted, monospace=True)
 
     def _tick(self, dt: float) -> None:
         self._total_elapsed += dt
@@ -315,7 +315,7 @@ class TavernApp(App):
         ctx.text(ctx.w / 2, py + 14, "Press Space to start", size=BODY, color=W,
                  align="top_center", monospace=True, bold=False, elide=False, selectable=False)
         ctx.text(ctx.w / 2, py + 14 + BODY + 8, "NPCs will converse via AI",
-                 size=CAPTION, color=MUTED,
+                 size=CAPTION, color=ctx.theme.muted,
                  align="top_center", monospace=True, bold=False, elide=False, selectable=False)
 
     def _draw_scene(self, ctx: RenderContext, floor_y: float,

--- a/src/overlays.rs
+++ b/src/overlays.rs
@@ -2718,7 +2718,8 @@ impl PlexiApp {
         // Take fields out of the ProcessApp, call the modal, put them back.
         // Two separate borrows so Rust doesn't see a conflict.
         let (mut pending_prompts, mut outbound_events, mut permissions,
-             mut secret_input_buf, mut permission_store, type_id, workspace_root) = {
+             mut secret_input_buf, mut permission_store, mut deferred_ai_queries,
+             type_id, workspace_root, ai_broker, http_tx, proc_pane_id) = {
             let pane = match self.windows[active].panes.get_mut(&pane_id) {
                 Some(crate::pane::Pane::App(a)) => a,
                 _ => return,
@@ -2733,8 +2734,12 @@ impl PlexiApp {
                 std::mem::take(&mut proc.permissions),
                 std::mem::take(&mut proc.secret_input_buf),
                 std::mem::take(&mut proc.permission_store),
+                std::mem::take(&mut proc.deferred_ai_queries),
                 proc.type_id.clone(),
                 proc.workspace_root.clone(),
+                std::sync::Arc::clone(&proc.ai_broker),
+                proc.http_tx.clone(),
+                proc.pane_id,
             )
         };
 
@@ -2750,6 +2755,10 @@ impl PlexiApp {
             &config_dir,
             &mut permission_store,
             &colors,
+            &mut deferred_ai_queries,
+            ai_broker,
+            http_tx,
+            proc_pane_id,
         );
 
         // Put the data back.
@@ -2763,6 +2772,7 @@ impl PlexiApp {
         proc.permissions = permissions;
         proc.secret_input_buf = secret_input_buf;
         proc.permission_store = permission_store;
+        proc.deferred_ai_queries = deferred_ai_queries;
     }
 
     /// Context-close confirmation dialog. Shows pane inventory with three choices:

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 use render_session::RenderSession;
 
 use crate::app_permissions::{AppPermissions, Capability};
-use crate::app_protocol::{ControlCommand, DrawCommand, Modifiers, PlexiEvent, RenderCommand};
+use crate::app_protocol::{AiMessage, AiTool, ControlCommand, DrawCommand, Modifiers, ModelTier, PlexiEvent, RenderCommand};
 use crate::app_trait::{App, AppCommand, AppRenderContext};
 use crate::audio::{AudioDevice, CaptureSession};
 use crate::midi::{MidiDevice, MidiInputSession, MidiOutputHandle};
@@ -57,6 +57,21 @@ pub enum PendingPrompt {
     Secret {
         key: String,
     },
+}
+
+// ---------------------------------------------------------------------------
+// DeferredAiQuery — an AiQuery held pending first-run consent
+// ---------------------------------------------------------------------------
+
+/// A `AiQuery` request deferred because `ai.query` was withheld pending consent.
+/// Drained and re-dispatched (or errored) when the user resolves the modal.
+#[derive(Debug)]
+pub(crate) struct DeferredAiQuery {
+    pub(crate) request_id: String,
+    pub(crate) model_tier: ModelTier,
+    pub(crate) system: String,
+    pub(crate) messages: Vec<AiMessage>,
+    pub(crate) tools: Vec<AiTool>,
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +163,9 @@ pub struct ProcessApp {
     pub(crate) pipe_registry: Arc<Mutex<TypedPipeRegistry>>,
     pub(crate) run_registry: RunRegistry,
     pub(crate) pending_prompts: VecDeque<PendingPrompt>,
+    /// AiQuery requests withheld pending first-run `ai.query` consent.
+    /// Drained on consent resolution — dispatched if granted, errored if denied.
+    pub(crate) deferred_ai_queries: VecDeque<DeferredAiQuery>,
     pub(crate) status_summary: Option<String>,
     /// Navigation stack maintained by `DrawCommand::PushNav` / `PopNav`.
     /// Each entry carries a stable `view_id` and a display `title`. When the
@@ -667,6 +685,7 @@ impl ProcessApp {
             ))),
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
+            deferred_ai_queries: VecDeque::new(),
             status_summary: None,
             nav_stack: Vec::new(),
             outbound_events: VecDeque::new(),
@@ -812,6 +831,7 @@ impl ProcessApp {
             ))),
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
+            deferred_ai_queries: VecDeque::new(),
             status_summary: None,
             nav_stack: Vec::new(),
             outbound_events: VecDeque::new(),

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -3,11 +3,13 @@
 use crate::app_permissions::AppPermissions;
 use crate::app_protocol::PlexiEvent;
 use crate::event_log::{self, HostEvent};
+use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
 use crate::workspace_secrets::SecretStore;
 use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::{mpsc::Sender, Arc};
 
-use super::PendingPrompt;
+use super::{DeferredAiQuery, PendingPrompt};
 
 /// Persist a granted secret to the keychain so the user is not prompted again.
 ///
@@ -91,6 +93,10 @@ pub(crate) fn show_prompt_modal(
     _config_dir: &Path,
     permission_store: &mut crate::app_permissions::PermissionStore,
     colors: &crate::theme::Colors,
+    deferred_ai_queries: &mut VecDeque<DeferredAiQuery>,
+    ai_broker: Arc<dyn AiBroker>,
+    http_tx: Sender<PlexiEvent>,
+    pane_id: u64,
 ) {
     let Some(prompt) = pending_prompts.front() else {
         return;
@@ -268,6 +274,70 @@ pub(crate) fn show_prompt_modal(
                     request_id,
                     granted: actually_granted,
                 });
+                // Drain any AiQuery requests that were withheld pending this consent.
+                if capability == "ai.query" && !deferred_ai_queries.is_empty() {
+                    if actually_granted {
+                        log::info!(
+                            "prompts: ai.query granted for {} — re-dispatching {} deferred queries",
+                            type_id,
+                            deferred_ai_queries.len()
+                        );
+                        while let Some(q) = deferred_ai_queries.pop_front() {
+                            let broker = Arc::clone(&ai_broker);
+                            let app_id = type_id.to_string();
+                            let tx = http_tx.clone();
+                            let ws_root = workspace_root.to_path_buf();
+                            let open_panes = crate::plexi_ai::broker::get_pane_snapshot();
+                            let tool_dispatcher = std::sync::Arc::new(
+                                crate::plexi_ai::tool_dispatch::ToolDispatcher::from_registry(
+                                    pane_id,
+                                    type_id.to_string(),
+                                    ws_root.clone(),
+                                ),
+                            );
+                            std::thread::Builder::new()
+                                .name(format!("ai-query-deferred-{app_id}-{}", q.request_id))
+                                .spawn(move || {
+                                    let resp = broker.dispatch(AiBrokerRequest {
+                                        app_id,
+                                        model_tier: q.model_tier,
+                                        system: q.system,
+                                        messages: q.messages,
+                                        tools: q.tools,
+                                        workspace_root: Some(ws_root),
+                                        open_panes,
+                                        tool_dispatcher: Some(tool_dispatcher),
+                                    });
+                                    let event = PlexiEvent::AiResponse {
+                                        request_id: q.request_id,
+                                        content: resp.content,
+                                        tokens_in: resp.tokens_in,
+                                        tokens_out: resp.tokens_out,
+                                        error: resp.error,
+                                    };
+                                    if let Err(e) = tx.send(event) {
+                                        log::warn!("ai broker: deferred response receiver dropped: {e}");
+                                    }
+                                })
+                                .expect("failed to spawn deferred ai-query thread");
+                        }
+                    } else {
+                        log::info!(
+                            "prompts: ai.query denied for {} — erroring {} deferred queries",
+                            type_id,
+                            deferred_ai_queries.len()
+                        );
+                        while let Some(q) = deferred_ai_queries.pop_front() {
+                            outbound_events.push_back(PlexiEvent::AiResponse {
+                                request_id: q.request_id,
+                                content: None,
+                                tokens_in: 0,
+                                tokens_out: 0,
+                                error: Some("capability denied by user".to_string()),
+                            });
+                        }
+                    }
+                }
             }
             Some(PendingPrompt::Secret { key }) => {
                 let value = if actually_granted && !secret_input_buf.is_empty() {

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -282,19 +282,23 @@ pub(crate) fn show_prompt_modal(
                             type_id,
                             deferred_ai_queries.len()
                         );
+                        // Build ToolDispatcher once — pane_id, type_id, workspace_root are
+                        // identical for all queries in this queue.
+                        let ws_root = workspace_root.to_path_buf();
+                        let tool_dispatcher = std::sync::Arc::new(
+                            crate::plexi_ai::tool_dispatch::ToolDispatcher::from_registry(
+                                pane_id,
+                                type_id.to_string(),
+                                ws_root.clone(),
+                            ),
+                        );
                         while let Some(q) = deferred_ai_queries.pop_front() {
                             let broker = Arc::clone(&ai_broker);
                             let app_id = type_id.to_string();
                             let tx = http_tx.clone();
-                            let ws_root = workspace_root.to_path_buf();
+                            let ws_root_clone = ws_root.clone();
                             let open_panes = crate::plexi_ai::broker::get_pane_snapshot();
-                            let tool_dispatcher = std::sync::Arc::new(
-                                crate::plexi_ai::tool_dispatch::ToolDispatcher::from_registry(
-                                    pane_id,
-                                    type_id.to_string(),
-                                    ws_root.clone(),
-                                ),
-                            );
+                            let td = std::sync::Arc::clone(&tool_dispatcher);
                             std::thread::Builder::new()
                                 .name(format!("ai-query-deferred-{app_id}-{}", q.request_id))
                                 .spawn(move || {
@@ -304,9 +308,9 @@ pub(crate) fn show_prompt_modal(
                                         system: q.system,
                                         messages: q.messages,
                                         tools: q.tools,
-                                        workspace_root: Some(ws_root),
+                                        workspace_root: Some(ws_root_clone),
                                         open_panes,
-                                        tool_dispatcher: Some(tool_dispatcher),
+                                        tool_dispatcher: Some(td),
                                     });
                                     let event = PlexiEvent::AiResponse {
                                         request_id: q.request_id,

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1000,19 +1000,45 @@ impl ProcessApp {
                 if let PermissionCheck::Denied(_reason) =
                     check(&self.permissions, Capability::AiQuery)
                 {
-                    log::warn!(
-                        "ProcessApp[{}]: AiQuery {request_id} denied — capability not declared",
-                        self.type_id
-                    );
-                    self.outbound_events.push_back(PlexiEvent::AiResponse {
-                        request_id,
-                        content: None,
-                        tokens_in: 0,
-                        tokens_out: 0,
-                        error: Some(
-                            "capability denied: ai.query not declared in manifest".to_string(),
-                        ),
-                    });
+                    if is_blocked(&self.permissions, Capability::AiQuery) {
+                        // Permanently blocked by user — deny immediately.
+                        log::warn!(
+                            "ProcessApp[{}]: AiQuery {request_id} denied — ai.query permanently blocked",
+                            self.type_id
+                        );
+                        self.outbound_events.push_back(PlexiEvent::AiResponse {
+                            request_id,
+                            content: None,
+                            tokens_in: 0,
+                            tokens_out: 0,
+                            error: Some("capability denied: ai.query blocked".to_string()),
+                        });
+                    } else {
+                        // Withheld — capability declared but first-run consent not yet given.
+                        // Defer the query and trigger the consent modal.
+                        log::info!(
+                            "ProcessApp[{}]: AiQuery {request_id} withheld — queuing for ai.query consent",
+                            self.type_id
+                        );
+                        self.deferred_ai_queries.push_back(super::DeferredAiQuery {
+                            request_id,
+                            model_tier,
+                            system,
+                            messages,
+                            tools,
+                        });
+                        // Deduplicate: only push a prompt if one isn't already pending.
+                        let already_pending = self.pending_prompts.iter().any(|p| {
+                            matches!(p, super::PendingPrompt::Capability { capability, .. }
+                                if capability == "ai.query")
+                        });
+                        if !already_pending {
+                            self.pending_prompts.push_back(super::PendingPrompt::Capability {
+                                request_id: uuid::Uuid::new_v4().to_string(),
+                                capability: "ai.query".to_string(),
+                            });
+                        }
+                    }
                     return;
                 }
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1016,6 +1016,25 @@ impl ProcessApp {
                     } else {
                         // Withheld — capability declared but first-run consent not yet given.
                         // Defer the query and trigger the consent modal.
+                        // Cap the deferred queue to prevent thread exhaustion when consent
+                        // is slow or the app fires many queries before the modal is shown.
+                        if self.deferred_ai_queries.len() >= 16 {
+                            log::warn!(
+                                "ProcessApp[{}]: AiQuery {request_id} dropped — deferred queue full (>=16 pending consent)",
+                                self.type_id
+                            );
+                            self.outbound_events.push_back(PlexiEvent::AiResponse {
+                                request_id,
+                                content: None,
+                                tokens_in: 0,
+                                tokens_out: 0,
+                                error: Some(
+                                    "capability withheld: too many deferred queries pending consent"
+                                        .to_string(),
+                                ),
+                            });
+                            return;
+                        }
                         log::info!(
                             "ProcessApp[{}]: AiQuery {request_id} withheld — queuing for ai.query consent",
                             self.type_id

--- a/src/process_app/tests/ai_tests.rs
+++ b/src/process_app/tests/ai_tests.rs
@@ -13,7 +13,7 @@ use super::super::*;
 use crate::app_permissions::AppPermissions;
 use crate::app_protocol::{AiMessage, AppRequest, ModelTier, PlexiEvent};
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest, AiBrokerResponse};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
 /// Test broker: records every dispatch and returns a canned response.
@@ -42,22 +42,37 @@ fn make_app(capabilities: HashSet<Capability>) -> Option<ProcessApp> {
     Some(app)
 }
 
+fn make_blocked_app() -> Option<ProcessApp> {
+    let mut blocked = HashSet::new();
+    blocked.insert(Capability::AiQuery);
+    let (app, _tx) = ProcessApp::new_for_test(
+        7,
+        AppPermissions {
+            capabilities: HashSet::new(),
+            blocked,
+            is_builtin: false,
+            allowed_hosts: vec![],
+        },
+    );
+    Some(app)
+}
+
 #[test]
 fn denied_app_gets_capability_denied_response() {
-    // App without `ai.query` capability: route_command must immediately
+    // App with `ai.query` permanently BLOCKED: route_command must immediately
     // queue an AiResponse with the canonical "capability denied" error
     // — synchronously, without ever invoking the broker.
-    let Some(mut app) = make_app(HashSet::new()) else {
+    let Some(mut app) = make_blocked_app() else {
         eprintln!("skipping: no /bin/sh available");
         return;
     };
 
-    // Inject a broker that would *panic* if called. The denied path
+    // Inject a broker that would *panic* if called. The blocked path
     // must short-circuit before reaching dispatch.
     struct PanicBroker;
     impl AiBroker for PanicBroker {
         fn dispatch(&self, _: AiBrokerRequest) -> AiBrokerResponse {
-            panic!("denied path must never call the broker");
+            panic!("blocked path must never call the broker");
         }
     }
     app.ai_broker = Arc::new(PanicBroker);
@@ -73,8 +88,7 @@ fn denied_app_gets_capability_denied_response() {
         tools: vec![],
     });
 
-    // Denied path is synchronous — the response is on outbound_events
-    // immediately, no thread, no http_rx wait.
+    // Blocked path is synchronous — the response is on outbound_events immediately.
     let resp = app
         .outbound_events
         .iter()
@@ -97,13 +111,67 @@ fn denied_app_gets_capability_denied_response() {
                 err.contains("capability denied"),
                 "denial message must say `capability denied`: {err}"
             );
-            assert!(
-                err.contains("ai.query"),
-                "denial message must name the capability: {err}"
-            );
         }
         other => panic!("expected AiResponse, got {other:?}"),
     }
+}
+
+#[test]
+fn withheld_app_defers_ai_query_and_queues_consent_prompt() {
+    // App without `ai.query` capability but not blocked (withheld / first-run):
+    // route_command must defer the query and push a consent PendingPrompt,
+    // without calling the broker or emitting an AiResponse.
+    let Some(mut app) = make_app(HashSet::new()) else {
+        eprintln!("skipping: no /bin/sh available");
+        return;
+    };
+
+    struct PanicBroker;
+    impl AiBroker for PanicBroker {
+        fn dispatch(&self, _: AiBrokerRequest) -> AiBrokerResponse {
+            panic!("withheld path must never call the broker");
+        }
+    }
+    app.ai_broker = Arc::new(PanicBroker);
+
+    app.route_command(AppRequest::AiQuery {
+        request_id: "req-withheld".to_string(),
+        model_tier: ModelTier::Low,
+        system: "system".to_string(),
+        messages: vec![AiMessage {
+            role: "user".to_string(),
+            content: "hello".to_string(),
+        }],
+        tools: vec![],
+    });
+
+    // No immediate AiResponse — query is deferred.
+    assert!(
+        !app.outbound_events.iter().any(|e| matches!(e, PlexiEvent::AiResponse { .. })),
+        "withheld path must not produce immediate AiResponse"
+    );
+    // Query stored in deferred queue.
+    assert_eq!(app.deferred_ai_queries.len(), 1);
+    assert_eq!(app.deferred_ai_queries[0].request_id, "req-withheld");
+    // Consent prompt queued.
+    let has_ai_prompt = app.pending_prompts.iter().any(|p| {
+        matches!(p, PendingPrompt::Capability { capability, .. } if capability == "ai.query")
+    });
+    assert!(has_ai_prompt, "withheld path must push ai.query consent prompt");
+
+    // Second query while prompt is already pending must NOT push a duplicate prompt.
+    app.route_command(AppRequest::AiQuery {
+        request_id: "req-withheld-2".to_string(),
+        model_tier: ModelTier::Low,
+        system: "system".to_string(),
+        messages: vec![],
+        tools: vec![],
+    });
+    assert_eq!(app.deferred_ai_queries.len(), 2, "second deferred query must be stored");
+    let prompt_count = app.pending_prompts.iter().filter(|p| {
+        matches!(p, PendingPrompt::Capability { capability, .. } if capability == "ai.query")
+    }).count();
+    assert_eq!(prompt_count, 1, "must not push duplicate consent prompt");
 }
 
 #[test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -283,18 +283,19 @@ mod tests {
 
     /// Regression guard for PR #536: `AiQuery` was silently dropped into
     /// `pending_frame` (visual buffer) instead of being routed through
-    /// `route_command`. Confirmed by the fact that `outbound_events` stays
-    /// empty — the command was never dispatched.
+    /// `route_command`. Confirmed by the fact that routing state stays
+    /// unchanged — the command was never dispatched.
     ///
-    /// Uses a pane with no `ai.query` capability so the denial response lands
-    /// synchronously on `outbound_events` — no background thread, no sleep.
-    /// The capability-denied path still proves the regression: if AiQuery
-    /// were dropped into `pending_frame` the denial would never happen and
-    /// `outbound_events` would remain empty.
+    /// Uses a pane with no `ai.query` capability (withheld / first-run).
+    /// With the consent-auto-trigger fix, the withheld path defers the query
+    /// and queues a consent prompt instead of emitting an immediate AiResponse.
+    /// Either path proves the routing regression was not reintroduced: if
+    /// AiQuery were dropped into `pending_frame`, neither the deferred queue
+    /// nor the pending prompt would be populated.
     #[test]
     fn ai_query_reaches_route_command_not_pending_frame() {
         let mut h = HostHarness::new();
-        // No capabilities → AiQuery hits the synchronous denial path in route_command.
+        // No capabilities (withheld) → AiQuery defers and queues consent prompt.
         let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
 
         h.inject(pane, ai_query("req-1"));
@@ -311,14 +312,28 @@ mod tests {
             proc.background_tick();
         }
 
-        let effects = h.effects_drain(pane);
+        // Withheld path: query is deferred + consent prompt queued.
+        let (has_deferred, has_prompt) = {
+            let win = &mut h.app.windows[0];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+                panic!("expected App pane");
+            };
+            let AppRuntime::Process(proc) = &mut app_pane.runtime else {
+                panic!("expected Process runtime");
+            };
+            let has_deferred = !proc.deferred_ai_queries.is_empty();
+            let has_prompt = proc.pending_prompts.iter().any(|p| {
+                matches!(p, crate::process_app::PendingPrompt::Capability { capability, .. }
+                    if capability == "ai.query")
+            });
+            (has_deferred, has_prompt)
+        };
         assert!(
-            !effects.is_empty(),
-            "AiQuery must produce an outbound event — got none. \
+            has_deferred,
+            "AiQuery must be deferred — got none. \
              This means it was silently dropped instead of being routed."
         );
-        let has_ai_response = effects.iter().any(|e| matches!(e, PlexiEvent::AiResponse { .. }));
-        assert!(has_ai_response, "Expected AiResponse in effects, got: {:?}", effects);
+        assert!(has_prompt, "ai.query consent prompt must be queued after deferred AiQuery");
     }
 
     // -- State snapshot -------------------------------------------------------


### PR DESCRIPTION
Closes #1594

## Summary

- When `ai.query` is withheld (declared in manifest, first-run consent pending), `AiQuery` now defers the request and queues a consent modal instead of immediately denying with a misleading "capability not declared" error
- Added `DeferredAiQuery` queue to `ProcessApp`; routing distinguishes withheld (defer+prompt) from blocked (immediate deny)
- On consent resolution: granted → deferred queries dispatched via broker; denied → clean error returned to each queued call

## Done When

- Launching `pixel-art-tavern` on a fresh beta profile (no stored `ai.query` consent) shows the consent modal before any NPC speaks
- Granting consent: NPC conversations proceed normally
- Denying consent: each `ai_query` call returns a clean error; the rest of the app keeps running
- Consent decision persists — relaunching does not show the modal again
- `cargo test --bin plexi` passes

## Notes

- `check()` returns `Denied` for both "not declared" and "withheld" — the distinction is `is_blocked()`: blocked=true means permanent deny, blocked=false means withheld → show consent modal
- Deduplication: a second `AiQuery` while consent is already pending doesn't push a duplicate `PendingPrompt`
- Test updated: `denied_app_gets_capability_denied_response` now uses a blocked app; new `withheld_app_defers_ai_query_and_queues_consent_prompt` covers the defer path