### PR TITLE
Configurable pane_gap, pane_title_font_size, and click flash (#724, #803, #1141)

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -5,6 +5,12 @@
 
 font_size = 14.0
 
+# Gap between panes in pixels. Default: 4. Range: 0–20.
+# pane_gap = 4
+
+# Font size for the pane name bar (shown when a pane is renamed). Default: 11. Range: 6–32.
+# pane_title_font_size = 11
+
 # ── Theme ──────────────────────────────────────────────────────
 # Pick a preset OR customize individual colors below.
 # Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark, solarized-light

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -256,6 +256,7 @@ struct EdgePulse {
 }
 
 pub(crate) struct ClickFlash {
+    pub(crate) window_id: u64,
     pub(crate) tile: egui_tiles::TileId,
     pub(crate) started_at: std::time::Instant,
 }
@@ -1186,7 +1187,9 @@ impl PlexiApp {
     /// so that the grep pattern `windows[active].focused_pane = ` has zero matches outside tests.
     pub(crate) fn set_window_focused_pane(&mut self, win_idx: usize, tile: egui_tiles::TileId) {
         self.windows[win_idx].focused_pane = Some(tile);
-        self.click_flash = Some(ClickFlash { tile, started_at: std::time::Instant::now() });
+        let window_id = self.windows[win_idx].window_id;
+        log::info!("focus: flash set — win={window_id} tile={tile:?}");
+        self.click_flash = Some(ClickFlash { window_id, tile, started_at: std::time::Instant::now() });
     }
 
     /// Restore focused pane in a specific window from a saved `Option<TileId>`.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -255,6 +255,11 @@ struct EdgePulse {
     started_at: std::time::Instant,
 }
 
+pub(crate) struct ClickFlash {
+    pub(crate) tile: egui_tiles::TileId,
+    pub(crate) started_at: std::time::Instant,
+}
+
 pub struct PlexiApp {
     pub(crate) pty_event_rx: mpsc::Receiver<(u64, PtyEvent)>,
     pub(crate) pty_event_tx: mpsc::Sender<(u64, PtyEvent)>,
@@ -437,6 +442,8 @@ pub struct PlexiApp {
     pane_anims: Vec<PaneSwapAnim>,
     /// Boundary edge pulse — shown when a swap is attempted at the wall.
     edge_pulse: Option<EdgePulse>,
+    /// Exponential accent flash on focus change (#1141).
+    pub(crate) click_flash: Option<ClickFlash>,
     /// Channel receiver fed by the background update-check thread. Sends the
     /// latest version string exactly once if a newer release is available.
     update_rx: Option<std::sync::mpsc::Receiver<String>>,
@@ -978,6 +985,7 @@ impl PlexiApp {
                     pane_snapshot_len: 0,
                     pane_anims: Vec::new(),
                     edge_pulse: None,
+                    click_flash: None,
                     update_rx: Some(update_rx),
                     update_available: None,
                     pane_ipc_rx,
@@ -1153,6 +1161,7 @@ impl PlexiApp {
             pane_snapshot_len: 0,
             pane_anims: Vec::new(),
             edge_pulse: None,
+            click_flash: None,
             update_rx: Some(update_rx),
             update_available: None,
             pane_ipc_rx,
@@ -1177,6 +1186,7 @@ impl PlexiApp {
     /// so that the grep pattern `windows[active].focused_pane = ` has zero matches outside tests.
     pub(crate) fn set_window_focused_pane(&mut self, win_idx: usize, tile: egui_tiles::TileId) {
         self.windows[win_idx].focused_pane = Some(tile);
+        self.click_flash = Some(ClickFlash { tile, started_at: std::time::Instant::now() });
     }
 
     /// Restore focused pane in a specific window from a saved `Option<TileId>`.
@@ -1318,6 +1328,7 @@ impl PlexiApp {
             pane_snapshot_len: 0,
             pane_anims: Vec::new(),
             edge_pulse: None,
+            click_flash: None,
             show_cli_setup_prompt: false,
             cli_setup_check_result: None,
             show_completions_banner: false,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -6,6 +6,9 @@ use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
 use egui_tiles::Tile;
 use std::collections::HashMap;
 
+const FLASH_DUR: f32 = 0.4;
+const FLASH_TAU: f32 = 0.10;
+
 impl PlexiApp {
     /// Early per-frame work that runs before overlay dispatch and panel rendering.
     /// Handles adopted context paths, finder service drains, notification polling,
@@ -444,14 +447,12 @@ impl PlexiApp {
                 if zoomed_pane.is_none() && !suppress_focus {
                     if let Some(tile_id) = ctx.focused_pane {
                         if let Some(rect) = ctx.tree.tiles.rect(tile_id) {
-                            let gap = self.config.pane_gap.unwrap_or(4.0).clamp(0.0, 20.0);
-                            const FLASH_DUR: f32 = 0.4;
-                            const TAU: f32 = 0.10;
+                            let gap = behavior.pane_gap;
                             let stroke_color = if let Some(ref flash) = self.click_flash {
-                                if flash.tile == tile_id {
+                                if flash.window_id == ctx.window_id && flash.tile == tile_id {
                                     let elapsed = flash.started_at.elapsed().as_secs_f32();
                                     if elapsed < FLASH_DUR {
-                                        let boost = (-elapsed / TAU).exp();
+                                        let boost = (-elapsed / FLASH_TAU).exp();
                                         ui.ctx().request_repaint();
                                         self.colors.accent.gamma_multiply((1.0 + boost).clamp(1.0, 2.0))
                                     } else {
@@ -476,7 +477,6 @@ impl PlexiApp {
 
                 // Expire click_flash once FLASH_DUR has elapsed.
                 if let Some(ref flash) = self.click_flash {
-                    const FLASH_DUR: f32 = 0.4;
                     if flash.started_at.elapsed().as_secs_f32() >= FLASH_DUR {
                         self.click_flash = None;
                     }
@@ -492,8 +492,9 @@ impl PlexiApp {
 
                 if canvas_focus_changed {
                     if let Some(new_tile) = ctx.focused_pane {
-                        log::info!("focus: canvas click flash → tile={:?}", new_tile);
-                        self.click_flash = Some(ClickFlash { tile: new_tile, started_at: std::time::Instant::now() });
+                        let win_id = ctx.window_id;
+                        log::info!("focus: canvas click flash → win={win_id} tile={new_tile:?}");
+                        self.click_flash = Some(ClickFlash { window_id: win_id, tile: new_tile, started_at: std::time::Instant::now() });
                     }
                 }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,7 +1,6 @@
 //! Rendering helpers extracted from the main `eframe::App::update()` loop.
 
-use super::FocusLayer;
-use super::PlexiApp;
+use super::{ClickFlash, FocusLayer, PlexiApp};
 use crate::tiling::{PaneId, PlexiBehavior};
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
 use egui_tiles::Tile;
@@ -423,6 +422,8 @@ impl PlexiApp {
                     portal_info,
                     modal_open,
                     ctrl_held,
+                    pane_gap: self.config.pane_gap.unwrap_or(4.0).clamp(0.0, 20.0),
+                    pane_title_font_size: self.config.pane_title_font_size.unwrap_or(11.0).clamp(6.0, 32.0),
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {
@@ -443,8 +444,26 @@ impl PlexiApp {
                 if zoomed_pane.is_none() && !suppress_focus {
                     if let Some(tile_id) = ctx.focused_pane {
                         if let Some(rect) = ctx.tree.tiles.rect(tile_id) {
-                            let gap = 4.0;
-                            let stroke = egui::Stroke::new(gap, self.colors.accent);
+                            let gap = self.config.pane_gap.unwrap_or(4.0).clamp(0.0, 20.0);
+                            const FLASH_DUR: f32 = 0.4;
+                            const TAU: f32 = 0.10;
+                            let stroke_color = if let Some(ref flash) = self.click_flash {
+                                if flash.tile == tile_id {
+                                    let elapsed = flash.started_at.elapsed().as_secs_f32();
+                                    if elapsed < FLASH_DUR {
+                                        let boost = (-elapsed / TAU).exp();
+                                        ui.ctx().request_repaint();
+                                        self.colors.accent.gamma_multiply((1.0 + boost).clamp(1.0, 2.0))
+                                    } else {
+                                        self.colors.accent
+                                    }
+                                } else {
+                                    self.colors.accent
+                                }
+                            } else {
+                                self.colors.accent
+                            };
+                            let stroke = egui::Stroke::new(gap, stroke_color);
                             ui.painter().rect_stroke(
                                 rect,
                                 0.0,
@@ -455,6 +474,14 @@ impl PlexiApp {
                     }
                 }
 
+                // Expire click_flash once FLASH_DUR has elapsed.
+                if let Some(ref flash) = self.click_flash {
+                    const FLASH_DUR: f32 = 0.4;
+                    if flash.started_at.elapsed().as_secs_f32() >= FLASH_DUR {
+                        self.click_flash = None;
+                    }
+                }
+
                 let canvas_focus_changed = if let Some(new) = behavior.new_focused {
                     let changed = Some(new) != canvas_old_focus;
                     ctx.focused_pane = Some(new);
@@ -462,6 +489,13 @@ impl PlexiApp {
                 } else {
                     false
                 };
+
+                if canvas_focus_changed {
+                    if let Some(new_tile) = ctx.focused_pane {
+                        log::info!("focus: canvas click flash → tile={:?}", new_tile);
+                        self.click_flash = Some(ClickFlash { tile: new_tile, started_at: std::time::Instant::now() });
+                    }
+                }
 
                 let should_close_exited = behavior.close_exited.is_some();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ const KNOWN_TOP_LEVEL: &[&str] = &[
     "font_size", "theme_preset", "theme", "beta", "log",
     "notifications", "ai", "confirm_quit", "confirm_close",
     "keybindings", "quick_note", "focus_history_depth", "agents", "cli",
+    "pane_gap", "pane_title_font_size",
 ];
 const KNOWN_AGENTS: &[&str] = &["low", "medium", "high"];
 const KNOWN_CLI: &[&str] = &["tips"];
@@ -272,6 +273,10 @@ impl KeybindingsConfig {
 #[derive(Deserialize, Default, Clone)]
 pub struct PlexiConfig {
     pub font_size: Option<f32>,
+    /// Inter-pane gap width in pixels. Default: 4.0. Clamped to [0.0, 20.0].
+    pub pane_gap: Option<f32>,
+    /// Pane title bar font size. Default: 11.0. Clamped to [6.0, 32.0].
+    pub pane_title_font_size: Option<f32>,
     pub theme_preset: Option<String>,
     pub theme: Option<ThemeConfig>,
     pub beta: Option<BetaConfig>,
@@ -804,6 +809,12 @@ impl PlexiConfig {
         }
         if other.confirm_close.is_some() {
             self.confirm_close = other.confirm_close;
+        }
+        if other.pane_gap.is_some() {
+            self.pane_gap = other.pane_gap;
+        }
+        if other.pane_title_font_size.is_some() {
+            self.pane_title_font_size = other.pane_title_font_size;
         }
         match (self.theme.as_mut(), other.theme) {
             (Some(existing), Some(incoming)) => existing.overlay(incoming),

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -35,6 +35,7 @@ pub fn render(
     pane_names: &HashMap<PaneId, String>,
     tab_info: &HashMap<TileId, (usize, usize)>,
     workspace_root: Option<&Path>,
+    pane_title_font_size: f32,
 ) -> bool {
     if terminal.exited {
         let rect = ui.max_rect();
@@ -61,6 +62,7 @@ pub fn render(
         pane_names,
         colors,
         outside_workspace,
+        pane_title_font_size,
     );
 
     let font_size = terminal.font_size;
@@ -102,6 +104,7 @@ fn render_name_bar_and_dots(
     pane_names: &HashMap<PaneId, String>,
     colors: &Colors,
     outside_workspace: bool,
+    name_font_size: f32,
 ) {
     let name_bar_height = 20.0;
     let has_name = pane_names.contains_key(pane_id);
@@ -137,7 +140,7 @@ fn render_name_bar_and_dots(
                 bar_rect.center(),
                 egui::Align2::CENTER_CENTER,
                 name,
-                egui::FontId::proportional(11.0),
+                egui::FontId::proportional(name_font_size),
                 colors.text_dim,
             );
         }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -88,6 +88,10 @@ pub struct PlexiBehavior<'a> {
     pub modal_open: bool,
     /// True when the Control modifier is held — triggers the pane ID ghost overlay.
     pub ctrl_held: bool,
+    /// Resolved inter-pane gap width (from config, default 4.0).
+    pub pane_gap: f32,
+    /// Resolved pane title bar font size (from config, default 11.0).
+    pub pane_title_font_size: f32,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -155,6 +159,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 &self.pane_names,
                 &self.tab_info,
                 self.workspace_root.as_deref(),
+                self.pane_title_font_size,
             );
             if close_exited {
                 self.close_exited = Some(tile_id);
@@ -290,7 +295,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
     }
 
     fn gap_width(&self, _style: &egui::Style) -> f32 {
-        4.0
+        self.pane_gap
     }
 
     fn resize_stroke(&self, _style: &egui::Style, resize_state: ResizeState) -> egui::Stroke {


### PR DESCRIPTION
Closes #724, Closes #803, Closes #1141

## Summary

**#724 — config(tiling): configurable inter-pane gap width**
- Add `pane_gap: Option<f32>` to `PlexiConfig`; default 4.0, clamped 0–20px
- Thread through `PlexiBehavior.pane_gap` and use in `gap_width()` and focus outline stroke

**#803 — ux(pane): configurable pane title bar font size**
- Add `pane_title_font_size: Option<f32>` to `PlexiConfig`; default 11.0, clamped 6–32px
- Thread through `PlexiBehavior.pane_title_font_size` → `terminal_pane::render` → `render_name_bar_and_dots`

**#1141 — ux(pane-focus): exponential opacity flash on pane click**
- Add `ClickFlash` struct alongside `EdgePulse`; store `click_flash: Option<ClickFlash>` on `PlexiApp`
- Both canvas clicks and keyboard navigation via `set_window_focused_pane` trigger the flash
- Focus outline applies `gamma_multiply((1.0 + exp(-t/0.1)).clamp(1.0, 2.0))` for 400ms; drives repaints only while active

## Done When — #724

Setting `pane_gap = 8` in `config.toml` and restarting Plexi results in visibly wider gaps between panes. Setting `pane_gap = 0` produces flush/borderless panes.

## Done When — #803

`pane_title_font_size` in `config.toml` controls the title bar text size. Existing behavior is preserved when the key is absent.

## Done When — #1141

- Clicking any pane produces a visible bright flash on the focus border that decays to normal brightness within ~400ms
- The decay is exponential: pops at click, settles quickly, no hard cutoff artifact
- Keyboard focus navigation triggers the same flash
- No visible jank or extra repaint cost when no animation is in flight