### PR TITLE
feat(sdk/pgap): mouse events missing modifier state — blocks shift-click, cmd-click in apps (#1680)

### DIFF
--- a/apps/dev/input-inspector/input_inspector.py
+++ b/apps/dev/input-inspector/input_inspector.py
@@ -19,6 +19,11 @@ if os.path.isdir(_sdk_path):
 from plexi_sdk import App, RenderContext, BG, SURFACE, HIGHLIGHT, FG, MUTED, ACCENT
 from plexi_sdk import BODY, CAPTION, PAD
 
+def _fmt_mods(mods: dict) -> str:
+    parts = [k[0].upper() for k in ("shift", "ctrl", "alt", "cmd") if mods.get(k)]
+    return "  [" + "+".join(parts) + "]" if parts else ""
+
+
 MAX_EVENTS = 200
 MOVE_LOG_MIN_INTERVAL = 1.0 / 30.0
 SCROLL_LOG_MIN_INTERVAL = 1.0 / 20.0
@@ -96,16 +101,18 @@ class InputInspectorApp(App):
     def on_click(self, ctx: RenderContext, x: float, y: float, button: str) -> None:
         self._push("click", f"click  {button}  ({x:.0f}, {y:.0f})")
 
-    def on_mouse_down(self, ctx: RenderContext, x: float, y: float, button: str) -> None:
+    def on_mouse_down(self, ctx: RenderContext, x: float, y: float, button: str, mods: dict = {}) -> None:  # noqa: ARG002
         if button not in self._held_buttons:
             self._held_buttons.append(button)
-        self._push("mouse_down", f"down   {button}  ({x:.0f}, {y:.0f})")
+        mod_str = _fmt_mods(mods)
+        self._push("mouse_down", f"down   {button}  ({x:.0f}, {y:.0f}){mod_str}")
 
-    def on_mouse_up(self, ctx: RenderContext, x: float, y: float, button: str) -> None:
+    def on_mouse_up(self, ctx: RenderContext, x: float, y: float, button: str, mods: dict = {}) -> None:  # noqa: ARG002
         self._held_buttons = [b for b in self._held_buttons if b != button]
-        self._push("mouse_up", f"up     {button}  ({x:.0f}, {y:.0f})")
+        mod_str = _fmt_mods(mods)
+        self._push("mouse_up", f"up     {button}  ({x:.0f}, {y:.0f}){mod_str}")
 
-    def on_mouse_move(self, ctx: RenderContext, x: float, y: float, buttons: list) -> None:
+    def on_mouse_move(self, ctx: RenderContext, x: float, y: float, buttons: list, mods: dict = {}) -> None:  # noqa: ARG002
         self._mouse_pos = (x, y)
         now = time.monotonic()
         button_state = tuple(buttons)
@@ -114,7 +121,8 @@ class InputInspectorApp(App):
             or button_state != self._last_move_buttons
         ):
             held = ", ".join(buttons) if buttons else "—"
-            self._push("mouse_move", f"move   ({x:.0f}, {y:.0f})  held={held}")
+            mod_str = _fmt_mods(mods)
+            self._push("mouse_move", f"move   ({x:.0f}, {y:.0f})  held={held}{mod_str}")
             self._last_move_log_at = now
             self._last_move_buttons = button_state
 

--- a/apps/dev/node-canvas/main.py
+++ b/apps/dev/node-canvas/main.py
@@ -266,7 +266,7 @@ class NodeCanvas(App):
 
     # ── Mouse events ──────────────────────────────────────────────────────────
 
-    def on_mouse_down(self, _ctx: RenderContext, x: float, y: float, button: str) -> None:
+    def on_mouse_down(self, _ctx: RenderContext, x: float, y: float, button: str, _mods: dict = {}) -> None:
         if button != "primary":
             return
 
@@ -297,7 +297,7 @@ class NodeCanvas(App):
             self._pan_anchor = (x, y, self._cam_x, self._cam_y)
             self.emit.info("node-canvas: pan start")
 
-    def on_mouse_move(self, _ctx: RenderContext, x: float, y: float, _buttons: list) -> None:
+    def on_mouse_move(self, _ctx: RenderContext, x: float, y: float, _buttons: list, _mods: dict = {}) -> None:
         if self._pan_anchor:
             ax, ay, cam_x, cam_y = self._pan_anchor
             self._cam_x = cam_x + (x - ax)
@@ -319,7 +319,7 @@ class NodeCanvas(App):
             self._drag_conn = (fn, fp, x, y)
             self.emit.schedule_render()
 
-    def on_mouse_up(self, _ctx: RenderContext, x: float, y: float, button: str) -> None:
+    def on_mouse_up(self, _ctx: RenderContext, x: float, y: float, button: str, _mods: dict = {}) -> None:
         if button != "primary":
             return
 

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -196,20 +196,25 @@ class LogsApp(App):
                 self._copy_row    = min(self._copy_row, len(filtered) - 1)
                 self._copy_anchor = None
 
-    def on_mouse_down(self, _ctx: RenderContext, _x: float, y: float, button: str) -> None:  # noqa: ARG002
-        if button != "left":
+    def on_mouse_down(self, _ctx: RenderContext, _x: float, y: float, button: str, mods: dict = {}) -> None:  # noqa: ARG002
+        if button not in ("left", "primary"):
             return
         row = self._row_at_y(y)
         if row is None:
             return
         self._copy_mode   = True
-        self._copy_anchor = row
-        self._copy_row    = row
         self._is_dragging = True
-        self.emit.info(f"logs: mouse select started at row {row}")
+        if mods.get("shift") and self._copy_anchor is not None:
+            # Extend existing selection — anchor stays, only row moves.
+            self._copy_row = row
+            self.emit.info(f"logs: shift-click extend selection to row {row}")
+        else:
+            self._copy_anchor = row
+            self._copy_row    = row
+            self.emit.info(f"logs: mouse select started at row {row}")
 
-    def on_mouse_move(self, _ctx: RenderContext, _x: float, y: float, buttons: list) -> None:
-        if not self._is_dragging or "left" not in buttons:
+    def on_mouse_move(self, _ctx: RenderContext, _x: float, y: float, buttons: list, _mods: dict = {}) -> None:  # noqa: ARG002
+        if not self._is_dragging or not any(b in buttons for b in ("left", "primary")):
             self._is_dragging = False
             return
         row = self._row_at_y(y)
@@ -217,8 +222,8 @@ class LogsApp(App):
             self._copy_row = row
             self._ensure_copy_row_visible()
 
-    def on_mouse_up(self, _ctx: RenderContext, _x: float, _y: float, button: str) -> None:  # noqa: ARG002
-        if button == "left":
+    def on_mouse_up(self, _ctx: RenderContext, _x: float, _y: float, button: str, _mods: dict = {}) -> None:  # noqa: ARG002
+        if button in ("left", "primary"):
             self._is_dragging = False
 
     def _row_at_y(self, y: float) -> "int | None":

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -108,9 +108,9 @@ class App:
     Task (dispatched as asyncio tasks — event loop continues):
         on_key(ctx, key, mods)                      — on Key event
         on_click(ctx, x, y, button)                 — on Click event
-        on_mouse_down(ctx, x, y, button)            — on MouseDown event
-        on_mouse_up(ctx, x, y, button)              — on MouseUp event
-        on_mouse_move(ctx, x, y, buttons)           — on MouseMove event
+        on_mouse_down(ctx, x, y, button, mods={})   — on MouseDown event
+        on_mouse_up(ctx, x, y, button, mods={})     — on MouseUp event
+        on_mouse_move(ctx, x, y, buttons, mods={})  — on MouseMove event
         on_command(ctx, text)                        — on Command event
         on_paste(ctx, text)                          — on Paste event
         on_text_submitted(ctx, id, text)             — on TextInput Enter press
@@ -268,9 +268,9 @@ class App:
     def on_render(self, _ctx: RenderContext) -> None: pass
     def on_key(self, _ctx: RenderContext, _key: str, _mods: dict) -> "Coroutine[Any, Any, None] | None": return None
     def on_click(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> "Coroutine[Any, Any, None] | None": return None
-    def on_mouse_down(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> "Coroutine[Any, Any, None] | None": return None
-    def on_mouse_up(self, _ctx: RenderContext, _x: float, _y: float, _button: str) -> "Coroutine[Any, Any, None] | None": return None
-    def on_mouse_move(self, _ctx: RenderContext, _x: float, _y: float, _buttons: list) -> "Coroutine[Any, Any, None] | None": return None
+    def on_mouse_down(self, _ctx: RenderContext, _x: float, _y: float, _button: str, _mods: dict = {}) -> "Coroutine[Any, Any, None] | None": return None
+    def on_mouse_up(self, _ctx: RenderContext, _x: float, _y: float, _button: str, _mods: dict = {}) -> "Coroutine[Any, Any, None] | None": return None
+    def on_mouse_move(self, _ctx: RenderContext, _x: float, _y: float, _buttons: list, _mods: dict = {}) -> "Coroutine[Any, Any, None] | None": return None
     def on_command(self, _ctx: RenderContext, _text: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_paste(self, _ctx: RenderContext, _text: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_pipe_message(self, _ctx: RenderContext, _pipe_id: str, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
@@ -972,19 +972,19 @@ class App:
                 elif t == "mouse_down":
                     ctx = self._make_ctx()
                     await self._dispatch_hook(self.on_mouse_down, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
-                                              ev.get("button", "primary"))
+                                              ev.get("button", "primary"), ev.get("modifiers", {}))
 
                 elif t == "mouse_up":
                     ctx = self._make_ctx()
                     await self._dispatch_hook(self.on_mouse_up, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
-                                              ev.get("button", "primary"))
+                                              ev.get("button", "primary"), ev.get("modifiers", {}))
 
                 elif t == "mouse_move":
                     self._mx = ev.get("x", 0.0)
                     self._my = ev.get("y", 0.0)
                     ctx = self._make_ctx()
                     await self._dispatch_hook(self.on_mouse_move, ctx, ev.get("x", 0.0), ev.get("y", 0.0),
-                                              ev.get("buttons", []))
+                                              ev.get("buttons", []), ev.get("modifiers", {}))
 
                 elif t == "command":
                     ctx = self._make_ctx()

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -84,13 +84,13 @@ pub enum PlexiEvent {
     /// Mouse click at logical coordinates within the app surface.
     Click { x: f32, y: f32, button: MouseButton },
     /// Pointer button pressed (fires on the frame the button goes down).
-    MouseDown { x: f32, y: f32, button: MouseButton },
+    MouseDown { x: f32, y: f32, button: MouseButton, modifiers: Modifiers },
     /// Pointer button released (fires on the frame the button goes up).
-    MouseUp { x: f32, y: f32, button: MouseButton },
+    MouseUp { x: f32, y: f32, button: MouseButton, modifiers: Modifiers },
     /// Pointer moved over the app surface. Only fires when the app has opted in
     /// via `DrawCommand::SetMouseTracking { enabled: true }`. Pane-local
     /// coordinates; `buttons` lists which buttons are currently held.
-    MouseMove { x: f32, y: f32, buttons: Vec<MouseButton> },
+    MouseMove { x: f32, y: f32, buttons: Vec<MouseButton>, modifiers: Modifiers },
     /// User submitted a command via the command bar.
     Command { text: String },
     /// Response to a runtime CapabilityRequest.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1667,6 +1667,13 @@ impl App for ProcessApp {
         if !pill_consumed_click {
             let origin = pane_rect.min;
 
+            // Read frame-level modifier state once; shared by all mouse events
+            // this frame so each event carries the same consistent snapshot.
+            let frame_mods = ui.input(|i| {
+                let m = i.modifiers;
+                Modifiers { shift: m.shift, ctrl: m.ctrl, alt: m.alt, cmd: m.command }
+            });
+
             // MouseDown — fires on the frame the primary or secondary button goes down.
             if let Some(pos) = mouse_response.interact_pointer_pos() {
                 let is_primary_down = ui.input(|i| {
@@ -1678,10 +1685,16 @@ impl App for ProcessApp {
                         && pane_rect.contains(i.pointer.interact_pos().unwrap_or(pos))
                 });
                 if is_primary_down {
+                    log::info!(
+                        "app::{}: mouse_down primary ({:.0},{:.0}) shift={} cmd={}",
+                        self.type_id, pos.x - origin.x, pos.y - origin.y,
+                        frame_mods.shift, frame_mods.cmd
+                    );
                     self.send_event(&PlexiEvent::MouseDown {
                         x: pos.x - origin.x,
                         y: pos.y - origin.y,
                         button: crate::app_protocol::MouseButton::Primary,
+                        modifiers: frame_mods.clone(),
                     });
                     needs_click_repaint = true;
                 }
@@ -1690,6 +1703,7 @@ impl App for ProcessApp {
                         x: pos.x - origin.x,
                         y: pos.y - origin.y,
                         button: crate::app_protocol::MouseButton::Secondary,
+                        modifiers: frame_mods.clone(),
                     });
                     needs_click_repaint = true;
                 }
@@ -1711,6 +1725,7 @@ impl App for ProcessApp {
                         x,
                         y,
                         button: crate::app_protocol::MouseButton::Primary,
+                        modifiers: frame_mods.clone(),
                     });
                     self.send_event(&PlexiEvent::Click {
                         x,
@@ -1724,6 +1739,7 @@ impl App for ProcessApp {
                         x,
                         y,
                         button: crate::app_protocol::MouseButton::Secondary,
+                        modifiers: frame_mods.clone(),
                     });
                     self.send_event(&PlexiEvent::Click {
                         x,
@@ -1757,6 +1773,7 @@ impl App for ProcessApp {
                             x: pos.x - origin.x,
                             y: pos.y - origin.y,
                             buttons,
+                            modifiers: frame_mods.clone(),
                         });
                         needs_tracking_repaint = true;
                     }


### PR DESCRIPTION
Closes #1680

## Summary

- Added `modifiers: Modifiers` field (shift/ctrl/alt/cmd booleans) to `MouseDown`, `MouseUp`, and `MouseMove` PGAP protocol events on the host side (`src/app_protocol.rs` + `src/process_app/mod.rs`)
- Updated Python SDK base class signatures and dispatcher to pass `mods` dict to all three handlers; `mods={}` default preserves backward compat for existing apps
- Logs app `on_mouse_down` now checks `mods.get("shift")` to extend an existing selection vs. starting fresh; input-inspector surfaces modifier state in its event log

## Done When

`on_mouse_down` receives `mods={"shift": True}` when shift is held; shift-click in Logs app extends the selection.

## Notes

- Modifier state is captured once per frame via `ui.input(|i| i.modifiers)` and shared across all mouse events emitted that frame for a consistent snapshot
- `on_mouse_up` and `on_mouse_move` in Logs/node-canvas accept `_mods` but don't act on it — accepting the param is required to avoid `TypeError` from the SDK's positional dispatch