### PR TITLE
feat(cli): plexi demo extended — close, open app, notify, create app (#1754)

### DIFF
--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -35,11 +35,11 @@ pub fn demo_cli() -> i32 {
     eprintln!("\x1b[1;36m");
     eprintln!("  Plexi — Quick Tutorial");
     eprintln!("\x1b[0m");
-    eprintln!("  Two moves. That's all you need to know.");
+    eprintln!("  Seven moves. That's all you need to know.");
     eprintln!();
 
     // Step 1 — split
-    print_step_header(1, 2, "Split a pane");
+    print_step_header(1, 7, "Split a pane");
     eprintln!("    Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
     eprintln!();
 
@@ -61,10 +61,10 @@ pub fn demo_cli() -> i32 {
             return 1;
         }
     };
-    print_step_complete(1, 2);
+    print_step_complete(1, 7);
 
     // Step 2 — navigate
-    print_step_header(2, 2, "Navigate panes");
+    print_step_header(2, 7, "Navigate panes");
     eprintln!("       \x1b[2m^\x1b[0m");
     eprintln!("       K");
     eprintln!("    H     L");
@@ -80,7 +80,7 @@ pub fn demo_cli() -> i32 {
     // Any other pane ID appearing between these two resets the state so that
     // a second ⌘D split cannot satisfy the round-trip without actual navigation.
     let mut saw_split_depart = false;
-    if let Err(e) = poll_event(&events_path, after_split_offset, |kind, obj| {
+    let after_nav_offset = match poll_event(&events_path, after_split_offset, |kind, obj| {
         if kind != "focus_changed" { return false; }
         let Some(pid) = obj.get("pane_id").and_then(|v| v.as_u64()) else { return false };
         if !saw_split_depart {
@@ -95,11 +95,99 @@ pub fn demo_cli() -> i32 {
             false
         }
     }) {
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
+    print_step_complete(2, 7);
+
+    // Step 3 — close pane
+    print_step_header(3, 7, "Close a pane");
+    eprintln!("    Press  \x1b[1m[ \u{2318}W ]\x1b[0m  to close the split pane.");
+    eprintln!();
+    let after_close_offset = match poll_event(&events_path, after_nav_offset, |kind, obj| {
+        if kind == "pane_closed" {
+            if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
+                return id == split_pane_id;
+            }
+        }
+        false
+    }) {
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
+    print_step_complete(3, 7);
+
+    // Step 4 — open an app
+    print_step_header(4, 7, "Open an app");
+    eprintln!("    Open a new split (\x1b[1m\u{2318}D\x1b[0m), then in the new pane run:");
+    eprintln!("    \x1b[1mplexi open balls\x1b[0m");
+    eprintln!();
+    let after_app_offset = match poll_event(&events_path, after_close_offset, |kind, _| {
+        kind == "app_spawned"
+    }) {
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
+    print_step_complete(4, 7);
+
+    // Step 5 — send a notification
+    print_step_header(5, 7, "Send a notification");
+    eprintln!("    In any pane, run:");
+    eprintln!("    \x1b[1mplexi notify --title \"Hello\"\x1b[0m");
+    eprintln!();
+    let after_notify_offset = match poll_event(&events_path, after_app_offset, |kind, _| {
+        kind == "notification_posted"
+    }) {
+        Ok(offset) => offset,
+        Err(e) => {
+            eprintln!("error watching {}: {e}", events_path.display());
+            return 1;
+        }
+    };
+    print_step_complete(5, 7);
+
+    // Step 6 — scaffold a new app (keypress-advance; app init has no event log path)
+    print_step_header(6, 7, "Scaffold a new app");
+    eprintln!("    In any pane, run:");
+    eprintln!("    \x1b[1mplexi app init my-app\x1b[0m");
+    eprintln!();
+    eprintln!("    Then switch back here and press  \x1b[1m[Enter]\x1b[0m  to continue.");
+    eprintln!();
+    {
+        use std::io::BufRead;
+        let _ = std::io::stdin().lock().lines().next();
+    }
+    // Snapshot offset after keypress so step 7 only catches context_created events
+    // that follow — not any that may have been emitted during steps 1–6.
+    let after_app_init_offset = std::fs::metadata(&events_path)
+        .map(|m| m.len())
+        .unwrap_or(after_notify_offset);
+    print_step_complete(6, 7);
+
+    // Step 7 — create a new context
+    print_step_header(7, 7, "Create a context");
+    eprintln!("    In any pane, run:");
+    eprintln!("    \x1b[1mplexi context new\x1b[0m");
+    eprintln!();
+    eprintln!("    Contexts are how you organise work in Plexi.");
+    eprintln!();
+    if let Err(e) = poll_event(&events_path, after_app_init_offset, |kind, _| {
+        kind == "context_created"
+    }) {
         eprintln!("error watching {}: {e}", events_path.display());
         return 1;
     }
 
-    eprintln!("  \x1b[1;32m\u{2713} 2/2 \u{2014} You know Plexi.\x1b[0m");
+    eprintln!("  \x1b[1;32m\u{2713} 7/7 \u{2014} Plexi is yours.\x1b[0m");
     eprintln!();
     log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");
     0

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -142,6 +142,17 @@ pub enum HostEvent {
         direction: String,
         timestamp: String,
     },
+    /// A pane was closed.
+    PaneClosed {
+        pane_id: u64,
+        timestamp: String,
+    },
+    /// A new context was created.
+    ContextCreated {
+        context_id: u64,
+        name: String,
+        timestamp: String,
+    },
 }
 
 // ── Wire envelope ─────────────────────────────────────────────────────────────

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -588,11 +588,6 @@ impl PlexiApp {
                         self.delete_window(ctx_idx);
                     }
                 }
-                log::info!("close_pane_by_id: emitting PaneClosed pane_id={pane_id}");
-                crate::event_log::emit(crate::event_log::HostEvent::PaneClosed {
-                    pane_id,
-                    timestamp: crate::event_log::now_timestamp(),
-                });
                 return;
             }
         }
@@ -692,6 +687,11 @@ impl PlexiApp {
             }
 
             let removed = if let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.remove(tile_id) {
+                log::info!("close_tile: emitting PaneClosed pane_id={pane_id}");
+                crate::event_log::emit(crate::event_log::HostEvent::PaneClosed {
+                    pane_id,
+                    timestamp: crate::event_log::now_timestamp(),
+                });
                 ctx.panes.remove(&pane_id)
             } else {
                 None

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -588,6 +588,11 @@ impl PlexiApp {
                         self.delete_window(ctx_idx);
                     }
                 }
+                log::info!("close_pane_by_id: emitting PaneClosed pane_id={pane_id}");
+                crate::event_log::emit(crate::event_log::HostEvent::PaneClosed {
+                    pane_id,
+                    timestamp: crate::event_log::now_timestamp(),
+                });
                 return;
             }
         }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -294,6 +294,7 @@ impl PlexiApp {
         let new_ctx_idx = self.router.len() - 1;
         self.renaming_window = Some(new_ctx_idx);
         self.rename_buffer = self.router.get(new_ctx_idx).name.clone();
+        self.save_workspace();
         log::info!(
             "new_context_empty: emitting ContextCreated context_id={ctx_id} name={}",
             self.rename_buffer

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -235,6 +235,15 @@ impl PlexiApp {
         self.rename_buffer = ctx_name;
 
         self.save_workspace();
+        log::info!(
+            "new_context: emitting ContextCreated context_id={child_ctx_id} name={}",
+            self.rename_buffer
+        );
+        crate::event_log::emit(crate::event_log::HostEvent::ContextCreated {
+            context_id: child_ctx_id,
+            name: self.rename_buffer.clone(),
+            timestamp: crate::event_log::now_timestamp(),
+        });
     }
 
     /// Fallback path for `new_context` when no non-portal pane is focused:
@@ -285,6 +294,15 @@ impl PlexiApp {
         let new_ctx_idx = self.router.len() - 1;
         self.renaming_window = Some(new_ctx_idx);
         self.rename_buffer = self.router.get(new_ctx_idx).name.clone();
+        log::info!(
+            "new_context_empty: emitting ContextCreated context_id={ctx_id} name={}",
+            self.rename_buffer
+        );
+        crate::event_log::emit(crate::event_log::HostEvent::ContextCreated {
+            context_id: ctx_id,
+            name: self.rename_buffer.clone(),
+            timestamp: crate::event_log::now_timestamp(),
+        });
     }
 
     /// Create a new context at a specific directory path. The terminal pane


### PR DESCRIPTION
Closes #1754

## Summary

- Added `PaneClosed` and `ContextCreated` variants to `event_log::HostEvent`, emitted from `close_pane_by_id` (layout.rs) and both `new_context_wrap_pane` / `new_context_empty` (workspace.rs)
- Extended `demo_cli()` from 2 steps to 7: close pane (⌘W, event-polled), open app (event-polled), notify (event-polled), scaffold app (keypress-advance), context new (event-polled)
- Step 6 uses stdin `read_line` advance since `app init` runs as a CLI subprocess with no event log emission

## Done When

- After ⌘W: prints `✓ 3/7` automatically
- After `plexi open balls` (or any app): prints `✓ 4/7` automatically
- After `plexi notify --title "Hello"`: prints `✓ 5/7` automatically
- After `plexi app init my-app` + Enter: prints `✓ 6/7`
- After `plexi context new`: prints `✓ 7/7 — Plexi is yours.`
- All existing steps (1/7 and 2/7) still pass

## Notes

- `close_pane_by_id` had exactly one `return` site — emit fires before that single return
- `ContextCreated` is emitted after `save_workspace()` in the wrap-pane path, and after `rename_buffer` is set in the empty path — both use `self.rename_buffer` for the name since `ctx_name` is moved earlier
- Step 7 snapshots the event log offset after the Enter keypress so spurious `context_created` events from steps 1–6 can't falsely advance it