### PR TITLE
fix(config): alpha config stays default, beta as staging, add TOML migration (#1587)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ Each build channel is a **fully isolated instance** — its own binary, app bund
 
 **PR builds** are ephemeral isolated instances installed by `just pr-install <N>` from inside the feature worktree. They never capture the bare `plexi` symlink. Remove them after merge with `just pr-clean <N>`.
 
+**Alpha config stays default.** `~/.plexi-alpha/config.toml` is reset to the default template on every `just install`. Never customize it — use beta or main for personal config. PR builds seed from the alpha config, so a customized alpha would pollute every PR channel.
+
+**Beta config is the staging ground.** `~/.plexi-beta/config.toml` is your personal staging config — customize it freely for migration testing and advanced feature exploration. It is NOT reset on install.
+
 **Workspace** (`.plexi/workspace.toml`) is a separate per-project concept — the directory a user initializes with `plexi workspace init` inside their project root. It is not the same as the profile dir. Never run `workspace init` from `~` — it would create `~/.plexi/workspace.toml`, colliding with the main channel profile dir.
 
 **When writing test instructions for a PR build:** use `plexi-pr-<N>` (not `plexi`), and if the feature requires workspace context, direct the user to `cd` into a real project dir first.

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -3,6 +3,8 @@
 # ║  Changes take effect on next launch.                        ║
 # ╚══════════════════════════════════════════════════════════════╝
 
+config_version = 1
+
 font_size = 14.0
 
 # Gap between panes in pixels. Default: 4. Range: 0–20.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -159,7 +159,13 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CONFIG="$profile_dir/config.toml"
-if [ ! -f "$CONFIG" ]; then
+if [[ "$channel" == "alpha" ]]; then
+  # Alpha always runs with the default template — never user-customized.
+  # PR builds seed their config from alpha, so a custom alpha would
+  # pollute every PR channel. Reset on every install.
+  cat "$SCRIPT_DIR/default-config.toml" > "$CONFIG"
+  echo "config: reset to defaults (alpha channel stays default)"
+elif [ ! -f "$CONFIG" ]; then
   ALPHA_CONFIG="$HOME/.plexi-alpha/config.toml"
   if [[ "$channel" == pr-* ]] && [ -f "$ALPHA_CONFIG" ]; then
     cp "$ALPHA_CONFIG" "$CONFIG"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl std::fmt::Display for ConfigDiagnostic {
 }
 
 const KNOWN_TOP_LEVEL: &[&str] = &[
-    "font_size", "theme_preset", "theme", "beta", "log",
+    "config_version", "font_size", "theme_preset", "theme", "beta", "log",
     "notifications", "ai", "confirm_quit", "confirm_close",
     "keybindings", "quick_note", "focus_history_depth", "agents", "cli",
     "pane_gap", "pane_title_font_size",
@@ -272,6 +272,7 @@ impl KeybindingsConfig {
 
 #[derive(Deserialize, Default, Clone)]
 pub struct PlexiConfig {
+    pub config_version: Option<u32>,
     pub font_size: Option<f32>,
     /// Inter-pane gap width in pixels. Default: 4.0. Clamped to [0.0, 20.0].
     pub pane_gap: Option<f32>,
@@ -680,6 +681,72 @@ pub fn build_pythonpath(bundle_sdk: Option<&std::path::Path>) -> String {
 
 pub const CONFIG_TEMPLATE: &str = include_str!("../scripts/default-config.toml");
 
+pub const CURRENT_CONFIG_VERSION: u32 = 1;
+
+/// Migrates an existing config file forward to `CURRENT_CONFIG_VERSION`.
+///
+/// Uses line-based text manipulation to preserve comments. Each version bump
+/// adds a migration arm keyed by the target version. After all migrations run,
+/// the `config_version` line is written back so subsequent calls are no-ops.
+pub fn migrate_config(path: &Path) {
+    let data = match std::fs::read_to_string(path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            log::warn!("config migrate: failed to read {}: {e}", path.display());
+            return;
+        }
+    };
+
+    let current_version = toml::from_str::<PlexiConfig>(&data)
+        .ok()
+        .and_then(|c| c.config_version)
+        .unwrap_or(0);
+
+    if current_version >= CURRENT_CONFIG_VERSION {
+        return;
+    }
+
+    log::info!(
+        "config migrate: {} at v{current_version}, migrating to v{CURRENT_CONFIG_VERSION}",
+        path.display()
+    );
+
+    let mut lines: Vec<String> = data.lines().map(str::to_owned).collect();
+    let mut version = current_version;
+
+    // v0 → v1: add config_version field after the opening comment header
+    if version < 1 {
+        if !lines.iter().any(|l| l.starts_with("config_version")) {
+            let insert_at = lines
+                .iter()
+                .position(|l| !l.starts_with('#') && !l.trim().is_empty())
+                .unwrap_or(0);
+            lines.insert(insert_at, String::new());
+            lines.insert(insert_at, "config_version = 1".to_string());
+        } else {
+            for l in lines.iter_mut() {
+                if l.starts_with("config_version") {
+                    *l = "config_version = 1".to_string();
+                    break;
+                }
+            }
+        }
+        version = 1;
+    }
+
+    let trailing_newline = data.ends_with('\n');
+    let mut updated = lines.join("\n");
+    if trailing_newline {
+        updated.push('\n');
+    }
+
+    match std::fs::write(path, &updated) {
+        Ok(()) => log::info!("config migrate: {} migrated to v{version}", path.display()),
+        Err(e) => log::error!("config migrate: failed to write {}: {e}", path.display()),
+    }
+}
+
 /// Ensures the config file exists, creating it from the default template if not.
 /// Returns the config file path.
 pub fn ensure_config_exists() -> std::path::PathBuf {
@@ -755,6 +822,7 @@ impl PlexiConfig {
                 Err(e) => log::warn!("config: could not write default config to {path:?}: {e}"),
             }
         }
+        migrate_config(&path);
         Self::load_from_path(&path).unwrap_or_default()
     }
 
@@ -1276,6 +1344,46 @@ mod tests {
             merged.theme.as_ref().and_then(|t| t.bg_darkest.clone()),
             Some("#000000".to_string())
         );
+    }
+
+    #[test]
+    fn migrate_config_adds_version_to_v0() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "font_size = 14.0\n").unwrap();
+        migrate_config(&path);
+        let result = fs::read_to_string(&path).unwrap();
+        assert!(
+            result.contains("config_version = 1"),
+            "version should be added: {result}"
+        );
+        assert!(
+            result.contains("font_size = 14.0"),
+            "font_size should be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn migrate_config_no_op_when_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let content = "config_version = 1\nfont_size = 14.0\n";
+        fs::write(&path, content).unwrap();
+        migrate_config(&path);
+        let result = fs::read_to_string(&path).unwrap();
+        assert_eq!(result, content, "should not modify an already-current config");
+    }
+
+    #[test]
+    fn migrate_config_preserves_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let content = "# My comment\nfont_size = 14.0\n";
+        fs::write(&path, content).unwrap();
+        migrate_config(&path);
+        let result = fs::read_to_string(&path).unwrap();
+        assert!(result.contains("# My comment"), "comments should be preserved: {result}");
+        assert!(result.contains("config_version = 1"), "version should be added: {result}");
     }
 
 }


### PR DESCRIPTION
Closes #1587

## Summary

- **Alpha config reset on every install:** `scripts/install.sh` now always overwrites `~/.plexi-alpha/config.toml` with the default template, regardless of whether it already exists. PR builds seed from alpha, so a customized alpha would propagate to every PR channel.
- **Config version migration system:** Added `config_version = 1` to `default-config.toml` and `PlexiConfig` struct. `migrate_config()` in `src/config.rs` uses text-based line manipulation (preserves comments) to migrate existing configs from v0 to v1 by inserting the `config_version` field. Called from `PlexiConfig::load()` at startup — idempotent, no-op after first run.
- **CLAUDE.md documentation:** Added explicit "alpha config stays default, beta is staging" convention to the Build Channels section.

## Done When

- [ ] Alpha profile's config.toml is reset to defaults (or not created) on install
- [ ] Document in CLAUDE.md: "alpha config stays default, beta config is staging"
- [ ] Design config migration approach (version field in TOML, migration functions keyed by version)

## Notes

- `migrate_config` uses line-based text manipulation instead of `toml::to_string_pretty` — the latter would strip all comments from the heavily-documented config file.
- `config_version` is not included in `PlexiConfig::overlay()` since it's a migration artifact, not a user setting.
- `migrate-config.sh` is left unchanged; it handles additive section migrations. The Rust `migrate_config()` handles version-keyed structural migrations.
- Future migrations: add a new `if version < N { ... }` arm to `migrate_config()` and bump `CURRENT_CONFIG_VERSION`.