### PR TITLE
fix(ui/sidebar): breadcrumb overflow + right-edge chips paint into panel border (#1894)

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -40,6 +40,8 @@ impl PlexiApp {
 
         // Breadcrumb bar — only shown when navigated into a sub-context.
         if self.router.current_depth() > 0 {
+            ui.scope(|ui| {
+            ui.set_max_width(ui.available_width());
             ui.horizontal(|ui| {
                 ui.add_space(16.0);
                 let mut path_ids: Vec<u64> = self.router.depth_stack.iter()
@@ -77,6 +79,7 @@ impl PlexiApp {
                         ui.label(RichText::new("\u{203A}").color(self.colors.text_dim));
                     }
                 }
+            });
             });
             ui.separator();
         }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -116,7 +116,7 @@ impl ContextItem {
                 let right_reserve = if action_enabled { ACTION_ZONE_WIDTH + 4.0 } else { 8.0 };
                 let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
                 let count_w = if pane_count > 0 { 18.0 } else { 0.0 };
-                let text_max = (ui.available_width() - right_reserve - badge_w - count_w).max(0.0);
+                let text_max = (ui.available_width() - right_reserve - badge_w - count_w - ui.spacing().item_spacing.x * 2.0).max(0.0);
 
                 // Name + subtitle share truncation zone so neither wraps and adds height.
                 ui.scope(|ui| {
@@ -180,13 +180,16 @@ impl ContextItem {
                             } else {
                                 ui.add_space(11.0);
                             }
-                            ui.add(
-                                egui::Label::new(
-                                    egui::RichText::new(&row.label).size(11.0).color(pane_label_color),
-                                )
-                                .selectable(false)
-                                .truncate(),
-                            );
+                            ui.scope(|ui| {
+                                ui.set_max_width(ui.available_width());
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(&row.label).size(11.0).color(pane_label_color),
+                                    )
+                                    .selectable(false)
+                                    .truncate(),
+                                );
+                            });
                         });
                     });
                     let pane_rect = row_scope.response.rect;


### PR DESCRIPTION
Closes #1894

## Summary

- Wrap breadcrumb `ui.horizontal()` in `ui.scope()` + `set_max_width(available_width())` so buttons constrain to the 220px panel instead of overflowing the right edge
- Subtract `item_spacing.x * 2.0` from `text_max` in the pane-count chip calculation to account for inter-widget spacing that `available_width()` doesn't reflect, eliminating the thin border artifact
- Wrap pane row label in `ui.scope()` + `set_max_width(available_width())` so `.truncate()` has a concrete constraint to truncate against

## Done When

- Breadcrumb with 4+ nested contexts truncates cleanly within the sidebar panel (no overflow past right edge).
- Pane count chips (`2`, `3`, etc.) are fully visible on every context row with no thin vertical line artifact at the panel border.
- Long pane names in the expanded pane list show egui ellipsis truncation and never overflow the panel.
- `cargo build` clean.

## Notes

The `ui.scope()` pattern follows the `description_label` convention from `src/widgets.rs` — setting `set_max_width` on a shared `Ui` corrupts layout of other widgets in the same row, so every width constraint goes inside a scope.