### PR TITLE
fix(host): defer overlay-unsafe app command side effects while modals own input (#1599)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -361,7 +361,8 @@ impl PlexiApp {
 
 #[cfg(test)]
 mod ownership_tests {
-    use crate::app_protocol::ArtifactOpenMode;
+    use crate::app::FocusLayer;
+    use crate::app_protocol::{ArtifactOpenMode, NotifyKind, NotifyScope};
     use crate::app_trait::AppCommand;
     use crate::pane::{AppRuntime, Pane};
     use crate::testing::HostHarness;
@@ -479,6 +480,113 @@ mod ownership_tests {
             } if *sid == pane_id && *cid == 1)
         });
         assert!(found, "QueryContextState must appear in drained commands");
+    }
+
+    /// ShowNotification is overlay-safe: must reach `pending_notifications` even
+    /// when a modal holds keyboard input (otherwise notifications from background
+    /// apps would be silently lost while the user is interacting with a modal).
+    #[test]
+    fn show_notification_safe_while_overlay_active() {
+        let mut h = HostHarness::new();
+        let pane_id = h.add_test_pane();
+        h.run_frames(1); // stabilize tile layout
+
+        // Simulate a modal owning keyboard input.
+        h.app.push_focus_layer(FocusLayer::NotificationModal);
+        h.app.show_notification_modal = true;
+        // Test constructor initialises notifications_enabled = false; enable it so
+        // ShowNotification is not silently dropped by the master-switch guard.
+        h.app.notifications_enabled = true;
+        assert!(h.app.input_captured_by_overlay(), "overlay must be active");
+
+        push_command(
+            &mut h,
+            pane_id,
+            AppCommand::ShowNotification {
+                notify_id: "overlay-safe-notify".to_string(),
+                sender_pane_id: pane_id,
+                source_context_id: 0,
+                level: "info".to_string(),
+                title: "notification while modal open".to_string(),
+                body: String::new(),
+                kind: NotifyKind::Message,
+                options: vec![],
+                input_prompt: None,
+                required: false,
+                priority: 0,
+                scope: NotifyScope::Context,
+                image_inline: None,
+                image_pipe_id: None,
+                timeout_secs: None,
+                on_dismiss: None,
+            },
+        );
+
+        h.run_frames(1);
+
+        let found = h
+            .app
+            .pending_notifications
+            .iter()
+            .any(|n| n.notify_id == "overlay-safe-notify");
+        assert!(
+            found,
+            "ShowNotification must reach pending_notifications immediately even while overlay is active"
+        );
+        assert!(
+            h.app.overlay_held_cmds.is_empty(),
+            "ShowNotification must not be placed in the overlay hold queue"
+        );
+    }
+
+    /// SpawnPane is overlay-unsafe: must be held while a modal owns input and
+    /// released only after the overlay is dismissed.
+    #[test]
+    fn spawn_pane_deferred_while_overlay_active_released_after() {
+        let mut h = HostHarness::new();
+        let pane_id = h.add_test_pane();
+        h.run_frames(1); // stabilize
+
+        // Simulate a modal owning keyboard input.
+        h.app.push_focus_layer(FocusLayer::NotificationModal);
+        h.app.show_notification_modal = true;
+        assert!(h.app.input_captured_by_overlay(), "overlay must be active");
+
+        push_command(
+            &mut h,
+            pane_id,
+            AppCommand::SpawnPane {
+                type_id: "__test_nonexistent__".to_string(),
+                layout: "split".to_string(),
+                args: vec![],
+                pipe_id: None,
+                from_pane_id: Some(pane_id),
+                request_id: Some("defer-test".to_string()),
+                target_context: None,
+            },
+        );
+
+        h.run_frames(1);
+
+        // SpawnPane must be held, not dispatched.
+        assert_eq!(
+            h.app.overlay_held_cmds.len(),
+            1,
+            "SpawnPane must be held in overlay_held_cmds while overlay is active"
+        );
+
+        // Dismiss the modal.
+        h.app.show_notification_modal = false;
+        h.app.pop_focus_layer(&FocusLayer::NotificationModal);
+        assert!(!h.app.input_captured_by_overlay(), "overlay must be inactive after pop");
+
+        h.run_frames(1);
+
+        // Hold queue must be empty — the command was released this frame.
+        assert!(
+            h.app.overlay_held_cmds.is_empty(),
+            "overlay_held_cmds must be empty after overlay releases"
+        );
     }
 
     /// QueryContextState for non-descendant context: the dispatch handler

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -462,6 +462,11 @@ pub struct PlexiApp {
     pub(crate) focus_started_at: Option<std::time::Instant>,
     /// Last observed system theme for auto-switching catppuccin variants (#1776).
     pub(crate) last_system_theme: Option<egui::Theme>,
+    /// App commands held while a modal overlay owns keyboard input. Released and
+    /// dispatched on the first frame where `input_captured_by_overlay()` is false.
+    /// Only overlay-unsafe side effects are held here; safe commands (ShowNotification,
+    /// pipes, queries) are dispatched immediately even during overlay ownership.
+    pub(crate) overlay_held_cmds: Vec<crate::app_trait::AppCommand>,
 }
 
 #[cfg(test)]
@@ -993,6 +998,7 @@ impl PlexiApp {
                     last_logged_focus: None,
                     focus_started_at: None,
                     last_system_theme: None,
+                    overlay_held_cmds: Vec::new(),
 
                 };
                 app.apply_context_transition_effects();
@@ -1169,6 +1175,7 @@ impl PlexiApp {
             last_logged_focus: None,
             focus_started_at: None,
             last_system_theme: None,
+            overlay_held_cmds: Vec::new(),
         };
         app.apply_context_transition_effects();
         app
@@ -1341,6 +1348,7 @@ impl PlexiApp {
             last_logged_focus: None,
             focus_started_at: None,
             last_system_theme: None,
+            overlay_held_cmds: Vec::new(),
         }, pane_ipc_tx)
     }
 
@@ -1430,6 +1438,40 @@ impl PlexiApp {
             .find(|c| c.context_id == context_id)
             .and_then(|c| c.description.clone())
             .unwrap_or_default()
+    }
+}
+
+/// Returns true for app commands that must NOT execute while a modal overlay
+/// owns keyboard input. Safe commands (ShowNotification, pipes, queries) always
+/// dispatch immediately. Unsafe commands (layout/terminal mutations, focus changes)
+/// are held in `overlay_held_cmds` and released on the next modal-free frame.
+fn is_overlay_unsafe_cmd(cmd: &crate::app_trait::AppCommand) -> bool {
+    use crate::app_trait::AppCommand;
+    match cmd {
+        AppCommand::SpawnApp { .. }
+        | AppCommand::SpawnPane { .. }
+        | AppCommand::RequestLinkedTerminal { .. }
+        | AppCommand::RunInLinkedTerminal { .. }
+        | AppCommand::InsertPathToken { .. }
+        | AppCommand::OpenArtifact { .. } => true,
+        AppCommand::DeliverNotifyAction { host_action, .. } => {
+            host_action.as_deref().map(|a| a.starts_with("pane_focus:")).unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+fn overlay_unsafe_cmd_name(cmd: &crate::app_trait::AppCommand) -> &'static str {
+    use crate::app_trait::AppCommand;
+    match cmd {
+        AppCommand::SpawnApp { .. } => "SpawnApp",
+        AppCommand::SpawnPane { .. } => "SpawnPane",
+        AppCommand::RequestLinkedTerminal { .. } => "RequestLinkedTerminal",
+        AppCommand::RunInLinkedTerminal { .. } => "RunInLinkedTerminal",
+        AppCommand::InsertPathToken { .. } => "InsertPathToken",
+        AppCommand::OpenArtifact { .. } => "OpenArtifact",
+        AppCommand::DeliverNotifyAction { .. } => "DeliverNotifyAction(pane_focus)",
+        _ => "unknown",
     }
 }
 
@@ -1545,7 +1587,18 @@ impl eframe::App for PlexiApp {
         // while a modal holds focus. Background apps emitting notifications
         // must reach the queue *now*, not be buffered until the modal
         // closes (which caused the "ghost queue appears on reopen" bug).
-        let deferred_app_cmds = self.drain_all_app_commands();
+        let fresh_cmds = self.drain_all_app_commands();
+        // When the overlay releases, prepend any held unsafe commands so they
+        // execute before new commands this frame (FIFO order preserved).
+        let deferred_app_cmds: Vec<_> = if !self.input_captured_by_overlay() && !self.overlay_held_cmds.is_empty() {
+            let released = std::mem::take(&mut self.overlay_held_cmds);
+            log::info!("app_cmd: releasing {} held command(s) — overlay released", released.len());
+            let mut all = released;
+            all.extend(fresh_cmds);
+            all
+        } else {
+            fresh_cmds
+        };
         self.sync_app_cwd();
 
         // Dispatch any DeliverNotifyAction commands the early modal render
@@ -1555,6 +1608,18 @@ impl eframe::App for PlexiApp {
         // Handle deferred app commands returned from dispatch_app_key_events.
         for cmd in deferred_app_cmds {
             use crate::app_trait::AppCommand;
+            // Hold overlay-unsafe side effects (layout/terminal mutations, focus changes)
+            // while a modal owns input. Safe commands (ShowNotification, pipes, queries)
+            // dispatch immediately. Released on the next modal-free frame.
+            if self.input_captured_by_overlay() && is_overlay_unsafe_cmd(&cmd) {
+                log::info!(
+                    "app_cmd: deferring {} — overlay active ({} total held)",
+                    overlay_unsafe_cmd_name(&cmd),
+                    self.overlay_held_cmds.len() + 1,
+                );
+                self.overlay_held_cmds.push(cmd);
+                continue;
+            }
             match cmd {
                 AppCommand::SpawnApp {
                     type_id,


### PR DESCRIPTION
Closes #1599

## Summary

- Add `overlay_held_cmds: Vec<AppCommand>` to `PlexiApp`; commands that would mutate pane layout, terminal contents, or active focus are deferred here while `input_captured_by_overlay()` is true
- Classify commands as overlay-safe (`ShowNotification`, pipes, queries — dispatch immediately) vs overlay-unsafe (`SpawnApp`, `SpawnPane`, `RequestLinkedTerminal`, `RunInLinkedTerminal`, `InsertPathToken`, `OpenArtifact`, focus-changing `DeliverNotifyAction` — hold and release FIFO on the first modal-free frame)
- Add `is_overlay_unsafe_cmd` / `overlay_unsafe_cmd_name` free functions; log deferrals and releases at `info` level

## Done When

- A HostHarness test proves `ShowNotification` still appears while a modal is active.
- A HostHarness test proves a background `SpawnPane` or linked-terminal command does not execute until the modal closes.
- Notification modal actions still dispatch immediately when selected from the modal itself.
- `cargo test --bin plexi` passes.

## Notes

`drain_all_app_commands()` continues to run every frame unconstrained — the fix is at dispatch time, not drain time, preserving the existing notification-queue behaviour. Modal-originated `DeliverNotifyAction` commands are already dispatched via the `early_modal_cmds` path (before the drain loop) and are unaffected.