### PR TITLE
feat(host): Style O visual pass — styled L1 component widgets (Button, Input, Badge) (#1899)

### DIFF
--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -38,15 +38,18 @@ class CounterTree(App):
                             "type": "button",
                             "node_id": "decrement",
                             "label": "−",
+                            "_l0": {"type": "text", "text": "−"},
                         },
                         {
                             "type": "badge",
                             "label": f"{self.count}",
+                            "_l0": {"type": "text", "text": f"{self.count}"},
                         },
                         {
                             "type": "button",
                             "node_id": "increment",
                             "label": "+",
+                            "_l0": {"type": "text", "text": "+"},
                         },
                     ],
                 },
@@ -55,6 +58,7 @@ class CounterTree(App):
                     "node_id": "label_input",
                     "value": self.label,
                     "placeholder": "Enter a label…",
+                    "_l0": {"type": "text", "text": self.label},
                 },
                 {
                     "type": "text",

--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -1,4 +1,9 @@
-"""Counter app demonstrating the component tree API (epic #1897 B3)."""
+"""Counter app demonstrating the component tree API (epic #1897 B3).
+
+Button/Input nodes are included for visual Style O verification only.
+ComponentEvent routing to Python apps is not yet in the SDK — button
+clicks and input changes have no effect until that is wired up.
+"""
 from plexi_sdk import App, State
 
 

--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -4,6 +4,7 @@ from plexi_sdk import App, State
 
 class CounterTree(App):
     count = State(0)
+    label = State("")
 
     def on_key(self, ctx, key, mods):
         if key in ("up", "="):
@@ -15,12 +16,40 @@ class CounterTree(App):
         ctx.render_tree({
             "type": "stack",
             "direction": "vertical",
+            "gap": 8.0,
             "children": [
                 {
                     "type": "text",
                     "text": f"Count: {self.count}",
                     "size": 18.0,
                     "color": "#cdd6f4",
+                },
+                {
+                    "type": "stack",
+                    "direction": "horizontal",
+                    "gap": 8.0,
+                    "children": [
+                        {
+                            "type": "button",
+                            "node_id": "decrement",
+                            "label": "−",
+                        },
+                        {
+                            "type": "badge",
+                            "label": f"{self.count}",
+                        },
+                        {
+                            "type": "button",
+                            "node_id": "increment",
+                            "label": "+",
+                        },
+                    ],
+                },
+                {
+                    "type": "input",
+                    "node_id": "label_input",
+                    "value": self.label,
+                    "placeholder": "Enter a label…",
                 },
                 {
                     "type": "text",

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -179,31 +179,32 @@ pub(crate) fn render_component_tree(
             let text_h = galley.size().y;
             let btn_w = (text_w + crate::style::SPACE_SM * 2.0).max(48.0);
             let btn_h = text_h + BTN_PAD_V * 2.0;
-            // Allocate layout space, then interact with a stable node_id so
-            // press+release tracking survives across frames (same pattern as
-            // Interactive node — auto-ID from allocate_exact_size is not stable).
             let (rect, _) = ui.allocate_exact_size(egui::vec2(btn_w, btn_h), egui::Sense::hover());
-            let sense = if *disabled { egui::Sense::hover() } else { egui::Sense::click() };
-            let response = ui.interact(rect, egui::Id::new(node_id.as_str()), sense);
+            // The pane-wide ui.interact(pane_rect, ...) registered after this
+            // render pass wins egui's pointer priority. Use raw input instead of
+            // response.hovered()/clicked() to bypass the consumption ordering.
+            let pointer_pos =
+                ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
+            let is_hovered = !*disabled && pointer_pos.map_or(false, |p| rect.contains(p));
+            let is_clicked = is_hovered && ui.input(|i| i.pointer.primary_clicked());
             let painter = ui.painter();
             painter.rect_filled(rect, crate::style::RADIUS_MD, colors.bg_active);
             if !*disabled {
-                let stroke_color =
-                    if response.hovered() { colors.accent } else { colors.border };
+                let stroke_color = if is_hovered { colors.accent } else { colors.border };
                 painter.rect_stroke(
                     rect,
                     crate::style::RADIUS_MD,
                     egui::Stroke::new(1.0, stroke_color),
                     egui::StrokeKind::Inside,
                 );
-                if response.hovered() {
+                if is_hovered {
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
             }
             let text_pos =
                 egui::pos2(rect.center().x - text_w / 2.0, rect.center().y - text_h / 2.0);
             painter.galley(text_pos, galley, text_color);
-            if response.clicked() {
+            if is_clicked {
                 log::info!("render_components: Button click node_id={node_id}");
                 events.push(ComponentEventPayload {
                     node_id: node_id.clone(),

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -179,9 +179,12 @@ pub(crate) fn render_component_tree(
             let text_h = galley.size().y;
             let btn_w = (text_w + crate::style::SPACE_SM * 2.0).max(48.0);
             let btn_h = text_h + BTN_PAD_V * 2.0;
+            // Allocate layout space, then interact with a stable node_id so
+            // press+release tracking survives across frames (same pattern as
+            // Interactive node — auto-ID from allocate_exact_size is not stable).
+            let (rect, _) = ui.allocate_exact_size(egui::vec2(btn_w, btn_h), egui::Sense::hover());
             let sense = if *disabled { egui::Sense::hover() } else { egui::Sense::click() };
-            let (rect, response) =
-                ui.allocate_exact_size(egui::vec2(btn_w, btn_h), sense);
+            let response = ui.interact(rect, egui::Id::new(node_id.as_str()), sense);
             let painter = ui.painter();
             painter.rect_filled(rect, crate::style::RADIUS_MD, colors.bg_active);
             if !*disabled {

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -5,7 +5,7 @@
 //! `Input`, `Interactive`) fire `ComponentEvent`s back to the app via the
 //! returned `Vec<ComponentEventPayload>` (task A3).
 
-use egui::{Color32, Ui};
+use egui::Ui;
 
 use crate::app_protocol::{StackDirection, UiNode};
 use crate::theme::Colors;
@@ -171,11 +171,37 @@ pub(crate) fn render_component_tree(
         // ── L1 sugar ─────────────────────────────────────────────────────────
 
         UiNode::Button { node_id, label, disabled, .. } => {
-            let response = ui.add_enabled(!disabled, egui::Button::new(label.as_str()));
-            if response.clicked() {
-                log::info!(
-                    "render_components: Button click node_id={node_id}"
+            const BTN_PAD_H: f32 = 8.0;
+            const BTN_PAD_V: f32 = 5.0;
+            let text_color = if *disabled { colors.text_dim } else { colors.text_primary };
+            let font_id = egui::FontId::proportional(crate::style::TEXT_BODY);
+            let galley = ui.fonts(|f| f.layout_no_wrap(label.clone(), font_id, text_color));
+            let text_w = galley.size().x;
+            let text_h = galley.size().y;
+            let btn_w = (text_w + BTN_PAD_H * 2.0).max(48.0);
+            let btn_h = text_h + BTN_PAD_V * 2.0;
+            let sense = if *disabled { egui::Sense::hover() } else { egui::Sense::click() };
+            let (rect, response) =
+                ui.allocate_exact_size(egui::vec2(btn_w, btn_h), sense);
+            let painter = ui.painter();
+            painter.rect_filled(rect, crate::style::RADIUS_MD, colors.bg_active);
+            if !*disabled {
+                let stroke_color =
+                    if response.hovered() { colors.accent } else { colors.border };
+                painter.rect_stroke(
+                    rect,
+                    crate::style::RADIUS_MD,
+                    egui::Stroke::new(1.0, stroke_color),
+                    egui::StrokeKind::Inside,
                 );
+                if response.hovered() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
+            }
+            let text_pos = egui::pos2(rect.center().x - text_w / 2.0, rect.min.y + BTN_PAD_V);
+            painter.galley(text_pos, galley, text_color);
+            if response.clicked() {
+                log::info!("render_components: Button click node_id={node_id}");
                 events.push(ComponentEventPayload {
                     node_id: node_id.clone(),
                     event_type: "click".into(),
@@ -186,9 +212,12 @@ pub(crate) fn render_component_tree(
 
         UiNode::Input { node_id, value, placeholder, .. } => {
             let mut val_buf = value.clone();
-            let response = ui.add(
-                egui::TextEdit::singleline(&mut val_buf)
-                    .hint_text(placeholder.as_str()),
+            let response = crate::widgets::styled_text_input(
+                ui,
+                &mut val_buf,
+                placeholder.as_str(),
+                egui::Id::new(node_id.as_str()),
+                colors,
             );
             if response.changed() {
                 log::debug!(
@@ -221,16 +250,24 @@ pub(crate) fn render_component_tree(
                 parse_color(fill).unwrap_or(colors.accent)
             };
             let fg_color = if fg.is_empty() {
-                Color32::from_rgb(0x1e, 0x1e, 0x2e)
+                colors.text_primary
             } else {
-                parse_color(fg).unwrap_or(Color32::from_rgb(0x1e, 0x1e, 0x2e))
+                parse_color(fg).unwrap_or(colors.text_primary)
             };
             egui::Frame::new()
                 .fill(fill_color)
-                .corner_radius(egui::CornerRadius::same(4))
-                .inner_margin(egui::Margin::symmetric(6, 2))
+                .stroke(egui::Stroke::new(1.0, colors.border))
+                .corner_radius(egui::CornerRadius::same(6))
+                .inner_margin(egui::Margin::symmetric(
+                    crate::style::BADGE_PAD_H as i8,
+                    crate::style::BADGE_PAD_V as i8,
+                ))
                 .show(ui, |ui| {
-                    ui.label(egui::RichText::new(label.as_str()).color(fg_color).size(12.0));
+                    ui.label(
+                        egui::RichText::new(label.as_str())
+                            .color(fg_color)
+                            .size(crate::style::TEXT_CAPTION),
+                    );
                 });
         }
 

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -171,14 +171,13 @@ pub(crate) fn render_component_tree(
         // ── L1 sugar ─────────────────────────────────────────────────────────
 
         UiNode::Button { node_id, label, disabled, .. } => {
-            const BTN_PAD_H: f32 = 8.0;
             const BTN_PAD_V: f32 = 5.0;
             let text_color = if *disabled { colors.text_dim } else { colors.text_primary };
             let font_id = egui::FontId::proportional(crate::style::TEXT_BODY);
             let galley = ui.fonts(|f| f.layout_no_wrap(label.clone(), font_id, text_color));
             let text_w = galley.size().x;
             let text_h = galley.size().y;
-            let btn_w = (text_w + BTN_PAD_H * 2.0).max(48.0);
+            let btn_w = (text_w + crate::style::SPACE_SM * 2.0).max(48.0);
             let btn_h = text_h + BTN_PAD_V * 2.0;
             let sense = if *disabled { egui::Sense::hover() } else { egui::Sense::click() };
             let (rect, response) =
@@ -198,7 +197,8 @@ pub(crate) fn render_component_tree(
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
             }
-            let text_pos = egui::pos2(rect.center().x - text_w / 2.0, rect.min.y + BTN_PAD_V);
+            let text_pos =
+                egui::pos2(rect.center().x - text_w / 2.0, rect.center().y - text_h / 2.0);
             painter.galley(text_pos, galley, text_color);
             if response.clicked() {
                 log::info!("render_components: Button click node_id={node_id}");
@@ -257,7 +257,7 @@ pub(crate) fn render_component_tree(
             egui::Frame::new()
                 .fill(fill_color)
                 .stroke(egui::Stroke::new(1.0, colors.border))
-                .corner_radius(egui::CornerRadius::same(6))
+                .corner_radius(egui::CornerRadius::same(crate::style::RADIUS_BADGE as u8))
                 .inner_margin(egui::Margin::symmetric(
                     crate::style::BADGE_PAD_H as i8,
                     crate::style::BADGE_PAD_V as i8,

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -172,23 +172,29 @@ pub(crate) fn render_component_tree(
 
         UiNode::Button { node_id, label, disabled, .. } => {
             const BTN_PAD_V: f32 = 5.0;
-            let text_color = if *disabled { colors.text_dim } else { colors.text_primary };
             let font_id = egui::FontId::proportional(crate::style::TEXT_BODY);
-            let galley = ui.fonts(|f| f.layout_no_wrap(label.clone(), font_id, text_color));
+            // Layout with placeholder color; painter.galley() overrides per-state below.
+            let galley = ui.fonts(|f| {
+                f.layout_no_wrap(label.clone(), font_id, egui::Color32::WHITE)
+            });
             let text_w = galley.size().x;
             let text_h = galley.size().y;
             let btn_w = (text_w + crate::style::SPACE_SM * 2.0).max(48.0);
             let btn_h = text_h + BTN_PAD_V * 2.0;
             let (rect, _) = ui.allocate_exact_size(egui::vec2(btn_w, btn_h), egui::Sense::hover());
-            // The pane-wide ui.interact(pane_rect, ...) registered after this
-            // render pass wins egui's pointer priority. Use raw input instead of
-            // response.hovered()/clicked() to bypass the consumption ordering.
+            // Use raw PointerState — button_down/button_pressed read pointer_events directly
+            // and are not affected by the pane-wide Sense::click_and_drag() widget registered
+            // later at process_app/mod.rs:1676.
             let pointer_pos =
                 ui.input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
             let is_hovered = !*disabled && pointer_pos.map_or(false, |p| rect.contains(p));
-            let is_clicked = is_hovered && ui.input(|i| i.pointer.primary_clicked());
+            let is_down =
+                is_hovered && ui.input(|i| i.pointer.button_down(egui::PointerButton::Primary));
+            let is_just_pressed =
+                is_hovered && ui.input(|i| i.pointer.button_pressed(egui::PointerButton::Primary));
             let painter = ui.painter();
-            painter.rect_filled(rect, crate::style::RADIUS_MD, colors.bg_active);
+            let fill = if is_down { colors.accent } else { colors.bg_active };
+            painter.rect_filled(rect, crate::style::RADIUS_MD, fill);
             if !*disabled {
                 let stroke_color = if is_hovered { colors.accent } else { colors.border };
                 painter.rect_stroke(
@@ -201,11 +207,13 @@ pub(crate) fn render_component_tree(
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
             }
+            let text_color =
+                if *disabled { colors.text_dim } else if is_down { colors.bg_active } else { colors.text_primary };
             let text_pos =
                 egui::pos2(rect.center().x - text_w / 2.0, rect.center().y - text_h / 2.0);
             painter.galley(text_pos, galley, text_color);
-            if is_clicked {
-                log::info!("render_components: Button click node_id={node_id}");
+            if is_just_pressed {
+                log::info!("render_components: Button press node_id={node_id}");
                 events.push(ComponentEventPayload {
                     node_id: node_id.clone(),
                     event_type: "click".into(),


### PR DESCRIPTION
Closes #1899

## Summary

- **Button**: replaced `egui::Button` with painter-based rect — `bg_active` fill, `border`/`accent` stroke on hover, `RADIUS_MD` corners, `text_dim` + no stroke when disabled
- **Input**: replaced bare `TextEdit::singleline` with `crate::widgets::styled_text_input` — accent active border, `bg_active` fill, `RADIUS_MD` corners; `change`/`submit` event shapes unchanged
- **Badge**: standardised to `RADIUS_BADGE` (6px), `BADGE_PAD_H/V` tokens, `colors.text_primary` fg fallback (was hardcoded `#1e1e2e`), adds 1px `border` stroke
- **counter-tree app**: extended with Button, Badge, and Input nodes for immediate visual verification on `plexi-alpha app open counter-tree`

## Done When

- `plexi-alpha app open counter-tree` shows a visually styled Button (filled rounded rect, accent stroke on hover) and Input (elevated border zone) — not plain egui defaults
- `cargo test --bin plexi` green (no regressions)
- `L1::Button` disabled state renders with dim text and no accent stroke

## Notes

- `Color32` import in `render_components.rs` removed — was only used in the Badge fg hardcode that's now replaced with `colors.text_primary`
- Pre-existing test failure `cwd_for_welcome_tab_falls_back_to_window_path_when_no_root` is environment-specific and present on alpha before this branch