### PR TITLE
feat(sdk/python): route ComponentEvent to on_component_event callback (#1904)

### DIFF
--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -10,7 +10,7 @@ class CounterTree(App):
     count = State(0)
     label = State("")
 
-    def on_component_event(self, ctx, node_id, event_type, payload):
+    def on_component_event(self, ctx, node_id, event_type, _payload):
         if event_type == "click":
             if node_id == "increment":
                 self.count += 1
@@ -18,7 +18,7 @@ class CounterTree(App):
                 self.count -= 1
         ctx.info(f"component_event node_id={node_id!r} event_type={event_type!r}")
 
-    def on_key(self, ctx, key, mods):
+    def on_key(self, _ctx, key, _mods):
         if key in ("up", "="):
             self.count += 1
         elif key in ("down", "-"):

--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -1,8 +1,7 @@
 """Counter app demonstrating the component tree API (epic #1897 B3).
 
-Button/Input nodes are included for visual Style O verification only.
-ComponentEvent routing to Python apps is not yet in the SDK — button
-clicks and input changes have no effect until that is wired up.
+Button clicks route through on_component_event (issue #1904).
+Keyboard shortcuts (up/down/+/-) also work.
 """
 from plexi_sdk import App, State
 
@@ -10,6 +9,14 @@ from plexi_sdk import App, State
 class CounterTree(App):
     count = State(0)
     label = State("")
+
+    def on_component_event(self, ctx, node_id, event_type, payload):
+        if event_type == "click":
+            if node_id == "increment":
+                self.count += 1
+            elif node_id == "decrement":
+                self.count -= 1
+        ctx.info(f"component_event node_id={node_id!r} event_type={event_type!r}")
 
     def on_key(self, ctx, key, mods):
         if key in ("up", "="):

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -304,6 +304,7 @@ class App:
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll_delta(self, _ctx: RenderContext, _delta_y: float) -> "Coroutine[Any, Any, None] | None": return None
+    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload) -> "Coroutine[Any, Any, None] | None": return None
     def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when a list_view selection changes via j/k/up/down."""
         return None
@@ -1035,6 +1036,15 @@ class App:
                 elif t == "pipe_message":
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_pipe_message, ctx, ev.get("pipe_id", ""), ev.get("payload"))
+
+                elif t == "component_event":
+                    ctx = self._make_ctx()
+                    self._dispatch_hook_task(
+                        self.on_component_event, ctx,
+                        ev.get("node_id", ""),
+                        ev.get("event_type", ""),
+                        ev.get("payload"),
+                    )
 
                 elif t == "path_changed":
                     ctx = self._make_ctx()

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -304,7 +304,7 @@ class App:
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll_delta(self, _ctx: RenderContext, _delta_y: float) -> "Coroutine[Any, Any, None] | None": return None
-    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload) -> "Coroutine[Any, Any, None] | None": return None
+    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
     def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when a list_view selection changes via j/k/up/down."""
         return None


### PR DESCRIPTION
Closes #1904

## Summary

- Add `on_component_event(ctx, node_id, event_type, payload)` stub to `App` base class so apps can override it without `AttributeError`
- Wire `elif t == "component_event":` into the SDK event dispatch loop — previously these events were silently dropped
- Update `counter-tree` app to demonstrate: clicking the − / + buttons now decrements / increments the count

## Done When

- `plexi-alpha app open counter-tree`: clicking "−" decrements the count, clicking "+" increments it
- `cargo test --bin plexi` green (no Rust changes — no test impact expected)

## Notes

No Rust changes required — the host already emits `component_event` JSON; the SDK was just missing the dispatch case.