### PR TITLE
feat(ui/command-palette): Style O visual pass — type badges on results and keyboard hint footer (#1902)

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -430,6 +430,7 @@ impl PlexiApp {
                                                 &colors,
                                                 |ui| {
                                                     ui.horizontal(|ui| {
+                                                        crate::widgets::key_chip(ui, "ctx", &colors);
                                                         if !workspace_name.is_empty() {
                                                             ui.label(
                                                                 RichText::new(workspace_name.as_str())
@@ -496,11 +497,14 @@ impl PlexiApp {
                                                 is_selected,
                                                 &colors,
                                                 |ui| {
-                                                    crate::render_components::render_component_tree(
-                                                        ui,
-                                                        &row_node,
-                                                        &colors,
-                                                    );
+                                                    ui.horizontal(|ui| {
+                                                        crate::widgets::key_chip(ui, "app", &colors);
+                                                        crate::render_components::render_component_tree(
+                                                            ui,
+                                                            &row_node,
+                                                            &colors,
+                                                        );
+                                                    });
                                                 },
                                             );
 
@@ -519,6 +523,15 @@ impl PlexiApp {
                                     }
                                 }
                             });
+
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            crate::widgets::key_combo_list(ui, &[&["↑↓"]], Some("navigate"), &colors);
+                            ui.add_space(crate::style::SPACE_MD);
+                            crate::widgets::key_combo_list(ui, &[&["↵"]], Some("select"), &colors);
+                            ui.add_space(crate::style::SPACE_MD);
+                            crate::widgets::key_combo_list(ui, &[&["esc"]], Some("dismiss"), &colors);
+                        });
 
                         if let Some(i) = hover_select {
                             if mouse_moved {


### PR DESCRIPTION
Closes #1902

## Summary

- Prepends `key_chip("ctx", ...)` to context/pane result rows in the command palette so each entry shows a styled type badge
- Prepends `key_chip("app", ...)` to app result rows, wrapping the existing `render_component_tree` call in a horizontal layout
- Adds a `ui.separator()` and a horizontal footer row with `key_combo_list` hints (`↑↓ navigate`, `↵ select`, `esc dismiss`) after the scroll area

## Done When

- Opening the command palette (Cmd+P) shows a "ctx" chip prefix on context/pane results and an "app" chip on app results
- A dim footer with ↑↓, ↵, esc key chips appears below the result list
- Existing palette keyboard navigation is unaffected
- `cargo test --bin plexi` green (command_row_node tests pass)

## Notes

- Used three separate `key_combo_list` calls in a horizontal layout with `SPACE_MD` gaps — matches the pattern from `overlays/inspector.rs`
- `build_app_row_node` is unchanged; the chip is injected in the `selectable_row` closure, preserving all existing tests