### PR TITLE
feat(ui/sidebar): Style O visual pass — type badges and status dots on pane rows (#1901)

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -263,6 +263,15 @@ impl AppRuntime {
             app.pending_notification_count = count;
         }
     }
+
+    /// Current lifecycle state — used for sidebar status dots.
+    /// Builtin apps are always Running (they don't have a process lifecycle).
+    pub fn lifecycle_state(&self) -> crate::process_app::LifecycleState {
+        match self {
+            AppRuntime::Process(app) => app.lifecycle.state(),
+            AppRuntime::Builtin(_) => crate::process_app::LifecycleState::Running,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -121,21 +121,41 @@ impl PlexiApp {
             // Build pane rows for the active context — renders inside ContextItem scope.
             let pane_rows: Vec<PaneRowItem> = if is_active && pane_count > 0 {
                 pane_ids.iter().enumerate().map(|(idx, &pane_id)| {
-                    let label = self.windows.iter()
+                    let pane_opt = self.windows.iter()
                         .filter(|w| w.context_id == ctx_id)
-                        .find_map(|w| w.panes.get(&pane_id))
-                        .map(|p| match p {
-                            crate::pane::Pane::Terminal(t) => {
-                                t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1))
-                            }
-                            crate::pane::Pane::App(a) => a.name.clone(),
-                            crate::pane::Pane::Portal(_) => "portal".to_string(),
-                        })
-                        .unwrap_or_else(|| format!("pane {}", idx + 1));
+                        .find_map(|w| w.panes.get(&pane_id));
+                    let (label, kind, status) = match pane_opt {
+                        Some(crate::pane::Pane::Terminal(t)) => (
+                            t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1)),
+                            "Terminal".to_string(),
+                            "running".to_string(),
+                        ),
+                        Some(crate::pane::Pane::App(a)) => {
+                            use crate::process_app::LifecycleState;
+                            let st = match a.runtime.lifecycle_state() {
+                                LifecycleState::Running => "running",
+                                LifecycleState::Booting => "idle",
+                                LifecycleState::Hung | LifecycleState::Crashed | LifecycleState::ProtocolError => "crashed",
+                            };
+                            (a.name.clone(), "App".to_string(), st.to_string())
+                        }
+                        Some(crate::pane::Pane::Portal(_)) => (
+                            "portal".to_string(),
+                            "Portal".to_string(),
+                            "idle".to_string(),
+                        ),
+                        None => (
+                            format!("pane {}", idx + 1),
+                            "Terminal".to_string(),
+                            "idle".to_string(),
+                        ),
+                    };
                     PaneRowItem {
                         pane_id,
                         label,
                         is_focused: focused_pane_idx == Some(idx),
+                        kind,
+                        status,
                     }
                 }).collect()
             } else {

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -43,6 +43,10 @@ pub struct PaneRowItem {
     pub pane_id: u64,
     pub label: String,
     pub is_focused: bool,
+    /// Pane type: "Terminal" | "App" | "Portal"
+    pub kind: String,
+    /// Lifecycle status: "running" | "busy" | "crashed" | "idle" (Portal/unknown)
+    pub status: String,
 }
 
 pub struct ContextItem {
@@ -187,6 +191,23 @@ impl ContextItem {
                         ui.set_width(ui.available_width());
                         ui.horizontal(|ui| {
                             ui.add_space(pane_indent);
+                            // Type badge ("term" / "app" / "portal")
+                            crate::widgets::pane_type_badge(ui, &row.kind, colors);
+                            ui.add_space(4.0);
+                            // Status dot — 5px filled circle
+                            let dot_color = match row.status.as_str() {
+                                "busy" => with_alpha(accent_color, row_alpha),
+                                "running" => with_alpha(Color32::from_rgb(0x4c, 0xaf, 0x50), row_alpha),
+                                "crashed" | "hung" | "error" => with_alpha(colors.danger, row_alpha),
+                                _ => with_alpha(text_dim, row_alpha * 0.5),
+                            };
+                            let dot_radius = 2.5_f32;
+                            let (dot_rect, _) = ui.allocate_exact_size(
+                                Vec2::new(dot_radius * 2.0, dot_radius * 2.0),
+                                Sense::hover(),
+                            );
+                            ui.painter().circle_filled(dot_rect.center(), dot_radius, dot_color);
+                            ui.add_space(4.0);
                             crate::render_components::render_component_tree(ui, &label_node, colors);
                         });
                     });


### PR DESCRIPTION
Closes #1901

## Summary

- Extends `PaneRowItem` with `kind` (Terminal/App/Portal) and `status` (running/busy/crashed/idle) fields
- Adds `lifecycle_state()` method to `AppRuntime` — delegates to `ProcessApp.lifecycle.state()` for process apps, returns `Running` for builtins
- Renders `pane_type_badge()` chip ("term"/"app") + 5px coloured status dot before each expanded pane row label in the sidebar

## Done When

- `plexi-alpha app open counter-tree` (or any App pane in the sidebar) shows "app" chip + coloured status dot on expanded pane rows
- Terminal pane rows show "term" chip + green dot when running
- `cargo test --bin plexi` green

## Notes

- `LifecycleState` has no `Busy`/`Coding` variant (enum: `Booting`, `Running`, `Hung`, `Crashed`, `ProtocolError`) — issue spec was aspirational; mapped `Hung/Crashed/ProtocolError` → "crashed" and `Booting` → "idle"
- Status dot colours: green (#4caf50) for running, accent for busy, danger for crashed/hung/error, text_dim×0.5 for idle