### PR TITLE
feat(ui/overlays): Style O visual pass — confirmation modals (#1903)

### DIFF
--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -28,7 +28,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 10))
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
@@ -104,7 +104,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(egui::Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(20, 16))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -127,9 +127,9 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Close")
                                             .size(12.0)
-                                            .color(self.colors.text_primary),
+                                            .color(self.colors.bg_darkest),
                                     )
-                                    .fill(self.colors.bg_active),
+                                    .fill(self.colors.danger),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -144,7 +144,7 @@ impl PlexiApp {
                                             .size(12.0)
                                             .color(self.colors.text_dim),
                                     )
-                                    .frame(false),
+                                    .fill(self.colors.bg_active),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -307,7 +307,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(colors.bg_sidebar)
                     .stroke(egui::Stroke::new(1.0, colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(20, 16))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -341,9 +341,9 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Close all")
                                             .size(12.0)
-                                            .color(colors.text_primary),
+                                            .color(colors.bg_darkest),
                                     )
-                                    .fill(colors.bg_active),
+                                    .fill(colors.danger),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -356,7 +356,7 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Dissolve")
                                             .size(12.0)
-                                            .color(colors.text_primary),
+                                            .color(colors.text_dim),
                                     )
                                     .fill(colors.bg_active),
                                 )
@@ -373,7 +373,7 @@ impl PlexiApp {
                                             .size(12.0)
                                             .color(colors.text_dim),
                                     )
-                                    .frame(false),
+                                    .fill(colors.bg_active),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -588,7 +588,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -677,7 +677,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);


### PR DESCRIPTION
Closes #1903

## Summary

- Modal frames on close-pane, context-close, quit, rename-pane, and rename-context overlays updated from `R6` (6px) to `RADIUS_LG` (12px) corner radius
- Destructive buttons (Close, Close all) now use `colors.danger` fill with `colors.bg_darkest` text to visually distinguish destructive actions
- Secondary buttons (Cancel, Dissolve, Keep Open) now use `colors.bg_active` fill with `colors.text_dim` text; removed frameless `.frame(false)` style

## Done When

- Close-pane confirm modal shows a red (danger) "Close" button and a secondary-styled "Cancel" button
- Context-close confirm shows red "Close All", secondary "Keep Open"
- Quit confirm shows 12px corner radius (no button — triple-tap counter widget only)
- All modal frames have 12px corner radius
- `cargo test --bin plexi` green

## Notes

- `bg_base` token does not exist in `theme::Colors` — used `bg_darkest` as the darkest background token for contrast against danger fill
- `R6` constant in `src/overlays/mod.rs` is intentionally preserved — other overlays still use it
- The pre-existing `cwd_for_welcome_tab_falls_back_to_window_path_when_no_root` test failure exists on alpha and is unrelated to this change