### PR TITLE
feat: Style O visual pass + SDK ComponentEvent routing (#1901–#1904)

### DIFF
--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -10,7 +10,7 @@ class CounterTree(App):
     count = State(0)
     label = State("")
 
-    def on_component_event(self, ctx, node_id, event_type, payload):
+    def on_component_event(self, ctx, node_id, event_type, _payload):
         if event_type == "click":
             if node_id == "increment":
                 self.count += 1
@@ -18,7 +18,7 @@ class CounterTree(App):
                 self.count -= 1
         ctx.info(f"component_event node_id={node_id!r} event_type={event_type!r}")
 
-    def on_key(self, ctx, key, mods):
+    def on_key(self, _ctx, key, _mods):
         if key in ("up", "="):
             self.count += 1
         elif key in ("down", "-"):

--- a/apps/counter-tree/counter_tree.py
+++ b/apps/counter-tree/counter_tree.py
@@ -1,8 +1,7 @@
 """Counter app demonstrating the component tree API (epic #1897 B3).
 
-Button/Input nodes are included for visual Style O verification only.
-ComponentEvent routing to Python apps is not yet in the SDK — button
-clicks and input changes have no effect until that is wired up.
+Button clicks route through on_component_event (issue #1904).
+Keyboard shortcuts (up/down/+/-) also work.
 """
 from plexi_sdk import App, State
 
@@ -10,6 +9,14 @@ from plexi_sdk import App, State
 class CounterTree(App):
     count = State(0)
     label = State("")
+
+    def on_component_event(self, ctx, node_id, event_type, payload):
+        if event_type == "click":
+            if node_id == "increment":
+                self.count += 1
+            elif node_id == "decrement":
+                self.count -= 1
+        ctx.info(f"component_event node_id={node_id!r} event_type={event_type!r}")
 
     def on_key(self, ctx, key, mods):
         if key in ("up", "="):

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -304,6 +304,7 @@ class App:
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll_delta(self, _ctx: RenderContext, _delta_y: float) -> "Coroutine[Any, Any, None] | None": return None
+    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload) -> "Coroutine[Any, Any, None] | None": return None
     def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when a list_view selection changes via j/k/up/down."""
         return None
@@ -1035,6 +1036,15 @@ class App:
                 elif t == "pipe_message":
                     ctx = self._make_ctx()
                     self._dispatch_hook_task(self.on_pipe_message, ctx, ev.get("pipe_id", ""), ev.get("payload"))
+
+                elif t == "component_event":
+                    ctx = self._make_ctx()
+                    self._dispatch_hook_task(
+                        self.on_component_event, ctx,
+                        ev.get("node_id", ""),
+                        ev.get("event_type", ""),
+                        ev.get("payload"),
+                    )
 
                 elif t == "path_changed":
                     ctx = self._make_ctx()

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -304,7 +304,7 @@ class App:
     def on_timer(self, _ctx: RenderContext, _timer_id: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll(self, _ctx: RenderContext, _id: str, _offset_y: float) -> "Coroutine[Any, Any, None] | None": return None
     def on_scroll_delta(self, _ctx: RenderContext, _delta_y: float) -> "Coroutine[Any, Any, None] | None": return None
-    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload) -> "Coroutine[Any, Any, None] | None": return None
+    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
     def on_list_select(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when a list_view selection changes via j/k/up/down."""
         return None

--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -430,6 +430,7 @@ impl PlexiApp {
                                                 &colors,
                                                 |ui| {
                                                     ui.horizontal(|ui| {
+                                                        crate::widgets::key_chip(ui, "ctx", &colors);
                                                         if !workspace_name.is_empty() {
                                                             ui.label(
                                                                 RichText::new(workspace_name.as_str())
@@ -496,11 +497,14 @@ impl PlexiApp {
                                                 is_selected,
                                                 &colors,
                                                 |ui| {
-                                                    crate::render_components::render_component_tree(
-                                                        ui,
-                                                        &row_node,
-                                                        &colors,
-                                                    );
+                                                    ui.horizontal(|ui| {
+                                                        crate::widgets::key_chip(ui, "app", &colors);
+                                                        crate::render_components::render_component_tree(
+                                                            ui,
+                                                            &row_node,
+                                                            &colors,
+                                                        );
+                                                    });
                                                 },
                                             );
 
@@ -519,6 +523,15 @@ impl PlexiApp {
                                     }
                                 }
                             });
+
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            crate::widgets::key_combo_list(ui, &[&["↑↓"]], Some("navigate"), &colors);
+                            ui.add_space(crate::style::SPACE_MD);
+                            crate::widgets::key_combo_list(ui, &[&["↵"]], Some("select"), &colors);
+                            ui.add_space(crate::style::SPACE_MD);
+                            crate::widgets::key_combo_list(ui, &[&["esc"]], Some("dismiss"), &colors);
+                        });
 
                         if let Some(i) = hover_select {
                             if mouse_moved {

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -28,7 +28,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 10))
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
@@ -104,7 +104,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(egui::Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(20, 16))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -127,9 +127,9 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Close")
                                             .size(12.0)
-                                            .color(self.colors.text_primary),
+                                            .color(self.colors.bg_darkest),
                                     )
-                                    .fill(self.colors.bg_active),
+                                    .fill(self.colors.danger),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -144,7 +144,7 @@ impl PlexiApp {
                                             .size(12.0)
                                             .color(self.colors.text_dim),
                                     )
-                                    .frame(false),
+                                    .fill(self.colors.bg_active),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -307,7 +307,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(colors.bg_sidebar)
                     .stroke(egui::Stroke::new(1.0, colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(crate::style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(20, 16))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -341,9 +341,9 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Close all")
                                             .size(12.0)
-                                            .color(colors.text_primary),
+                                            .color(colors.bg_darkest),
                                     )
-                                    .fill(colors.bg_active),
+                                    .fill(colors.danger),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()
@@ -356,7 +356,7 @@ impl PlexiApp {
                                     egui::Button::new(
                                         RichText::new("Dissolve")
                                             .size(12.0)
-                                            .color(colors.text_primary),
+                                            .color(colors.text_dim),
                                     )
                                     .fill(colors.bg_active),
                                 )
@@ -373,7 +373,7 @@ impl PlexiApp {
                                             .size(12.0)
                                             .color(colors.text_dim),
                                     )
-                                    .frame(false),
+                                    .fill(colors.bg_active),
                                 )
                                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                                 .clicked()

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -588,7 +588,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);
@@ -677,7 +677,7 @@ impl PlexiApp {
                 egui::Frame::new()
                     .fill(self.colors.bg_sidebar)
                     .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
+                    .corner_radius(style::RADIUS_LG)
                     .inner_margin(egui::Margin::symmetric(16, 12))
                     .show(ui, |ui| {
                         ui.set_width(MODAL_WIDTH);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -263,6 +263,15 @@ impl AppRuntime {
             app.pending_notification_count = count;
         }
     }
+
+    /// Current lifecycle state — used for sidebar status dots.
+    /// Builtin apps are always Running (they don't have a process lifecycle).
+    pub fn lifecycle_state(&self) -> crate::process_app::LifecycleState {
+        match self {
+            AppRuntime::Process(app) => app.lifecycle.state(),
+            AppRuntime::Builtin(_) => crate::process_app::LifecycleState::Running,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -121,21 +121,41 @@ impl PlexiApp {
             // Build pane rows for the active context — renders inside ContextItem scope.
             let pane_rows: Vec<PaneRowItem> = if is_active && pane_count > 0 {
                 pane_ids.iter().enumerate().map(|(idx, &pane_id)| {
-                    let label = self.windows.iter()
+                    let pane_opt = self.windows.iter()
                         .filter(|w| w.context_id == ctx_id)
-                        .find_map(|w| w.panes.get(&pane_id))
-                        .map(|p| match p {
-                            crate::pane::Pane::Terminal(t) => {
-                                t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1))
-                            }
-                            crate::pane::Pane::App(a) => a.name.clone(),
-                            crate::pane::Pane::Portal(_) => "portal".to_string(),
-                        })
-                        .unwrap_or_else(|| format!("pane {}", idx + 1));
+                        .find_map(|w| w.panes.get(&pane_id));
+                    let (label, kind, status) = match pane_opt {
+                        Some(crate::pane::Pane::Terminal(t)) => (
+                            t.name.clone().unwrap_or_else(|| format!("terminal {}", idx + 1)),
+                            "Terminal".to_string(),
+                            "running".to_string(),
+                        ),
+                        Some(crate::pane::Pane::App(a)) => {
+                            use crate::process_app::LifecycleState;
+                            let st = match a.runtime.lifecycle_state() {
+                                LifecycleState::Running => "running",
+                                LifecycleState::Booting => "idle",
+                                LifecycleState::Hung | LifecycleState::Crashed | LifecycleState::ProtocolError => "crashed",
+                            };
+                            (a.name.clone(), "App".to_string(), st.to_string())
+                        }
+                        Some(crate::pane::Pane::Portal(_)) => (
+                            "portal".to_string(),
+                            "Portal".to_string(),
+                            "idle".to_string(),
+                        ),
+                        None => (
+                            format!("pane {}", idx + 1),
+                            "Terminal".to_string(),
+                            "idle".to_string(),
+                        ),
+                    };
                     PaneRowItem {
                         pane_id,
                         label,
                         is_focused: focused_pane_idx == Some(idx),
+                        kind,
+                        status,
                     }
                 }).collect()
             } else {

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -43,6 +43,10 @@ pub struct PaneRowItem {
     pub pane_id: u64,
     pub label: String,
     pub is_focused: bool,
+    /// Pane type: "Terminal" | "App" | "Portal"
+    pub kind: String,
+    /// Lifecycle status: "running" | "busy" | "crashed" | "idle" (Portal/unknown)
+    pub status: String,
 }
 
 pub struct ContextItem {
@@ -187,6 +191,23 @@ impl ContextItem {
                         ui.set_width(ui.available_width());
                         ui.horizontal(|ui| {
                             ui.add_space(pane_indent);
+                            // Type badge ("term" / "app" / "portal")
+                            crate::widgets::pane_type_badge(ui, &row.kind, colors);
+                            ui.add_space(4.0);
+                            // Status dot — 5px filled circle
+                            let dot_color = match row.status.as_str() {
+                                "busy" => with_alpha(accent_color, row_alpha),
+                                "running" => with_alpha(Color32::from_rgb(0x4c, 0xaf, 0x50), row_alpha),
+                                "crashed" | "hung" | "error" => with_alpha(colors.danger, row_alpha),
+                                _ => with_alpha(text_dim, row_alpha * 0.5),
+                            };
+                            let dot_radius = 2.5_f32;
+                            let (dot_rect, _) = ui.allocate_exact_size(
+                                Vec2::new(dot_radius * 2.0, dot_radius * 2.0),
+                                Sense::hover(),
+                            );
+                            ui.painter().circle_filled(dot_rect.center(), dot_radius, dot_color);
+                            ui.add_space(4.0);
                             crate::render_components::render_component_tree(ui, &label_node, colors);
                         });
                     });


### PR DESCRIPTION
## Summary

Bundles four related issues into a single PR:

- **#1904 (P1)** `sdk/python`: route `ComponentEvent` to `on_component_event` callback — makes L1 `Button`/`Input` widgets interactive
- **#1901 (P2)** `ui/sidebar`: Style O — type badges (`term`/`app`) and status dots on pane rows
- **#1902 (P2)** `ui/command-palette`: Style O — `ctx`/`app` type chips on results + keyboard hint footer
- **#1903 (P2)** `ui/overlays`: Style O — confirmation modals get danger-red buttons and `RADIUS_LG` frames

## Files changed

| File | Issue |
|---|---|
| `sdk/python/plexi_sdk/_app.py` | #1904 |
| `apps/counter-tree/counter_tree.py` | #1904 |
| `src/pane.rs` | #1901 |
| `src/sidebar.rs` | #1901 |
| `src/sidebar_row.rs` | #1901 |
| `src/command_palette.rs` | #1902 |
| `src/overlays/confirmations.rs` | #1903 |
| `src/overlays/misc.rs` | #1903 |

## Notes

- `LifecycleState` has no `Busy`/`Coding` variant — the "busy" dot colour arm is wired but never fires; reserved for future state.
- `bg_base` token absent in `theme::Colors` — `bg_darkest` used on danger buttons for contrast.
- 676/677 tests pass; 1 pre-existing failure (`welcome_tab_falls_back_to_home_dir_when_no_root`) unrelated to this change.

## Test plan

- [ ] `plexi-pr-1909 app open counter-tree` — clicking `−`/`+` buttons changes the count
- [ ] Sidebar shows `term`/`app` chips + coloured status dots on expanded pane rows
- [ ] Command palette (`Cmd+P`) shows `ctx`/`app` chips on results; keyboard hint footer below list
- [ ] Close-pane confirm shows red "Close" + secondary "Cancel"
- [ ] `cargo test --bin plexi` — 676 pass, 1 pre-existing fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)