### PR TITLE
fix(host): revert Lane E host UI migration -- restore clean sidebar and overlay rendering (#1910)

### DIFF
--- a/src/command_palette.rs
+++ b/src/command_palette.rs
@@ -1,9 +1,7 @@
 use egui::{Align2, Color32, CornerRadius, RichText, Stroke, Vec2};
 
 use crate::app::PlexiApp;
-use crate::app_protocol::{StackDirection, UiNode, UiPadding};
 use crate::overlays::MODAL_WIDTH;
-use crate::theme::Colors;
 use crate::widgets::selectable_row;
 
 enum PaletteEntry {
@@ -484,23 +482,47 @@ impl PlexiApp {
                                                 ui.add_space(2.0);
                                             }
 
-                                            let row_node = build_app_row_node(
-                                                name,
-                                                description,
-                                                *running_in_background,
-                                                *is_workspace_local,
-                                                &colors,
-                                            );
                                             let (r, _) = selectable_row(
                                                 ui,
                                                 is_selected,
                                                 &colors,
                                                 |ui| {
-                                                    crate::render_components::render_component_tree(
-                                                        ui,
-                                                        &row_node,
-                                                        &colors,
-                                                    );
+                                                    ui.horizontal(|ui| {
+                                                        ui.label(
+                                                            RichText::new("⬡")
+                                                                .size(10.0)
+                                                                .color(colors.accent),
+                                                        );
+                                                        ui.add_space(4.0);
+                                                        ui.label(
+                                                            RichText::new(name.as_str())
+                                                                .size(12.0)
+                                                                .color(colors.text_primary),
+                                                        );
+                                                        if *running_in_background {
+                                                            ui.add_space(6.0);
+                                                            ui.label(
+                                                                RichText::new("bg")
+                                                                    .size(9.0)
+                                                                    .color(colors.text_dim),
+                                                            );
+                                                        }
+                                                        if *is_workspace_local {
+                                                            ui.add_space(6.0);
+                                                            ui.label(
+                                                                RichText::new("ws")
+                                                                    .size(9.0)
+                                                                    .color(colors.accent),
+                                                            );
+                                                        }
+                                                    });
+                                                    if !description.is_empty() {
+                                                        ui.label(
+                                                            RichText::new(description.as_str())
+                                                                .size(9.0)
+                                                                .color(colors.text_dim),
+                                                        );
+                                                    }
                                                 },
                                             );
 
@@ -546,7 +568,6 @@ impl PlexiApp {
 
     /// Jump to a window by index, switching context if necessary.
     /// If `pane_id` is provided, also focuses that specific pane in the window.
-
     fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
         let target_ctx_id = self.windows[ctx_idx].context_id;
         if let Some(ctx_idx_sidebar) = self
@@ -586,175 +607,4 @@ impl PlexiApp {
         }
     }
 
-}
-
-// ── Free helpers — component-tree builders ────────────────────────────────────
-
-fn color_hex(c: Color32) -> String {
-    format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-}
-
-/// Build a `UiNode` tree for an app palette row.
-///
-/// Returns a vertical `Stack` with:
-/// - a horizontal name row: hex icon + app name + optional "bg" / "ws" badges
-/// - an optional description line (dim, small)
-///
-/// Extracted so the node construction is testable without a live egui context.
-/// Used by `draw_command_palette` to render `PaletteEntry::App` rows.
-pub(crate) fn build_app_row_node(
-    name: &str,
-    description: &str,
-    running_in_background: bool,
-    is_workspace_local: bool,
-    colors: &Colors,
-) -> UiNode {
-    let mut name_children: Vec<UiNode> = vec![
-        UiNode::Text {
-            text: "⬡".to_string(),
-            size: 10.0,
-            color: color_hex(colors.accent),
-            bold: false,
-            monospace: false,
-        },
-        UiNode::Text {
-            text: name.to_string(),
-            size: 12.0,
-            color: color_hex(colors.text_primary),
-            bold: false,
-            monospace: false,
-        },
-    ];
-    if running_in_background {
-        name_children.push(UiNode::Text {
-            text: "bg".to_string(),
-            size: 9.0,
-            color: color_hex(colors.text_dim),
-            bold: false,
-            monospace: false,
-        });
-    }
-    if is_workspace_local {
-        name_children.push(UiNode::Text {
-            text: "ws".to_string(),
-            size: 9.0,
-            color: color_hex(colors.accent),
-            bold: false,
-            monospace: false,
-        });
-    }
-
-    let name_row = UiNode::Stack {
-        direction: StackDirection::Horizontal,
-        children: name_children,
-        gap: 4.0,
-        padding: UiPadding::default(),
-    };
-
-    if description.is_empty() {
-        name_row
-    } else {
-        UiNode::Stack {
-            direction: StackDirection::Vertical,
-            children: vec![
-                name_row,
-                UiNode::Text {
-                    text: description.to_string(),
-                    size: 9.0,
-                    color: color_hex(colors.text_dim),
-                    bold: false,
-                    monospace: false,
-                },
-            ],
-            gap: 2.0,
-            padding: UiPadding::default(),
-        }
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod command_palette_node_tests {
-    use super::*;
-    use crate::config::ThemeConfig;
-    use crate::theme::Colors;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// The app row node must always include the app name as a `UiNode::Text`.
-    #[test]
-    fn command_row_node_includes_label() {
-        let colors = test_colors();
-        let node = build_app_row_node("MyApp", "", false, false, &colors);
-
-        // Without description the top-level node is the name row (horizontal Stack).
-        let children = match &node {
-            UiNode::Stack { children, direction, .. } => {
-                assert!(matches!(direction, StackDirection::Horizontal));
-                children
-            }
-            _ => panic!("expected UiNode::Stack for name-only row"),
-        };
-
-        // Second child is the app name text.
-        assert!(children.len() >= 2);
-        if let UiNode::Text { text, .. } = &children[1] {
-            assert_eq!(text, "MyApp");
-        } else {
-            panic!("expected UiNode::Text at index 1");
-        }
-    }
-
-    /// When `running_in_background` is true the name row contains a "bg" badge node.
-    #[test]
-    fn command_row_node_includes_bg_badge() {
-        let colors = test_colors();
-        let node = build_app_row_node("Foo", "", true, false, &colors);
-        let children = match &node {
-            UiNode::Stack { children, .. } => children,
-            _ => panic!("expected Stack"),
-        };
-        let has_bg = children.iter().any(|n| {
-            matches!(n, UiNode::Text { text, .. } if text == "bg")
-        });
-        assert!(has_bg, "expected 'bg' badge node");
-    }
-
-    /// When `is_workspace_local` is true the name row contains a "ws" badge node.
-    #[test]
-    fn command_row_node_includes_ws_badge() {
-        let colors = test_colors();
-        let node = build_app_row_node("Bar", "", false, true, &colors);
-        let children = match &node {
-            UiNode::Stack { children, .. } => children,
-            _ => panic!("expected Stack"),
-        };
-        let has_ws = children.iter().any(|n| {
-            matches!(n, UiNode::Text { text, .. } if text == "ws")
-        });
-        assert!(has_ws, "expected 'ws' badge node");
-    }
-
-    /// When a non-empty description is provided the top node is a vertical Stack
-    /// whose second child carries the description text.
-    #[test]
-    fn command_row_node_description_vertical_stack() {
-        let colors = test_colors();
-        let node = build_app_row_node("MyApp", "does stuff", false, false, &colors);
-        match &node {
-            UiNode::Stack { direction, children, .. } => {
-                assert!(matches!(direction, StackDirection::Vertical));
-                assert_eq!(children.len(), 2);
-                if let UiNode::Text { text, .. } = &children[1] {
-                    assert_eq!(text, "does stuff");
-                } else {
-                    panic!("expected description UiNode::Text at index 1");
-                }
-            }
-            _ => panic!("expected vertical Stack when description is non-empty"),
-        }
-    }
 }

--- a/src/minimap.rs
+++ b/src/minimap.rs
@@ -176,16 +176,14 @@ pub fn render_minimap(
         egui::StrokeKind::Inside,
     );
 
-    // Workspace name — rendered via component tree (E2 migration pattern).
+    // Workspace name
     let name_x = panel_rect.center().x - name_w * 0.5;
     let name_y = panel_rect.min.y + padding * 0.5;
-    let name_rect = egui::Rect::from_min_size(
+    ui.painter().galley(
         egui::pos2(name_x, name_y),
-        egui::Vec2::new(name_w, name_h),
+        name_galley,
+        colors.text_primary,
     );
-    let name_node = build_workspace_name_node(workspace_name, colors.text_primary);
-    let mut name_ui = ui.new_child(egui::UiBuilder::new().max_rect(name_rect));
-    crate::render_components::render_component_tree(&mut name_ui, &name_node, colors);
 
     let grid_origin = egui::pos2(
         panel_min.x + (panel_w - grid_pixel_w) * 0.5,
@@ -264,57 +262,4 @@ pub fn render_minimap(
     }
 
     clicked
-}
-
-/// Build a `UiNode::Text` for the minimap workspace name label.
-///
-/// Extracted so the node construction is testable without a live egui context.
-/// Callers render via `render_component_tree` inside a positioned child UI.
-pub(crate) fn build_workspace_name_node(
-    workspace_name: &str,
-    color: egui::Color32,
-) -> crate::app_protocol::UiNode {
-    crate::app_protocol::UiNode::Text {
-        text: workspace_name.to_string(),
-        size: NAME_FONT_SIZE,
-        color: format!(
-            "#{:02x}{:02x}{:02x}{:02x}",
-            color.r(), color.g(), color.b(), color.a()
-        ),
-        bold: false,
-        monospace: false,
-    }
-}
-
-#[cfg(test)]
-mod minimap_component_tree_tests {
-    use super::*;
-
-    /// `build_workspace_name_node` produces a `UiNode::Text` with the correct
-    /// text, size, and a valid hex color string — no egui context required.
-    #[test]
-    fn workspace_name_node_fields() {
-        let color = egui::Color32::from_rgb(0xab, 0xcd, 0xef);
-        let node = build_workspace_name_node("my workspace", color);
-        if let crate::app_protocol::UiNode::Text { text, size, color: color_str, bold, monospace } = node {
-            assert_eq!(text, "my workspace");
-            assert_eq!(size, NAME_FONT_SIZE);
-            assert!(color_str.starts_with('#'), "color should be a hex string, got: {color_str}");
-            assert!(!bold);
-            assert!(!monospace);
-        } else {
-            panic!("expected UiNode::Text");
-        }
-    }
-
-    /// Empty workspace name produces a valid (empty text) node without panicking.
-    #[test]
-    fn workspace_name_node_empty_name() {
-        let node = build_workspace_name_node("", egui::Color32::WHITE);
-        if let crate::app_protocol::UiNode::Text { text, .. } = node {
-            assert_eq!(text, "");
-        } else {
-            panic!("expected UiNode::Text");
-        }
-    }
 }

--- a/src/overlays/inspector.rs
+++ b/src/overlays/inspector.rs
@@ -1,22 +1,4 @@
 use super::*;
-use crate::app_protocol::UiNode;
-
-/// Build a `UiNode::Text` for the pane ID label displayed in each inspector row.
-///
-/// Renders as `#<id>` at caption size with the dim text color.  Extracted so
-/// construction is testable without a live egui context.
-pub(crate) fn build_pane_id_label_node(pane_id: crate::tiling::PaneId, colors: &Colors) -> UiNode {
-    let color_hex = |c: egui::Color32| {
-        format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-    };
-    UiNode::Text {
-        text: format!("#{pane_id}"),
-        size: style::TEXT_CAPTION,
-        color: color_hex(colors.text_dim),
-        bold: false,
-        monospace: false,
-    }
-}
 
 struct PaneRow {
     id: PaneId,
@@ -37,9 +19,11 @@ fn render_inspector_pane_row(
     let row_id = row.id;
     let (row_resp, _) = crate::widgets::selectable_row(ui, is_selected, colors, |ui| {
         ui.horizontal_centered(|ui| {
-            // Pane ID label via component tree.
-            let id_node = build_pane_id_label_node(row_id, colors);
-            crate::render_components::render_component_tree(ui, &id_node, colors);
+            ui.label(
+                RichText::new(format!("#{}", row_id))
+                    .size(style::TEXT_CAPTION)
+                    .color(colors.text_dim),
+            );
             crate::widgets::pane_type_badge(ui, row.kind, colors);
             let display_name: &str = if row.name.is_empty() { row.kind } else { &row.name };
             ui.label(
@@ -719,46 +703,5 @@ impl PlexiApp {
         _ctx: &egui::Context,
     ) -> crate::app_trait::KeyDisposition {
         crate::app_trait::KeyDisposition::Consumed
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod inspector_component_tree_tests {
-    use super::*;
-    use crate::app_protocol::UiNode;
-    use crate::config::ThemeConfig;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// Pane ID label node must be `UiNode::Text` with `#<id>` format at caption size.
-    #[test]
-    fn pane_id_label_node_format() {
-        let colors = test_colors();
-        let node = build_pane_id_label_node(42, &colors);
-        if let UiNode::Text { text, size, bold, monospace, color } = node {
-            assert_eq!(text, "#42");
-            assert_eq!(size, style::TEXT_CAPTION);
-            assert!(!bold);
-            assert!(!monospace);
-            assert!(!color.is_empty(), "color must be set to text_dim hex");
-        } else {
-            panic!("expected UiNode::Text");
-        }
-    }
-
-    /// Pane ID 0 should still render as `#0` without panicking.
-    #[test]
-    fn pane_id_label_node_zero() {
-        let colors = test_colors();
-        let node = build_pane_id_label_node(0, &colors);
-        if let UiNode::Text { text, .. } = node {
-            assert_eq!(text, "#0");
-        } else {
-            panic!("expected UiNode::Text");
-        }
     }
 }

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -170,26 +170,6 @@ fn draw_notification_image(
     }
 }
 
-/// Build a `UiNode::Text` for the notification modal title.
-///
-/// The title is rendered large and bold, centered inside the modal frame.
-/// Extracted so construction is testable without a live egui context.
-pub(crate) fn build_notification_title_node(
-    title: &str,
-    colors: &crate::theme::Colors,
-) -> crate::app_protocol::UiNode {
-    let color_hex = |c: egui::Color32| {
-        format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-    };
-    crate::app_protocol::UiNode::Text {
-        text: title.to_string(),
-        size: style::TEXT_TITLE_XL,
-        color: color_hex(colors.text_primary),
-        bold: true,
-        monospace: false,
-    }
-}
-
 impl PlexiApp {
     pub(crate) fn draw_notification_modal(&mut self, ctx: &egui::Context) -> Vec<AppCommand> {
         use crate::app_protocol::NotifyKind;
@@ -488,12 +468,13 @@ impl PlexiApp {
 
                         ui.add_space(style::SPACE_XL);
 
-                        // Title — centered, large. Node built via component tree.
-                        let title_node =
-                            build_notification_title_node(&notif.title, &self.colors);
+                        // Title — centered, large.
                         ui.vertical_centered(|ui| {
-                            crate::render_components::render_component_tree(
-                                ui, &title_node, &self.colors,
+                            ui.label(
+                                RichText::new(&notif.title)
+                                    .size(style::TEXT_TITLE_XL)
+                                    .color(self.colors.text_primary)
+                                    .strong(),
                             );
                         });
 
@@ -1033,47 +1014,5 @@ impl PlexiApp {
         }
 
         crate::app_trait::KeyDisposition::Consumed
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod notification_modal_component_tree_tests {
-    use super::*;
-    use crate::app_protocol::UiNode;
-    use crate::config::ThemeConfig;
-    use crate::theme::Colors;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// Title node must be a `UiNode::Text` with the correct text, size, and bold flag.
-    #[test]
-    fn notification_title_node_structure() {
-        let colors = test_colors();
-        let node = build_notification_title_node("Hello world", &colors);
-        if let UiNode::Text { text, size, bold, monospace, color } = node {
-            assert_eq!(text, "Hello world");
-            assert_eq!(size, style::TEXT_TITLE_XL);
-            assert!(bold, "title must be bold");
-            assert!(!monospace);
-            assert!(!color.is_empty(), "color must be set");
-        } else {
-            panic!("expected UiNode::Text");
-        }
-    }
-
-    /// Empty title produces an empty-text node rather than erroring.
-    #[test]
-    fn notification_title_node_empty_title() {
-        let colors = test_colors();
-        let node = build_notification_title_node("", &colors);
-        if let UiNode::Text { text, .. } = node {
-            assert_eq!(text, "");
-        } else {
-            panic!("expected UiNode::Text");
-        }
     }
 }

--- a/src/overlays/setup.rs
+++ b/src/overlays/setup.rs
@@ -1,24 +1,4 @@
 use super::*;
-use crate::app_protocol::UiNode;
-
-/// Build a `UiNode::Text` for the welcome screen disclaimer line.
-///
-/// Renders in italic hint style at the dim text colour.  Extracted so
-/// construction is testable without a live egui context.
-pub(crate) fn build_welcome_disclaimer_node(colors: &crate::theme::Colors) -> UiNode {
-    let color_hex = |c: egui::Color32| {
-        format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-    };
-    UiNode::Text {
-        text: "Caution: early-stage passion project. If you encounter \
-               any issues, don't hesitate to reach out."
-            .to_string(),
-        size: style::TEXT_HINT,
-        color: color_hex(colors.text_dim),
-        bold: false,
-        monospace: false,
-    }
-}
 
 impl PlexiApp {
     /// Render the spatial-grid minimap in the top-right corner of the work
@@ -150,10 +130,14 @@ impl PlexiApp {
                         });
                     }
                     ui.add_space(style::SPACE_MD);
-                    // Disclaimer rendered via component tree.
-                    let disclaimer_node = build_welcome_disclaimer_node(&colors);
-                    crate::render_components::render_component_tree(
-                        ui, &disclaimer_node, &colors,
+                    ui.label(
+                        RichText::new(
+                            "Caution: early-stage passion project. If you encounter \
+                             any issues, don't hesitate to reach out.",
+                        )
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim)
+                        .italics(),
                     );
                     ui.add_space(style::SPACE_XL);
 
@@ -445,38 +429,5 @@ impl PlexiApp {
         _ctx: &egui::Context,
     ) -> crate::app_trait::KeyDisposition {
         crate::app_trait::KeyDisposition::Consumed
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod setup_component_tree_tests {
-    use super::*;
-    use crate::app_protocol::UiNode;
-    use crate::config::ThemeConfig;
-    use crate::theme::Colors;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// Disclaimer node must be `UiNode::Text` containing the expected copy.
-    #[test]
-    fn welcome_disclaimer_node_structure() {
-        let colors = test_colors();
-        let node = build_welcome_disclaimer_node(&colors);
-        if let UiNode::Text { text, size, bold, monospace, color } = node {
-            assert!(
-                text.contains("Caution"),
-                "disclaimer must contain 'Caution'"
-            );
-            assert_eq!(size, style::TEXT_HINT);
-            assert!(!bold);
-            assert!(!monospace);
-            assert!(!color.is_empty(), "color must be set");
-        } else {
-            panic!("expected UiNode::Text");
-        }
     }
 }

--- a/src/overlays/toolbar.rs
+++ b/src/overlays/toolbar.rs
@@ -1,40 +1,4 @@
 use super::*;
-use crate::app_protocol::UiNode;
-
-/// Build a `UiNode::Text` for the toolbar version label.
-///
-/// `update_available` controls whether the label renders with the accent
-/// colour and an up-arrow prefix (update pending) or the dim colour and a
-/// plain `vX.Y.Z` format (up-to-date).
-///
-/// Extracted so the node construction is testable without a live egui context.
-pub(crate) fn build_version_label_node(
-    version: &str,
-    update_available: bool,
-    colors: &crate::theme::Colors,
-) -> UiNode {
-    let color_hex = |c: egui::Color32| {
-        format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-    };
-    let (text, color) = if update_available {
-        (
-            format!("\u{2191} v{version}"),
-            color_hex(colors.accent),
-        )
-    } else {
-        (
-            format!("v{version}"),
-            color_hex(colors.text_dim),
-        )
-    };
-    UiNode::Text {
-        text,
-        size: 10.0,
-        color,
-        bold: false,
-        monospace: false,
-    }
-}
 
 impl PlexiApp {
     pub(crate) fn draw_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -81,26 +45,22 @@ impl PlexiApp {
                     self.show_shortcuts = !self.show_shortcuts;
                 }
 
-                let update_avail = self.update_available.is_some();
-                let version_node =
-                    build_version_label_node(env!("CARGO_PKG_VERSION"), update_avail, &self.colors);
-                let version_rich = if let UiNode::Text { text, size, color, bold, .. } = &version_node {
-                    let mut r = RichText::new(text.as_str()).size(*size);
-                    if let Some(c) = crate::process_app::render::parse_color(color) {
-                        r = r.color(c);
-                    }
-                    if *bold { r = r.strong(); }
-                    r
+                let version_label = if self.update_available.is_some() {
+                    RichText::new(format!("\u{2191} v{}", env!("CARGO_PKG_VERSION")))
+                        .size(10.0)
+                        .color(self.colors.accent)
                 } else {
-                    RichText::new(format!("v{}", env!("CARGO_PKG_VERSION"))).size(10.0)
+                    RichText::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+                        .size(10.0)
+                        .color(self.colors.text_dim)
                 };
-                let hover_text = if update_avail {
+                let hover_text = if self.update_available.is_some() {
                     "Update available — click to open changelog"
                 } else {
                     "Changelog"
                 };
                 if ui
-                    .add(egui::Button::new(version_rich).frame(false))
+                    .add(egui::Button::new(version_label).frame(false))
                     .on_hover_cursor(egui::CursorIcon::PointingHand)
                     .on_hover_text(hover_text)
                     .clicked()
@@ -135,51 +95,5 @@ impl PlexiApp {
                 }
             });
         });
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod toolbar_component_tree_tests {
-    use super::*;
-    use crate::config::ThemeConfig;
-    use crate::theme::Colors;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// Up-to-date: label is `v1.2.3`, color is text_dim, no up-arrow.
-    #[test]
-    fn version_label_node_up_to_date() {
-        let colors = test_colors();
-        let node = build_version_label_node("1.2.3", false, &colors);
-        if let UiNode::Text { text, size, bold, monospace, .. } = node {
-            assert_eq!(text, "v1.2.3");
-            assert_eq!(size, 10.0);
-            assert!(!bold);
-            assert!(!monospace);
-        } else {
-            panic!("expected UiNode::Text");
-        }
-    }
-
-    /// Update available: label prefixed with ↑ and uses accent color.
-    #[test]
-    fn version_label_node_update_available() {
-        let colors = test_colors();
-        let node = build_version_label_node("2.0.0", true, &colors);
-        if let UiNode::Text { text, size, color, bold, monospace } = node {
-            assert!(text.contains("2.0.0"), "version must appear in label");
-            assert!(text.contains('\u{2191}'), "up-arrow must appear when update is available");
-            assert_eq!(size, 10.0);
-            assert!(!bold);
-            assert!(!monospace);
-            // Color must be the accent — non-empty hex string.
-            assert!(!color.is_empty(), "color must be set for update-available state");
-        } else {
-            panic!("expected UiNode::Text");
-        }
     }
 }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1,8 +1,6 @@
-use crate::app_protocol::{StackDirection, UiNode, UiPadding};
 use crate::context::WindowMenuAction;
 use crate::sidebar_row::{SidebarAction, ContextItem, PaneRowItem};
-use crate::theme::Colors;
-use egui::{Align, Color32, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
+use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
@@ -49,7 +47,10 @@ impl PlexiApp {
                     .collect();
                 path_ids.push(self.router.active().context_id);
 
+                let dim = path_ids.len() >= 3;
                 let truncate = path_ids.len() >= 5;
+
+                // Indices into path_ids to display. usize::MAX is the ellipsis placeholder.
                 let display_indices: Vec<usize> = if truncate {
                     let last = path_ids.len() - 1;
                     vec![0, usize::MAX, last - 1, last]
@@ -57,21 +58,25 @@ impl PlexiApp {
                     (0..path_ids.len()).collect()
                 };
 
-                // Resolve segment names (usize::MAX → "…" ellipsis placeholder).
-                let segment_names: Vec<String> = display_indices.iter().map(|&idx| {
+                for (pos, &idx) in display_indices.iter().enumerate() {
                     if idx == usize::MAX {
-                        "…".to_string()
+                        ui.label(RichText::new("…").color(self.colors.text_dim));
                     } else {
-                        self.router.iter()
+                        let name = self.router.iter()
                             .find(|c| c.context_id == path_ids[idx])
-                            .map(|c| c.name.clone())
-                            .unwrap_or_else(|| "?".to_string())
+                            .map(|c| c.name.as_str())
+                            .unwrap_or("?");
+                        let text = if dim {
+                            RichText::new(name).color(self.colors.text_dim)
+                        } else {
+                            RichText::new(name)
+                        };
+                        let _ = ui.small_button(text);
                     }
-                }).collect();
-
-                let dim = path_ids.len() >= 3;
-                let crumb_node = build_breadcrumb_node(&segment_names, dim, &self.colors);
-                crate::render_components::render_component_tree(ui, &crumb_node, &self.colors);
+                    if pos < display_indices.len() - 1 {
+                        ui.label(RichText::new("\u{203A}").color(self.colors.text_dim));
+                    }
+                }
             });
             ui.separator();
         }
@@ -423,158 +428,6 @@ impl PlexiApp {
 
         if add_clicked {
             self.new_context();
-        }
-    }
-}
-
-// ── Free helpers — component-tree builders ────────────────────────────────────
-
-fn color_hex(c: Color32) -> String {
-    format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-}
-
-/// Build a `UiNode` for the sidebar breadcrumb bar.
-///
-/// `segments` is the ordered list of context names to display (already
-/// resolved, including `"…"` for truncation placeholders).
-/// `dim` controls whether segment text uses `text_dim` (true) or inherits
-/// the default foreground (false).
-///
-/// Returns a horizontal `Stack` of alternating label nodes and `›` separator
-/// nodes.  Extracted so the node construction is testable without egui.
-pub(crate) fn build_breadcrumb_node(segments: &[String], dim: bool, colors: &Colors) -> UiNode {
-    let text_color = color_hex(colors.text_dim);
-    let sep_color = color_hex(colors.text_dim);
-
-    let mut children: Vec<UiNode> = Vec::new();
-    for (i, seg) in segments.iter().enumerate() {
-        children.push(UiNode::Text {
-            text: seg.clone(),
-            size: 10.0,
-            color: if dim { text_color.clone() } else { String::new() },
-            bold: false,
-            monospace: false,
-        });
-        if i < segments.len() - 1 {
-            children.push(UiNode::Text {
-                text: "\u{203A}".to_string(), // ›
-                size: 10.0,
-                color: sep_color.clone(),
-                bold: false,
-                monospace: false,
-            });
-        }
-    }
-
-    UiNode::Stack {
-        direction: StackDirection::Horizontal,
-        children,
-        gap: 3.0,
-        padding: UiPadding::default(),
-    }
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod sidebar_node_tests {
-    use super::*;
-    use crate::config::ThemeConfig;
-
-    fn test_colors() -> Colors {
-        Colors::from_config(&ThemeConfig::default())
-    }
-
-    /// Breadcrumb node for a two-segment path should contain 3 children
-    /// (label, separator, label).
-    #[test]
-    fn sidebar_header_node_structure() {
-        let colors = test_colors();
-        let segs = vec!["root".to_string(), "child".to_string()];
-        let node = build_breadcrumb_node(&segs, false, &colors);
-
-        match &node {
-            UiNode::Stack { direction, children, gap, .. } => {
-                assert!(matches!(direction, StackDirection::Horizontal));
-                // 2 labels + 1 separator = 3
-                assert_eq!(children.len(), 3, "expected 3 children (label + sep + label)");
-                assert!(*gap > 0.0);
-                // First child is "root"
-                if let UiNode::Text { text, .. } = &children[0] {
-                    assert_eq!(text, "root");
-                } else {
-                    panic!("expected Text at index 0");
-                }
-                // Second child is separator ›
-                if let UiNode::Text { text, .. } = &children[1] {
-                    assert_eq!(text, "\u{203A}");
-                } else {
-                    panic!("expected separator Text at index 1");
-                }
-                // Third child is "child"
-                if let UiNode::Text { text, .. } = &children[2] {
-                    assert_eq!(text, "child");
-                } else {
-                    panic!("expected Text at index 2");
-                }
-            }
-            _ => panic!("expected horizontal Stack"),
-        }
-    }
-
-    /// A single-segment breadcrumb has no separator.
-    #[test]
-    fn breadcrumb_single_segment_no_separator() {
-        let colors = test_colors();
-        let segs = vec!["only".to_string()];
-        let node = build_breadcrumb_node(&segs, false, &colors);
-        match &node {
-            UiNode::Stack { children, .. } => {
-                assert_eq!(children.len(), 1);
-                if let UiNode::Text { text, .. } = &children[0] {
-                    assert_eq!(text, "only");
-                } else {
-                    panic!("expected Text");
-                }
-            }
-            _ => panic!("expected Stack"),
-        }
-    }
-
-    /// When `dim` is true every segment text node has a non-empty color string.
-    #[test]
-    fn breadcrumb_dim_sets_color() {
-        let colors = test_colors();
-        let segs = vec!["a".to_string(), "b".to_string()];
-        let node = build_breadcrumb_node(&segs, true, &colors);
-        match &node {
-            UiNode::Stack { children, .. } => {
-                // Odd-indexed children are separators (always colored); even are segments.
-                for (i, child) in children.iter().enumerate() {
-                    if i % 2 == 0 {
-                        if let UiNode::Text { color, .. } = child {
-                            assert!(!color.is_empty(), "dim segment should have a color string");
-                        }
-                    }
-                }
-            }
-            _ => panic!("expected Stack"),
-        }
-    }
-
-    /// When `dim` is false segment nodes have an empty color (inherit default).
-    #[test]
-    fn breadcrumb_non_dim_empty_color() {
-        let colors = test_colors();
-        let segs = vec!["x".to_string()];
-        let node = build_breadcrumb_node(&segs, false, &colors);
-        match &node {
-            UiNode::Stack { children, .. } => {
-                if let UiNode::Text { color, .. } = &children[0] {
-                    assert!(color.is_empty(), "non-dim segment should have empty color");
-                }
-            }
-            _ => panic!("expected Stack"),
         }
     }
 }

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -1,5 +1,4 @@
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
-use crate::app_protocol::UiNode;
 use crate::theme::Colors;
 
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
@@ -172,22 +171,22 @@ impl ContextItem {
                     } else {
                         with_alpha(text_dim, row_alpha * 0.75)
                     };
-                    // Pane label — rendered via component tree (E2 migration pattern).
-                    // The focus indicator glyph and truncating label are each a
-                    // `UiNode::Text`; both are laid out inside a horizontal stack so
-                    // visual output is identical to the previous direct-egui path.
-                    // TODO E3/E4: full migration of ContextItem name row pending.
-                    let label_node = build_pane_label_node(
-                        &row.label,
-                        row.is_focused,
-                        pane_label_color,
-                        with_alpha(accent_color, row_alpha),
-                    );
                     let row_scope = ui.scope(|ui| {
                         ui.set_width(ui.available_width());
                         ui.horizontal(|ui| {
                             ui.add_space(pane_indent);
-                            crate::render_components::render_component_tree(ui, &label_node, colors);
+                            if row.is_focused {
+                                ui.label(egui::RichText::new("▸").size(9.0).color(with_alpha(accent_color, row_alpha)));
+                            } else {
+                                ui.add_space(11.0);
+                            }
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(&row.label).size(11.0).color(pane_label_color),
+                                )
+                                .selectable(false)
+                                .truncate(),
+                            );
                         });
                     });
                     let pane_rect = row_scope.response.rect;
@@ -308,110 +307,5 @@ impl ContextItem {
         };
 
         (action, response)
-    }
-}
-
-/// Build a `UiNode` for a single pane row label inside an expanded context.
-///
-/// Returns a horizontal `Stack` with:
-/// - a focus indicator glyph (`▸` or a blank spacer) as `UiNode::Text`
-/// - the pane label as `UiNode::Text`
-///
-/// Extracted so the node construction is testable without a live egui context.
-pub(crate) fn build_pane_label_node(
-    label: &str,
-    is_focused: bool,
-    label_color: Color32,
-    accent_color: Color32,
-) -> UiNode {
-    let color_hex = |c: Color32| {
-        format!("#{:02x}{:02x}{:02x}{:02x}", c.r(), c.g(), c.b(), c.a())
-    };
-
-    let indicator = UiNode::Text {
-        text: if is_focused { "▸".to_string() } else { "   ".to_string() },
-        size: 9.0,
-        color: color_hex(if is_focused { accent_color } else { Color32::TRANSPARENT }),
-        bold: false,
-        monospace: false,
-    };
-
-    let name = UiNode::Text {
-        text: label.to_string(),
-        size: 11.0,
-        color: color_hex(label_color),
-        bold: false,
-        monospace: false,
-    };
-
-    UiNode::Stack {
-        direction: crate::app_protocol::StackDirection::Horizontal,
-        children: vec![indicator, name],
-        gap: 0.0,
-        padding: crate::app_protocol::UiPadding::default(),
-    }
-}
-
-#[cfg(test)]
-mod sidebar_row_component_tree_tests {
-    use super::*;
-
-    /// `build_pane_label_node` returns a horizontal Stack with two Text children.
-    #[test]
-    fn pane_label_node_structure() {
-        let label_color = Color32::from_rgb(0xaa, 0xbb, 0xcc);
-        let accent_color = Color32::from_rgb(0x11, 0x22, 0x33);
-        let node = build_pane_label_node("my pane", true, label_color, accent_color);
-        if let UiNode::Stack { direction, children, gap, .. } = node {
-            assert_eq!(direction, crate::app_protocol::StackDirection::Horizontal);
-            assert_eq!(children.len(), 2);
-            assert_eq!(gap, 0.0);
-            // First child: focus indicator glyph
-            if let UiNode::Text { text, size, .. } = &children[0] {
-                assert_eq!(text, "▸");
-                assert_eq!(*size, 9.0);
-            } else {
-                panic!("expected UiNode::Text for indicator");
-            }
-            // Second child: pane label
-            if let UiNode::Text { text, size, .. } = &children[1] {
-                assert_eq!(text, "my pane");
-                assert_eq!(*size, 11.0);
-            } else {
-                panic!("expected UiNode::Text for label");
-            }
-        } else {
-            panic!("expected UiNode::Stack");
-        }
-    }
-
-    /// Non-focused rows use a blank spacer as the indicator.
-    #[test]
-    fn pane_label_node_unfocused_spacer() {
-        let node = build_pane_label_node("pane2", false, Color32::WHITE, Color32::WHITE);
-        if let UiNode::Stack { children, .. } = node {
-            if let UiNode::Text { text, .. } = &children[0] {
-                assert_ne!(text, "▸", "unfocused row must not show the focus glyph");
-            } else {
-                panic!("expected UiNode::Text");
-            }
-        } else {
-            panic!("expected UiNode::Stack");
-        }
-    }
-
-    /// Empty label produces a valid node without panicking.
-    #[test]
-    fn pane_label_node_empty_label() {
-        let node = build_pane_label_node("", false, Color32::WHITE, Color32::WHITE);
-        if let UiNode::Stack { children, .. } = node {
-            if let UiNode::Text { text, .. } = &children[1] {
-                assert_eq!(text, "");
-            } else {
-                panic!("expected UiNode::Text for label");
-            }
-        } else {
-            panic!("expected UiNode::Stack");
-        }
     }
 }


### PR DESCRIPTION
Closes #1910

## Summary

- Reverts Lane E (E2/E3/E4) from the Agent App Platform epic (#1898) -- the component model is for apps, not host chrome
- Restores sidebar breadcrumbs, pane labels, minimap workspace name, command palette app rows, and 4 overlay modules to direct egui rendering
- Lanes A-D (protocol, SDK, broker, distribution) and E1 (overlay module split) are untouched
- Net: -810 lines, +99 lines across 8 files

## Done When

- Sidebar renders context names with path and dots only -- no type badges, no UiNode-based breadcrumbs, no pane counts
- Overlays render via direct egui, not render_component_tree()
- `cargo test --bin plexi` green
- `counter-tree` example app still renders via component tree (app rendering path intact)
- No `UiNode` imports remain in sidebar.rs, sidebar_row.rs, minimap.rs, command_palette.rs, or overlay modules

## Notes

- The only remaining `app_protocol` reference in reverted files is `NotifyKind` in notification_modal.rs (Lane C, not Lane E)
- 1 pre-existing test failure (`cwd_for_welcome_tab`) unrelated to this change
- Follow-up: close #1901, #1902, #1894 as superseded after merge