### PR TITLE
fix(scratchpad): use $EDITOR/$VISUAL, spawn new terminal pane (#1920)

### DIFF
--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -1,6 +1,5 @@
 use super::pane::pane_send_cli;
-
-use super::{binary_in_path};
+use super::binary_in_path;
 
 pub fn notes_list_cli() -> i32 {
     let notes_dir = crate::config::config_dir().join("notes");
@@ -75,7 +74,7 @@ pub fn notes_open_cli() -> i32 {
         }
     };
 
-    let editor = if binary_in_path("micro") { "micro" } else if binary_in_path("nano") { "nano" } else { "vim" };
+    let editor = crate::pane_ops::create::preferred_editor();
     let cmd = format!(
         "selected=$(ls -t {notes_dir_str}/*.md 2>/dev/null | fzf --header='Select note'); [ -n \"$selected\" ] && {editor} \"$selected\"\r"
     );

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -988,7 +988,7 @@ impl PlexiApp {
     ///
     /// Spawns a fresh horizontal-split terminal running `$EDITOR <scratchpad>` so the
     /// command works from any focused pane type (terminal, app, file browser, etc.).
-    /// The scratchpad file persists at `<config_dir>/scratchpad.md` across sessions.
+    /// The scratchpad file is a timestamped note under `<config_dir>/notes/`.
     pub(crate) fn open_scratchpad(&mut self) {
         let path = scratchpad_file();
         if let Some(parent) = path.parent() {
@@ -1000,7 +1000,10 @@ impl PlexiApp {
         let path_str = path.display().to_string();
         let editor = preferred_editor();
         log::info!("scratchpad: spawning terminal pane with '{editor} {path_str}'");
-        let args = vec![editor.clone(), path_str];
+        // Split editor command into tokens so multi-word values like "code --wait"
+        // are passed as separate args — shell_join quotes each element individually.
+        let mut args: Vec<String> = editor.split_whitespace().map(str::to_string).collect();
+        args.push(path_str);
         if let Err(e) = self.launch_app_by_id_with_layout(
             "terminal",
             Some("split_h".to_string()),

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1983,7 +1983,12 @@ pub(crate) fn preferred_editor() -> String {
     for var in ["VISUAL", "EDITOR"] {
         if let Ok(val) = std::env::var(var) {
             let bin = val.split_whitespace().next().unwrap_or("").to_string();
-            if !bin.is_empty() && cli_binary_in_path(&bin) {
+            let exists = if bin.contains('/') {
+                std::path::Path::new(&bin).is_file()
+            } else {
+                cli_binary_in_path(&bin)
+            };
+            if !bin.is_empty() && exists {
                 return val;
             }
         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -984,47 +984,31 @@ impl PlexiApp {
         self.open_builtin_app_pane(app, perms, cwd, None, Some("overlay"), None);
     }
 
-    /// Open a terminal editor in the focused pane for scratchpad editing.
+    /// Open a terminal editor in a new terminal pane for scratchpad editing.
     ///
-    /// Injects `micro <path>` (or `nano` fallback) into the focused terminal's PTY.
+    /// Spawns a fresh horizontal-split terminal running `$EDITOR <scratchpad>` so the
+    /// command works from any focused pane type (terminal, app, file browser, etc.).
     /// The scratchpad file persists at `<config_dir>/scratchpad.md` across sessions.
     pub(crate) fn open_scratchpad(&mut self) {
-        let active = self.active_window;
-
-        let focused_tile = match self.windows[active].focused_pane {
-            Some(t) => t,
-            None => {
-                log::warn!("scratchpad: no focused pane — ignored");
-                return;
-            }
-        };
-        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
-            Some(egui_tiles::Tile::Pane(id)) => *id,
-            _ => {
-                log::warn!("scratchpad: focused tile is not a pane — ignored");
-                return;
-            }
-        };
-        let Some(term) = self.windows[active].panes.get_mut(&pane_id).and_then(Pane::as_terminal_mut) else {
-            log::warn!("scratchpad: focused pane {pane_id} is not a terminal — ignored");
-            return;
-        };
-
         let path = scratchpad_file();
         if let Some(parent) = path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 log::warn!("scratchpad: could not create notes dir {:?}: {e}", parent);
-            } else {
-                log::info!("scratchpad: notes dir {:?} ready", parent);
+                return;
             }
         }
         let path_str = path.display().to_string();
-        let escaped = crate::shell::shell_quote(&path_str);
         let editor = preferred_editor();
-
-        let cmd = format!("{editor} {escaped}\r");
-        log::info!("scratchpad: injecting '{editor} {escaped}' into terminal pane {pane_id}");
-        term.backend.process_command(BackendCommand::Write(cmd.into_bytes()));
+        log::info!("scratchpad: spawning terminal pane with '{editor} {path_str}'");
+        let args = vec![editor.clone(), path_str];
+        if let Err(e) = self.launch_app_by_id_with_layout(
+            "terminal",
+            Some("split_h".to_string()),
+            &args,
+            None,
+        ) {
+            log::error!("scratchpad: failed to spawn terminal pane: {e}");
+        }
     }
 
     /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
@@ -1987,12 +1971,24 @@ fn scratchpad_file() -> PathBuf {
     crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
 }
 
-/// Resolve the preferred terminal editor: `micro` if available, else `nano`, then `vim`.
-fn preferred_editor() -> &'static str {
-    for editor in ["micro", "nano", "vim"] {
-        if cli_binary_in_path(editor) {
-            return editor;
+/// Resolve the preferred terminal editor.
+///
+/// Checks `$VISUAL` then `$EDITOR` (standard Unix convention) first. Falls back to
+/// probing `micro`, `nano`, `vim` in PATH if neither env var is set or the named binary
+/// is not found.
+pub(crate) fn preferred_editor() -> String {
+    for var in ["VISUAL", "EDITOR"] {
+        if let Ok(val) = std::env::var(var) {
+            let bin = val.split_whitespace().next().unwrap_or("").to_string();
+            if !bin.is_empty() && cli_binary_in_path(&bin) {
+                return val;
+            }
         }
     }
-    "nano"
+    for editor in ["micro", "nano", "vim"] {
+        if cli_binary_in_path(editor) {
+            return editor.to_string();
+        }
+    }
+    "nano".to_string()
 }

--- a/src/pane_ops/mod.rs
+++ b/src/pane_ops/mod.rs
@@ -11,7 +11,7 @@
 //! `PlexiApp` regardless of file, so call sites elsewhere in the crate are
 //! unchanged.
 
-mod create;
+pub(crate) mod create;
 mod layout;
 mod workspace;
 


### PR DESCRIPTION
Closes #1920

## Summary

- Rewrote `preferred_editor()` to check `$VISUAL` then `$EDITOR` env vars first (standard Unix convention), falling back to the existing micro → nano → vim probe only when neither is set
- Rewrote `open_scratchpad()` to spawn a new horizontal-split terminal pane via `launch_app_by_id_with_layout("terminal", "split_h", ...)` instead of injecting into the focused PTY — works from any pane type (app, file browser, terminal)
- Deduplicated editor resolution in `src/cli/notes.rs` to call the shared `preferred_editor()` helper

## Done When

- Cmd+Shift+Space while focused on a file browser pane opens a new terminal pane running `$EDITOR <scratchpad>` (no "not a terminal" warning in log)
- If `EDITOR=hx` is set in the environment, `hx` is launched (not micro)
- If `EDITOR` is unset, micro/nano/vim fallback chain still works
- `cargo test --bin plexi` is green

## Notes

Made `pane_ops::create` module `pub(crate)` to allow `notes.rs` to call `preferred_editor()` — previously the module was private. The pre-existing `draw_triple_tap_overlay` build error is unrelated to this change and present on alpha base.