### PR TITLE
feat(scratchpad): native text-editor builtin pane, open from any pane type (#1920)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod file_browser;
 mod host;
 mod keys;
 mod launch_failed;
+mod text_editor_app;
 mod logging;
 #[cfg(target_os = "macos")]
 mod finder_service;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1962,11 +1962,9 @@ mod quick_note_tests {
     }
 }
 
-/// Timestamped scratchpad file path: `<config_dir>/notes/YYYY-MM-DD_HHMMSS.md`.
+/// Static scratchpad file path: `<config_dir>/notes/scratch.md`.
 fn scratchpad_file() -> PathBuf {
-    use chrono::Local;
-    let timestamp = Local::now().format("%Y-%m-%d_%H%M%S").to_string();
-    crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
+    crate::config::config_dir().join("notes").join("scratch.md")
 }
 
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -24,8 +24,15 @@ use std::path::PathBuf;
 /// `launch_app_by_id_with_layout` requires no further changes.
 ///
 /// `"terminal"` is intentionally absent — it is a PTY pane, not an `App`.
-fn builtin_factory(_id: &str, _args: &[String]) -> Option<Box<dyn App>> {
-    match _id {
+fn builtin_factory(id: &str, args: &[String]) -> Option<Box<dyn App>> {
+    match id {
+        "text-editor" => {
+            let path = args
+                .first()
+                .map(|s| std::path::PathBuf::from(s))
+                .unwrap_or_else(|| crate::config::config_dir().join("notes").join("scratch.md"));
+            Some(Box::new(crate::text_editor_app::TextEditorApp::new(path)))
+        }
         _ => None,
     }
 }
@@ -984,47 +991,22 @@ impl PlexiApp {
         self.open_builtin_app_pane(app, perms, cwd, None, Some("overlay"), None);
     }
 
-    /// Open a terminal editor in the focused pane for scratchpad editing.
+    /// Open a native text-editor pane for scratchpad editing.
     ///
-    /// Injects `micro <path>` (or `nano` fallback) into the focused terminal's PTY.
-    /// The scratchpad file persists at `<config_dir>/scratchpad.md` across sessions.
+    /// Launches the built-in `text-editor` app pane with the scratchpad file path.
+    /// Works from any focused pane type (terminal, app, file browser).
     pub(crate) fn open_scratchpad(&mut self) {
-        let active = self.active_window;
-
-        let focused_tile = match self.windows[active].focused_pane {
-            Some(t) => t,
-            None => {
-                log::warn!("scratchpad: no focused pane — ignored");
-                return;
-            }
-        };
-        let pane_id = match self.windows[active].tree.tiles.get(focused_tile) {
-            Some(egui_tiles::Tile::Pane(id)) => *id,
-            _ => {
-                log::warn!("scratchpad: focused tile is not a pane — ignored");
-                return;
-            }
-        };
-        let Some(term) = self.windows[active].panes.get_mut(&pane_id).and_then(Pane::as_terminal_mut) else {
-            log::warn!("scratchpad: focused pane {pane_id} is not a terminal — ignored");
-            return;
-        };
-
         let path = scratchpad_file();
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                log::warn!("scratchpad: could not create notes dir {:?}: {e}", parent);
-            } else {
-                log::info!("scratchpad: notes dir {:?} ready", parent);
-            }
-        }
         let path_str = path.display().to_string();
-        let escaped = crate::shell::shell_quote(&path_str);
-        let editor = preferred_editor();
-
-        let cmd = format!("{editor} {escaped}\r");
-        log::info!("scratchpad: injecting '{editor} {escaped}' into terminal pane {pane_id}");
-        term.backend.process_command(BackendCommand::Write(cmd.into_bytes()));
+        log::info!("scratchpad: opening text-editor pane for {:?}", path);
+        if let Err(e) = self.launch_app_by_id_with_layout(
+            "text-editor",
+            Some("split_h".to_string()),
+            &[path_str],
+            None,
+        ) {
+            log::warn!("scratchpad: failed to launch text-editor pane: {e}");
+        }
     }
 
     /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
@@ -1987,12 +1969,4 @@ fn scratchpad_file() -> PathBuf {
     crate::config::config_dir().join("notes").join(format!("{timestamp}.md"))
 }
 
-/// Resolve the preferred terminal editor: `micro` if available, else `nano`, then `vim`.
-fn preferred_editor() -> &'static str {
-    for editor in ["micro", "nano", "vim"] {
-        if cli_binary_in_path(editor) {
-            return editor;
-        }
-    }
-    "nano"
-}
+

--- a/src/text_editor_app.rs
+++ b/src/text_editor_app.rs
@@ -1,0 +1,149 @@
+//! Built-in file-backed text editor pane.
+
+use crate::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
+use crate::style;
+use egui::RichText;
+use std::path::PathBuf;
+
+pub struct TextEditorApp {
+    path: PathBuf,
+    content: String,
+    dirty: bool,
+    wants_close: bool,
+    load_error: Option<String>,
+}
+
+impl TextEditorApp {
+    pub fn new(path: PathBuf) -> Self {
+        let (content, load_error) = match std::fs::read_to_string(&path) {
+            Ok(s) => (s, None),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
+            Err(e) => (String::new(), Some(e.to_string())),
+        };
+        log::info!("TextEditorApp: opened {:?} ({} bytes)", path, content.len());
+        Self { path, content, dirty: false, wants_close: false, load_error }
+    }
+
+    fn save(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        if let Some(parent) = self.path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::warn!("TextEditorApp: could not create parent dir {:?}: {e}", parent);
+                return;
+            }
+        }
+        match std::fs::write(&self.path, &self.content) {
+            Ok(()) => {
+                log::info!("TextEditorApp: saved {:?} ({} bytes)", self.path, self.content.len());
+                self.dirty = false;
+            }
+            Err(e) => log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path),
+        }
+    }
+}
+
+impl App for TextEditorApp {
+    fn type_id(&self) -> &'static str {
+        "text-editor"
+    }
+
+    fn display_name(&self) -> String {
+        self.path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "text-editor".to_string())
+    }
+
+    fn keyboard_capture(&self) -> bool {
+        true
+    }
+
+    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+        if input.modifiers.command && input.key_pressed(egui::Key::S) {
+            self.save();
+            return KeyDisposition::Consumed;
+        }
+        KeyDisposition::Passthrough
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+        let colors = ctx.colors;
+
+        if let Some(err) = &self.load_error {
+            ui.centered_and_justified(|ui| {
+                ui.label(
+                    RichText::new(format!("Failed to open file: {err}"))
+                        .size(style::TEXT_BODY)
+                        .color(colors.danger),
+                );
+            });
+            return;
+        }
+
+        ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
+        ui.visuals_mut().override_text_color = Some(colors.text_primary);
+
+        let available = ui.available_rect_before_wrap();
+        let response = ui.add_sized(
+            available.size(),
+            egui::TextEdit::multiline(&mut self.content)
+                .font(egui::TextStyle::Monospace)
+                .desired_width(f32::INFINITY)
+                .frame(false),
+        );
+
+        if response.changed() {
+            self.dirty = true;
+        }
+
+        // Save hint at bottom
+        if self.dirty {
+            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                ui.add_space(style::SPACE_SM);
+                ui.label(
+                    RichText::new("Cmd+S to save")
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+            });
+        }
+    }
+
+    fn wants_close(&self) -> bool {
+        self.wants_close
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<AppCommand> {
+        vec![]
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "path": self.path.to_string_lossy() }))
+    }
+
+    fn restore_state(&mut self, state: &serde_json::Value) {
+        if let Some(p) = state.get("path").and_then(|v| v.as_str()) {
+            let new_path = PathBuf::from(p);
+            if new_path != self.path {
+                self.save();
+                let (content, load_error) = match std::fs::read_to_string(&new_path) {
+                    Ok(s) => (s, None),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
+                    Err(e) => (String::new(), Some(e.to_string())),
+                };
+                self.path = new_path;
+                self.content = content;
+                self.load_error = load_error;
+                self.dirty = false;
+            }
+        }
+    }
+}
+
+impl Drop for TextEditorApp {
+    fn drop(&mut self) {
+        self.save();
+    }
+}

--- a/src/text_editor_app.rs
+++ b/src/text_editor_app.rs
@@ -24,22 +24,26 @@ impl TextEditorApp {
         Self { path, content, dirty: false, wants_close: false, load_error }
     }
 
-    fn save(&mut self) {
+    fn save(&mut self) -> bool {
         if !self.dirty {
-            return;
+            return true;
         }
         if let Some(parent) = self.path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 log::warn!("TextEditorApp: could not create parent dir {:?}: {e}", parent);
-                return;
+                return false;
             }
         }
         match std::fs::write(&self.path, &self.content) {
             Ok(()) => {
                 log::info!("TextEditorApp: saved {:?} ({} bytes)", self.path, self.content.len());
                 self.dirty = false;
+                true
             }
-            Err(e) => log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path),
+            Err(e) => {
+                log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path);
+                false
+            }
         }
     }
 }
@@ -85,13 +89,19 @@ impl App for TextEditorApp {
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
-        // Reserve space at the bottom for the "Cmd+S to save" hint when dirty.
-        let hint_height = style::TEXT_HINT + style::SPACE_SM * 2.0;
-        let mut available = ui.available_rect_before_wrap();
+        // Render hint first so egui reserves its space before TextEdit fills the rest.
         if self.dirty {
-            available.max.y -= hint_height;
+            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                ui.add_space(style::SPACE_SM);
+                ui.label(
+                    RichText::new("Cmd+S to save")
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+            });
         }
 
+        let available = ui.available_rect_before_wrap();
         let response = ui.add_sized(
             available.size(),
             egui::TextEdit::multiline(&mut self.content)
@@ -102,15 +112,6 @@ impl App for TextEditorApp {
 
         if response.changed() {
             self.dirty = true;
-        }
-
-        if self.dirty {
-            ui.add_space(style::SPACE_SM);
-            ui.label(
-                RichText::new("Cmd+S to save")
-                    .size(style::TEXT_HINT)
-                    .color(colors.text_dim),
-            );
         }
     }
 
@@ -131,16 +132,17 @@ impl App for TextEditorApp {
             let new_path = PathBuf::from(p);
             if new_path != self.path {
                 log::info!("TextEditorApp: switching from {:?} to {:?}", self.path, new_path);
-                self.save();
-                let (content, load_error) = match std::fs::read_to_string(&new_path) {
-                    Ok(s) => (s, None),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
-                    Err(e) => (String::new(), Some(e.to_string())),
-                };
-                self.path = new_path;
-                self.content = content;
-                self.load_error = load_error;
-                self.dirty = false;
+                if self.save() {
+                    let (content, load_error) = match std::fs::read_to_string(&new_path) {
+                        Ok(s) => (s, None),
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
+                        Err(e) => (String::new(), Some(e.to_string())),
+                    };
+                    self.path = new_path;
+                    self.content = content;
+                    self.load_error = load_error;
+                    self.dirty = false;
+                }
             }
         }
     }

--- a/src/text_editor_app.rs
+++ b/src/text_editor_app.rs
@@ -11,6 +11,8 @@ pub struct TextEditorApp {
     dirty: bool,
     wants_close: bool,
     load_error: Option<String>,
+    /// True once we have called request_focus() on the TextEdit after open.
+    focus_requested: bool,
 }
 
 impl TextEditorApp {
@@ -21,7 +23,7 @@ impl TextEditorApp {
             Err(e) => (String::new(), Some(e.to_string())),
         };
         log::info!("TextEditorApp: opened {:?} ({} bytes)", path, content.len());
-        Self { path, content, dirty: false, wants_close: false, load_error }
+        Self { path, content, dirty: false, wants_close: false, load_error, focus_requested: false }
     }
 
     fn save(&mut self) -> bool {
@@ -89,19 +91,13 @@ impl App for TextEditorApp {
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
-        // Render hint first so egui reserves its space before TextEdit fills the rest.
+        // Pre-shrink the available rect so the hint renders below without overlap.
+        let hint_height = style::TEXT_HINT + style::SPACE_SM * 2.0;
+        let mut available = ui.available_rect_before_wrap();
         if self.dirty {
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                ui.add_space(style::SPACE_SM);
-                ui.label(
-                    RichText::new("Cmd+S to save")
-                        .size(style::TEXT_HINT)
-                        .color(colors.text_dim),
-                );
-            });
+            available.max.y -= hint_height;
         }
 
-        let available = ui.available_rect_before_wrap();
         let response = ui.add_sized(
             available.size(),
             egui::TextEdit::multiline(&mut self.content)
@@ -112,6 +108,21 @@ impl App for TextEditorApp {
 
         if response.changed() {
             self.dirty = true;
+        }
+
+        // Auto-focus on first render so the user can type immediately.
+        if !self.focus_requested {
+            response.request_focus();
+            self.focus_requested = true;
+        }
+
+        if self.dirty {
+            ui.add_space(style::SPACE_SM);
+            ui.label(
+                RichText::new("Cmd+S to save")
+                    .size(style::TEXT_HINT)
+                    .color(colors.text_dim),
+            );
         }
     }
 
@@ -142,6 +153,7 @@ impl App for TextEditorApp {
                     self.content = content;
                     self.load_error = load_error;
                     self.dirty = false;
+                    self.focus_requested = false;
                 }
             }
         }

--- a/src/text_editor_app.rs
+++ b/src/text_editor_app.rs
@@ -61,7 +61,7 @@ impl App for TextEditorApp {
     }
 
     fn keyboard_capture(&self) -> bool {
-        true
+        false
     }
 
     fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {

--- a/src/text_editor_app.rs
+++ b/src/text_editor_app.rs
@@ -85,7 +85,13 @@ impl App for TextEditorApp {
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
-        let available = ui.available_rect_before_wrap();
+        // Reserve space at the bottom for the "Cmd+S to save" hint when dirty.
+        let hint_height = style::TEXT_HINT + style::SPACE_SM * 2.0;
+        let mut available = ui.available_rect_before_wrap();
+        if self.dirty {
+            available.max.y -= hint_height;
+        }
+
         let response = ui.add_sized(
             available.size(),
             egui::TextEdit::multiline(&mut self.content)
@@ -98,16 +104,13 @@ impl App for TextEditorApp {
             self.dirty = true;
         }
 
-        // Save hint at bottom
         if self.dirty {
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                ui.add_space(style::SPACE_SM);
-                ui.label(
-                    RichText::new("Cmd+S to save")
-                        .size(style::TEXT_HINT)
-                        .color(colors.text_dim),
-                );
-            });
+            ui.add_space(style::SPACE_SM);
+            ui.label(
+                RichText::new("Cmd+S to save")
+                    .size(style::TEXT_HINT)
+                    .color(colors.text_dim),
+            );
         }
     }
 
@@ -127,6 +130,7 @@ impl App for TextEditorApp {
         if let Some(p) = state.get("path").and_then(|v| v.as_str()) {
             let new_path = PathBuf::from(p);
             if new_path != self.path {
+                log::info!("TextEditorApp: switching from {:?} to {:?}", self.path, new_path);
                 self.save();
                 let (content, load_error) = match std::fs::read_to_string(&new_path) {
                     Ok(s) => (s, None),


### PR DESCRIPTION
Closes #1920

## Summary

- Adds `TextEditorApp` — a new builtin `App` implementation backed by a file path, rendering an egui `TextEdit::multiline` with Cmd+S save and auto-save on drop
- Wires `builtin_factory()` to map `"text-editor"` → `TextEditorApp::new(path_from_args)`
- Rewrites `open_scratchpad()` to drop the terminal-pane guard entirely and call `launch_app_by_id_with_layout("text-editor", "split_h", &[path])` — works from any pane type

## Done When

- Cmd+Shift+Space opens a native egui text editor pane (not a terminal pane with micro)
- Editor works from any focused pane type (terminal, app, file browser)
- File is saved when the pane is closed
- `cargo test --bin plexi` is green

## Notes

- `preferred_editor()` and its micro/nano/vim detection were deleted (no longer needed)
- `keyboard_capture()` returns `true` so host shortcuts don't fire while editing
- Pre-existing test failure `welcome_tab_falls_back_to_home_dir_when_no_root` exists on alpha — not a regression from this PR