### PR TITLE
feat(cli): unify pane spawning under `pane new` (#1923)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -168,7 +168,7 @@ impl PlexiApp {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
                 }
-                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, workspace_root, .. } => {
+                crate::app_protocol::AppRequest::SpawnPane { type_id, layout, args, ephemeral, response_file, from_pane_id, cwd, no_focus, path, workspace_root, name, .. } => {
                     log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} workspace_root={workspace_root:?} response_file={response_file:?}");
                     let new_pane_id = self.host.next_pane_id();
 
@@ -223,6 +223,11 @@ impl PlexiApp {
                                             log::info!("pane_ipc: spawn_pane terminal layout={layout_str} (empty context fallback)");
                                             self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, new_pane_first, cwd_override);
                                             if *no_focus { self.active_window = active; }
+                                            if let Some(ref pane_name) = name {
+                                                if !pane_name.is_empty() {
+                                                    self.apply_inline_pane_name(new_pane_id, pane_name);
+                                                }
+                                            }
                                             if let Some(rf) = response_file {
                                                 let json = format!("{{\"pane_id\":{new_pane_id}}}");
                                                 if let Err(e) = std::fs::write(rf, &json) {
@@ -243,6 +248,11 @@ impl PlexiApp {
                                 self.split_focused(vertical, initial_cmd.as_deref(), *ephemeral, new_pane_first, cwd_override);
                                 if *no_focus {
                                     self.active_window = active;
+                                }
+                                if let Some(ref pane_name) = name {
+                                    if !pane_name.is_empty() {
+                                        self.apply_inline_pane_name(new_pane_id, pane_name);
+                                    }
                                 }
                                 // Skip rest of split path
                                 if let Some(rf) = response_file {
@@ -323,6 +333,14 @@ impl PlexiApp {
                         if *no_focus {
                             self.active_window = active;
                             self.restore_window_focused_pane(target_win, orig_focused_in_target);
+                        }
+                    }
+                    // Apply inline name if provided (only on success)
+                    if launch_result.is_ok() {
+                        if let Some(ref pane_name) = name {
+                            if !pane_name.is_empty() {
+                                self.apply_inline_pane_name(new_pane_id, pane_name);
+                            }
                         }
                     }
                     if let Some(rf) = response_file {
@@ -824,5 +842,21 @@ impl PlexiApp {
         for pane_id in panes_to_close {
             self.close_pane_by_id(pane_id);
         }
+    }
+
+    /// Apply an inline pane name immediately after spawn. Sets `name_locked` so
+    /// OSC title sequences don't overwrite the explicit label.
+    fn apply_inline_pane_name(&mut self, pane_id: u64, pane_name: &str) {
+        log::info!("pane_ipc: spawn_pane: applying inline name={pane_name:?} to pane_id={pane_id}");
+        for win in &mut self.windows {
+            if let Some(pane) = win.panes.get_mut(&pane_id) {
+                if let Some(t) = pane.as_terminal_mut() {
+                    t.name_locked = true;
+                    t.name = Some(pane_name.to_string());
+                    return;
+                }
+            }
+        }
+        log::warn!("pane_ipc: spawn_pane: could not apply name to pane_id={pane_id} (not found or not a terminal)");
     }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -335,8 +335,7 @@ impl PlexiApp {
                             self.restore_window_focused_pane(target_win, orig_focused_in_target);
                         }
                     }
-                    // Apply inline name if provided (only on success)
-                    if launch_result.is_ok() {
+                    if type_id == "terminal" && launch_result.is_ok() {
                         if let Some(ref pane_name) = name {
                             if !pane_name.is_empty() {
                                 self.apply_inline_pane_name(new_pane_id, pane_name);

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1345,6 +1345,10 @@ pub enum AppRequest {
         /// a descendant of the requesting app's context (#1518).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         target_context: Option<u64>,
+        /// Inline pane name — applied immediately after spawn so the pane
+        /// starts with a human-readable label instead of the default shell title.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
     },
 
     /// Set the title displayed on a terminal pane's tab. Sent by `plexi pane set-title`

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -3177,6 +3177,31 @@ mod tests {
     }
 
     #[test]
+    fn spawn_pane_name_round_trips_serde() {
+        let json = r#"{"type":"spawn_pane","type_id":"terminal","name":"dev server"}"#;
+        let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            DrawCommand::Host(AppRequest::SpawnPane { name, .. }) => {
+                assert_eq!(name.as_deref(), Some("dev server"));
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(serialised.contains(r#""name":"dev server""#), "name missing: {serialised}");
+
+        let json_absent = r#"{"type":"spawn_pane","type_id":"terminal"}"#;
+        let cmd_absent: DrawCommand = serde_json::from_str(json_absent).expect("deserialise absent");
+        match &cmd_absent {
+            DrawCommand::Host(AppRequest::SpawnPane { name, .. }) => {
+                assert!(name.is_none(), "absent name must deserialise to None");
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised_absent = serde_json::to_string(&cmd_absent).expect("serialise absent");
+        assert!(!serialised_absent.contains("name"), "name should be omitted when None: {serialised_absent}");
+    }
+
+    #[test]
     fn pane_spawned_with_request_id_round_trips_serde() {
         let json = r#"{"type":"pane_spawned","pane_id":99,"request_id":"req-abc"}"#;
         let event: PlexiEvent = serde_json::from_str(json).expect("deserialise");

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -413,6 +413,62 @@ pub enum UpdateCmd {
 
 #[derive(Subcommand)]
 pub enum PaneCmd {
+    /// Open a new pane (terminal by default, or --app/--mcp/--cli for other types).
+    ///
+    /// Examples:
+    ///   plexi pane new                          # empty terminal, split right
+    ///   plexi pane new "npm run dev" -n "dev"   # terminal with command, named
+    ///   plexi pane new --app snake -n "game"    # app pane
+    ///   plexi pane new --mcp npx @mcp/server-filesystem /tmp
+    New {
+        /// Shell command to run (terminal mode, ignored with --app/--mcp/--cli)
+        cmd: Option<String>,
+        /// Name the pane
+        #[arg(long, short = 'n')]
+        name: Option<String>,
+        /// Split below instead of right
+        #[arg(long, short = 'd', conflicts_with_all = ["left", "up", "tab", "window", "overlay"])]
+        down: bool,
+        /// Split left
+        #[arg(long, conflicts_with_all = ["down", "up", "tab", "window", "overlay"])]
+        left: bool,
+        /// Split up
+        #[arg(long, conflicts_with_all = ["down", "left", "tab", "window", "overlay"])]
+        up: bool,
+        /// New tab
+        #[arg(long, conflicts_with_all = ["down", "left", "up", "window", "overlay"])]
+        tab: bool,
+        /// New window
+        #[arg(long, conflicts_with_all = ["down", "left", "up", "tab", "overlay"])]
+        window: bool,
+        /// Overlay pane
+        #[arg(long, conflicts_with_all = ["down", "left", "up", "tab", "window"])]
+        overlay: bool,
+        /// Pane ID to split relative to (default: focused pane)
+        #[arg(long)]
+        from: Option<u64>,
+        /// Open an installed app instead of a terminal
+        #[arg(long, conflicts_with_all = ["mcp", "cli_tool"])]
+        app: Option<String>,
+        /// Wrap an MCP server
+        #[arg(long, num_args = 1.., value_name = "CMD", allow_hyphen_values = true, conflicts_with_all = ["app", "cli_tool"])]
+        mcp: Vec<String>,
+        /// Wrap a CLI tool with a visual UI
+        #[arg(long = "cli", value_name = "BINARY", conflicts_with_all = ["app", "mcp"])]
+        cli_tool: Option<String>,
+        /// Close the pane when the command finishes
+        #[arg(long, short = 'e')]
+        ephemeral: bool,
+        /// Keep focus on the current pane
+        #[arg(long)]
+        no_focus: bool,
+        /// Working directory
+        #[arg(long, value_hint = ValueHint::DirPath)]
+        cwd: Option<String>,
+        /// Extra arguments passed through to the app
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        extra_args: Vec<String>,
+    },
     /// Rename a pane.
     ///
     /// With one argument, renames the current pane: plexi pane name "My Project"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -176,7 +176,7 @@ pub use install::{install_cli, install_pack_cli, install_workspace_pack_cli, ple
 pub use list::{freeze_cli, parse_notify_choice};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
-pub use open::{open_cli, terminal_cli};
+pub use open::{open_cli, terminal_cli, pane_new_cli};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -92,8 +92,14 @@ pub fn pane_new_cli(
         mcp.to_vec()
     } else if is_app {
         extra_args.to_vec()
+    } else if let Some(c) = cmd {
+        let command = std::iter::once(c)
+            .chain(extra_args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+        vec![command]
     } else {
-        cmd.map(|c| vec![c.to_string()]).unwrap_or_default()
+        Vec::new()
     };
 
     let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -2,21 +2,103 @@ use super::{send_to_socket};
 use super::pane::open_github_ephemeral;
 use std::io;
 
-pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
-    // Intercept github: prefix for ephemeral open-without-install.
-    if type_id.starts_with("github:") {
-        return open_github_ephemeral(type_id, layout, from_pane_id, cwd);
+/// Poll a response file until it appears (or timeout). Shared by all spawn paths.
+fn wait_for_response(response_file: &str) -> i32 {
+    let response_path = std::path::PathBuf::from(response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                            eprintln!("error: {msg}");
+                            return 1;
+                        }
+                        if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+                            println!("{pid}");
+                            return 0;
+                        }
+                    }
+                    print!("{content}");
+                    return 0;
+                }
+                Err(e) => {
+                    log::warn!("pane_new: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// Unified pane spawning. All CLI spawn paths funnel through here.
+pub fn pane_new_cli(
+    cmd: Option<&str>,
+    name: Option<&str>,
+    layout: &str,
+    from_pane_id: Option<u64>,
+    cwd: Option<&str>,
+    ephemeral: bool,
+    no_focus: bool,
+    app: Option<&str>,
+    mcp: &[String],
+    cli_tool: Option<&str>,
+    extra_args: &[String],
+) -> i32 {
+    // --cli mode: run help parser, then open as descriptor-renderer app
+    if let Some(binary) = cli_tool {
+        log::info!("pane_new:cli: running --help parser for `{binary}`");
+        match crate::cli::help_parser::parse_help_to_descriptor(binary) {
+            Ok(json) => {
+                let id = uuid::Uuid::new_v4();
+                let tmp = std::env::temp_dir().join(format!("plexi-descriptor-{id}.json"));
+                if let Err(e) = std::fs::write(&tmp, &json) {
+                    eprintln!("error: could not write descriptor temp file: {e}");
+                    return 1;
+                }
+                let path = tmp.to_string_lossy().to_string();
+                // Recurse as an app open with descriptor-renderer
+                return pane_new_cli(
+                    None, name, layout, from_pane_id, cwd,
+                    ephemeral, no_focus, Some("descriptor-renderer"), &[], None, &[path],
+                );
+            }
+            Err(e) => {
+                eprintln!("error: could not parse --help output for `{binary}`: {e}");
+                return 1;
+            }
+        }
     }
 
-    if type_id == "terminal" {
-        log::warn!("open:cli: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
-        eprintln!("warning: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
-    }
+    // Determine mode: app or terminal
+    let is_app = app.is_some() || !mcp.is_empty();
+    let type_id = if let Some(a) = app {
+        a.to_string()
+    } else if !mcp.is_empty() {
+        "mcp-renderer".to_string()
+    } else {
+        "terminal".to_string()
+    };
+
+    let args: Vec<String> = if !mcp.is_empty() {
+        mcp.to_vec()
+    } else if is_app {
+        extra_args.to_vec()
+    } else {
+        cmd.map(|c| vec![c.to_string()]).unwrap_or_default()
+    };
 
     let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());
 
-    // Socket path is set when running inside a Plexi pane — use it directly so
-    // the command reaches the correct running instance regardless of channel.
+    // Socket path — inside a Plexi pane
     if std::env::var("PLEXI_SOCKET").is_ok() {
         let id = uuid::Uuid::new_v4();
         let response_file = crate::config::config_dir()
@@ -30,56 +112,32 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
             "layout": layout,
             "response_file": response_file,
         });
+        if ephemeral {
+            payload["ephemeral"] = serde_json::Value::Bool(true);
+        }
         if let Some(pid) = from_pane_id {
             payload["from_pane_id"] = serde_json::Value::Number(pid.into());
         }
         if let Some(cwd) = cwd {
             payload["cwd"] = serde_json::Value::String(cwd.to_string());
         }
-        log::info!("open:cli: sending via socket from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+        if no_focus {
+            payload["no_focus"] = serde_json::Value::Bool(true);
+        }
+        if let Some(n) = name {
+            payload["name"] = serde_json::Value::String(n.to_string());
+        }
+        log::info!("pane_new:cli: sending via socket type_id={type_id} name={name:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
         }
-        let response_path = std::path::PathBuf::from(&response_file);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if response_path.exists() {
-                match std::fs::read_to_string(&response_path) {
-                    Ok(content) => {
-                        let _ = std::fs::remove_file(&response_path);
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                            if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                                eprintln!("error: {msg}");
-                                return 1;
-                            }
-                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
-                                println!("{pid}");
-                                return 0;
-                            }
-                        }
-                        // Fallback: print raw content
-                        print!("{content}");
-                        return 0;
-                    }
-                    Err(e) => {
-                        log::warn!("open:cli: could not read response file: {e}");
-                        eprintln!("error: could not read response file: {e}");
-                        return 1;
-                    }
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                eprintln!("error: timed out waiting for open response");
-                return 1;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
+        return wait_for_response(&response_file);
     }
 
-    // Fallback: write to the spawn-queue for the channel this binary belongs to.
+    // Fallback: spawn-queue (outside a Plexi pane)
     if from_pane_id.is_some() {
-        log::warn!("open:cli: --from-pane-id requires PLEXI_SOCKET (run inside a Plexi pane); ignoring");
+        log::warn!("pane_new:cli: --from-pane-id requires PLEXI_SOCKET (run inside a Plexi pane); ignoring");
         eprintln!("warning: --from-pane-id is ignored outside a Plexi pane");
     }
     let queue_dir = crate::config::config_dir().join("spawn-queue");
@@ -96,109 +154,6 @@ pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_
         "args": args,
         "layout": layout,
     });
-    if let Some(cwd) = cwd {
-        queue_payload["cwd"] = serde_json::Value::String(cwd.to_string());
-    }
-    let file = queue_dir.join(format!("{id}.json"));
-    if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
-        eprintln!("error: could not write spawn request: {e}");
-        return 1;
-    }
-    log::info!("cli: open queued: type_id={type_id} cwd={cwd:?}");
-    println!("queued: open {type_id}");
-    println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
-    0
-}
-
-/// `plexi terminal [cmd] [--ephemeral] [--layout=X] [--no-focus]`
-///
-/// Opens a terminal pane. Supports the --ephemeral flag which closes the pane when the
-/// process exits, and --no-focus to keep focus on the originating pane.
-pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>, no_focus: bool) -> i32 {
-    let layout_str = layout.unwrap_or("split_v");
-    let args: Vec<String> = cmd.map(|c| vec![c.to_string()]).unwrap_or_default();
-    let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());
-
-    if std::env::var("PLEXI_SOCKET").is_ok() {
-        let id = uuid::Uuid::new_v4();
-        let response_file = crate::config::config_dir()
-            .join(format!("spawn-pane-response-{id}.json"))
-            .to_string_lossy()
-            .into_owned();
-        let mut payload = serde_json::json!({
-            "type": "spawn_pane",
-            "type_id": "terminal",
-            "args": args,
-            "layout": layout_str,
-            "response_file": response_file,
-        });
-        if ephemeral {
-            payload["ephemeral"] = serde_json::Value::Bool(true);
-        }
-        if let Some(pid) = from_pane_id {
-            payload["from_pane_id"] = serde_json::Value::Number(pid.into());
-        }
-        if let Some(cwd) = cwd {
-            payload["cwd"] = serde_json::Value::String(cwd.to_string());
-        }
-        if no_focus {
-            payload["no_focus"] = serde_json::Value::Bool(true);
-        }
-        log::info!("terminal:cli: sending via socket ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
-        let code = send_to_socket(payload);
-        if code != 0 {
-            return code;
-        }
-        let response_path = std::path::PathBuf::from(&response_file);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if response_path.exists() {
-                match std::fs::read_to_string(&response_path) {
-                    Ok(content) => {
-                        let _ = std::fs::remove_file(&response_path);
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
-                                println!("{pid}");
-                                return 0;
-                            }
-                        }
-                        print!("{content}");
-                        return 0;
-                    }
-                    Err(e) => {
-                        log::warn!("terminal:cli: could not read response file: {e}");
-                        eprintln!("error: could not read response file: {e}");
-                        return 1;
-                    }
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                eprintln!("error: timed out waiting for terminal response");
-                return 1;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-    }
-
-    // Fallback: spawn-queue (outside a Plexi pane)
-    if from_pane_id.is_some() {
-        log::warn!("terminal:cli: --from-pane-id requires PLEXI_SOCKET (run inside a Plexi pane); ignoring");
-        eprintln!("warning: --from-pane-id is ignored outside a Plexi pane");
-    }
-    let queue_dir = crate::config::config_dir().join("spawn-queue");
-    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
-        eprintln!("error: could not create spawn queue: {e}");
-        return 1;
-    }
-    let id = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let mut queue_payload = serde_json::json!({
-        "type_id": "terminal",
-        "args": args,
-        "layout": layout_str,
-    });
     if ephemeral {
         queue_payload["ephemeral"] = serde_json::Value::Bool(true);
     }
@@ -208,15 +163,40 @@ pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, fr
     if no_focus {
         queue_payload["no_focus"] = serde_json::Value::Bool(true);
     }
+    if let Some(n) = name {
+        queue_payload["name"] = serde_json::Value::String(n.to_string());
+    }
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
-    log::info!("terminal:cli: queued ephemeral={ephemeral} no_focus={no_focus} cwd={cwd:?}");
-    println!("queued: open terminal");
+    log::info!("pane_new:cli: queued type_id={type_id} name={name:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd:?}");
+    println!("queued: open {type_id}");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
     0
+}
+
+/// Thin wrapper preserving the existing `plexi app open` call site.
+pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
+    // Intercept github: prefix for ephemeral open-without-install.
+    if type_id.starts_with("github:") {
+        return open_github_ephemeral(type_id, layout, from_pane_id, cwd);
+    }
+
+    if type_id == "terminal" {
+        log::warn!("open:cli: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
+        eprintln!("warning: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
+    }
+
+    let layout_str = layout.unwrap_or("split_h");
+    pane_new_cli(None, None, layout_str, from_pane_id, cwd, false, false, Some(type_id), &[], None, args)
+}
+
+/// Thin wrapper preserving the existing `plexi terminal` call site.
+pub fn terminal_cli(cmd: Option<&str>, ephemeral: bool, layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>, no_focus: bool) -> i32 {
+    let layout_str = layout.unwrap_or("split_v");
+    pane_new_cli(cmd, None, layout_str, from_pane_id, cwd, ephemeral, no_focus, None, &[], None, &[])
 }
 
 /// Read a line from stdin with echo disabled (for password-style input).

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,6 +486,19 @@ fn main() -> eframe::Result {
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                         PaneCmd::Capture { pane_id, lines, full_output, from_cursor } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output, from_cursor)),
+                        PaneCmd::New { cmd, name, down, left, up, tab, window, overlay, from, app, mcp, cli_tool, ephemeral, no_focus, cwd, extra_args } => {
+                            let layout = if down { "split_v" }
+                                else if left { "split_left" }
+                                else if up { "split_above" }
+                                else if tab { "tab" }
+                                else if window { "new_window" }
+                                else if overlay { "overlay" }
+                                else { "split_h" };
+                            std::process::exit(cli::pane_new_cli(
+                                cmd.as_deref(), name.as_deref(), layout, from, cwd.as_deref(),
+                                ephemeral, no_focus, app.as_deref(), &mcp, cli_tool.as_deref(), &extra_args,
+                            ));
+                        }
                     },
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1320,6 +1320,7 @@ mod tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1360,6 +1361,7 @@ mod tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1403,6 +1405,7 @@ mod tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1445,6 +1448,7 @@ mod tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1497,6 +1501,7 @@ mod tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1547,6 +1552,7 @@ mod tests {
                 path: None,
                 workspace_root: None,
                 target_context: None,
+                name: None,
             });
             h.run_frames(2);
         }
@@ -1882,6 +1888,7 @@ mod quick_note_tests {
                 path: None,
                 workspace_root: None,
                 target_context: Some(999),
+                name: None,
             },
         ));
         h.run_frames(1);
@@ -1919,6 +1926,7 @@ mod quick_note_tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 
@@ -1939,6 +1947,7 @@ mod quick_note_tests {
             path: None,
             workspace_root: None,
             target_context: None,
+            name: None,
         });
         h.run_frames(2);
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -775,6 +775,7 @@ impl ProcessApp {
                 path: _,
                 workspace_root: _,
                 target_context,
+                name: _,
             } => {
                 if let PermissionCheck::Denied(reason) =
                     check(&self.permissions, Capability::PanesSpawn)


### PR DESCRIPTION
Closes #1923

## Summary

- Adds `plexi pane new` as the universal spawn command, absorbing `terminal` and `app open` into a single verb with unified flags
- Inline `--name`/`-n` sets pane name at creation time (no follow-up `pane name` needed), directional layout flags (`-d`/`--down`, `--left`, `--up`, `--tab`, `--window`, `--overlay`) replace verbose `--layout split_h` strings, `--from` shortens `--from-pane-id`
- `terminal` and `app open` become thin wrappers forwarding to `pane_new_cli` — zero breaking changes
- Adds `name` field to `SpawnPane` protocol; host applies it immediately via `apply_inline_pane_name` with `name_locked=true`
- Extracts `wait_for_response` helper to deduplicate socket polling between terminal and app spawn paths

## Done When

- `plexi pane new "echo hello" -n "test" -d` splits below, names the pane "test", prints pane ID
- `plexi pane new --app snake -n "game"` opens snake app in a split, named "game"
- `plexi terminal "echo hi"` still works (forwards to pane new)
- `plexi app open snake` still works (forwards to pane new)
- All existing tests pass (656 pass, 1 pre-existing failure unrelated)

## Notes

- Default layout for `pane new` is `split_h` (split right), matching `app open` behavior. The old `terminal` default was `split_v` (split below) — that default is preserved in the `terminal_cli` wrapper.
- The `--cli` mode runs the help parser inline in `pane_new_cli` and recurses as an app open with `descriptor-renderer`, so `--name` works for CLI-wrapped panes too.