### PR TITLE
refactor(ui/overlays): extract modal_shell helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 Newest releases appear first.
+## [0.0.600] — 2026-06-03
+
+### Changes
+- refactor(cli): remove layout_hint from manifests and registry (#1928)
+- fix(terminal): strip trailing punctuation from clickable URLs (#1549)
+- feat(sdk): default Esc behavior in base App class (#1631)
+- refactor(cli): clean namespace split for pane new vs app open (#1928)
+- fix(cli): pane new direction flags produce wrong split orientation (#1927)
+- feat(scaffold): trim app init template to 30-line L1 example
+- feat(apps): migrate balls, snake, tetris, stats to L1 rendering
+- refactor: move 6 non-core apps to apps/dev/
+- docs(roadmap): check off L1 app migration (v0.0.597)
+- feat(apps): migrate 11 apps from L0 draw commands to L1 Component rendering
+- feat(cli): unify pane spawning under `pane new` (#1923) (#1926)
+- feat(scratchpad): native text-editor builtin pane, open from any pane type (#1920) (#1922)
+- fix(snake-race): request panes.spawn capability before spawning
+- fix(snake-race): replace bare color constants with ctx.theme.* lookups
+- Add keyboard shortcut tip for context_set_root, document CLI pane naming and tips patterns
+- fix: restore draw_triple_tap_overlay after inspector removal, clean up dead code
+- Remove context inspector modal, replace Cmd+I with SetContextRootFromCwd action
 ## [0.0.599] — 2026-06-03
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,7 +2833,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "0.0.599"
+version = "0.0.600"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "0.0.599"
+version = "0.0.600"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -70,95 +70,84 @@ impl PlexiApp {
             }
         });
 
-        // Scrim — visually reinforces modal capture and mirrors the command
-        // palette / notification modal chrome.
-        let screen_rect = ctx.screen_rect();
-        egui::Area::new(egui::Id::new("confirm_close_scrim"))
-            .fixed_pos(screen_rect.min)
-            .order(egui::Order::Middle)
-            .show(ctx, |ui| {
-                ui.painter().rect_filled(
-                    screen_rect,
-                    0.0,
-                    egui::Color32::from_black_alpha(120),
+        // Scrim + centered modal with consistent chrome.
+        // `scrim_cancelled`: set by modal_shell when user clicks outside the modal.
+        // `btn_cancelled`: set by the Cancel button inside the closure.
+        // `btn_confirmed`: set by the Close button inside the closure.
+        // All three are merged into `confirmed`/`cancelled` after the call.
+        let mut scrim_cancelled = false;
+        let (btn_confirmed, btn_cancelled) = modal_shell(
+            ctx,
+            "confirm_close_overlay",
+            &self.colors,
+            &mut scrim_cancelled,
+            |ui| {
+                let mut c = false;
+                let mut k = false;
+                ui.label(
+                    RichText::new("Close pane?")
+                        .size(13.0)
+                        .color(self.colors.text_primary)
+                        .strong(),
                 );
-                let scrim_response = ui.allocate_rect(screen_rect, egui::Sense::click());
-                if scrim_response.clicked() {
-                    cancelled = true;
-                }
-            });
-
-        egui::Area::new(egui::Id::new("confirm_close_overlay"))
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(self.colors.bg_sidebar)
-                    .stroke(egui::Stroke::new(1.0, self.colors.border))
-                    .corner_radius(crate::style::RADIUS_LG)
-                    .inner_margin(egui::Margin::symmetric(20, 16))
-                    .show(ui, |ui| {
-                        ui.set_width(MODAL_WIDTH);
-                        ui.label(
-                            RichText::new("Close pane?")
-                                .size(13.0)
-                                .color(self.colors.text_primary)
-                                .strong(),
-                        );
-                        ui.add_space(6.0);
-                        ui.label(
-                            RichText::new("The running process will be terminated.")
-                                .size(12.0)
-                                .color(self.colors.text_dim),
-                        );
-                        ui.add_space(12.0);
-                        ui.horizontal(|ui| {
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Close")
-                                            .size(12.0)
-                                            .color(self.colors.bg_darkest),
-                                    )
-                                    .fill(self.colors.danger),
-                                )
-                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                .clicked()
-                            {
-                                confirmed = true;
-                            }
-                            ui.add_space(8.0);
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Cancel")
-                                            .size(12.0)
-                                            .color(self.colors.text_dim),
-                                    )
-                                    .fill(self.colors.bg_active),
-                                )
-                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                .clicked()
-                            {
-                                cancelled = true;
-                            }
-                            ui.add_space(12.0);
-                            crate::widgets::key_chip(ui, "Enter", &self.colors);
-                            ui.label(
-                                RichText::new("confirm")
-                                    .size(style::TEXT_HINT)
+                ui.add_space(6.0);
+                ui.label(
+                    RichText::new("The running process will be terminated.")
+                        .size(12.0)
+                        .color(self.colors.text_dim),
+                );
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Close")
+                                    .size(12.0)
+                                    .color(self.colors.bg_darkest),
+                            )
+                            .fill(self.colors.danger),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        c = true;
+                    }
+                    ui.add_space(8.0);
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Cancel")
+                                    .size(12.0)
                                     .color(self.colors.text_dim),
-                            );
-                            ui.add_space(style::SPACE_SM);
-                            crate::widgets::key_chip(ui, "Esc", &self.colors);
-                            ui.label(
-                                RichText::new("cancel")
-                                    .size(style::TEXT_HINT)
-                                    .color(self.colors.text_dim),
-                            );
-                        });
-                    });
-            });
+                            )
+                            .fill(self.colors.bg_active),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        k = true;
+                    }
+                    ui.add_space(12.0);
+                    crate::widgets::key_chip(ui, "Enter", &self.colors);
+                    ui.label(
+                        RichText::new("confirm")
+                            .size(style::TEXT_HINT)
+                            .color(self.colors.text_dim),
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    crate::widgets::key_chip(ui, "Esc", &self.colors);
+                    ui.label(
+                        RichText::new("cancel")
+                            .size(style::TEXT_HINT)
+                            .color(self.colors.text_dim),
+                    );
+                });
+                (c, k)
+            },
+        )
+        .unwrap_or((false, false));
+        confirmed |= btn_confirmed;
+        cancelled |= scrim_cancelled | btn_cancelled;
 
         if confirmed {
             self.pending_close = false;
@@ -278,126 +267,118 @@ impl PlexiApp {
             }
         });
 
-        let screen_rect = ctx.screen_rect();
-        egui::Area::new(egui::Id::new("ctx_close_confirm_scrim"))
-            .fixed_pos(screen_rect.min)
-            .order(egui::Order::Middle)
-            .show(ctx, |ui| {
-                ui.painter().rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(120));
-                let scrim_resp = ui.allocate_rect(screen_rect, egui::Sense::click());
-                if scrim_resp.clicked() {
-                    cancelled = true;
-                }
-            });
-
         let colors = self.colors;
-        egui::Area::new(egui::Id::new("ctx_close_confirm_modal"))
-            .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(colors.bg_sidebar)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
-                    .corner_radius(crate::style::RADIUS_LG)
-                    .inner_margin(egui::Margin::symmetric(20, 16))
-                    .show(ui, |ui| {
-                        ui.set_width(MODAL_WIDTH);
+        // Scrim + centered modal with consistent chrome.
+        let mut scrim_cancelled = false;
+        let (btn_close_all, btn_dissolve, btn_cancelled) = modal_shell(
+            ctx,
+            "ctx_close_confirm_modal",
+            &colors,
+            &mut scrim_cancelled,
+            |ui| {
+                let mut ca = false;
+                let mut dv = false;
+                let mut ck = false;
+                let title = if state.context_name.is_empty() {
+                    "Close context?".to_string()
+                } else {
+                    format!("Close \"{}\"?", state.context_name)
+                };
+                ui.label(
+                    RichText::new(&title)
+                        .size(13.0)
+                        .color(colors.text_primary)
+                        .strong(),
+                );
+                ui.add_space(8.0);
 
-                        let title = if state.context_name.is_empty() {
-                            "Close context?".to_string()
-                        } else {
-                            format!("Close \"{}\"?", state.context_name)
-                        };
-                        ui.label(
-                            RichText::new(&title)
-                                .size(13.0)
-                                .color(colors.text_primary)
-                                .strong(),
-                        );
-                        ui.add_space(8.0);
+                for item in &state.items {
+                    let label = format!("{} — {}", item.kind, item.name);
+                    ui.label(
+                        RichText::new(&label)
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                }
 
-                        for item in &state.items {
-                            let label = format!("{} — {}", item.kind, item.name);
-                            ui.label(
-                                RichText::new(&label)
-                                    .size(style::TEXT_HINT)
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Close all")
+                                    .size(12.0)
+                                    .color(colors.bg_darkest),
+                            )
+                            .fill(colors.danger),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        ca = true;
+                    }
+                    ui.add_space(6.0);
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Dissolve")
+                                    .size(12.0)
                                     .color(colors.text_dim),
-                            );
-                        }
+                            )
+                            .fill(colors.bg_active),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        dv = true;
+                    }
+                    ui.add_space(6.0);
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new("Cancel")
+                                    .size(12.0)
+                                    .color(colors.text_dim),
+                            )
+                            .fill(colors.bg_active),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        ck = true;
+                    }
+                });
 
-                        ui.add_space(12.0);
-                        ui.horizontal(|ui| {
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Close all")
-                                            .size(12.0)
-                                            .color(colors.bg_darkest),
-                                    )
-                                    .fill(colors.danger),
-                                )
-                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                .clicked()
-                            {
-                                close_all = true;
-                            }
-                            ui.add_space(6.0);
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Dissolve")
-                                            .size(12.0)
-                                            .color(colors.text_dim),
-                                    )
-                                    .fill(colors.bg_active),
-                                )
-                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                .clicked()
-                            {
-                                dissolve = true;
-                            }
-                            ui.add_space(6.0);
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Cancel")
-                                            .size(12.0)
-                                            .color(colors.text_dim),
-                                    )
-                                    .fill(colors.bg_active),
-                                )
-                                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                .clicked()
-                            {
-                                cancelled = true;
-                            }
-                        });
-
-                        ui.add_space(8.0);
-                        ui.horizontal(|ui| {
-                            crate::widgets::key_chip(ui, "Enter", &colors);
-                            ui.label(
-                                RichText::new("close all")
-                                    .size(style::TEXT_HINT)
-                                    .color(colors.text_dim),
-                            );
-                            ui.add_space(style::SPACE_SM);
-                            crate::widgets::key_chip(ui, "D", &colors);
-                            ui.label(
-                                RichText::new("dissolve")
-                                    .size(style::TEXT_HINT)
-                                    .color(colors.text_dim),
-                            );
-                            ui.add_space(style::SPACE_SM);
-                            crate::widgets::key_chip(ui, "Esc", &colors);
-                            ui.label(
-                                RichText::new("cancel")
-                                    .size(style::TEXT_HINT)
-                                    .color(colors.text_dim),
-                            );
-                        });
-                    });
-            });
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    crate::widgets::key_chip(ui, "Enter", &colors);
+                    ui.label(
+                        RichText::new("close all")
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    crate::widgets::key_chip(ui, "D", &colors);
+                    ui.label(
+                        RichText::new("dissolve")
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    crate::widgets::key_chip(ui, "Esc", &colors);
+                    ui.label(
+                        RichText::new("cancel")
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                });
+                (ca, dv, ck)
+            },
+        )
+        .unwrap_or((false, false, false));
+        close_all |= btn_close_all;
+        dissolve |= btn_dissolve;
+        cancelled |= scrim_cancelled | btn_cancelled;
 
         if close_all {
             let idx = self.router.iter().position(|c| c.context_id == state.context_id);

--- a/src/overlays/mod.rs
+++ b/src/overlays/mod.rs
@@ -40,6 +40,57 @@ use crate::app::PlexiApp;
 pub(crate) const MODAL_WIDTH: f32 = 400.0;
 pub(crate) const R6: CornerRadius = CornerRadius::same(6);
 
+/// Render a centered modal with scrim, cancel-on-click-outside, and consistent chrome.
+/// Returns `Some(R)` with the content's return value, or `None` if the scrim was clicked
+/// (in which case `*cancelled` is set to `true`).
+pub(crate) fn modal_shell<R>(
+    ctx: &egui::Context,
+    id: &str,
+    colors: &crate::theme::Colors,
+    cancelled: &mut bool,
+    content: impl FnOnce(&mut egui::Ui) -> R,
+) -> Option<R> {
+    let screen_rect = ctx.screen_rect();
+
+    // Scrim
+    egui::Area::new(egui::Id::new(format!("{id}_scrim")))
+        .fixed_pos(screen_rect.min)
+        .order(egui::Order::Middle)
+        .show(ctx, |ui| {
+            ui.painter().rect_filled(
+                screen_rect,
+                0.0,
+                egui::Color32::from_black_alpha(style::SCRIM_ALPHA),
+            );
+            let scrim_response = ui.allocate_rect(screen_rect, egui::Sense::click());
+            if scrim_response.clicked() {
+                *cancelled = true;
+            }
+        });
+
+    // Modal
+    let resp = egui::Area::new(egui::Id::new(id))
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            egui::Frame::new()
+                .fill(colors.bg_sidebar)
+                .stroke(egui::Stroke::new(1.0, colors.border))
+                .corner_radius(style::RADIUS_LG)
+                .inner_margin(egui::Margin::symmetric(
+                    style::MODAL_PADDING_H,
+                    style::MODAL_PADDING_V,
+                ))
+                .show(ui, |ui| {
+                    ui.set_width(MODAL_WIDTH);
+                    content(ui)
+                })
+                .inner
+        });
+
+    Some(resp.inner)
+}
+
 /// Show a native macOS folder picker using rfd's async API.
 /// Blocks the calling (background) thread; must NOT be called on the main thread.
 pub(crate) fn pick_folder() -> Option<std::path::PathBuf> {

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -90,7 +90,7 @@ impl PlexiApp {
                 ui.painter().rect_filled(
                     screen_rect,
                     0.0,
-                    egui::Color32::from_black_alpha(230),
+                    egui::Color32::from_black_alpha(style::SCRIM_ALPHA),
                 );
             });
 
@@ -318,7 +318,7 @@ impl PlexiApp {
                 ui.painter().rect_filled(
                     screen_rect,
                     0.0,
-                    egui::Color32::from_black_alpha(230),
+                    egui::Color32::from_black_alpha(style::SCRIM_ALPHA),
                 );
             });
 
@@ -662,7 +662,7 @@ impl PlexiApp {
             .fixed_pos(screen_rect.min)
             .order(egui::Order::Middle)
             .show(ctx, |ui| {
-                ui.painter().rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(230));
+                ui.painter().rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(style::SCRIM_ALPHA));
             });
 
         let modal_w = (screen_rect.width() * 0.6).min(672.0).max(408.0);


### PR DESCRIPTION
## Summary
- Add `modal_shell()` to `overlays/mod.rs` with consistent scrim alpha (`SCRIM_ALPHA`), corner radius (`RADIUS_LG`), and padding (`MODAL_PADDING_H/V`)
- Convert both confirmation modals (`draw_confirm_close`, `draw_context_close_confirm`) to use `modal_shell`
- Normalize quick_note scrim alphas from hardcoded 230 to `style::SCRIM_ALPHA`

## Test plan
- [x] `cargo test --bin plexi` passes (657/657, 1 pre-existing failure)
- [ ] Open close-pane confirmation (Cmd+W on a pane), verify scrim + modal renders correctly, click-to-cancel works
- [ ] Open context-close confirmation, verify same
- [ ] Open QuickNote (Cmd+0), verify scrim renders (should be same alpha as confirmation modals now)

Closes #1915