### PR TITLE
feat(host/pane-ops): viewport overtake indicator bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 Newest releases appear first.
+## [0.0.600] — 2026-06-03
+
+### Changes
+- refactor(cli): remove layout_hint from manifests and registry (#1928)
+- fix(terminal): strip trailing punctuation from clickable URLs (#1549)
+- feat(sdk): default Esc behavior in base App class (#1631)
+- refactor(cli): clean namespace split for pane new vs app open (#1928)
+- fix(cli): pane new direction flags produce wrong split orientation (#1927)
+- feat(scaffold): trim app init template to 30-line L1 example
+- feat(apps): migrate balls, snake, tetris, stats to L1 rendering
+- refactor: move 6 non-core apps to apps/dev/
+- docs(roadmap): check off L1 app migration (v0.0.597)
+- feat(apps): migrate 11 apps from L0 draw commands to L1 Component rendering
+- feat(cli): unify pane spawning under `pane new` (#1923) (#1926)
+- feat(scratchpad): native text-editor builtin pane, open from any pane type (#1920) (#1922)
+- fix(snake-race): request panes.spawn capability before spawning
+- fix(snake-race): replace bare color constants with ctx.theme.* lookups
+- Add keyboard shortcut tip for context_set_root, document CLI pane naming and tips patterns
+- fix: restore draw_triple_tap_overlay after inspector removal, clean up dead code
+- Remove context inspector modal, replace Cmd+I with SetContextRootFromCwd action
 ## [0.0.599] — 2026-06-03
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,7 +2833,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plexi"
-version = "0.0.599"
+version = "0.0.600"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "plexi"
-version = "0.0.599"
+version = "0.0.600"
 edition = "2021"
 
 [package.metadata.bundle]

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -16,8 +16,52 @@ use egui::RichText;
 const NAV_BAR_HEIGHT: f32 = 32.0;
 /// Horizontal padding inside the nav bar.
 const NAV_BAR_PAD: f32 = style::SPACE_SM;
+/// Height of the overtake indicator bar shown when this app replaced another pane.
+const OVERTAKE_BAR_HEIGHT: f32 = 24.0;
 
 pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_focused: bool) {
+    // Viewport overtake indicator — shows when this app has replaced another pane's content.
+    if app_pane.overlay_replaced.is_some() {
+        let bar_rect = egui::Rect::from_min_size(
+            ui.cursor().left_top(),
+            egui::vec2(ui.available_width(), OVERTAKE_BAR_HEIGHT),
+        );
+
+        ui.painter().rect_filled(bar_rect, 0.0, colors.bg_active);
+
+        ui.allocate_new_ui(egui::UiBuilder::new().max_rect(bar_rect), |ui| {
+            ui.horizontal_centered(|ui| {
+                ui.add_space(NAV_BAR_PAD);
+
+                // Show the replaced pane's name/type.
+                let replaced_label = match app_pane.overlay_replaced.as_deref() {
+                    Some(crate::pane::Pane::Terminal(t)) => {
+                        t.name.as_deref().unwrap_or("Terminal").to_string()
+                    }
+                    Some(crate::pane::Pane::App(a)) => a.name.clone(),
+                    Some(crate::pane::Pane::Portal(_)) => "Portal".to_string(),
+                    None => unreachable!(),
+                };
+
+                ui.label(
+                    RichText::new(format!("← {replaced_label}"))
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.add_space(NAV_BAR_PAD);
+                    crate::widgets::key_chip(ui, "Esc", colors);
+                    ui.label(
+                        RichText::new("return")
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                });
+            });
+        });
+    }
+
     // Check if we need a nav bar (non-empty stack).
     let nav_title: Option<String> = app_pane
         .runtime


### PR DESCRIPTION
## Summary
- Add a 24px indicator bar at the top of app panes that have replaced another pane's content (overlay mode)
- Shows the replaced pane's name with a left arrow and an "Esc return" key chip hint
- The core overlay mechanism (overlay_replaced, Esc to restore) was already fully implemented; this adds the missing visual indicator

## Test plan
- [x] `cargo test --bin plexi` passes (657/657, 1 pre-existing failure)
- [ ] Open an app in overlay mode (`plexi app open snake`), verify the indicator bar appears at the top showing "← Terminal" and "Esc return"
- [ ] Press Escape, verify the terminal is restored
- [ ] Open an app with `--right` flag, verify no indicator bar (not overlay mode)

Closes #1924