### PR TITLE
fix(host/notifications): auto-dismiss when originating pane focused (#1635)

### DIFF
--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -243,4 +243,57 @@ impl PlexiApp {
             .filter(|n| self.notification_is_visible(n))
             .count()
     }
+
+    /// Auto-dismiss non-required notifications whose `sender_pane_id` matches
+    /// the currently focused pane. Called once per frame from `update_preamble`.
+    ///
+    /// Required notifications (interactive prompts that need an explicit
+    /// response) are exempt and must always be dismissed manually.
+    pub(crate) fn auto_dismiss_sender_focused_notifications(&mut self) {
+        let win = &self.windows[self.active_window];
+        let focused_pane_id = win
+            .focused_pane
+            .and_then(|tile_id| Self::find_pane_in_tile(&win.tree, tile_id));
+
+        let Some(focused_id) = focused_pane_id else {
+            return;
+        };
+
+        let auto_dismiss_ids: Vec<String> = self
+            .pending_notifications
+            .iter()
+            .filter(|n| !n.required && n.sender_pane_id == focused_id)
+            .map(|n| n.notify_id.clone())
+            .collect();
+
+        if auto_dismiss_ids.is_empty() {
+            return;
+        }
+
+        for id in &auto_dismiss_ids {
+            let Some(pos) = self
+                .pending_notifications
+                .iter()
+                .position(|n| &n.notify_id == id)
+            else {
+                continue;
+            };
+            let n = self.pending_notifications.remove(pos);
+            log::info!(
+                "notify:auto_dismiss: pane_id={focused_id} focused — dismissing notify_id={} title={:?}",
+                n.notify_id,
+                n.title
+            );
+            if self.current_notify_id.as_deref() == Some(&n.notify_id) {
+                self.current_notify_id = None;
+            }
+        }
+
+        if self.show_notification_modal && self.sorted_notification_ids().is_empty() {
+            self.show_notification_modal = false;
+            log::info!("notify:auto_dismiss: modal closed — no visible notifications remain");
+        }
+
+        self.save_notifications();
+    }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -50,6 +50,10 @@ impl PlexiApp {
         // include all open panes in the workspace context (#396).
         self.update_pane_context_snapshot();
 
+        // Auto-dismiss notifications from the focused pane before reconciling
+        // the focus stack so modal state is already correct this frame.
+        self.auto_dismiss_sender_focused_notifications();
+
         // Focus stack: reconcile layer state BEFORE any input routing so
         // `input_captured_by_overlay()` answers correctly this frame.
         self.sync_notification_modal_focus();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1343,3 +1343,152 @@ fn new_context_creates_top_level_empty_context() {
         "inline rename opened for new context"
     );
 }
+
+// ── #1635: auto-dismiss when originating pane is focused ─────────────────────
+
+/// #1635: non-required notification from a focused pane must be auto-dismissed.
+#[test]
+fn auto_dismiss_removes_non_required_notification_when_sender_focused() {
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+
+    // Focus the pane.
+    h.app.pane_navigate(pane_id);
+
+    let ctx_id = h.app.router.active().context_id;
+    let win_id = h.app.windows[h.app.active_window].window_id;
+
+    // Push a non-required notification from the focused pane.
+    h.app.pending_notifications.push(PendingNotification {
+        notify_id: "n-auto-dismiss".into(),
+        sender_pane_id: pane_id,
+        source_context_id: ctx_id,
+        source_window_id: win_id,
+        level: "info".into(),
+        title: "Should go away".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        priority: 100,
+        scope: crate::app_protocol::NotifyScope::Global,
+        image_inline: None,
+        image_pipe_id: None,
+        response_file: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        enqueued_at: std::time::Instant::now(),
+        tombstoned: false,
+        deliver_after: None,
+    });
+    h.app.show_notification_modal = true;
+    h.app.current_notify_id = Some("n-auto-dismiss".into());
+
+    assert_eq!(h.app.pending_notifications.len(), 1, "notification queued");
+
+    h.app.auto_dismiss_sender_focused_notifications();
+
+    assert!(
+        h.app.pending_notifications.is_empty(),
+        "non-required notification from focused pane must be auto-dismissed"
+    );
+    assert!(
+        !h.app.show_notification_modal,
+        "modal must close when queue empties via auto-dismiss"
+    );
+    assert!(
+        h.app.current_notify_id.is_none(),
+        "current_notify_id must be cleared after dismissal"
+    );
+}
+
+/// #1635: required notifications must NOT be auto-dismissed even when sender is focused.
+#[test]
+fn auto_dismiss_spares_required_notifications() {
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+
+    h.app.pane_navigate(pane_id);
+
+    let ctx_id = h.app.router.active().context_id;
+    let win_id = h.app.windows[h.app.active_window].window_id;
+
+    h.app.pending_notifications.push(PendingNotification {
+        notify_id: "n-required".into(),
+        sender_pane_id: pane_id,
+        source_context_id: ctx_id,
+        source_window_id: win_id,
+        level: "info".into(),
+        title: "Must stay".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: true,  // <-- required
+        priority: 100,
+        scope: crate::app_protocol::NotifyScope::Global,
+        image_inline: None,
+        image_pipe_id: None,
+        response_file: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        enqueued_at: std::time::Instant::now(),
+        tombstoned: false,
+        deliver_after: None,
+    });
+
+    h.app.auto_dismiss_sender_focused_notifications();
+
+    assert_eq!(
+        h.app.pending_notifications.len(),
+        1,
+        "required notification must not be auto-dismissed"
+    );
+}
+
+/// #1635: notification from a DIFFERENT pane (not the focused one) must be left alone.
+#[test]
+fn auto_dismiss_does_not_touch_other_pane_notifications() {
+    let mut h = HostHarness::new();
+    let sender_id = h.add_test_pane();
+    let focused_id = h.add_test_pane();
+
+    // Focus the second pane, NOT the sender.
+    h.app.pane_navigate(focused_id);
+
+    let ctx_id = h.app.router.active().context_id;
+    let win_id = h.app.windows[h.app.active_window].window_id;
+
+    h.app.pending_notifications.push(PendingNotification {
+        notify_id: "n-other-pane".into(),
+        sender_pane_id: sender_id,  // different from focused_id
+        source_context_id: ctx_id,
+        source_window_id: win_id,
+        level: "info".into(),
+        title: "From other pane".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        priority: 100,
+        scope: crate::app_protocol::NotifyScope::Global,
+        image_inline: None,
+        image_pipe_id: None,
+        response_file: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        enqueued_at: std::time::Instant::now(),
+        tombstoned: false,
+        deliver_after: None,
+    });
+
+    h.app.auto_dismiss_sender_focused_notifications();
+
+    assert_eq!(
+        h.app.pending_notifications.len(),
+        1,
+        "notification from a non-focused pane must not be auto-dismissed"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `auto_dismiss_sender_focused_notifications()` to `notifications.rs` — called once per frame from `update_preamble`, before focus-stack sync
- When the focused pane matches a pending notification's `sender_pane_id`, the notification is removed automatically (non-required only)
- `show_notification_modal` is set to `false` when no visible notifications remain after auto-dismiss
- `log::info!` emitted for each auto-dismissed notification and on modal close

## Behaviour

| Case | Result |
|---|---|
| Focus moves to notification's sender pane | Notification auto-dismissed |
| Notification has `required: true` | NOT dismissed — user must respond |
| Focused pane is different from sender | Notification untouched |

## Test plan

- [ ] `cargo test --bin plexi auto_dismiss` — 3 new HostHarness tests pass
- [ ] `cargo test --bin plexi` — 660 pass, 1 pre-existing failure (`welcome_tab_falls_back_to_home_dir_when_no_root`) unrelated to this PR
- [ ] Manual: open an app, trigger a non-required notification, focus the sender pane — notification dismisses
- [ ] Manual: trigger a required notification (choice/input), focus sender — notification stays

Closes #1635