### PR TITLE
refactor(protocol): remove _l0 fallback fields from L1 UiNode variants

### DIFF
--- a/apps/dev/counter-tree/counter_tree.py
+++ b/apps/dev/counter-tree/counter_tree.py
@@ -37,19 +37,16 @@ class CounterTree(App):
                         {
                             "type": "button",
                             "node_id": "decrement",
-                            "label": "−",
-                            "_l0": {"type": "text", "text": "−"},
+                            "label": "\u2212",
                         },
                         {
                             "type": "badge",
                             "label": f"{self.count}",
-                            "_l0": {"type": "text", "text": f"{self.count}"},
                         },
                         {
                             "type": "button",
                             "node_id": "increment",
                             "label": "+",
-                            "_l0": {"type": "text", "text": "+"},
                         },
                     ],
                 },
@@ -57,8 +54,7 @@ class CounterTree(App):
                     "type": "input",
                     "node_id": "label_input",
                     "value": self.label,
-                    "placeholder": "Enter a label…",
-                    "_l0": {"type": "text", "text": self.label},
+                    "placeholder": "Enter a label\u2026",
                 },
                 {
                     "type": "text",

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1562,7 +1562,7 @@ class ListRow:
 # defined in ``src/app_protocol.rs``.  ``to_node()`` returns a plain dict
 # with a ``"type"`` field; B3 (``ctx.render_tree``) will serialise the tree
 # to the host.  L0 types return their dict directly; L1 sugar types include
-# an additional ``"_l0"`` key with the L0 fallback tree.
+# L1 sugar types are rendered natively by the host.
 
 
 class Tabs:
@@ -1679,7 +1679,7 @@ class Grid:
 class Toggle:
     """On/off toggle switch (L1 sugar).
 
-    The ``_l0`` fallback is an Interactive wrapper around a text indicator.
+    Renders as an Interactive node with a horizontal stack indicator.
 
     Example::
 
@@ -1693,21 +1693,6 @@ class Toggle:
         self.label = label
 
     def to_node(self) -> dict:
-        indicator = "● " if self.value else "○ "
-        display_text = indicator + self.label if self.label else indicator.strip()
-
-        l0_child: dict = {
-            "type": "text",
-            "text": display_text,
-        }
-        l0: dict = {
-            "type": "interactive",
-            "node_id": self.node_id,
-            "child": l0_child,
-            "on_click": True,
-            "on_hover": False,
-        }
-
         return {
             "type": "interactive",
             "node_id": self.node_id,
@@ -1723,7 +1708,6 @@ class Toggle:
             },
             "on_click": True,
             "on_hover": False,
-            "_l0": l0,
         }
 
 

--- a/sdk/python/tests/test_new_components.py
+++ b/sdk/python/tests/test_new_components.py
@@ -115,14 +115,6 @@ def test_toggle_on_click_is_true() -> None:
     assert node["on_click"] is True
 
 
-def test_toggle_has_l0_fallback() -> None:
-    node = Toggle("t", value=True, label="X").to_node()
-    assert "_l0" in node
-    l0 = node["_l0"]
-    assert l0["type"] == "interactive"
-    assert l0["node_id"] == "t"
-
-
 def test_toggle_type_is_interactive() -> None:
     node = Toggle("t", value=False).to_node()
     assert node["type"] == "interactive"

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -608,8 +608,7 @@ pub struct UiPadding {
 }
 
 /// Component tree node. L0 primitives compose into rich UI; L1 sugar variants
-/// carry a mandatory `_l0: Box<UiNode>` for forward compatibility — the host
-/// always has an L0 fallback to render if it doesn't recognise the L1 tag.
+/// are rendered natively by the host.
 ///
 /// `JsonSchema` is implemented manually to avoid schemars recursion issues
 /// (UiNode contains Box<UiNode>).
@@ -663,38 +662,34 @@ pub enum UiNode {
     Surface { id: String },
 
     // ── L1 sugar ─────────────────────────────────────────────────────────
-    /// Host-rendered button. `_l0` is the fallback L0 tree.
+    /// Host-rendered button.
     Button {
         node_id: String,
         label: String,
         #[serde(default)]
         disabled: bool,
-        _l0: Box<UiNode>,
     },
-    /// Host-rendered text input. `_l0` is the fallback L0 tree.
+    /// Host-rendered text input.
     Input {
         node_id: String,
         #[serde(default)]
         placeholder: String,
         value: String,
-        _l0: Box<UiNode>,
     },
-    /// Host-rendered pill badge. `_l0` is the fallback L0 tree.
+    /// Host-rendered pill badge.
     Badge {
         label: String,
         #[serde(default)]
         fill: String,
         #[serde(default)]
         fg: String,
-        _l0: Box<UiNode>,
     },
-    /// Coloured dot indicator. `_l0` is the fallback L0 tree.
+    /// Coloured dot indicator.
     Dot {
         color: String,
         /// 0.0 means default size.
         #[serde(default)]
         size: f32,
-        _l0: Box<UiNode>,
     },
 }
 
@@ -736,21 +731,21 @@ impl PartialEq for UiNode {
                     == serde_json::to_string(cmd2.as_ref()).ok()
             }
             (UiNode::Surface { id: i1 }, UiNode::Surface { id: i2 }) => i1 == i2,
-            (UiNode::Button { node_id: n1, label: l1, disabled: d1, _l0: lo1 },
-             UiNode::Button { node_id: n2, label: l2, disabled: d2, _l0: lo2 }) => {
-                n1 == n2 && l1 == l2 && d1 == d2 && lo1 == lo2
+            (UiNode::Button { node_id: n1, label: l1, disabled: d1 },
+             UiNode::Button { node_id: n2, label: l2, disabled: d2 }) => {
+                n1 == n2 && l1 == l2 && d1 == d2
             }
-            (UiNode::Input { node_id: n1, placeholder: ph1, value: v1, _l0: lo1 },
-             UiNode::Input { node_id: n2, placeholder: ph2, value: v2, _l0: lo2 }) => {
-                n1 == n2 && ph1 == ph2 && v1 == v2 && lo1 == lo2
+            (UiNode::Input { node_id: n1, placeholder: ph1, value: v1 },
+             UiNode::Input { node_id: n2, placeholder: ph2, value: v2 }) => {
+                n1 == n2 && ph1 == ph2 && v1 == v2
             }
-            (UiNode::Badge { label: l1, fill: f1, fg: fg1, _l0: lo1 },
-             UiNode::Badge { label: l2, fill: f2, fg: fg2, _l0: lo2 }) => {
-                l1 == l2 && f1 == f2 && fg1 == fg2 && lo1 == lo2
+            (UiNode::Badge { label: l1, fill: f1, fg: fg1 },
+             UiNode::Badge { label: l2, fill: f2, fg: fg2 }) => {
+                l1 == l2 && f1 == f2 && fg1 == fg2
             }
-            (UiNode::Dot { color: c1, size: s1, _l0: lo1 },
-             UiNode::Dot { color: c2, size: s2, _l0: lo2 }) => {
-                c1 == c2 && s1 == s2 && lo1 == lo2
+            (UiNode::Dot { color: c1, size: s1 },
+             UiNode::Dot { color: c2, size: s2 }) => {
+                c1 == c2 && s1 == s2
             }
             _ => false,
         }
@@ -3679,34 +3674,6 @@ mod ui_node_tests {
         assert!(json.contains(r#""type":"stack""#), "stack tag missing: {json}");
         assert!(json.contains(r#""type":"text""#), "text tag missing: {json}");
         assert!(json.contains(r#""text":"hello""#), "text content missing: {json}");
-    }
-
-    #[test]
-    fn button_with_l0_round_trips_serde() {
-        let node = UiNode::Button {
-            node_id: "btn1".into(),
-            label: "Click me".into(),
-            disabled: false,
-            _l0: Box::new(UiNode::Text {
-                text: "Click me".into(),
-                size: 0.0,
-                color: String::new(),
-                bold: false,
-                monospace: false,
-            }),
-        };
-        let json = serde_json::to_string(&node).expect("serialize");
-        assert!(json.contains(r#""type":"button""#), "button tag missing: {json}");
-        assert!(json.contains(r#""node_id":"btn1""#), "node_id missing: {json}");
-        assert!(json.contains(r#""_l0""#), "_l0 field key missing from serialized JSON: {json}");
-        let round_tripped: UiNode = serde_json::from_str(&json).expect("deserialize");
-        match round_tripped {
-            UiNode::Button { node_id, label, .. } => {
-                assert_eq!(node_id, "btn1");
-                assert_eq!(label, "Click me");
-            }
-            other => panic!("expected Button, got {other:?}"),
-        }
     }
 
     #[test]

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -461,13 +461,6 @@ mod render_component_tree_tests {
             node_id: "btn1".into(),
             label: "Click me".into(),
             disabled: false,
-            _l0: Box::new(UiNode::Text {
-                text: "Click me".into(),
-                size: 14.0,
-                color: String::new(),
-                bold: false,
-                monospace: false,
-            }),
         };
         if let UiNode::Button { node_id, label, disabled, .. } = &node {
             assert_eq!(node_id, "btn1");


### PR DESCRIPTION
## Summary

- Removes `_l0: Box<UiNode>` from all four L1 variants: `Button`, `Input`, `Badge`, `Dot`
- Updates the manual `PartialEq` impl to drop `_l0` comparisons
- Deletes `button_with_l0_round_trips_serde` test (only tested _l0 serialization)
- Cleans up `render_components.rs` test construction site
- Removes `_l0` dict keys from Python SDK `Toggle.to_node()` and `counter_tree.py`
- Deletes `test_toggle_has_l0_fallback` Python test

**Serde compatibility:** UiNode uses `#[serde(tag = "type")]` with no `deny_unknown_fields`, so older SDK payloads that still send `_l0` will be silently ignored.

## Test plan

- [x] `cargo build --bin plexi` passes
- [x] `cargo test --bin plexi`: 656 passed, 1 pre-existing unrelated failure (`welcome_tab_falls_back_to_home_dir_when_no_root`)
- [x] `uv run pytest tests/test_new_components.py`: 23 passed