### PR TITLE
fix(overlays): allow QuickNote to open over non-critical modals (#1626)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -53,6 +53,44 @@ impl PlexiApp {
         });
     }
 
+    /// Returns `true` when the current top focus layer is a non-critical modal
+    /// that QuickNote (Cmd+0) is allowed to dismiss and replace.
+    ///
+    /// Critical modals (`ConfirmClose`, `CapabilityModal`, `ContextCloseConfirm`)
+    /// require explicit user acknowledgement and must NOT be preempted.
+    /// Non-critical modals (`NotificationModal`, `CommandPalette`) can be safely
+    /// dismissed so QuickNote can open on top.
+    pub(crate) fn is_quick_note_preemptable(&self) -> bool {
+        matches!(
+            self.focus_stack.last(),
+            Some(FocusLayer::NotificationModal) | Some(FocusLayer::CommandPalette)
+        )
+    }
+
+    /// Dismiss the current non-critical modal so QuickNote can open on top.
+    /// Only call after `is_quick_note_preemptable()` returns `true`.
+    pub(crate) fn dismiss_preemptable_modal(&mut self) {
+        match self.focus_stack.last().cloned() {
+            Some(FocusLayer::NotificationModal) => {
+                log::info!("quick_note: dismissing NotificationModal to open QuickNote");
+                self.show_notification_modal = false;
+                self.focus_stack.retain(|l| *l != FocusLayer::NotificationModal);
+            }
+            Some(FocusLayer::CommandPalette) => {
+                log::info!("quick_note: dismissing CommandPalette to open QuickNote");
+                self.show_command_palette = false;
+                self.focus_stack.retain(|l| *l != FocusLayer::CommandPalette);
+                self.ctx.memory_mut(|m| {
+                    let palette_id = egui::Id::new("palette_search");
+                    if m.focused() == Some(palette_id) {
+                        m.surrender_focus(palette_id);
+                    }
+                });
+            }
+            _ => {}
+        }
+    }
+
     /// True when a modal overlay owns keyboard input. Used by `update()` to
     /// drain remaining key events after the overlay has rendered so panes see
     /// an empty input buffer this frame.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1466,6 +1466,22 @@ impl eframe::App for PlexiApp {
         // even when an overlay holds focus (see early-return guard in `keys::poll_actions`).
         let mut early_modal_cmds: Vec<crate::app_trait::AppCommand> = Vec::new();
         let overlay_key_disposition = if self.input_captured_by_overlay() {
+            // Step 0: QuickNote preemption (#1626).
+            // Cmd+0 is a high-priority action that must fire even when a non-critical
+            // modal is open. Consume the key here — before the overlay draw phase can
+            // absorb it via a focused TextEdit widget — then dismiss the non-critical
+            // modal and open QuickNote. Critical modals (ConfirmClose, CapabilityModal,
+            // ContextCloseConfirm) are not preemptable and fall through to handle_key.
+            let qn_binding = self.key_bindings.open_quick_note;
+            let qn_pressed = ctx.input_mut(|i| i.consume_key(qn_binding.0, qn_binding.1));
+            if qn_pressed && self.is_quick_note_preemptable() {
+                self.dismiss_preemptable_modal();
+                self.open_quick_note_modal();
+                self.sync_notification_modal_focus();
+                self.sync_command_palette_focus();
+                log::info!("quick_note: opened by preempting non-critical modal");
+                crate::app_trait::KeyDisposition::Consumed
+            } else {
             // Step 1: run the overlay's handle_key (consumes its owned key events).
             let disposition = match self.focus_stack.last() {
                 Some(FocusLayer::NotificationModal) => self.notification_modal_handle_key(ctx),
@@ -1542,6 +1558,7 @@ impl eframe::App for PlexiApp {
             self.sync_text_input_focus();
             self.sync_capability_modal_focus();
             disposition
+            } // end else (non-preempted path)
         } else {
             crate::app_trait::KeyDisposition::Passthrough
         };

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1344,6 +1344,7 @@ fn new_context_creates_top_level_empty_context() {
     );
 }
 
+
 // ── #1635: auto-dismiss when originating pane is focused ─────────────────────
 
 /// #1635: non-required notification from a focused pane must be auto-dismissed.
@@ -1490,5 +1491,98 @@ fn auto_dismiss_does_not_touch_other_pane_notifications() {
         h.app.pending_notifications.len(),
         1,
         "notification from a non-focused pane must not be auto-dismissed"
+    );
+}
+
+// ── QuickNote preemption tests (#1626) ────────────────────────────────────
+
+/// #1626: Cmd+0 with a NotificationModal on the focus stack must dismiss the
+/// modal and push FocusLayer::QuickNote to the top.
+#[test]
+fn quicknote_preempts_notification_modal() {
+    let mut h = HostHarness::new();
+    h.add_test_pane();
+
+    // Simulate a NotificationModal being open.
+    h.app.push_focus_layer(FocusLayer::NotificationModal);
+    assert_eq!(
+        h.app.focus_stack.last(),
+        Some(&FocusLayer::NotificationModal),
+        "NotificationModal must be on top before preemption"
+    );
+    assert!(
+        h.app.is_quick_note_preemptable(),
+        "NotificationModal must be preemptable"
+    );
+
+    h.app.dismiss_preemptable_modal();
+    h.app.open_quick_note_modal();
+
+    assert_eq!(
+        h.app.focus_stack.last(),
+        Some(&FocusLayer::QuickNote),
+        "QuickNote must be on top after preemption"
+    );
+}
+
+/// #1626: Cmd+0 with CommandPalette on the focus stack must dismiss the
+/// palette and push FocusLayer::QuickNote to the top.
+#[test]
+fn quicknote_preempts_command_palette() {
+    let mut h = HostHarness::new();
+    h.add_test_pane();
+
+    h.app.push_focus_layer(FocusLayer::CommandPalette);
+    assert!(
+        h.app.is_quick_note_preemptable(),
+        "CommandPalette must be preemptable"
+    );
+
+    h.app.dismiss_preemptable_modal();
+    h.app.open_quick_note_modal();
+
+    assert_eq!(
+        h.app.focus_stack.last(),
+        Some(&FocusLayer::QuickNote),
+        "QuickNote must be on top after preempting CommandPalette"
+    );
+}
+
+/// #1626: ConfirmClose is critical and must NOT be preemptable by QuickNote.
+#[test]
+fn quicknote_does_not_preempt_confirm_close() {
+    let mut h = HostHarness::new();
+    h.add_test_pane();
+
+    h.app.push_focus_layer(FocusLayer::ConfirmClose);
+    assert!(
+        !h.app.is_quick_note_preemptable(),
+        "ConfirmClose must NOT be preemptable"
+    );
+}
+
+/// #1626: CapabilityModal is critical and must NOT be preemptable by QuickNote.
+#[test]
+fn quicknote_does_not_preempt_capability_modal() {
+    let mut h = HostHarness::new();
+    h.add_test_pane();
+
+    h.app.push_focus_layer(FocusLayer::CapabilityModal);
+    assert!(
+        !h.app.is_quick_note_preemptable(),
+        "CapabilityModal must NOT be preemptable"
+    );
+}
+
+/// #1626: ContextCloseConfirm is critical and must NOT be preemptable.
+#[test]
+fn quicknote_does_not_preempt_context_close_confirm() {
+    let mut h = HostHarness::new();
+    h.add_test_pane();
+
+    h.app.push_focus_layer(FocusLayer::ContextCloseConfirm);
+    assert!(
+        !h.app.is_quick_note_preemptable(),
+        "ContextCloseConfirm must NOT be preemptable"
     );
 }


### PR DESCRIPTION
## Summary

- Cmd+0 (QuickNote) was silently blocked when `NotificationModal` or `CommandPalette` held focus — the overlay's draw phase absorbed the key via a focused `TextEdit` widget before `poll_actions` could see it
- Fix: in the overlay dispatch block, consume the QuickNote key binding **before** `handle_key`/draw runs; if the current layer is non-critical, dismiss it and open QuickNote
- Critical modals (`ConfirmClose`, `CapabilityModal`, `ContextCloseConfirm`) are not preemptable — QuickNote falls through to normal modal handling

## Changes

- `src/app/focus.rs`: `is_quick_note_preemptable()` — returns `true` for `NotificationModal` and `CommandPalette`; `dismiss_preemptable_modal()` — cleanly closes the modal and releases egui focus
- `src/app/mod.rs`: Step 0 in the overlay dispatch block — consumes QuickNote key and preempts if layer is non-critical
- `src/app/tests.rs`: 5 HostHarness regression tests (2 preemption cases, 3 critical-modal guards)

## Test plan

- [ ] Open `NotificationModal` (Cmd+Shift+A), press Cmd+0 — QuickNote opens
- [ ] Open `CommandPalette` (Cmd+P), press Cmd+0 — QuickNote opens  
- [ ] Trigger `ConfirmClose` dialog, press Cmd+0 — dialog stays (no preemption)
- [ ] `cargo test --bin plexi app::tests::quicknote` — 5 tests pass

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)