### PR TITLE
chore(apps): core app theming audit -- ctx.theme + FooterKeys across Core 9

### DIFF
--- a/apps/backlog/backlog.py
+++ b/apps/backlog/backlog.py
@@ -24,7 +24,6 @@ from plexi_sdk.ui import (
     SelectList, TextInput,
     SPACE_MD, TEXT_HINT, TEXT_BODY, TEXT_CAPTION,
 )
-from plexi_sdk.ui import theme
 
 
 def _detect_channel_backlog_dir() -> "Path | None":
@@ -81,24 +80,24 @@ class _TwoPaneBody(Component):
 
         if not has_any_dir:
             app.emit.info("backlog: no dirs found — showing empty-state guide")
-            ctx.text(x + 12, y + 12, "No notes yet.", size=TEXT_BODY, color=theme.fg)
+            ctx.text(x + 12, y + 12, "No notes yet.", size=TEXT_BODY, color=ctx.theme.fg)
             if app.global_only:
                 ctx.text(x + 12, y + 34,
                          "No channel-level backlog found. Press ⌘0 to create a Quick Note.",
-                         size=TEXT_HINT, color=theme.muted, max_width=w - 24)
+                         size=TEXT_HINT, color=ctx.theme.muted, max_width=w - 24)
             else:
                 ctx.text(x + 12, y + 34,
                          "Press ⌘0 to open Quick Note, then press Enter twice to send to your backlog.",
-                         size=TEXT_HINT, color=theme.muted, max_width=w - 24)
+                         size=TEXT_HINT, color=ctx.theme.muted, max_width=w - 24)
             return
 
         # Vertical divider between list and preview
-        ctx.rect(x + list_w, y, 1.0, h, theme.highlight)
+        ctx.rect(x + list_w, y, 1.0, h, ctx.theme.highlight)
 
         # ── Item list ────────────────────────────────────────────────────────────
         if not app.filtered:
             msg = "No results" if app.search_query else "Backlog is empty"
-            ctx.text(x + 12, y + 12, msg, size=TEXT_CAPTION, color=theme.muted)
+            ctx.text(x + 12, y + 12, msg, size=TEXT_CAPTION, color=ctx.theme.muted)
         else:
             app._item_list.render(ctx, x, y, list_w, h)
 
@@ -107,13 +106,13 @@ class _TwoPaneBody(Component):
         pw = w - (list_w + 14) - 10
         if app.preview_path and app.preview_text is not None:
             ctx.text(px, y - SPACE_MD, app.preview_path.name,
-                     size=TEXT_HINT, color=theme.accent, bold=True, max_width=pw)
+                     size=TEXT_HINT, color=ctx.theme.accent, bold=True, max_width=pw)
             lines = app.preview_text.splitlines()
             for li, line in enumerate(lines):
                 ly = y + li * 15.0
                 if ly > y + h - 4:
                     break
-                color = theme.fg if not line.startswith("#") else theme.accent
+                color = ctx.theme.fg if not line.startswith("#") else ctx.theme.accent
                 ctx.text(px, ly, line, size=TEXT_HINT, color=color, monospace=True,
                          max_width=pw)
 
@@ -280,10 +279,10 @@ class BacklogApp(App):
         if self.in_search:
             footer_widget: Component = Footer(
                 f"/ {self.search_query}▌",  # block cursor
-                color=theme.accent,
+                color=ctx.theme.accent,
             )
         elif self.status:
-            footer_widget = Footer(self.status, color=theme.success)
+            footer_widget = Footer(self.status, color=ctx.theme.success)
         else:
             footer_widget = FooterKeys([
                 ("j/k", "navigate"),
@@ -310,22 +309,22 @@ class BacklogApp(App):
         # ── Add-item overlay ─────────────────────────────────────────────────────
         if self.in_add:
             ox, oy, ow, oh = w / 2 - 200, h / 2 - 36, 400, 86
-            ctx.rect(ox, oy, ow, oh, theme.surface, radius=6.0)
-            ctx.rect(ox, oy, ow, 1, theme.highlight)
+            ctx.rect(ox, oy, ow, oh, ctx.theme.surface, radius=6.0)
+            ctx.rect(ox, oy, ow, 1, ctx.theme.highlight)
             ctx.text(ox + 16, oy + 12, "New backlog item",
-                     size=TEXT_CAPTION, color=theme.accent, bold=True)
+                     size=TEXT_CAPTION, color=ctx.theme.accent, bold=True)
             self._add_input.render(ctx, ox + 16, oy + 36, ow - 32, self._add_input.height)
 
         # ── Delete confirm overlay ───────────────────────────────────────────────
         if self.confirm_delete and self.filtered:
             name = self.filtered[self.selected].name
             ox, oy, ow, oh = w / 2 - 170, h / 2 - 36, 340, 72
-            ctx.rect(ox, oy, ow, oh, theme.surface, radius=6.0)
-            ctx.rect(ox, oy, ow, 1, theme.highlight)
+            ctx.rect(ox, oy, ow, oh, ctx.theme.surface, radius=6.0)
+            ctx.rect(ox, oy, ow, 1, ctx.theme.highlight)
             ctx.text(ox + 16, oy + 14, f"Delete '{name}'?",
-                     size=TEXT_BODY, color=theme.danger, bold=True)
+                     size=TEXT_BODY, color=ctx.theme.danger, bold=True)
             ctx.text(ox + 16, oy + 36, "Enter → confirm    Esc → cancel",
-                     size=TEXT_HINT, color=theme.muted)
+                     size=TEXT_HINT, color=ctx.theme.muted)
 
     # ── Keys ─────────────────────────────────────────────────────────────────────
 

--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -12,7 +12,6 @@ from plexi_sdk.ui import (
     Column, Card, AppBar, Heading, FooterKeys, ButtonRow, Spacer, Component,
     SPACE_SM, SPACE_MD,
 )
-from plexi_sdk.ui import theme
 
 # Grid geometry — fixed per-button size; gap matches Card inner gap default.
 BTN_W = 64.0
@@ -81,17 +80,17 @@ class CalcApp(App):
             if label in self._btns:
                 continue  # "." only appears once, but guard for safety
             if _is_op(label):
-                fill = theme.accent
-                hover_fill = "#b9d0f7"
-                text_color = theme.bg
+                fill = ctx.theme.accent
+                hover_fill = ctx.theme.highlight
+                text_color = ctx.theme.bg
             elif _is_clear(label):
-                fill = theme.danger
-                hover_fill = "#f5a3b5"
-                text_color = theme.bg
+                fill = ctx.theme.danger
+                hover_fill = ctx.theme.surface
+                text_color = ctx.theme.bg
             else:
-                fill = theme.surface
-                hover_fill = "#45475a"
-                text_color = theme.fg
+                fill = ctx.theme.surface
+                hover_fill = ctx.theme.highlight
+                text_color = ctx.theme.fg
 
             self._btns[label] = ButtonRow(
                 id=f"btn_{label}",

--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -14,8 +14,6 @@ from plexi_sdk.ui import (
 COL_W = 130.0
 CELL_PAD = 8.0
 ROW_H = 24.0
-STRIPE = "#0d0d0d"
-HEADER_BG = "#1a1a2e"
 
 
 class CsvViewer(App):
@@ -162,7 +160,7 @@ class CsvViewer(App):
         col_end = min(len(self._headers), col_start + visible_cols)
 
         # Header row
-        ctx.rect(0, y, w, ROW_H, fill=HEADER_BG, radius=0.0)
+        ctx.rect(0, y, w, ROW_H, fill=ctx.theme.surface, radius=0.0)
         for ci, col_idx in enumerate(range(col_start, col_end)):
             x = ci * COL_W + CELL_PAD
             label = self._headers[col_idx] if col_idx < len(self._headers) else ""
@@ -181,7 +179,7 @@ class CsvViewer(App):
         for ri, row_idx in enumerate(range(row_start, row_end)):
             row_y = y + ri * ROW_H
             if ri % 2 == 1:
-                ctx.rect(0, row_y, w, ROW_H, fill=STRIPE, radius=0.0)
+                ctx.rect(0, row_y, w, ROW_H, fill=ctx.theme.bg_darkest, radius=0.0)
             row = self._rows[row_idx]
             for ci, col_idx in enumerate(range(col_start, col_end)):
                 x = ci * COL_W + CELL_PAD

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -47,7 +47,7 @@ class _SnakeCanvas(Component):
         # Grid border
         ctx.rect(ox - 2, oy - 2, COLS * CELL + 4, ROWS * CELL + 4,
                  fill=ctx.theme.muted, radius=2.0)
-        ctx.rect(ox, oy, COLS * CELL, ROWS * CELL, fill="#11111b")
+        ctx.rect(ox, oy, COLS * CELL, ROWS * CELL, fill=ctx.theme.bg_darkest)
         # Food
         fx, fy = app._food
         ctx.rect(ox + fx * CELL + 2, oy + fy * CELL + 2,
@@ -61,7 +61,7 @@ class _SnakeCanvas(Component):
         if app._dead:
             msg = "GAME OVER — press R to restart"
             ctx.rect(ox + COLS * CELL / 2 - 150, oy + ROWS * CELL / 2 - 18,
-                     300, 36, fill="#1e1e2e", radius=6.0)
+                     300, 36, fill=ctx.theme.bg, radius=6.0)
             ctx.text(ox + COLS * CELL / 2 - 140,
                      oy + ROWS * CELL / 2 - 8,
                      msg, size=13.0, color=ctx.theme.danger)

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -286,7 +286,7 @@ class _StatsCanvas(Component):
 
         # stats bar
         stats_y = y + treemap_h
-        ctx.rect(x, stats_y, w, STATS_BAR_H, fill="#181825")
+        ctx.rect(x, stats_y, w, STATS_BAR_H, fill=ctx.theme.surface)
         ctx.line(x, stats_y, x + w, stats_y, color=dim(ctx.theme.muted, 60), width=1.0)
         ctx.line(x, stats_y + STATS_BAR_H, x + w, stats_y + STATS_BAR_H,
                  color=dim(ctx.theme.muted, 60), width=1.0)
@@ -298,14 +298,14 @@ class _StatsCanvas(Component):
                  size=TEXT_CAPTION, color=ctx.theme.accent, bold=True, align="center")
         ctx.text(x + third * 1.5, stats_text_y,
                  f"{app.total_visits} visits",
-                 size=TEXT_CAPTION, color="#a6e3a1", bold=True, align="center")
+                 size=TEXT_CAPTION, color=ctx.theme.success, bold=True, align="center")
         ctx.text(x + third * 2.5, stats_text_y,
                  f"{app.total_projects} projects",
-                 size=TEXT_CAPTION, color="#f9e2af", bold=True, align="center")
+                 size=TEXT_CAPTION, color=ctx.theme.warning, bold=True, align="center")
 
         # timeline strip
         tl_y = stats_y + STATS_BAR_H
-        ctx.rect(x, tl_y, w, TIMELINE_H, fill="#11111b")
+        ctx.rect(x, tl_y, w, TIMELINE_H, fill=ctx.theme.bg_darkest)
 
         bar_y = tl_y + 4
         bar_h = TIMELINE_H - 20

--- a/apps/tetris/tetris.py
+++ b/apps/tetris/tetris.py
@@ -203,22 +203,22 @@ class _TetrisCanvas(Component):
         px = bx + board_w + cell
         py = by
 
-        ctx.text(px, py, "SCORE", size=10, color="#6c7086")
+        ctx.text(px, py, "SCORE", size=10, color=ctx.theme.muted)
         py += 16
-        ctx.text(px, py, f"{app.score:,}", size=20, color="#cdd6f4", bold=True)
+        ctx.text(px, py, f"{app.score:,}", size=20, color=ctx.theme.fg, bold=True)
         py += 32
 
-        ctx.text(px, py, "LINES", size=10, color="#6c7086")
+        ctx.text(px, py, "LINES", size=10, color=ctx.theme.muted)
         py += 16
-        ctx.text(px, py, str(app.lines), size=16, color="#cdd6f4")
+        ctx.text(px, py, str(app.lines), size=16, color=ctx.theme.fg)
         py += 28
 
-        ctx.text(px, py, "LEVEL", size=10, color="#6c7086")
+        ctx.text(px, py, "LEVEL", size=10, color=ctx.theme.muted)
         py += 16
-        ctx.text(px, py, str(app.level), size=16, color="#cdd6f4")
+        ctx.text(px, py, str(app.level), size=16, color=ctx.theme.fg)
         py += 36
 
-        ctx.text(px, py, "NEXT", size=10, color="#6c7086")
+        ctx.text(px, py, "NEXT", size=10, color=ctx.theme.muted)
         py += 16
         nc = app.next.color()
         ps = cell * 0.72
@@ -233,16 +233,16 @@ class _TetrisCanvas(Component):
             oy = by + (board_h - oh) / 2
             ctx.rect(ox, oy, ow, oh, fill="#000000cc", radius=4.0)
             ctx.text(ox + ow / 2 - 52, oy + 16, "GAME OVER",
-                     size=22, color="#f38ba8", bold=True)
+                     size=22, color=ctx.theme.danger, bold=True)
             ctx.text(ox + ow / 2 - 42, oy + 46, "R to restart",
-                     size=13, color="#cdd6f4")
+                     size=13, color=ctx.theme.fg)
 
         elif app.paused:
             ow = board_w
             oh = 50.0
             ctx.rect(bx, by + (board_h - oh) / 2, ow, oh, fill="#000000cc", radius=4.0)
             ctx.text(bx + ow / 2 - 28, by + (board_h - oh) / 2 + 14,
-                     "PAUSED", size=18, color="#f9e2af", bold=True)
+                     "PAUSED", size=18, color=ctx.theme.warning, bold=True)
 
         # Drive the game loop — ~60 fps when active or animating, ~10 fps when paused/over.
         active = not app.game_over and (not app.paused or app.clear_anim is not None)

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -10,7 +10,7 @@ from plexi_sdk import (
 )
 from plexi_sdk.ui import (
     Column, AppBar, Spacer, Footer, FooterKeys,
-    Label, Section, Scrollable, SelectList, TextInput,
+    Label, Section, Scrollable, SelectList, TextInput, theme,
 )
 
 API = "https://en.wikipedia.org/w/api.php"
@@ -141,7 +141,7 @@ class WikiApp(App):
         if self._mode == "search":
             children: list = [self._search_input]
             if self._error_msg:
-                children.append(Label(f"Error: {self._error_msg}", tone="hint", color="#ff4444"))
+                children.append(Label(f"Error: {self._error_msg}", tone="hint", color=theme.danger))
             else:
                 children.append(Label("Type a query and press Enter", tone="hint"))
             return children


### PR DESCRIPTION
## Summary

- Replace all hardcoded hex UI colors and module-level `theme` singleton references with `ctx.theme.*` across 7 core apps (backlog, calc, csv_viewer, wikipedia, stats, snake, tetris)
- `todo`, `quick-note`, and `balls` were already clean -- no changes needed
- Game art palettes (tetromino canonical colors, ball physics palette) preserved as specified

## Changes per app

| App | Change |
|---|---|
| `backlog` | `theme.{fg,muted,highlight,accent,success,surface,danger}` -> `ctx.theme.*`, remove unused import |
| `calc` | `theme.*` -> `ctx.theme.*` in `on_init`, hardcoded hover hex -> `ctx.theme.highlight/surface`, remove import |
| `csv_viewer` | `STRIPE="#0d0d0d"` -> `ctx.theme.bg_darkest`, `HEADER_BG="#1a1a2e"` -> `ctx.theme.surface` |
| `wikipedia` | error label `"#ff4444"` -> `theme.danger` (via singleton; Label.color is static, can't use ctx) |
| `stats` | stats bar `"#181825"` -> `ctx.theme.surface`, timeline `"#11111b"` -> `ctx.theme.bg_darkest`, visits/projects colors -> `ctx.theme.success/warning` |
| `snake` | grid bg `"#11111b"` -> `ctx.theme.bg_darkest`, game-over overlay `"#1e1e2e"` -> `ctx.theme.bg` |
| `tetris` | info panel labels `"#6c7086"/"#cdd6f4"` -> `ctx.theme.muted/fg`, GAME OVER -> `ctx.theme.danger`, PAUSED -> `ctx.theme.warning` |

## Test plan

- [ ] Open each updated app in alpha and verify colors render correctly
- [ ] Toggle between light/dark themes if available -- verify colors adapt
- [ ] Verify game apps (snake, tetris, balls) still look correct -- game palettes unchanged

Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)