### PR TITLE
feat(sdk): route ComponentEvent to on_component_event (#1904)

### DIFF
--- a/apps/dev/counter-tree/counter_tree.py
+++ b/apps/dev/counter-tree/counter_tree.py
@@ -1,8 +1,6 @@
-"""Counter app demonstrating the component tree API (epic #1897 B3).
+"""Counter app demonstrating L1 ComponentEvent routing.
 
-Button/Input nodes are included for visual Style O verification only.
-ComponentEvent routing to Python apps is not yet in the SDK — button
-clicks and input changes have no effect until that is wired up.
+Button clicks and input changes fire on_component_event with matching node_id.
 """
 from plexi_sdk import App, State
 
@@ -10,6 +8,17 @@ from plexi_sdk import App, State
 class CounterTree(App):
     count = State(0)
     label = State("")
+
+    def on_component_event(self, ctx, node_id, event_type, payload):
+        if event_type == "click":
+            if node_id == "increment":
+                self.count += 1
+                ctx.info(f"increment -> {self.count}")
+            elif node_id == "decrement":
+                self.count -= 1
+                ctx.info(f"decrement -> {self.count}")
+        elif event_type == "change" and node_id == "label_input":
+            self.label = (payload or {}).get("value", "")
 
     def on_key(self, ctx, key, mods):
         if key in ("up", "="):
@@ -37,7 +46,7 @@ class CounterTree(App):
                         {
                             "type": "button",
                             "node_id": "decrement",
-                            "label": "\u2212",
+                            "label": "−",
                         },
                         {
                             "type": "badge",
@@ -54,11 +63,11 @@ class CounterTree(App):
                     "type": "input",
                     "node_id": "label_input",
                     "value": self.label,
-                    "placeholder": "Enter a label\u2026",
+                    "placeholder": "Enter a label…",
                 },
                 {
                     "type": "text",
-                    "text": "up/down or +/- to change",
+                    "text": self.label or "up/down or click buttons",
                     "size": 12.0,
                     "color": "#6c7086",
                 },

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -113,6 +113,8 @@ class App:
         on_mouse_move(ctx, x, y, buttons, mods={})  — on MouseMove event
         on_command(ctx, text)                        — on Command event
         on_paste(ctx, text)                          — on Paste event
+        on_component_event(ctx, node_id, event_type, payload)
+                                                    — on L1 ComponentEvent (button click, input change)
         on_text_submitted(ctx, id, text)             — on TextInput Enter press
         on_pipe_message(ctx, pipe_id, payload)       — on PipeMessage
         on_path_changed(ctx, cwd)                    — on PathChanged
@@ -316,6 +318,7 @@ class App:
     def on_list_activate(self, _ctx: "RenderContext", _id: str, _index: int) -> "Coroutine[Any, Any, None] | None":
         """Called when Enter is pressed on a selected list_view item."""
         return None
+    def on_component_event(self, _ctx: RenderContext, _node_id: str, _event_type: str, _payload: Any) -> "Coroutine[Any, Any, None] | None": return None
     def on_text_submitted(self, _ctx: RenderContext, _id: str, _text: str) -> "Coroutine[Any, Any, None] | None": return None
     def on_file_picked(self, _ctx: RenderContext, _request_id: str, _paths: "list[str]") -> "Coroutine[Any, Any, None] | None":
         """Called when the user selected one or more files in the picker.
@@ -1224,6 +1227,15 @@ class App:
                     request_id = str(ev.get("request_id", ""))
                     ctx = self._make_ctx()
                     await self._dispatch_hook(self.on_file_pick_cancelled, ctx, request_id)
+
+                elif t == "component_event":
+                    ctx = self._make_ctx()
+                    self._dispatch_hook_task(
+                        self.on_component_event, ctx,
+                        ev.get("node_id", ""),
+                        ev.get("event_type", ""),
+                        ev.get("payload"),
+                    )
 
                 elif t == "tool_call":
                     # v3.7 tool protocol (#399). Host asks this pane to execute


### PR DESCRIPTION
Closes #1904

## Summary

- Add `on_component_event(ctx, node_id, event_type, payload)` stub to the SDK `App` base class
- Wire `elif t == "component_event"` dispatch case in the event loop so L1 Button/Input interactions reach apps
- Update counter-tree demo to handle button clicks and input changes via the new hook

## Done When

- `plexi-alpha app open counter-tree`: clicking "−" decrements the count, clicking "+" increments it
- `cargo test --bin plexi` green (no Rust changes)

## Notes

Host already fires `ComponentEvent` from `render_components.rs` and forwards via `process_app/render.rs`. This was purely a Python SDK gap.