### PR TITLE
feat(open): auto-set pane title to wrapped command (#1037)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -176,7 +176,7 @@ pub use install::{install_cli, install_pack_cli, install_workspace_pack_cli, ple
 pub use list::{freeze_cli, parse_notify_choice};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
-pub use open::{open_cli, terminal_cli, pane_new_cli};
+pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -183,6 +183,43 @@ pub fn pane_new_cli(
     0
 }
 
+/// Derive a short display name for an MCP pane from the server command args.
+///
+/// Rules (matching the issue spec):
+/// - Skip leading runner tokens (`npx`, `node`, `uvx`, `python`, `python3`, `bunx`)
+/// - Take the first remaining arg as the package/server name
+/// - Strip a leading `@scope/` prefix
+/// - Strip a leading `server-` prefix from the remainder
+/// - Prefix the result with `"mcp: "`
+///
+/// Examples:
+///   `["npx", "@modelcontextprotocol/server-filesystem", "/tmp"]` → `"mcp: filesystem"`
+///   `["uvx", "mcp-server-fetch"]`                               → `"mcp: fetch"`
+///   `["npx", "@scope/server-git"]`                              → `"mcp: git"`
+pub fn mcp_pane_title(args: &[String]) -> String {
+    const RUNNERS: &[&str] = &["npx", "node", "uvx", "bunx", "python", "python3", "deno", "bun"];
+    let name = args
+        .iter()
+        .find(|a| !RUNNERS.contains(&a.as_str()) && !a.starts_with('-'))
+        .map(String::as_str)
+        .unwrap_or("mcp");
+
+    // Strip leading `@scope/` if present
+    let after_scope = if let Some(pos) = name.find('/') {
+        &name[pos + 1..]
+    } else {
+        name
+    };
+
+    // Strip leading `server-` or `mcp-server-` prefix
+    let short = after_scope
+        .strip_prefix("mcp-server-")
+        .or_else(|| after_scope.strip_prefix("server-"))
+        .unwrap_or(after_scope);
+
+    format!("mcp: {short}")
+}
+
 /// Thin wrapper preserving the existing `plexi app open` call site.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     // Intercept github: prefix for ephemeral open-without-install.
@@ -227,4 +264,50 @@ fn read_line_plain() -> io::Result<String> {
         .trim_end_matches('\n')
         .trim_end_matches('\r')
         .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mcp_pane_title;
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn mcp_title_npx_scoped_server() {
+        assert_eq!(
+            mcp_pane_title(&args(&["npx", "@modelcontextprotocol/server-filesystem", "/tmp"])),
+            "mcp: filesystem"
+        );
+    }
+
+    #[test]
+    fn mcp_title_uvx_mcp_server_prefix() {
+        assert_eq!(
+            mcp_pane_title(&args(&["uvx", "mcp-server-fetch"])),
+            "mcp: fetch"
+        );
+    }
+
+    #[test]
+    fn mcp_title_scoped_server_git() {
+        assert_eq!(
+            mcp_pane_title(&args(&["npx", "@scope/server-git"])),
+            "mcp: git"
+        );
+    }
+
+    #[test]
+    fn mcp_title_bare_binary() {
+        assert_eq!(
+            mcp_pane_title(&args(&["my-mcp-tool"])),
+            "mcp: my-mcp-tool"
+        );
+    }
+
+    #[test]
+    fn mcp_title_empty_args() {
+        assert_eq!(mcp_pane_title(&[]), "mcp: mcp");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,11 +263,25 @@ fn main() -> eframe::Result {
                                 log::info!("app_open:cli: opening app type_id={tid}");
                                 std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id, None));
                             } else if !mcp.is_empty() {
-                                log::info!("app_open:cli: launching mcp-renderer with command {:?}", mcp);
-                                std::process::exit(cli::open_cli("mcp-renderer", &mcp, layout.as_deref(), from_pane_id, None));
+                                let title = cli::mcp_pane_title(&mcp);
+                                log::info!("app_open:cli: launching mcp-renderer with command {:?}, auto-title={title:?}", mcp);
+                                let layout_str = layout.as_deref().unwrap_or("split_h");
+                                std::process::exit(cli::pane_new_cli(
+                                    None,
+                                    Some(title.as_str()),
+                                    layout_str,
+                                    from_pane_id,
+                                    None,
+                                    false,
+                                    false,
+                                    Some("mcp-renderer"),
+                                    &mcp,
+                                    None,
+                                    &[],
+                                ));
                             } else {
                                 let binary = cli_flag.unwrap();
-                                log::info!("app_open:cli: running --help parser for `{binary}`");
+                                log::info!("app_open:cli: running --help parser for `{binary}`, auto-title={binary:?}");
                                 match crate::cli::help_parser::parse_help_to_descriptor(&binary) {
                                     Ok(json) => {
                                         let id = uuid::Uuid::new_v4();
@@ -278,13 +292,20 @@ fn main() -> eframe::Result {
                                             std::process::exit(1);
                                         }
                                         let path = tmp.to_string_lossy().into_owned();
+                                        let layout_str = layout.as_deref().unwrap_or("split_h");
                                         log::info!("app_open:cli: launching descriptor-renderer with descriptor at {path}");
-                                        std::process::exit(cli::open_cli(
-                                            "descriptor-renderer",
-                                            &[path],
-                                            layout.as_deref(),
+                                        std::process::exit(cli::pane_new_cli(
+                                            None,
+                                            Some(binary.as_str()),
+                                            layout_str,
                                             from_pane_id,
                                             None,
+                                            false,
+                                            false,
+                                            Some("descriptor-renderer"),
+                                            &[],
+                                            None,
+                                            &[path],
                                         ));
                                     }
                                     Err(e) => {


### PR DESCRIPTION
## Summary

- Adds `mcp_pane_title()` in `src/cli/open.rs` that derives a short display name from MCP server command args, stripping runner tokens (npx/uvx/node/etc.), scope prefixes (`@scope/`), and server name prefixes (`server-`/`mcp-server-`), then prefixes with `"mcp: "`
- For `plexi app open --cli <binary>`, the binary name becomes the pane title automatically
- Both `--mcp` and `--cli` paths in `main.rs` now call `pane_new_cli` directly (bypassing the name-less `open_cli` wrapper) so the computed title flows into the `spawn_pane` payload
- 5 unit tests cover the name extraction rules

## Examples

- `plexi app open --mcp npx @modelcontextprotocol/server-filesystem /tmp` → pane title: `mcp: filesystem`
- `plexi app open --mcp uvx mcp-server-fetch` → pane title: `mcp: fetch`
- `plexi app open --cli git` → pane title: `git`

## Test plan

- [ ] `cargo test --bin plexi -- open::tests` passes (5/5)
- [ ] `plexi app open --mcp npx @modelcontextprotocol/server-filesystem /tmp` → pane title shows "mcp: filesystem" in the pane list
- [ ] `plexi app open --cli git` → pane title shows "git"

Closes #1037