### PR TITLE
docs(apps): annotate Core 9 as L1 reference implementations (#1952)

### DIFF
--- a/apps/backlog/backlog.py
+++ b/apps/backlog/backlog.py
@@ -9,6 +9,20 @@ Shows items from two sources merged by mtime:
 Items from the channel backlog are prefixed with [ch] in the list.
 
 Pass -g/--global to show only channel-level items: plexi open backlog -g
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Column layout with AppBar + growable body + FooterKeys
+  - SelectList for navigable item lists
+  - TextInput for inline item creation (overlay)
+  - Two-pane split via custom Component (escape hatch for HSplit)
+  - Filesystem persistence (read/write/delete backlog .md files)
+  - CLI argument parsing via Arg descriptor
+  - Multi-source data merging (workspace + channel backlog dirs)
+  - Search/filter mode with live refiltering
+  - Confirm-delete overlay pattern
+  - ctx.theme colors throughout (no hardcoded colors)
 """
 
 import os

--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
 """Calculator — L1 component-based rendering.
 
-Demonstrates: ButtonRow click detection, AppBar, Heading, FooterKeys.
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Column layout with AppBar + Card + Heading + FooterKeys
+  - ButtonRow for clickable grid buttons (mouse tracking)
+  - Custom Component (ButtonGrid) for fixed grid layout
+  - State machine: digit entry, pending operator, equals evaluation
+  - ctx.theme colors for button fills (accent, danger, surface)
+  - on_escape for contextual clear vs. close
 """
 import os
 import sys

--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""CSV Viewer — browse and inspect CSV files in the launch directory."""
+"""CSV Viewer — browse and inspect CSV files in the launch directory.
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Two-view navigation: file list (L1 SelectList) and detail grid
+  - Column layout with AppBar + Section + SelectList + FooterKeys
+  - Filesystem capability: reads CSV files from workspace_root
+  - Detail view uses raw ctx.rect/ctx.text for dense columnar data (escape hatch)
+  - Horizontal and vertical scrolling in detail mode
+  - ctx.theme colors throughout (accent for headers, fg for data, surface for rows)
+  - on_inject for test seam (seed state without filesystem)
+"""
 
 import csv
 from pathlib import Path

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
-"""Logs — live tail of the Plexi host log, newest-first, color-coded by level."""
+"""Logs — live tail of the Plexi host log, newest-first, color-coded by level.
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Live data polling via on_timer (2s interval)
+  - AppBar + FooterKeys (L1) framing raw columnar log rows (escape hatch)
+  - Level-based filtering with clickable chip buttons (ctx.button)
+  - Target-based filtering (cycle through unique log targets)
+  - Search mode with host text_input
+  - Copy mode: keyboard + mouse selection, clipboard integration
+  - Mouse tracking: click-to-select, drag-to-extend, shift-click
+  - ctx.theme colors for level badges (danger, warning, accent)
+  - Scrollbar rendering with viewport clipping (push_clip/pop_clip)
+  NOTE: Some copy-mode highlight colors are hardcoded (no theme equivalent).
+"""
 
 import os
 import re

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+"""Stats — usage dashboard showing active time, visits, and project treemap.
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Column layout with AppBar + growable canvas Component + FooterKeys
+  - Treemap visualization via squarify algorithm (custom Component escape hatch)
+  - Drill-down navigation with view stack (click to zoom, Esc to go back)
+  - Timeline strip with hour markers (rolling 24h window)
+  - Event data parsing from events.jsonl (PLEXI_SOCKET-aware path resolution)
+  - Tree data structure with rollup aggregation
+  - Mouse click handling (on_click) for treemap cell and timeline interaction
+  - ctx.theme colors for text and surfaces; PALETTE for categorical treemap colors
+  - status_summary for pane status bar integration
+"""
 from __future__ import annotations
 
 import json

--- a/apps/todo/todo.py
+++ b/apps/todo/todo.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Todo — fs.read + fs.write + persistence example for PGAP v3."""
+"""Todo — the "hello world that's useful." Simple list with persistence.
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Fully L1: Column + AppBar + Section + SelectList + FooterKeys + Label + Spacer
+  - TextInput for inline item creation
+  - JSON file persistence (.plexi/todos.json in workspace)
+  - on_path_changed: reloads data when workspace context changes
+  - on_escape for contextual mode exit (add mode vs. close)
+  - Minimal state: list of dicts, selected index, adding flag
+"""
 
 import json
 import pathlib

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Wikipedia — net.http + L1 component example for PGAP v3."""
+"""Wikipedia — search and read Wikipedia articles via the MediaWiki API.
+
+L1 Reference Implementation
+============================
+Patterns demonstrated:
+  - Fully L1: Column + AppBar + Section + SelectList + Scrollable + Label + FooterKeys
+  - TextInput for search queries
+  - net.http capability request (async, with CapabilityDeniedError handling)
+  - Async networking via threading + emit.run_sync(emit.http_get(...))
+  - Multi-view navigation: search -> results -> article (Esc to go back)
+  - on_inject for test seam (seed mode/query/results/extract without network)
+  - Scrollable wrapping Label for long article text
+  - Loading state management with status_summary
+"""
 
 import json
 import threading


### PR DESCRIPTION
Closes #1952

## Summary
- Added L1 Reference Implementation header comment blocks to all 7 existing Core 9 apps
- **backlog**: list + inline actions + persistence + two-pane layout + search/filter + CLI args
- **calc**: grid layout + ButtonRow click events + state machine + ctx.theme button colors
- **csv_viewer**: two-view navigation + SelectList + filesystem capability + detail grid escape hatch
- **logs**: live polling via on_timer + level/target filtering + copy mode + mouse tracking + clipboard
- **stats**: treemap visualization + drill-down navigation + timeline strip + event data parsing
- **todo**: fully L1 (SelectList + TextInput + JSON persistence + on_path_changed)
- **wikipedia**: fully L1 (TextInput + async net.http + multi-view navigation + Scrollable + on_inject test seam)

## Audit Results
- All 7 apps use ctx.theme (or the equivalent module-level `theme` singleton) for colors
- All 7 apps use FooterKeys for keyboard shortcut display
- All 7 apps use L1 nodes; escape hatches (custom Component with raw ctx calls) are documented where used
- Logs app has a small number of hardcoded copy-mode highlight colors (no theme equivalent exists); noted in header
- Stats app uses a categorical PALETTE for treemap colors (by design); noted in header
- 2 Core 9 apps not yet implemented (Assistant, Quick Note) are not touched

## Test plan
- [ ] Verify each app still launches and renders correctly on alpha after merge
- [ ] Confirm header comments are visible at top of each file