### PR TITLE
feat(sdk): layout fundamentals — headline alignment, character padding (#1527)

### DIFF
--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -443,12 +443,14 @@ class Section(Component):
     """Section divider with a small uppercase label sitting above the rule.
 
     Vertical stack: SPACE_SM padding, label (TEXT_HINT), SPACE_XS, divider,
-    SPACE_SM padding.
+    SPACE_XS padding. The bottom padding is intentionally tight (SPACE_XS
+    instead of SPACE_SM) so the section headline sits close to its
+    associated content block below.
     """
     title: str
 
     def measure(self, avail_w: float) -> float:
-        return SPACE_SM + TEXT_HINT + SPACE_XS + 1.0 + SPACE_SM
+        return SPACE_SM + TEXT_HINT + SPACE_XS + 1.0 + SPACE_XS
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         label_y = y + SPACE_SM
@@ -475,7 +477,7 @@ class KeyRow(Component):
     description: str
 
     HEIGHT = 28.0
-    CHIP_PAD_V = 1.0  # used for measure() height only
+    CHIP_PAD_V = 3.0  # used for measure() height only; keep in sync with KEYCHIP_PAD_V in style.rs
 
     def _keys(self) -> List[str]:
         if isinstance(self.key, list):
@@ -783,7 +785,7 @@ class FooterKeys(Component):
 
     # TOP_GAP reduced from SPACE_MD (12px) to SPACE_SM (8px) — trimmer chrome.
     TOP_GAP = SPACE_SM
-    CHIP_H = TEXT_HINT + 2.0 * 1.0   # TEXT_HINT + 2*CHIP_PAD_V
+    CHIP_H = TEXT_HINT + 2.0 * 3.0   # TEXT_HINT + 2*KEYCHIP_PAD_V (style.rs)
     # Single-row height. The host wraps the row to multiple lines when
     # `max_width` can't fit everything; very narrow panes may render past
     # this measurement. Apps wanting exact bounded footers should put

--- a/sdk/python/tests/test_no_overlap.py
+++ b/sdk/python/tests/test_no_overlap.py
@@ -103,5 +103,5 @@ def test_render_into_returns_consumed_height(render_into_app: Path) -> None:
     text_cmds = [c for c in cmds if c.get("type") == "text" and "content_y=" in c.get("text", "")]
     assert text_cmds, "Expected a text command reporting content_y"
     reported_y = float(text_cmds[0]["text"].split("=")[1])
-    # AppBar is 35px (34 band + 1 divider), Section is 32px (8+11+4+1+8) — total ~67px
-    assert 60 < reported_y < 80, f"content_y should be ~67px, got {reported_y}"
+    # AppBar is 35px (34 band + 1 divider), Section is 28px (8+11+4+1+4) — total ~63px
+    assert 55 < reported_y < 75, f"content_y should be ~63px, got {reported_y}"

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -448,7 +448,7 @@ pub(crate) fn render_component_tree(
         }
 
         UiNode::Section { title, .. } => {
-            let total_h = style::SPACE_SM + style::TEXT_HINT + 4.0 + 1.0 + style::SPACE_SM;
+            let total_h = style::SPACE_SM + style::TEXT_HINT + style::SPACE_XS + 1.0 + style::SPACE_XS;
             let (rect, _) =
                 ui.allocate_exact_size(egui::vec2(ui.available_width(), total_h), egui::Sense::hover());
             let painter = ui.painter();
@@ -461,7 +461,7 @@ pub(crate) fn render_component_tree(
                 )
             });
             painter.galley(egui::pos2(rect.min.x, label_y), galley, colors.text_dim);
-            let line_y = label_y + style::TEXT_HINT + 4.0;
+            let line_y = label_y + style::TEXT_HINT + style::SPACE_XS;
             painter.rect_filled(
                 egui::Rect::from_min_size(
                     egui::pos2(rect.min.x, line_y),

--- a/src/style.rs
+++ b/src/style.rs
@@ -20,13 +20,14 @@
 //! ## When to add a token
 //! When two or more places need the same value. The token set here is
 //! intentionally minimal — only the constants actually referenced in the
-//! codebase. Add scale holes (e.g. `SPACE_XS`, `MODAL_WIDTH_SM`) as soon as
-//! a migration needs them, not speculatively.
+//! codebase. Add scale holes (e.g. `MODAL_WIDTH_SM`) as soon as a
+//! migration needs them, not speculatively.
 
 use egui::CornerRadius;
 
 // ── Spacing scale ──────────────────────────────────────────────────────────
 // 4-based scale. Use these for padding, margins, gaps between siblings.
+pub const SPACE_XS: f32 = 4.0;
 pub const SPACE_SM: f32 = 8.0;
 pub const SPACE_MD: f32 = 12.0;
 pub const SPACE_XL: f32 = 24.0;
@@ -84,7 +85,7 @@ pub const BADGE_MIN_W: f32 = 32.0;  // floor width; prevents single-char scrunch
 // ── App protocol — KeyChip geometry ──────────────────────────────────────
 // Padding tokens for the host-rendered KeyChip / KeyChipRow DrawCommands.
 pub const KEYCHIP_PAD_H: f32 = 5.0;    // horizontal padding (text-to-edge each side)
-pub const KEYCHIP_PAD_V: f32 = 1.0;    // vertical padding
+pub const KEYCHIP_PAD_V: f32 = 3.0;    // vertical padding
 pub const KEYCHIP_MIN_W: f32 = 16.0;   // floor width; prevents single-char cramping
 pub const KEYCHIP_GAP: f32 = 2.0;      // gap between chips in a KeyChipRow
 pub const KEYCHIP_DESC_GAP: f32 = 10.0; // gap between last chip and description


### PR DESCRIPTION
Closes #1527

## Summary
- **Section headline alignment**: reduced Section bottom padding from `SPACE_SM` (8px) to `SPACE_XS` (4px) in both the Python SDK and Rust L1 renderer, so the section label/rule sits closer to the content block beneath it instead of floating with 20px of dead space
- **Character padding in chip boxes**: increased `KEYCHIP_PAD_V` from 1.0 to 3.0 in `style.rs`, matching the host-side overlay chip padding (`KEYCAP_PAD_V = 3.0` in `widgets.rs`). Updated SDK-side `CHIP_PAD_V` and `FooterKeys.CHIP_H` to match
- Added `SPACE_XS` (4.0) to the Rust spacing scale in `style.rs`

## Files changed
- `src/style.rs` -- added `SPACE_XS`, bumped `KEYCHIP_PAD_V` 1.0 -> 3.0
- `src/render_components.rs` -- Section L1 renderer uses `SPACE_XS` for bottom pad and label-to-rule gap
- `sdk/python/plexi_sdk/ui.py` -- Section measure uses `SPACE_XS` bottom pad; KeyRow `CHIP_PAD_V` 1.0 -> 3.0; FooterKeys `CHIP_H` updated
- `sdk/python/tests/test_no_overlap.py` -- updated Section height comment and assertion range