### PR TITLE
feat(host): app launch arguments (#1638)

### DIFF
--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -16,7 +16,7 @@ Patterns demonstrated:
 import csv
 from pathlib import Path
 
-from plexi_sdk import App, RenderContext  # type: ignore[attr-defined]
+from plexi_sdk import App, Arg, RenderContext  # type: ignore[attr-defined]
 from plexi_sdk.ui import (
     AppBar, Column, FooterKeys, Label, Section,
     SelectList, Spacer,
@@ -28,20 +28,43 @@ ROW_H = 24.0
 
 
 class CsvViewer(App):
+    file: Arg[str | None] = Arg(positional=True, default=None)
+
     def on_init(self, ctx: RenderContext) -> None:
         launch_dir = Path(ctx.workspace_root) if ctx.workspace_root else Path.cwd()
-        self._files: list[Path] = sorted(
+
+        # If a file path was passed as a launch argument, open it directly
+        if self.file:
+            target = Path(self.file)
+            if not target.is_absolute():
+                target = launch_dir / target
+            if target.is_file():
+                self._files: list[Path] = [target]
+                self._dir = target.parent
+                self._selected = 0
+                self._mode = "detail"
+                self._headers: list[str] = []
+                self._rows: list[list[str]] = []
+                self._v_scroll = 0
+                self._h_scroll = 0
+                self._file_hints: dict[Path, str] = {}
+                self._file_list = SelectList([{"name": target.name}])
+                self._load_csv(target)
+                ctx.info(f"csv_viewer: opened {target} via launch arg")
+                return
+
+        self._files = sorted(
             launch_dir.glob("*.csv"), key=lambda p: p.name.lower()
         )
         self._dir = launch_dir
         self._selected = 0
         self._mode = "list"
-        self._headers: list[str] = []
-        self._rows: list[list[str]] = []
+        self._headers = []
+        self._rows = []
         self._v_scroll = 0
         self._h_scroll = 0
         # Cache file sizes once at init to avoid stat() calls inside on_render
-        self._file_hints: dict[Path, str] = {}
+        self._file_hints = {}
         for p in self._files:
             try:
                 kb = p.stat().st_size / 1024

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -160,6 +160,7 @@ class App:
         self.workspace_root: str = ""
         self.capabilities: list[str] = []
         self.feature_flags: list[str] = []
+        self.launch_args: list[str] = []
         self._rect: dict = {"x": 0.0, "y": 0.0, "w": 800.0, "h": 600.0}
         self._compact_threshold: float = 280.0
         self._regular_threshold: float = 480.0
@@ -969,6 +970,7 @@ class App:
                     self.workspace_root = ev.get("workspace_root", "")
                     self.capabilities = ev.get("capabilities", [])
                     self.feature_flags = ev.get("feature_flags", [])
+                    self.launch_args = ev.get("args", [])
                     self._compact_threshold = ev.get("compact_threshold", 280.0)
                     self._regular_threshold = ev.get("regular_threshold", 480.0)
                     # Apply host theme (light/dark + user overrides) so app-drawn

--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -34,6 +34,7 @@ class RenderContext:
         self.workspace_root = workspace_root
         self.capabilities = capabilities
         self.feature_flags = feature_flags
+        self.args: list[str] = app.launch_args
         # Active host theme (light/dark + user overrides). Read colors via
         # ctx.theme.<role>, e.g. ctx.theme.accent / ctx.theme.bg / ctx.theme.danger.
         from ._theme import theme as _theme

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -70,6 +70,11 @@ pub enum PlexiEvent {
         /// Empty map ⇒ app falls back to its built-in dark constants.
         #[serde(default)]
         theme: std::collections::HashMap<String, String>,
+        /// Launch arguments passed via `plexi app open <id> -- <args>` or
+        /// programmatic SpawnPane. Also forwarded as subprocess argv for
+        /// backward compatibility. Empty when no args were provided.
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// Request a new frame. App replies with DrawCommands terminated by FrameDone.
     Render {

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -79,6 +79,7 @@ fn spawn_and_collect_frame(
         compact_threshold: 280.0,
         regular_threshold: 480.0,
         theme: render_colors().to_theme_map(),
+        args: vec![],
     };
     let init_json = serde_json::to_string(&init)
         .map_err(|e| format!("failed to serialize Init: {e}"))?;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -310,6 +310,13 @@ impl PlexiApp {
         }
         let manifest_id = app_pane.manifest_id.clone();
         let workspace_root = app_pane.workspace_root.clone();
+        // Preserve launch args across hot-reload so the reloaded app gets the
+        // same arguments the original was opened with.
+        let saved_launch_args: Vec<String> = if let crate::pane::AppRuntime::Process(ref proc) = app_pane.runtime {
+            proc.launch_args.clone()
+        } else {
+            Vec::new()
+        };
 
         log::info!(
             "app::{manifest_id} reload triggered ({reason}) for pane {pane_id}"
@@ -318,7 +325,7 @@ impl PlexiApp {
         // Launch the replacement first — if launch fails, leave the old
         // subprocess running so the pane stays usable.
         let cwd = workspace_root.clone();
-        let new_process_opt = self.registry.launch_process(&manifest_id, &cwd, &[]);
+        let new_process_opt = self.registry.launch_process(&manifest_id, &cwd, &saved_launch_args);
         // Path-launched apps (app run / app init) are never inserted into the
         // registry's in-memory map, so launch_process returns None. Fall back
         // to loading the manifest directly from workspace_root.
@@ -335,7 +342,7 @@ impl PlexiApp {
                         installed.manifest.name.clone(),
                         &installed.bin_path,
                         &cwd,
-                        &[],
+                        &saved_launch_args,
                         workspace_root.clone(),
                         caps,
                         keyboard_capture,

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -307,6 +307,9 @@ pub struct ProcessApp {
     /// checks wants_close() each frame and calls close_pane gracefully,
     /// avoiding the crash-restart path that sys.exit() would trigger.
     wants_close_self: bool,
+    /// Launch arguments passed via CLI or SpawnPane. Forwarded in PlexiEvent::Init
+    /// so the SDK can expose them as ctx.args.
+    pub(crate) launch_args: Vec<String>,
 }
 
 impl ProcessApp {
@@ -742,6 +745,7 @@ impl ProcessApp {
             mcp_server: mcp_server_handle,
             mcp_pending: std::collections::HashMap::new(),
             wants_close_self: false,
+            launch_args: args.to_vec(),
         })
     }
 
@@ -888,6 +892,7 @@ impl ProcessApp {
             mcp_server: None,
             mcp_pending: std::collections::HashMap::new(),
             wants_close_self: false,
+            launch_args: Vec::new(),
         };
         (app, draw_tx)
     }
@@ -1363,6 +1368,7 @@ impl App for ProcessApp {
                 .iter()
                 .map(|c| c.to_string())
                 .collect();
+            log::info!("ProcessApp[{}]: sending Init with {} launch arg(s)", self.type_id, self.launch_args.len());
             self.send_event(&PlexiEvent::Init {
                 protocol: "pgap/3".to_string(),
                 app_id: self.type_id.clone(),
@@ -1372,6 +1378,7 @@ impl App for ProcessApp {
                 compact_threshold: self.compact_threshold,
                 regular_threshold: self.regular_threshold,
                 theme: ctx.colors.to_theme_map(),
+                args: self.launch_args.clone(),
             });
             // Inject persisted state before first render so on_inject runs with data.
             let state = load_app_state(&self.type_id, &self.workspace_root);


### PR DESCRIPTION
Closes #1638

## Summary
- Add `args` field to `PlexiEvent::Init` so apps receive launch arguments through the protocol wire, not just `sys.argv`
- `ProcessApp` stores `launch_args` from CLI/SpawnPane and includes them in Init
- Hot-reload preserves launch args across app restarts
- Python SDK: `App.launch_args` populated from Init, `ctx.args` exposes them in RenderContext
- CSV Viewer accepts an optional positional file path arg to open a specific file directly (e.g. `plexi app open csv_viewer data.csv`)

## Test plan
- [ ] `plexi app open csv_viewer` still lists CSV files in workspace_root (no regression)
- [ ] `plexi app open csv_viewer /path/to/file.csv` opens that file directly in detail mode
- [ ] Hot-reload of an app opened with args preserves the args across reload
- [ ] `cargo test --bin plexi` passes (2 pre-existing failures unrelated)