### PR TITLE
feat(host+sdk): PGAP TextEdit node (#1951)

### DIFF
--- a/apps/examples/text-edit-demo/manifest.toml
+++ b/apps/examples/text-edit-demo/manifest.toml
@@ -1,0 +1,12 @@
+schema_version = 1
+
+[app]
+id = "text-edit-demo"
+type = "app"
+name = "TextEdit Demo"
+version = "0.1.0"
+description = "Demonstrates the TextEdit node: single-line and multiline text input."
+entry = "text_edit_demo.py"
+
+[app.capabilities]
+capabilities = []

--- a/apps/examples/text-edit-demo/text_edit_demo.py
+++ b/apps/examples/text-edit-demo/text_edit_demo.py
@@ -1,0 +1,48 @@
+"""TextEdit demo: single-line and multiline text input via the component tree.
+
+Shows a single-line input (Enter submits) and a multiline editor (Cmd+Enter
+submits). Submitted values are logged below each field.
+"""
+from plexi_sdk import App, State, TextEdit
+
+
+class TextEditDemo(App):
+    single_value = State("")
+    multi_value = State("")
+    single_log = State("")
+    multi_log = State("")
+
+    def on_component_event(self, ctx, node_id, event_type, payload):
+        value = (payload or {}).get("value", "")
+        if event_type == "change":
+            if node_id == "single":
+                self.single_value = value
+            elif node_id == "multi":
+                self.multi_value = value
+        elif event_type == "submit":
+            if node_id == "single":
+                self.single_log = f"Submitted: {value}"
+                ctx.info(f"single submit: {value}")
+            elif node_id == "multi":
+                self.multi_log = f"Submitted: {value}"
+                ctx.info(f"multi submit: {value}")
+
+    def on_render(self, ctx):
+        ctx.render_tree({
+            "type": "stack",
+            "direction": "vertical",
+            "gap": 12.0,
+            "padding": {"top": 12.0, "right": 16.0, "bottom": 16.0, "left": 16.0},
+            "children": [
+                {"type": "app_bar", "title": "TextEdit Demo", "subtitle": ""},
+                {"type": "section", "title": "Single-line"},
+                TextEdit("single", placeholder="Type and press Enter...", value=self.single_value).to_node(),
+                {"type": "label", "text": self.single_log or "No submission yet", "size": 0.0, "color": "", "tone": "hint", "bold": False, "monospace": False, "max_lines": 1},
+                {"type": "section", "title": "Multiline (Cmd+Enter to submit)"},
+                TextEdit("multi", placeholder="Type here...\nCmd+Enter to submit", value=self.multi_value, multiline=True).to_node(),
+                {"type": "label", "text": self.multi_log or "No submission yet", "size": 0.0, "color": "", "tone": "hint", "bold": False, "monospace": False, "max_lines": 3},
+            ],
+        })
+
+
+TextEditDemo().run()

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -495,6 +495,7 @@ from .ui import (
     Toggle as Toggle,
     Clickable as Clickable,
     ProgressBar as ProgressBar,
+    TextEdit as TextEdit,
 )
 # Live host theme (light/dark + user overrides), populated from Init. Also on
 # ctx.theme. Read colors via theme.<role>: theme.bg, theme.accent, theme.danger…

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1148,6 +1148,46 @@ class TextInput(Component):
         return self._submitted
 
 
+class TextEdit:
+    """Host-rendered text editor node for component trees (PGAP v3.5+).
+
+    Produces a ``UiNode::TextEdit`` wire dict. The host maintains a persistent
+    buffer keyed on ``node_id``. Typing fires ``ComponentEvent`` with
+    ``event_type="change"`` and ``payload={"value": "..."}``; Enter (single-line)
+    or Cmd+Enter (multiline) fires ``event_type="submit"``.
+
+    Use this in ``ctx.render_tree()`` calls, not inside ``ctx.render(Column([...]))``.
+
+    Example::
+
+        ctx.render_tree(TextEdit("notes", placeholder="Type here...", multiline=True).to_node())
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        placeholder: str = "",
+        value: str = "",
+        multiline: bool = False,
+        max_length: int = 0,
+    ) -> None:
+        self.node_id = node_id
+        self.placeholder = placeholder
+        self.value = value
+        self.multiline = multiline
+        self.max_length = max_length
+
+    def to_node(self) -> dict:
+        return {
+            "type": "text_edit",
+            "node_id": self.node_id,
+            "placeholder": self.placeholder,
+            "value": self.value,
+            "multiline": self.multiline,
+            "max_length": self.max_length,
+        }
+
+
 @dataclass
 class ChatBubble(Component):
     """A chat message bubble with left/right alignment and colored background.
@@ -2013,7 +2053,7 @@ __all__ = [
     "Component", "Column", "Card",
     "AppBar", "Section", "KeyRow", "Heading", "Label",
     "Spacer", "Divider", "ScrollLog", "Scrollable", "Footer", "FooterKeys",
-    "ListItem", "Row", "TextInput", "ChatBubble",
+    "ListItem", "Row", "TextInput", "TextEdit", "ChatBubble",
     "SelectList", "FormField",
     "InfoTable", "ButtonRow",
     # badge primitive

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -699,6 +699,26 @@ pub enum UiNode {
         placeholder: String,
         value: String,
     },
+    /// Host-rendered text editor with multiline and max_length support.
+    ///
+    /// The host maintains a persistent buffer keyed on `node_id`. On each
+    /// frame the app sends its last-known `value`; the host seeds the buffer
+    /// from it only when a new `node_id` appears. Typing fires
+    /// `ComponentEvent { event_type: "change", payload: { value } }` and
+    /// Enter (single-line) or Cmd+Enter (multiline) fires
+    /// `ComponentEvent { event_type: "submit", payload: { value } }`.
+    TextEdit {
+        node_id: String,
+        #[serde(default)]
+        placeholder: String,
+        #[serde(default)]
+        value: String,
+        #[serde(default)]
+        multiline: bool,
+        /// 0 means no limit.
+        #[serde(default)]
+        max_length: usize,
+    },
     /// Host-rendered pill badge.
     Badge {
         label: String,
@@ -825,6 +845,10 @@ impl PartialEq for UiNode {
             (UiNode::Input { node_id: n1, placeholder: ph1, value: v1 },
              UiNode::Input { node_id: n2, placeholder: ph2, value: v2 }) => {
                 n1 == n2 && ph1 == ph2 && v1 == v2
+            }
+            (UiNode::TextEdit { node_id: n1, placeholder: ph1, value: v1, multiline: m1, max_length: ml1 },
+             UiNode::TextEdit { node_id: n2, placeholder: ph2, value: v2, multiline: m2, max_length: ml2 }) => {
+                n1 == n2 && ph1 == ph2 && v1 == v2 && m1 == m2 && ml1 == ml2
             }
             (UiNode::Badge { label: l1, fill: f1, fg: fg1 },
              UiNode::Badge { label: l2, fill: f2, fg: fg2 }) => {

--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -194,12 +194,14 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
             .show(ctx, |ui| {
                 let mut lv_offsets = std::collections::HashMap::new();
                 let mut lv_last_sel = std::collections::HashMap::new();
+                let mut te_buffers = std::collections::HashMap::new();
                 crate::process_app::render::render_draw_commands(
                     ui, rect, commands, &colors, &mut cm_cache, &peaks,
                     &mut img_cache, &std::env::temp_dir(), false,
                     &mut lv_offsets,
                     &mut lv_last_sel,
                     &mut Vec::new(),
+                    &mut te_buffers,
                 );
             });
     });

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -45,6 +45,7 @@ pub(crate) fn render_draw_commands(
     list_view_scroll_offsets: &mut HashMap<String, f32>,
     list_view_last_aligned_sel: &mut HashMap<String, usize>,
     outbound_events: &mut Vec<crate::app_protocol::PlexiEvent>,
+    text_edit_buffers: &mut HashMap<String, String>,
 ) {
     let origin = pane_rect.min;
 
@@ -1010,7 +1011,7 @@ pub(crate) fn render_draw_commands(
                     pane_rect.min
                 );
                 let component_events =
-                    crate::render_components::render_component_tree(ui, root, colors);
+                    crate::render_components::render_component_tree(ui, root, colors, text_edit_buffers);
                 for evt in component_events {
                     log::info!(
                         "render: ComponentEvent node_id={} event_type={}",

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -10,6 +10,10 @@ pub(crate) struct RenderSession {
     /// Per-input text buffers, keyed on the `id` field of `DrawCommand::TextInput`.
     /// Persists between frames and survives submit (cleared on submit via `submit_text_input`).
     pub(crate) text_input_buffers: HashMap<String, String>,
+    /// Per-TextEdit node buffers for `UiNode::TextEdit` in the component tree.
+    /// Keyed on `node_id`. Seeded from the app's `value` field when a new
+    /// node_id appears; persists across frames so the host owns the live text.
+    pub(crate) text_edit_buffers: HashMap<String, String>,
     /// IDs of `TextInput` widgets visible in the most recently rendered frame.
     /// Used to detect newly-visible inputs for auto-focus.
     text_input_visible_prev: HashSet<String>,
@@ -40,6 +44,7 @@ impl RenderSession {
     pub(crate) fn new() -> Self {
         Self {
             text_input_buffers: HashMap::new(),
+            text_edit_buffers: HashMap::new(),
             text_input_visible_prev: HashSet::new(),
             text_input_has_focus: false,
             scroll_offsets: HashMap::new(),
@@ -89,6 +94,7 @@ impl RenderSession {
             &mut self.list_view_scroll_offsets,
             &mut self.list_view_last_aligned_sel,
             &mut self.outbound_events,
+            &mut self.text_edit_buffers,
         );
 
         // ── Pass 2: TextInput widgets ────────────────────────────────────────

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -28,10 +28,15 @@ pub(crate) struct ComponentEventPayload {
 ///
 /// `colors` is the active host theme — passed through so L1 sugar nodes and
 /// `Raw` escape-hatch nodes have consistent theming.
+///
+/// `text_edit_buffers` provides persistent per-node_id text buffers for
+/// `UiNode::TextEdit` nodes. The buffer is seeded from the app's `value`
+/// field when a new node_id first appears.
 pub(crate) fn render_component_tree(
     ui: &mut Ui,
     node: &UiNode,
     colors: &Colors,
+    text_edit_buffers: &mut std::collections::HashMap<String, String>,
 ) -> Vec<ComponentEventPayload> {
     let mut events: Vec<ComponentEventPayload> = Vec::new();
 
@@ -45,10 +50,10 @@ pub(crate) fn render_component_tree(
                 }
                 if padding.left > 0.0 {
                     ui.indent("stack_left_pad", |ui| {
-                        events.extend(render_stack(ui, direction, children, *gap, colors));
+                        events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers));
                     });
                 } else {
-                    events.extend(render_stack(ui, direction, children, *gap, colors));
+                    events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers));
                 }
                 if padding.bottom > 0.0 {
                     ui.add_space(padding.bottom);
@@ -63,14 +68,14 @@ pub(crate) fn render_component_tree(
                 egui::ScrollArea::vertical()
             };
             scroll.show(ui, |ui| {
-                events.extend(render_component_tree(ui, child, colors));
+                events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
             });
         }
 
         UiNode::Layer { children } => {
             // V1: sequential rendering (true Z-stacking is a future improvement).
             for child in children {
-                events.extend(render_component_tree(ui, child, colors));
+                events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
             }
         }
 
@@ -97,7 +102,7 @@ pub(crate) fn render_component_tree(
             // Render the child inside an interact-sense scope so we get a
             // Response covering the child's bounding rect.
             let child_response = ui.scope(|ui| {
-                let child_evts = render_component_tree(ui, child, colors);
+                let child_evts = render_component_tree(ui, child, colors, text_edit_buffers);
                 // Bubble child events up.
                 (child_evts, ui.min_rect())
             });
@@ -149,6 +154,7 @@ pub(crate) fn render_component_tree(
                 &mut std::collections::HashMap::new(),
                 &mut std::collections::HashMap::new(),
                 &mut raw_events,
+                text_edit_buffers,
             );
             // Convert any ComponentEvent payloads back from PlexiEvent (unlikely
             // from a Raw draw command, but keep the pipeline consistent).
@@ -252,6 +258,88 @@ pub(crate) fn render_component_tree(
                     node_id: node_id.clone(),
                     event_type: "submit".into(),
                     payload: Some(serde_json::json!({ "value": val_buf })),
+                });
+            }
+        }
+
+        UiNode::TextEdit { node_id, placeholder, value, multiline, max_length, .. } => {
+            // Seed the buffer from the app's value when this node_id first appears.
+            let buffer = text_edit_buffers
+                .entry(node_id.clone())
+                .or_insert_with(|| value.clone());
+
+            // Enforce max_length by truncating the buffer if it exceeds the limit.
+            if *max_length > 0 && buffer.len() > *max_length {
+                buffer.truncate(*max_length);
+            }
+
+            let prev_value = buffer.clone();
+            let widget_id = egui::Id::new(("text_edit_node", node_id.as_str()));
+
+            let response = ui.scope(|ui| {
+                ui.visuals_mut().text_cursor.stroke.width = 1.5;
+                ui.visuals_mut().text_cursor.stroke.color = colors.accent;
+                ui.visuals_mut().extreme_bg_color = colors.bg_active;
+                ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+                ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+
+                if *multiline {
+                    let mut edit = egui::TextEdit::multiline(buffer)
+                        .id(widget_id)
+                        .desired_width(f32::INFINITY)
+                        .hint_text(placeholder.as_str())
+                        .font(egui::TextStyle::Body);
+                    if *max_length > 0 {
+                        edit = edit.char_limit(*max_length);
+                    }
+                    ui.add(edit)
+                } else {
+                    let mut edit = egui::TextEdit::singleline(buffer)
+                        .id(widget_id)
+                        .desired_width(f32::INFINITY)
+                        .hint_text(placeholder.as_str())
+                        .font(egui::TextStyle::Body)
+                        .margin(egui::Margin::symmetric(8, 5));
+                    if *max_length > 0 {
+                        edit = edit.char_limit(*max_length);
+                    }
+                    ui.add(edit)
+                }
+            }).inner;
+
+            // Emit "change" event when value differs from previous frame.
+            if *buffer != prev_value {
+                log::debug!(
+                    "render_components: TextEdit change node_id={node_id} value={:?}",
+                    buffer
+                );
+                events.push(ComponentEventPayload {
+                    node_id: node_id.clone(),
+                    event_type: "change".into(),
+                    payload: Some(serde_json::json!({ "value": *buffer })),
+                });
+            }
+
+            // Submit: Enter for single-line, Cmd+Enter for multiline.
+            let should_submit = if *multiline {
+                response.has_focus()
+                    && ui.input(|i| {
+                        i.key_pressed(egui::Key::Enter) && i.modifiers.command
+                    })
+            } else {
+                response.lost_focus()
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
+            };
+
+            if should_submit {
+                log::info!(
+                    "render_components: TextEdit submit node_id={node_id} value={:?}",
+                    buffer
+                );
+                events.push(ComponentEventPayload {
+                    node_id: node_id.clone(),
+                    event_type: "submit".into(),
+                    payload: Some(serde_json::json!({ "value": *buffer })),
                 });
             }
         }
@@ -523,7 +611,7 @@ pub(crate) fn render_component_tree(
                 .inner_margin(egui::Margin::same(pad as i8))
                 .show(ui, |ui| {
                     for child in children {
-                        events.extend(render_component_tree(ui, child, colors));
+                        events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
                     }
                 });
         }
@@ -607,6 +695,7 @@ fn render_stack(
     children: &[UiNode],
     gap: f32,
     colors: &Colors,
+    text_edit_buffers: &mut std::collections::HashMap<String, String>,
 ) -> Vec<ComponentEventPayload> {
     let mut events = Vec::new();
     match direction {
@@ -616,7 +705,7 @@ fn render_stack(
                     if i > 0 && gap > 0.0 {
                         ui.add_space(gap);
                     }
-                    events.extend(render_component_tree(ui, child, colors));
+                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
                 }
             });
         }
@@ -626,7 +715,7 @@ fn render_stack(
                     if i > 0 && gap > 0.0 {
                         ui.add_space(gap);
                     }
-                    events.extend(render_component_tree(ui, child, colors));
+                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
                 }
             });
         }
@@ -820,5 +909,55 @@ mod render_component_tree_tests {
         };
         assert_eq!(evt.event_type, "click");
         assert_eq!(evt.node_id, "wrap1");
+    }
+
+    /// `UiNode::TextEdit` node can be constructed with all fields.
+    #[test]
+    fn text_edit_node_constructable() {
+        let node = UiNode::TextEdit {
+            node_id: "editor1".into(),
+            placeholder: "Type here...".into(),
+            value: "hello".into(),
+            multiline: true,
+            max_length: 100,
+        };
+        if let UiNode::TextEdit { node_id, placeholder, value, multiline, max_length, .. } = &node {
+            assert_eq!(node_id, "editor1");
+            assert_eq!(placeholder, "Type here...");
+            assert_eq!(value, "hello");
+            assert!(*multiline);
+            assert_eq!(*max_length, 100);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    /// `UiNode::TextEdit` PartialEq works.
+    #[test]
+    fn text_edit_partial_eq() {
+        let a = UiNode::TextEdit {
+            node_id: "e".into(),
+            placeholder: "p".into(),
+            value: "v".into(),
+            multiline: false,
+            max_length: 0,
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    /// Serde round-trip for `UiNode::TextEdit`.
+    #[test]
+    fn text_edit_serde_roundtrip() {
+        let node = UiNode::TextEdit {
+            node_id: "te1".into(),
+            placeholder: "hint".into(),
+            value: "val".into(),
+            multiline: true,
+            max_length: 50,
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let parsed: UiNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, parsed);
     }
 }


### PR DESCRIPTION
Closes #1951

## Summary
- Add `UiNode::TextEdit` variant with fields: `node_id`, `placeholder`, `value`, `multiline`, `max_length`
- Host renders as egui TextEdit with styled visuals (accent cursor, border treatment)
- Host-side persistent buffer per `node_id` (seeded from app value on first appearance)
- `ComponentEvent { event_type: "change", payload: { value } }` on every keystroke
- `ComponentEvent { event_type: "submit", payload: { value } }` on Enter (single-line) or Cmd+Enter (multiline)
- `max_length` enforced via egui `char_limit` + buffer truncation
- Python SDK `TextEdit(node_id, placeholder, value, multiline, max_length)` node builder exported from `plexi_sdk`
- POC app `apps/examples/text-edit-demo/` with single-line and multiline inputs
- 3 new unit tests: construction, PartialEq, serde round-trip

## Files changed
- `src/app_protocol.rs` -- new `UiNode::TextEdit` variant + PartialEq arm
- `src/render_components.rs` -- rendering logic, text_edit_buffers threading, tests
- `src/process_app/render_session.rs` -- `text_edit_buffers` HashMap
- `src/process_app/render.rs` -- thread buffers through render_draw_commands
- `src/app_render.rs` -- add missing arg at headless render call site
- `sdk/python/plexi_sdk/ui.py` -- `TextEdit` class
- `sdk/python/plexi_sdk/__init__.py` -- export `TextEdit`
- `apps/examples/text-edit-demo/` -- manifest + demo app