### PR TITLE
feat(cli): plexi doctor capability audit (#1346)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -167,6 +167,15 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: Option<NotesCmd>,
     },
+    /// Audit all installed apps for capability and config gaps.
+    ///
+    /// Checks every installed app's declared capabilities against your current config.toml
+    /// and reports what's working and what needs to be configured. Use --json for scripting.
+    Doctor {
+        /// Output results as JSON (for scripting or agent use)
+        #[arg(long)]
+        json: bool,
+    },
     /// Interactive keybinding tutorial — learn split and navigate in real time.
     ///
     /// Walk through two fundamental Plexi interactions inside a live pane:

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,95 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct DoctorReport {
+    healthy: bool,
+    apps: Vec<AppReport>,
+}
+
+#[derive(Serialize)]
+struct AppReport {
+    id: String,
+    missing: Vec<String>,
+}
+
+pub fn doctor_cli(json: bool) -> i32 {
+    log::info!("cli:doctor: starting capability audit (json={json})");
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let registry = crate::app_registry::AppRegistry::load(&cwd);
+    let config = crate::config::PlexiConfig::load_with_workspace(
+        crate::config::active_workspace_root().as_deref(),
+    );
+
+    let installed = registry.list();
+    if installed.is_empty() {
+        if json {
+            println!(r#"{{"healthy":true,"apps":[]}}"#);
+        } else {
+            println!("No apps installed.");
+        }
+        return 0;
+    }
+
+    let mut sick_apps: Vec<AppReport> = Vec::new();
+    let total = installed.len();
+
+    for app in &installed {
+        let missing = registry.check_config_capabilities(&app.manifest.id, &config);
+        if !missing.is_empty() {
+            sick_apps.push(AppReport {
+                id: app.manifest.id.clone(),
+                missing,
+            });
+        }
+    }
+
+    let healthy = sick_apps.is_empty();
+    let sick_count = sick_apps.len();
+
+    if json {
+        let report = DoctorReport {
+            healthy,
+            apps: sick_apps,
+        };
+        match serde_json::to_string_pretty(&report) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("error: failed to serialize doctor report: {e}");
+                return 1;
+            }
+        }
+    } else {
+        let no_color = std::env::var_os("NO_COLOR").is_some();
+        let green = if no_color { "" } else { "\x1b[32m" };
+        let red = if no_color { "" } else { "\x1b[31m" };
+        let dim = if no_color { "" } else { "\x1b[2m" };
+        let reset = if no_color { "" } else { "\x1b[0m" };
+
+        println!("Checking {total} installed app(s)...\n");
+
+        if healthy {
+            println!("  {green}\u{2713}{reset} {total} app(s) -- all capabilities satisfied");
+        } else {
+            let ok_count = total - sick_count;
+            if ok_count > 0 {
+                println!("  {green}\u{2713}{reset} {ok_count} app(s) -- all capabilities satisfied");
+            }
+            for app in &sick_apps {
+                let first = &app.missing[0];
+                println!("  {red}\u{2717}{reset} {:12} -- {first}", app.id);
+                for reason in app.missing.iter().skip(1) {
+                    println!("  {:14} {dim}-- {reason}{reset}", "");
+                }
+                println!("  {:14} {dim}--> run: plexi config edit{reset}", "");
+            }
+            println!(
+                "\n{sick_count} app(s) have unsatisfied capabilities. Run 'plexi config edit' to fix."
+            );
+        }
+    }
+
+    log::info!("cli:doctor: audit complete -- {total} app(s), {sick_count} unhealthy");
+
+    if healthy { 0 } else { 1 }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,6 +105,7 @@ pub mod config_cli;
 pub mod context_cli;
 pub mod demo;
 pub mod descriptor;
+pub mod doctor;
 pub mod install;
 pub mod list;
 pub mod notes;
@@ -172,6 +173,7 @@ pub use context_cli::{
     context_set_root_cli, context_current_cli, context_describe_cli, context_push_cli,
 };
 pub use demo::demo_cli;
+pub use doctor::doctor_cli;
 pub use install::{install_cli, install_pack_cli, install_workspace_pack_cli, plexi_uninstall_cli, update_cli, self_update_cli};
 pub use list::{freeze_cli, parse_notify_choice};
 pub use notes::{notes_list_cli, notes_open_cli};

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,7 @@ fn main() -> eframe::Result {
                         Some(NotesCmd::List) | None => std::process::exit(cli::notes_list_cli()),
                         Some(NotesCmd::Open) => std::process::exit(cli::notes_open_cli()),
                     },
+                    Commands::Doctor { json } => std::process::exit(cli::doctor_cli(json)),
                     Commands::Demo => std::process::exit(cli::demo_cli()),
                 }
             }


### PR DESCRIPTION
Closes #1346

## Summary
- Add `plexi doctor` command that audits all installed apps' declared capabilities against the current `config.toml`
- Reports healthy vs unhealthy apps with human-readable fix hints (colored output, respects `NO_COLOR`)
- Supports `--json` flag for agent/scripting use: `{"healthy": bool, "apps": [{"id": str, "missing": [str]}]}`
- Exits 0 when all apps are satisfied, 1 when any capability is missing
- Uses existing `AppRegistry::check_config_capabilities()` from #1345

## Files changed
- `src/cli/args.rs` -- added `Doctor { json }` variant to `Commands` enum in the System section
- `src/cli/doctor.rs` -- new module with `doctor_cli(json: bool) -> i32`
- `src/cli/mod.rs` -- registered module and re-export
- `src/main.rs` -- dispatch arm for `Commands::Doctor`