### PR TITLE
feat(cli): plexi pane command (#1972)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -596,6 +596,21 @@ pub enum PaneCmd {
         /// Key to press
         key: String,
     },
+    /// Send a shell command to a terminal pane as if typed from the keyboard.
+    ///
+    /// Use `--enter` to append a newline so the command is submitted immediately.
+    ///
+    /// Example: plexi pane command 42 "git status" --enter
+    #[command(name = "command")]
+    Command {
+        /// Pane id to send the command to (from `plexi pane list`)
+        pane_id: u64,
+        /// Text to send to the pane
+        text: String,
+        /// Append a newline after the text, submitting it as a command
+        #[arg(long, short = 'e')]
+        enter: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,15 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::pane_close_cli(id));
                         }
                         PaneCmd::Send { pane_id, text } => std::process::exit(cli::pane_send_cli(pane_id, &text)),
+                        PaneCmd::Command { pane_id, text, enter } => {
+                            let payload = if enter {
+                                format!("{text}\n")
+                            } else {
+                                text.clone()
+                            };
+                            log::info!("pane_command:cli: pane_id={pane_id} len={} enter={enter}", payload.len());
+                            std::process::exit(cli::pane_send_cli(pane_id, &payload));
+                        }
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),


### PR DESCRIPTION
Closes #1972

## Summary
- Adds `plexi pane command <id> <text>` subcommand under `plexi pane`
- `--enter` / `-e` flag appends a newline to submit the text as a shell command
- Routes through the existing `send_to_pane` socket protocol — no host changes needed
- Re-uses `pane_send_cli` on the CLI side; the host's `SendToPane` handler already interprets literal `\n` as Enter, so a real newline in the payload works correctly

## Files changed
- `src/cli/args.rs` — new `Command` variant in `PaneCmd`
- `src/main.rs` — dispatch branch for `PaneCmd::Command`

## Test plan
- [ ] `plexi-alpha pane command <id> "echo hello" --enter` inside a Plexi terminal pane types and submits the command
- [ ] Without `--enter`, text is typed but not submitted
- [ ] `plexi pane command --help` shows usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)