### PR TITLE
feat(ai): auto-discover local LLM servers (#1973)

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -4,12 +4,95 @@ use serde::Serialize;
 struct DoctorReport {
     healthy: bool,
     apps: Vec<AppReport>,
+    llm_servers: Vec<LlmServerReport>,
 }
 
 #[derive(Serialize)]
 struct AppReport {
     id: String,
     missing: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct LlmServerReport {
+    name: String,
+    url: String,
+    models: Vec<String>,
+}
+
+/// Probe a single LLM server endpoint.
+/// Returns `Some(models)` if the server is reachable and returns a parseable model list.
+fn probe_llm_server(url: &str) -> Option<Vec<String>> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(std::time::Duration::from_millis(1500))
+        .timeout(std::time::Duration::from_secs(2))
+        .build();
+
+    let resp = match agent.get(url).call() {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("cli:doctor: llm probe {url} -- not reachable: {e}");
+            return None;
+        }
+    };
+
+    let text = match resp.into_string() {
+        Ok(t) => t,
+        Err(e) => {
+            log::debug!("cli:doctor: llm probe {url} -- read error: {e}");
+            return None;
+        }
+    };
+
+    let body: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("cli:doctor: llm probe {url} -- bad JSON: {e}");
+            return None;
+        }
+    };
+
+    // Ollama /api/tags returns {"models":[{"name":"..."},...]}
+    // OpenAI-compatible /v1/models returns {"data":[{"id":"..."},...]}
+    let models: Vec<String> = if let Some(arr) = body["models"].as_array() {
+        arr.iter()
+            .filter_map(|m| m["name"].as_str().map(|s| s.to_string()))
+            .collect()
+    } else if let Some(arr) = body["data"].as_array() {
+        arr.iter()
+            .filter_map(|m| m["id"].as_str().map(|s| s.to_string()))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Some(models)
+}
+
+/// Probe all well-known local LLM server endpoints and return discovered servers.
+fn discover_llm_servers() -> Vec<LlmServerReport> {
+    let candidates = [
+        ("Ollama", "http://localhost:11434", "/api/tags"),
+        ("LM Studio", "http://localhost:1234", "/v1/models"),
+        ("llama.cpp", "http://localhost:8080", "/v1/models"),
+    ];
+
+    let mut found = Vec::new();
+    for (name, base, path) in &candidates {
+        let url = format!("{base}{path}");
+        if let Some(models) = probe_llm_server(&url) {
+            log::info!(
+                "cli:doctor: found local LLM server -- name={name} url={base} models={}",
+                models.len()
+            );
+            found.push(LlmServerReport {
+                name: name.to_string(),
+                url: base.to_string(),
+                models,
+            });
+        }
+    }
+    found
 }
 
 pub fn doctor_cli(json: bool) -> i32 {
@@ -21,12 +104,27 @@ pub fn doctor_cli(json: bool) -> i32 {
         crate::config::active_workspace_root().as_deref(),
     );
 
+    // Probe for local LLM servers before the app audit.
+    let llm_servers = discover_llm_servers();
+
     let installed = registry.list();
     if installed.is_empty() {
         if json {
-            println!(r#"{{"healthy":true,"apps":[]}}"#);
+            let report = DoctorReport {
+                healthy: true,
+                apps: Vec::new(),
+                llm_servers,
+            };
+            match serde_json::to_string_pretty(&report) {
+                Ok(s) => println!("{s}"),
+                Err(e) => {
+                    eprintln!("error: failed to serialize doctor report: {e}");
+                    return 1;
+                }
+            }
         } else {
             println!("No apps installed.");
+            print_llm_section(&llm_servers);
         }
         return 0;
     }
@@ -51,6 +149,7 @@ pub fn doctor_cli(json: bool) -> i32 {
         let report = DoctorReport {
             healthy,
             apps: sick_apps,
+            llm_servers,
         };
         match serde_json::to_string_pretty(&report) {
             Ok(s) => println!("{s}"),
@@ -87,9 +186,31 @@ pub fn doctor_cli(json: bool) -> i32 {
                 "\n{sick_count} app(s) have unsatisfied capabilities. Run 'plexi config edit' to fix."
             );
         }
+
+        print_llm_section(&llm_servers);
     }
 
     log::info!("cli:doctor: audit complete -- {total} app(s), {sick_count} unhealthy");
 
     if healthy { 0 } else { 1 }
+}
+
+/// Print the local LLM servers section to stdout.
+fn print_llm_section(servers: &[LlmServerReport]) {
+    println!("\nLocal LLM servers:");
+    if servers.is_empty() {
+        println!("  No local LLM servers detected");
+    } else {
+        for s in servers {
+            let count = s.models.len();
+            let model_summary = if count == 0 {
+                "(no models listed)".to_string()
+            } else if count <= 3 {
+                s.models.join(", ")
+            } else {
+                format!("{}, ... ({} total)", s.models[..3].join(", "), count)
+            };
+            println!("  {} ({}) -- {}", s.name, s.url, model_summary);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Probes Ollama (`localhost:11434/api/tags`), LM Studio (`localhost:1234/v1/models`), and llama.cpp (`localhost:8080/v1/models`) at `plexi doctor` time
- Uses `ureq` with 1.5s connect / 2s total timeout — no hang when nothing is running
- Displays a "Local LLM servers:" section: names, URLs, and model list (first 3 + count if more)
- JSON output gains a `llm_servers` field with `name`, `url`, and `models` array

## Test plan

- [ ] Run `plexi-pr-<N> doctor` with Ollama running — confirm section shows `Ollama (http://localhost:11434) -- <model names>`
- [ ] Run with no local LLM servers — confirm section shows `No local LLM servers detected`
- [ ] Run `plexi-pr-<N> doctor --json` — confirm `llm_servers` field is present and populated
- [ ] Confirm `plexi doctor` completes in <5s even when all three ports are closed

Closes #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)