### PR TITLE
feat(host/context): new-child-context shortcut (#1833)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2695,6 +2695,9 @@ impl eframe::App for PlexiApp {
                     self.new_context();
                     self.save_workspace();
                 }
+                Action::NewChildContext => {
+                    self.new_child_context_from_keyboard();
+                }
                 Action::PushPaneToSubcontext => {
                     self.push_pane_to_subcontext(None);
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -803,6 +803,41 @@ fn create_child_context_auto_zooms() {
     assert_eq!(app.router.current_depth(), 1);
 }
 
+/// Issue #1833: new_child_context_from_keyboard creates a child of the active context
+/// and auto-zooms into it (push_depth + switch_workspace). In PTY-less test environments
+/// the terminal creation fails — verify the depth stack is unchanged and the active context
+/// is unmodified in that case.
+#[test]
+fn new_child_context_from_keyboard_zooms_into_child() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let parent_ctx_id = app.router.active().context_id;
+    let initial_depth = app.router.current_depth();
+    let initial_ctx_count = app.router.len();
+
+    app.new_child_context_from_keyboard();
+
+    if app.router.len() == initial_ctx_count {
+        // PTY unavailable — no child created, state unchanged.
+        assert_eq!(app.router.current_depth(), initial_depth,
+            "depth stack must be unchanged when child creation fails");
+        assert_eq!(app.router.active().context_id, parent_ctx_id,
+            "active context must not change when child creation fails");
+    } else {
+        // Child was created and we zoomed in.
+        assert_eq!(app.router.len(), initial_ctx_count + 1,
+            "exactly one new context added");
+        assert_ne!(app.router.active().context_id, parent_ctx_id,
+            "active context must switch to the new child");
+        assert_eq!(app.router.active().parent_id, Some(parent_ctx_id),
+            "child's parent_id must be the original context");
+        assert_eq!(app.router.current_depth(), initial_depth + 1,
+            "depth stack must grow by one after auto-zoom");
+    }
+}
+
 /// Issue #1392: unlimited nesting after killing the depth cap and adoption branch.
 /// Build a 4-level chain (root → A → B → C → D) and verify that each parent's
 /// window contains a Portal tile pointing at the corresponding child.

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "open_file_browser", "open_quick_note", "open_config", "reload_config",
     "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
     "open_scratchpad", "set_context_root_from_cwd",
+    "push_to_subcontext", "new_child_context",
 ];
 
 pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
@@ -213,6 +214,7 @@ pub struct KeybindingsConfig {
     pub toggle_notification_modal: Option<String>,
     pub open_scratchpad: Option<String>,
     pub push_to_subcontext: Option<String>,
+    pub new_child_context: Option<String>,
     pub set_context_root_from_cwd: Option<String>,
 }
 
@@ -268,6 +270,7 @@ impl KeybindingsConfig {
         overlay_field!(toggle_notification_modal);
         overlay_field!(open_scratchpad);
         overlay_field!(push_to_subcontext);
+        overlay_field!(new_child_context);
         overlay_field!(set_context_root_from_cwd);
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -28,6 +28,8 @@ use crate::config::KeybindingsConfig;
 // Cmd+F                       — terminal search (handled inside egui_term, not host)
 // Cmd+E                       — file browser
 // Cmd+Shift+I                 — set context root from focused pane CWD
+// Cmd+Option+N                — extract focused pane into a new sub-context (portal)
+// Cmd+Shift+Option+N          — new child context under current context (empty, auto-zoom)
 // Cmd+0                       — quick note
 // Cmd+1–9                     — switch context (sidebar)
 // Escape (app active)         — close app
@@ -119,6 +121,9 @@ pub enum Action {
     /// Push the focused pane into a new sub-context. The pane becomes a portal
     /// and its content moves into the child. Bound to Cmd+Option+N.
     PushPaneToSubcontext,
+    /// Create a new empty child context under the current context and auto-zoom
+    /// into it. Bound to Cmd+Shift+Option+N.
+    NewChildContext,
     /// Zoom out of the current sub-context to the parent. Bound to Cmd+Escape.
     ContextZoomOut,
     /// Set the active context root to the focused pane's CWD. Bound to Cmd+Shift+I.
@@ -173,6 +178,7 @@ pub struct KeyBindings {
     pub open_scratchpad: (egui::Modifiers, egui::Key),
     pub context_zoom_out: (egui::Modifiers, egui::Key),
     pub push_to_subcontext: (egui::Modifiers, egui::Key),
+    pub new_child_context: (egui::Modifiers, egui::Key),
     pub set_context_root_from_cwd: (egui::Modifiers, egui::Key),
 }
 
@@ -185,6 +191,9 @@ fn cmd_ctrl() -> egui::Modifiers {
 }
 fn cmd_alt() -> egui::Modifiers {
     egui::Modifiers { alt: true, ..egui::Modifiers::COMMAND }
+}
+fn cmd_shift_alt() -> egui::Modifiers {
+    egui::Modifiers { shift: true, alt: true, ..egui::Modifiers::COMMAND }
 }
 impl Default for KeyBindings {
     fn default() -> Self {
@@ -232,8 +241,9 @@ impl Default for KeyBindings {
             toggle_notification_modal: (cmd_shift(), egui::Key::A),
             open_scratchpad:           (cmd_shift(), egui::Key::Space),
             context_zoom_out:          (cmd(),       egui::Key::Escape),
-            push_to_subcontext:        (cmd_alt(),   egui::Key::N),
-            set_context_root_from_cwd: (cmd_shift(), egui::Key::I),
+            push_to_subcontext:        (cmd_alt(),       egui::Key::N),
+            new_child_context:         (cmd_shift_alt(), egui::Key::N),
+            set_context_root_from_cwd: (cmd_shift(),     egui::Key::I),
         }
     }
 }
@@ -383,6 +393,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(toggle_notification_modal, "toggle_notification_modal");
     apply_override!(open_scratchpad, "open_scratchpad");
     apply_override!(push_to_subcontext, "push_to_subcontext");
+    apply_override!(new_child_context, "new_child_context");
     apply_override!(set_context_root_from_cwd, "set_context_root_from_cwd");
 
     // Conflict detection
@@ -430,6 +441,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("toggle_notification_modal", bindings.toggle_notification_modal),
         ("open_scratchpad",           bindings.open_scratchpad),
         ("push_to_subcontext",        bindings.push_to_subcontext),
+        ("new_child_context",         bindings.new_child_context),
         ("set_context_root_from_cwd", bindings.set_context_root_from_cwd),
     ];
 
@@ -526,6 +538,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         BindingEntry { modifiers: b.split_down.0,               key: b.split_down.1,               exact: false, context: BindingContext::Normal, action: Action::SplitDown },
         BindingEntry { modifiers: b.split_right.0,              key: b.split_right.1,              exact: true,  context: BindingContext::Normal, action: Action::SplitRight },
         BindingEntry { modifiers: b.push_to_subcontext.0,       key: b.push_to_subcontext.1,       exact: false, context: BindingContext::Normal, action: Action::PushPaneToSubcontext },
+        BindingEntry { modifiers: b.new_child_context.0,        key: b.new_child_context.1,        exact: false, context: BindingContext::Normal, action: Action::NewChildContext },
         BindingEntry { modifiers: b.new_context.0,              key: b.new_context.1,              exact: false, context: BindingContext::Normal, action: Action::NewContext },
         BindingEntry { modifiers: b.new_page_right.0,           key: b.new_page_right.1,           exact: true,  context: BindingContext::Normal, action: Action::NewPageRight },
         BindingEntry { modifiers: b.toggle_minimap.0,           key: b.toggle_minimap.1,           exact: false, context: BindingContext::Normal, action: Action::ToggleMinimap },

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -115,6 +115,37 @@ impl PlexiApp {
         Ok(())
     }
 
+    /// Create a new empty child context under the current context and auto-zoom
+    /// into it. Bound to Cmd+Shift+Option+N. Uses the current context's path as
+    /// the child's working directory and names the child "Sub-context N".
+    pub(crate) fn new_child_context_from_keyboard(&mut self) {
+        let parent_ctx_id = self.router.active().context_id;
+        let parent_name = self.router.active().name.clone();
+        let parent_path = self.router.active().path.clone();
+        let current_win_id = self.windows[self.active_window].window_id;
+        let current_focused = self.windows[self.active_window].focused_pane;
+
+        log::info!(
+            "new_child_context_from_keyboard: parent_ctx_id={parent_ctx_id} parent_name={parent_name} path={}",
+            parent_path.display()
+        );
+
+        match self.new_child_context(&parent_name, parent_path) {
+            Ok(()) => {
+                let new_ctx_idx = self.router.len() - 1;
+                self.router.push_depth(parent_ctx_id, current_win_id, current_focused);
+                self.switch_workspace(new_ctx_idx);
+                log::info!(
+                    "new_child_context_from_keyboard: zoomed into child ctx_id={}",
+                    self.router.active().context_id
+                );
+            }
+            Err(e) => {
+                log::warn!("new_child_context_from_keyboard: failed to create child context: {e}");
+            }
+        }
+    }
+
     pub(crate) fn push_pane_to_subcontext(&mut self, name: Option<String>) {
         let parent_win_idx = self.active_window;
         let parent_ctx_id = self.windows[parent_win_idx].context_id;


### PR DESCRIPTION
## Summary

- Adds `Action::NewChildContext` bound to `Cmd+Shift+Option+N` — creates an empty child context under the current context and auto-zooms into it
- Adds `new_child_context_from_keyboard()` helper in `pane_ops/workspace.rs` that calls the existing `new_child_context()` and handles the auto-zoom (push_depth + switch_workspace)
- Adds `new_child_context` field to `KeybindingsConfig` and `KNOWN_KEYBINDINGS` so the binding can be user-overridden via `config.toml [keybindings]`
- Adds `new_child_context_from_keyboard_zooms_into_child` HostHarness test covering the zoom + depth-stack behavior
- Binding is `Cmd+Shift+Option+N` (not `Cmd+Option+N` which is already occupied by `PushPaneToSubcontext`)

## Test plan

- [ ] Press `Cmd+Shift+Option+N` — verify a new child context is created under the current context and auto-zooms in
- [ ] Press `Cmd+Escape` to zoom back out — verify parent context is restored
- [ ] `cargo test --bin plexi` green (1 pre-existing failure in `welcome_tab_falls_back_to_home_dir_when_no_root` exists on alpha before this PR)

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)