### PR TITLE
fix(pgap): TextEdit focus and styling (#1971)

### DIFF
--- a/src/app_render.rs
+++ b/src/app_render.rs
@@ -196,6 +196,7 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
                 let mut lv_offsets = std::collections::HashMap::new();
                 let mut lv_last_sel = std::collections::HashMap::new();
                 let mut te_buffers = std::collections::HashMap::new();
+                let mut te_focus_ctx = crate::render_components::TextEditFocusCtx::new();
                 crate::process_app::render::render_draw_commands(
                     ui, rect, commands, &colors, &mut cm_cache, &peaks,
                     &mut img_cache, &std::env::temp_dir(), false,
@@ -203,6 +204,7 @@ fn render_commands_to_png(commands: &[RenderCommand], width: u32, height: u32) -
                     &mut lv_last_sel,
                     &mut Vec::new(),
                     &mut te_buffers,
+                    &mut te_focus_ctx,
                 );
             });
     });

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -46,6 +46,7 @@ pub(crate) fn render_draw_commands(
     list_view_last_aligned_sel: &mut HashMap<String, usize>,
     outbound_events: &mut Vec<crate::app_protocol::PlexiEvent>,
     text_edit_buffers: &mut HashMap<String, String>,
+    text_edit_focus_ctx: &mut crate::render_components::TextEditFocusCtx,
 ) {
     let origin = pane_rect.min;
 
@@ -1011,7 +1012,7 @@ pub(crate) fn render_draw_commands(
                     pane_rect.min
                 );
                 let component_events =
-                    crate::render_components::render_component_tree(ui, root, colors, text_edit_buffers);
+                    crate::render_components::render_component_tree(ui, root, colors, text_edit_buffers, text_edit_focus_ctx);
                 for evt in component_events {
                     log::info!(
                         "render: ComponentEvent node_id={} event_type={}",

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -17,8 +17,9 @@ pub(crate) struct RenderSession {
     /// IDs of `TextInput` widgets visible in the most recently rendered frame.
     /// Used to detect newly-visible inputs for auto-focus.
     text_input_visible_prev: HashSet<String>,
-    /// True when any `TextInput` widget had egui focus during the last render pass.
-    /// Read by `handle_key` in mod.rs to suppress key forwarding while the user types.
+    /// True when any `TextInput` or `TextEdit` widget had egui focus during the
+    /// last render pass. Read by `handle_key` in mod.rs to suppress key
+    /// forwarding while the user types.
     pub(crate) text_input_has_focus: bool,
     /// Per-region scroll offsets for `DrawCommand::BeginScroll` / `EndScroll`.
     /// Key = scroll region id; value = current vertical offset in logical pixels.
@@ -38,6 +39,9 @@ pub(crate) struct RenderSession {
     /// Events accumulated during one render pass. Drained after render into
     /// `ProcessApp::outbound_events` by `drain_events`.
     pub(crate) outbound_events: Vec<PlexiEvent>,
+    /// Focus/visibility tracking for `UiNode::TextEdit` nodes in component trees.
+    /// Persists across frames to detect newly-visible fields for auto-focus.
+    text_edit_focus_ctx: crate::render_components::TextEditFocusCtx,
 }
 
 impl RenderSession {
@@ -53,6 +57,7 @@ impl RenderSession {
             list_view_intercepts_nav: false,
             pane_just_focused: false,
             outbound_events: Vec::new(),
+            text_edit_focus_ctx: crate::render_components::TextEditFocusCtx::new(),
         }
     }
 
@@ -80,6 +85,10 @@ impl RenderSession {
     ) {
         log::debug!("render_session: render pane_id={} cmds={}", pane_id, frame.len());
 
+        // Propagate pane_just_focused into the TextEdit focus context so
+        // ComponentTree TextEdit nodes auto-focus on pane switch.
+        self.text_edit_focus_ctx.pane_just_focused = self.pane_just_focused;
+
         // ── Pass 1: draw commands ────────────────────────────────────────────
         crate::process_app::render::render_draw_commands(
             ui,
@@ -95,6 +104,7 @@ impl RenderSession {
             &mut self.list_view_last_aligned_sel,
             &mut self.outbound_events,
             &mut self.text_edit_buffers,
+            &mut self.text_edit_focus_ctx,
         );
 
         // ── Pass 2: TextInput widgets ────────────────────────────────────────
@@ -110,6 +120,15 @@ impl RenderSession {
         if !scroll_consumed {
             self.render_app_scroll(ui, pane_rect, frame);
         }
+
+        // Merge TextEdit focus state: if any ComponentTree TextEdit has focus,
+        // suppress key forwarding (same as TextInput focus).
+        if self.text_edit_focus_ctx.any_has_focus {
+            self.text_input_has_focus = true;
+        }
+
+        // Rotate TextEdit visibility sets for next-frame auto-focus detection.
+        self.text_edit_focus_ctx.end_frame();
     }
 
     /// Pass 2: render every `RenderCommand::TextInput` as a real egui `TextEdit`.

--- a/src/render_components.rs
+++ b/src/render_components.rs
@@ -21,6 +21,48 @@ pub(crate) struct ComponentEventPayload {
     pub(crate) payload: Option<serde_json::Value>,
 }
 
+/// Focus and styling context for `UiNode::TextEdit` nodes within a component
+/// tree render pass. Tracks auto-focus state so only the first newly-visible
+/// TextEdit gets focused, and reports back whether any TextEdit has egui focus
+/// (so the host can suppress key forwarding).
+pub(crate) struct TextEditFocusCtx {
+    /// Set of TextEdit node_ids that were visible in the previous frame.
+    /// Used to detect newly-appearing fields for auto-focus.
+    pub(crate) prev_visible: std::collections::HashSet<String>,
+    /// Node_ids visible in the current frame. After render, this becomes
+    /// the next frame's `prev_visible`.
+    pub(crate) current_visible: std::collections::HashSet<String>,
+    /// True if the pane was just focused (tab switch, click).
+    pub(crate) pane_just_focused: bool,
+    /// Set to true during the frame once any TextEdit has been auto-focused,
+    /// preventing multiple fields from grabbing focus simultaneously.
+    focus_granted_this_frame: bool,
+    /// Set to true if any TextEdit has egui focus during this render pass.
+    /// Read by `RenderSession` to suppress key forwarding while the user types.
+    pub(crate) any_has_focus: bool,
+}
+
+impl TextEditFocusCtx {
+    pub(crate) fn new() -> Self {
+        Self {
+            prev_visible: std::collections::HashSet::new(),
+            current_visible: std::collections::HashSet::new(),
+            pane_just_focused: false,
+            focus_granted_this_frame: false,
+            any_has_focus: false,
+        }
+    }
+
+    /// Call after each frame to rotate visibility sets.
+    pub(crate) fn end_frame(&mut self) {
+        std::mem::swap(&mut self.prev_visible, &mut self.current_visible);
+        self.current_visible.clear();
+        self.focus_granted_this_frame = false;
+        self.any_has_focus = false;
+        self.pane_just_focused = false;
+    }
+}
+
 /// Render a `UiNode` tree into the provided egui `Ui`.
 ///
 /// Returns any interaction events that occurred during this frame so the
@@ -32,11 +74,15 @@ pub(crate) struct ComponentEventPayload {
 /// `text_edit_buffers` provides persistent per-node_id text buffers for
 /// `UiNode::TextEdit` nodes. The buffer is seeded from the app's `value`
 /// field when a new node_id first appears.
+///
+/// `focus_ctx` tracks auto-focus and click-focus state for TextEdit nodes
+/// across recursive calls.
 pub(crate) fn render_component_tree(
     ui: &mut Ui,
     node: &UiNode,
     colors: &Colors,
     text_edit_buffers: &mut std::collections::HashMap<String, String>,
+    focus_ctx: &mut TextEditFocusCtx,
 ) -> Vec<ComponentEventPayload> {
     let mut events: Vec<ComponentEventPayload> = Vec::new();
 
@@ -50,10 +96,10 @@ pub(crate) fn render_component_tree(
                 }
                 if padding.left > 0.0 {
                     ui.indent("stack_left_pad", |ui| {
-                        events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers));
+                        events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers, focus_ctx));
                     });
                 } else {
-                    events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers));
+                    events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers, focus_ctx));
                 }
                 if padding.bottom > 0.0 {
                     ui.add_space(padding.bottom);
@@ -68,14 +114,14 @@ pub(crate) fn render_component_tree(
                 egui::ScrollArea::vertical()
             };
             scroll.show(ui, |ui| {
-                events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
+                events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
             });
         }
 
         UiNode::Layer { children } => {
             // V1: sequential rendering (true Z-stacking is a future improvement).
             for child in children {
-                events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
+                events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
             }
         }
 
@@ -102,7 +148,7 @@ pub(crate) fn render_component_tree(
             // Render the child inside an interact-sense scope so we get a
             // Response covering the child's bounding rect.
             let child_response = ui.scope(|ui| {
-                let child_evts = render_component_tree(ui, child, colors, text_edit_buffers);
+                let child_evts = render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx);
                 // Bubble child events up.
                 (child_evts, ui.min_rect())
             });
@@ -141,6 +187,9 @@ pub(crate) fn render_component_tree(
             // V1: fresh cache per Raw node — loses cache state across frames.
             // A future pass will thread parent caches through. See epic #1897 A2.
             let mut raw_events: Vec<crate::app_protocol::PlexiEvent> = Vec::new();
+            // Raw escape-hatch uses a throwaway focus ctx — focus tracking doesn't
+            // apply to legacy draw commands embedded inside a component tree.
+            let mut raw_focus_ctx = TextEditFocusCtx::new();
             crate::process_app::render::render_draw_commands(
                 ui,
                 pane_rect,
@@ -155,6 +204,7 @@ pub(crate) fn render_component_tree(
                 &mut std::collections::HashMap::new(),
                 &mut raw_events,
                 text_edit_buffers,
+                &mut raw_focus_ctx,
             );
             // Convert any ComponentEvent payloads back from PlexiEvent (unlikely
             // from a Raw draw command, but keep the pipeline consistent).
@@ -273,39 +323,78 @@ pub(crate) fn render_component_tree(
                 buffer.truncate(*max_length);
             }
 
+            // Track visibility for auto-focus detection.
+            let newly_visible = !focus_ctx.prev_visible.contains(node_id.as_str());
+            focus_ctx.current_visible.insert(node_id.clone());
+
             let prev_value = buffer.clone();
             let widget_id = egui::Id::new(("text_edit_node", node_id.as_str()));
 
+            // Styling matches QuickNote overlay: frameless, monospace, accent cursor,
+            // dim hint text. See src/overlays/quick_note.rs lines 138-154.
             let response = ui.scope(|ui| {
                 ui.visuals_mut().text_cursor.stroke.width = 1.5;
                 ui.visuals_mut().text_cursor.stroke.color = colors.accent;
-                ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-                ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
 
                 if *multiline {
+                    let hint = egui::RichText::new(placeholder.as_str())
+                        .color(colors.text_dim.linear_multiply(0.3))
+                        .size(style::TEXT_BODY);
                     let mut edit = egui::TextEdit::multiline(buffer)
                         .id(widget_id)
+                        .font(egui::FontId::monospace(style::TEXT_BODY))
+                        .text_color(colors.text_primary)
                         .desired_width(f32::INFINITY)
-                        .hint_text(placeholder.as_str())
-                        .font(egui::TextStyle::Body);
+                        .frame(false)
+                        .hint_text(hint);
                     if *max_length > 0 {
                         edit = edit.char_limit(*max_length);
                     }
                     ui.add(edit)
                 } else {
+                    let hint = egui::RichText::new(placeholder.as_str())
+                        .color(colors.text_dim.linear_multiply(0.3))
+                        .size(style::TEXT_BODY);
                     let mut edit = egui::TextEdit::singleline(buffer)
                         .id(widget_id)
+                        .font(egui::FontId::monospace(style::TEXT_BODY))
+                        .text_color(colors.text_primary)
                         .desired_width(f32::INFINITY)
-                        .hint_text(placeholder.as_str())
-                        .font(egui::TextStyle::Body)
-                        .margin(egui::Margin::symmetric(8, 5));
+                        .frame(false)
+                        .hint_text(hint);
                     if *max_length > 0 {
                         edit = edit.char_limit(*max_length);
                     }
                     ui.add(edit)
                 }
             }).inner;
+
+            // Auto-focus: first newly-visible TextEdit, or first TextEdit when
+            // the pane just gained keyboard focus.
+            if (newly_visible || focus_ctx.pane_just_focused)
+                && !focus_ctx.focus_granted_this_frame
+            {
+                response.request_focus();
+                focus_ctx.focus_granted_this_frame = true;
+                log::info!(
+                    "render_components: TextEdit auto-focus node_id={node_id} newly_visible={newly_visible} pane_focused={}",
+                    focus_ctx.pane_just_focused
+                );
+            }
+
+            // Click-to-focus: if the user clicked inside the TextEdit area,
+            // request focus so the cursor appears and typing works.
+            if response.clicked() {
+                response.request_focus();
+                log::debug!(
+                    "render_components: TextEdit click-focus node_id={node_id}"
+                );
+            }
+
+            // Track focus for key suppression.
+            if response.has_focus() {
+                focus_ctx.any_has_focus = true;
+            }
 
             // Emit "change" event when value differs from previous frame.
             if *buffer != prev_value {
@@ -611,7 +700,7 @@ pub(crate) fn render_component_tree(
                 .inner_margin(egui::Margin::same(pad as i8))
                 .show(ui, |ui| {
                     for child in children {
-                        events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
+                        events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
                     }
                 });
         }
@@ -696,6 +785,7 @@ fn render_stack(
     gap: f32,
     colors: &Colors,
     text_edit_buffers: &mut std::collections::HashMap<String, String>,
+    focus_ctx: &mut TextEditFocusCtx,
 ) -> Vec<ComponentEventPayload> {
     let mut events = Vec::new();
     match direction {
@@ -705,7 +795,7 @@ fn render_stack(
                     if i > 0 && gap > 0.0 {
                         ui.add_space(gap);
                     }
-                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
+                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
                 }
             });
         }
@@ -715,7 +805,7 @@ fn render_stack(
                     if i > 0 && gap > 0.0 {
                         ui.add_space(gap);
                     }
-                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers));
+                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
                 }
             });
         }


### PR DESCRIPTION
Closes #1971

## Summary

- **Auto-focus**: First TextEdit in a component tree auto-focuses on app open and on pane focus switch, using a `TextEditFocusCtx` that tracks newly-visible node_ids across frames
- **Click-to-focus**: Clicking a TextEdit calls `response.request_focus()` so the cursor appears and typing works immediately
- **QuickNote-matching styling**: Frameless, monospace font (`TEXT_BODY`), accent cursor, dim hint text with `linear_multiply(0.3)` -- identical to the QuickNote overlay text input
- **Key suppression**: TextEdit focus state merges into `text_input_has_focus` so the host suppresses app key forwarding while the user types

## Files changed

- `src/render_components.rs` -- `TextEditFocusCtx` struct, focus handling and restyled TextEdit rendering
- `src/process_app/render_session.rs` -- owns `TextEditFocusCtx`, propagates `pane_just_focused`, merges focus state
- `src/process_app/render.rs` -- threads `text_edit_focus_ctx` through `render_draw_commands`
- `src/app_render.rs` -- passes throwaway focus ctx in test/snapshot renderer

## Test plan

- [ ] `plexi-alpha app open text-edit-demo` -- click a TextEdit field, verify cursor appears and typing works
- [ ] Open app with TextEdit -- verify first field is auto-focused on load (cursor visible without clicking)
- [ ] Compare TextEdit styling to QuickNote (Cmd+0 Enter) -- font, cursor color, hint text should match
- [ ] Switch panes away and back -- verify TextEdit re-focuses
- [ ] `cargo test --bin plexi` -- 673 pass, 1 pre-existing failure (unrelated welcome_tab test)