### PR TITLE
feat(cli): plexi pane state (#1975)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -488,6 +488,42 @@ impl PlexiApp {
                         );
                     }
                 }
+                crate::app_protocol::AppRequest::GetPaneState { pane_id, response_file } => {
+                    log::info!("pane_ipc: kind=get_pane_state pane_id={pane_id} response_file={response_file:?}");
+                    let json_str = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
+                        None => {
+                            log::warn!("pane_ipc: get_pane_state: pane_id={pane_id} not found");
+                            serde_json::json!({"error": format!("pane {pane_id} not found")}).to_string()
+                        }
+                        Some(pane) => {
+                            if let Some(app_pane) = pane.as_app() {
+                                let frame = app_pane.runtime.frame_json().unwrap_or(serde_json::Value::Array(vec![]));
+                                serde_json::json!({
+                                    "pane_id": pane_id,
+                                    "type": "app",
+                                    "title": app_pane.name,
+                                    "manifest_id": app_pane.manifest_id,
+                                    "frame": frame,
+                                }).to_string()
+                            } else if let Some(term) = pane.as_terminal() {
+                                let title = term.name.clone().unwrap_or_else(|| "terminal".to_string());
+                                serde_json::json!({
+                                    "pane_id": pane_id,
+                                    "type": "terminal",
+                                    "title": title,
+                                }).to_string()
+                            } else {
+                                serde_json::json!({
+                                    "pane_id": pane_id,
+                                    "type": "unknown",
+                                }).to_string()
+                            }
+                        }
+                    };
+                    if let Err(e) = std::fs::write(response_file, &json_str) {
+                        log::error!("pane_ipc: get_pane_state: could not write response file {response_file:?}: {e}");
+                    }
+                }
                 crate::app_protocol::AppRequest::Notify {
                     level, title, body, kind, options, input_prompt,
                     required, priority, image_inline, image_pipe_id,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1549,6 +1549,15 @@ pub enum AppRequest {
         from_cursor: Option<u64>,
     },
 
+    /// Query the last-rendered UI state of a pane. Sent by `plexi pane state`.
+    /// For app panes: host writes a JSON object with a `frame` array of RenderCommands.
+    /// For terminal panes: host writes a simple status object.
+    /// Host writes `{"error":"..."}` if the pane is not found.
+    GetPaneState {
+        pane_id: u64,
+        response_file: String,
+    },
+
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
     CreateContext {
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -611,6 +611,19 @@ pub enum PaneCmd {
         #[arg(long, short = 'e')]
         enter: bool,
     },
+    /// Return the current UI state of a pane as JSON.
+    ///
+    /// For app panes: returns a JSON object with a `frame` array of RenderCommands
+    /// representing the last-rendered L1 UiNode tree. Agents can use this to inspect
+    /// what an app is currently displaying.
+    ///
+    /// For terminal panes: returns a simple status object (type, title, pane_id).
+    ///
+    /// Example: plexi pane state 42
+    State {
+        /// Pane id to query (from `plexi pane list`)
+        pane_id: u64,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -183,6 +183,7 @@ pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,
+    pane_state_cli,
 };
 pub use routine::{routine_list, routine_run};
 pub use run::{run_list_commands, run_command};

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -496,6 +496,59 @@ pub fn pane_capture_cli(pane_id: Option<u64>, lines: usize, full_output: bool, f
     }
 }
 
+/// `plexi pane state <id>`
+///
+/// Sends a `get_pane_state` command to PLEXI_SOCKET. For app panes, the host
+/// writes a JSON object containing the last-rendered frame (RenderCommand array).
+/// For terminal panes, returns a simple status object. Returns 0 on success, 1 on error.
+pub fn pane_state_cli(pane_id: u64) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-state-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    log::info!("pane_state:cli: pane_id={pane_id} response_file={response_file:?}");
+
+    let code = send_to_socket(serde_json::json!({
+        "type": "get_pane_state",
+        "pane_id": pane_id,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                            eprintln!("error: {err}");
+                            return 1;
+                        }
+                    }
+                    return print_json_output(&content);
+                }
+                Err(e) => {
+                    log::warn!("pane_state:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane state response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,6 +532,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                         PaneCmd::Capture { pane_id, lines, full_output, from_cursor } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output, from_cursor)),
+                        PaneCmd::State { pane_id } => std::process::exit(cli::pane_state_cli(pane_id)),
                         PaneCmd::New { cmd, name, down, left, up, right, tab, window, overlay, from, ephemeral, no_focus, cwd } => {
                             let layout = if down { "split_v" }
                                 else if left { "split_left" }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -263,6 +263,15 @@ impl AppRuntime {
             app.pending_notification_count = count;
         }
     }
+
+    /// Serialize the last-rendered frame (Vec<RenderCommand>) as a JSON array.
+    /// Returns `None` for builtin apps (no accessible frame).
+    pub(crate) fn frame_json(&self) -> Option<serde_json::Value> {
+        match self {
+            AppRuntime::Process(app) => serde_json::to_value(&app.frame).ok(),
+            AppRuntime::Builtin(_) => None,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1785,6 +1785,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::GetPaneState { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: GetPaneState pane_id={pane_id} received in app routing — ignored (host-only command)",
+                    self.type_id
+                );
+            }
 
             // ── Query context state (#1518) ───────────────────────────────
             AppRequest::QueryContextState { context_id } => {


### PR DESCRIPTION
Closes #1975

## Summary
- Adds `plexi pane state <id>` subcommand to the pane CLI
- Routes through `PLEXI_SOCKET` via a new `GetPaneState` `AppRequest` variant
- For app panes: returns a JSON object with `pane_id`, `type`, `title`, `manifest_id`, and `frame` (the last-rendered `Vec<RenderCommand>` serialized as a JSON array)
- For terminal panes: returns a simple status object with `pane_id`, `type`, `title`
- Adds `AppRuntime::frame_json()` accessor on `pane.rs` to expose the `pub(crate) frame` field
- `GetPaneState` in `routing.rs` is a no-op warn (host-only, same pattern as `CapturePane`)

## Files changed
- `src/app_protocol.rs` — new `GetPaneState` variant on `AppRequest`
- `src/app/lifecycle.rs` — host handler writes response file
- `src/pane.rs` — `AppRuntime::frame_json()` accessor
- `src/process_app/routing.rs` — no-op arm to satisfy exhaustive match
- `src/cli/pane.rs` — `pane_state_cli()` function
- `src/cli/args.rs` — `PaneCmd::State` variant
- `src/cli/mod.rs` — re-export `pane_state_cli`
- `src/main.rs` — dispatch `PaneCmd::State`

## Test plan
- [ ] Inside a Plexi alpha pane with an app open: `plexi pane state <app-pane-id>` prints JSON with `frame` array
- [ ] `plexi pane state <terminal-pane-id>` prints `{"pane_id":N,"type":"terminal","title":"..."}`
- [ ] `plexi pane state 99999` (nonexistent) exits 1 with `error: pane 99999 not found`
- [ ] `cargo build` passes (confirmed locally)