### PR TITLE
feat(host): pane-level hiding (#1948)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -774,6 +774,7 @@ impl PlexiApp {
                                     pane_group: Some("cwd".to_string()),
                                     linked_pane_id: None,
                                     overlay_replaced: None,
+                                    hidden: false,
                                 })));
                             }
                             "secrets_manager" => {
@@ -792,6 +793,7 @@ impl PlexiApp {
                                     pane_group: None,
                                     linked_pane_id: None,
                                     overlay_replaced: None,
+                                    hidden: false,
                                 })));
                             }
                             other => {
@@ -809,6 +811,7 @@ impl PlexiApp {
                                         pane_group: registry.group_for(other),
                                         linked_pane_id: None,
                                         overlay_replaced: None,
+                                        hidden: false,
                                     })));
                                 }
                             }
@@ -822,6 +825,7 @@ impl PlexiApp {
                                 pane_id: saved_pane.id,
                                 target_context_id: *context_id,
                                 context_state: None,
+                                hidden: false,
                             })));
                         }
                     }
@@ -842,7 +846,10 @@ impl PlexiApp {
                         }
                     }
 
-                    if let Some(pane) = pane_entry {
+                    if let Some(mut pane) = pane_entry {
+                        if saved_pane.hidden {
+                            pane.set_hidden(true);
+                        }
                         panes.insert(saved_pane.id, pane);
                     }
                 }
@@ -1353,6 +1360,7 @@ impl PlexiApp {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         };
 
         let win = &mut self.windows[0];
@@ -2589,6 +2597,25 @@ impl eframe::App for PlexiApp {
                             // has not been pushed yet.
                             self.sync_rename_pane_focus();
                             log::info!("rename_pane: opened for pane {pane_id:?}");
+                        }
+                    }
+                }
+                Action::HidePane => {
+                    let win = &mut self.windows[self.active_window];
+                    if let Some(focused_tile) = win.focused_pane {
+                        if let Some(Tile::Pane(pane_id)) = win.tree.tiles.get(focused_tile) {
+                            let pane_id = *pane_id;
+                            if let Some(pane) = win.panes.get_mut(&pane_id) {
+                                let new_val = !pane.is_hidden();
+                                pane.set_hidden(new_val);
+                                let name = match pane {
+                                    Pane::Terminal(t) => t.name.clone().unwrap_or_default(),
+                                    Pane::App(a) => a.name.clone(),
+                                    Pane::Portal(_) => String::new(),
+                                };
+                                log::info!("pane_hide: pane={pane_id} name={name:?} hidden={new_val}");
+                                self.save_workspace();
+                            }
                         }
                     }
                 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -139,6 +139,7 @@ fn send_to_pane_searches_all_windows() {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         }
     };
     win1.panes.insert(cross_window_pane_id, crate::pane::Pane::App(Box::new(app_pane)));
@@ -204,6 +205,7 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
         pane_group: None,
         linked_pane_id: None,
         overlay_replaced: None,
+        hidden: false,
     }));
     h.app.windows[0].panes.insert(orphan_id, orphan_pane);
     assert!(h.app.windows[0].tree.tiles.find_pane(&orphan_id).is_none(), "orphan has no tile");
@@ -946,6 +948,7 @@ fn delete_context_portal_resets_stale_focused_pane() {
                 pane_id: portal_pane_id,
                 target_context_id: child_id,
                 context_state: None,
+                hidden: false,
             })),
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,7 @@ pub struct KeybindingsConfig {
     pub push_to_subcontext: Option<String>,
     pub new_child_context: Option<String>,
     pub set_context_root_from_cwd: Option<String>,
+    pub hide_pane: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -272,6 +273,7 @@ impl KeybindingsConfig {
         overlay_field!(push_to_subcontext);
         overlay_field!(new_child_context);
         overlay_field!(set_context_root_from_cwd);
+        overlay_field!(hide_pane);
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -26,6 +26,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+Up / Cmd+Down           — scroll
 // Cmd+= / Cmd+-               — font size
 // Cmd+F                       — terminal search (handled inside egui_term, not host)
+// Cmd+U                       — toggle pane hidden state
 // Cmd+E                       — file browser
 // Cmd+Shift+I                 — set context root from focused pane CWD
 // Cmd+Option+N                — extract focused pane into a new sub-context (portal)
@@ -128,6 +129,8 @@ pub enum Action {
     ContextZoomOut,
     /// Set the active context root to the focused pane's CWD. Bound to Cmd+Shift+I.
     SetContextRootFromCwd,
+    /// Toggle hidden state on the focused pane. Bound to Cmd+U.
+    HidePane,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -180,6 +183,7 @@ pub struct KeyBindings {
     pub push_to_subcontext: (egui::Modifiers, egui::Key),
     pub new_child_context: (egui::Modifiers, egui::Key),
     pub set_context_root_from_cwd: (egui::Modifiers, egui::Key),
+    pub hide_pane: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -244,6 +248,7 @@ impl Default for KeyBindings {
             push_to_subcontext:        (cmd_alt(),       egui::Key::N),
             new_child_context:         (cmd_shift_alt(), egui::Key::N),
             set_context_root_from_cwd: (cmd_shift(),     egui::Key::I),
+            hide_pane:                 (cmd(),           egui::Key::U),
         }
     }
 }
@@ -395,6 +400,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(push_to_subcontext, "push_to_subcontext");
     apply_override!(new_child_context, "new_child_context");
     apply_override!(set_context_root_from_cwd, "set_context_root_from_cwd");
+    apply_override!(hide_pane, "hide_pane");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -443,6 +449,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("push_to_subcontext",        bindings.push_to_subcontext),
         ("new_child_context",         bindings.new_child_context),
         ("set_context_root_from_cwd", bindings.set_context_root_from_cwd),
+        ("hide_pane",                 bindings.hide_pane),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -552,6 +559,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         BindingEntry { modifiers: b.open_secrets_manager.0,     key: b.open_secrets_manager.1,     exact: false, context: BindingContext::Normal, action: Action::OpenSecretsManager },
         BindingEntry { modifiers: b.force_reload_app.0,         key: b.force_reload_app.1,         exact: false, context: BindingContext::Normal, action: Action::ForceReloadApp },
         BindingEntry { modifiers: b.set_context_root_from_cwd.0, key: b.set_context_root_from_cwd.1, exact: false, context: BindingContext::Normal, action: Action::SetContextRootFromCwd },
+        BindingEntry { modifiers: b.hide_pane.0,                key: b.hide_pane.1,                exact: false, context: BindingContext::Normal, action: Action::HidePane },
         BindingEntry { modifiers: b.open_scratchpad.0,          key: b.open_scratchpad.1,          exact: false, context: BindingContext::Normal, action: Action::OpenScratchpad },
         // context_zoom_out is Cmd+Escape — not exact because plain Escape is AppActive only,
         // so there is no subset conflict on this key.

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -24,6 +24,8 @@ pub struct PortalPane {
     pub pane_id: PaneId,
     pub target_context_id: u64,
     pub context_state: Option<crate::context_state::ContextState>,
+    /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
+    pub hidden: bool,
 }
 
 impl Pane {
@@ -32,6 +34,22 @@ impl Pane {
             Pane::Terminal(t) => t.id,
             Pane::App(a) => a.id,
             Pane::Portal(p) => p.pane_id,
+        }
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        match self {
+            Pane::Terminal(t) => t.hidden,
+            Pane::App(a) => a.hidden,
+            Pane::Portal(p) => p.hidden,
+        }
+    }
+
+    pub fn set_hidden(&mut self, val: bool) {
+        match self {
+            Pane::Terminal(t) => t.hidden = val,
+            Pane::App(a) => a.hidden = val,
+            Pane::Portal(p) => p.hidden = val,
         }
     }
 
@@ -110,6 +128,8 @@ pub struct TerminalPane {
     pub(crate) outside_workspace_cached: bool,
     pub(crate) outside_workspace_checked_at: Option<std::time::Instant>,
     pub(crate) outside_workspace_root: Option<PathBuf>,
+    /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
+    pub hidden: bool,
 }
 
 impl TerminalPane {
@@ -139,6 +159,7 @@ impl TerminalPane {
             outside_workspace_cached: false,
             outside_workspace_checked_at: None,
             outside_workspace_root: None,
+            hidden: false,
         })
     }
 }
@@ -281,5 +302,7 @@ pub struct AppPane {
     /// Pane hidden by an overlay app. Closing the app restores this pane instead
     /// of deleting the tile.
     pub overlay_replaced: Option<Box<Pane>>,
+    /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
+    pub hidden: bool,
 }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -151,6 +151,7 @@ impl PlexiApp {
                 pane_group: group,
                 linked_pane_id,
                 overlay_replaced,
+                hidden: false,
             }))
         };
 
@@ -268,6 +269,7 @@ impl PlexiApp {
                 pane_group: None,
                 linked_pane_id: None,
                 overlay_replaced: None,
+                hidden: false,
             })),
         );
         if self.windows[active].focused_pane.is_none() {
@@ -502,6 +504,7 @@ impl PlexiApp {
                 pane_group: group,
                 linked_pane_id,
                 overlay_replaced,
+                hidden: false,
             }))
         };
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -1632,6 +1632,7 @@ mod move_to_adjacent_window_tests {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         }))
     }
 
@@ -1745,6 +1746,7 @@ mod pop_pane_to_new_window_tests {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         }))
     }
 
@@ -1889,6 +1891,7 @@ mod move_to_row_boundary_tests {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         }))
     }
 
@@ -2075,6 +2078,7 @@ mod context_root_cwd_tests {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         };
         let tile = app.windows[0].tree.tiles.insert_pane(pane_id);
         app.windows[0].tree.root = Some(tile);
@@ -2101,7 +2105,7 @@ mod context_root_cwd_tests {
         let mut app = test_app();
         assert!(app.router.active().root.is_none());
         let pane_id: u64 = 99;
-        let portal = PortalPane { pane_id, target_context_id: 1, context_state: None };
+        let portal = PortalPane { pane_id, target_context_id: 1, context_state: None, hidden: false };
         let tile = app.windows[0].tree.tiles.insert_pane(pane_id);
         app.windows[0].tree.root = Some(tile);
         app.windows[0].focused_pane = Some(tile);
@@ -2165,6 +2169,7 @@ mod navigate_boundary_tests {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         }))
     }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -81,6 +81,7 @@ impl PlexiApp {
                     pane_id: sub_ctx_pane_id,
                     target_context_id: ctx_id,
                     context_state: None,
+                    hidden: false,
                 })),
             );
         } else {
@@ -217,6 +218,7 @@ impl PlexiApp {
                 pane_id: portal_pane_id,
                 target_context_id: ctx_id,
                 context_state: None,
+                hidden: false,
             })),
         );
 
@@ -909,6 +911,7 @@ impl PlexiApp {
             let mut saved_panes = Vec::new();
             for (&id, pane) in &win.panes {
                 debug_assert_eq!(pane.id(), id);
+                let pane_hidden = pane.is_hidden();
                 if let Some(t) = pane.as_terminal() {
                     let cwd = shell::get_pid_cwd(t.backend.child_pid())
                         .unwrap_or_else(|| win.path.clone());
@@ -919,6 +922,7 @@ impl PlexiApp {
                         name: t.name.clone(),
                         app_id: None,
                         app_state: None,
+                        hidden: pane_hidden,
                     });
                 } else if let Some(a) = pane.as_app() {
                     saved_panes.push(crate::workspace::SavedPane {
@@ -928,6 +932,7 @@ impl PlexiApp {
                         name: Some(a.name.clone()),
                         app_id: Some(a.runtime.type_id().to_string()),
                         app_state: a.runtime.serialize_state(),
+                        hidden: pane_hidden,
                     });
                 } else if let Some(child_ctx_id) = pane.portal_target() {
                     saved_panes.push(crate::workspace::SavedPane {
@@ -937,6 +942,7 @@ impl PlexiApp {
                         name: None,
                         app_id: None,
                         app_state: None,
+                        hidden: pane_hidden,
                     });
                 }
             }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -98,11 +98,22 @@ impl PlexiApp {
                 None
             };
 
-            // Build pane dots for this context row.
+            // Build pane dots for this context row — track which are hidden.
             let pane_dots = if pane_count > 0 {
+                let mut hidden_set = std::collections::HashSet::new();
+                for (dot_idx, &pid) in pane_ids.iter().enumerate() {
+                    let is_hidden = self.windows.iter()
+                        .filter(|w| w.context_id == ctx_id)
+                        .find_map(|w| w.panes.get(&pid))
+                        .map_or(false, |p| p.is_hidden());
+                    if is_hidden {
+                        hidden_set.insert(dot_idx);
+                    }
+                }
                 Some(PaneDots {
                     count: pane_count,
                     focused_idx: focused_pane_idx,
+                    hidden_set,
                 })
             } else {
                 None

--- a/src/sidebar_row.rs
+++ b/src/sidebar_row.rs
@@ -41,6 +41,8 @@ pub enum SidebarAction {
 pub struct PaneDots {
     pub count: usize,
     pub focused_idx: Option<usize>,
+    /// Set of dot indices that are hidden (rendered as stroke-only outlines).
+    pub hidden_set: std::collections::HashSet<usize>,
 }
 
 pub struct ContextItem {
@@ -169,12 +171,18 @@ impl ContextItem {
                         let cy = rect.center().y;
                         for dot_i in 0..capped {
                             let cx = rect.min.x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+                            let is_hidden = dots.hidden_set.contains(&dot_i);
                             let color = if dots.focused_idx == Some(dot_i) {
                                 with_alpha(accent_color, row_alpha)
                             } else {
                                 with_alpha(text_dim, if is_dragging { 0.15 } else { 0.35 })
                             };
-                            painter.circle_filled(egui::pos2(cx, cy), PANE_DOT_RADIUS, color);
+                            let center = egui::pos2(cx, cy);
+                            if is_hidden {
+                                painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0, color));
+                            } else {
+                                painter.circle_filled(center, PANE_DOT_RADIUS, color);
+                            }
                         }
                         if dots.count > PANE_DOT_MAX {
                             let overflow_x = rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -123,6 +123,7 @@ impl HostHarness {
             pane_group: None,
             linked_pane_id: None,
             overlay_replaced: None,
+            hidden: false,
         };
 
         let win = &mut self.app.windows[0];

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -272,14 +272,25 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
     }
 
     fn tab_title_for_pane(&mut self, pane: &PaneId) -> egui::WidgetText {
-        let label = if let Some(name) = self.pane_names.get(pane) {
+        let is_hidden = self.panes.get(pane).map_or(false, |p| p.is_hidden());
+        let base_label = if let Some(name) = self.pane_names.get(pane) {
             name.clone()
         } else {
             format!("Terminal {}", pane + 1)
         };
+        let label = if is_hidden {
+            format!("{base_label} (hidden)")
+        } else {
+            base_label
+        };
+        let color = if is_hidden {
+            crate::sidebar_row::with_alpha(self.colors.text_dim, 0.5)
+        } else {
+            self.colors.text_dim
+        };
         egui::RichText::new(label)
             .size(11.0)
-            .color(self.colors.text_dim)
+            .color(color)
             .into()
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -49,6 +49,8 @@ pub struct SavedPane {
     pub app_id: Option<String>,
     #[serde(default)]
     pub app_state: Option<serde_json::Value>,
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, Debug)]
@@ -135,6 +137,7 @@ mod tests {
                 app_id: matches!(kind, SavedPaneKind::App)
                     .then(|| "snake".to_string()),
                 app_state: None,
+                hidden: false,
             };
             let json = serde_json::to_string(&pane).expect("serialize");
             let restored: SavedPane = serde_json::from_str(&json).expect("deserialize");
@@ -150,6 +153,7 @@ mod tests {
             name: None,
             app_id: None,
             app_state: None,
+            hidden: false,
         };
         let json = serde_json::to_string(&portal_pane).expect("serialize portal");
         let restored: SavedPane = serde_json::from_str(&json).expect("deserialize portal");


### PR DESCRIPTION
Closes #1948

## Summary

- Adds `hidden: bool` to all pane variants (Terminal, App, Portal) with `is_hidden()`/`set_hidden()` on the `Pane` enum
- Binds `Cmd+U` to toggle hidden state on the focused pane (`HidePane` action)
- Hidden panes render as stroke-only outline dots in the sidebar instead of filled circles
- Tab titles for hidden panes are dimmed and suffixed with "(hidden)"
- Hidden state persists across restarts via `SavedPane.hidden` in workspace.json (`#[serde(default)]` for backward compat)
- `info!` log line on every hide/unhide with pane id and name

## Visual changes

- **Sidebar dots**: hidden panes show as outline circles; focused + hidden = accent-colored outline
- **Tab chrome**: dimmed title text at 50% opacity with " (hidden)" suffix

## Files changed

- `src/pane.rs` - `hidden` field on all pane structs + `is_hidden`/`set_hidden` on enum
- `src/workspace.rs` - `hidden` field on `SavedPane` with serde default
- `src/keys.rs` - `HidePane` action bound to `Cmd+U`
- `src/config.rs` - `hide_pane` in `KeybindingsConfig`
- `src/sidebar_row.rs` - `hidden_set` on `PaneDots`, outline rendering for hidden dots
- `src/sidebar.rs` - Build hidden_set when constructing PaneDots
- `src/tiling.rs` - Dim + suffix in `tab_title_for_pane`
- `src/app/mod.rs` - Action handler, restore hidden on workspace load
- `src/pane_ops/workspace.rs` - Save hidden flag
- `src/pane_ops/create.rs` - Default `hidden: false` on new panes
- `src/testing.rs`, `src/app/tests.rs`, `src/pane_ops/layout.rs` - Test constructor updates

## Test plan

- [ ] `Cmd+U` on a focused pane toggles its sidebar dot from filled to outline
- [ ] Hidden pane's tab title shows dimmed with "(hidden)" suffix
- [ ] Pane still works normally when focused (input, process, rendering)
- [ ] Hidden state persists across restart
- [ ] Check `~/.plexi-alpha/plexi.log` for `pane_hide:` log lines on toggle
- [ ] 674/675 tests pass (1 pre-existing failure on alpha)