### PR TITLE
feat(cli): prefix-based open namespace (#1529)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -221,6 +221,12 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: DescriptorCmd,
     },
+    /// List completions for prefix-based open (hidden, used by shell completions)
+    #[command(hide = true, name = "_complete-open")]
+    CompleteOpen {
+        /// Prefix to complete: "cli:", "mcp:", "app:", or empty for all
+        prefix: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,3 +1,79 @@
+/// Output completion candidates for `plexi app open <prefix>`.
+///
+/// Called by the hidden `_complete-open` subcommand. Outputs one candidate
+/// per line, ready for shell consumption.
+///
+/// - `"cli:"` -> embedded + cached CLI names, prefixed with `cli:`
+/// - `"mcp:"` -> embedded + user MCP names, prefixed with `mcp:`
+/// - `"app:"` -> installed app IDs, prefixed with `app:`
+/// - `""` or anything else -> all three categories plus bare app IDs
+pub fn complete_open_cli(prefix: &str) -> i32 {
+    match prefix {
+        "cli:" | "cli" => {
+            let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            for name in crate::cli::registry::list_clis() {
+                names.insert(name);
+            }
+            for name in crate::cli::registry::list_cached_cli_names() {
+                names.insert(name);
+            }
+            for name in names {
+                println!("cli:{name}");
+            }
+        }
+        "mcp:" | "mcp" => {
+            for name in crate::cli::registry::list_mcp_names() {
+                println!("mcp:{name}");
+            }
+        }
+        "app:" | "app" => {
+            let apps_dir = crate::config::config_dir().join("apps");
+            if let Ok(read) = std::fs::read_dir(&apps_dir) {
+                let mut names: Vec<String> = read
+                    .flatten()
+                    .filter(|e| e.path().is_dir())
+                    .filter_map(|e| e.file_name().into_string().ok())
+                    .collect();
+                names.sort();
+                for name in names {
+                    println!("app:{name}");
+                }
+            }
+        }
+        _ => {
+            // All categories: bare app IDs + prefixed variants
+            let apps_dir = crate::config::config_dir().join("apps");
+            if let Ok(read) = std::fs::read_dir(&apps_dir) {
+                let mut names: Vec<String> = read
+                    .flatten()
+                    .filter(|e| e.path().is_dir())
+                    .filter_map(|e| e.file_name().into_string().ok())
+                    .collect();
+                names.sort();
+                for name in &names {
+                    println!("{name}");
+                }
+            }
+            // CLI names
+            let mut cli_names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            for name in crate::cli::registry::list_clis() {
+                cli_names.insert(name);
+            }
+            for name in crate::cli::registry::list_cached_cli_names() {
+                cli_names.insert(name);
+            }
+            for name in cli_names {
+                println!("cli:{name}");
+            }
+            // MCP names
+            for name in crate::cli::registry::list_mcp_names() {
+                println!("mcp:{name}");
+            }
+        }
+    }
+    0
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     use clap::CommandFactory;
     use clap_complete::{generate, Shell};
@@ -12,11 +88,63 @@ pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
         let mut buf = Vec::new();
         generate(shell_variant, &mut cmd, binary_name, &mut buf);
         let script = String::from_utf8(buf).unwrap_or_default();
-        print!("{}", fix_zsh_workspace_path_conflict(&script));
+        let script = fix_zsh_workspace_path_conflict(&script);
+        let script = inject_zsh_open_completions(&script, binary_name);
+        print!("{script}");
     } else {
         generate(shell_variant, &mut cmd, binary_name, &mut std::io::stdout());
     }
     0
+}
+
+/// Inject a dynamic completion function for `plexi app open <TAB>` into the
+/// zsh completion script. Replaces the static `type_id` spec with a call to
+/// the hidden `_complete-open` subcommand, which enumerates app IDs, CLI
+/// registry names, MCP registry names, and cached descriptors at runtime.
+fn inject_zsh_open_completions(script: &str, binary_name: &str) -> String {
+    // The generated script has a line like:
+    //   ':type_id -- App id to open ...:' \
+    // We replace it with a dynamic completion that calls our binary.
+    let mut result = String::with_capacity(script.len() + 512);
+    let mut injected_helper = false;
+    for line in script.lines() {
+        if line.contains("::type_id") && line.contains("App id to open") {
+            // Replace static spec with dynamic completion
+            result.push_str(&format!(
+                "':type_id -- App, CLI, or MCP name (app:, cli:, mcp: prefix):__{binary_name}_open_completions' \\",
+            ));
+            result.push('\n');
+            if !injected_helper {
+                injected_helper = true;
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    // Append the helper function at the end (before the final line which is
+    // usually the compdef call or the last function call).
+    if injected_helper {
+        let helper = format!(
+            r#"
+__{binary_name}_open_completions() {{
+    local -a completions
+    completions=(${{(f)"$({binary_name} _complete-open "${{words[CURRENT]%%:*}}"  2>/dev/null)"}})
+    compadd -a completions
+}}
+"#,
+        );
+        // Insert before the final compdef line
+        if let Some(pos) = result.rfind("\ncompdef ") {
+            result.insert_str(pos, &helper);
+        } else {
+            // No compdef found, append at end
+            result.push_str(&helper);
+        }
+    }
+
+    result
 }
 
 /// clap_complete emits `workspace_path` as a positional spec before the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -167,7 +167,7 @@ pub(super) fn binary_in_path(name: &str) -> bool {
 
 // ── Public re-exports (preserve crate::cli::fn_name() call sites in main.rs) ──
 pub use app::{app_init, app_uninstall, app_install_with_pin, app_run, app_info, app_list, app_render, app_dev, app_publish, app_update_cli};
-pub use completions::completions_cli;
+pub use completions::{completions_cli, complete_open_cli};
 pub use config_cli::{config_check, config_edit, config_get, config_reset};
 pub use context_cli::{
     context_new_cli, context_zoom_cli, context_zoom_out_cli, context_open_cli,
@@ -179,7 +179,7 @@ pub use install::{install_cli, install_pack_cli, install_workspace_pack_cli, ple
 pub use list::{freeze_cli, parse_notify_choice};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
-pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title};
+pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title, parse_prefix, open_cli_by_name, open_mcp_by_name, OpenPrefix};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -220,6 +220,147 @@ pub fn mcp_pane_title(args: &[String]) -> String {
     format!("mcp: {short}")
 }
 
+/// Parsed prefix from a `type_id` string like `app:snake`, `cli:git`, `mcp:filesystem`.
+pub enum OpenPrefix {
+    /// `app:<name>` -- explicit app registry lookup
+    App(String),
+    /// `cli:<name>` -- CLI registry/crawl lookup
+    Cli(String),
+    /// `mcp:<name>` -- MCP registry lookup
+    Mcp(String),
+    /// No prefix -- backwards compat (try app registry, then CLI registry)
+    Bare(String),
+}
+
+/// Parse a `type_id` argument into an `OpenPrefix`.
+pub fn parse_prefix(type_id: &str) -> OpenPrefix {
+    if let Some(name) = type_id.strip_prefix("app:") {
+        OpenPrefix::App(name.to_string())
+    } else if let Some(name) = type_id.strip_prefix("cli:") {
+        OpenPrefix::Cli(name.to_string())
+    } else if let Some(name) = type_id.strip_prefix("mcp:") {
+        OpenPrefix::Mcp(name.to_string())
+    } else {
+        OpenPrefix::Bare(type_id.to_string())
+    }
+}
+
+/// Open a named CLI tool via the Tier 1/2/3 resolution chain (registry then crawl).
+///
+/// Writes a descriptor to a temp file and opens it with `cli-renderer`.
+pub fn open_cli_by_name(
+    name: &str,
+    layout: Option<&str>,
+    from_pane_id: Option<u64>,
+    cwd: Option<&str>,
+) -> i32 {
+    log::info!("open:prefix: resolving cli:{name}");
+
+    // Tier 2: registry lookup
+    match crate::cli::registry::lookup(name, None) {
+        Ok(descriptor) => {
+            log::info!("open:prefix: cli:{name} resolved from registry");
+            let json = match serde_json::to_string_pretty(&descriptor) {
+                Ok(j) => j,
+                Err(e) => {
+                    eprintln!("error: could not serialize descriptor for `{name}`: {e}");
+                    return 1;
+                }
+            };
+            let id = uuid::Uuid::new_v4();
+            let tmp = std::env::temp_dir().join(format!("plexi-descriptor-{id}.json"));
+            if let Err(e) = std::fs::write(&tmp, &json) {
+                eprintln!("error: could not write descriptor temp file: {e}");
+                return 1;
+            }
+            let path = tmp.to_string_lossy().to_string();
+            let layout_str = layout.unwrap_or("split_h");
+            return pane_new_cli(
+                None, Some(name), layout_str, from_pane_id, cwd,
+                false, false, Some("cli-renderer"), &[], None, &[path],
+            );
+        }
+        Err(crate::cli::registry::RegistryError::NotFound { .. }) => {
+            // Fall through to Tier 3
+        }
+        Err(e) => {
+            eprintln!("error: registry lookup for `{name}` failed: {e}");
+            return 1;
+        }
+    }
+
+    // Tier 3: crawl --help and cache
+    log::info!("open:prefix: cli:{name} not in registry, falling back to crawl");
+    match crate::cli::crawl::crawl(name) {
+        Ok(result) => {
+            let tag = if result.from_cache { "cached" } else { "fresh crawl" };
+            log::info!("open:prefix: cli:{name} resolved via {tag}");
+            let json = match serde_json::to_string_pretty(&result.descriptor) {
+                Ok(j) => j,
+                Err(e) => {
+                    eprintln!("error: could not serialize descriptor for `{name}`: {e}");
+                    return 1;
+                }
+            };
+            let id = uuid::Uuid::new_v4();
+            let tmp = std::env::temp_dir().join(format!("plexi-descriptor-{id}.json"));
+            if let Err(e) = std::fs::write(&tmp, &json) {
+                eprintln!("error: could not write descriptor temp file: {e}");
+                return 1;
+            }
+            let path = tmp.to_string_lossy().to_string();
+            let layout_str = layout.unwrap_or("split_h");
+            pane_new_cli(
+                None, Some(name), layout_str, from_pane_id, cwd,
+                false, false, Some("cli-renderer"), &[], None, &[path],
+            )
+        }
+        Err(e) => {
+            eprintln!("error: could not resolve CLI `{name}`: {e}");
+            1
+        }
+    }
+}
+
+/// Open a named MCP server from the registry.
+///
+/// Looks up the `command` array from `registry/mcp/<name>.json` and opens it
+/// with `mcp-renderer`.
+pub fn open_mcp_by_name(
+    name: &str,
+    layout: Option<&str>,
+    from_pane_id: Option<u64>,
+    cwd: Option<&str>,
+) -> i32 {
+    log::info!("open:prefix: resolving mcp:{name}");
+
+    match crate::cli::registry::lookup_mcp(name) {
+        Some(entry) => {
+            log::info!("open:prefix: mcp:{} ({}) resolved, command={:?}", entry.name, entry.description, entry.command);
+            let title = mcp_pane_title(&entry.command);
+            let layout_str = layout.unwrap_or("split_h");
+            pane_new_cli(
+                None,
+                Some(&title),
+                layout_str,
+                from_pane_id,
+                cwd,
+                false,
+                false,
+                Some("mcp-renderer"),
+                &entry.command,
+                None,
+                &[],
+            )
+        }
+        None => {
+            eprintln!("error: MCP server `{name}` not found in registry");
+            eprintln!("hint: use `plexi app open --mcp <command>...` for unnamed MCP servers");
+            1
+        }
+    }
+}
+
 /// Thin wrapper preserving the existing `plexi app open` call site.
 pub fn open_cli(type_id: &str, args: &[String], layout: Option<&str>, from_pane_id: Option<u64>, cwd: Option<&str>) -> i32 {
     // Intercept github: prefix for ephemeral open-without-install.
@@ -268,10 +409,51 @@ fn read_line_plain() -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::mcp_pane_title;
+    use super::{mcp_pane_title, parse_prefix, OpenPrefix};
 
     fn args(v: &[&str]) -> Vec<String> {
         v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn prefix_app() {
+        match parse_prefix("app:snake") {
+            OpenPrefix::App(name) => assert_eq!(name, "snake"),
+            _ => panic!("expected App prefix"),
+        }
+    }
+
+    #[test]
+    fn prefix_cli() {
+        match parse_prefix("cli:git") {
+            OpenPrefix::Cli(name) => assert_eq!(name, "git"),
+            _ => panic!("expected Cli prefix"),
+        }
+    }
+
+    #[test]
+    fn prefix_mcp() {
+        match parse_prefix("mcp:filesystem") {
+            OpenPrefix::Mcp(name) => assert_eq!(name, "filesystem"),
+            _ => panic!("expected Mcp prefix"),
+        }
+    }
+
+    #[test]
+    fn prefix_bare() {
+        match parse_prefix("snake") {
+            OpenPrefix::Bare(name) => assert_eq!(name, "snake"),
+            _ => panic!("expected Bare prefix"),
+        }
+    }
+
+    #[test]
+    fn prefix_github_stays_bare() {
+        // github: is handled by open_cli, not the prefix router
+        match parse_prefix("github:owner/repo") {
+            OpenPrefix::Bare(name) => assert_eq!(name, "github:owner/repo"),
+            _ => panic!("expected Bare for github: prefix"),
+        }
     }
 
     #[test]

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -188,6 +188,94 @@ fn read_and_parse(
     }
 }
 
+// ── MCP registry ─────────────────────────────────────────────────────────────
+
+/// A parsed MCP server entry from the registry (`registry/mcp/<name>.json`).
+#[derive(Debug, serde::Deserialize)]
+pub struct McpEntry {
+    pub name: String,
+    pub description: String,
+    pub command: Vec<String>,
+}
+
+/// Look up a named MCP server from the embedded registry or user override.
+///
+/// Resolution order: user-override dir (`~/.plexi-<channel>/registry/mcp/`)
+/// then embedded (`registry/mcp/`). First match wins.
+pub fn lookup_mcp(name: &str) -> Option<McpEntry> {
+    // 1. User override
+    if let Some(override_root) = user_override_dir() {
+        let path = override_root.join("mcp").join(format!("{name}.json"));
+        if let Ok(json) = std::fs::read_to_string(&path) {
+            if let Ok(entry) = serde_json::from_str::<McpEntry>(&json) {
+                return Some(entry);
+            }
+        }
+    }
+
+    // 2. Embedded
+    let embedded_path = format!("mcp/{name}.json");
+    if let Some(file) = EMBEDDED_REGISTRY.get_file(&embedded_path) {
+        if let Some(json) = file.contents_utf8() {
+            if let Ok(entry) = serde_json::from_str::<McpEntry>(json) {
+                return Some(entry);
+            }
+        }
+    }
+
+    None
+}
+
+/// List all MCP server names available in embedded + user override registries.
+pub fn list_mcp_names() -> Vec<String> {
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    // Embedded: registry/mcp/*.json
+    if let Some(mcp_dir) = EMBEDDED_REGISTRY.get_dir("mcp") {
+        for file in mcp_dir.files() {
+            if let Some(stem) = file.path().file_stem().and_then(|s| s.to_str()) {
+                names.insert(stem.to_string());
+            }
+        }
+    }
+
+    // User override: ~/.plexi-<channel>/registry/mcp/*.json
+    if let Some(override_root) = user_override_dir() {
+        let mcp_dir = override_root.join("mcp");
+        if let Ok(read) = std::fs::read_dir(&mcp_dir) {
+            for entry in read.flatten() {
+                let path = entry.path();
+                if path.extension().map(|e| e == "json").unwrap_or(false) {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        names.insert(stem.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    names.into_iter().collect()
+}
+
+/// List all cached CLI descriptor names from `~/.plexi-<channel>/cache/descriptors/`.
+pub fn list_cached_cli_names() -> Vec<String> {
+    let cache_dir = crate::config::config_dir()
+        .join("cache")
+        .join("descriptors");
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    if let Ok(read) = std::fs::read_dir(&cache_dir) {
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.extension().map(|e| e == "json").unwrap_or(false) {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    names.insert(stem.to_string());
+                }
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
 /// Iterate all CLI directories present in either the embedded or override
 /// backend. Used by `plexi registry watch` to walk the registered CLI set.
 pub fn list_clis() -> Vec<String> {
@@ -357,6 +445,26 @@ mod tests {
         let names = list_clis();
         for cli in &["gh", "cargo", "npm"] {
             assert!(names.iter().any(|n| n == cli), "expected {cli} in {names:?}");
+        }
+    }
+
+    #[test]
+    fn lookup_mcp_returns_embedded_entry() {
+        let entry = lookup_mcp("filesystem").expect("filesystem should exist in embedded MCP registry");
+        assert_eq!(entry.name, "filesystem");
+        assert!(!entry.command.is_empty());
+    }
+
+    #[test]
+    fn lookup_mcp_returns_none_for_unknown() {
+        assert!(lookup_mcp("nonexistent-mcp-zzz").is_none());
+    }
+
+    #[test]
+    fn list_mcp_names_returns_seeded_entries() {
+        let names = list_mcp_names();
+        for name in &["filesystem", "git", "github"] {
+            assert!(names.iter().any(|n| n == name), "expected {name} in {names:?}");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,8 +266,25 @@ fn main() -> eframe::Result {
                                 std::process::exit(2);
                             }
                             if let Some(tid) = type_id {
-                                log::info!("app_open:cli: opening app type_id={tid}");
-                                std::process::exit(cli::open_cli(&tid, &extra_args, layout.as_deref(), from_pane_id, None));
+                                // Prefix routing: cli:, mcp:, app:, or bare name
+                                match cli::parse_prefix(&tid) {
+                                    cli::OpenPrefix::Cli(name) => {
+                                        log::info!("app_open:cli: prefix-routed cli:{name}");
+                                        std::process::exit(cli::open_cli_by_name(&name, layout.as_deref(), from_pane_id, None));
+                                    }
+                                    cli::OpenPrefix::Mcp(name) => {
+                                        log::info!("app_open:cli: prefix-routed mcp:{name}");
+                                        std::process::exit(cli::open_mcp_by_name(&name, layout.as_deref(), from_pane_id, None));
+                                    }
+                                    cli::OpenPrefix::App(name) => {
+                                        log::info!("app_open:cli: prefix-routed app:{name}");
+                                        std::process::exit(cli::open_cli(&name, &extra_args, layout.as_deref(), from_pane_id, None));
+                                    }
+                                    cli::OpenPrefix::Bare(name) => {
+                                        log::info!("app_open:cli: opening app type_id={name}");
+                                        std::process::exit(cli::open_cli(&name, &extra_args, layout.as_deref(), from_pane_id, None));
+                                    }
+                                }
                             } else if !mcp.is_empty() {
                                 let title = cli::mcp_pane_title(&mcp);
                                 log::info!("app_open:cli: launching mcp-renderer with command {:?}, auto-title={title:?}", mcp);
@@ -551,6 +568,9 @@ fn main() -> eframe::Result {
                     Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
                         std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));
                     }
+                    Commands::CompleteOpen { prefix } => {
+                        std::process::exit(cli::complete_open_cli(&prefix));
+                    },
                     Commands::Descriptor { cmd } => match cmd {
                         DescriptorCmd::Probe { command, no_registry, no_crawl, json, extra_args } => {
                             if json {


### PR DESCRIPTION
Closes #1529

## Summary

- Adds prefix-based routing to `plexi app open` so `cli:git`, `mcp:filesystem`, and `app:snake` dispatch to the correct handler without flags
- `cli:<name>` resolves through Tier 2 registry then Tier 3 crawl+cache
- `mcp:<name>` resolves from embedded + user-override MCP registry (`registry/mcp/<name>.json`)
- `app:<name>` routes directly to app registry (explicit prefix)
- Bare names (no prefix) preserve existing behavior -- no regression
- `--mcp` flag for raw unnamed MCP passthrough remains unchanged
- Hidden `_complete-open` subcommand + zsh injection for dynamic tab completion of `cli:`, `mcp:`, `app:` prefixed names

## Test plan

- [ ] `plexi app open cli:git` opens the git CLI wrapper via registry descriptor
- [ ] `plexi app open cli:nonexistent` triggers crawl fallback, then shows error if binary not found
- [ ] `plexi app open mcp:filesystem` opens mcp-renderer with the filesystem server command
- [ ] `plexi app open mcp:nonexistent` shows "not found in registry" error with hint
- [ ] `plexi app open app:snake` opens snake (same as bare `snake`)
- [ ] `plexi app open snake` (bare, no prefix) still works -- no regression
- [ ] `plexi app open --mcp npx -y @modelcontextprotocol/server-brave-search` still works unchanged
- [ ] `plexi _complete-open cli:` outputs prefixed CLI names (registry + cached)
- [ ] `plexi _complete-open mcp:` outputs prefixed MCP names
- [ ] `plexi _complete-open app:` outputs prefixed installed app IDs
- [ ] `cargo test --bin plexi -- "open::tests"` passes (10 tests)
- [ ] `cargo test --bin plexi -- "registry::tests"` passes (17 tests including 3 new MCP tests)