### PR TITLE
feat(ui): context-level parking (#1949)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -297,6 +297,8 @@ pub struct PlexiApp {
     pub(crate) description_buffer: String,
     pub(crate) description_focus_requested: bool,
     pub(crate) drag_context: Option<usize>,
+    /// Whether the "Parked (N)" section in the sidebar is expanded.
+    pub(crate) parked_section_expanded: bool,
     pub(crate) registry: AppRegistry,
     pub(crate) show_command_palette: bool,
     pub(crate) palette_query: String,
@@ -933,6 +935,7 @@ impl PlexiApp {
                     description_buffer: String::new(),
                     description_focus_requested: false,
                     drag_context: None,
+                    parked_section_expanded: false,
                     show_command_palette: false,
                     palette_query: String::new(),
                     palette_selected: 0,
@@ -1066,6 +1069,7 @@ impl PlexiApp {
                     context_id: 1,
                     parent_id: None,
                     depth: 0,
+                    parked: false,
                 }],
                 0,
             ),
@@ -1105,6 +1109,7 @@ impl PlexiApp {
             description_buffer: String::new(),
             description_focus_requested: false,
             drag_context: None,
+            parked_section_expanded: false,
             show_command_palette: false,
             palette_query: String::new(),
             palette_selected: 0,
@@ -1233,6 +1238,7 @@ impl PlexiApp {
                     context_id: 1,
                     parent_id: None,
                     depth: 0,
+                    parked: false,
                 }],
                 0,
             ),
@@ -1269,6 +1275,7 @@ impl PlexiApp {
             description_buffer: String::new(),
             description_focus_requested: false,
             drag_context: None,
+            parked_section_expanded: false,
             show_command_palette: false,
             palette_query: String::new(),
             palette_selected: 0,
@@ -2738,6 +2745,9 @@ impl eframe::App for PlexiApp {
                             log::warn!("SetContextRootFromCwd: no CWD available for focused pane");
                         }
                     }
+                }
+                Action::ParkContext => {
+                    self.toggle_park_active_context();
                 }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -191,8 +191,13 @@ impl PlexiApp {
     /// Count of window- or context-scoped notifications whose source_context_id == the id of ctx_idx.
     /// Used for per-context sidebar badges on inactive contexts. Global notifications
     /// are excluded — they already appear everywhere via notification_is_visible.
+    /// Returns 0 for parked contexts — they produce no visual noise.
     pub(crate) fn context_notification_count(&self, ctx_idx: usize) -> usize {
-        let ctx_id = self.router.get(ctx_idx).context_id;
+        let ctx = self.router.get(ctx_idx);
+        if ctx.parked {
+            return 0;
+        }
+        let ctx_id = ctx.context_id;
         self.pending_notifications
             .iter()
             .filter(|n| {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -47,6 +47,7 @@ fn pane_navigate_cross_window_updates_active_window() {
         context_id: 2,
         parent_id: None,
         depth: 0,
+        parked: false,
     });
 
     assert_eq!(h.app.active_window, 0);
@@ -70,6 +71,7 @@ fn pane_navigate_cross_window_syncs_router() {
         context_id: 2,
         parent_id: None,
         depth: 0,
+        parked: false,
     });
 
     assert_eq!(h.app.router.active_idx(), 0);
@@ -93,6 +95,7 @@ fn dispatch_notify_action_pane_focus_navigates() {
         context_id: 2,
         parent_id: None,
         depth: 0,
+        parked: false,
     });
 
     assert_eq!(h.app.active_window, 0);
@@ -152,6 +155,7 @@ fn send_to_pane_searches_all_windows() {
         context_id: 2,
         parent_id: None,
         depth: 0,
+        parked: false,
     });
 
     // active_window remains 0 — pane is in window 1.
@@ -917,6 +921,7 @@ fn delete_context_portal_resets_stale_focused_pane() {
         context_id: child_id,
         parent_id: Some(root_id),
         depth: 1,
+        parked: false,
     });
     app.context_active_window.insert(child_id, child_win_id);
     {
@@ -1002,6 +1007,7 @@ fn delete_context_cascades_and_cleans_depth_stack() {
         context_id: a_id,
         parent_id: Some(root_id),
         depth: 1,
+        parked: false,
     });
     app.router.push(crate::context::Context {
         name: "B".to_string(),
@@ -1011,6 +1017,7 @@ fn delete_context_cascades_and_cleans_depth_stack() {
         context_id: b_id,
         parent_id: Some(a_id),
         depth: 2,
+        parked: false,
     });
 
     // Push minimal windows for A and B without PTY dependency.
@@ -1307,6 +1314,7 @@ fn context_transition_rescans_registry() {
         context_id: ctx_b_id,
         parent_id: None,
         depth: 0,
+        parked: false,
     });
     app.windows.push(Window {
         name: "Context B".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ pub struct KeybindingsConfig {
     pub new_child_context: Option<String>,
     pub set_context_root_from_cwd: Option<String>,
     pub hide_pane: Option<String>,
+    pub park_context: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -274,6 +275,7 @@ impl KeybindingsConfig {
         overlay_field!(new_child_context);
         overlay_field!(set_context_root_from_cwd);
         overlay_field!(hide_pane);
+        overlay_field!(park_context);
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -49,6 +49,10 @@ pub struct Context {
     /// from `parent_id` chain at runtime.
     #[serde(default)]
     pub depth: u32,
+    /// When true, this context is parked: hidden from the active sidebar list,
+    /// collapsed into a "Parked (N)" divider at the bottom. All panes stay alive.
+    #[serde(default)]
+    pub parked: bool,
 }
 
 /// A window is a single spatial grid page — a pane layout with focus and zoom state.

--- a/src/context_state.rs
+++ b/src/context_state.rs
@@ -169,6 +169,7 @@ mod tests {
             context_id: id,
             parent_id: parent,
             depth: if parent.is_some() { 1 } else { 0 },
+            parked: false,
         }
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -29,6 +29,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+U                       — toggle pane hidden state
 // Cmd+E                       — file browser
 // Cmd+Shift+I                 — set context root from focused pane CWD
+// Cmd+Shift+U                 — park/unpark context
 // Cmd+Option+N                — extract focused pane into a new sub-context (portal)
 // Cmd+Shift+Option+N          — new child context under current context (empty, auto-zoom)
 // Cmd+0                       — quick note
@@ -131,6 +132,8 @@ pub enum Action {
     SetContextRootFromCwd,
     /// Toggle hidden state on the focused pane. Bound to Cmd+U.
     HidePane,
+    /// Park/unpark the focused context. Bound to Cmd+Shift+U.
+    ParkContext,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -184,6 +187,7 @@ pub struct KeyBindings {
     pub new_child_context: (egui::Modifiers, egui::Key),
     pub set_context_root_from_cwd: (egui::Modifiers, egui::Key),
     pub hide_pane: (egui::Modifiers, egui::Key),
+    pub park_context: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -249,6 +253,7 @@ impl Default for KeyBindings {
             new_child_context:         (cmd_shift_alt(), egui::Key::N),
             set_context_root_from_cwd: (cmd_shift(),     egui::Key::I),
             hide_pane:                 (cmd(),           egui::Key::U),
+            park_context:              (cmd_shift(),     egui::Key::U),
         }
     }
 }
@@ -401,6 +406,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(new_child_context, "new_child_context");
     apply_override!(set_context_root_from_cwd, "set_context_root_from_cwd");
     apply_override!(hide_pane, "hide_pane");
+    apply_override!(park_context, "park_context");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -450,6 +456,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("new_child_context",         bindings.new_child_context),
         ("set_context_root_from_cwd", bindings.set_context_root_from_cwd),
         ("hide_pane",                 bindings.hide_pane),
+        ("park_context",             bindings.park_context),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -560,6 +567,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         BindingEntry { modifiers: b.force_reload_app.0,         key: b.force_reload_app.1,         exact: false, context: BindingContext::Normal, action: Action::ForceReloadApp },
         BindingEntry { modifiers: b.set_context_root_from_cwd.0, key: b.set_context_root_from_cwd.1, exact: false, context: BindingContext::Normal, action: Action::SetContextRootFromCwd },
         BindingEntry { modifiers: b.hide_pane.0,                key: b.hide_pane.1,                exact: false, context: BindingContext::Normal, action: Action::HidePane },
+        BindingEntry { modifiers: b.park_context.0,              key: b.park_context.1,              exact: false, context: BindingContext::Normal, action: Action::ParkContext },
         BindingEntry { modifiers: b.open_scratchpad.0,          key: b.open_scratchpad.1,          exact: false, context: BindingContext::Normal, action: Action::OpenScratchpad },
         // context_zoom_out is Cmd+Escape — not exact because plain Escape is AppActive only,
         // so there is no subset conflict on this key.

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -50,6 +50,7 @@ impl PlexiApp {
                                     let rows: &[(&[&str], &str)] = &[
                                         (&["\u{2318}", "N"], "New window right"),
                                         (&["\u{2318}", "\u{21E7}", "N"], "New context"),
+                                        (&["\u{2318}", "\u{21E7}", "U"], "Park context"),
                                         (&["\u{2318}", "D"], "Split right"),
                                         (&["\u{2318}", "\u{21E7}", "D"], "Split down"),
                                         (&["\u{2318}", "\\"], "Split right (mirror)"),

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -97,6 +97,7 @@ impl PlexiApp {
             context_id: ctx_id,
             parent_id: Some(parent_id),
             depth: child_depth,
+            parked: false,
         });
         self.windows.push(crate::context::Window {
             name: String::new(),
@@ -237,6 +238,7 @@ impl PlexiApp {
             context_id: ctx_id,
             parent_id: Some(parent_ctx_id),
             depth: child_depth,
+            parked: false,
         });
         self.windows.push(Window {
             name: String::new(),
@@ -290,6 +292,7 @@ impl PlexiApp {
             context_id: ctx_id,
             parent_id: None,
             depth: 0,
+            parked: false,
         });
         self.windows.push(Window {
             name: String::new(),
@@ -373,6 +376,7 @@ impl PlexiApp {
             context_id: ctx_id,
             parent_id: None,
             depth: 0,
+            parked: false,
         });
         self.windows.push(Window {
             name: String::new(),
@@ -726,6 +730,49 @@ impl PlexiApp {
             self.context_active_window.insert(ctx_id, wid);
             self.record_context_visit(wid);
         }
+    }
+
+    /// Toggle parked state on the active context. When parking, focus moves
+    /// to the nearest unparked neighbor. When unparking (called from sidebar
+    /// click), the context is restored and focused.
+    pub(crate) fn toggle_park_active_context(&mut self) {
+        let idx = self.router.active_idx();
+        let is_parked = self.router.get(idx).parked;
+
+        if is_parked {
+            // Unpark
+            self.router.get_mut(idx).parked = false;
+            log::info!("context: unparked '{}' (idx={idx})", self.router.get(idx).name);
+            self.save_workspace();
+            return;
+        }
+
+        // Park the active context
+        let name = self.router.get(idx).name.clone();
+        self.router.get_mut(idx).parked = true;
+        log::info!("context: parked '{name}' (idx={idx})");
+
+        // Find the nearest unparked context to switch focus to.
+        // Search forward first, then backward.
+        let len = self.router.len();
+        let next_unparked = (1..len)
+            .map(|offset| (idx + offset) % len)
+            .find(|&i| !self.router.get(i).parked);
+
+        if let Some(new_idx) = next_unparked {
+            self.switch_workspace(new_idx);
+        }
+        // If all contexts are parked, stay on the current one (degenerate case).
+
+        self.save_workspace();
+    }
+
+    /// Unpark a specific context by index and switch focus to it.
+    pub(crate) fn unpark_context(&mut self, idx: usize) {
+        self.router.get_mut(idx).parked = false;
+        log::info!("context: unparked '{}' (idx={idx})", self.router.get(idx).name);
+        self.switch_workspace(idx);
+        self.save_workspace();
     }
 
     /// Set the `root` of the active context.

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -44,12 +44,14 @@ impl PlexiApp {
         let mut menu_action: Option<(usize, WindowMenuAction)> = None;
         let mut row_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
         let mut drag_released = false;
+        let mut unpark_context: Option<usize> = None;
 
         let focused_cwd = self.windows.get(self.active_window)
             .and_then(|w| w.focused_pane.map(|tile| (w, tile)))
             .and_then(|(w, tile)| w.get_focused_pane_cwd(tile));
 
         // Build display order: top-level contexts first, each followed by children.
+        // Separate into active (unparked) and parked lists.
         let mut display_order: Vec<usize> = Vec::with_capacity(num_contexts);
         for i in 0..num_contexts {
             if self.router.get(i).parent_id.is_none() {
@@ -69,7 +71,18 @@ impl PlexiApp {
             }
         }
 
-        for &i in &display_order {
+        // Partition: active contexts render in the main list, parked ones below.
+        let active_order: Vec<usize> = display_order.iter()
+            .copied()
+            .filter(|&i| !self.router.get(i).parked)
+            .collect();
+        let parked_order: Vec<usize> = display_order.iter()
+            .copied()
+            .filter(|&i| self.router.get(i).parked)
+            .collect();
+
+        // ── Active contexts ─────────────────────────────────────────────
+        for &i in &active_order {
             let is_active = i == self.router.active_idx();
             let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
@@ -274,6 +287,69 @@ impl PlexiApp {
             }
         }
 
+        // ── Parked section ──────────────────────────────────────────────
+        let parked_count = parked_order.len();
+        if parked_count > 0 {
+            ui.add_space(8.0);
+
+            // Divider row: "Parked (N)" -- clickable to expand/collapse
+            let divider_id = egui::Id::new("parked_divider");
+            let expanded = self.parked_section_expanded;
+            let chevron = if expanded { "\u{25BE}" } else { "\u{25B8}" }; // ▾ or ▸
+            let divider_text = format!("{chevron} Parked ({parked_count})");
+
+            let divider_response = ui.horizontal(|ui| {
+                ui.add_space(16.0);
+                ui.add(
+                    egui::Label::new(
+                        RichText::new(divider_text)
+                            .size(10.0)
+                            .color(self.colors.text_dim),
+                    )
+                    .selectable(false)
+                    .sense(egui::Sense::click()),
+                )
+            }).inner;
+
+            let response = ui.interact(divider_response.rect, divider_id, egui::Sense::click());
+            if response.clicked() || divider_response.clicked() {
+                self.parked_section_expanded = !self.parked_section_expanded;
+            }
+            if response.hovered() || divider_response.hovered() {
+                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+            }
+
+            // Expanded: show parked context names
+            if self.parked_section_expanded {
+                for &i in &parked_order {
+                    let ctx_name = self.router.get(i).name.clone();
+                    let text_color = self.colors.text_dim;
+
+                    let row_response = ui.horizontal(|ui| {
+                        ui.add_space(24.0);
+                        ui.add(
+                            egui::Label::new(
+                                RichText::new(&ctx_name)
+                                    .size(11.0)
+                                    .color(text_color),
+                            )
+                            .selectable(false)
+                            .sense(egui::Sense::click()),
+                        )
+                    }).inner;
+
+                    let row_id = egui::Id::new(("parked_ctx", i));
+                    let interact = ui.interact(row_response.rect, row_id, egui::Sense::click());
+                    if interact.clicked() || row_response.clicked() {
+                        unpark_context = Some(i);
+                    }
+                    if interact.hovered() || row_response.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+                }
+            }
+        }
+
         // Drop slot + drag reorder
         let drop_index: Option<usize> = if self.drag_context.is_some() {
             ui.input(|i| i.pointer.hover_pos())
@@ -296,13 +372,13 @@ impl PlexiApp {
         if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
             if dst != src && dst != src + 1 {
                 let line_y = if dst == 0 {
-                    row_rects[0].min.y
+                    row_rects.first().map_or(0.0, |r| r.min.y)
                 } else if dst >= row_rects.len() {
-                    row_rects[row_rects.len() - 1].max.y
+                    row_rects.last().map_or(0.0, |r| r.max.y)
                 } else {
                     row_rects[dst - 1].max.y
                 };
-                let x0 = row_rects[0].min.x;
+                let x0 = row_rects.first().map_or(0.0, |r| r.min.x);
                 ui.painter().line_segment(
                     [egui::pos2(x0, line_y), egui::pos2(x0 + sidebar_width, line_y)],
                     Stroke::new(2.0, self.colors.accent),
@@ -310,7 +386,9 @@ impl PlexiApp {
             }
         }
 
-        if let Some((i, action)) = menu_action {
+        if let Some(i) = unpark_context {
+            self.unpark_context(i);
+        } else if let Some((i, action)) = menu_action {
             match action {
                 WindowMenuAction::Rename => {
                     self.renaming_window = Some(i);

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -222,6 +222,7 @@ mod tests {
             context_id: 42,
             parent_id: Some(1),
             depth: 1,
+            parked: false,
         };
         let json = serde_json::to_string(&ctx).expect("serialize");
         let restored: Context = serde_json::from_str(&json).expect("deserialize");

--- a/src/workspace_router.rs
+++ b/src/workspace_router.rs
@@ -168,6 +168,7 @@ mod tests {
             context_id: id,
             parent_id,
             depth,
+            parked: false,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `parked: bool` field to `Context` struct (serde-default, persisted)
- Bind Cmd+Shift+U to `ParkContext` action: parks the active context, moves focus to nearest unparked neighbor
- Sidebar partitions contexts into active (rendered normally) and parked (collapsed "Parked (N)" divider at bottom)
- Clicking a parked context in the expanded section restores it and focuses it
- Notification badges suppressed for parked contexts (return 0)
- Shortcut added to shortcuts overlay

## Files changed

- `src/context.rs` -- `parked: bool` field
- `src/keys.rs` -- `ParkContext` action + Cmd+Shift+U binding
- `src/config.rs` -- `park_context` override in `KeybindingsConfig`
- `src/app/mod.rs` -- `parked_section_expanded` UI state + action handler
- `src/pane_ops/workspace.rs` -- `toggle_park_active_context()` + `unpark_context()`
- `src/sidebar.rs` -- partition active/parked, render parked divider section
- `src/app/notifications.rs` -- suppress badges for parked contexts
- `src/overlays/misc.rs` -- shortcut hint

Closes #1949