### PR TITLE
feat(host): move pane between contexts (#1634)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -110,6 +110,7 @@ impl PlexiApp {
                 | Some(FocusLayer::TextInput)
                 | Some(FocusLayer::ContextCloseConfirm)
                 | Some(FocusLayer::CapabilityModal)
+                | Some(FocusLayer::MovePanePicker)
         )
     }
 
@@ -700,6 +701,21 @@ impl PlexiApp {
         } else if !should_own && has_layer {
             log::info!("capability_modal: focus released — prompt queue drained");
             self.focus_stack.retain(|l| *l != FocusLayer::CapabilityModal);
+        }
+    }
+
+    /// Reconcile the move-pane picker focus layer with `move_pane_picker`.
+    pub(crate) fn sync_move_pane_picker_focus(&mut self) {
+        let should_own = self.move_pane_picker.is_some();
+        let has_layer = self
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::MovePanePicker);
+        if should_own && !has_layer {
+            self.push_focus_layer(FocusLayer::MovePanePicker);
+        } else if !should_own && has_layer {
+            log::info!("focus: MovePanePicker layer removed by sync (retain)");
+            self.focus_stack.retain(|l| *l != FocusLayer::MovePanePicker);
         }
     }
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -657,6 +657,55 @@ impl PlexiApp {
                     log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);
                     self.push_pane_to_subcontext(name.clone());
                 }
+                crate::app_protocol::AppRequest::MovePaneToContext { pane_id, target_context_id, target_context_name, response_file } => {
+                    log::info!("pane_ipc: kind=move_pane_to_context pane_id={pane_id} target_id={target_context_id:?} target_name={target_context_name:?}");
+                    let pane_id = *pane_id;
+                    let response_file = response_file.clone();
+
+                    // Resolve target context_id from name or direct id.
+                    let resolved_id = if let Some(id) = target_context_id {
+                        Some(*id)
+                    } else if let Some(name) = target_context_name {
+                        // Try parsing as u64 first, then match by name.
+                        if let Ok(id) = name.parse::<u64>() {
+                            Some(id)
+                        } else {
+                            self.router.iter()
+                                .find(|c| c.name.eq_ignore_ascii_case(name))
+                                .map(|c| c.context_id)
+                        }
+                    } else {
+                        None
+                    };
+
+                    let result = match resolved_id {
+                        None => {
+                            log::warn!("pane_ipc: move_pane_to_context: no target context resolved");
+                            "error: target context not found"
+                        }
+                        Some(target_id) => {
+                            // Find the window containing this pane and focus it first.
+                            let found = self.windows.iter().enumerate().find_map(|(win_idx, win)| {
+                                win.tree.tiles.find_pane(&pane_id).map(|tile_id| (win_idx, tile_id))
+                            });
+                            if let Some((win_idx, tile_id)) = found {
+                                self.active_window = win_idx;
+                                self.windows[win_idx].focused_pane = Some(tile_id);
+                                self.move_focused_pane_to_context(target_id);
+                                "ok"
+                            } else {
+                                log::warn!("pane_ipc: move_pane_to_context: pane_id={pane_id} not found");
+                                "error: pane not found"
+                            }
+                        }
+                    };
+
+                    if let Some(path) = response_file {
+                        if let Err(e) = std::fs::write(&path, format!("{result}\n")) {
+                            log::warn!("move_pane_to_context: failed to write response to {path}: {e}");
+                        }
+                    }
+                }
                 _ => {
                     log::warn!("pane_ipc: unsupported command kind, dropping");
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -95,6 +95,8 @@ pub(crate) enum FocusLayer {
     /// so the modal renders in step 2 of `update()` with exclusive keyboard
     /// ownership — before `dispatch_app_key_events` can steal Escape.
     CapabilityModal,
+    /// Move-pane-to-context picker overlay.
+    MovePanePicker,
 }
 
 /// What a `TextInputOverlay` commit should do.
@@ -257,6 +259,13 @@ pub(crate) struct ClickFlash {
     pub(crate) window_id: u64,
     pub(crate) tile: egui_tiles::TileId,
     pub(crate) started_at: std::time::Instant,
+}
+
+pub(crate) struct MovePanePickerState {
+    /// (context_id, context_name) of each eligible target context.
+    pub(crate) targets: Vec<(u64, String)>,
+    /// Cursor index into `targets`.
+    pub(crate) selected: usize,
 }
 
 pub struct PlexiApp {
@@ -447,6 +456,10 @@ pub struct PlexiApp {
     /// Receiver for AppRequests sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::AppRequest>,
+    /// Move-pane-to-context picker. When Some, the picker overlay is visible.
+    /// Contains (context_id, context_name) pairs for available targets and a
+    /// selected-index cursor.
+    pub(crate) move_pane_picker: Option<MovePanePickerState>,
     /// Last (window_id, tile_id) pair that was logged as a FocusChanged event.
     /// Uses stable window_id (u64) not a vector index so removals don't corrupt it.
     /// Compared at end of each frame to detect genuine focus transitions.
@@ -982,6 +995,7 @@ impl PlexiApp {
                     click_flash: None,
                     update_rx: Some(update_rx),
                     update_available: None,
+                    move_pane_picker: None,
                     pane_ipc_rx,
                     last_logged_focus: None,
                     focus_started_at: None,
@@ -1154,6 +1168,7 @@ impl PlexiApp {
             click_flash: None,
             update_rx: Some(update_rx),
             update_available: None,
+            move_pane_picker: None,
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
@@ -1322,6 +1337,7 @@ impl PlexiApp {
             show_completions_banner: false,
             update_rx: None,
             update_available: None,
+            move_pane_picker: None,
             pane_ipc_rx,
             last_logged_focus: None,
             focus_started_at: None,
@@ -1497,6 +1513,7 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::TextInput) => self.text_input_handle_key(ctx),
                 Some(FocusLayer::ContextCloseConfirm) => self.context_close_confirm_handle_key(ctx),
                 Some(FocusLayer::CapabilityModal) => self.capability_modal_handle_key(ctx),
+                Some(FocusLayer::MovePanePicker) => self.move_pane_picker_handle_key(ctx),
                 None => crate::app_trait::KeyDisposition::Passthrough,
             };
             // Step 2: render the overlay (visual only — key reads already done above).
@@ -1542,6 +1559,9 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::CapabilityModal) => {
                     self.draw_capability_modal(ctx);
                 }
+                Some(FocusLayer::MovePanePicker) => {
+                    self.draw_move_pane_picker(ctx);
+                }
                 None => {}
             }
             // The overlay may have self-closed (notification queue drained,
@@ -1557,6 +1577,7 @@ impl eframe::App for PlexiApp {
             self.sync_cli_setup_prompt_focus();
             self.sync_text_input_focus();
             self.sync_capability_modal_focus();
+            self.sync_move_pane_picker_focus();
             disposition
             } // end else (non-preempted path)
         } else {
@@ -2711,6 +2732,9 @@ impl eframe::App for PlexiApp {
                             log::warn!("SetContextRootFromCwd: no CWD available for focused pane");
                         }
                     }
+                }
+                Action::MovePaneToContext => {
+                    self.open_move_pane_picker();
                 }
                 Action::ToggleMinimap => {
                     self.minimap.toggle();

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -1916,6 +1916,21 @@ pub enum AppRequest {
         filter: Vec<String>,
         multiple: bool,
     },
+
+    // ── Pane move (#1634) ────────────────────────────────────────────────────
+    /// Move a pane to a different existing context.
+    /// CLI: `plexi pane move <pane_id> --context <name|id>`.
+    /// Exactly one of `target_context_id` or `target_context_name` must be set.
+    /// `response_file` receives "ok\n" on success or "error: ...\n" on failure.
+    MovePaneToContext {
+        pane_id: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_context_id: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_context_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
+    },
 }
 
 /// Inline-handled commands (processed directly in `ui()` or `background_tick()`).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -624,6 +624,16 @@ pub enum PaneCmd {
         /// Pane id to query (from `plexi pane list`)
         pane_id: u64,
     },
+    /// Move a pane to a different context.
+    ///
+    /// Example: plexi pane move 42 --context "My Project"
+    Move {
+        /// Pane id to move (from `plexi pane list`)
+        pane_id: u64,
+        /// Target context name or numeric context id
+        #[arg(long)]
+        context: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -183,7 +183,7 @@ pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,
-    pane_state_cli,
+    pane_state_cli, pane_move_cli,
 };
 pub use routine::{routine_list, routine_run};
 pub use run::{run_list_commands, run_command};

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -549,6 +549,70 @@ pub fn pane_state_cli(pane_id: u64) -> i32 {
     }
 }
 
+/// `plexi pane move <pane_id> --context <name|id>`
+///
+/// Sends a `move_pane_to_context` command to PLEXI_SOCKET. Polls a response
+/// file for success/error. Returns 0 on success, 1 on error.
+pub fn pane_move_cli(pane_id: u64, context: &str) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("pane-move-response-{id}.txt"))
+        .to_string_lossy()
+        .into_owned();
+
+    log::info!("pane_move:cli: pane_id={pane_id} context={context:?} response_file={response_file:?}");
+
+    // If context parses as a u64, send as target_context_id; otherwise as name.
+    let payload = if let Ok(ctx_id) = context.parse::<u64>() {
+        serde_json::json!({
+            "type": "move_pane_to_context",
+            "pane_id": pane_id,
+            "target_context_id": ctx_id,
+            "response_file": response_file,
+        })
+    } else {
+        serde_json::json!({
+            "type": "move_pane_to_context",
+            "pane_id": pane_id,
+            "target_context_name": context,
+            "response_file": response_file,
+        })
+    };
+
+    let code = send_to_socket(payload);
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    let trimmed = content.trim();
+                    if trimmed == "ok" {
+                        return 0;
+                    }
+                    eprintln!("{trimmed}");
+                    return 1;
+                }
+                Err(e) => {
+                    log::warn!("pane_move:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane move response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 /// `plexi open <type_id> [args...] [--layout=X]`
 ///
 /// When called from inside a Plexi pane (PLEXI_SOCKET is set), sends a

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,7 @@ pub struct KeybindingsConfig {
     pub push_to_subcontext: Option<String>,
     pub new_child_context: Option<String>,
     pub set_context_root_from_cwd: Option<String>,
+    pub move_pane_to_context: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -272,6 +273,7 @@ impl KeybindingsConfig {
         overlay_field!(push_to_subcontext);
         overlay_field!(new_child_context);
         overlay_field!(set_context_root_from_cwd);
+        overlay_field!(move_pane_to_context);
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -30,6 +30,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+Shift+I                 — set context root from focused pane CWD
 // Cmd+Option+N                — extract focused pane into a new sub-context (portal)
 // Cmd+Shift+Option+N          — new child context under current context (empty, auto-zoom)
+// Cmd+Shift+Option+M          — move focused pane to a different existing context
 // Cmd+0                       — quick note
 // Cmd+1–9                     — switch context (sidebar)
 // Escape (app active)         — close app
@@ -128,6 +129,9 @@ pub enum Action {
     ContextZoomOut,
     /// Set the active context root to the focused pane's CWD. Bound to Cmd+Shift+I.
     SetContextRootFromCwd,
+    /// Open the context picker to move the focused pane into a different context.
+    /// Bound to Cmd+Shift+Option+M.
+    MovePaneToContext,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -180,6 +184,7 @@ pub struct KeyBindings {
     pub push_to_subcontext: (egui::Modifiers, egui::Key),
     pub new_child_context: (egui::Modifiers, egui::Key),
     pub set_context_root_from_cwd: (egui::Modifiers, egui::Key),
+    pub move_pane_to_context: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -244,6 +249,7 @@ impl Default for KeyBindings {
             push_to_subcontext:        (cmd_alt(),       egui::Key::N),
             new_child_context:         (cmd_shift_alt(), egui::Key::N),
             set_context_root_from_cwd: (cmd_shift(),     egui::Key::I),
+            move_pane_to_context:      (cmd_shift_alt(), egui::Key::M),
         }
     }
 }
@@ -395,6 +401,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(push_to_subcontext, "push_to_subcontext");
     apply_override!(new_child_context, "new_child_context");
     apply_override!(set_context_root_from_cwd, "set_context_root_from_cwd");
+    apply_override!(move_pane_to_context, "move_pane_to_context");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -443,6 +450,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("push_to_subcontext",        bindings.push_to_subcontext),
         ("new_child_context",         bindings.new_child_context),
         ("set_context_root_from_cwd", bindings.set_context_root_from_cwd),
+        ("move_pane_to_context",      bindings.move_pane_to_context),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -552,6 +560,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         BindingEntry { modifiers: b.open_secrets_manager.0,     key: b.open_secrets_manager.1,     exact: false, context: BindingContext::Normal, action: Action::OpenSecretsManager },
         BindingEntry { modifiers: b.force_reload_app.0,         key: b.force_reload_app.1,         exact: false, context: BindingContext::Normal, action: Action::ForceReloadApp },
         BindingEntry { modifiers: b.set_context_root_from_cwd.0, key: b.set_context_root_from_cwd.1, exact: false, context: BindingContext::Normal, action: Action::SetContextRootFromCwd },
+        BindingEntry { modifiers: b.move_pane_to_context.0,     key: b.move_pane_to_context.1,     exact: false, context: BindingContext::Normal, action: Action::MovePaneToContext },
         BindingEntry { modifiers: b.open_scratchpad.0,          key: b.open_scratchpad.1,          exact: false, context: BindingContext::Normal, action: Action::OpenScratchpad },
         // context_zoom_out is Cmd+Escape — not exact because plain Escape is AppActive only,
         // so there is no subset conflict on this key.

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,6 +533,7 @@ fn main() -> eframe::Result {
                         PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
                         PaneCmd::Capture { pane_id, lines, full_output, from_cursor } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output, from_cursor)),
                         PaneCmd::State { pane_id } => std::process::exit(cli::pane_state_cli(pane_id)),
+                        PaneCmd::Move { pane_id, context } => std::process::exit(cli::pane_move_cli(pane_id, &context)),
                         PaneCmd::New { cmd, name, down, left, up, right, tab, window, overlay, from, ephemeral, no_focus, cwd } => {
                             let layout = if down { "split_v" }
                                 else if left { "split_left" }

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -850,4 +850,178 @@ impl PlexiApp {
     ) -> crate::app_trait::KeyDisposition {
         crate::app_trait::KeyDisposition::Consumed
     }
+
+    pub(crate) fn move_pane_picker_handle_key(
+        &mut self,
+        ctx: &egui::Context,
+    ) -> crate::app_trait::KeyDisposition {
+        let target_count = self
+            .move_pane_picker
+            .as_ref()
+            .map(|p| p.targets.len())
+            .unwrap_or(0);
+        if target_count == 0 {
+            self.move_pane_picker = None;
+            return crate::app_trait::KeyDisposition::Consumed;
+        }
+
+        ctx.input_mut(|input| {
+            // Escape = cancel.
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+                log::info!("move_pane_picker: cancelled by Escape");
+                self.move_pane_picker = None;
+                return;
+            }
+
+            // J / ArrowDown = next item.
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::J)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+            {
+                if let Some(ref mut picker) = self.move_pane_picker {
+                    picker.selected = (picker.selected + 1) % picker.targets.len();
+                }
+            }
+
+            // K / ArrowUp = previous item.
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::K)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+            {
+                if let Some(ref mut picker) = self.move_pane_picker {
+                    picker.selected =
+                        (picker.selected + picker.targets.len() - 1) % picker.targets.len();
+                }
+            }
+
+            // Enter = confirm selection.
+            if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
+                let target_id = self
+                    .move_pane_picker
+                    .as_ref()
+                    .and_then(|p| p.targets.get(p.selected).map(|(id, _)| *id));
+                self.move_pane_picker = None;
+                if let Some(id) = target_id {
+                    log::info!("move_pane_picker: confirmed target context_id={id}");
+                    self.move_focused_pane_to_context(id);
+                }
+                return;
+            }
+
+            // Digit keys = instant select (1-9 maps to index 0-8).
+            let digit_keys = [
+                (egui::Key::Num1, 0usize),
+                (egui::Key::Num2, 1),
+                (egui::Key::Num3, 2),
+                (egui::Key::Num4, 3),
+                (egui::Key::Num5, 4),
+                (egui::Key::Num6, 5),
+                (egui::Key::Num7, 6),
+                (egui::Key::Num8, 7),
+                (egui::Key::Num9, 8),
+            ];
+            for (key, idx) in digit_keys {
+                if input.consume_key(egui::Modifiers::NONE, key) {
+                    let target_id = self
+                        .move_pane_picker
+                        .as_ref()
+                        .and_then(|p| p.targets.get(idx).map(|(id, _)| *id));
+                    self.move_pane_picker = None;
+                    if let Some(id) = target_id {
+                        log::info!("move_pane_picker: instant-select via digit, target context_id={id}");
+                        self.move_focused_pane_to_context(id);
+                    }
+                    return;
+                }
+            }
+        });
+
+        crate::app_trait::KeyDisposition::Consumed
+    }
+
+    pub(crate) fn draw_move_pane_picker(&mut self, ctx: &egui::Context) {
+        let Some(ref picker) = self.move_pane_picker else {
+            return;
+        };
+        let targets = picker.targets.clone();
+        let selected = picker.selected;
+        let colors = self.colors.clone();
+
+        let mut cancelled = false;
+        super::modal_shell(ctx, "move_pane_picker", &colors, &mut cancelled, |ui| {
+            ui.label(
+                egui::RichText::new("Move pane to context")
+                    .size(crate::style::TEXT_BODY)
+                    .color(colors.text_primary),
+            );
+            ui.add_space(crate::style::SPACE_SM);
+
+            for (i, (_ctx_id, name)) in targets.iter().enumerate() {
+                let is_selected = i == selected;
+                let bg = if is_selected {
+                    colors.bg_active
+                } else {
+                    egui::Color32::TRANSPARENT
+                };
+                let text_color = if is_selected {
+                    colors.text_primary
+                } else {
+                    colors.text_dim
+                };
+
+                let frame = egui::Frame::new()
+                    .fill(bg)
+                    .corner_radius(crate::style::RADIUS_MD)
+                    .inner_margin(egui::Margin::symmetric(8, 4));
+                frame.show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        // Digit shortcut badge.
+                        if i < 9 {
+                            crate::widgets::key_chip(
+                                ui,
+                                &format!("{}", i + 1),
+                                &colors,
+                            );
+                            ui.add_space(crate::style::SPACE_SM);
+                        }
+                        ui.label(
+                            egui::RichText::new(name)
+                                .size(crate::style::TEXT_BODY)
+                                .color(text_color),
+                        );
+                    });
+                });
+            }
+
+            ui.add_space(crate::style::SPACE_SM);
+            ui.horizontal(|ui| {
+                crate::widgets::key_combo(ui, &["J", "K"], &colors);
+                ui.add_space(4.0);
+                ui.label(
+                    egui::RichText::new("navigate")
+                        .size(crate::style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+                ui.add_space(crate::style::SPACE_SM);
+                crate::widgets::key_chip(ui, "Enter", &colors);
+                ui.add_space(4.0);
+                ui.label(
+                    egui::RichText::new("confirm")
+                        .size(crate::style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+                ui.add_space(crate::style::SPACE_SM);
+                crate::widgets::key_chip(ui, "Esc", &colors);
+                ui.add_space(4.0);
+                ui.label(
+                    egui::RichText::new("cancel")
+                        .size(crate::style::TEXT_HINT)
+                        .color(colors.text_dim),
+                );
+            });
+        });
+
+        if cancelled {
+            log::info!("move_pane_picker: cancelled by scrim click");
+            self.move_pane_picker = None;
+        }
+    }
 }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -897,6 +897,178 @@ impl PlexiApp {
         self.windows[self.active_window].focused_pane = new_focus;
     }
 
+    /// Open the move-pane-to-context picker overlay. Populates the target list
+    /// with all contexts except the one that owns the currently focused pane.
+    pub(crate) fn open_move_pane_picker(&mut self) {
+        let win = &self.windows[self.active_window];
+        let Some(focused_tile) = win.focused_pane else {
+            log::warn!("open_move_pane_picker: no focused pane");
+            return;
+        };
+        if !matches!(win.tree.tiles.get(focused_tile), Some(egui_tiles::Tile::Pane(_))) {
+            log::warn!("open_move_pane_picker: focused tile is not a pane");
+            return;
+        }
+        let current_ctx_id = win.context_id;
+        let targets: Vec<(u64, String)> = self.router.iter()
+            .filter(|c| c.context_id != current_ctx_id)
+            .map(|c| (c.context_id, c.name.clone()))
+            .collect();
+        if targets.is_empty() {
+            log::info!("open_move_pane_picker: only one context exists, nothing to move to");
+            return;
+        }
+        log::info!(
+            "open_move_pane_picker: {} target context(s) available",
+            targets.len()
+        );
+        self.move_pane_picker = Some(crate::app::MovePanePickerState {
+            targets,
+            selected: 0,
+        });
+    }
+
+    /// Move the focused pane from its current context/window into the target
+    /// context identified by `target_context_id`. If the target has no windows,
+    /// one is created. The pane is inserted at the root of the target's active
+    /// window. Focus switches to the target context.
+    pub(crate) fn move_focused_pane_to_context(&mut self, target_context_id: u64) {
+        use egui_tiles::{Container, SimplificationOptions, Tile};
+
+        let src_idx = self.active_window;
+        let Some(focused_tile) = self.windows[src_idx].focused_pane else {
+            log::warn!("move_focused_pane_to_context: no focused pane");
+            return;
+        };
+        let src_pane_id = match self.windows[src_idx].tree.tiles.get(focused_tile) {
+            Some(Tile::Pane(id)) => *id,
+            _ => {
+                log::warn!("move_focused_pane_to_context: focused tile is not a pane");
+                return;
+            }
+        };
+
+        // Don't allow moving portal panes.
+        if self.windows[src_idx].panes.get(&src_pane_id)
+            .map(|p| p.as_portal().is_some())
+            .unwrap_or(false)
+        {
+            log::warn!("move_focused_pane_to_context: cannot move a portal pane");
+            return;
+        }
+
+        // Validate target context exists.
+        let target_ctx_idx = match self.router.position(|c| c.context_id == target_context_id) {
+            Some(idx) => idx,
+            None => {
+                log::warn!("move_focused_pane_to_context: target context {target_context_id} not found");
+                return;
+            }
+        };
+
+        // Determine next focus in the source window before extraction.
+        let next_src_focus = self.windows[src_idx].find_next_focus(focused_tile);
+
+        // Extract pane from source window.
+        let extracted_pane = {
+            let win = &mut self.windows[src_idx];
+            if let Some(parent_id) = win.tree.tiles.parent_of(focused_tile) {
+                if let Some(Tile::Container(parent)) = win.tree.tiles.get_mut(parent_id) {
+                    parent.remove_child(focused_tile);
+                }
+            }
+            win.tree.tiles.remove(focused_tile);
+            let pane = win.panes.remove(&src_pane_id);
+            win.tree.simplify(&SimplificationOptions {
+                all_panes_must_have_tabs: true,
+                ..SimplificationOptions::default()
+            });
+            win.focused_pane = next_src_focus;
+            pane
+        };
+
+        let Some(pane) = extracted_pane else {
+            log::error!("move_focused_pane_to_context: pane {src_pane_id} not found in source window");
+            return;
+        };
+
+        // If source window is now empty, delete it.
+        if self.windows[src_idx].panes.is_empty() {
+            self.delete_window(src_idx);
+        }
+
+        // Find (or create) the target context's active window.
+        let dst_win_idx = {
+            let preferred = self.context_active_window.get(&target_context_id).copied();
+            if let Some(win_id) = preferred {
+                self.windows.iter().position(|w| w.window_id == win_id && w.context_id == target_context_id)
+            } else {
+                self.windows.iter().position(|w| w.context_id == target_context_id)
+            }
+        };
+
+        let dst_win_idx = match dst_win_idx {
+            Some(idx) => idx,
+            None => {
+                // Target context has no windows: create one.
+                let win_id = self.next_window_id;
+                self.next_window_id += 1;
+                let target_path = self.router.get(target_ctx_idx).path.clone();
+                self.windows.push(Window {
+                    name: String::new(),
+                    path: target_path,
+                    tree: egui_tiles::Tree::empty("move_target"),
+                    panes: std::collections::HashMap::new(),
+                    focused_pane: None,
+                    zoomed_pane: None,
+                    grid_x: 0,
+                    grid_y: 0,
+                    window_id: win_id,
+                    context_id: target_context_id,
+                });
+                self.context_active_window.insert(target_context_id, win_id);
+                self.windows.len() - 1
+            }
+        };
+
+        // Insert pane into target window.
+        let win = &mut self.windows[dst_win_idx];
+        let new_tile = win.tree.tiles.insert_pane(src_pane_id);
+        win.panes.insert(src_pane_id, pane);
+
+        if win.tree.root.is_none() {
+            win.tree.root = Some(new_tile);
+        } else if let Some(root) = win.tree.root {
+            // Wrap existing root + new tile in a horizontal split.
+            let inserted_inline = if let Some(Tile::Container(Container::Linear(linear))) =
+                win.tree.tiles.get_mut(root)
+            {
+                if linear.dir == egui_tiles::LinearDir::Horizontal {
+                    linear.children.push(new_tile);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !inserted_inline {
+                let container_tile = win.tree.tiles.insert_horizontal_tile(vec![root, new_tile]);
+                win.tree.root = Some(container_tile);
+            }
+        }
+        win.focused_pane = Some(new_tile);
+
+        log::info!(
+            "move_focused_pane_to_context: pane {} moved to context {} (window idx {})",
+            src_pane_id, target_context_id, dst_win_idx
+        );
+
+        // Switch to the target context.
+        self.switch_workspace(target_ctx_idx);
+        self.save_workspace();
+    }
+
     pub(crate) fn save_workspace(&self) {
         let mut saved_contexts = Vec::new();
         let mut saved_windows = Vec::new();

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1740,6 +1740,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::MovePaneToContext { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received MovePaneToContext over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
 
             // ── App state save ─────────────────────────────────────────────
             AppRequest::SaveAppState { payload } => {


### PR DESCRIPTION
Closes #1634

## Summary
- Adds `Cmd+Shift+Option+M` keyboard shortcut to open a context picker and move the focused pane to a different existing context
- Adds `plexi pane move <pane_id> --context <name|id>` CLI command for programmatic pane moves
- Adds `MovePaneToContext` IPC/AppRequest with both name and numeric ID resolution
- Pane is extracted from source tile tree, inserted into target context's active window (or a new window if none exists)
- Source windows are cleaned up if left empty after extraction
- Focus follows the pane to the target context automatically

## Files changed
- `src/keys.rs` - new `MovePaneToContext` action + `Cmd+Shift+Option+M` binding
- `src/config.rs` - `move_pane_to_context` keybinding override field
- `src/app/mod.rs` - `MovePanePickerState`, `FocusLayer::MovePanePicker`, action dispatch
- `src/app/focus.rs` - focus layer sync for the picker overlay
- `src/overlays/misc.rs` - picker overlay with J/K nav, Enter confirm, digit instant-select
- `src/pane_ops/workspace.rs` - `open_move_pane_picker()` + `move_focused_pane_to_context()` core logic
- `src/app_protocol.rs` - `MovePaneToContext` AppRequest variant
- `src/app/lifecycle.rs` - IPC handler with name/id resolution
- `src/process_app/routing.rs` - PGAP no-op catch for the new variant
- `src/cli/args.rs` - `pane move` subcommand
- `src/cli/pane.rs` - `pane_move_cli()` with response file polling
- `src/cli/mod.rs` - export `pane_move_cli`
- `src/main.rs` - dispatch `PaneCmd::Move`

## Test plan
- [ ] Open two or more contexts in the sidebar
- [ ] Focus a terminal or app pane, press `Cmd+Shift+Option+M`
- [ ] Verify context picker overlay appears listing all other contexts
- [ ] Navigate with J/K, confirm with Enter or digit key
- [ ] Verify pane moves to the target context and focus follows
- [ ] Verify source window is cleaned up if it becomes empty
- [ ] Test `plexi pane move <id> --context "ContextName"` from CLI
- [ ] Test moving a pane to a context that has no windows (should create one)
- [ ] Verify portal panes cannot be moved (logged warning, no action)