### PR TITLE
fix(ui): hidden pane opacity + title improvements

### DIFF
--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -153,7 +153,11 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
 
         let is_focused = self.focused_tile == Some(tile_id) && !self.modal_open;
 
-        if !is_focused {
+        let is_hidden = self.panes.get(pane_id).map_or(false, |p| p.is_hidden());
+
+        if is_hidden {
+            ui.set_opacity(0.4);
+        } else if !is_focused {
             if let Some(opacity) = self.unfocused_opacity {
                 if opacity < 1.0 {
                     ui.set_opacity(opacity);
@@ -273,15 +277,12 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
 
     fn tab_title_for_pane(&mut self, pane: &PaneId) -> egui::WidgetText {
         let is_hidden = self.panes.get(pane).map_or(false, |p| p.is_hidden());
-        let base_label = if let Some(name) = self.pane_names.get(pane) {
-            name.clone()
-        } else {
-            format!("Terminal {}", pane + 1)
-        };
-        let label = if is_hidden {
-            format!("{base_label} (hidden)")
-        } else {
-            base_label
+        let explicit_name = self.pane_names.get(pane).cloned();
+        let label = match (is_hidden, explicit_name) {
+            (true, Some(name)) => format!("{name} (hidden)"),
+            (true, None) => "hidden".to_string(),
+            (false, Some(name)) => name,
+            (false, None) => format!("Terminal {}", pane + 1),
         };
         let color = if is_hidden {
             crate::sidebar_row::with_alpha(self.colors.text_dim, 0.5)


### PR DESCRIPTION
## Summary

- **Opacity:** When a pane is hidden (Cmd+U), the entire pane content area now renders at 40% opacity (`ui.set_opacity(0.4)`), making it visually obvious the pane is hidden. Previously only the tab title was dimmed.
- **Title:** Hidden panes with no explicit name now show just `"hidden"` in the tab instead of `"Terminal N (hidden)"`. Hidden panes with an explicit name still show `"<name> (hidden)"`.

## Changes

Single file: `src/tiling.rs`

1. `pane_ui`: Added `is_hidden` check before the unfocused-opacity block. Hidden panes take full 40% opacity regardless of focus/ghost-mode state.
2. `tab_title_for_pane`: Replaced the two-step label construction with a match on `(is_hidden, explicit_name)` covering all four cases cleanly.

## Test plan

- [ ] Open Plexi Alpha, create 2+ panes
- [ ] Press Cmd+U on the focused pane — content area should visually dim to ~40% opacity
- [ ] Tab title for unnamed hidden pane should show `hidden` (not `Terminal N (hidden)`)
- [ ] Tab title for a named hidden pane (use `plexi pane name`) should show `<name> (hidden)`
- [ ] Press Cmd+U again to unhide — opacity and title restore to normal
- [ ] Verify ghost mode (unfocused opacity) still works on non-hidden panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)