### PR TITLE
audit: full channel-aware workspace management system (#1997)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -275,7 +275,7 @@ impl PlexiApp {
 
         let mut all_diags = crate::config::validate_from_path(&crate::config::config_path());
         if let Some(root) = active_workspace.as_ref() {
-            let project_path = root.join(".plexi").join("config.toml");
+            let project_path = root.join(crate::config::workspace_channel_dir()).join("config.toml");
             all_diags.extend(crate::config::validate_from_path(&project_path));
         }
 

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -28,7 +28,8 @@ pub fn agent_add(name: &str) -> i32 {
         Err(code) => return code,
     };
 
-    let ws_agent_dir = workspace_root.join(".plexi").join("agents").join(name);
+    let channel_dir = crate::config::workspace_channel_dir();
+    let ws_agent_dir = workspace_root.join(&channel_dir).join("agents").join(name);
     let ws_agent_md = ws_agent_dir.join("AGENT.md");
 
     if ws_agent_md.exists() {
@@ -77,7 +78,8 @@ pub fn agent_update(name: &str) -> i32 {
         Err(code) => return code,
     };
 
-    let ws_agent_dir = workspace_root.join(".plexi").join("agents").join(name);
+    let channel_dir = crate::config::workspace_channel_dir();
+    let ws_agent_dir = workspace_root.join(&channel_dir).join("agents").join(name);
     let ws_agent_md = ws_agent_dir.join("AGENT.md");
 
     if !ws_agent_md.exists() {
@@ -131,7 +133,8 @@ pub fn agent_list() -> i32 {
         Err(code) => return code,
     };
 
-    let agents_dir = workspace_root.join(".plexi").join("agents");
+    let channel_dir = crate::config::workspace_channel_dir();
+    let agents_dir = workspace_root.join(&channel_dir).join("agents");
     if !agents_dir.is_dir() {
         println!("No agents installed in this workspace.");
         return 0;

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -145,7 +145,7 @@ pub fn app_init(name: &str, lang: &str, from_pane_id: Option<u64>) -> i32 {
             if current == std::path::Path::new("/") {
                 break;
             }
-            if current.join(".plexi").is_dir() {
+            if current.join(&channel_dir).is_dir() {
                 found = Some(current);
                 break;
             }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -122,9 +122,9 @@ pub fn install_pack_cli(spec: &str) -> i32 {
     }
 }
 
-/// `plexi install` with no args — detect `.plexi/apps.toml` and apply it.
+/// `plexi install` with no args — detect `<channel_dir>/apps.toml` and apply it.
 ///
-/// Walks up from CWD looking for `.plexi/` (the workspace marker), reads
+/// Walks up from CWD looking for the channel dir (workspace marker), reads
 /// `apps.toml` from it, and installs declared apps into the workspace-scoped
 /// channel apps dir (`<workspace_root>/<channel_dir>/apps/`).
 pub fn install_workspace_pack_cli() -> i32 {
@@ -134,7 +134,9 @@ pub fn install_workspace_pack_cli() -> i32 {
         Err(e) => { eprintln!("error: {e}"); return 1; }
     };
 
-    // Walk up from CWD looking for `.plexi/` (workspace marker).
+    let channel_dir = crate::config::workspace_channel_dir();
+
+    // Walk up from CWD looking for the channel dir (workspace marker).
     let workspace_root = {
         let home = dirs::home_dir();
         let mut current = cwd.clone();
@@ -148,7 +150,7 @@ pub fn install_workspace_pack_cli() -> i32 {
             if current == std::path::Path::new("/") {
                 break;
             }
-            if current.join(".plexi").is_dir() {
+            if current.join(&channel_dir).is_dir() {
                 found = Some(current);
                 break;
             }
@@ -161,14 +163,14 @@ pub fn install_workspace_pack_cli() -> i32 {
 
     let Some(root) = workspace_root else {
         eprintln!("Usage: plexi app install <source-spec>[@ref] | plexi app install --pack <path|core>");
-        eprintln!("  In a workspace (directory with .plexi/apps.toml), `plexi app install` applies the manifest.");
+        eprintln!("  In a workspace (directory with {channel_dir}/), `plexi app install` applies the manifest.");
         eprintln!("  Run `plexi workspace init` to initialize a workspace here.");
         return 1;
     };
 
-    let apps_toml = root.join(".plexi").join("apps.toml");
+    let apps_toml = root.join(&channel_dir).join("apps.toml");
     if !apps_toml.exists() {
-        eprintln!("no .plexi/apps.toml found in workspace at {}", root.display());
+        eprintln!("no {channel_dir}/apps.toml found in workspace at {}", root.display());
         eprintln!("  Declare app dependencies there, then re-run `plexi app install`.");
         eprintln!("  Usage: plexi app install <source-spec>[@ref] | plexi app install --pack <path|core>");
         return 1;

--- a/src/cli/install_host.rs
+++ b/src/cli/install_host.rs
@@ -843,17 +843,17 @@ pub fn examples_pack_ids() -> std::collections::HashSet<String> {
         .unwrap_or_default()
 }
 
-/// Read `<workspace_root>/.plexi/apps.toml` and install declared apps into the
+/// Read `<workspace_root>/<channel_dir>/apps.toml` and install declared apps into the
 /// workspace-scoped apps dir (`<workspace_root>/<channel_dir>/apps/`).
 pub fn apply_workspace_pack(
     workspace_root: &Path,
     cloner: &dyn Cloner,
 ) -> Result<Vec<InstallOutcome>, String> {
-    let apps_toml = workspace_root.join(".plexi").join("apps.toml");
+    let channel_dir = crate::config::workspace_channel_dir();
+    let apps_toml = workspace_root.join(&channel_dir).join("apps.toml");
     if !apps_toml.exists() {
         return Err(
-            "no .plexi/apps.toml found — run 'plexi workspace init' to initialize a workspace with a stub apps.toml"
-                .to_string(),
+            format!("no {channel_dir}/apps.toml found — run 'plexi workspace init' to initialize a workspace with a stub apps.toml"),
         );
     }
     let pack = Pack::from_path(&apps_toml)?;
@@ -869,10 +869,11 @@ pub fn apply_workspace_pack(
     Ok(apply_pack(cloner, &pack, &workspace_apps))
 }
 
-/// Return the set of app IDs declared in `<workspace_root>/.plexi/apps.toml`.
+/// Return the set of app IDs declared in `<workspace_root>/<channel_dir>/apps.toml`.
 /// Returns an empty set if the file is absent or unparseable.
 pub fn workspace_manifest_ids(workspace_root: &Path) -> std::collections::HashSet<String> {
-    let path = workspace_root.join(".plexi").join("apps.toml");
+    let channel_dir = crate::config::workspace_channel_dir();
+    let path = workspace_root.join(&channel_dir).join("apps.toml");
     match Pack::from_path(&path) {
         Ok(p) => p.apps.into_iter().map(|a| a.id).collect(),
         Err(e) => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 pub(super) const APP_ID: &str = "plexi-run";
-pub(super) const COMMANDS_FILE: &str = ".plexi/commands.toml";
+pub(super) fn commands_file() -> String {
+    format!("{}/commands.toml", crate::config::workspace_channel_dir())
+}
 
 
 /// Parsed .plexi/commands.toml

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,4 +1,4 @@
-use super::{PlexiCommands, COMMANDS_FILE, APP_ID, list_global_scripts, is_executable, print_tip};
+use super::{PlexiCommands, APP_ID, list_global_scripts, is_executable, print_tip};
 use std::process::Command;
 
 
@@ -15,11 +15,12 @@ pub fn run_list_commands() -> i32 {
         }
     };
 
-    let config_path = cwd.join(COMMANDS_FILE);
+    let commands_file = super::commands_file();
+    let config_path = cwd.join(&commands_file);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            log::info!("cli: no workspace commands.toml, falling back to global scripts");
+            log::info!("cli: no workspace {commands_file}, falling back to global scripts");
             let scripts_dir = crate::config::config_dir().join("scripts");
             let global_scripts = list_global_scripts(&scripts_dir);
             if !global_scripts.is_empty() {
@@ -46,13 +47,13 @@ pub fn run_list_commands() -> i32 {
     let config: PlexiCommands = match toml::from_str(&contents) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("error: failed to parse {COMMANDS_FILE}: {e}");
+            eprintln!("error: failed to parse {commands_file}: {e}");
             return 1;
         }
     };
 
     if config.commands.is_empty() {
-        println!("No commands defined in {COMMANDS_FILE}.");
+        println!("No commands defined in {commands_file}.");
         println!();
         println!("Add a command:");
         println!("  [commands]");
@@ -86,7 +87,8 @@ pub fn run_command(command_name: &str) -> i32 {
         }
     };
 
-    let config_path = cwd.join(COMMANDS_FILE);
+    let commands_file = super::commands_file();
+    let config_path = cwd.join(&commands_file);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -104,8 +106,8 @@ pub fn run_command(command_name: &str) -> i32 {
                     }
                 };
             }
-            eprintln!("error: no {COMMANDS_FILE} found in {}", cwd.display());
-            eprintln!("Create a .plexi/commands.toml to define runnable commands.");
+            eprintln!("error: no {commands_file} found in {}", cwd.display());
+            eprintln!("Create a {commands_file} to define runnable commands.");
             return 1;
         }
         Err(e) => {
@@ -117,7 +119,7 @@ pub fn run_command(command_name: &str) -> i32 {
     let config: PlexiCommands = match toml::from_str(&contents) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("error: failed to parse {COMMANDS_FILE}: {e}");
+            eprintln!("error: failed to parse {commands_file}: {e}");
             return 1;
         }
     };
@@ -127,7 +129,7 @@ pub fn run_command(command_name: &str) -> i32 {
         None => {
             eprintln!("error: unknown command '{command_name}'");
             if config.commands.is_empty() {
-                eprintln!("No commands defined in {COMMANDS_FILE}.");
+                eprintln!("No commands defined in {commands_file}.");
             } else {
                 let mut names: Vec<&str> = config.commands.keys().map(|s| s.as_str()).collect();
                 names.sort();

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -1,5 +1,4 @@
 use super::{print_tip};
-use super::app::app_init_config_dir;
 use super::open::read_secret_from_stdin;
 use std::io::{self, Write};
 
@@ -30,74 +29,17 @@ pub fn workspace_init() -> i32 {
             return 1;
         }
     }
-    match crate::workspace::secrets::init_workspace(&cwd) {
+    let channel_dir = crate::config::workspace_channel_dir();
+    match crate::workspace::secrets::init_workspace(&cwd, &channel_dir) {
         Ok(cfg) => {
-            log::info!("workspace_init:cli: initialized workspace_id={} at {}", cfg.id, cwd.display());
-            let channel_dir = app_init_config_dir();
-            let channel_path = cwd.join(&channel_dir);
-            let channel_created = if let Err(e) = std::fs::create_dir_all(&channel_path) {
-                log::warn!("workspace_init:cli: could not create channel dir {}: {e}", channel_path.display());
-                false
-            } else {
-                log::info!("workspace_init:cli: created channel dir {}", channel_path.display());
-                true
-            };
+            log::info!("workspace_init:cli: initialized workspace_id={} at {} channel_dir={}", cfg.id, cwd.display(), channel_dir);
             println!("Initialized workspace at {}", cwd.display());
             println!("  workspace id: {}", cfg.id);
-            println!("  router:       .plexi/secrets.toml (fallback = true)");
-            if channel_created {
-                println!("  channel dir:  {channel_dir}/");
-            }
-            // Write stub apps.toml if not already present.
-            let apps_toml = cwd.join(".plexi").join("apps.toml");
-            if !apps_toml.exists() {
-                let stub = concat!(
-                    "schema_version = 1\n\n",
-                    "# Declare workspace app dependencies here.\n",
-                    "# Run `plexi app install` in this directory to install them.\n",
-                    "#\n",
-                    "# Example:\n",
-                    "#\n",
-                    "# [[app]]\n",
-                    "# id      = \"gh-issues\"\n",
-                    "# source  = \"local:gh-issues\"\n",
-                    "# version = \"bundled\"\n",
-                    "#\n",
-                    "# [[app]]\n",
-                    "# id      = \"my-tool\"\n",
-                    "# source  = \"github:org/my-tool\"\n",
-                    "# version = \"v1.0.0\"\n",
-                );
-                if let Err(e) = std::fs::write(&apps_toml, stub) {
-                    log::warn!("workspace_init:cli: could not write apps.toml: {e}");
-                    eprintln!("warning: could not create .plexi/apps.toml: {e}");
-                } else {
-                    println!("  apps:         .plexi/apps.toml (declare app dependencies here)");
-                    log::info!("workspace_init:cli: wrote stub .plexi/apps.toml");
-                }
-            }
-            // Write stub commands.toml if not already present.
-            let commands_toml = cwd.join(".plexi").join("commands.toml");
-            if !commands_toml.exists() {
-                let stub = concat!(
-                    "# Workspace commands — run with: plexi run <name>\n",
-                    "#\n",
-                    "# Simple form:   build = \"cargo build\"\n",
-                    "# With metadata: dev = { run = \"npm run dev\", description = \"Start dev server\" }\n",
-                    "# With secrets:  deploy = { run = \"./deploy.sh\", secrets = [\"API_KEY\"] }\n",
-                    "\n",
-                    "[commands]\n",
-                    "guess = \"$PLEXI_CONFIG_DIR/scripts/guess\"\n",
-                );
-                if let Err(e) = std::fs::write(&commands_toml, stub) {
-                    log::warn!("workspace_init:cli: could not write commands.toml: {e}");
-                    eprintln!("warning: could not create .plexi/commands.toml: {e}");
-                } else {
-                    println!("  commands:     .plexi/commands.toml (run commands with: plexi run)");
-                    log::info!("workspace_init:cli: wrote stub .plexi/commands.toml");
-                }
-            }
-            print_tip("declare app dependencies in .plexi/apps.toml, then run `plexi app install`.");
+            println!("  channel dir:  {channel_dir}/");
+            println!("  router:       {channel_dir}/secrets.toml (fallback = true)");
+            println!("  apps:         {channel_dir}/apps.toml (declare app dependencies here)");
+            println!("  commands:     {channel_dir}/commands.toml (run commands with: plexi run)");
+            print_tip(&format!("declare app dependencies in {channel_dir}/apps.toml, then run `plexi app install`."));
             0
         }
         Err(e) => {
@@ -115,23 +57,24 @@ pub fn workspace_init() -> i32 {
 fn require_workspace(
 ) -> Result<(std::path::PathBuf, crate::workspace::secrets::WorkspaceConfig), String> {
     let cwd = std::env::current_dir().map_err(|e| format!("cwd: {e}"))?;
+    let channel_dir = crate::config::workspace_channel_dir();
     let root = match crate::app::registry::resolve_workspace_root(&cwd) {
         Some(r) => r,
         None => {
             return Err(format!(
-                "no .plexi/ workspace found at or above {}.\n\
+                "no {channel_dir}/ workspace found at or above {}.\n\
                  Run `plexi workspace init` first.",
                 cwd.display()
             ));
         }
     };
     let cfg = match crate::workspace::secrets::WorkspaceConfig::load(&root)
-        .map_err(|e| format!("read workspace.toml: {e}"))?
+        .map_err(|e| format!("read {channel_dir}/workspace.toml: {e}"))?
     {
         Some(c) => c,
         None => {
             return Err(format!(
-                ".plexi/ exists at {} but workspace.toml is missing.\n\
+                "{channel_dir}/ exists at {} but workspace.toml is missing.\n\
                  Run `plexi workspace init` to create it.",
                 root.display()
             ));
@@ -524,49 +467,47 @@ mod workspace_init_tests {
     /// Calls the internal init_workspace logic and then the channel-dir creation
     /// on a temp dir, asserting both `.plexi/` and the channel dir are present.
     #[test]
-    fn workspace_init_creates_channel_dir_alongside_plexi_dir() {
+    fn workspace_init_creates_channel_dir_with_all_files() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path().to_path_buf();
 
-        // Run init_workspace (creates .plexi/)
-        crate::workspace::secrets::init_workspace(&cwd)
+        let channel_dir = crate::config::workspace_channel_dir();
+        // Run init_workspace (creates channel dir with workspace.toml + secrets.toml)
+        crate::workspace::secrets::init_workspace(&cwd, &channel_dir)
             .expect("init_workspace should succeed in a temp dir");
 
-        // Replicate the channel dir creation from workspace_init()
-        let channel_dir = super::app_init_config_dir();
-        let channel_path = cwd.join(&channel_dir);
-        fs::create_dir_all(&channel_path).expect("create_dir_all should succeed");
-
         assert!(
-            cwd.join(".plexi").is_dir(),
-            ".plexi/ dir must exist after workspace init"
+            cwd.join(&channel_dir).is_dir(),
+            "{channel_dir}/ dir must exist after workspace init"
         );
         assert!(
-            channel_path.is_dir(),
-            "{channel_dir}/ dir must exist after workspace init"
+            cwd.join(&channel_dir).join("workspace.toml").is_file(),
+            "{channel_dir}/workspace.toml must exist after init"
+        );
+        assert!(
+            cwd.join(&channel_dir).join("secrets.toml").is_file(),
+            "{channel_dir}/secrets.toml must exist after init"
         );
     }
 
-    /// After init, resolve_workspace_root must still find the workspace and the channel dir must exist.
+    /// After init, resolve_workspace_root must still find the workspace.
     #[test]
-    fn workspace_remains_resolvable_after_channel_dir_creation() {
+    fn workspace_remains_resolvable_after_init() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path().to_path_buf();
 
-        crate::workspace::secrets::init_workspace(&cwd)
+        let channel_dir = crate::config::workspace_channel_dir();
+        crate::workspace::secrets::init_workspace(&cwd, &channel_dir)
             .expect("init_workspace should succeed");
-
-        let channel_dir = super::app_init_config_dir();
-        std::fs::create_dir_all(cwd.join(&channel_dir)).unwrap();
 
         let found = crate::app::registry::resolve_workspace_root(&cwd);
         assert!(
             found.is_some(),
-            "resolve_workspace_root should still find the workspace (via .plexi/) after channel dir creation"
+            "resolve_workspace_root should find the workspace after init"
         );
         assert!(
             cwd.join(&channel_dir).is_dir(),
-            "channel directory should exist alongside .plexi/"
+            "channel directory should exist after init"
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -656,11 +656,14 @@ pub fn workspace_channel_dir() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
-    let basename = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-        .unwrap_or_else(|| "plexi".to_string());
-    channel_suffix_from_basename(&basename)
+    static CHANNEL_DIR: OnceLock<String> = OnceLock::new();
+    CHANNEL_DIR.get_or_init(|| {
+        let basename = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "plexi".to_string());
+        channel_suffix_from_basename(&basename)
+    }).clone()
 }
 
 /// Returns the config directory name based on the running binary basename.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -157,7 +157,7 @@ fn check_unknown_keys(
 pub fn validate_all() -> Vec<ConfigDiagnostic> {
     let mut diags = validate_from_path(&config_path());
     if let Some(root) = active_workspace_root() {
-        let project_path = root.join(".plexi").join("config.toml");
+        let project_path = root.join(workspace_channel_dir()).join("config.toml");
         diags.extend(validate_from_path(&project_path));
     }
     diags
@@ -645,6 +645,22 @@ fn channel_suffix_from_basename(basename: &str) -> String {
     } else {
         ".plexi".to_string()
     }
+}
+
+/// Returns the workspace channel directory name for the current binary.
+/// This is the dot-prefixed dir used inside workspace roots to scope
+/// workspace state per channel: `.plexi` (main), `.plexi-alpha`, `.plexi-beta`,
+/// `.plexi-pr-N`, etc. This is the single source of truth for workspace
+/// channel dirs — never derive it independently elsewhere.
+pub fn workspace_channel_dir() -> String {
+    if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
+        return format!(".plexi-{profile}");
+    }
+    let basename = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| "plexi".to_string());
+    channel_suffix_from_basename(&basename)
 }
 
 /// Returns the config directory name based on the running binary basename.

--- a/src/host/anchor.rs
+++ b/src/host/anchor.rs
@@ -32,13 +32,14 @@ pub struct Anchor {
 }
 
 impl Anchor {
-    /// Detect an anchor at `path`. Returns `Some` if `path/.plexi/` exists
+    /// Detect an anchor at `path`. Returns `Some` if `path/<channel_dir>/` exists
     /// and `path` is not a profile directory (`~/.plexi*`).
     ///
     /// Reads `workspace.toml` for workspace_id and context defaults if present.
     pub fn detect(path: &Path) -> Option<Self> {
-        let dot_plexi = path.join(".plexi");
-        if !dot_plexi.is_dir() {
+        let channel_dir = crate::config::workspace_channel_dir();
+        let channel_path = path.join(&channel_dir);
+        if !channel_path.is_dir() {
             return None;
         }
 

--- a/src/host/event_log.rs
+++ b/src/host/event_log.rs
@@ -268,7 +268,7 @@ fn append_line(file: &mut std::fs::File, line: &str) {
 /// is consistent across registry, secrets, and event logging.
 pub fn find_workspace_events_path(start: &std::path::Path) -> Option<PathBuf> {
     crate::app::registry::resolve_workspace_root(start)
-        .map(|root| root.join(".plexi").join("events.jsonl"))
+        .map(|root| root.join(crate::config::workspace_channel_dir()).join("events.jsonl"))
 }
 
 /// Returns the current UTC timestamp as an RFC 3339 string.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -9,11 +9,10 @@ use std::path::PathBuf;
 
 /// Auto-initialize a project workspace at `root` if one does not already exist.
 ///
-/// Creates only the channel-specific dir (e.g. `.plexi-alpha/`, `.plexi-pr-N/`).
-/// This is what `resolve_workspace_root` uses for discovery — no channel-agnostic
-/// `.plexi/` is created here. Full channel-aware workspace init is tracked in #1997.
+/// Calls the shared `init_workspace` function which creates all workspace files
+/// (workspace.toml, secrets.toml, apps.toml, commands.toml) under the channel dir.
 ///
-/// Idempotent — skips if the channel dir already exists.
+/// Idempotent — skips if the channel dir already has workspace.toml.
 /// Non-fatal — logs warn on failure but never prevents the root from being set.
 fn auto_init_workspace(root: &std::path::Path) {
     // Guard: never init at home dir, filesystem root, or inside a Plexi profile dir.
@@ -30,24 +29,20 @@ fn auto_init_workspace(root: &std::path::Path) {
         return;
     }
 
-    let channel_dir_name = crate::config::config_dir()
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(".plexi")
-        .to_string();
-    let channel_path = root.join(&channel_dir_name);
+    let channel_dir = crate::config::workspace_channel_dir();
+    let channel_path = root.join(&channel_dir);
     if channel_path.exists() {
         log::info!("auto_init_workspace: already initialized at {}", root.display());
         return;
     }
-    match std::fs::create_dir_all(&channel_path) {
-        Ok(()) => log::info!(
-            "auto_init_workspace: created {}/{} ",
-            root.display(), channel_dir_name
+    match crate::workspace::secrets::init_workspace(root, &channel_dir) {
+        Ok(cfg) => log::info!(
+            "auto_init_workspace: created {}/{channel_dir} workspace_id={}",
+            root.display(), cfg.id
         ),
         Err(e) => log::warn!(
-            "auto_init_workspace: could not create {}: {e}",
-            channel_path.display()
+            "auto_init_workspace: could not create {}/{channel_dir}: {e}",
+            root.display()
         ),
     }
 }

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -271,7 +271,7 @@ fn build_context_prefix(
 
     // Append up to 20 recent workspace events (~8000 chars budget).
     let events_path = workspace_root
-        .join(".plexi")
+        .join(crate::config::workspace_channel_dir())
         .join("events.jsonl");
     let recent = crate::host::event_log::read_recent(&events_path, 20);
     if !recent.is_empty() {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2062,8 +2062,9 @@ fn load_app_state(type_id: &str, workspace_root: &std::path::Path) -> serde_json
     let filename = format!("{type_id}.json");
 
     // Migrate old app_state/ → app_states/ on first access (workspace).
-    let ws_old = workspace_root.join(".plexi").join("app_state");
-    let ws_new = workspace_root.join(".plexi").join("app_states");
+    let channel_dir = crate::config::workspace_channel_dir();
+    let ws_old = workspace_root.join(&channel_dir).join("app_state");
+    let ws_new = workspace_root.join(&channel_dir).join("app_states");
     migrate_app_state_dir(&ws_old, &ws_new);
 
     let workspace_path = ws_new.join(&filename);

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1744,9 +1744,10 @@ impl ProcessApp {
             // ── App state save ─────────────────────────────────────────────
             AppRequest::SaveAppState { payload } => {
                 let filename = format!("{}.json", self.type_id);
-                let workspace_toml = self.workspace_root.join(".plexi").join("workspace.toml");
+                let channel_dir = crate::config::workspace_channel_dir();
+                let workspace_toml = self.workspace_root.join(&channel_dir).join("workspace.toml");
                 let state_path = if workspace_toml.exists() {
-                    self.workspace_root.join(".plexi").join("app_states").join(&filename)
+                    self.workspace_root.join(&channel_dir).join("app_states").join(&filename)
                 } else {
                     crate::config::config_dir().join("app_states").join(&filename)
                 };

--- a/src/workspace/secrets.rs
+++ b/src/workspace/secrets.rs
@@ -343,10 +343,10 @@ pub struct WorkspaceContextConfig {
 }
 
 impl WorkspaceConfig {
-    /// Read `<root>/.plexi/workspace.toml`. Returns `None` if the file does
+    /// Read `<root>/<channel_dir>/workspace.toml`. Returns `None` if the file does
     /// not exist; returns `Err` only on a present-but-invalid file.
     pub fn load(workspace_root: &Path) -> Result<Option<Self>, String> {
-        let path = workspace_root.join(".plexi").join("workspace.toml");
+        let path = workspace_root.join(crate::config::workspace_channel_dir()).join("workspace.toml");
         let raw = match std::fs::read_to_string(&path) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -359,22 +359,6 @@ impl WorkspaceConfig {
             .map_err(|e| format!("parse {}: {e}", path.display()))
     }
 
-    /// Read or create — if the file does not exist, generate a fresh UUID and
-    /// write a minimal `id = "<uuid>"` file. The rest of `workspace.toml` is
-    /// owned by #308 Phase 1; we only touch the `id` line.
-    pub fn load_or_init(workspace_root: &Path) -> Result<Self, String> {
-        if let Some(cfg) = Self::load(workspace_root)? {
-            return Ok(cfg);
-        }
-        let id = uuid::Uuid::new_v4().to_string();
-        let dir = workspace_root.join(".plexi");
-        std::fs::create_dir_all(&dir)
-            .map_err(|e| format!("create {}: {e}", dir.display()))?;
-        let path = dir.join("workspace.toml");
-        std::fs::write(&path, format!("id = \"{id}\"\n"))
-            .map_err(|e| format!("write {}: {e}", path.display()))?;
-        Ok(Self { id, context: None })
-    }
 }
 
 // ── secrets.toml (router) ────────────────────────────────────────────────────
@@ -396,11 +380,11 @@ impl WorkspaceSecrets {
         toml::from_str::<Self>(raw).map_err(|e| format!("parse secrets.toml: {e}"))
     }
 
-    /// Read `<root>/.plexi/secrets.toml`. Returns `None` if the file does
+    /// Read `<root>/<channel_dir>/secrets.toml`. Returns `None` if the file does
     /// not exist; returns `Err` if it exists but is malformed (incl. missing
     /// `fallback`).
     pub fn load(workspace_root: &Path) -> Result<Option<Self>, String> {
-        let path = workspace_root.join(".plexi").join("secrets.toml");
+        let path = workspace_root.join(crate::config::workspace_channel_dir()).join("secrets.toml");
         let raw = match std::fs::read_to_string(&path) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -478,19 +462,37 @@ pub fn resolve(
 
 // ── Workspace init helpers ───────────────────────────────────────────────────
 
-/// `plexi workspace init` scaffolds:
-///   - `<root>/.plexi/workspace.toml` with a fresh UUID (idempotent — keeps
-///     existing id if present)
-///   - `<root>/.plexi/secrets.toml` with `fallback = true` (chosen as the
-///     ergonomic default; users opt into stricter `false` later)
-///   - `<root>/.plexi/.gitignore` so the secrets file and host caches never
-///     end up in git. **Existing `.gitignore` files are preserved verbatim**
-///     so user edits survive subsequent `init` runs.
+/// `plexi workspace init` scaffolds all workspace files under `channel_dir`
+/// (e.g. `.plexi-alpha/` or `.plexi/` for main):
+///   - `<root>/<channel_dir>/workspace.toml` with a fresh UUID (idempotent)
+///   - `<root>/<channel_dir>/secrets.toml` with `fallback = true`
+///   - `<root>/<channel_dir>/.gitignore` so secrets never end up in git
+///
+/// `channel_dir` is the dot-prefixed workspace channel directory name
+/// (e.g. `.plexi-alpha`, `.plexi`, `.plexi-pr-N`).
 ///
 /// Returns the resolved `WorkspaceConfig` so the caller can echo the UUID.
-pub fn init_workspace(workspace_root: &Path) -> Result<WorkspaceConfig, String> {
-    let cfg = WorkspaceConfig::load_or_init(workspace_root)?;
-    let secrets_path = workspace_root.join(".plexi").join("secrets.toml");
+pub fn init_workspace(workspace_root: &Path, channel_dir: &str) -> Result<WorkspaceConfig, String> {
+    // Write workspace.toml under the channel dir
+    let ws_path = workspace_root.join(channel_dir).join("workspace.toml");
+    let cfg = if ws_path.exists() {
+        let raw = std::fs::read_to_string(&ws_path)
+            .map_err(|e| format!("read {}: {e}", ws_path.display()))?;
+        toml::from_str::<WorkspaceConfig>(&raw)
+            .map_err(|e| format!("parse {}: {e}", ws_path.display()))?
+    } else {
+        // Create the channel dir and write a fresh workspace.toml
+        let dir = workspace_root.join(channel_dir);
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("create {}: {e}", dir.display()))?;
+        let id = uuid::Uuid::new_v4().to_string();
+        std::fs::write(&ws_path, format!("id = \"{id}\"\n"))
+            .map_err(|e| format!("write {}: {e}", ws_path.display()))?;
+        WorkspaceConfig { id, context: None }
+    };
+
+    // secrets.toml under the channel dir
+    let secrets_path = workspace_root.join(channel_dir).join("secrets.toml");
     if !secrets_path.exists() {
         let template = "# Workspace secret routing — see issue #322.\n\
                         # fallback: when no [apps.<id>] / [default] route matches a canonical\n\
@@ -505,6 +507,46 @@ pub fn init_workspace(workspace_root: &Path) -> Result<WorkspaceConfig, String> 
         std::fs::write(&secrets_path, template)
             .map_err(|e| format!("write {}: {e}", secrets_path.display()))?;
     }
+
+    // stub apps.toml under the channel dir
+    let apps_toml = workspace_root.join(channel_dir).join("apps.toml");
+    if !apps_toml.exists() {
+        let stub = concat!(
+            "schema_version = 1\n\n",
+            "# Declare workspace app dependencies here.\n",
+            "# Run `plexi app install` in this directory to install them.\n",
+            "#\n",
+            "# Example:\n",
+            "#\n",
+            "# [[app]]\n",
+            "# id      = \"gh-issues\"\n",
+            "# source  = \"local:gh-issues\"\n",
+            "# version = \"bundled\"\n",
+            "#\n",
+            "# [[app]]\n",
+            "# id      = \"my-tool\"\n",
+            "# source  = \"github:org/my-tool\"\n",
+            "# version = \"v1.0.0\"\n",
+        );
+        let _ = std::fs::write(&apps_toml, stub);
+    }
+
+    // stub commands.toml under the channel dir
+    let commands_toml = workspace_root.join(channel_dir).join("commands.toml");
+    if !commands_toml.exists() {
+        let stub = concat!(
+            "# Workspace commands — run with: plexi run <name>\n",
+            "#\n",
+            "# Simple form:   build = \"cargo build\"\n",
+            "# With metadata: dev = { run = \"npm run dev\", description = \"Start dev server\" }\n",
+            "# With secrets:  deploy = { run = \"./deploy.sh\", secrets = [\"API_KEY\"] }\n",
+            "\n",
+            "[commands]\n",
+            "guess = \"$PLEXI_CONFIG_DIR/scripts/guess\"\n",
+        );
+        let _ = std::fs::write(&commands_toml, stub);
+    }
+
     write_gitignore_if_absent(workspace_root)?;
     Ok(cfg)
 }
@@ -521,7 +563,7 @@ const GITIGNORE_TEMPLATE: &str = "# Auto-generated by plexi workspace init.\n\
 /// Write `<root>/.plexi/.gitignore` only when the file does not already exist.
 /// User edits to an existing file are preserved verbatim.
 fn write_gitignore_if_absent(workspace_root: &Path) -> Result<(), String> {
-    let dir = workspace_root.join(".plexi");
+    let dir = workspace_root.join(crate::config::workspace_channel_dir());
     std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     let path = dir.join(".gitignore");
     if path.exists() {
@@ -546,10 +588,10 @@ pub fn write_default_route(
     canonical: &str,
     friendly: &str,
 ) -> Result<(), String> {
-    let secrets_path = workspace_root.join(".plexi").join("secrets.toml");
+    let secrets_path = workspace_root.join(crate::config::workspace_channel_dir()).join("secrets.toml");
 
     if !secrets_path.exists() {
-        let dir = workspace_root.join(".plexi");
+        let dir = workspace_root.join(crate::config::workspace_channel_dir());
         std::fs::create_dir_all(&dir)
             .map_err(|e| format!("create {}: {e}", dir.display()))?;
         let content = format!("fallback = true\n\n[default]\n{canonical} = \"{friendly}\"\n");
@@ -786,20 +828,22 @@ mod tests {
     #[test]
     fn workspace_config_load_or_init_writes_uuid_when_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        let cfg = WorkspaceConfig::load_or_init(tmp.path()).expect("load_or_init");
+        let channel_dir = crate::config::workspace_channel_dir();
+        let cfg = init_workspace(tmp.path(), &channel_dir).expect("load_or_init");
         assert!(uuid::Uuid::parse_str(&cfg.id).is_ok());
         // Idempotent — second call returns the same id.
-        let cfg2 = WorkspaceConfig::load_or_init(tmp.path()).expect("second load");
+        let cfg2 = init_workspace(tmp.path(), &channel_dir).expect("second load");
         assert_eq!(cfg.id, cfg2.id);
     }
 
     #[test]
     fn init_workspace_creates_workspace_and_secrets_files() {
         let tmp = tempfile::tempdir().unwrap();
-        init_workspace(tmp.path()).expect("init_workspace");
-        assert!(tmp.path().join(".plexi").join("workspace.toml").is_file());
+        let channel_dir = crate::config::workspace_channel_dir();
+        init_workspace(tmp.path(), &channel_dir).expect("init_workspace");
+        assert!(tmp.path().join(&channel_dir).join("workspace.toml").is_file());
         let secrets_raw =
-            std::fs::read_to_string(tmp.path().join(".plexi").join("secrets.toml")).unwrap();
+            std::fs::read_to_string(tmp.path().join(&channel_dir).join("secrets.toml")).unwrap();
         // Generated secrets.toml must parse cleanly with the required field.
         let parsed = WorkspaceSecrets::parse(&secrets_raw).expect("template parses");
         assert!(parsed.fallback);
@@ -808,14 +852,15 @@ mod tests {
     #[test]
     fn init_writes_gitignore_when_absent() {
         let tmp = tempfile::tempdir().unwrap();
-        let gitignore = tmp.path().join(".plexi").join(".gitignore");
+        let channel_dir = crate::config::workspace_channel_dir();
+        let gitignore = tmp.path().join(&channel_dir).join(".gitignore");
         assert!(!gitignore.exists());
 
-        init_workspace(tmp.path()).expect("init_workspace");
+        init_workspace(tmp.path(), &channel_dir).expect("init_workspace");
 
         assert!(
             gitignore.is_file(),
-            "init must create .plexi/.gitignore"
+            "init must create {channel_dir}/.gitignore"
         );
         let raw = std::fs::read_to_string(&gitignore).unwrap();
         assert!(raw.contains("secrets.toml"), "got: {raw}");
@@ -825,13 +870,14 @@ mod tests {
     #[test]
     fn init_preserves_existing_gitignore() {
         let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join(".plexi");
+        let channel_dir = crate::config::workspace_channel_dir();
+        let dir = tmp.path().join(&channel_dir);
         std::fs::create_dir_all(&dir).unwrap();
         let gitignore = dir.join(".gitignore");
         let custom = "# my own rules\nfoo\nbar\n";
         std::fs::write(&gitignore, custom).unwrap();
 
-        init_workspace(tmp.path()).expect("init_workspace");
+        init_workspace(tmp.path(), &channel_dir).expect("init_workspace");
 
         let raw = std::fs::read_to_string(&gitignore).unwrap();
         assert_eq!(

--- a/src/workspace/secrets.rs
+++ b/src/workspace/secrets.rs
@@ -528,7 +528,8 @@ pub fn init_workspace(workspace_root: &Path, channel_dir: &str) -> Result<Worksp
             "# source  = \"github:org/my-tool\"\n",
             "# version = \"v1.0.0\"\n",
         );
-        let _ = std::fs::write(&apps_toml, stub);
+        std::fs::write(&apps_toml, stub)
+            .map_err(|e| format!("write {}: {e}", apps_toml.display()))?;
     }
 
     // stub commands.toml under the channel dir
@@ -544,7 +545,8 @@ pub fn init_workspace(workspace_root: &Path, channel_dir: &str) -> Result<Worksp
             "[commands]\n",
             "guess = \"$PLEXI_CONFIG_DIR/scripts/guess\"\n",
         );
-        let _ = std::fs::write(&commands_toml, stub);
+        std::fs::write(&commands_toml, stub)
+            .map_err(|e| format!("write {}: {e}", commands_toml.display()))?;
     }
 
     write_gitignore_if_absent(workspace_root)?;


### PR DESCRIPTION
Closes #1997

## Summary

- Add `workspace_channel_dir()` to `config/mod.rs` as the single source of truth for workspace channel directories (`.plexi`, `.plexi-alpha`, etc.)
- Rewrite `init_workspace()` to take a `channel_dir` parameter and create all workspace files (workspace.toml, secrets.toml, apps.toml, commands.toml, .gitignore) under it in one call
- Wire all callers across CLI and host to use the channel dir for reads and writes — no more split writes to `.plexi/` and `.plexi-alpha/`
- On non-main channels, `plexi workspace init` now creates only `<channel_dir>/` with all files inside; `.plexi/` is never created
- Main channel (`plexi`) uses `.plexi/` as its channel dir — backward compatible

## Done When

- [x] `plexi workspace init` on alpha creates only `.plexi-alpha/` with all workspace files inside
- [x] `plexi secret set`, `plexi run`, `plexi app install` all resolve via the channel dir
- [x] `auto_init_workspace` calls the shared init function and produces the full structure
- [x] No `.plexi/` dir is created on non-main channels
- [x] Main channel (`plexi`) still uses `.plexi/` (it IS the channel dir for stable)
- [x] Existing workspaces with `.plexi/` on main channel continue to work

## Notes

- 16 files changed across config, workspace secrets, CLI (workspace, run, install, agent, app, config_cli), pane_ops, host (anchor, event_log), process_app (routing, mod), plexi_ai (broker), and app/focus
- Pre-existing test compilation errors (E0432 unresolved imports) are not introduced by this change — same errors on alpha base