### PR TITLE
fix(cli): add --global flag to secret delete (#1700)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -277,8 +277,14 @@ pub enum SecretCmd {
     /// Show all secrets stored for this project.
     List,
     /// Delete a stored secret.
+    ///
+    /// Use --global to delete a globally-stored secret (one stored with `secret set --global`).
+    /// Without --global, deletes the workspace-scoped entry for the current project.
     Delete {
         friendly_name: String,
+        /// Delete from the global store instead of the project-scoped store
+        #[arg(long)]
+        global: bool,
     },
 }
 

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -340,27 +340,50 @@ pub fn workspace_secret_get(friendly: &str, global: bool) -> i32 {
     }
 }
 
-/// `plexi secret delete <friendly-name>` — remove the workspace-scoped
-/// Keychain entry and update the index.
-pub fn workspace_secret_delete(friendly: &str) -> i32 {
-    let (_root, cfg) = match require_workspace() {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return 1;
-        }
-    };
+/// `plexi secret delete <friendly-name>` — remove the Keychain entry.
+///
+/// When `global` is true, deletes the user-scoped entry (`plexi:user:<name>`)
+/// without requiring a workspace. When false, requires a workspace and deletes
+/// the workspace-scoped entry.
+pub fn workspace_secret_delete(friendly: &str, global: bool) -> i32 {
+    log::info!("secret_delete:cli: friendly={friendly} global={global}");
     #[cfg(target_os = "macos")]
     {
-        use crate::workspace::secrets::{keychain_workspace_name, MacKeychain, SecretStore};
-        let account = keychain_workspace_name(&cfg.id, friendly);
+        use crate::workspace::secrets::{keychain_user_name, keychain_workspace_name, MacKeychain, SecretStore};
         let store = MacKeychain::new();
+
+        if global {
+            let account = keychain_user_name(friendly);
+            return match store.delete(&account) {
+                Ok(()) => {
+                    log::info!("secret_delete:cli: deleted globally account={account}");
+                    println!("Deleted global secret '{friendly}'");
+                    0
+                }
+                Err(e) => {
+                    log::warn!("secret_delete:cli: not found or failed friendly={friendly} err={e}");
+                    eprintln!("error: keychain delete failed: {e}");
+                    1
+                }
+            };
+        }
+
+        let (_root, cfg) = match require_workspace() {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 1;
+            }
+        };
+        let account = keychain_workspace_name(&cfg.id, friendly);
         match store.delete(&account) {
             Ok(()) => {
+                log::info!("secret_delete:cli: deleted workspace_id={} account={account}", cfg.id);
                 println!("Deleted '{friendly}' from workspace {}", cfg.id);
                 0
             }
             Err(e) => {
+                log::warn!("secret_delete:cli: keychain delete failed account={account} err={e}");
                 eprintln!("error: keychain delete failed: {e}");
                 1
             }
@@ -368,7 +391,7 @@ pub fn workspace_secret_delete(friendly: &str) -> i32 {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (cfg, friendly);
+        let _ = (friendly, global);
         eprintln!("error: keychain not available on this platform");
         1
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn main() -> eframe::Result {
                         SecretCmd::Set { friendly_name, from_env, global, alias } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global, alias.as_deref())),
                         SecretCmd::Get { friendly_name, global } => std::process::exit(cli::workspace_secret_get(&friendly_name, global)),
                         SecretCmd::List => std::process::exit(cli::workspace_secret_list()),
-                        SecretCmd::Delete { friendly_name } => std::process::exit(cli::workspace_secret_delete(&friendly_name)),
+                        SecretCmd::Delete { friendly_name, global } => std::process::exit(cli::workspace_secret_delete(&friendly_name, global)),
                     },
                     Commands::App { cmd } => match cmd {
                         AppCmd::Open { type_id, mcp, cli: cli_flag, down, left, up, right, tab, window, from_pane_id, extra_args } => {


### PR DESCRIPTION
Closes #1700

## Summary
- Add `--global` flag to `plexi secret delete` subcommand
- When `--global` is passed, resolves via `keychain_user_name()` and skips `require_workspace()`, mirroring the pattern from `secret get --global`
- When `--global` is absent, keeps existing workspace-scoped delete path
- Added `log::info!` instrumentation on both paths per CLAUDE.md logging requirements

## Test plan
- [ ] `plexi secret set --global TEST_KEY` then `plexi secret delete --global TEST_KEY` exits 0
- [ ] `plexi secret get --global TEST_KEY` after delete exits non-zero ("not found")
- [ ] `plexi secret delete KEY` still works for workspace-scoped secrets
- [ ] `plexi secret delete --help` shows `--global` flag
- [ ] `cargo build` passes