### PR TITLE
fix(cli): app uninstall finds workspace-local apps (#1699)

### DIFF
--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -284,6 +284,9 @@ pub struct InstalledApp {
     /// surface the missing-secret prompt at first launch.
     pub secrets: HashMap<String, SecretDecl>,
     pub bin_path: PathBuf,
+    /// Root directory of this app's installation (the directory containing
+    /// `manifest.toml`). Set by `load_app`; used by uninstall and hot-reload.
+    pub app_dir: PathBuf,
     /// Which discovery layer this entry came from. Set by `scan_dir`; the
     /// value returned by `load_app` is a placeholder and is overwritten at
     /// insert time.
@@ -463,6 +466,7 @@ impl AppRegistry {
             launch: manifest.launch,
             secrets: manifest.secrets,
             bin_path,
+            app_dir: app_dir.clone(),
             // Placeholders — `scan_dir` overwrites both with real values.
             source: RegistrySource::Global,
             workspace_root: None,
@@ -498,12 +502,12 @@ impl AppRegistry {
             .unwrap_or(false)
     }
 
-    /// Path to the app's installation directory (parent of `bin_path`).
+    /// Path to the app's installation directory (contains `manifest.toml`).
     /// Used by the file watcher; returns `None` when the app id is unknown.
     pub fn app_dir_for(&self, app_id: &str) -> Option<PathBuf> {
         self.apps
             .get(app_id)
-            .and_then(|a| a.bin_path.parent().map(Path::to_path_buf))
+            .map(|a| a.app_dir.clone())
     }
 
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -288,14 +288,23 @@ fn scaffold_rust_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> {
     Ok(())
 }
 
-/// `plexi app uninstall <id> [--yes]` — remove a globally installed app with optional confirmation.
+/// `plexi app uninstall <id> [--yes]` — remove an installed app (global or workspace-local).
 pub fn app_uninstall(id: &str, assume_yes: bool) -> i32 {
-    let target_root = crate::app::registry::apps_dir();
-    let app_dir = target_root.join(id);
-    if !app_dir.exists() {
-        eprintln!("error: app '{id}' not found");
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let registry = crate::app::registry::AppRegistry::load(&cwd);
+    let Some(installed) = registry.get(id) else {
+        eprintln!("error: app '{id}' not found — run `plexi app list` to see installed apps");
         return 1;
-    }
+    };
+    let app_dir = installed.app_dir.clone();
+    let target_root = match app_dir.parent() {
+        Some(p) => p.to_path_buf(),
+        None => {
+            eprintln!("error: could not determine parent directory for '{id}'");
+            return 1;
+        }
+    };
+    log::info!("app_uninstall: resolving '{id}' via registry → {:?}", app_dir);
     let core_ids = crate::cli::install_host::core_pack_ids();
     if core_ids.contains(id) {
         eprintln!("note: '{id}' is a core app — it will be re-installed on the next Plexi launch");


### PR DESCRIPTION
Closes #1699

## Summary
- `app_uninstall` previously hardcoded the global apps dir (`~/.plexi-<channel>/apps/`), causing "app not found" for apps created with `plexi app init` in a workspace
- Fix loads the registry (which already scans both global and workspace-local paths), looks up the app by ID, and uses the resolved `app_dir`
- Added `app_dir: PathBuf` to `InstalledApp` (populated by `load_app`) as the canonical installation root
- Updated `app_dir_for` to use `installed.app_dir` directly instead of `bin_path.parent()` (more correct for nested entry paths)

## Test plan
- [ ] `plexi-alpha app init test-app` in a workspace dir, then `plexi-alpha app uninstall test-app` succeeds
- [ ] Global app uninstall (`~/.plexi-alpha/apps/<id>`) still works
- [ ] `cargo build` passes
- [ ] 82 lib tests pass (registry tests cover workspace-local app scanning)