### PR TITLE
feat(apps/assistant): session persistence — save/resume conversations (#2006)

### DIFF
--- a/apps/assistant/assistant.py
+++ b/apps/assistant/assistant.py
@@ -9,9 +9,14 @@ Patterns demonstrated:
   - Streaming via on_ai_stream_chunk + schedule_render
   - Background ai_query with emit.run_sync
   - Column + AppBar + Scrollable + TextInput + FooterKeys
+  - Session persistence via JSON in .plexi/assistant_sessions/
 """
 
+import json
+import os
 import threading
+from datetime import datetime, timezone
+from pathlib import Path
 
 from plexi_sdk import App, RenderContext
 from plexi_sdk.ui import (
@@ -30,7 +35,61 @@ class AssistantApp(App):
         self._is_streaming = False
         self._input = TextInput("chat-input", placeholder="Type a message...", height=48.0)
         self._scroll = Scrollable(child=Spacer())  # replaced each render
-        ctx.info("AssistantApp ready")
+        self._session_id = _new_session_id()
+        self._sessions_dir: Path | None = _resolve_sessions_dir(ctx.workspace_root)
+        self._load_latest_session()
+        ctx.info(f"AssistantApp ready — sessions dir: {self._sessions_dir}")
+
+    # ── Session persistence ────────────────────────────────────────────────────
+
+    def _load_latest_session(self) -> None:
+        """Load the most recent session file, or start fresh if none exists."""
+        if self._sessions_dir is None:
+            return
+        try:
+            files = sorted(self._sessions_dir.glob("*.json"), reverse=True)
+            if not files:
+                return
+            latest = files[0]
+            data = json.loads(latest.read_text(encoding="utf-8"))
+            messages = data.get("messages", [])
+            if not isinstance(messages, list):
+                raise ValueError("messages is not a list")
+            self._messages = messages
+            self._session_id = latest.stem
+            self.emit.info(f"Resumed session {self._session_id} ({len(messages)} messages)")
+        except Exception as e:
+            self.emit.warn(f"Could not load session (starting fresh): {e}")
+            self._messages = []
+            self._session_id = _new_session_id()
+
+    def _save_session(self) -> None:
+        """Persist the current conversation to a JSON file."""
+        if self._sessions_dir is None:
+            return
+        try:
+            self._sessions_dir.mkdir(parents=True, exist_ok=True)
+            path = self._sessions_dir / f"{self._session_id}.json"
+            payload = {
+                "session_id": self._session_id,
+                "created": self._session_id,
+                "model_tier": MODEL_TIER,
+                "messages": self._messages,
+            }
+            path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        except Exception as e:
+            self.emit.warn(f"Could not save session: {e}")
+
+    def _new_conversation(self) -> None:
+        """Start a fresh session, discarding in-memory history."""
+        if self._is_streaming:
+            return
+        self._messages = []
+        self._session_id = _new_session_id()
+        self.emit.info(f"New session started: {self._session_id}")
+        self.emit.schedule_render()
+
+    # ── AI query ───────────────────────────────────────────────────────────────
 
     def on_ai_stream_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
         self._streaming_text += delta
@@ -52,6 +111,7 @@ class AssistantApp(App):
             if not self._streaming_text and resp.content:
                 self._streaming_text = resp.content
             self._messages.append({"role": "assistant", "content": self._streaming_text})
+            self._save_session()
         except Exception as e:
             self.emit.error(f"ai_query failed: {e}")
             self._messages.append({"role": "assistant", "content": f"Error: {e}"})
@@ -71,6 +131,8 @@ class AssistantApp(App):
         self._streaming_text = ""
         threading.Thread(target=self._send_query, daemon=True).start()
         self.emit.schedule_render()
+
+    # ── Rendering ──────────────────────────────────────────────────────────────
 
     def _build_chat_column(self) -> Column:
         """Build a Column of ChatBubble nodes for the message history."""
@@ -94,7 +156,7 @@ class AssistantApp(App):
         self._scroll.scroll_offset = max(0.0, self._scroll._child_h - self._scroll._avail_h)
 
         subtitle = f"model: {MODEL_TIER}"
-        footer_keys = [("Enter", "send"), ("Esc", "quit")]
+        footer_keys = [("Enter", "send"), ("N", "new"), ("Esc", "quit")]
         if self._is_streaming:
             footer_keys = [("...", "streaming"), ("Esc", "quit")]
 
@@ -109,9 +171,34 @@ class AssistantApp(App):
         if submitted is not None:
             self._submit(submitted)
 
-    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
             self.emit.schedule_render()
+            return
+        # Cmd+N or bare 'n' (when not focused on input) starts a new conversation.
+        if key == "n" and mods.get("cmd"):
+            self._new_conversation()
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _new_session_id() -> str:
+    """Generate a session ID from the current UTC timestamp."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _resolve_sessions_dir(workspace_root: str) -> Path | None:
+    """Return .plexi/assistant_sessions/ under workspace_root, or None if unavailable."""
+    if not workspace_root:
+        return None
+    root = Path(workspace_root)
+    plexi_dir = root / ".plexi"
+    # Only use workspace storage if .plexi/ already exists (i.e. workspace is initialised).
+    if not plexi_dir.exists():
+        # Fall back to a dir next to the script so the app still persists.
+        script_dir = Path(os.path.abspath(__file__)).parent
+        return script_dir / "sessions"
+    return plexi_dir / "assistant_sessions"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2006

## Summary
- Conversations auto-save as JSON in `.plexi/assistant_sessions/` after each assistant reply
- Most recent session loads on app restart
- Falls back to `sessions/` next to the script when workspace is not initialised
- Cmd+N starts a new conversation; footer updated to show N key hint
- Graceful handling of missing dirs and corrupt/missing session files

## Test plan
- [ ] Start conversation, close app, reopen — conversation resumes
- [ ] Cmd+N clears history and starts a new session
- [ ] Session files are human-readable JSON in `.plexi/assistant_sessions/`
- [ ] App starts clean if session file is corrupt (deleted or malformed JSON)