### PR TITLE
fix(cli): config get supports all config fields via TOML path lookup (#1701)

### DIFF
--- a/src/cli/config_cli.rs
+++ b/src/cli/config_cli.rs
@@ -63,21 +63,108 @@ pub fn config_edit() -> i32 {
 
 pub fn config_get(key: &str) -> i32 {
     log::info!("config_get: resolving key={key}");
-    let config = crate::config::PlexiConfig::load_with_workspace(
-        crate::config::active_workspace_root().as_deref(),
-    );
-    let agents = config.agents.as_ref();
-    let value = match key {
-        "agents.low" => agents.map(|a| a.effective_low()).unwrap_or(crate::config::DEFAULT_AGENT_LOW),
-        "agents.medium" => agents.map(|a| a.effective_medium()).unwrap_or(crate::config::DEFAULT_AGENT_MEDIUM),
-        "agents.high" => agents.map(|a| a.effective_high()).unwrap_or(crate::config::DEFAULT_AGENT_HIGH),
-        _ => {
-            eprintln!("error: unknown config key {key:?} — supported keys: agents.low, agents.medium, agents.high");
+
+    // agents.* are special-cased because they have programmatic defaults
+    // not stored in config.toml — always return via effective_*() for those.
+    match key {
+        "agents.low" | "agents.medium" | "agents.high" => {
+            let config = crate::config::PlexiConfig::load_with_workspace(
+                crate::config::active_workspace_root().as_deref(),
+            );
+            let agents = config.agents.as_ref();
+            let value = match key {
+                "agents.low" => {
+                    agents.map(|a| a.effective_low()).unwrap_or(crate::config::DEFAULT_AGENT_LOW)
+                }
+                "agents.medium" => {
+                    agents.map(|a| a.effective_medium()).unwrap_or(crate::config::DEFAULT_AGENT_MEDIUM)
+                }
+                _ => agents.map(|a| a.effective_high()).unwrap_or(crate::config::DEFAULT_AGENT_HIGH),
+            };
+            println!("{value}");
+            return 0;
+        }
+        _ => {}
+    }
+
+    // Generic path: load config as a raw TOML value and walk the dot-separated key.
+    // Workspace config (if present) overlays the global config at the TOML level.
+    let global_path = crate::config::config_path();
+    let mut root: toml::Value = match std::fs::read_to_string(&global_path) {
+        Ok(data) => match toml::from_str(&data) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("error: could not parse {}: {e}", global_path.display());
+                return 1;
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => toml::Value::Table(toml::map::Map::new()),
+        Err(e) => {
+            eprintln!("error: could not read {}: {e}", global_path.display());
             return 1;
         }
     };
-    println!("{value}");
+
+    // Overlay workspace config on top if one exists.
+    if let Some(workspace_root) = crate::config::active_workspace_root() {
+        let project_path = workspace_root.join(".plexi").join("config.toml");
+        if let Ok(data) = std::fs::read_to_string(&project_path) {
+            if let Ok(project_val) = toml::from_str::<toml::Value>(&data) {
+                toml_merge(&mut root, project_val);
+            }
+        }
+    }
+
+    // Walk the dot-separated key path.
+    let mut current = &root;
+    for segment in key.split('.') {
+        match current {
+            toml::Value::Table(table) => {
+                match table.get(segment) {
+                    Some(v) => current = v,
+                    None => {
+                        eprintln!(
+                            "error: config key {key:?} not set (no value at {segment:?} in the current config)"
+                        );
+                        return 1;
+                    }
+                }
+            }
+            _ => {
+                eprintln!("error: config key {key:?} not found (path traverses a non-table value)");
+                return 1;
+            }
+        }
+    }
+
+    println!("{}", toml_value_to_string(current));
     0
+}
+
+/// Recursively merge `src` on top of `dst` — table keys in `src` override `dst`;
+/// non-table values replace outright.
+fn toml_merge(dst: &mut toml::Value, src: toml::Value) {
+    match (dst, src) {
+        (toml::Value::Table(dst_table), toml::Value::Table(src_table)) => {
+            for (k, v) in src_table {
+                let entry = dst_table.entry(k).or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+                toml_merge(entry, v);
+            }
+        }
+        (dst, src) => *dst = src,
+    }
+}
+
+/// Format a TOML value as a plain string for CLI output.
+fn toml_value_to_string(v: &toml::Value) -> String {
+    match v {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Integer(i) => i.to_string(),
+        toml::Value::Float(f) => f.to_string(),
+        toml::Value::Boolean(b) => b.to_string(),
+        toml::Value::Datetime(dt) => dt.to_string(),
+        toml::Value::Array(_) | toml::Value::Table(_) => v.to_string(),
+    }
 }
 
 pub fn config_reset() -> i32 {


### PR DESCRIPTION
Closes #1701

## Summary
- Replace hardcoded 3-key match with generic TOML path walker
- `agents.low/medium/high` retain their `effective_*()` programmatic defaults
- All other fields resolved by walking dot-separated segments through the merged global + workspace `config.toml`
- Workspace config overlays global config at the TOML level (same semantics as `load_with_workspace`)
- Helper functions `toml_merge` and `toml_value_to_string` are file-private

## Test plan
- [ ] `plexi config get cli.tips` returns `true` (or user's value)
- [ ] `plexi config get log.level` returns the configured log level
- [ ] `plexi config get ai.backend` returns backend value
- [ ] `plexi config get agents.low` still returns the default agent command
- [ ] `plexi config get font_size` returns font size value
- [ ] Invalid key gives a helpful error naming the missing segment
- [ ] `cargo build` passes