### PR TITLE
fix(cli): routine run uses PLEXI_SOCKET for error feedback (#1702)

### DIFF
--- a/src/cli/routine.rs
+++ b/src/cli/routine.rs
@@ -1,3 +1,4 @@
+use super::open::pane_new_cli;
 use super::run::{ROUTINES_FILE, RoutinesCliConfig};
 
 pub fn routine_list() -> i32 {
@@ -76,27 +77,20 @@ pub fn routine_run(name: &str) -> i32 {
         }
     };
 
-    // Spawn via spawn-queue as a terminal pane
-    let queue_dir = crate::config::config_dir().join("spawn-queue");
-    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
-        eprintln!("error: could not create spawn queue: {e}");
-        return 1;
-    }
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let payload = serde_json::json!({
-        "type_id": "terminal",
-        "args": [routine.command.clone()],
-        "ephemeral": routine.ephemeral,
-        "no_focus": false,
-    });
-    let file = queue_dir.join(format!("{ts}.json"));
-    if let Err(e) = std::fs::write(&file, payload.to_string()) {
-        eprintln!("error: could not write spawn request: {e}");
-        return 1;
-    }
-    println!("queued: run routine '{name}' — command: {}", routine.command);
-    0
+    // Spawn via socket (when inside a Plexi pane) with spawn-queue fallback.
+    // pane_new_cli implements the socket-first pattern used by all other spawn paths.
+    log::info!("cli: routine run '{name}' — dispatching command: {}", routine.command);
+    pane_new_cli(
+        Some(&routine.command),
+        Some(name),
+        "split_h",
+        None,
+        None,
+        routine.ephemeral,
+        false,
+        None,
+        &[],
+        None,
+        &[],
+    )
 }


### PR DESCRIPTION
## Summary

- `plexi routine run` was always writing to the spawn-queue, even when `PLEXI_SOCKET` is set (inside a Plexi pane)
- This meant no error feedback, no pane ID returned, and unnecessary poll latency
- Fix: replace the hand-rolled spawn-queue logic with a call to `pane_new_cli`, which already implements the socket-first + spawn-queue fallback pattern used by `terminal_cli`, `open_cli`, and all other pane-spawning commands
- Inside a pane: returns the pane ID on success, surfaces errors immediately
- Outside a pane: falls back to spawn-queue with the existing `queued:` message

## Test plan

- [ ] Inside a Plexi alpha pane: `plexi routine run <valid-name>` — should print a pane ID and open the terminal
- [ ] Inside a Plexi alpha pane: `plexi routine run nonexistent-routine-name` — should print an error (TOML lookup fails before spawn; name-not-found still caught before queuing)
- [ ] Outside a Plexi pane: `plexi routine run <valid-name>` — should print `queued: open terminal` and queue normally

Closes #1702

🤖 Generated with [Claude Code](https://claude.com/claude-code)