### PR TITLE
feat(cli): inject PLEXI_CONTEXT_ID/NAME/ROOT env vars into spawned panes (#1831)

### DIFF
--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -67,7 +67,9 @@ impl PlexiApp {
         let ctx_id = self.windows[active].context_id;
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
-        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
+        let settings = Self::make_backend_settings(new_id, resolved_cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
         let Some(term) = TerminalPane::new(
             new_id,
             self.ctx.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -749,6 +749,12 @@ impl PlexiApp {
             let ctx_desc_map: std::collections::HashMap<u64, String> = ws.contexts.iter()
                 .filter_map(|c| c.description.as_ref().map(|d| (c.context_id, d.clone())))
                 .collect();
+            let ctx_root_map: std::collections::HashMap<u64, PathBuf> = ws.contexts.iter()
+                .filter_map(|c| c.root.as_ref().map(|r| (c.context_id, r.clone())))
+                .collect();
+            let ctx_depth_map: std::collections::HashMap<u64, u32> = ws.contexts.iter()
+                .map(|c| (c.context_id, c.depth))
+                .collect();
             for saved_win in ws.windows {
                 let mut panes = HashMap::new();
                 for saved_pane in &saved_win.panes {
@@ -843,7 +849,9 @@ impl PlexiApp {
                     if pane_entry.is_none() {
                         let ctx_name = ctx_name_map.get(&saved_win.context_id).cloned().unwrap_or_default();
                         let ctx_desc = ctx_desc_map.get(&saved_win.context_id).cloned().unwrap_or_default();
-                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name, &ctx_desc);
+                        let ctx_root = ctx_root_map.get(&saved_win.context_id);
+                        let ctx_depth = ctx_depth_map.get(&saved_win.context_id).copied().unwrap_or(0);
+                        let settings = Self::make_backend_settings(saved_pane.id, cwd, &colors, saved_win.context_id, &ctx_name, &ctx_desc, ctx_root, ctx_depth);
                         if let Some(mut pane) = TerminalPane::new(
                             saved_pane.id,
                             cc.egui_ctx.clone(),
@@ -1406,8 +1414,13 @@ impl PlexiApp {
         context_id: u64,
         context_name: &str,
         context_description: &str,
+        context_root: Option<&PathBuf>,
+        context_depth: u32,
     ) -> BackendSettings {
-        log::info!("make_backend_settings: pane_id={pane_id} context_id={context_id} context_name={context_name:?}");
+        log::info!(
+            "make_backend_settings: pane_id={pane_id} context_id={context_id} \
+             context_name={context_name:?} context_root={context_root:?} context_depth={context_depth}"
+        );
         let mut env = shell::build_env();
         env.insert("PLEXI_PANE_ID".into(), pane_id.to_string());
         let socket = crate::config::config_dir()
@@ -1418,6 +1431,10 @@ impl PlexiApp {
         env.insert("PLEXI_CONTEXT_ID".into(), context_id.to_string());
         env.insert("PLEXI_CONTEXT_NAME".into(), context_name.to_string());
         env.insert("PLEXI_CONTEXT_DESCRIPTION".into(), context_description.to_string());
+        if let Some(root) = context_root {
+            env.insert("PLEXI_CONTEXT_ROOT".into(), root.to_string_lossy().into_owned());
+        }
+        env.insert("PLEXI_CONTEXT_DEPTH".into(), context_depth.to_string());
         BackendSettings {
             shell: shell::detect_shell(),
             args: vec!["-l".to_string()],
@@ -1439,6 +1456,19 @@ impl PlexiApp {
             .find(|c| c.context_id == context_id)
             .and_then(|c| c.description.clone())
             .unwrap_or_default()
+    }
+
+    pub(crate) fn context_root_for(&self, context_id: u64) -> Option<PathBuf> {
+        self.router.iter()
+            .find(|c| c.context_id == context_id)
+            .and_then(|c| c.root.clone())
+    }
+
+    pub(crate) fn context_depth_for(&self, context_id: u64) -> u32 {
+        self.router.iter()
+            .find(|c| c.context_id == context_id)
+            .map(|c| c.depth)
+            .unwrap_or(0)
     }
 }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -574,7 +574,9 @@ impl PlexiApp {
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
         if let Some(cmd) = initial_cmd {
             log::info!("create_single_pane_tree: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -617,12 +619,14 @@ impl PlexiApp {
         let ctx_id = self.windows[win_idx].context_id;
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
         let cwd = cwd_override.or_else(|| self.windows[win_idx].get_focused_pane_cwd(target_tile));
         log::info!(
             "spawn_terminal_pane_at: win_idx={win_idx} target_tile={target_tile:?} new_id={new_id} \
              vertical={vertical} keep_focus={keep_focus} initial_cmd={initial_cmd:?}"
         );
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
         if let Some(cmd) = initial_cmd {
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
         }
@@ -1175,7 +1179,9 @@ impl PlexiApp {
         let ctx_id = self.windows.get(active).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
 
         super::apply_initial_cmd(&mut settings, cmd, !stay_alive);
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -260,7 +260,9 @@ impl PlexiApp {
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
         if let Some(cmd) = initial_cmd {
             log::info!("split_focused: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -353,9 +355,11 @@ impl PlexiApp {
             let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
             let ctx_name = self.context_name_for(ctx_id);
             let ctx_desc = self.context_description_for(ctx_id);
+            let ctx_root = self.context_root_for(ctx_id);
+            let ctx_depth = self.context_depth_for(ctx_id);
             let cwd = self.cwd_for_welcome_tab();
             log::info!("new_tab (empty context): cwd={cwd:?} context_root={:?}", self.router.active().root);
-            let mut settings = Self::make_backend_settings(new_id, Some(cwd), &self.colors, ctx_id, &ctx_name, &ctx_desc);
+            let mut settings = Self::make_backend_settings(new_id, Some(cwd), &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
             if let Some(cmd) = initial_cmd {
                 log::info!("new_tab (empty context): initial_cmd={cmd:?} close_on_exit={close_on_exit}");
                 super::apply_initial_cmd(&mut settings, cmd, close_on_exit);
@@ -393,7 +397,9 @@ impl PlexiApp {
         let ctx_id = self.windows.get(self.active_window).map(|w| w.context_id).unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
-        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc);
+        let ctx_root = self.context_root_for(ctx_id);
+        let ctx_depth = self.context_depth_for(ctx_id);
+        let mut settings = Self::make_backend_settings(new_id, cwd, &self.colors, ctx_id, &ctx_name, &ctx_desc, ctx_root.as_ref(), ctx_depth);
         if let Some(cmd) = initial_cmd {
             log::info!("new_tab: initial_cmd={cmd:?} close_on_exit={close_on_exit}");
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);


### PR DESCRIPTION
## Summary
- Injects `PLEXI_CONTEXT_ROOT` (from `Context.root`) and `PLEXI_CONTEXT_DEPTH` into all spawned pane environments alongside the existing `PLEXI_CONTEXT_ID`, `PLEXI_CONTEXT_NAME`, and `PLEXI_CONTEXT_DESCRIPTION` vars
- Adds `context_root_for()` and `context_depth_for()` helper methods on `App`, mirroring the existing `context_name_for()` pattern
- Updates `make_backend_settings()` to accept the new params; propagates through all 8 call sites (canvas_bindings, pane_ops/create ×3, pane_ops/layout ×3, workspace restore path)
- Workspace restore builds `ctx_root_map` and `ctx_depth_map` so panes reopened at startup also receive correct context env vars
- `info!()` log at spawn confirms injected `context_root` and `depth` values

## Test plan
- [ ] Open a terminal inside a named context with a root set — `env | grep PLEXI_CONTEXT` shows `PLEXI_CONTEXT_ID`, `PLEXI_CONTEXT_NAME`, `PLEXI_CONTEXT_ROOT`, `PLEXI_CONTEXT_DEPTH`
- [ ] Open a terminal in a sub-context — `PLEXI_CONTEXT_DEPTH` is > 0
- [ ] Open a terminal in a context with no root set — `PLEXI_CONTEXT_ROOT` absent from env, `PLEXI_CONTEXT_DEPTH=0`
- [ ] Restart Plexi with saved workspace — restored panes also have correct context vars
- [ ] `cargo test --bin plexi` green

Closes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)