### PR TITLE
feat(host): send pane in direction — Ctrl+Opt+Cmd+HJKL (#1710)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2462,6 +2462,42 @@ impl eframe::App for PlexiApp {
                         crate::pane_ops::SwapResult::NoFocus => {}
                     }
                 }
+                Action::SendPane(dir) => {
+                    match self.send_pane(dir) {
+                        crate::pane_ops::SwapResult::Swapped {
+                            rect_a, rect_b, ..
+                        } => {
+                            let now = std::time::Instant::now();
+                            self.pane_anims = vec![
+                                PaneSwapAnim { from: rect_a, to: rect_b, started_at: now },
+                                PaneSwapAnim { from: rect_b, to: rect_a, started_at: now },
+                            ];
+                            self.ctx.request_repaint();
+                        }
+                        crate::pane_ops::SwapResult::AtBoundary => {
+                            // For U/D at boundary: edge-pulse only (no row-boundary move).
+                            // For L/R at boundary: try cross-window send (focus stays on source).
+                            let moved = match dir {
+                                crate::host::keys::Direction::Down
+                                | crate::host::keys::Direction::Up => false,
+                                _ => self.send_pane_to_adjacent_window(dir),
+                            };
+                            if moved {
+                                self.ctx.request_repaint();
+                            } else if let Some(focused) =
+                                self.windows[self.active_window].focused_pane
+                            {
+                                self.edge_pulse = Some(EdgePulse {
+                                    tile: focused,
+                                    dir,
+                                    started_at: std::time::Instant::now(),
+                                });
+                                self.ctx.request_repaint();
+                            }
+                        }
+                        crate::pane_ops::SwapResult::NoFocus => {}
+                    }
+                }
                 Action::ClosePane => {
                     // If the focused app pane has a non-empty nav stack
                     // (via PushNav), Escape routes NavBack to the app

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -60,7 +60,9 @@ const KNOWN_AI_OLLAMA: &[&str] = &["host", "model_low", "model_medium", "model_h
 const KNOWN_KEYBINDINGS: &[&str] = &[
     "quit", "close_pane", "toggle_command_palette", "split_horizontal",
     "split_vertical", "split_right", "split_down", "swap_pane_left",
-    "swap_pane_down", "swap_pane_up", "swap_pane_right", "navigate_left",
+    "swap_pane_down", "swap_pane_up", "swap_pane_right",
+    "send_pane_left", "send_pane_down", "send_pane_up", "send_pane_right",
+    "navigate_left",
     "navigate_down", "navigate_up", "navigate_right", "new_tab", "next_tab",
     "prev_tab", "first_tab", "last_tab", "nav_back", "focus_history_forward",
     "toggle_sidebar", "toggle_zoom", "toggle_shortcuts", "rename_context",
@@ -184,6 +186,10 @@ pub struct KeybindingsConfig {
     pub swap_pane_down: Option<String>,
     pub swap_pane_up: Option<String>,
     pub swap_pane_right: Option<String>,
+    pub send_pane_left: Option<String>,
+    pub send_pane_down: Option<String>,
+    pub send_pane_up: Option<String>,
+    pub send_pane_right: Option<String>,
     pub navigate_left: Option<String>,
     pub navigate_down: Option<String>,
     pub navigate_up: Option<String>,
@@ -242,6 +248,10 @@ impl KeybindingsConfig {
         overlay_field!(swap_pane_down);
         overlay_field!(swap_pane_up);
         overlay_field!(swap_pane_right);
+        overlay_field!(send_pane_left);
+        overlay_field!(send_pane_down);
+        overlay_field!(send_pane_up);
+        overlay_field!(send_pane_right);
         overlay_field!(navigate_left);
         overlay_field!(navigate_down);
         overlay_field!(navigate_up);

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -9,7 +9,8 @@ use crate::config::KeybindingsConfig;
 // Cmd+Shift+N                 — new context (sidebar item)
 // Cmd+W                       — close pane
 // Cmd+H/J/K/L                 — navigate panes (falls through to adjacent window at boundary)
-// Cmd+Ctrl+H/J/K/L            — swap focused pane with neighbor in direction
+// Cmd+Ctrl+H/J/K/L            — swap focused pane with neighbor in direction (focus follows)
+// Cmd+Ctrl+Opt+H/J/K/L        — send focused pane in direction (focus stays)
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
 // Cmd+Shift+L/H               — next/prev tab
@@ -118,6 +119,10 @@ pub enum Action {
     /// Swap the focused pane with its neighbor in the given direction.
     /// Bound to Cmd+Ctrl+H/J/K/L.
     SwapPane(Direction),
+    /// Send the focused pane in a direction without following focus.
+    /// Focus stays at the vacated tile (on whatever pane fills that slot).
+    /// Bound to Cmd+Ctrl+Opt+H/J/K/L.
+    SendPane(Direction),
     /// Open the scratchpad overlay. Bound to Cmd+Shift+Space.
     OpenScratchpad,
     /// Push the focused pane into a new sub-context. The pane becomes a portal
@@ -151,6 +156,10 @@ pub struct KeyBindings {
     pub swap_pane_down: (egui::Modifiers, egui::Key),
     pub swap_pane_up: (egui::Modifiers, egui::Key),
     pub swap_pane_right: (egui::Modifiers, egui::Key),
+    pub send_pane_left: (egui::Modifiers, egui::Key),
+    pub send_pane_down: (egui::Modifiers, egui::Key),
+    pub send_pane_up: (egui::Modifiers, egui::Key),
+    pub send_pane_right: (egui::Modifiers, egui::Key),
     pub navigate_left: (egui::Modifiers, egui::Key),
     pub navigate_down: (egui::Modifiers, egui::Key),
     pub navigate_up: (egui::Modifiers, egui::Key),
@@ -203,6 +212,9 @@ fn cmd_alt() -> egui::Modifiers {
 fn cmd_shift_alt() -> egui::Modifiers {
     egui::Modifiers { shift: true, alt: true, ..egui::Modifiers::COMMAND }
 }
+fn cmd_ctrl_alt() -> egui::Modifiers {
+    egui::Modifiers { ctrl: true, alt: true, ..egui::Modifiers::COMMAND }
+}
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {
@@ -213,10 +225,14 @@ impl Default for KeyBindings {
             split_vertical:            (cmd_shift(), egui::Key::D),
             split_right:               (cmd(),       egui::Key::Backslash),
             split_down:                (cmd_shift(), egui::Key::Backslash),
-            swap_pane_left:            (cmd_ctrl(),  egui::Key::H),
-            swap_pane_down:            (cmd_ctrl(),  egui::Key::J),
-            swap_pane_up:              (cmd_ctrl(),  egui::Key::K),
-            swap_pane_right:           (cmd_ctrl(),  egui::Key::L),
+            swap_pane_left:            (cmd_ctrl(),     egui::Key::H),
+            swap_pane_down:            (cmd_ctrl(),     egui::Key::J),
+            swap_pane_up:              (cmd_ctrl(),     egui::Key::K),
+            swap_pane_right:           (cmd_ctrl(),     egui::Key::L),
+            send_pane_left:            (cmd_ctrl_alt(), egui::Key::H),
+            send_pane_down:            (cmd_ctrl_alt(), egui::Key::J),
+            send_pane_up:              (cmd_ctrl_alt(), egui::Key::K),
+            send_pane_right:           (cmd_ctrl_alt(), egui::Key::L),
             navigate_left:             (cmd(),       egui::Key::H),
             navigate_down:             (cmd(),       egui::Key::J),
             navigate_up:               (cmd(),       egui::Key::K),
@@ -371,6 +387,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(swap_pane_down, "swap_pane_down");
     apply_override!(swap_pane_up, "swap_pane_up");
     apply_override!(swap_pane_right, "swap_pane_right");
+    apply_override!(send_pane_left, "send_pane_left");
+    apply_override!(send_pane_down, "send_pane_down");
+    apply_override!(send_pane_up, "send_pane_up");
+    apply_override!(send_pane_right, "send_pane_right");
     apply_override!(navigate_left, "navigate_left");
     apply_override!(navigate_down, "navigate_down");
     apply_override!(navigate_up, "navigate_up");
@@ -421,6 +441,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("swap_pane_down",            bindings.swap_pane_down),
         ("swap_pane_up",              bindings.swap_pane_up),
         ("swap_pane_right",           bindings.swap_pane_right),
+        ("send_pane_left",            bindings.send_pane_left),
+        ("send_pane_down",            bindings.send_pane_down),
+        ("send_pane_up",              bindings.send_pane_up),
+        ("send_pane_right",           bindings.send_pane_right),
         ("navigate_left",             bindings.navigate_left),
         ("navigate_down",             bindings.navigate_down),
         ("navigate_up",               bindings.navigate_up),
@@ -529,10 +553,14 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         // ── Normal bindings (suppressed when overlay/capture active) ─────────
         BindingEntry { modifiers: b.split_vertical.0,           key: b.split_vertical.1,           exact: false, context: BindingContext::Normal, action: Action::SplitVertical },
         BindingEntry { modifiers: b.split_horizontal.0,         key: b.split_horizontal.1,         exact: true,  context: BindingContext::Normal, action: Action::SplitHorizontal },
-        BindingEntry { modifiers: b.swap_pane_left.0,           key: b.swap_pane_left.1,           exact: false, context: BindingContext::Normal, action: Action::SwapPane(Direction::Left) },
-        BindingEntry { modifiers: b.swap_pane_down.0,           key: b.swap_pane_down.1,           exact: false, context: BindingContext::Normal, action: Action::SwapPane(Direction::Down) },
-        BindingEntry { modifiers: b.swap_pane_up.0,             key: b.swap_pane_up.1,             exact: false, context: BindingContext::Normal, action: Action::SwapPane(Direction::Up) },
-        BindingEntry { modifiers: b.swap_pane_right.0,          key: b.swap_pane_right.1,          exact: false, context: BindingContext::Normal, action: Action::SwapPane(Direction::Right) },
+        BindingEntry { modifiers: b.swap_pane_left.0,           key: b.swap_pane_left.1,           exact: true,  context: BindingContext::Normal, action: Action::SwapPane(Direction::Left) },
+        BindingEntry { modifiers: b.swap_pane_down.0,           key: b.swap_pane_down.1,           exact: true,  context: BindingContext::Normal, action: Action::SwapPane(Direction::Down) },
+        BindingEntry { modifiers: b.swap_pane_up.0,             key: b.swap_pane_up.1,             exact: true,  context: BindingContext::Normal, action: Action::SwapPane(Direction::Up) },
+        BindingEntry { modifiers: b.swap_pane_right.0,          key: b.swap_pane_right.1,          exact: true,  context: BindingContext::Normal, action: Action::SwapPane(Direction::Right) },
+        BindingEntry { modifiers: b.send_pane_left.0,           key: b.send_pane_left.1,           exact: false, context: BindingContext::Normal, action: Action::SendPane(Direction::Left) },
+        BindingEntry { modifiers: b.send_pane_down.0,           key: b.send_pane_down.1,           exact: false, context: BindingContext::Normal, action: Action::SendPane(Direction::Down) },
+        BindingEntry { modifiers: b.send_pane_up.0,             key: b.send_pane_up.1,             exact: false, context: BindingContext::Normal, action: Action::SendPane(Direction::Up) },
+        BindingEntry { modifiers: b.send_pane_right.0,          key: b.send_pane_right.1,          exact: false, context: BindingContext::Normal, action: Action::SendPane(Direction::Right) },
         BindingEntry { modifiers: b.new_tab.0,                  key: b.new_tab.1,                  exact: false, context: BindingContext::Normal, action: Action::NewTab },
         BindingEntry { modifiers: b.next_tab.0,                 key: b.next_tab.1,                 exact: false, context: BindingContext::Normal, action: Action::NextTab },
         BindingEntry { modifiers: b.prev_tab.0,                 key: b.prev_tab.1,                 exact: false, context: BindingContext::Normal, action: Action::PrevTab },

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -153,6 +153,32 @@ impl PlexiApp {
                                             .color(colors.text_dim),
                                     );
                                     ui.end_row();
+
+                                    crate::ui::widgets::key_combo_list(
+                                        ui,
+                                        &[&["\u{2318}", "\u{2303}", "H", "J", "K", "L"]],
+                                        None,
+                                        colors,
+                                    );
+                                    ui.label(
+                                        RichText::new("Swap pane (focus follows)")
+                                            .size(style::TEXT_HINT)
+                                            .color(colors.text_dim),
+                                    );
+                                    ui.end_row();
+
+                                    crate::ui::widgets::key_combo_list(
+                                        ui,
+                                        &[&["\u{2318}", "\u{2303}", "\u{2325}", "H", "J", "K", "L"]],
+                                        None,
+                                        colors,
+                                    );
+                                    ui.label(
+                                        RichText::new("Send pane (focus stays)")
+                                            .size(style::TEXT_HINT)
+                                            .color(colors.text_dim),
+                                    );
+                                    ui.end_row();
                                 });
                         });
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -880,6 +880,113 @@ impl PlexiApp {
         SwapResult::Swapped { rect_a, rect_b }
     }
 
+    /// Send the focused pane in `dir` without following focus.
+    ///
+    /// Within-window: swaps tile contents like `swap_pane` but keeps focus on
+    /// the **original tile** — the neighbor's pane ends up under the cursor.
+    ///
+    /// At boundary (no neighbor within this window):
+    /// - L/R: delegates to `send_pane_to_adjacent_window` — pane moves to the
+    ///   adjacent grid window; focus stays on whatever pane remains in the source
+    ///   window. If the source becomes empty, returns `AtBoundary` (edge-pulse).
+    /// - U/D: always returns `AtBoundary` (edge-pulse only; no row-boundary move).
+    pub(crate) fn send_pane(&mut self, dir: Direction) -> SwapResult {
+        use egui_tiles::Tile;
+        let active = self.active_window;
+        let ctx = &mut self.windows[active];
+
+        let Some(focused) = ctx.focused_pane else {
+            return SwapResult::NoFocus;
+        };
+
+        let Some(neighbor) = ctx.find_pane_in_direction_from(focused, dir) else {
+            log::info!("send_pane({:?}): at boundary within window", dir);
+            // For L/R, try cross-window send. For U/D, edge-pulse.
+            return SwapResult::AtBoundary;
+        };
+
+        let rect_a = ctx.tree.tiles.rect(focused).unwrap_or(egui::Rect::ZERO);
+        let rect_b = ctx.tree.tiles.rect(neighbor).unwrap_or(egui::Rect::ZERO);
+
+        let pane_a = match ctx.tree.tiles.get(focused) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+        let pane_b = match ctx.tree.tiles.get(neighbor) {
+            Some(Tile::Pane(id)) => *id,
+            _ => return SwapResult::NoFocus,
+        };
+
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(focused) {
+            *id = pane_b;
+        }
+        if let Some(Tile::Pane(id)) = ctx.tree.tiles.get_mut(neighbor) {
+            *id = pane_a;
+        }
+
+        // Focus stays on the original tile (now containing pane_b).
+        // focused_pane is unchanged — it already points at `focused`.
+
+        log::info!(
+            "send_pane({:?}): pane {} ↔ pane {} (tiles {:?} ↔ {:?}), focus stays at {:?}",
+            dir, pane_a, pane_b, focused, neighbor, focused
+        );
+
+        SwapResult::Swapped { rect_a, rect_b }
+    }
+
+    /// Move the focused pane to an adjacent grid window without following focus.
+    ///
+    /// Unlike `move_focused_pane_to_adjacent_window`, the active window stays
+    /// on the source and focus stays on whatever pane fills the vacated slot.
+    ///
+    /// Returns `true` if the pane was moved (source still has panes remaining),
+    /// `false` if there is no adjacent window or the source would become empty
+    /// (caller shows the edge pulse for both cases).
+    pub(crate) fn send_pane_to_adjacent_window(&mut self, dir: Direction) -> bool {
+        let src_idx = self.active_window;
+
+        // Peek: does the source window have more than one pane?
+        // If it has only one pane, moving it out empties the source — no pane
+        // to stay focused on, so we edge-pulse instead.
+        if self.windows[src_idx].panes.len() <= 1 {
+            log::info!(
+                "send_pane_to_adjacent_window({:?}): source would become empty — edge pulse",
+                dir
+            );
+            return false;
+        }
+
+        // Determine next_src_focus before calling move_focused_pane_to_adjacent_window
+        // (the function sets it internally, but we need active_window to remain src_idx).
+        let focused_tile = match self.windows[src_idx].focused_pane {
+            Some(t) => t,
+            None => return false,
+        };
+        let next_src_focus = self.windows[src_idx].find_next_focus(focused_tile);
+
+        // Delegate the actual move (this sets active_window = adj_idx).
+        let moved = self.move_focused_pane_to_adjacent_window(dir);
+        if !moved {
+            return false;
+        }
+
+        // Restore active window to source (which survived since it had >1 pane).
+        // find the source by its previously known index — it may have shifted if adj
+        // was deleted, but since source had >1 pane it was never deleted.
+        self.active_window = src_idx;
+
+        // Restore focus to the pane that filled the vacated slot in the source.
+        self.windows[src_idx].focused_pane = next_src_focus;
+
+        log::info!(
+            "send_pane_to_adjacent_window({:?}): pane sent, focus stays at source window",
+            dir
+        );
+
+        true
+    }
+
     /// Move the focused pane to the first (`end=false`, Cmd+Ctrl+K) or last
     /// (`end=true`, Cmd+Ctrl+J) column position in the current context row by
     /// creating a new window at that boundary. Returns `true` if the move
@@ -1604,6 +1711,33 @@ mod swap_tests {
         // No neighbors (rects unset = Rect::ZERO, geometric search returns None)
         assert!(matches!(app.swap_pane(Direction::Right), SwapResult::AtBoundary));
     }
+}
+
+#[cfg(test)]
+mod send_pane_tests {
+    use super::*;
+
+    fn test_app() -> PlexiApp {
+        let ctx = egui::Context::default();
+        let ft = crate::platform::logging::new_frame_tick();
+        PlexiApp::new_for_test(ctx, ft).0
+    }
+
+    #[test]
+    fn send_pane_no_focus_returns_no_focus() {
+        let mut app = test_app();
+        assert!(matches!(app.send_pane(Direction::Right), SwapResult::NoFocus));
+    }
+
+    #[test]
+    fn send_pane_at_boundary_with_single_pane() {
+        let mut app = test_app();
+        let tile = app.windows[0].tree.tiles.insert_pane(1u64);
+        app.windows[0].focused_pane = Some(tile);
+        // No neighbors (rects unset = Rect::ZERO, geometric search returns None)
+        assert!(matches!(app.send_pane(Direction::Right), SwapResult::AtBoundary));
+    }
+
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `SendPane(Direction)` action bound to `Cmd+Ctrl+Opt+H/J/K/L`
- Unlike `SwapPane`, focus stays at the vacated tile after the move — the pane that fills the slot gets focus
- Cross-window L/R send: pane moves to adjacent grid window; source window focus stays (edge-pulse if source would become empty)
- U/D at boundary: edge-pulse only (no row-boundary move, per issue spec)
- Shortcuts overlay updated to show both swap and send bindings

## Test plan

- [ ] Split a window: `Cmd+D` to create 3 panes side-by-side
- [ ] Focus the middle pane
- [ ] Press `Cmd+Ctrl+Opt+L` — middle pane moves right; focus stays on the tile that now holds the right pane's content
- [ ] Press `Cmd+Ctrl+Opt+H` — confirm symmetric behavior
- [ ] Press `Cmd+Ctrl+Opt+J` at boundary — edge-pulse, no cross-window move
- [ ] `Cmd+N` to create a second window, focus source window, press `Cmd+Ctrl+Opt+L` with 2+ panes — pane moves to adjacent window, focus stays on source
- [ ] With single pane in source window: `Cmd+Ctrl+Opt+L` toward adjacent window — edge-pulse (source would become empty)
- [ ] `Cmd+/` to open shortcuts overlay — verify swap and send both appear in NAVIGATION section
- [ ] `SwapPane` (Cmd+Ctrl+HJKL) behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)