### PR TITLE
fix(host/context): delete empty portal window after delete_context (#2029)

### DIFF
--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -557,3 +557,109 @@ fn new_context_creates_top_level_empty_context() {
         "inline rename opened for new context"
     );
 }
+
+/// Issue #2029: closing a sub-context portal that is the sole pane on a window must
+/// delete that window. Previously the window survived empty, showing the welcome screen.
+#[test]
+fn delete_context_collapses_empty_portal_window() {
+    use std::collections::HashMap;
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    // Window 0 already exists (the initial window for the root context).
+    let root_id = app.router.active().context_id;
+    let (root_tile, _root_pane_id) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(root_tile);
+
+    // Add a second window to the root context (simulates a two-page layout).
+    let win2_id = 77701u64;
+    {
+        let mut tiles = egui_tiles::Tiles::default();
+        // Intentionally no real pane tile yet — the portal will be inserted below.
+        let placeholder = tiles.insert_pane(77702u64);
+        app.windows.push(Window {
+            name: String::new(),
+            path: std::path::PathBuf::from("/tmp/test_2029"),
+            tree: egui_tiles::Tree::new("test_2029_win2", placeholder, tiles),
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 1,
+            grid_y: 0,
+            window_id: win2_id,
+            context_id: root_id,
+        });
+    }
+
+    // Register a child context (no PTY needed — manual insertion).
+    let child_id = 77710u64;
+    let child_win_id = 77711u64;
+    app.router.push(crate::host::context::Context {
+        name: "Child2029".to_string(),
+        path: std::path::PathBuf::from("/tmp/test_2029_child"),
+        root: None,
+        description: None,
+        context_id: child_id,
+        parent_id: Some(root_id),
+        depth: 1,
+        parked: false,
+    });
+    app.context_active_window.insert(child_id, child_win_id);
+    {
+        let mut tiles = egui_tiles::Tiles::default();
+        let r = tiles.insert_pane(77712u64);
+        app.windows.push(Window {
+            name: String::new(),
+            path: std::path::PathBuf::from("/tmp/test_2029_child"),
+            tree: egui_tiles::Tree::new("test_2029_child", r, tiles),
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: child_win_id,
+            context_id: child_id,
+        });
+    }
+
+    // Insert a Portal pane into window 1 (the second root window) as its ONLY pane.
+    let portal_pane_id = 77720u64;
+    {
+        // Replace the placeholder pane map entry with the portal.
+        let win2 = app.windows.iter_mut().find(|w| w.window_id == win2_id).unwrap();
+        // Clear the placeholder from the pane map (tree already has the tile; pane map is separate).
+        // Insert the portal pane.
+        let portal_tile = win2.tree.tiles.insert_pane(portal_pane_id);
+        win2.tree.root = Some(portal_tile);
+        win2.panes.clear();
+        win2.panes.insert(
+            portal_pane_id,
+            crate::host::pane::Pane::Portal(Box::new(crate::host::pane::PortalPane {
+                pane_id: portal_pane_id,
+                target_context_id: child_id,
+                context_state: None,
+                hidden: false,
+            })),
+        );
+        win2.focused_pane = Some(portal_tile);
+    }
+
+    // Preconditions.
+    assert_eq!(app.windows.iter().filter(|w| w.context_id == root_id).count(), 2,
+        "setup: root context has 2 windows");
+
+    // Delete the child context (removes the portal from win2, leaving it empty).
+    let child_idx = app.router.position(|c| c.context_id == child_id).unwrap();
+    app.delete_context(child_idx);
+
+    // win2 must be gone — root context now has exactly 1 window.
+    let root_windows: Vec<_> = app.windows.iter().filter(|w| w.context_id == root_id).collect();
+    assert_eq!(root_windows.len(), 1,
+        "empty portal window must be deleted after delete_context");
+
+    // The surviving window still has its pane.
+    assert!(root_windows[0].panes.contains_key(&_root_pane_id),
+        "original root pane must survive");
+}

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -663,3 +663,99 @@ fn delete_context_collapses_empty_portal_window() {
     assert!(root_windows[0].panes.contains_key(&_root_pane_id),
         "original root pane must survive");
 }
+
+/// Issue #2029 (edge case): when ALL windows in a context each contain only a portal
+/// to the deleted child, none has a non-empty sibling — so ALL must be preserved.
+/// Deleting all of them would strip the context of every window, violating the invariant.
+#[test]
+fn delete_context_keeps_all_empty_windows_when_no_nonempty_sibling() {
+    use std::collections::HashMap;
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    // Window 0 already exists for root_id but has NO real pane — it will also be empty after portal removal.
+    // Add window 1 to root_id; both will have only a portal pane.
+    let win2_id = 88801u64;
+    {
+        let mut tiles = egui_tiles::Tiles::default();
+        let placeholder = tiles.insert_pane(88802u64);
+        app.windows.push(Window {
+            name: String::new(),
+            path: std::path::PathBuf::from("/tmp/test_2029_edge"),
+            tree: egui_tiles::Tree::new("test_2029_edge_win2", placeholder, tiles),
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 1,
+            grid_y: 0,
+            window_id: win2_id,
+            context_id: root_id,
+        });
+    }
+
+    // Child context.
+    let child_id = 88810u64;
+    let child_win_id = 88811u64;
+    app.router.push(crate::host::context::Context {
+        name: "ChildEdge".to_string(),
+        path: std::path::PathBuf::from("/tmp/test_2029_edge_child"),
+        root: None,
+        description: None,
+        context_id: child_id,
+        parent_id: Some(root_id),
+        depth: 1,
+        parked: false,
+    });
+    app.context_active_window.insert(child_id, child_win_id);
+    {
+        let mut tiles = egui_tiles::Tiles::default();
+        let r = tiles.insert_pane(88812u64);
+        app.windows.push(Window {
+            name: String::new(),
+            path: std::path::PathBuf::from("/tmp/test_2029_edge_child"),
+            tree: egui_tiles::Tree::new("test_2029_edge_child", r, tiles),
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: child_win_id,
+            context_id: child_id,
+        });
+    }
+
+    // Insert a portal into window 0 (initially has no panes) and window 1 — both portal-only.
+    for (win_id, portal_pane_id) in [(app.windows[0].window_id, 88820u64), (win2_id, 88821u64)] {
+        let win = app.windows.iter_mut().find(|w| w.window_id == win_id).unwrap();
+        let portal_tile = win.tree.tiles.insert_pane(portal_pane_id);
+        win.tree.root = Some(portal_tile);
+        win.panes.clear();
+        win.panes.insert(
+            portal_pane_id,
+            crate::host::pane::Pane::Portal(Box::new(crate::host::pane::PortalPane {
+                pane_id: portal_pane_id,
+                target_context_id: child_id,
+                context_state: None,
+                hidden: false,
+            })),
+        );
+    }
+
+    assert_eq!(app.windows.iter().filter(|w| w.context_id == root_id).count(), 2,
+        "setup: 2 windows in root context, both portal-only");
+
+    let child_idx = app.router.position(|c| c.context_id == child_id).unwrap();
+    app.delete_context(child_idx);
+
+    // Both windows became empty but neither had a non-empty sibling — both must survive.
+    // The root context must still have windows (invariant: context always has >= 1 window).
+    let root_windows = app.windows.iter().filter(|w| w.context_id == root_id).count();
+    assert!(root_windows >= 1,
+        "root context must retain at least 1 window; got {root_windows}");
+    // Specifically: neither empty window had a non-empty sibling, so both are kept.
+    assert_eq!(root_windows, 2,
+        "both portal-only windows must survive when no non-empty sibling exists");
+}

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -549,11 +549,12 @@ impl PlexiApp {
         }
 
         // 4b. Delete surviving windows that are now empty (portal was their only pane),
-        //     but only if another window exists for the same context (sole-page guard).
+        //     but only if a non-empty sibling window exists for the same context. This
+        //     preserves the invariant that every context retains at least one window.
         {
             let mut empty_indices: Vec<usize> = self.windows.iter().enumerate()
                 .filter(|(_, w)| w.panes.is_empty())
-                .filter(|(_, w)| self.windows.iter().filter(|o| o.context_id == w.context_id).count() > 1)
+                .filter(|(_, w)| self.windows.iter().any(|o| o.context_id == w.context_id && !o.panes.is_empty()))
                 .map(|(i, _)| i)
                 .collect();
             empty_indices.sort_unstable_by(|a, b| b.cmp(a)); // reverse order

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -548,7 +548,24 @@ impl PlexiApp {
             }
         }
 
-        // 4b. Reset any focused_pane that now points to a removed Portal tile.
+        // 4b. Delete surviving windows that are now empty (portal was their only pane),
+        //     but only if another window exists for the same context (sole-page guard).
+        {
+            let mut empty_indices: Vec<usize> = self.windows.iter().enumerate()
+                .filter(|(_, w)| w.panes.is_empty())
+                .filter(|(_, w)| self.windows.iter().filter(|o| o.context_id == w.context_id).count() > 1)
+                .map(|(i, _)| i)
+                .collect();
+            empty_indices.sort_unstable_by(|a, b| b.cmp(a)); // reverse order
+            for idx in empty_indices {
+                log::info!(
+                    "delete_context: window idx={idx} is empty after portal removal — deleting it",
+                );
+                self.delete_window(idx);
+            }
+        }
+
+        // 4c. Reset any focused_pane that now points to a removed Portal tile.
         for win in &mut self.windows {
             if let Some(fp) = win.focused_pane {
                 if win.tree.tiles.get(fp).is_none() {


### PR DESCRIPTION
Closes #2029

## Summary

- After `delete_context` removes portal tiles from surviving windows, any window that is now empty and has at least one sibling in the same context is deleted via `delete_window` (reverse-index order to avoid index shifting)
- The sole-page guard from `close_pane_by_id` is mirrored: a window that is the only window for its context is kept alive (welcome screen is correct for a context with no panes)
- Adds regression test `delete_context_collapses_empty_portal_window` covering the two-window case

## Done When

- `cargo test --bin plexi` is green with the new test passing
- Manually: closing a sub-context portal that is the sole pane on a non-sole window deletes the window; user returns to remaining windows without a welcome screen appearing

## Notes

Fix is a single loop in `delete_context` (step 4b) — no changes to `close_pane_by_id` or confirmation overlay needed.