### PR TITLE
fix(sdk): update capabilities list on capability_decision grant (#1659)

### DIFF
--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -754,6 +754,10 @@ class App:
                     q = self._pending_capability.pop(req_id, None)
                     if q:
                         q.put_nowait(granted)
+                    if granted:
+                        cap = ev.get("capability", "")
+                        if cap and cap not in self.capabilities:
+                            self.capabilities.append(cap)
 
                 elif t == "secret_value":
                     key = ev.get("key", "")


### PR DESCRIPTION
Closes #1659

## Summary

- **Bug 1 (SDK):** In `_app.py`, the `capability_decision` handler now appends the granted capability to `self.capabilities` so that `load_image` (and any other client-side capability guard) sees runtime grants instead of the stale Init snapshot. Without this, `load_image` always raised `net.http capability not declared in manifest` even after consent was granted.
- **Bug 2 (bluesky stutter):** The `apps/dev/bluesky` app was archived in commit `52feeb64` before this branch was cut — it no longer exists in `origin/alpha`. The serial `measure_text_wrapped` loop fix is moot with no app to apply it to. The SDK fix is the high-value change and benefits every app using `capability_request` + `load_image`.