### PR TITLE
fix(install): add guardrails to prevent silent path errors in install.sh

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -4,6 +4,16 @@
 
 ---
 
+## [cargo · ship] Changing target-dir causes silent install failures
+
+All repo worktrees share a single build cache via `[build] target-dir` in `.cargo/config.toml` (or `CARGO_TARGET_DIR`). `scripts/install.sh` resolves the bundle path by calling `cargo metadata` at install time so it always points at the canonical target directory.
+
+**If you change the target-dir setting, install.sh automatically adapts.** But if `cargo metadata` fails (Python 3 missing, not in a cargo workspace, etc.), the script now exits immediately with a clear error rather than falling back to `"target"` and silently installing nothing.
+
+**Root cause of original failure (d21a8d0f):** the script previously hardcoded `"target"` as a fallback, so when the actual target dir was different (e.g. a shared sibling path), `cargo bundle` built to the real location but the copy step silently found nothing and exited 0. Fixed by: (a) making the metadata lookup non-optional (empty result = immediate failure), and (b) naming the exact path in the bundle-not-found error so engineers can diff expected vs. actual.
+
+---
+
 ## [git · ship] Unpushed alpha commits are silently lost when ship-issue agents rebase
 
 `ship-issue` runs `git pull --rebase origin alpha` at Phase 1. If there are commits on the local alpha branch that haven't been pushed to origin, the rebase replays them on top of origin's HEAD — but if those commits touch files that were also changed by merged PRs (e.g. skill files, CLAUDE.md), they will conflict and be silently dropped or overwritten.

--- a/justfile
+++ b/justfile
@@ -116,6 +116,22 @@ sdk-dev:
 # Always cleans the previous PR build first for a fully fresh install.
 # Alias for: just channel-install pr-<number>
 pr-install number: fetch-python-runtime
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Preflight: confirm we're running from a valid repo worktree with Cargo.toml present.
+    if [[ ! -f "Cargo.toml" ]] || ! grep -q 'name = "plexi"' Cargo.toml 2>/dev/null; then
+      echo "Error: pr-install must be run from inside the PLEXI repo root or a worktree."
+      echo "  Current directory: $(pwd)"
+      echo "  Expected a Cargo.toml with name = \"plexi\"."
+      exit 1
+    fi
+    # Preflight: confirm cargo metadata resolves a target-dir before starting a build.
+    _target_dir="$(cargo metadata --format-version=1 --no-deps 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "")"
+    if [[ -z "$_target_dir" ]]; then
+      echo "Error: could not resolve cargo target directory."
+      echo "  Make sure 'cargo metadata' runs cleanly from $(pwd) and Python 3 is available."
+      exit 1
+    fi
     bash scripts/pr-clean.sh {{number}}
     bash scripts/install.sh "pr-{{number}}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,8 +37,22 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-# Resolve target-dir from .cargo/config.toml (worktrees share a single target/).
-_target_dir="$(cargo metadata --format-version=1 --no-deps 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "target")"
+# Resolve target-dir from cargo metadata so all worktrees share a single build
+# cache. The CARGO_TARGET_DIR env var or a [build] target-dir in .cargo/config.toml
+# points every worktree at <repo-root>/target/ rather than a per-worktree target/.
+# INVARIANT: if you change the target-dir in .cargo/config.toml, update this
+# resolver too. A mismatch causes install to silently skip the binary because the
+# bundle lands in the old path while this script looks in the new one.
+_target_dir="$(cargo metadata --format-version=1 --no-deps 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "")"
+
+# Preflight: fail fast if target-dir resolution failed rather than building and
+# then discovering the bundle in the wrong place.
+if [[ -z "$_target_dir" ]]; then
+  echo "Error: could not resolve cargo target directory."
+  echo "  Make sure 'cargo metadata' runs cleanly from $(pwd) and Python 3 is available."
+  exit 1
+fi
+
 app_src="${_target_dir}/release/bundle/osx/Plexi.app"
 app_dest="/Applications/${display}.app"
 bin_dest="/usr/local/bin/plexi${suffix}"
@@ -47,7 +61,10 @@ profile_dir="$HOME/.plexi${suffix}"
 cargo bundle --release
 
 if [[ ! -d "$app_src" ]]; then
-  echo "Error: bundle not found at $app_src"
+  echo "Error: bundle not found at: $app_src"
+  echo "  Expected cargo to produce the bundle at that path."
+  echo "  If you changed target-dir in .cargo/config.toml, update the cargo metadata"
+  echo "  resolver in scripts/install.sh to match (see INVARIANT comment above)."
   exit 1
 fi
 


### PR DESCRIPTION
Closes #1550

## Summary

- `scripts/install.sh`: remove the silent `"target"` fallback — if `cargo metadata` returns empty, the script now exits immediately with a diagnostic message naming the problem (not in a workspace, Python 3 missing, etc.)
- `scripts/install.sh`: the bundle-not-found error now names the exact path that was checked and includes a remediation hint pointing at the `INVARIANT` comment
- `justfile` `pr-install` recipe: added preflight checks before the build — validates we're in a PLEXI repo root and that `cargo metadata` resolves a target-dir, so bad-CWD mistakes fail before the build starts
- `GOTCHAS.md`: documents the worktree/shared-target-dir invariant and the root cause of the original failure (d21a8d0f) so future engineers know why the metadata lookup is non-optional

## Test plan
- [ ] Run `just pr-install <N>` from outside the repo root — should fail with clear "must be run from inside the PLEXI repo root" error
- [ ] Confirm `just install` still works normally from a valid worktree
- [ ] Manually break `cargo metadata` (e.g. `python3 -c 'import sys; sys.exit(1)'` stub) and confirm the new failure message appears