### PR TITLE
feat(apps/examples): coding, research, writing agent apps (#2035)

### DIFF
--- a/apps/examples/coding-agent/coding_agent.py
+++ b/apps/examples/coding-agent/coding_agent.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Coding Agent — AI assistant specialized for code review and debugging.
+
+L1 Example App
+==============
+Demonstrates:
+  - Specialized system prompt (senior software engineer persona)
+  - Monospace rendering for code blocks via ChatBubble
+  - Streaming via on_ai_stream_chunk + schedule_render
+  - Session persistence via JSON in .plexi/coding_agent_sessions/
+  - Same patterns as apps/assistant/ with a focused persona
+"""
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    Column, AppBar, ChatBubble, Scrollable, Spacer,
+    FooterKeys, TextInput, Label,
+)
+
+SYSTEM_PROMPT = (
+    "You are a senior software engineer with deep expertise in systems programming, "
+    "debugging, and code review. When reviewing code, identify bugs, suggest "
+    "improvements, and explain your reasoning clearly. Use concrete examples. "
+    "When debugging, ask clarifying questions before proposing solutions. "
+    "Prefer precise, technical language. Format code snippets with proper indentation. "
+    "Be direct and concise — engineers value signal over padding."
+)
+MODEL_TIER = "medium"
+
+
+class CodingAgentApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._messages: list[dict] = []
+        self._streaming_text = ""
+        self._is_streaming = False
+        self._input = TextInput("chat-input", placeholder="Paste code or describe the problem...", height=48.0)
+        self._scroll = Scrollable(child=Spacer())
+        self._session_id = _new_session_id()
+        self._sessions_dir: Path | None = _resolve_sessions_dir(ctx.workspace_root)
+        self._load_latest_session()
+        ctx.info(f"CodingAgentApp ready — sessions dir: {self._sessions_dir}")
+
+    # ── Session persistence ──────────────────────────────────────────────────
+
+    def _load_latest_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            files = sorted(self._sessions_dir.glob("*.json"), reverse=True)
+            if not files:
+                return
+            latest = files[0]
+            data = json.loads(latest.read_text(encoding="utf-8"))
+            messages = data.get("messages", [])
+            if not isinstance(messages, list):
+                raise ValueError("messages is not a list")
+            self._messages = messages
+            self._session_id = latest.stem
+            self.emit.info(f"Resumed session {self._session_id} ({len(messages)} messages)")
+        except Exception as e:
+            self.emit.warn(f"Could not load session (starting fresh): {e}")
+            self._messages = []
+            self._session_id = _new_session_id()
+
+    def _save_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            self._sessions_dir.mkdir(parents=True, exist_ok=True)
+            path = self._sessions_dir / f"{self._session_id}.json"
+            payload = {
+                "session_id": self._session_id,
+                "created": self._session_id,
+                "model_tier": MODEL_TIER,
+                "messages": self._messages,
+            }
+            path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        except Exception as e:
+            self.emit.warn(f"Could not save session: {e}")
+
+    def _new_conversation(self) -> None:
+        if self._is_streaming:
+            return
+        self._messages = []
+        self._session_id = _new_session_id()
+        self.emit.info(f"New session started: {self._session_id}")
+        self.emit.schedule_render()
+
+    # ── AI query ─────────────────────────────────────────────────────────────
+
+    def on_ai_stream_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
+        self._streaming_text += delta
+        self.emit.schedule_render()
+
+    def _send_query(self) -> None:
+        messages = [{"role": m["role"], "content": m["content"]} for m in self._messages]
+        try:
+            resp = self.emit.run_sync(
+                self.emit.ai_query(
+                    model_tier=MODEL_TIER,
+                    system=SYSTEM_PROMPT,
+                    messages=messages,
+                )
+            )
+            if not self._streaming_text and resp.content:
+                self._streaming_text = resp.content
+            self._messages.append({"role": "assistant", "content": self._streaming_text})
+            self._save_session()
+        except Exception as e:
+            self.emit.error(f"ai_query failed: {e}")
+            self._messages.append({"role": "assistant", "content": f"Error: {e}"})
+        finally:
+            self._is_streaming = False
+            self._streaming_text = ""
+            self.emit.schedule_render()
+
+    def _submit(self, text: str) -> None:
+        if self._is_streaming:
+            return
+        text = text.strip()
+        if not text:
+            return
+        self._messages.append({"role": "user", "content": text})
+        self._is_streaming = True
+        self._streaming_text = ""
+        threading.Thread(target=self._send_query, daemon=True).start()
+        self.emit.schedule_render()
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def _build_chat_column(self) -> Column:
+        children = []
+        for msg in self._messages:
+            role = "user" if msg["role"] == "user" else "assistant"
+            children.append(ChatBubble(text=msg["content"], role=role, max_lines=200))
+        if self._is_streaming and self._streaming_text:
+            children.append(ChatBubble(
+                text=self._streaming_text, role="assistant", max_lines=200,
+            ))
+        elif self._is_streaming:
+            children.append(Label("Analyzing...", tone="hint"))
+        if not children:
+            children.append(Label("Paste code, describe a bug, or ask for a review.", tone="hint"))
+        return Column(children, padding=0.0, padding_top=0.0, gap=8.0)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        self._scroll.child = self._build_chat_column()
+        self._scroll.scroll_offset = max(0.0, self._scroll._child_h - self._scroll._avail_h)
+
+        subtitle = f"model: {MODEL_TIER} | senior engineer"
+        footer_keys = [("Enter", "send"), ("N", "new"), ("Esc", "quit")]
+        if self._is_streaming:
+            footer_keys = [("...", "reviewing"), ("Esc", "quit")]
+
+        ctx.render(Column([
+            AppBar(title="Coding Agent", subtitle=subtitle),
+            self._scroll,
+            self._input,
+            FooterKeys(footer_keys),
+        ]))
+
+        submitted = self._input.submitted
+        if submitted is not None:
+            self._submit(submitted)
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if self._scroll.handle_key(key):
+            self.emit.schedule_render()
+            return
+        if key == "n" and mods.get("cmd"):
+            self._new_conversation()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _new_session_id() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _resolve_sessions_dir(workspace_root: str) -> Path | None:
+    if not workspace_root:
+        return None
+    root = Path(workspace_root)
+    plexi_dir = root / ".plexi"
+    if not plexi_dir.exists():
+        script_dir = Path(os.path.abspath(__file__)).parent
+        return script_dir / "sessions"
+    return plexi_dir / "coding_agent_sessions"
+
+
+if __name__ == "__main__":
+    CodingAgentApp().run()

--- a/apps/examples/coding-agent/coding_agent.py
+++ b/apps/examples/coding-agent/coding_agent.py
@@ -169,7 +169,7 @@ class CodingAgentApp(App):
         if submitted is not None:
             self._submit(submitted)
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
             self.emit.schedule_render()
             return

--- a/apps/examples/coding-agent/manifest.toml
+++ b/apps/examples/coding-agent/manifest.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+
+[app]
+id = "coding-agent"
+type = "app"
+name = "Coding Agent"
+version = "0.1.0"
+description = "AI coding assistant focused on code review, debugging, and engineering best practices."
+entry = "coding_agent.py"
+
+[app.capabilities]
+capabilities = ["ai.query"]
+
+[launch]

--- a/apps/examples/research-agent/manifest.toml
+++ b/apps/examples/research-agent/manifest.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+
+[app]
+id = "research-agent"
+type = "app"
+name = "Research Agent"
+version = "0.1.0"
+description = "AI research assistant that summarizes topics, cites sources, and helps structure findings."
+entry = "research_agent.py"
+
+[app.capabilities]
+capabilities = ["ai.query"]
+
+[launch]

--- a/apps/examples/research-agent/research_agent.py
+++ b/apps/examples/research-agent/research_agent.py
@@ -172,7 +172,7 @@ class ResearchAgentApp(App):
         if submitted is not None:
             self._submit(submitted)
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
             self.emit.schedule_render()
             return

--- a/apps/examples/research-agent/research_agent.py
+++ b/apps/examples/research-agent/research_agent.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Research Agent — AI assistant specialized for research, summarization, and analysis.
+
+L1 Example App
+==============
+Demonstrates:
+  - Specialized system prompt (research analyst persona)
+  - Citation-aware responses (analyst is prompted to cite claims)
+  - Streaming via on_ai_stream_chunk + schedule_render
+  - Session persistence via JSON in .plexi/research_agent_sessions/
+  - Same patterns as apps/assistant/ with a focused persona
+"""
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    Column, AppBar, ChatBubble, Scrollable, Spacer,
+    FooterKeys, TextInput, Label,
+)
+
+SYSTEM_PROMPT = (
+    "You are a research analyst with expertise in synthesizing information across "
+    "domains. Your strengths are: summarizing complex topics clearly, identifying "
+    "key claims and their supporting evidence, noting where sources conflict or "
+    "where evidence is weak, and structuring findings in a scannable format. "
+    "When you make factual claims, indicate whether they are well-established, "
+    "contested, or uncertain. Use structured output (bullet points, numbered lists, "
+    "headers) to make your summaries easy to scan. Flag gaps in your knowledge "
+    "honestly rather than speculating. When asked to research a topic, start with "
+    "a brief overview, then go deeper on request."
+)
+MODEL_TIER = "medium"
+
+
+class ResearchAgentApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._messages: list[dict] = []
+        self._streaming_text = ""
+        self._is_streaming = False
+        self._input = TextInput("chat-input", placeholder="Ask about a topic to research...", height=48.0)
+        self._scroll = Scrollable(child=Spacer())
+        self._session_id = _new_session_id()
+        self._sessions_dir: Path | None = _resolve_sessions_dir(ctx.workspace_root)
+        self._load_latest_session()
+        ctx.info(f"ResearchAgentApp ready — sessions dir: {self._sessions_dir}")
+
+    # ── Session persistence ──────────────────────────────────────────────────
+
+    def _load_latest_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            files = sorted(self._sessions_dir.glob("*.json"), reverse=True)
+            if not files:
+                return
+            latest = files[0]
+            data = json.loads(latest.read_text(encoding="utf-8"))
+            messages = data.get("messages", [])
+            if not isinstance(messages, list):
+                raise ValueError("messages is not a list")
+            self._messages = messages
+            self._session_id = latest.stem
+            self.emit.info(f"Resumed session {self._session_id} ({len(messages)} messages)")
+        except Exception as e:
+            self.emit.warn(f"Could not load session (starting fresh): {e}")
+            self._messages = []
+            self._session_id = _new_session_id()
+
+    def _save_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            self._sessions_dir.mkdir(parents=True, exist_ok=True)
+            path = self._sessions_dir / f"{self._session_id}.json"
+            payload = {
+                "session_id": self._session_id,
+                "created": self._session_id,
+                "model_tier": MODEL_TIER,
+                "messages": self._messages,
+            }
+            path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        except Exception as e:
+            self.emit.warn(f"Could not save session: {e}")
+
+    def _new_conversation(self) -> None:
+        if self._is_streaming:
+            return
+        self._messages = []
+        self._session_id = _new_session_id()
+        self.emit.info(f"New session started: {self._session_id}")
+        self.emit.schedule_render()
+
+    # ── AI query ─────────────────────────────────────────────────────────────
+
+    def on_ai_stream_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
+        self._streaming_text += delta
+        self.emit.schedule_render()
+
+    def _send_query(self) -> None:
+        messages = [{"role": m["role"], "content": m["content"]} for m in self._messages]
+        try:
+            resp = self.emit.run_sync(
+                self.emit.ai_query(
+                    model_tier=MODEL_TIER,
+                    system=SYSTEM_PROMPT,
+                    messages=messages,
+                )
+            )
+            if not self._streaming_text and resp.content:
+                self._streaming_text = resp.content
+            self._messages.append({"role": "assistant", "content": self._streaming_text})
+            self._save_session()
+        except Exception as e:
+            self.emit.error(f"ai_query failed: {e}")
+            self._messages.append({"role": "assistant", "content": f"Error: {e}"})
+        finally:
+            self._is_streaming = False
+            self._streaming_text = ""
+            self.emit.schedule_render()
+
+    def _submit(self, text: str) -> None:
+        if self._is_streaming:
+            return
+        text = text.strip()
+        if not text:
+            return
+        self._messages.append({"role": "user", "content": text})
+        self._is_streaming = True
+        self._streaming_text = ""
+        threading.Thread(target=self._send_query, daemon=True).start()
+        self.emit.schedule_render()
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def _build_chat_column(self) -> Column:
+        children = []
+        for msg in self._messages:
+            role = "user" if msg["role"] == "user" else "assistant"
+            children.append(ChatBubble(text=msg["content"], role=role, max_lines=200))
+        if self._is_streaming and self._streaming_text:
+            children.append(ChatBubble(
+                text=self._streaming_text, role="assistant", max_lines=200,
+            ))
+        elif self._is_streaming:
+            children.append(Label("Researching...", tone="hint"))
+        if not children:
+            children.append(Label("Ask about any topic — I'll summarize and cite key findings.", tone="hint"))
+        return Column(children, padding=0.0, padding_top=0.0, gap=8.0)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        self._scroll.child = self._build_chat_column()
+        self._scroll.scroll_offset = max(0.0, self._scroll._child_h - self._scroll._avail_h)
+
+        subtitle = f"model: {MODEL_TIER} | research analyst"
+        footer_keys = [("Enter", "send"), ("N", "new"), ("Esc", "quit")]
+        if self._is_streaming:
+            footer_keys = [("...", "researching"), ("Esc", "quit")]
+
+        ctx.render(Column([
+            AppBar(title="Research Agent", subtitle=subtitle),
+            self._scroll,
+            self._input,
+            FooterKeys(footer_keys),
+        ]))
+
+        submitted = self._input.submitted
+        if submitted is not None:
+            self._submit(submitted)
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if self._scroll.handle_key(key):
+            self.emit.schedule_render()
+            return
+        if key == "n" and mods.get("cmd"):
+            self._new_conversation()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _new_session_id() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _resolve_sessions_dir(workspace_root: str) -> Path | None:
+    if not workspace_root:
+        return None
+    root = Path(workspace_root)
+    plexi_dir = root / ".plexi"
+    if not plexi_dir.exists():
+        script_dir = Path(os.path.abspath(__file__)).parent
+        return script_dir / "sessions"
+    return plexi_dir / "research_agent_sessions"
+
+
+if __name__ == "__main__":
+    ResearchAgentApp().run()

--- a/apps/examples/writing-agent/manifest.toml
+++ b/apps/examples/writing-agent/manifest.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+
+[app]
+id = "writing-agent"
+type = "app"
+name = "Writing Agent"
+version = "0.1.0"
+description = "AI writing editor that improves clarity, tone, and structure in your writing."
+entry = "writing_agent.py"
+
+[app.capabilities]
+capabilities = ["ai.query"]
+
+[launch]

--- a/apps/examples/writing-agent/writing_agent.py
+++ b/apps/examples/writing-agent/writing_agent.py
@@ -172,7 +172,7 @@ class WritingAgentApp(App):
         if submitted is not None:
             self._submit(submitted)
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
             self.emit.schedule_render()
             return

--- a/apps/examples/writing-agent/writing_agent.py
+++ b/apps/examples/writing-agent/writing_agent.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Writing Agent — AI assistant specialized for improving clarity, tone, and structure.
+
+L1 Example App
+==============
+Demonstrates:
+  - Specialized system prompt (writing editor persona)
+  - Iterative editing workflow (paste text, get suggestions)
+  - Streaming via on_ai_stream_chunk + schedule_render
+  - Session persistence via JSON in .plexi/writing_agent_sessions/
+  - Same patterns as apps/assistant/ with a focused persona
+"""
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from plexi_sdk import App, RenderContext
+from plexi_sdk.ui import (
+    Column, AppBar, ChatBubble, Scrollable, Spacer,
+    FooterKeys, TextInput, Label,
+)
+
+SYSTEM_PROMPT = (
+    "You are a skilled writing editor with a sharp eye for clarity, tone, and structure. "
+    "Your role is to help writers improve their work — not to rewrite it for them. "
+    "When given text to review, offer specific, actionable suggestions: identify "
+    "sentences that are unclear or wordy, flag tone inconsistencies, suggest stronger "
+    "word choices, and note structural issues (e.g. buried lede, weak opening, "
+    "unclear argument flow). When you rewrite a passage, explain what you changed "
+    "and why. Respect the writer's voice — your edits should sound like a better "
+    "version of them, not like you. Ask what the piece is for and who the audience "
+    "is if that context would sharpen your feedback."
+)
+MODEL_TIER = "medium"
+
+
+class WritingAgentApp(App):
+    def on_init(self, ctx: RenderContext) -> None:
+        self._messages: list[dict] = []
+        self._streaming_text = ""
+        self._is_streaming = False
+        self._input = TextInput("chat-input", placeholder="Paste text to edit or describe what you're working on...", height=48.0)
+        self._scroll = Scrollable(child=Spacer())
+        self._session_id = _new_session_id()
+        self._sessions_dir: Path | None = _resolve_sessions_dir(ctx.workspace_root)
+        self._load_latest_session()
+        ctx.info(f"WritingAgentApp ready — sessions dir: {self._sessions_dir}")
+
+    # ── Session persistence ──────────────────────────────────────────────────
+
+    def _load_latest_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            files = sorted(self._sessions_dir.glob("*.json"), reverse=True)
+            if not files:
+                return
+            latest = files[0]
+            data = json.loads(latest.read_text(encoding="utf-8"))
+            messages = data.get("messages", [])
+            if not isinstance(messages, list):
+                raise ValueError("messages is not a list")
+            self._messages = messages
+            self._session_id = latest.stem
+            self.emit.info(f"Resumed session {self._session_id} ({len(messages)} messages)")
+        except Exception as e:
+            self.emit.warn(f"Could not load session (starting fresh): {e}")
+            self._messages = []
+            self._session_id = _new_session_id()
+
+    def _save_session(self) -> None:
+        if self._sessions_dir is None:
+            return
+        try:
+            self._sessions_dir.mkdir(parents=True, exist_ok=True)
+            path = self._sessions_dir / f"{self._session_id}.json"
+            payload = {
+                "session_id": self._session_id,
+                "created": self._session_id,
+                "model_tier": MODEL_TIER,
+                "messages": self._messages,
+            }
+            path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        except Exception as e:
+            self.emit.warn(f"Could not save session: {e}")
+
+    def _new_conversation(self) -> None:
+        if self._is_streaming:
+            return
+        self._messages = []
+        self._session_id = _new_session_id()
+        self.emit.info(f"New session started: {self._session_id}")
+        self.emit.schedule_render()
+
+    # ── AI query ─────────────────────────────────────────────────────────────
+
+    def on_ai_stream_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
+        self._streaming_text += delta
+        self.emit.schedule_render()
+
+    def _send_query(self) -> None:
+        messages = [{"role": m["role"], "content": m["content"]} for m in self._messages]
+        try:
+            resp = self.emit.run_sync(
+                self.emit.ai_query(
+                    model_tier=MODEL_TIER,
+                    system=SYSTEM_PROMPT,
+                    messages=messages,
+                )
+            )
+            if not self._streaming_text and resp.content:
+                self._streaming_text = resp.content
+            self._messages.append({"role": "assistant", "content": self._streaming_text})
+            self._save_session()
+        except Exception as e:
+            self.emit.error(f"ai_query failed: {e}")
+            self._messages.append({"role": "assistant", "content": f"Error: {e}"})
+        finally:
+            self._is_streaming = False
+            self._streaming_text = ""
+            self.emit.schedule_render()
+
+    def _submit(self, text: str) -> None:
+        if self._is_streaming:
+            return
+        text = text.strip()
+        if not text:
+            return
+        self._messages.append({"role": "user", "content": text})
+        self._is_streaming = True
+        self._streaming_text = ""
+        threading.Thread(target=self._send_query, daemon=True).start()
+        self.emit.schedule_render()
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def _build_chat_column(self) -> Column:
+        children = []
+        for msg in self._messages:
+            role = "user" if msg["role"] == "user" else "assistant"
+            children.append(ChatBubble(text=msg["content"], role=role, max_lines=200))
+        if self._is_streaming and self._streaming_text:
+            children.append(ChatBubble(
+                text=self._streaming_text, role="assistant", max_lines=200,
+            ))
+        elif self._is_streaming:
+            children.append(Label("Editing...", tone="hint"))
+        if not children:
+            children.append(Label("Paste text for feedback, or describe what you're trying to write.", tone="hint"))
+        return Column(children, padding=0.0, padding_top=0.0, gap=8.0)
+
+    def on_render(self, ctx: RenderContext) -> None:
+        self._scroll.child = self._build_chat_column()
+        self._scroll.scroll_offset = max(0.0, self._scroll._child_h - self._scroll._avail_h)
+
+        subtitle = f"model: {MODEL_TIER} | writing editor"
+        footer_keys = [("Enter", "send"), ("N", "new"), ("Esc", "quit")]
+        if self._is_streaming:
+            footer_keys = [("...", "editing"), ("Esc", "quit")]
+
+        ctx.render(Column([
+            AppBar(title="Writing Agent", subtitle=subtitle),
+            self._scroll,
+            self._input,
+            FooterKeys(footer_keys),
+        ]))
+
+        submitted = self._input.submitted
+        if submitted is not None:
+            self._submit(submitted)
+
+    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+        if self._scroll.handle_key(key):
+            self.emit.schedule_render()
+            return
+        if key == "n" and mods.get("cmd"):
+            self._new_conversation()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _new_session_id() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _resolve_sessions_dir(workspace_root: str) -> Path | None:
+    if not workspace_root:
+        return None
+    root = Path(workspace_root)
+    plexi_dir = root / ".plexi"
+    if not plexi_dir.exists():
+        script_dir = Path(os.path.abspath(__file__)).parent
+        return script_dir / "sessions"
+    return plexi_dir / "writing_agent_sessions"
+
+
+if __name__ == "__main__":
+    WritingAgentApp().run()

--- a/packs/examples.toml
+++ b/packs/examples.toml
@@ -45,3 +45,18 @@ version = "bundled"
 id      = "calendar"
 source  = "local:calendar"
 version = "bundled"
+
+[[app]]
+id      = "coding-agent"
+source  = "local:coding-agent"
+version = "bundled"
+
+[[app]]
+id      = "research-agent"
+source  = "local:research-agent"
+version = "bundled"
+
+[[app]]
+id      = "writing-agent"
+source  = "local:writing-agent"
+version = "bundled"


### PR DESCRIPTION
Closes #2035

## Summary
- Add `coding-agent`, `research-agent`, `writing-agent` to `apps/examples/`
- Each is a direct variation of `apps/assistant/` with a focused system prompt
- All three registered in `packs/examples.toml` so they appear in the app list
- Demonstrates how to build specialized agent apps on top of `ai.query`

## Apps
- **coding-agent** — senior software engineer persona, code review / debugging focus
- **research-agent** — research analyst persona, summarization / citation focus
- **writing-agent** — writing editor persona, clarity / tone focus

## Test plan
- [ ] `plexi-alpha app open coding-agent` — opens and renders chat interface
- [ ] `plexi-alpha app open research-agent` — opens and renders chat interface
- [ ] `plexi-alpha app open writing-agent` — opens and renders chat interface
- [ ] Send a message in each; verify streaming works and response style matches persona
- [ ] Cmd+N starts a new conversation in each app