### PR TITLE
feat(apps/assistant): ExposeTools integration (#2034)

### DIFF
--- a/apps/assistant/assistant.py
+++ b/apps/assistant/assistant.py
@@ -10,6 +10,10 @@ Patterns demonstrated:
   - Background ai_query with emit.run_sync
   - Column + AppBar + Scrollable + TextInput + FooterKeys
   - Session persistence via JSON in .plexi/assistant_sessions/
+  - ExposeTools: registers an ask_assistant tool so other workspace apps
+    can invoke the assistant programmatically (#2034)
+  - Tool consumption: ai_query automatically receives tools exposed by
+    other panes in the same workspace via the host tool dispatcher
 """
 
 import json
@@ -24,7 +28,11 @@ from plexi_sdk.ui import (
     FooterKeys, TextInput, Label,
 )
 
-SYSTEM_PROMPT = "You are a helpful assistant. Be concise and clear."
+SYSTEM_PROMPT = (
+    "You are a helpful assistant. Be concise and clear. "
+    "You have access to tools offered by other running Plexi apps in this workspace — "
+    "use them when they help answer the user's request."
+)
 MODEL_TIER = "medium"
 
 
@@ -38,7 +46,54 @@ class AssistantApp(App):
         self._session_id = _new_session_id()
         self._sessions_dir: Path | None = _resolve_sessions_dir(ctx.workspace_root)
         self._load_latest_session()
+        self._register_tools()
         ctx.info(f"AssistantApp ready — sessions dir: {self._sessions_dir}")
+
+    # ── Tool registration (ExposeTools) ────────────────────────────────────────
+
+    def _register_tools(self) -> None:
+        """Register tools this app exposes to other workspace apps via ExposeTools.
+
+        The ask_assistant tool lets any other PGAP app in the same workspace
+        send a plain-text question to the assistant and receive a response
+        without requiring a full UI interaction.
+        """
+        @self.tool(
+            "ask_assistant",
+            description=(
+                "Send a question to the AI assistant and get a response. "
+                "Use this to query the assistant from another app without opening the chat UI."
+            ),
+            schema={
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The question or instruction to send to the assistant.",
+                    },
+                },
+                "required": ["question"],
+            },
+            timeout_ms=35000,
+        )
+        async def _handle_ask_assistant(args: dict) -> dict:
+            question = args.get("question", "").strip()
+            if not question:
+                return {"error": "question must not be empty"}
+            self.emit.info(f"ask_assistant tool invoked: {question[:80]!r}")
+            try:
+                resp = await self.emit.ai_query(
+                    model_tier=MODEL_TIER,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": question}],
+                )
+                answer = resp.content or ""
+                return {"answer": answer}
+            except Exception as exc:
+                self.emit.error(f"ask_assistant ai_query failed: {exc}")
+                return {"error": str(exc)}
+
+        self.emit.info("AssistantApp: exposed ask_assistant tool to workspace")
 
     # ── Session persistence ────────────────────────────────────────────────────
 
@@ -96,7 +151,13 @@ class AssistantApp(App):
         self.emit.schedule_render()
 
     def _send_query(self) -> None:
-        """Run ai_query on a background thread."""
+        """Run ai_query on a background thread.
+
+        The host tool dispatcher automatically injects tools exposed by other
+        panes in the same workspace into the ai_query call. The broker handles
+        the tool call loop internally, so this method receives the final
+        resolved response after any tool rounds complete.
+        """
         messages = [{"role": m["role"], "content": m["content"]} for m in self._messages]
         try:
             resp = self.emit.run_sync(

--- a/apps/assistant/assistant.py
+++ b/apps/assistant/assistant.py
@@ -76,7 +76,7 @@ class AssistantApp(App):
             },
             timeout_ms=35000,
         )
-        async def _handle_ask_assistant(args: dict) -> dict:
+        async def handle_ask_assistant(args: dict) -> dict:
             question = args.get("question", "").strip()
             if not question:
                 return {"error": "question must not be empty"}
@@ -232,7 +232,7 @@ class AssistantApp(App):
         if submitted is not None:
             self._submit(submitted)
 
-    def on_key(self, ctx: RenderContext, key: str, mods: dict) -> None:
+    def on_key(self, _ctx: RenderContext, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
             self.emit.schedule_render()
             return

--- a/apps/assistant/manifest.toml
+++ b/apps/assistant/manifest.toml
@@ -4,11 +4,14 @@ schema_version = 1
 id = "assistant"
 type = "app"
 name = "Assistant"
-version = "0.1.0"
-description = "AI chat assistant powered by Plexi's ai.query broker."
+version = "0.2.0"
+description = "AI chat assistant powered by Plexi's ai.query broker. Exposes an ask_assistant tool so other workspace apps can invoke it programmatically."
 entry = "assistant.py"
 
 [app.capabilities]
+# ai.query: issue brokered LLM calls. The host tool dispatcher automatically
+# injects tools exposed by other workspace panes into each ai_query call, so
+# the assistant can invoke them without any additional capability declaration.
 capabilities = ["ai.query"]
 
 [launch]


### PR DESCRIPTION
Closes #2034

## Summary
- Register `ask_assistant` tool via `@app.tool()` so other workspace apps can invoke the assistant programmatically through the host tool dispatcher
- Update `SYSTEM_PROMPT` to inform the model that workspace tools are available; the host automatically injects other panes' exposed tools into each `ai_query` call
- Bump manifest version to 0.2.0, updated description documents the tool capability

## How it works
- **Consuming tools from other apps:** `ai_query` already receives tools exposed by other panes automatically via `ToolDispatcher`. No extra capability needed beyond `ai.query`.
- **Exposing tools to other apps:** `@app.tool("ask_assistant", ...)` registers the handler and calls `emit.expose_tools()`, making the assistant queryable by any other pane in the same workspace.

## Test plan
- [ ] Open assistant alongside another app that exposes tools (e.g. a calculator app with an `add` tool)
- [ ] Ask the assistant to use the other app's tool — verify it calls through and returns the result
- [ ] From another app, call `ask_assistant` tool with a question — verify the assistant responds via tool result
- [ ] Verify `plexi.log` shows `AssistantApp: exposed ask_assistant tool to workspace` on startup