### PR TITLE
feat(cli): plexi app action <id> <action> [args] (#1980)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -524,6 +524,38 @@ impl PlexiApp {
                         log::error!("pane_ipc: get_pane_state: could not write response file {response_file:?}: {e}");
                     }
                 }
+                crate::app_protocol::AppRequest::SendAppAction { pane_id, action, args, response_file } => {
+                    log::info!("pane_ipc: kind=send_app_action pane_id={pane_id} action={action:?} args={args:?}");
+                    let result = match self.windows.iter_mut().find_map(|win| win.panes.get_mut(pane_id)) {
+                        None => {
+                            log::warn!("pane_ipc: send_app_action: pane_id={pane_id} not found");
+                            Err(format!("pane {pane_id} not found"))
+                        }
+                        Some(pane) => {
+                            if let Some(app_pane) = pane.as_app_mut() {
+                                app_pane.runtime.queue_outbound_event(
+                                    crate::app_protocol::PlexiEvent::Action {
+                                        action: action.clone(),
+                                        args: args.clone(),
+                                    }
+                                );
+                                Ok(())
+                            } else {
+                                log::warn!("pane_ipc: send_app_action: pane_id={pane_id} is not an app pane");
+                                Err(format!("pane {pane_id} is not an app pane"))
+                            }
+                        }
+                    };
+                    if let Some(rf) = response_file {
+                        let json = match &result {
+                            Ok(()) => serde_json::json!({"ok": true}).to_string(),
+                            Err(msg) => serde_json::json!({"error": msg}).to_string(),
+                        };
+                        if let Err(e) = std::fs::write(rf, &json) {
+                            log::error!("pane_ipc: send_app_action: could not write response file: {e}");
+                        }
+                    }
+                }
                 crate::app_protocol::AppRequest::Notify {
                     level, title, body, kind, options, input_prompt,
                     required, priority, image_inline, image_pipe_id,

--- a/src/app_protocol.rs
+++ b/src/app_protocol.rs
@@ -98,6 +98,16 @@ pub enum PlexiEvent {
     MouseMove { x: f32, y: f32, buttons: Vec<MouseButton>, modifiers: Modifiers },
     /// User submitted a command via the command bar.
     Command { text: String },
+    /// Semantic action dispatched by `plexi app action <pane_id> <action> [args...]`.
+    /// Apps receive this in `on_event` and dispatch on `action` name.
+    /// `args` is empty when no extra arguments were provided.
+    Action {
+        /// Action name, e.g. "refresh", "navigate-to", "add-item".
+        action: String,
+        /// Optional positional arguments forwarded as-is from the CLI.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+    },
     /// Response to a runtime CapabilityRequest.
     CapabilityDecision { request_id: String, granted: bool },
     /// Secret broker response. value is None when denied.
@@ -1556,6 +1566,20 @@ pub enum AppRequest {
     GetPaneState {
         pane_id: u64,
         response_file: String,
+    },
+
+    /// Dispatch a semantic action to an app pane. Sent by `plexi app action <pane_id> <action> [args...]`.
+    /// Host delivers `PlexiEvent::Action { action, args }` to the target app pane.
+    /// Writes `{"ok":true}` or `{"error":"..."}` to `response_file`.
+    SendAppAction {
+        pane_id: u64,
+        /// Action name, e.g. "refresh", "navigate-to".
+        action: String,
+        /// Optional extra arguments forwarded from the CLI.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
     },
 
     /// Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -977,6 +977,70 @@ pub fn app_update_cli(id: Option<&str>) -> i32 {
     0
 }
 
+/// `plexi app action <pane_id> <action> [args...]`
+///
+/// Sends a `send_app_action` message to the host over PLEXI_SOCKET.
+/// The host delivers a `PlexiEvent::Action { action, args }` to the target app pane.
+/// Returns 0 on success, 1 on error.
+pub fn app_action_cli(pane_id: u64, action: &str, args: &[String]) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("app-action-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    log::info!(
+        "app_action:cli: pane_id={pane_id} action={action:?} args={args:?} response_file={response_file:?}"
+    );
+
+    let mut payload = serde_json::json!({
+        "type": "send_app_action",
+        "pane_id": pane_id,
+        "action": action,
+        "response_file": response_file,
+    });
+    if !args.is_empty() {
+        payload["args"] = serde_json::json!(args);
+    }
+
+    let code = super::send_to_socket(payload);
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            return 0;
+                        }
+                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+                            eprintln!("error: {msg}");
+                            return 1;
+                        }
+                    }
+                    return 0;
+                }
+                Err(e) => {
+                    log::warn!("app_action:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for app action response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 #[cfg(test)]
 mod app_install_workspace_tests {
     use tempfile::TempDir;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -460,6 +460,23 @@ pub enum AppCmd {
         /// App id to check (omit to check all installed apps)
         id: Option<String>,
     },
+    /// Send a semantic action to a running app pane.
+    ///
+    /// Unlike `pane command` (which sends raw text), `app action` delivers a structured
+    /// semantic event directly to the app's event handler — no keystroke simulation.
+    ///
+    /// Example: plexi app action 42 refresh
+    /// Example: plexi app action 42 navigate-to /some/path
+    #[command(name = "action")]
+    Action {
+        /// Pane id of the target app pane (from `plexi pane list`)
+        pane_id: u64,
+        /// Action name to invoke (e.g. "refresh", "navigate-to", "add-item")
+        action: String,
+        /// Optional arguments forwarded to the action handler
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -171,7 +171,7 @@ pub(super) fn binary_in_path(name: &str) -> bool {
 }
 
 // ── Public re-exports (preserve crate::cli::fn_name() call sites in main.rs) ──
-pub use app::{app_init, app_uninstall, app_install_with_pin, app_run, app_info, app_list, app_render, app_dev, app_publish, app_update_cli};
+pub use app::{app_init, app_uninstall, app_install_with_pin, app_run, app_info, app_list, app_render, app_dev, app_publish, app_update_cli, app_action_cli};
 pub use completions::{completions_cli, complete_open_cli};
 pub use config_cli::{config_check, config_edit, config_get, config_reset};
 pub use context_cli::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,10 @@ fn main() -> eframe::Result {
                             log::info!("app_update:cli: id={id:?}");
                             std::process::exit(cli::app_update_cli(id.as_deref()));
                         }
+                        AppCmd::Action { pane_id, action, args } => {
+                            log::info!("app_action:cli: pane_id={pane_id} action={action:?} args={args:?}");
+                            std::process::exit(cli::app_action_cli(pane_id, &action, &args));
+                        }
                     },
                     Commands::Uninstall { keep_data, yes } => std::process::exit(cli::plexi_uninstall_cli(keep_data, yes)),
                     Commands::Update { subcommand } => match subcommand {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1793,6 +1793,14 @@ impl ProcessApp {
                 );
             }
 
+            // ── SendAppAction — host-only, routed via PLEXI_SOCKET ────────
+            AppRequest::SendAppAction { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: SendAppAction pane_id={pane_id} received in app routing — ignored (host-only command)",
+                    self.type_id
+                );
+            }
+
             // ── Query context state (#1518) ───────────────────────────────
             AppRequest::QueryContextState { context_id } => {
                 log::info!(


### PR DESCRIPTION
Closes #1980

## Summary
- Add `plexi app action <pane_id> <action> [args...]` subcommand under `plexi app`
- Sends structured `PlexiEvent::Action { action, args }` to the target app pane (no keystroke simulation)
- New `AppRequest::SendAppAction` socket message handled in `lifecycle.rs` — routes to `queue_outbound_event` on the process app
- New `PlexiEvent::Action` event added to the protocol for apps to handle in `on_event`
- Shell completions wired up automatically via clap
- `process_app/routing.rs` exhaustive match updated (host-only guard, logs warn and ignores)