### PR TITLE
fix(cli): use channel-scoped workspace dir for routines.toml (#2017)

### DIFF
--- a/src/cli/routine.rs
+++ b/src/cli/routine.rs
@@ -1,5 +1,5 @@
 use super::open::pane_new_cli;
-use super::run::{ROUTINES_FILE, RoutinesCliConfig};
+use super::run::{routines_file, RoutinesCliConfig};
 
 pub fn routine_list() -> i32 {
     log::info!("cli: routine list");
@@ -7,13 +7,14 @@ pub fn routine_list() -> i32 {
         Ok(d) => d,
         Err(e) => { eprintln!("error: could not determine current directory: {e}"); return 1; }
     };
-    let config_path = cwd.join(ROUTINES_FILE);
+    let rf = routines_file();
+    let config_path = cwd.join(&rf);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("No routines configured.");
             println!();
-            println!("To set up routines, create {} in your project:", ROUTINES_FILE);
+            println!("To set up routines, create {} in your project:", rf);
             println!("  [[routine]]");
             println!("  name = \"morning-sync\"");
             println!("  command = \"./scripts/morning.sh\"");
@@ -25,10 +26,10 @@ pub fn routine_list() -> i32 {
     };
     let config: RoutinesCliConfig = match toml::from_str(&contents) {
         Ok(c) => c,
-        Err(e) => { eprintln!("error: failed to parse {ROUTINES_FILE}: {e}"); return 1; }
+        Err(e) => { eprintln!("error: failed to parse {rf}: {e}"); return 1; }
     };
     if config.routine.is_empty() {
-        println!("No routines defined in {ROUTINES_FILE}.");
+        println!("No routines defined in {rf}.");
         return 0;
     }
     println!("Routines:");
@@ -52,23 +53,24 @@ pub fn routine_run(name: &str) -> i32 {
         Ok(d) => d,
         Err(e) => { eprintln!("error: could not determine current directory: {e}"); return 1; }
     };
-    let config_path = cwd.join(ROUTINES_FILE);
+    let rf = routines_file();
+    let config_path = cwd.join(&rf);
     let contents = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("error: no {ROUTINES_FILE} found in {}", cwd.display());
+            eprintln!("error: no {rf} found in {}", cwd.display());
             return 1;
         }
         Err(e) => { eprintln!("error: could not read {}: {e}", config_path.display()); return 1; }
     };
     let config: RoutinesCliConfig = match toml::from_str(&contents) {
         Ok(c) => c,
-        Err(e) => { eprintln!("error: failed to parse {ROUTINES_FILE}: {e}"); return 1; }
+        Err(e) => { eprintln!("error: failed to parse {rf}: {e}"); return 1; }
     };
     let routine = match config.routine.iter().find(|r| r.name == name) {
         Some(r) => r,
         None => {
-            eprintln!("error: routine '{name}' not found in {ROUTINES_FILE}");
+            eprintln!("error: routine '{name}' not found in {rf}");
             if !config.routine.is_empty() {
                 let names: Vec<&str> = config.routine.iter().map(|r| r.name.as_str()).collect();
                 eprintln!("Available routines: {}", names.join(", "));

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -266,7 +266,9 @@ pub fn run_command(command_name: &str) -> i32 {
 
 // ── plexi routine subcommands ─────────────────────────────────────────────────
 
-pub(super) const ROUTINES_FILE: &str = ".plexi/routines.toml";
+pub(super) fn routines_file() -> String {
+    format!("{}/routines.toml", crate::config::workspace_channel_dir())
+}
 
 /// Parsed `.plexi/routines.toml` for CLI use
 #[derive(serde::Deserialize)]

--- a/src/host/scheduler.rs
+++ b/src/host/scheduler.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-const ROUTINES_FILE: &str = ".plexi/routines.toml";
+fn routines_file() -> String {
+    format!("{}/routines.toml", crate::config::workspace_channel_dir())
+}
 
 /// Parsed `.plexi/routines.toml`
 #[derive(Deserialize, Default)]
@@ -76,7 +78,7 @@ impl Scheduler {
         }
         self.loaded_roots.insert(root.to_path_buf(), std::time::Instant::now());
 
-        let path = root.join(ROUTINES_FILE);
+        let path = root.join(routines_file());
         if !path.exists() {
             // Prune any entries that came from this root (file was deleted)
             self.entries.retain(|e| e.source_root != root);


### PR DESCRIPTION
Closes #2017

## Summary

- Replaced hardcoded `.plexi/routines.toml` const in `src/cli/run.rs` and `src/host/scheduler.rs` with a `routines_file()` function that calls `workspace_channel_dir()`, matching the existing `commands_file()` pattern
- `plexi-alpha routine run/list` now looks for `.plexi-alpha/routines.toml` instead of `.plexi/routines.toml`
- Same fix applied to the host-side scheduler so background routine loading is also channel-correct

## Done When

- `plexi-alpha routine run <name>` resolves `.plexi-alpha/routines.toml` in the workspace

## Notes

The `commands_file()` function in `src/cli/mod.rs` was the exact pattern to follow — the fix is symmetric.