### PR TITLE
Fix Cmd+[ / Cmd+] focus history across context switches (#2043)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -226,7 +226,12 @@ impl PlexiApp {
             }
             self.windows[idx].focused_pane = Some(tile_id);
             self.active_window = idx;
-            log::info!("focus_history: back — to window={window_id} tile={tile_id:?} history_len={}", self.pane_focus_history.len());
+            // Sync sidebar: router active must match the context of the window we navigated to.
+            let ctx_id = self.windows[idx].context_id;
+            if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
+                self.router.set_active(ctx_idx);
+            }
+            log::info!("focus_history: back — to window={window_id} tile={tile_id:?} ctx={ctx_id} history_len={}", self.pane_focus_history.len());
             break;
         }
         self.navigating_history = false;
@@ -261,7 +266,12 @@ impl PlexiApp {
             }
             self.windows[idx].focused_pane = Some(tile_id);
             self.active_window = idx;
-            log::info!("focus_history: forward — to window={window_id} tile={tile_id:?} future_len={}", self.pane_focus_future.len());
+            // Sync sidebar: router active must match the context of the window we navigated to.
+            let ctx_id = self.windows[idx].context_id;
+            if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
+                self.router.set_active(ctx_idx);
+            }
+            log::info!("focus_history: forward — to window={window_id} tile={tile_id:?} ctx={ctx_id} future_len={}", self.pane_focus_future.len());
             break;
         }
         self.navigating_history = false;

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -260,3 +260,129 @@ fn rename_pane_focus_layer_syncs_immediately() {
         "input_captured_by_overlay must be true while rename modal is open"
     );
 }
+
+/// Regression guard for #2043: switch_workspace must push focus history so
+/// Cmd+[ returns to the pane that was active before the context switch.
+#[test]
+fn switch_workspace_pushes_focus_history() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    // Set up a focused pane in context A (the initial context).
+    let (tile_a, _) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+    let win_a_id = app.windows[0].window_id;
+    let ctx_a_id = app.windows[0].context_id;
+
+    // Add a second context B with its own window.
+    let ctx_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    let win_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    app.router.push(crate::host::context::Context {
+        name: "ctx-b".into(),
+        path: std::path::PathBuf::from("/tmp"),
+        root: None,
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp"),
+        tree: egui_tiles::Tree::empty("test_ctx_b"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+    app.context_active_window.insert(ctx_b_id, win_b_id);
+    let ctx_b_idx = app.router.len() - 1;
+
+    // Switch to context B — this should record (win_a_id, tile_a) in history.
+    app.switch_workspace(ctx_b_idx);
+
+    assert!(
+        !app.pane_focus_history.is_empty(),
+        "focus history must be non-empty after switch_workspace"
+    );
+    let (recorded_win, recorded_tile) = app.pane_focus_history.last().unwrap();
+    assert_eq!(*recorded_win, win_a_id, "recorded window must be context A's window");
+    assert_eq!(*recorded_tile, tile_a, "recorded tile must be the pane focused in context A");
+
+    // Cmd+[ (step_focus_history_back) must restore focus to context A's window and tile.
+    app.step_focus_history_back();
+    assert_eq!(
+        app.windows[app.active_window].window_id,
+        win_a_id,
+        "active window must return to context A after step_focus_history_back"
+    );
+    assert_eq!(
+        app.windows[app.active_window].focused_pane,
+        Some(tile_a),
+        "focused pane must return to tile_a after step_focus_history_back"
+    );
+
+    let _ = ctx_a_id; // suppress unused warning
+}
+
+/// Regression guard for #2043: repeated switch_workspace calls do not
+/// double-push when the navigating_history guard is active.
+#[test]
+fn switch_workspace_no_double_push_during_history_navigation() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, _) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+
+    let ctx_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    let win_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    app.router.push(crate::host::context::Context {
+        name: "ctx-b".into(),
+        path: std::path::PathBuf::from("/tmp"),
+        root: None,
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp"),
+        tree: egui_tiles::Tree::empty("test_ctx_b2"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+    app.context_active_window.insert(ctx_b_id, win_b_id);
+    let ctx_b_idx = app.router.len() - 1;
+
+    app.switch_workspace(ctx_b_idx);
+    let history_len_after_switch = app.pane_focus_history.len();
+
+    // Simulate navigating_history = true (as happens inside step_focus_history_back).
+    app.navigating_history = true;
+    app.switch_workspace(0);
+    app.navigating_history = false;
+
+    assert_eq!(
+        app.pane_focus_history.len(),
+        history_len_after_switch,
+        "navigating_history guard must prevent push during history traversal"
+    );
+}

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -750,9 +750,11 @@ impl PlexiApp {
     /// calling `router.set_active` directly bypasses the minimap save/restore.
     pub(crate) fn switch_workspace(&mut self, new_ctx_idx: usize) {
         // Record the outgoing focus so Cmd+[ can return here from any context.
-        let old_window_id = self.windows[self.active_window].window_id;
-        let old_focus = self.windows[self.active_window].focused_pane;
-        self.push_focus_history(old_window_id, old_focus);
+        if let Some(w) = self.windows.get(self.active_window) {
+            let old_window_id = w.window_id;
+            let old_focus = w.focused_pane;
+            self.push_focus_history(old_window_id, old_focus);
+        }
 
         // Save current context's active window + minimap state.
         let old_ctx_id = self.router.active().context_id;

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -749,6 +749,11 @@ impl PlexiApp {
     /// This is the **only** place context navigation should be performed —
     /// calling `router.set_active` directly bypasses the minimap save/restore.
     pub(crate) fn switch_workspace(&mut self, new_ctx_idx: usize) {
+        // Record the outgoing focus so Cmd+[ can return here from any context.
+        let old_window_id = self.windows[self.active_window].window_id;
+        let old_focus = self.windows[self.active_window].focused_pane;
+        self.push_focus_history(old_window_id, old_focus);
+
         // Save current context's active window + minimap state.
         let old_ctx_id = self.router.active().context_id;
         self.context_active_window


### PR DESCRIPTION
Closes #2043

## Summary

- `switch_workspace` never pushed to `pane_focus_history` before this fix, so Cmd+[ had no entries to traverse after any sidebar click, Cmd+1-9, portal zoom, or ContextZoomOut
- Added a `push_focus_history(old_window_id, old_focus)` call at the very top of `switch_workspace`, before any mutation — all four call sites (sidebar, SwitchContext action, ToggleZoom, ContextZoomOut) go through this single function, so one change fixes them all
- Added two regression tests in `focus_tests.rs`: one verifying history is recorded and Cmd+[ restores cross-context focus, one verifying the `navigating_history` guard prevents double-push during traversal

## Done When

- Cmd+[ after a sidebar context switch returns focus to the pane that was active before the switch, across context boundaries.
- Cmd+] re-applies the forward step after a Cmd+[ across contexts.
- New HostHarness/focus tests covering cross-window history pass under `cargo test --bin plexi`.

## Notes

The `ContextZoomOut` path restores position via `router.pop_depth` independently — the `navigating_history` guard ensures that restoration path doesn't push duplicate history entries when Cmd+[ is pressed immediately after Cmd+Escape.