### PR TITLE
fix(host/navigation): rename modals pass keypresses through to zoomed pane terminal (#2046)

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -714,7 +714,7 @@ impl PlexiApp {
                                             use egui_term::TerminalView;
                                             use crate::ui::theme;
                                             let terminal = TerminalView::new(ui, &mut t.backend)
-                                                .set_focus(true)
+                                                .set_focus(!modal_open)
                                                 .set_theme(self.theme.clone())
                                                 .set_font(theme::terminal_font(font_size))
                                                 .set_size(Vec2::new(
@@ -727,7 +727,7 @@ impl PlexiApp {
                                     } else if let Some(a) = pane.as_app_mut() {
                                         let app_ctx = crate::app::app_trait::AppRenderContext {
                                             colors: &self.colors,
-                                            is_focused: true, // zoomed pane is always focused
+                                            is_focused: !modal_open,
                                         };
                                         a.runtime.ui(ui, &app_ctx);
                                     }


### PR DESCRIPTION
Closes #2046

## Summary

- In the zoomed-pane rendering path, `.set_focus(true)` was hardcoded for both terminal and app panes, ignoring whether a modal overlay was open
- Changed both calls to `.set_focus(!modal_open)` — `modal_open` is already computed at line 332 from `input_captured_by_overlay()` and passed through the same scope
- Non-zoomed panes already had this guard in `src/spatial/tiling.rs:154`; this brings the zoomed path into parity

## Done When

- Typing in the rename-pane modal while a pane is zoomed does not send characters to the PTY
- The rename-context modal captures keyboard focus while a pane is zoomed
- Non-zoomed rename flows are unaffected (no regression)

## Notes

Two-line fix. Both the terminal (`TerminalView`) and app pane (`AppRenderContext.is_focused`) branches in the zoomed overlay block needed the same guard.