### PR TITLE
fix(host/navigation): pane_navigate tab activation + zoom clear (#2050, #2053)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -625,7 +625,24 @@ impl PlexiApp {
         };
         let old_focus = self.windows[self.active_window].focused_pane;
         let old_window_id = self.windows[self.active_window].window_id;
+        // Clear any stale zoom on the destination window — a programmatic focus
+        // redirect must not leave zoomed_pane pointing at a pane that is no longer focused.
+        if self.windows[idx].zoomed_pane.is_some() {
+            self.windows[idx].zoomed_pane = None;
+            log::info!("notify:action: pane_navigate cleared stale zoom on window={idx}");
+        }
         self.windows[idx].focused_pane = Some(tile_id);
+        // Activate the parent Tabs container so the target pane is visible.
+        if let Some((tabs_id, child_id)) = self.windows[idx].find_ancestor_tabs(tile_id) {
+            if let Some(egui_tiles::Tile::Container(egui_tiles::Container::Tabs(tabs))) =
+                self.windows[idx].tree.tiles.get_mut(tabs_id)
+            {
+                tabs.set_active(child_id);
+                log::info!(
+                    "notify:action: pane_navigate activated tab tabs_id={tabs_id:?} child_id={child_id:?}"
+                );
+            }
+        }
         self.push_focus_history(old_window_id, old_focus);
         let prev = self.active_window;
         self.active_window = idx;


### PR DESCRIPTION
Closes #2050, Closes #2053

## Summary

**#2050 — pane_navigate does not activate parent Tabs container**
- After setting `focused_pane`, call `find_ancestor_tabs(tile_id)` and `tabs.set_active(child_id)` so navigating to a pane in a background tab brings that tab to the front.

**#2053 — pane_navigate does not clear stale zoomed_pane**
- Before mutating `focused_pane`, clear `zoomed_pane` on the destination window so a programmatic focus redirect never leaves the window in an inescapable zoom state.

Both fixes are in `pane_navigate` in `src/app/focus.rs`, matching the existing pattern used by split/close handlers.

## Done When — #2050

Clicking a notification action button that targets a pane in a non-active tab both brings the window to front and switches the tab so the target pane is visible and focused.

## Done When — #2053

With a zoomed pane on a window, clicking a notification `pane_focus:` action button: (1) zoom clears, (2) focused_pane is the target, (3) Cmd+Enter toggles zoom on the correct pane rather than entering a Portal.