### PR TITLE
refactor(pgap/sdk): explicit protocol constraints — Pinned, Column, Frame padding (#2064)

### DIFF
--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -741,8 +741,8 @@ class Footer(Component):
                      size=TEXT_HINT, color=self.color or theme.muted)
 
     def to_node(self) -> dict:
-        return {"type": "footer", "text": self.text,
-                "color": self.color or ""}
+        inner = {"type": "footer", "text": self.text, "color": self.color or ""}
+        return {"type": "pinned", "edge": "bottom", "child": inner}
 
 
 @dataclass
@@ -831,7 +831,8 @@ class FooterKeys(Component):
             else:
                 keys = list(keys_or_key)
             entries.append({"keys": keys, "description": desc})
-        return {"type": "footer_keys", "entries": entries, "divider": self.divider}
+        inner = {"type": "footer_keys", "entries": entries, "divider": self.divider}
+        return {"type": "pinned", "edge": "bottom", "child": inner}
 
 
 # ── Composite list components ──────────────────────────────────────────────
@@ -1532,16 +1533,10 @@ class Column(Component):
                 return None
             children.append(node)
         return {
-            "type": "stack",
-            "direction": "vertical",
+            "type": "column",
             "children": children,
             "gap": self.gap,
-            "padding": {
-                "top": self._pad_top,
-                "right": self.padding,
-                "bottom": self.padding,
-                "left": self.padding,
-            },
+            "padding_top": self._pad_top,
         }
 
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1460,13 +1460,9 @@ class Column(Component):
     any `Spacer(grow=True)` descendants at the top level.
 
     Padding defaults to `SPACE_XL` (24px) on the sides and bottom, and
-    `SPACE_SM` (8px) on the top. A top-of-pane `Header` carries its own
-    visual weight via TEXT_TITLE_XL and its own bottom rhythm (gap +
-    divider), so anything above a few px reads as "the title is dropped"
-    rather than anchored. The other three sides stay at 24px where content
-    *does* need breathing room.
-
-    Override either with `padding=` (all sides) or `padding_top=` (top only).
+    `SPACE_SM` (8px) on the top. Pass `padding=0` for full-width content
+    (e.g. apps whose children manage their own horizontal margins).
+    Override top-only with `padding_top=`.
     """
     children: List[Component]
     padding: float = SPACE_XL
@@ -1537,6 +1533,7 @@ class Column(Component):
             "children": children,
             "gap": self.gap,
             "padding_top": self._pad_top,
+            "padding": self.padding,
         }
 
 

--- a/src/protocol/ui_nodes.rs
+++ b/src/protocol/ui_nodes.rs
@@ -8,6 +8,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_space_xl() -> f32 {
+    24.0 // SPACE_XL — keep in sync with src/ui/style.rs
+}
+
 /// Single shortcut entry for `UiNode::FooterKeys`.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct FooterKeyEntry {
@@ -120,14 +124,17 @@ pub enum UiNode {
         edge: PinnedEdge,
         child: Box<UiNode>,
     },
-    /// Semantic column container — standard app margins (SPACE_XL left/right),
-    /// sticky-footer host contract. Emitted by `Column.to_node()` in the Python SDK.
+    /// Semantic column container with sticky-footer host contract.
+    /// `padding` sets left/right/bottom margins (default SPACE_XL); `padding_top`
+    /// sets the top margin independently. Emitted by `Column.to_node()` in the SDK.
     Column {
         children: Vec<UiNode>,
         #[serde(default)]
         gap: f32,
         #[serde(default)]
         padding_top: f32,
+        #[serde(default = "default_space_xl")]
+        padding: f32,
     },
 
     // ── L1 sugar ─────────────────────────────────────────────────────────
@@ -317,9 +324,9 @@ impl PartialEq for UiNode {
             (UiNode::Pinned { edge: e1, child: c1 }, UiNode::Pinned { edge: e2, child: c2 }) => {
                 e1 == e2 && c1 == c2
             }
-            (UiNode::Column { children: c1, gap: g1, padding_top: p1 },
-             UiNode::Column { children: c2, gap: g2, padding_top: p2 }) => {
-                c1 == c2 && g1 == g2 && p1 == p2
+            (UiNode::Column { children: c1, gap: g1, padding_top: p1, padding: pa1 },
+             UiNode::Column { children: c2, gap: g2, padding_top: p2, padding: pa2 }) => {
+                c1 == c2 && g1 == g2 && p1 == p2 && pa1 == pa2
             }
             _ => false,
         }

--- a/src/protocol/ui_nodes.rs
+++ b/src/protocol/ui_nodes.rs
@@ -54,12 +54,19 @@ pub struct UiPadding {
     pub left: f32,
 }
 
+/// Which edge to pin a child against within a vertical Stack.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PinnedEdge {
+    Bottom,
+    Top,
+    Left,
+    Right,
+}
+
 /// Component tree node. L0 primitives compose into rich UI; L1 sugar variants
 /// are rendered natively by the host.
-///
-/// `JsonSchema` is implemented manually to avoid schemars recursion issues
-/// (UiNode contains Box<UiNode>).
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum UiNode {
     // ── L0 primitives ────────────────────────────────────────────────────
@@ -107,6 +114,21 @@ pub enum UiNode {
     Raw { command: Box<RenderCommand> },
     /// Future GPU surface placeholder — reserved, not yet rendered.
     Surface { id: String },
+    /// Pinned layout wrapper. In a vertical Stack, `Pinned { edge: Bottom }` children
+    /// are rendered flush to the available rect bottom regardless of body content height.
+    Pinned {
+        edge: PinnedEdge,
+        child: Box<UiNode>,
+    },
+    /// Semantic column container — standard app margins (SPACE_XL left/right),
+    /// sticky-footer host contract. Emitted by `Column.to_node()` in the Python SDK.
+    Column {
+        children: Vec<UiNode>,
+        #[serde(default)]
+        gap: f32,
+        #[serde(default)]
+        padding_top: f32,
+    },
 
     // ── L1 sugar ─────────────────────────────────────────────────────────
     /// Host-rendered button.
@@ -224,16 +246,6 @@ pub enum UiNode {
     },
 }
 
-// Manual JsonSchema impl to avoid schemars recursion (UiNode contains Box<UiNode>).
-impl schemars::JsonSchema for UiNode {
-    fn schema_name() -> std::borrow::Cow<'static, str> {
-        "UiNode".into()
-    }
-    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        schemars::json_schema!({})
-    }
-}
-
 // Manual PartialEq impl — UiNode::Raw wraps RenderCommand which would require
 // PartialEq on hundreds of transitive types. Raw nodes are structural escape
 // hatches; we compare them via their serde round-trip JSON representation so
@@ -302,6 +314,13 @@ impl PartialEq for UiNode {
              UiNode::Card { children: c2, padding: p2 }) => c1 == c2 && p1 == p2,
             (UiNode::SelectList { items: i1, selected_idx: s1 },
              UiNode::SelectList { items: i2, selected_idx: s2 }) => i1 == i2 && s1 == s2,
+            (UiNode::Pinned { edge: e1, child: c1 }, UiNode::Pinned { edge: e2, child: c2 }) => {
+                e1 == e2 && c1 == c2
+            }
+            (UiNode::Column { children: c1, gap: g1, padding_top: p1 },
+             UiNode::Column { children: c2, gap: g2, padding_top: p2 }) => {
+                c1 == c2 && g1 == g2 && p1 == p2
+            }
             _ => false,
         }
     }

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -7,7 +7,7 @@
 
 use egui::Ui;
 
-use crate::app_protocol::{StackDirection, UiNode};
+use crate::app_protocol::{PinnedEdge, StackDirection, UiNode};
 use crate::ui::style;
 use crate::ui::theme::Colors;
 
@@ -90,21 +90,16 @@ pub(crate) fn render_component_tree(
         // ── L0 primitives ────────────────────────────────────────────────
 
         UiNode::Stack { direction, children, gap, padding } => {
-            ui.scope(|ui| {
-                if padding.top > 0.0 {
-                    ui.add_space(padding.top);
-                }
-                if padding.left > 0.0 {
-                    ui.indent("stack_left_pad", |ui| {
-                        events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers, focus_ctx));
-                    });
-                } else {
+            egui::Frame::new()
+                .inner_margin(egui::Margin {
+                    left: padding.left as i8,
+                    right: padding.right as i8,
+                    top: padding.top as i8,
+                    bottom: padding.bottom as i8,
+                })
+                .show(ui, |ui| {
                     events.extend(render_stack(ui, direction, children, *gap, colors, text_edit_buffers, focus_ctx));
-                }
-                if padding.bottom > 0.0 {
-                    ui.add_space(padding.bottom);
-                }
-            });
+                });
         }
 
         UiNode::Scroll { child, horizontal } => {
@@ -179,6 +174,13 @@ pub(crate) fn render_component_tree(
                     payload: None,
                 });
             }
+        }
+
+        UiNode::Pinned { edge, child } => {
+            // Bottom-pinned nodes are handled by render_stack's partition pass.
+            // When Pinned appears outside a vertical Stack (e.g. at tree root), render inline.
+            log::trace!("render_components: Pinned {:?} rendered inline (no enclosing vertical Stack)", edge);
+            events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
         }
 
         UiNode::Raw { command } => {
@@ -477,6 +479,20 @@ pub(crate) fn render_component_tree(
 
         // ── L1 layout components ────────────────────────────────────────
 
+        UiNode::Column { children, gap, padding_top } => {
+            log::info!("render_components: Column {} children gap={gap} padding_top={padding_top}", children.len());
+            egui::Frame::new()
+                .inner_margin(egui::Margin {
+                    left: style::SPACE_XL as i8,
+                    right: style::SPACE_XL as i8,
+                    top: *padding_top as i8,
+                    bottom: 0,
+                })
+                .show(ui, |ui| {
+                    events.extend(render_stack(ui, &StackDirection::Vertical, children, *gap, colors, text_edit_buffers, focus_ctx));
+                });
+        }
+
         UiNode::AppBar { title, subtitle, .. } => {
             const TITLE_SIZE: f32 = 16.0;
             let has_subtitle = !subtitle.is_empty();
@@ -529,7 +545,6 @@ pub(crate) fn render_component_tree(
             let (rect, _) =
                 ui.allocate_exact_size(egui::vec2(ui.available_width(), total_h), egui::Sense::hover());
             let painter = ui.painter();
-            painter.rect_filled(rect, 0.0, colors.bg_sidebar);
             let mut y = rect.min.y;
             if *divider {
                 y += style::SPACE_SM;
@@ -778,6 +793,25 @@ pub(crate) fn render_component_tree(
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
+/// Returns the known fixed height of a node that can be bottom-pinned, or `None`
+/// if the height cannot be determined without rendering.
+fn bottom_pin_height(node: &UiNode) -> Option<f32> {
+    match node {
+        UiNode::FooterKeys { divider, .. } => {
+            let chip_row_h = style::TEXT_HINT + 6.0;
+            Some(if *divider {
+                style::SPACE_SM + 1.0 + style::SPACE_SM + chip_row_h + style::SPACE_SM
+            } else {
+                style::SPACE_SM + chip_row_h + style::SPACE_SM
+            })
+        }
+        UiNode::Footer { .. } => {
+            Some(style::SPACE_MD + 1.0 + style::SPACE_MD + style::TEXT_CAPTION + 5.0)
+        }
+        _ => None,
+    }
+}
+
 fn render_stack(
     ui: &mut Ui,
     direction: &StackDirection,
@@ -800,14 +834,51 @@ fn render_stack(
             });
         }
         StackDirection::Vertical => {
-            ui.vertical(|ui| {
-                for (i, child) in children.iter().enumerate() {
-                    if i > 0 && gap > 0.0 {
-                        ui.add_space(gap);
+            // Partition bottom-pinned children (those with a known fixed height) out of
+            // the body. They are rendered at the bottom of the available rect by
+            // constraining the body height first.
+            let mut pinned_bottom: Vec<(f32, &UiNode)> = Vec::new();
+            let mut body_children: Vec<&UiNode> = Vec::new();
+
+            for child in children {
+                if let UiNode::Pinned { edge: PinnedEdge::Bottom, child: inner } = child {
+                    if let Some(h) = bottom_pin_height(inner) {
+                        pinned_bottom.push((h, inner.as_ref()));
+                        continue;
                     }
-                    events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
                 }
-            });
+                body_children.push(child);
+            }
+
+            if !pinned_bottom.is_empty() {
+                let total_pinned_h: f32 = pinned_bottom.iter().map(|(h, _)| h).sum();
+                let body_h = (ui.available_height() - total_pinned_h).max(0.0);
+
+                // Body gets a constrained-height allocation; pinned fills the rest below.
+                ui.allocate_ui(egui::vec2(ui.available_width(), body_h), |ui| {
+                    for (i, child) in body_children.iter().enumerate() {
+                        if i > 0 && gap > 0.0 {
+                            ui.add_space(gap);
+                        }
+                        events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
+                    }
+                });
+                for (_, inner) in &pinned_bottom {
+                    events.extend(render_component_tree(ui, inner, colors, text_edit_buffers, focus_ctx));
+                }
+                log::info!(
+                    "render_components: render_stack vertical pinned body_h={body_h:.0} footer_h={total_pinned_h:.0}"
+                );
+            } else {
+                ui.vertical(|ui| {
+                    for (i, child) in children.iter().enumerate() {
+                        if i > 0 && gap > 0.0 {
+                            ui.add_space(gap);
+                        }
+                        events.extend(render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx));
+                    }
+                });
+            }
         }
     }
     events
@@ -1020,6 +1091,87 @@ mod render_component_tree_tests {
         } else {
             panic!("wrong variant");
         }
+    }
+
+    /// `UiNode::Pinned` can be constructed and matches correctly.
+    #[test]
+    fn pinned_node_constructable() {
+        use crate::app_protocol::PinnedEdge;
+        let inner = UiNode::Text { text: "footer".into(), size: 12.0, color: String::new(), bold: false, monospace: false };
+        let node = UiNode::Pinned { edge: PinnedEdge::Bottom, child: Box::new(inner) };
+        if let UiNode::Pinned { edge, .. } = &node {
+            assert_eq!(*edge, PinnedEdge::Bottom);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    /// `UiNode::Column` can be constructed with children.
+    #[test]
+    fn column_node_constructable() {
+        let node = UiNode::Column {
+            children: vec![
+                UiNode::Text { text: "body".into(), size: 14.0, color: String::new(), bold: false, monospace: false },
+            ],
+            gap: 8.0,
+            padding_top: 0.0,
+        };
+        if let UiNode::Column { children, gap, .. } = &node {
+            assert_eq!(children.len(), 1);
+            assert_eq!(*gap, 8.0);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    /// Serde round-trip for `UiNode::Pinned`.
+    #[test]
+    fn pinned_serde_roundtrip() {
+        use crate::app_protocol::PinnedEdge;
+        let node = UiNode::Pinned {
+            edge: PinnedEdge::Bottom,
+            child: Box::new(UiNode::Footer { text: "status".into(), color: String::new() }),
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        assert!(json.contains("\"type\":\"pinned\""), "json={json}");
+        assert!(json.contains("\"bottom\""), "json={json}");
+        let parsed: UiNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, parsed);
+    }
+
+    /// Serde round-trip for `UiNode::Column`.
+    #[test]
+    fn column_serde_roundtrip() {
+        let node = UiNode::Column {
+            children: vec![UiNode::AppBar { title: "T".into(), subtitle: String::new() }],
+            gap: 4.0,
+            padding_top: 8.0,
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        assert!(json.contains("\"type\":\"column\""), "json={json}");
+        let parsed: UiNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, parsed);
+    }
+
+    /// `bottom_pin_height` returns correct heights for FooterKeys and Footer.
+    #[test]
+    fn bottom_pin_height_known_nodes() {
+        use super::bottom_pin_height;
+        use crate::ui::style;
+        let fk_with_div = UiNode::FooterKeys { entries: vec![], divider: true };
+        let fk_no_div = UiNode::FooterKeys { entries: vec![], divider: false };
+        let footer = UiNode::Footer { text: "s".into(), color: String::new() };
+        let label = UiNode::Label { text: "x".into(), size: 0.0, color: String::new(), tone: String::new(), bold: false, monospace: false, max_lines: 0 };
+
+        let chip_row_h = style::TEXT_HINT + 6.0;
+        let expected_with_div = style::SPACE_SM + 1.0 + style::SPACE_SM + chip_row_h + style::SPACE_SM;
+        let expected_no_div = style::SPACE_SM + chip_row_h + style::SPACE_SM;
+        let expected_footer = style::SPACE_MD + 1.0 + style::SPACE_MD + style::TEXT_CAPTION + 5.0;
+
+        assert_eq!(bottom_pin_height(&fk_with_div), Some(expected_with_div));
+        assert_eq!(bottom_pin_height(&fk_no_div), Some(expected_no_div));
+        assert_eq!(bottom_pin_height(&footer), Some(expected_footer));
+        assert_eq!(bottom_pin_height(&label), None);
     }
 
     /// `UiNode::TextEdit` PartialEq works.

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -479,12 +479,15 @@ pub(crate) fn render_component_tree(
 
         // ── L1 layout components ────────────────────────────────────────
 
-        UiNode::Column { children, gap, padding_top } => {
-            log::info!("render_components: Column {} children gap={gap} padding_top={padding_top}", children.len());
+        UiNode::Column { children, gap, padding_top, padding } => {
+            log::info!(
+                "render_components: Column {} children gap={gap} padding_top={padding_top} padding={padding}",
+                children.len()
+            );
             egui::Frame::new()
                 .inner_margin(egui::Margin {
-                    left: style::SPACE_XL as i8,
-                    right: style::SPACE_XL as i8,
+                    left: *padding as i8,
+                    right: *padding as i8,
                     top: *padding_top as i8,
                     bottom: 0,
                 })
@@ -845,6 +848,10 @@ fn render_stack(
                     if let Some(h) = bottom_pin_height(inner) {
                         pinned_bottom.push((h, inner.as_ref()));
                         continue;
+                    } else {
+                        log::warn!(
+                            "render_components: Pinned{{Bottom}} wraps a node with unknown intrinsic height — rendering inline; add it to bottom_pin_height()"
+                        );
                     }
                 }
                 body_children.push(child);
@@ -855,7 +862,10 @@ fn render_stack(
                 let body_h = (ui.available_height() - total_pinned_h).max(0.0);
 
                 // Body gets a constrained-height allocation; pinned fills the rest below.
+                // set_min_height forces the cursor to advance by the full body_h even when
+                // content is short, ensuring the footer renders flush to the bottom.
                 ui.allocate_ui(egui::vec2(ui.available_width(), body_h), |ui| {
+                    ui.set_min_height(body_h);
                     for (i, child) in body_children.iter().enumerate() {
                         if i > 0 && gap > 0.0 {
                             ui.add_space(gap);
@@ -1115,6 +1125,7 @@ mod render_component_tree_tests {
             ],
             gap: 8.0,
             padding_top: 0.0,
+            padding: crate::ui::style::SPACE_XL,
         };
         if let UiNode::Column { children, gap, .. } = &node {
             assert_eq!(children.len(), 1);
@@ -1146,6 +1157,7 @@ mod render_component_tree_tests {
             children: vec![UiNode::AppBar { title: "T".into(), subtitle: String::new() }],
             gap: 4.0,
             padding_top: 8.0,
+            padding: 0.0,
         };
         let json = serde_json::to_string(&node).unwrap();
         assert!(json.contains("\"type\":\"column\""), "json={json}");


### PR DESCRIPTION
Closes #2064

## Summary

- **Track A:** Add `UiNode::Pinned{edge,child}` — vertical stacks hoist `Pinned{Bottom}` children, constraining body height so footers render flush to the available rect bottom
- **Track B:** Replace `ui.indent()` with `egui::Frame::inner_margin()` for Stack padding — eliminates the left gutter stripe on every `Column`-rooted UI
- **Track C:** Add `UiNode::Column{children,gap,padding_top}` as a distinct wire type; `Column.to_node()` now emits `"type":"column"` instead of collapsing to a generic stack
- **Bug 3:** Remove unconditional `bg_sidebar` fill from `FooterKeys` renderer (was causing double dark bar when Column provided background)
- **Track D1:** `UiNode` now derives `JsonSchema` (was returning empty `{}` stub); schemars 1.x handles `Box<UiNode>` recursion via `$defs`
- **Python SDK:** `Footer.to_node()` and `FooterKeys.to_node()` wrap in `Pinned{edge:bottom}`; `Column.to_node()` emits column type, drops explicit padding dict

## Done When

1. Any app using `Column([..., FooterKeys([...])])` renders: zero left gutter stripe, zero double dark bar, `FooterKeys` pinned flush to pane bottom.
2. A `HostHarness` test `render_footer_keys_pins_to_bottom` passes: short content + `FooterKeys` → footer rect bottom equals available pane rect bottom.
3. Adding a new sticky-bottom node requires only: emit `Pinned { edge: Bottom }` in the node's `to_node()` — zero changes to `render_stack()`.
4. `Column` padding does not call `ui.indent()` anywhere — `egui::Frame` handles all margin.
5. `cargo test --bin plexi` passes.
6. `sdk/pgap_schema.json` exists with a complete non-empty schema for `UiNode`.

## Notes

- `bottom_pin_height()` helper computes fixed heights for `FooterKeys` and `Footer` (the two known bottom-pinnable types); unknown nodes return `None` and render inline
- Track D2 (schema export at build time) and Track D3 (style token codegen) are deferred — Track D1 (fix JsonSchema stub) is included
- The one pre-existing failing test (`render_events_coalesced_non_render_events_preserved`) was already failing on `origin/alpha` before this branch