### PR TITLE
feat(cli): plexi context list — enumerate all live contexts as JSON (#1686)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -90,6 +90,26 @@ impl PlexiApp {
                         log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
                     }
                 }
+                crate::app_protocol::AppRequest::ListContexts { response_file } => {
+                    log::info!("pane_ipc: kind=list_contexts response_file={:?}", response_file);
+                    let active_ctx_id = self.router.active().context_id;
+                    let entries: Vec<serde_json::Value> = self.router.iter().map(|ctx| {
+                        serde_json::json!({
+                            "context_id": ctx.context_id,
+                            "name": ctx.name,
+                            "path": ctx.path.to_string_lossy(),
+                            "root": ctx.root.as_ref().map(|p| p.to_string_lossy().into_owned()),
+                            "description": ctx.description,
+                            "parent_id": ctx.parent_id,
+                            "depth": ctx.depth,
+                            "active": ctx.context_id == active_ctx_id,
+                        })
+                    }).collect();
+                    let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                    if let Err(e) = std::fs::write(&response_file, &json_str) {
+                        log::error!("pane_ipc: list_contexts: could not write response file {response_file:?}: {e}");
+                    }
+                }
                 crate::app_protocol::AppRequest::GetPaneInfo { pane_id, response_file } => {
                     log::info!("pane_ipc: kind=get_pane_info pane_id={pane_id} response_file={:?}", response_file);
                     let active_win = self.active_window;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -102,12 +102,16 @@ impl PlexiApp {
                             "description": ctx.description,
                             "parent_id": ctx.parent_id,
                             "depth": ctx.depth,
-                            "active": ctx.context_id == active_ctx_id,
+                            "is_active": ctx.context_id == active_ctx_id,
                         })
                     }).collect();
                     let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
-                    if let Err(e) = std::fs::write(&response_file, &json_str) {
-                        log::error!("pane_ipc: list_contexts: could not write response file {response_file:?}: {e}");
+                    let temp_file = format!("{}.tmp", response_file);
+                    if let Err(e) = std::fs::write(&temp_file, &json_str) {
+                        log::error!("pane_ipc: list_contexts: could not write temp response file {temp_file:?}: {e}");
+                    } else if let Err(e) = std::fs::rename(&temp_file, &response_file) {
+                        log::error!("pane_ipc: list_contexts: could not rename temp response file to {response_file:?}: {e}");
+                        let _ = std::fs::remove_file(&temp_file);
                     }
                 }
                 crate::app_protocol::AppRequest::GetPaneInfo { pane_id, response_file } => {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -762,6 +762,8 @@ pub enum ContextCmd {
         /// Name for the new sub-context. Defaults to the pane name.
         name: Option<String>,
     },
+    /// List all open contexts as a JSON array.
+    List,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -210,11 +210,22 @@ fn print_json_output(json_str: &str) -> i32 {
         match Command::new("jq").arg(".").stdin(Stdio::piped()).spawn() {
             Ok(mut child) => {
                 if let Some(mut stdin) = child.stdin.take() {
-                    let _ = stdin.write_all(json_str.as_bytes());
+                    if let Err(e) = stdin.write_all(json_str.as_bytes()) {
+                        log::warn!("context_list:print_json_output: failed writing to jq stdin ({e})");
+                    }
                 }
-                let _ = child.wait();
-                log::info!("context_list:print_json_output: rendered via jq");
-                return 0;
+                match child.wait() {
+                    Ok(status) if status.success() => {
+                        log::info!("context_list:print_json_output: rendered via jq");
+                        return 0;
+                    }
+                    Ok(status) => {
+                        log::warn!("context_list:print_json_output: jq exited non-zero ({status}), falling back to serde");
+                    }
+                    Err(e) => {
+                        log::warn!("context_list:print_json_output: jq wait failed ({e}), falling back to serde");
+                    }
+                }
             }
             Err(e) => {
                 log::warn!("context_list:print_json_output: jq spawn failed ({e}), falling back to serde");
@@ -233,9 +244,9 @@ fn print_json_output(json_str: &str) -> i32 {
                 1
             }
         },
-        Err(_) => {
-            print!("{json_str}");
-            0
+        Err(e) => {
+            eprintln!("error: invalid JSON output: {e}");
+            1
         }
     }
 }

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -180,6 +180,7 @@ pub fn context_list_cli() -> i32 {
                     return print_json_output(&content);
                 }
                 Err(e) => {
+                    let _ = std::fs::remove_file(&response_path);
                     log::warn!("context_list:cli: could not read response file: {e}");
                     eprintln!("error: could not read response file: {e}");
                     return 1;
@@ -187,6 +188,7 @@ pub fn context_list_cli() -> i32 {
             }
         }
         if std::time::Instant::now() >= deadline {
+            let _ = std::fs::remove_file(&response_path);
             eprintln!("error: timed out waiting for context list response");
             return 1;
         }

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -145,3 +145,97 @@ pub fn context_current_cli() -> i32 {
     }
     0
 }
+
+/// `plexi context list`
+///
+/// Sends a `list_contexts` command to PLEXI_SOCKET. The host writes a JSON array
+/// to a response file; this function polls for it and prints it to stdout.
+/// Returns 0 on success, 1 on error.
+pub fn context_list_cli() -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("context-list-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+
+    let payload = serde_json::json!({
+        "type": "list_contexts",
+        "response_file": response_file,
+    });
+
+    log::info!("context_list:cli: sending via socket response_file={:?}", response_file);
+
+    let code = send_to_socket(payload);
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    return print_json_output(&content);
+                }
+                Err(e) => {
+                    log::warn!("context_list:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for context list response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn print_json_output(json_str: &str) -> i32 {
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
+
+    let jq_available = Command::new("jq")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if jq_available {
+        match Command::new("jq").arg(".").stdin(Stdio::piped()).spawn() {
+            Ok(mut child) => {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.write_all(json_str.as_bytes());
+                }
+                let _ = child.wait();
+                log::info!("context_list:print_json_output: rendered via jq");
+                return 0;
+            }
+            Err(e) => {
+                log::warn!("context_list:print_json_output: jq spawn failed ({e}), falling back to serde");
+            }
+        }
+    }
+
+    match serde_json::from_str::<serde_json::Value>(json_str) {
+        Ok(v) => match serde_json::to_string_pretty(&v) {
+            Ok(pretty) => {
+                println!("{pretty}");
+                0
+            }
+            Err(e) => {
+                eprintln!("error: could not serialize: {e}");
+                1
+            }
+        },
+        Err(_) => {
+            print!("{json_str}");
+            0
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -177,6 +177,7 @@ pub use config_cli::{config_check, config_edit, config_get, config_reset};
 pub use context_cli::{
     context_new_cli, context_zoom_cli, context_zoom_out_cli, context_open_cli,
     context_set_root_cli, context_current_cli, context_describe_cli, context_push_cli,
+    context_list_cli,
 };
 pub use demo::demo_cli;
 pub use doctor::doctor_cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -559,6 +559,7 @@ fn main() -> eframe::Result {
                         ContextCmd::Zoom { context_id } => std::process::exit(cli::context_zoom_cli(context_id)),
                         ContextCmd::ZoomOut => std::process::exit(cli::context_zoom_out_cli()),
                         ContextCmd::Push { name } => std::process::exit(cli::context_push_cli(name.as_deref())),
+                        ContextCmd::List => std::process::exit(cli::context_list_cli()),
                     },
                     Commands::Completions { shell } => {
                         let s = shell.as_deref().unwrap_or("zsh");

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1716,6 +1716,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::ListContexts { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: received ListContexts over PGAP — ignored (use PLEXI_SOCKET instead)",
+                    self.type_id
+                );
+            }
             AppRequest::FocusPane { .. } => {
                 log::warn!(
                     "ProcessApp[{}]: received FocusPane over PGAP — ignored (use PLEXI_SOCKET instead)",

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -646,6 +646,12 @@ pub enum AppRequest {
         context_id: Option<u64>,
     },
 
+    /// List all open contexts. Host writes a JSON array to `response_file`.
+    /// Sent by `plexi context list`.
+    ListContexts {
+        response_file: String,
+    },
+
     /// Query info for a specific pane by ID. Host writes JSON object to `response_file`.
     /// Sent by `plexi pane info`.
     GetPaneInfo {


### PR DESCRIPTION
Closes #1686

## Summary

- Adds `AppRequest::ListContexts { response_file }` variant to the IPC protocol; host iterates `self.router` and writes a JSON array of all live contexts to the response file
- Each context entry includes `context_id`, `name`, `path`, `root`, `description`, `parent_id`, `depth`, and `active` (whether it's the currently-focused context)
- `context_list_cli()` sends the socket message, polls the response file, and pretty-prints via jq (with serde fallback)

## Done When

`plexi context list` run from inside a Plexi pane prints a JSON array where each element has `context_id`, `name`, `path`, `root`, `description`, `parent_id`, `depth` — with at least one entry (the caller's own context).

## Notes

Added a no-op warn arm in `process_app/routing.rs` to satisfy the exhaustive match on `AppRequest` in the PGAP dispatch path — PGAP apps receive this over a different channel and don't handle it.