### PR TITLE
fix(ui/sidebar): context numbers renumber after parking (#2066)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2703,15 +2703,39 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SwitchContext(n) => {
-                    if n < self.router.len() {
-                        let target_parent = self.router.get(n).parent_id;
+                    // Map display position n (0-indexed) to the actual router index by
+                    // computing the same active display order the sidebar renders.
+                    let num = self.router.len();
+                    let mut display_order: Vec<usize> = Vec::with_capacity(num);
+                    for i in 0..num {
+                        if self.router.get(i).parent_id.is_none() {
+                            display_order.push(i);
+                            let ctx_id = self.router.get(i).context_id;
+                            for j in 0..num {
+                                if self.router.get(j).parent_id == Some(ctx_id) {
+                                    display_order.push(j);
+                                }
+                            }
+                        }
+                    }
+                    for i in 0..num {
+                        if !display_order.contains(&i) {
+                            display_order.push(i);
+                        }
+                    }
+                    let active_order: Vec<usize> = display_order.into_iter()
+                        .filter(|&i| !self.router.get(i).parked)
+                        .collect();
+                    if let Some(&router_idx) = active_order.get(n) {
+                        let target_parent = self.router.get(router_idx).parent_id;
                         let current_ctx_id = self.router.active().context_id;
                         if target_parent == Some(current_ctx_id) {
                             let current_win_id = self.windows[self.active_window].window_id;
                             let focused_tile = self.windows[self.active_window].focused_pane;
                             self.router.push_depth(current_ctx_id, current_win_id, focused_tile);
                         }
-                        self.switch_workspace(n);
+                        log::info!("SwitchContext: display_pos={} → router_idx={}", n + 1, router_idx);
+                        self.switch_workspace(router_idx);
                     }
                 }
                 Action::NextTab => {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -82,7 +82,7 @@ impl PlexiApp {
             .collect();
 
         // ── Active contexts ─────────────────────────────────────────────
-        for &i in &active_order {
+        for (display_idx, &i) in active_order.iter().enumerate() {
             let is_active = i == self.router.active_idx();
             let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
@@ -223,7 +223,7 @@ impl PlexiApp {
                 any_dragging,
                 action_enabled: num_contexts > 1 && !any_dragging,
                 ctx_name,
-                ctx_index: Some(i),
+                ctx_index: Some(display_idx),
                 badge_count,
                 subtitle,
                 pane_dots,


### PR DESCRIPTION
Closes #2066

## Summary

- Active contexts in the sidebar were numbered by their absolute router index `i` rather than their position in the filtered active list
- Changed the `active_order` loop to `enumerate()` so `display_idx` tracks position within the active (non-parked) set
- Pass `display_idx` instead of `i` to `ctx_index` — parked contexts are excluded, so remaining active contexts now renumber sequentially from 1

## Done When

- Park a context; remaining active contexts renumber correctly
- Context numbers are sequential starting from 1 for all active contexts
- Parked contexts remain unchanged

## Notes

`sidebar_row.rs` display logic (`idx + 1`) is unchanged — it was already correct; the bug was in the input.