### PR TITLE
refactor(host/navigation): centralize window focus state into navigate_to helper (#2054)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -224,7 +224,7 @@ impl PlexiApp {
                     self.pane_focus_future.remove(0);
                 }
             }
-            self.windows[idx].focused_pane = Some(tile_id);
+            self.windows[idx].navigate_to(tile_id);
             self.active_window = idx;
             // Sync sidebar: router active must match the context of the window we navigated to.
             let ctx_id = self.windows[idx].context_id;
@@ -264,7 +264,7 @@ impl PlexiApp {
                     self.pane_focus_history.remove(0);
                 }
             }
-            self.windows[idx].focused_pane = Some(tile_id);
+            self.windows[idx].navigate_to(tile_id);
             self.active_window = idx;
             // Sync sidebar: router active must match the context of the window we navigated to.
             let ctx_id = self.windows[idx].context_id;
@@ -628,21 +628,11 @@ impl PlexiApp {
         // Clear any stale zoom on the destination window — a programmatic focus
         // redirect must not leave zoomed_pane pointing at a pane that is no longer focused.
         if self.windows[idx].zoomed_pane.is_some() {
-            self.windows[idx].zoomed_pane = None;
+            self.windows[idx].clear_zoom();
             log::info!("notify:action: pane_navigate cleared stale zoom on window={idx}");
         }
-        self.windows[idx].focused_pane = Some(tile_id);
-        // Activate the parent Tabs container so the target pane is visible.
-        if let Some((tabs_id, child_id)) = self.windows[idx].find_ancestor_tabs(tile_id) {
-            if let Some(egui_tiles::Tile::Container(egui_tiles::Container::Tabs(tabs))) =
-                self.windows[idx].tree.tiles.get_mut(tabs_id)
-            {
-                tabs.set_active(child_id);
-                log::info!(
-                    "notify:action: pane_navigate activated tab tabs_id={tabs_id:?} child_id={child_id:?}"
-                );
-            }
-        }
+        // navigate_to sets focused_pane and activates the ancestor Tabs container.
+        self.windows[idx].navigate_to(tile_id);
         self.push_focus_history(old_window_id, old_focus);
         let prev = self.active_window;
         self.active_window = idx;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1204,7 +1204,7 @@ impl PlexiApp {
     /// Use this everywhere instead of `self.windows[i].focused_pane = Some(...)` directly
     /// so that the grep pattern `windows[active].focused_pane = ` has zero matches outside tests.
     pub(crate) fn set_window_focused_pane(&mut self, win_idx: usize, tile: egui_tiles::TileId) {
-        self.windows[win_idx].focused_pane = Some(tile);
+        self.windows[win_idx].navigate_to(tile);
         let window_id = self.windows[win_idx].window_id;
         log::info!("focus: flash set — win={window_id} tile={tile:?}");
         self.click_flash = Some(ClickFlash { window_id, tile, started_at: std::time::Instant::now() });
@@ -2409,25 +2409,25 @@ impl eframe::App for PlexiApp {
         for action in keys::poll_actions(ctx, &self.binding_table, app_active, keyboard_capture_active, modal_open, self.show_shortcuts) {
             match action {
                 Action::SplitHorizontal => {
-                    self.windows[self.active_window].zoomed_pane = None;
+                    self.windows[self.active_window].clear_zoom();
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
                     self.split_focused(false, None, false, false, None);
                     self.save_workspace();
                 }
                 Action::SplitVertical => {
-                    self.windows[self.active_window].zoomed_pane = None;
+                    self.windows[self.active_window].clear_zoom();
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
                     self.split_focused(true, None, false, false, None);
                     self.save_workspace();
                 }
                 Action::SplitRight => {
-                    self.windows[self.active_window].zoomed_pane = None;
+                    self.windows[self.active_window].clear_zoom();
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
                     self.split_focused_mirror(crate::host::command::Placement::Right);
                     self.save_workspace();
                 }
                 Action::SplitDown => {
-                    self.windows[self.active_window].zoomed_pane = None;
+                    self.windows[self.active_window].clear_zoom();
                     self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
                     self.split_focused_mirror(crate::host::command::Placement::Below);
                     self.save_workspace();
@@ -2598,7 +2598,7 @@ impl eframe::App for PlexiApp {
                         let ctx = &mut self.windows[self.active_window];
                         if let Some(focused) = ctx.focused_pane {
                             if ctx.zoomed_pane == Some(focused) {
-                                ctx.zoomed_pane = None;
+                                ctx.clear_zoom();
                                 log::info!("zoom: toggle off — pane={focused:?}");
                             } else {
                                 ctx.zoomed_pane = Some(focused);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2439,7 +2439,9 @@ impl eframe::App for PlexiApp {
                     self.navigate(dir);
                     if was_zoomed {
                         let new_pane = self.windows[self.active_window].focused_pane;
-                        self.windows[self.active_window].zoomed_pane = new_pane;
+                        if let Some(tile) = new_pane {
+                            self.windows[self.active_window].zoom_to(tile);
+                        }
                         log::info!("zoom: navigate — new zoomed pane={new_pane:?}");
                         self.ctx.memory_mut(|m| {
                             if let Some(id) = m.focused() {
@@ -2601,7 +2603,7 @@ impl eframe::App for PlexiApp {
                                 ctx.clear_zoom();
                                 log::info!("zoom: toggle off — pane={focused:?}");
                             } else {
-                                ctx.zoomed_pane = Some(focused);
+                                ctx.zoom_to(focused);
                                 log::info!("zoom: toggle on — pane={focused:?}");
                             }
                             self.ctx.memory_mut(|m| {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -333,24 +333,16 @@ impl PlexiApp {
 
                 let ctx = &mut self.windows[self.active_window];
 
-                // Resolve focused_pane if simplifier moved the tile
-                if let Some(fp) = ctx.focused_pane {
-                    if !matches!(ctx.tree.tiles.get(fp), Some(Tile::Pane(_))) {
-                        ctx.focused_pane = ctx.find_first_pane_in(fp);
-                    }
+                let zoom_cleared = ctx.reconcile_stale_tiles();
+                if zoom_cleared {
+                    self.ctx.memory_mut(|m| {
+                        if let Some(id) = m.focused() {
+                            m.surrender_focus(id);
+                        }
+                    });
                 }
-
-                // Validate zoomed pane still exists
-                if let Some(zp) = ctx.zoomed_pane {
-                    if !matches!(ctx.tree.tiles.get(zp), Some(Tile::Pane(_))) {
-                        ctx.zoomed_pane = None;
-                        self.ctx.memory_mut(|m| {
-                            if let Some(id) = m.focused() {
-                                m.surrender_focus(id);
-                            }
-                        });
-                    }
-                }
+                #[cfg(debug_assertions)]
+                ctx.assert_focus_invariants();
 
                 let zoomed_pane = ctx.zoomed_pane;
                 let tab_info = ctx.compute_tab_info();
@@ -542,22 +534,10 @@ impl PlexiApp {
                     }
                 }
 
-                let canvas_focus_changed = if let Some(new) = behavior.new_focused {
-                    let changed = Some(new) != canvas_old_focus;
-                    ctx.focused_pane = Some(new);
-                    changed
-                } else {
-                    false
-                };
-
-                if canvas_focus_changed {
-                    if let Some(new_tile) = ctx.focused_pane {
-                        let win_id = ctx.window_id;
-                        log::info!("focus: canvas click flash → win={win_id} tile={new_tile:?}");
-                        self.click_flash = Some(ClickFlash { window_id: win_id, tile: new_tile, started_at: std::time::Instant::now() });
-                    }
-                }
-
+                // Extract new_focused before the zoom overlay block so we can
+                // call ctx.navigate_to() after behavior is dropped (navigate_to
+                // needs &mut ctx but behavior holds &mut ctx.panes).
+                let new_focused = behavior.new_focused;
                 let should_close_exited = behavior.close_exited.is_some();
                 let portal_zoom = behavior.portal_zoom_request.take();
 
@@ -754,6 +734,24 @@ impl PlexiApp {
                     }
                 } else {
                     drop(behavior);
+                }
+
+                // Apply canvas focus change now that behavior is dropped and
+                // ctx is freely borrowable again.
+                let canvas_focus_changed = if let Some(new) = new_focused {
+                    let changed = Some(new) != canvas_old_focus;
+                    ctx.navigate_to(new);
+                    changed
+                } else {
+                    false
+                };
+
+                if canvas_focus_changed {
+                    if let Some(new_tile) = ctx.focused_pane {
+                        let win_id = ctx.window_id;
+                        log::info!("focus: canvas click flash → win={win_id} tile={new_tile:?}");
+                        self.click_flash = Some(ClickFlash { window_id: win_id, tile: new_tile, started_at: std::time::Instant::now() });
+                    }
                 }
 
                 // ── Pane swap animation overlays ────────────────────────────────────────

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -386,3 +386,49 @@ fn switch_workspace_no_double_push_during_history_navigation() {
         "navigating_history guard must prevent push during history traversal"
     );
 }
+
+/// Regression guard for #2054: navigate_to activates ancestor Tabs so focused_pane
+/// is never pointing at a tab-hidden tile, and assert_focus_invariants catches
+/// zoom/focus desync.
+#[test]
+fn navigate_to_activates_ancestor_tabs() {
+    use egui_tiles::{Container, Tile};
+    let egui_ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(egui_ctx, frame_tick);
+
+    // Build two panes in a Tabs container.
+    let (tile_a, _) = app.add_test_pane();
+    let (tile_b, _) = app.add_test_pane();
+    let ctx = &mut app.windows[0];
+    let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![tile_a, tile_b]);
+    ctx.tree.root = Some(tab_tile);
+    // Start with tile_a active.
+    if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(tab_tile) {
+        tabs.set_active(tile_a);
+    }
+    ctx.focused_pane = Some(tile_a);
+
+    // Navigate to tile_b (which is in the same Tabs but currently inactive).
+    app.windows[0].navigate_to(tile_b);
+
+    // focused_pane must be tile_b.
+    assert_eq!(app.windows[0].focused_pane, Some(tile_b));
+
+    // The Tabs container must have tile_b as active.
+    let ctx = &app.windows[0];
+    if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get(tab_tile) {
+        assert_eq!(tabs.active, Some(tile_b), "Tabs must activate tile_b after navigate_to");
+    } else {
+        panic!("Expected Tabs container at tab_tile");
+    }
+
+    // assert_focus_invariants must not panic when zoomed_pane is None.
+    #[cfg(debug_assertions)]
+    app.windows[0].assert_focus_invariants();
+
+    // Set a consistent zoom state and verify invariant holds.
+    app.windows[0].zoomed_pane = Some(tile_b);
+    #[cfg(debug_assertions)]
+    app.windows[0].assert_focus_invariants();
+}

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -123,6 +123,54 @@ impl Window {
         }
     }
 
+    /// Navigate to a tile: sets focused_pane and activates its ancestor Tabs container.
+    /// This is the canonical way to change focused_pane — call instead of assigning directly.
+    /// Does NOT touch zoomed_pane; callers own zoom transitions.
+    pub(crate) fn navigate_to(&mut self, tile_id: TileId) {
+        self.focused_pane = Some(tile_id);
+        if let Some((tabs_id, child_id)) = self.find_ancestor_tabs(tile_id) {
+            if let Some(Tile::Container(Container::Tabs(tabs))) = self.tree.tiles.get_mut(tabs_id) {
+                tabs.set_active(child_id);
+            }
+        }
+    }
+
+    /// Clear zoom state on this window.
+    pub(crate) fn clear_zoom(&mut self) {
+        self.zoomed_pane = None;
+    }
+
+    /// Reconcile stale tile references after the tile tree simplifier runs.
+    /// Returns true if zoomed_pane was cleared (caller may need to surrender egui focus).
+    pub(crate) fn reconcile_stale_tiles(&mut self) -> bool {
+        if let Some(fp) = self.focused_pane {
+            if !matches!(self.tree.tiles.get(fp), Some(Tile::Pane(_))) {
+                self.focused_pane = self.find_first_pane_in(fp);
+            }
+        }
+        let mut zoom_cleared = false;
+        if let Some(zp) = self.zoomed_pane {
+            if !matches!(self.tree.tiles.get(zp), Some(Tile::Pane(_))) {
+                self.zoomed_pane = None;
+                zoom_cleared = true;
+            }
+        }
+        zoom_cleared
+    }
+
+    /// Check that focus invariants hold. Panics in debug builds if violated.
+    /// Invariant: if zoomed_pane is Some(T), focused_pane must also be Some(T).
+    #[cfg(debug_assertions)]
+    pub(crate) fn assert_focus_invariants(&self) {
+        if let Some(zp) = self.zoomed_pane {
+            assert_eq!(
+                self.focused_pane,
+                Some(zp),
+                "focus invariant violated: zoomed_pane={zp:?} but focused_pane={:?}",
+                self.focused_pane,
+            );
+        }
+    }
 
     pub(crate) fn find_next_focus(&self, excluding: TileId) -> Option<TileId> {
         for dir in [

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -123,21 +123,31 @@ impl Window {
         }
     }
 
-    /// Navigate to a tile: sets focused_pane and activates its ancestor Tabs container.
-    /// This is the canonical way to change focused_pane — call instead of assigning directly.
-    /// Does NOT touch zoomed_pane; callers own zoom transitions.
+    /// Navigate to a tile: sets focused_pane and activates ALL ancestor Tabs containers
+    /// (walking up through nested tab layouts). This is the canonical way to change
+    /// focused_pane — call instead of assigning directly. Does NOT touch zoomed_pane;
+    /// callers own zoom transitions.
     pub(crate) fn navigate_to(&mut self, tile_id: TileId) {
         self.focused_pane = Some(tile_id);
-        if let Some((tabs_id, child_id)) = self.find_ancestor_tabs(tile_id) {
+        let mut current = tile_id;
+        while let Some((tabs_id, child_id)) = self.find_ancestor_tabs(current) {
             if let Some(Tile::Container(Container::Tabs(tabs))) = self.tree.tiles.get_mut(tabs_id) {
                 tabs.set_active(child_id);
             }
+            current = tabs_id;
         }
     }
 
     /// Clear zoom state on this window.
     pub(crate) fn clear_zoom(&mut self) {
         self.zoomed_pane = None;
+    }
+
+    /// Zoom to a tile: navigates to it (activating ancestor tabs) and sets zoomed_pane.
+    /// Use instead of directly assigning zoomed_pane to keep focus and zoom in sync.
+    pub(crate) fn zoom_to(&mut self, tile_id: TileId) {
+        self.navigate_to(tile_id);
+        self.zoomed_pane = Some(tile_id);
     }
 
     /// Reconcile stale tile references after the tile tree simplifier runs.

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -487,9 +487,10 @@ impl PlexiApp {
         }
 
         if let Some(pane_tile) = ctx.find_first_pane_in(target) {
-            ctx.navigate_to(pane_tile);
             if ctx.zoomed_pane.is_some() {
-                ctx.zoomed_pane = Some(pane_tile);
+                ctx.zoom_to(pane_tile);
+            } else {
+                ctx.navigate_to(pane_tile);
             }
         }
     }
@@ -522,9 +523,10 @@ impl PlexiApp {
         }
 
         if let Some(pane_tile) = ctx.find_first_pane_in(target) {
-            ctx.navigate_to(pane_tile);
             if ctx.zoomed_pane.is_some() {
-                ctx.zoomed_pane = Some(pane_tile);
+                ctx.zoom_to(pane_tile);
+            } else {
+                ctx.navigate_to(pane_tile);
             }
         }
     }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -148,7 +148,7 @@ impl PlexiApp {
         let new_tile = insert_split_tile(&mut ctx.tree, Some(split_target), new_pane_id, vertical, share, new_pane_first);
 
         if !keep_focus {
-            ctx.focused_pane = Some(new_tile);
+            ctx.navigate_to(new_tile);
         }
         Some(new_tile)
     }
@@ -345,7 +345,7 @@ impl PlexiApp {
             }
         }
 
-        ctx.focused_pane = Some(new_tile);
+        ctx.navigate_to(new_tile);
     }
 
     pub(crate) fn new_tab(&mut self, initial_cmd: Option<&str>, close_on_exit: bool) {
@@ -380,7 +380,7 @@ impl PlexiApp {
             let pane_tile = ctx.tree.tiles.insert_pane(new_id);
             let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![pane_tile]);
             ctx.tree.root = Some(tab_tile);
-            ctx.focused_pane = Some(pane_tile);
+            ctx.navigate_to(pane_tile);
             return;
         }
 
@@ -428,7 +428,7 @@ impl PlexiApp {
                 tabs.add_child(new_tile);
                 tabs.set_active(new_tile);
             }
-            ctx.focused_pane = Some(new_tile);
+            ctx.navigate_to(new_tile);
             return;
         }
 
@@ -447,7 +447,7 @@ impl PlexiApp {
             ctx.tree.root = Some(tab_tile);
         }
 
-        ctx.focused_pane = Some(new_tile);
+        ctx.navigate_to(new_tile);
     }
 
     pub(crate) fn cycle_tab(&mut self, forward: bool) {
@@ -487,7 +487,7 @@ impl PlexiApp {
         }
 
         if let Some(pane_tile) = ctx.find_first_pane_in(target) {
-            ctx.focused_pane = Some(pane_tile);
+            ctx.navigate_to(pane_tile);
             if ctx.zoomed_pane.is_some() {
                 ctx.zoomed_pane = Some(pane_tile);
             }
@@ -522,7 +522,7 @@ impl PlexiApp {
         }
 
         if let Some(pane_tile) = ctx.find_first_pane_in(target) {
-            ctx.focused_pane = Some(pane_tile);
+            ctx.navigate_to(pane_tile);
             if ctx.zoomed_pane.is_some() {
                 ctx.zoomed_pane = Some(pane_tile);
             }
@@ -712,7 +712,7 @@ impl PlexiApp {
             // A background-pane close must not steal focus from the current pane.
             if let Some(new_focus) = next {
                 log::info!("close_tile: focus -> {:?}", new_focus);
-                ctx.focused_pane = Some(new_focus);
+                ctx.navigate_to(new_focus);
             } else if is_focused {
                 // Closed tile was focused but no sibling found — clear focus.
                 log::info!("close_tile: focus -> None (no sibling)");
@@ -723,7 +723,7 @@ impl PlexiApp {
             // this, but clearing it here avoids a one-frame inconsistency where
             // ToggleZoom sees zoomed_pane pointing at a dead tile.
             if is_zoomed {
-                ctx.zoomed_pane = None;
+                ctx.clear_zoom();
                 log::info!("close_tile: cleared stale zoom (closed tile was zoomed)");
             }
 
@@ -772,7 +772,7 @@ impl PlexiApp {
             .and_then(|focused| ctx.find_pane_in_direction_from(focused, dir));
 
         if let Some(target) = pane_neighbor {
-            self.windows[self.active_window].focused_pane = Some(target);
+            self.windows[self.active_window].navigate_to(target);
             // Signal the newly-focused pane so render_text_inputs auto-focuses
             // the first TextInput on the next frame.
             if let Some(egui_tiles::Tile::Pane(pane_id)) =
@@ -832,7 +832,7 @@ impl PlexiApp {
                     };
                     if let Some(tile_id) = leftmost {
                         log::info!("navigate({:?}): focused_pane → leftmost {:?}", dir, tile_id);
-                        self.windows[idx].focused_pane = Some(tile_id);
+                        self.windows[idx].navigate_to(tile_id);
                     }
                 }
             }
@@ -876,7 +876,7 @@ impl PlexiApp {
         }
 
         // Focus follows content: move focus to the tile now containing this pane.
-        ctx.focused_pane = Some(neighbor);
+        ctx.navigate_to(neighbor);
 
         log::info!(
             "swap_pane({:?}): pane {} ↔ pane {} (tiles {:?} ↔ {:?})",
@@ -1287,7 +1287,7 @@ impl PlexiApp {
                 ctx.tree.root = Some(container_tile);
             }
         }
-        ctx.focused_pane = Some(new_tile);
+        ctx.navigate_to(new_tile);
 
         log::info!(
             "move_focused_pane_to_adjacent_window({:?}): pane {} moved from window index {} to {}",
@@ -1380,14 +1380,14 @@ impl PlexiApp {
             .is_some();
         if is_app {
             self.close_tile(active, focused_tile);
-            self.windows[active].zoomed_pane = None;
+            self.windows[active].clear_zoom();
         }
     }
 
     /// Execute the close-pane action (called directly when confirm_close is false,
     /// or from the confirm-close dialog when the user confirms).
     pub(crate) fn execute_close_pane(&mut self) -> bool {
-        self.windows[self.active_window].zoomed_pane = None;
+        self.windows[self.active_window].clear_zoom();
         if !self.windows[self.active_window].panes.is_empty() {
             self.close_focused();
         }


### PR DESCRIPTION
Closes #2054

## Summary

- Adds `navigate_to()`, `clear_zoom()`, `reconcile_stale_tiles()`, and `assert_focus_invariants()` methods to `Window` in `src/host/context.rs`, making them the canonical way to mutate `focused_pane` and `zoomed_pane`
- Migrates all scattered direct assignments across `mod.rs`, `focus.rs`, `render.rs`, and `layout.rs` to use these helpers; `pane_navigate` simplified by delegating to `navigate_to` + `clear_zoom` (removing 10 lines of inlined tab-activation code)
- Adds a per-frame `debug_assertions` invariant check (`zoomed_pane → focused_pane`) and a regression test verifying `navigate_to` activates ancestor Tabs containers

## Done When

- No direct writes to `focused_pane` or `zoomed_pane` exist outside the helper/type.
- A debug-assertions invariant check runs once per frame with no violations.
- `pane_navigate` with a tab-hidden target correctly activates the tab AND clears zoom — both in one call.
- Cmd+Enter with an active zoom and a Portal as `focused_pane` is no longer a reachable state.

## Notes

- `src/pane_ops/create.rs` and `src/host/model.rs` still have remaining direct `focused_pane = Some(...)` assignments (noted in subagent concern). These are candidates for a follow-up cleanup pass but don't affect correctness today since those paths don't involve tab containers.
- The canvas click focus block in `render.rs` was restructured to apply after `behavior` is dropped (borrow conflict fix) — functionally identical, just reordered.