### PR TITLE
feat(cli): plexi pane info --previous — return info for previously focused pane (#1611)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -236,8 +236,12 @@ impl PlexiApp {
                     if !found {
                         log::warn!("pane_ipc: get_previous_pane_info: no previous pane found in history");
                         let json_str = "{\"error\":\"no previous pane in history\"}";
-                        if let Err(e) = std::fs::write(response_file, json_str) {
-                            log::error!("pane_ipc: get_previous_pane_info: could not write error response: {e}");
+                        let temp_file = format!("{}.tmp", response_file);
+                        if let Err(e) = std::fs::write(&temp_file, json_str) {
+                            log::error!("pane_ipc: get_previous_pane_info: could not write temp error response {temp_file:?}: {e}");
+                        } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
+                            log::error!("pane_ipc: get_previous_pane_info: could not rename temp error response to {:?}: {e}", response_file);
+                            let _ = std::fs::remove_file(&temp_file);
                         }
                     }
                 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -177,6 +177,70 @@ impl PlexiApp {
                         }
                     }
                 }
+                crate::app_protocol::AppRequest::GetPreviousPaneInfo { response_file } => {
+                    log::info!("pane_ipc: kind=get_previous_pane_info response_file={:?}", response_file);
+                    let mut found = false;
+                    'prev_outer: for (window_id, tile_id) in self.pane_focus_history.iter().rev() {
+                        if let Some(win) = self.windows.iter().find(|w| w.window_id == *window_id) {
+                            if let Some(egui_tiles::Tile::Pane(pane_id)) = win.tree.tiles.get(*tile_id) {
+                                if let Some(pane) = win.panes.get(pane_id) {
+                                    let info = match pane {
+                                        crate::host::pane::Pane::Terminal(t) => {
+                                            let cwd = crate::host::shell::get_pid_cwd(t.backend.child_pid())
+                                                .map(|p| p.to_string_lossy().into_owned());
+                                            serde_json::json!({
+                                                "id": pane_id,
+                                                "type": "terminal",
+                                                "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
+                                                "focused": false,
+                                                "context_id": win.context_id,
+                                                "window_id": win.window_id,
+                                                "cwd": cwd,
+                                            })
+                                        }
+                                        crate::host::pane::Pane::App(a) => {
+                                            serde_json::json!({
+                                                "id": pane_id,
+                                                "type": "app",
+                                                "title": a.name.clone(),
+                                                "focused": false,
+                                                "context_id": win.context_id,
+                                                "window_id": win.window_id,
+                                                "cwd": a.workspace_root.to_string_lossy().as_ref(),
+                                                "manifest_id": a.manifest_id.clone(),
+                                            })
+                                        }
+                                        crate::host::pane::Pane::Portal(p) => {
+                                            serde_json::json!({
+                                                "id": pane_id,
+                                                "type": "portal",
+                                                "context_id": p.target_context_id,
+                                                "focused": false,
+                                            })
+                                        }
+                                    };
+                                    let json_str = serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
+                                    let temp_file = format!("{}.tmp", response_file);
+                                    if let Err(e) = std::fs::write(&temp_file, &json_str) {
+                                        log::error!("pane_ipc: get_previous_pane_info: could not write temp response file {temp_file:?}: {e}");
+                                    } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
+                                        log::error!("pane_ipc: get_previous_pane_info: could not rename temp response file to {:?}: {e}", response_file);
+                                        let _ = std::fs::remove_file(&temp_file);
+                                    }
+                                    found = true;
+                                    break 'prev_outer;
+                                }
+                            }
+                        }
+                    }
+                    if !found {
+                        log::warn!("pane_ipc: get_previous_pane_info: no previous pane found in history");
+                        let json_str = "{\"error\":\"no previous pane in history\"}";
+                        if let Err(e) = std::fs::write(response_file, json_str) {
+                            log::error!("pane_ipc: get_previous_pane_info: could not write error response: {e}");
+                        }
+                    }
+                }
                 crate::app_protocol::AppRequest::FocusPane { pane_id } => {
                     log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
                     if !self.pane_navigate(*pane_id) {

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -302,3 +302,81 @@ fn navigate_left_at_horizontal_boundary_still_page_navigates() {
     h.app.navigate(crate::host::keys::Direction::Left);
     assert_eq!(h.app.active_window, 0, "Left at boundary must not change active_window");
 }
+
+/// GetPreviousPaneInfo returns the last live entry from pane_focus_history.
+#[test]
+fn get_previous_pane_info_returns_previous_pane() {
+    let mut h = HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let pane_b = h.add_test_pane();
+
+    // Simulate: user was in pane_a, moved to pane_b (pushes pane_a's tile into history).
+    let tile_a = h.app.windows[0].tree.tiles.find_pane(&pane_a).expect("tile_a must exist");
+    let window_id = h.app.windows[0].window_id;
+    h.app.pane_focus_history.push((window_id, tile_a));
+
+    let resp_file = std::env::temp_dir().join("plexi_test_prev_pane_info.json");
+    let _ = std::fs::remove_file(&resp_file);
+
+    h.inject_ipc(crate::app_protocol::AppRequest::GetPreviousPaneInfo {
+        response_file: resp_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let json = std::fs::read_to_string(&resp_file).expect("response file must be written");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert!(v.get("error").is_none(), "unexpected error: {json}");
+    assert_eq!(v["id"].as_u64(), Some(pane_a), "previous pane must be pane_a, not pane_b; got: {json}");
+    let _ = std::fs::remove_file(&resp_file);
+    let _ = pane_b;
+}
+
+/// GetPreviousPaneInfo skips stale tile entries (tile no longer in tree) and
+/// falls through to the next valid entry.
+#[test]
+fn get_previous_pane_info_skips_stale_tile() {
+    let mut h = HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let window_id = h.app.windows[0].window_id;
+
+    // Push a stale (nonexistent) tile first, then a valid one.
+    let stale_tile = egui_tiles::TileId::from_u64(99999);
+    let tile_a = h.app.windows[0].tree.tiles.find_pane(&pane_a).expect("tile_a must exist");
+    h.app.pane_focus_history.push((window_id, tile_a));    // older: pane_a
+    h.app.pane_focus_history.push((window_id, stale_tile)); // newer (but stale)
+
+    let resp_file = std::env::temp_dir().join("plexi_test_prev_pane_stale.json");
+    let _ = std::fs::remove_file(&resp_file);
+
+    h.inject_ipc(crate::app_protocol::AppRequest::GetPreviousPaneInfo {
+        response_file: resp_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let json = std::fs::read_to_string(&resp_file).expect("response file must be written");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert!(v.get("error").is_none(), "unexpected error after stale skip: {json}");
+    assert_eq!(v["id"].as_u64(), Some(pane_a), "must fall through to pane_a after skipping stale tile; got: {json}");
+    let _ = std::fs::remove_file(&resp_file);
+}
+
+/// GetPreviousPaneInfo returns an error JSON when history is empty.
+#[test]
+fn get_previous_pane_info_empty_history_returns_error() {
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane();
+    assert!(h.app.pane_focus_history.is_empty(), "history must start empty");
+
+    let resp_file = std::env::temp_dir().join("plexi_test_prev_pane_empty.json");
+    let _ = std::fs::remove_file(&resp_file);
+
+    h.inject_ipc(crate::app_protocol::AppRequest::GetPreviousPaneInfo {
+        response_file: resp_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let json = std::fs::read_to_string(&resp_file).expect("response file must be written even on error");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert!(v.get("error").is_some(), "expected error field in response; got: {json}");
+    let _ = std::fs::remove_file(&resp_file);
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -630,8 +630,12 @@ pub enum PaneCmd {
     /// Useful in scripts: MY_PANE=$(plexi pane self)
     #[command(name = "self")]
     Self_,
-    /// Print details about the current pane as JSON.
-    Info,
+    /// Print details about the current pane (or the previously focused pane) as JSON.
+    Info {
+        /// Return info for the previously focused pane instead of the current one.
+        #[arg(long)]
+        previous: bool,
+    },
     /// Capture the last N lines of a pane's output as a JSON array.
     ///
     /// Defaults to the current pane when no pane id is given.

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -198,18 +198,81 @@ pub fn pane_self_cli() -> i32 {
 /// Sends a `get_pane_info` command to PLEXI_SOCKET for the current pane
 /// (identified by PLEXI_PANE_ID). Merges in client-side fields (socket, channel)
 /// and pretty-prints the result as JSON. Returns 0 on success, 1 on error.
-pub fn pane_info_cli() -> i32 {
-    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
-        Ok(v) => v,
-        Err(_) => {
-            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
-            return 1;
-        }
-    };
+pub fn pane_info_cli(previous: bool) -> i32 {
     let socket_path = match std::env::var("PLEXI_SOCKET") {
         Ok(v) => v,
         Err(_) => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return 1;
+        }
+    };
+
+    if previous {
+        let id = uuid::Uuid::new_v4();
+        let response_file = crate::config::config_dir()
+            .join(format!("pane-info-response-{id}.json"))
+            .to_string_lossy()
+            .into_owned();
+
+        let payload = serde_json::json!({
+            "type": "get_previous_pane_info",
+            "response_file": response_file,
+        });
+
+        log::info!("pane_info:cli: previous=true response_file={:?}", response_file);
+
+        let code = send_to_socket(payload);
+        if code != 0 {
+            return code;
+        }
+
+        let response_path = std::path::PathBuf::from(&response_file);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if response_path.exists() {
+                match std::fs::read_to_string(&response_path) {
+                    Ok(content) => {
+                        let _ = std::fs::remove_file(&response_path);
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                            if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+                                eprintln!("error: {err}");
+                                return 1;
+                            }
+                            let mut obj = v;
+                            obj["socket"] = serde_json::Value::String(socket_path.clone());
+                            let channel = crate::config::build_channel().unwrap_or_else(|| "main".to_string());
+                            obj["channel"] = serde_json::Value::String(channel);
+                            match serde_json::to_string(&obj) {
+                                Ok(json_str) => { return print_json_output(&json_str); }
+                                Err(e) => {
+                                    eprintln!("error: could not serialize response: {e}");
+                                    return 1;
+                                }
+                            }
+                        } else {
+                            eprintln!("error: invalid JSON from host: {content}");
+                            return 1;
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("pane_info:cli: could not read response file: {e}");
+                        eprintln!("error: could not read response file: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("error: timed out waiting for pane info response");
+                return 1;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
             return 1;
         }
     };

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -193,93 +193,16 @@ pub fn pane_self_cli() -> i32 {
     }
 }
 
-/// `plexi pane info`
+/// `plexi pane info [--previous]`
 ///
-/// Sends a `get_pane_info` command to PLEXI_SOCKET for the current pane
-/// (identified by PLEXI_PANE_ID). Merges in client-side fields (socket, channel)
-/// and pretty-prints the result as JSON. Returns 0 on success, 1 on error.
+/// Sends a `get_pane_info` or `get_previous_pane_info` command to PLEXI_SOCKET.
+/// Merges in client-side fields (socket, channel) and pretty-prints the result
+/// as JSON. Returns 0 on success, 1 on error.
 pub fn pane_info_cli(previous: bool) -> i32 {
     let socket_path = match std::env::var("PLEXI_SOCKET") {
         Ok(v) => v,
         Err(_) => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
-            return 1;
-        }
-    };
-
-    if previous {
-        let id = uuid::Uuid::new_v4();
-        let response_file = crate::config::config_dir()
-            .join(format!("pane-info-response-{id}.json"))
-            .to_string_lossy()
-            .into_owned();
-
-        let payload = serde_json::json!({
-            "type": "get_previous_pane_info",
-            "response_file": response_file,
-        });
-
-        log::info!("pane_info:cli: previous=true response_file={:?}", response_file);
-
-        let code = send_to_socket(payload);
-        if code != 0 {
-            return code;
-        }
-
-        let response_path = std::path::PathBuf::from(&response_file);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if response_path.exists() {
-                match std::fs::read_to_string(&response_path) {
-                    Ok(content) => {
-                        let _ = std::fs::remove_file(&response_path);
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                            if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
-                                eprintln!("error: {err}");
-                                return 1;
-                            }
-                            let mut obj = v;
-                            obj["socket"] = serde_json::Value::String(socket_path.clone());
-                            let channel = crate::config::build_channel().unwrap_or_else(|| "main".to_string());
-                            obj["channel"] = serde_json::Value::String(channel);
-                            match serde_json::to_string(&obj) {
-                                Ok(json_str) => { return print_json_output(&json_str); }
-                                Err(e) => {
-                                    eprintln!("error: could not serialize response: {e}");
-                                    return 1;
-                                }
-                            }
-                        } else {
-                            eprintln!("error: invalid JSON from host: {content}");
-                            return 1;
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!("pane_info:cli: could not read response file: {e}");
-                        eprintln!("error: could not read response file: {e}");
-                        return 1;
-                    }
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                eprintln!("error: timed out waiting for pane info response");
-                return 1;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-    }
-
-    let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
-        Ok(v) => v,
-        Err(_) => {
-            eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
-            return 1;
-        }
-    };
-    let pane_id: u64 = match pane_id_str.parse() {
-        Ok(n) => n,
-        Err(_) => {
-            eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
             return 1;
         }
     };
@@ -290,13 +213,34 @@ pub fn pane_info_cli(previous: bool) -> i32 {
         .to_string_lossy()
         .into_owned();
 
-    let payload = serde_json::json!({
-        "type": "get_pane_info",
-        "pane_id": pane_id,
-        "response_file": response_file,
-    });
-
-    log::info!("pane_info:cli: pane_id={pane_id} response_file={:?}", response_file);
+    let payload = if previous {
+        log::info!("pane_info:cli: previous=true response_file={:?}", response_file);
+        serde_json::json!({
+            "type": "get_previous_pane_info",
+            "response_file": response_file,
+        })
+    } else {
+        let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane");
+                return 1;
+            }
+        };
+        let pane_id: u64 = match pane_id_str.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                eprintln!("error: PLEXI_PANE_ID is not a valid number: {pane_id_str}");
+                return 1;
+            }
+        };
+        log::info!("pane_info:cli: pane_id={pane_id} response_file={:?}", response_file);
+        serde_json::json!({
+            "type": "get_pane_info",
+            "pane_id": pane_id,
+            "response_file": response_file,
+        })
+    };
 
     let code = send_to_socket(payload);
     if code != 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,7 +507,7 @@ fn main() -> eframe::Result {
                         }
                         PaneCmd::Key { pane_id, key } => std::process::exit(cli::pane_key_cli(pane_id, &key)),
                         PaneCmd::Self_ => std::process::exit(cli::pane_self_cli()),
-                        PaneCmd::Info => std::process::exit(cli::pane_info_cli()),
+                        PaneCmd::Info { previous } => std::process::exit(cli::pane_info_cli(previous)),
                         PaneCmd::Capture { pane_id, lines, full_output, from_cursor } => std::process::exit(cli::pane_capture_cli(pane_id, lines, full_output, from_cursor)),
                         PaneCmd::State { pane_id } => std::process::exit(cli::pane_state_cli(pane_id)),
                         PaneCmd::New { cmd, name, down, left, up, right, tab, window, overlay, from, ephemeral, no_focus, cwd } => {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1786,6 +1786,12 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::GetPreviousPaneInfo { .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: GetPreviousPaneInfo received in app routing — ignored (host-only command)",
+                    self.type_id
+                );
+            }
             AppRequest::CapturePane { pane_id, .. } => {
                 log::warn!(
                     "ProcessApp[{}]: CapturePane pane_id={pane_id} received in app routing — ignored (use PLEXI_SOCKET instead)",

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -659,6 +659,15 @@ pub enum AppRequest {
         response_file: String,
     },
 
+    /// Query info for the previously focused pane. Host walks `pane_focus_history`
+    /// from the end, finds the last entry whose tile resolves to a live pane, and
+    /// writes the same JSON shape as `GetPaneInfo` to `response_file`.
+    /// Returns `{"error":"..."}` if history is empty or no valid pane found.
+    /// Sent by `plexi pane info --previous`.
+    GetPreviousPaneInfo {
+        response_file: String,
+    },
+
     /// Move UI focus to a pane by PaneId. Sent by `plexi pane focus`. Fire-and-forget.
     FocusPane {
         pane_id: u64,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -3179,4 +3179,36 @@ mod ai_stream_chunk_tests {
             other => panic!("expected ComponentTree, got {other:?}"),
         }
     }
+
+    /// Wire-format round-trip for GetPreviousPaneInfo.
+    #[test]
+    fn get_previous_pane_info_round_trips_serde() {
+        let json = r#"{"type":"get_previous_pane_info","response_file":"/tmp/prev.json"}"#;
+        let req: AppRequest = serde_json::from_str(json).expect("deserialise");
+        match &req {
+            AppRequest::GetPreviousPaneInfo { response_file } => {
+                assert_eq!(response_file, "/tmp/prev.json");
+            }
+            other => panic!("expected GetPreviousPaneInfo, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&req).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"get_previous_pane_info""#),
+            "wire tag missing: {serialised}"
+        );
+        assert!(
+            serialised.contains(r#""response_file":"/tmp/prev.json""#),
+            "response_file missing: {serialised}"
+        );
+    }
+
+    /// Missing response_file must fail deserialization.
+    #[test]
+    fn get_previous_pane_info_missing_response_file_fails() {
+        let json = r#"{"type":"get_previous_pane_info"}"#;
+        assert!(
+            serde_json::from_str::<AppRequest>(json).is_err(),
+            "missing required response_file must fail"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1611

## Summary

- Added `GetPreviousPaneInfo` AppRequest variant to the protocol; host handler walks `pane_focus_history` in reverse to find the last live pane and writes the same JSON shape as `GetPaneInfo`
- CLI `pane_info_cli` now accepts `previous: bool`; when true, skips `PLEXI_PANE_ID` and sends `get_previous_pane_info` to the host socket
- `PaneCmd::Info` arg struct updated with `--previous` flag; clap-complete auto-generates the completion entry

## Done When

- `plexi pane info --previous` run from pane A (after focusing pane B then returning to pane A) prints the JSON info for pane B
- The output has the same fields as `plexi pane info` (id, type, title, focused, context_id, window_id, cwd)
- Running `plexi pane info --previous` with no focus history prints a clear error and exits non-zero
- `--help` for `plexi pane info` documents the flag

## Notes

- `focused` is always `false` in the previous-pane response (it's not currently focused by definition)
- Atomic write (tmp + rename) used in the host handler, matching the `ListContexts` pattern
- `process_app/routing.rs` got an exhaustive match arm that warns+ignores (host-only command)