### PR TITLE
feat(cli): app render accepts path or ID, workspace precondition audit (#1608, #1609)

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -485,9 +485,10 @@ pub fn app_list() -> i32 {
     super::list::list_cli()
 }
 
-/// `plexi app render <id> --size WxH [--state state.json] [--output path] [--png]`
-/// Renders an app headlessly. Default: JSON frame tree. With --png: PNG image.
-pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str>, png: bool) -> i32 {
+/// `plexi app render <app> --size WxH [--state state.json] [--output path] [--png]`
+/// Renders an app headlessly. `app` may be an installed app ID or a local directory path.
+/// Default output: JSON frame tree. With --png: PNG image.
+pub fn app_render(app: &str, size: &str, state: Option<&str>, output: Option<&str>, png: bool) -> i32 {
     // Parse WxH
     let (width, height) = match parse_render_size(size) {
         Some(v) => v,
@@ -509,10 +510,7 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
             }
         };
         match serde_json::from_str(&json) {
-            Ok(v) => {
-                log::info!("app_render[{id}]: loaded seed state from '{s}'");
-                Some(v)
-            }
+            Ok(v) => Some(v),
             Err(e) => {
                 eprintln!("error: invalid JSON in state file '{s}': {e}");
                 return 1;
@@ -522,20 +520,59 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
         None
     };
 
-    // Resolve the app binary
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    let registry = crate::app::registry::AppRegistry::load(&cwd);
-    let app_bin = match registry.list().into_iter().find(|a| a.manifest.id == id) {
-        Some(a) => a.bin_path.clone(),
-        None => {
-            eprintln!("error: app '{id}' not found — run `plexi app list` to see installed apps");
+    // Resolve (app_id, bin_path): path argument takes priority over registry lookup.
+    // A path is detected by prefix (./  ../  /) or by existing as a directory.
+    let (app_id, app_bin) = if app.starts_with("./") || app.starts_with("../") || app.starts_with('/') || std::path::Path::new(app).is_dir() {
+        let app_dir = match std::path::Path::new(app).canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("error: could not resolve '{app}': {e}");
+                return 1;
+            }
+        };
+        if !app_dir.is_dir() {
+            eprintln!("error: '{app}' is not a directory — expected an app directory containing manifest.toml");
             return 1;
+        }
+        let manifest_path = app_dir.join("manifest.toml");
+        let manifest_str = match std::fs::read_to_string(&manifest_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("error: no manifest.toml in {}: {e}", app_dir.display());
+                eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
+                return 1;
+            }
+        };
+        let manifest: crate::app::registry::AppManifest = match toml::from_str(&manifest_str) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("error: invalid manifest.toml: {e}");
+                return 1;
+            }
+        };
+        let entry = app_dir.join(&manifest.app.entry);
+        if !entry.exists() {
+            eprintln!("error: app entry '{}' not found in {}", manifest.app.entry, app_dir.display());
+            return 1;
+        }
+        log::info!("app_render[{}]: loaded from path '{app}'", manifest.app.id);
+        (manifest.app.id, entry)
+    } else {
+        // ID-based: registry lookup
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let registry = crate::app::registry::AppRegistry::load(&cwd);
+        match registry.list().into_iter().find(|a| a.manifest.id == app) {
+            Some(a) => (a.manifest.id.clone(), a.bin_path.clone()),
+            None => {
+                eprintln!("error: app '{app}' not found — run `plexi app list` to see installed apps");
+                return 1;
+            }
         }
     };
 
     if png {
         // PNG mode: rasterize and write binary
-        let png_bytes = match crate::render::app_render::render_app_to_png(id, &app_bin, width, height, seed_state) {
+        let png_bytes = match crate::render::app_render::render_app_to_png(&app_id, &app_bin, width, height, seed_state) {
             Ok(b) => b,
             Err(e) => {
                 eprintln!("error: render failed: {e}");
@@ -548,7 +585,7 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
                     eprintln!("error: could not write output to '{path}': {e}");
                     return 1;
                 }
-                log::info!("app_render[{id}]: wrote {width}×{height} PNG to '{path}'");
+                log::info!("app_render[{app_id}]: wrote {width}×{height} PNG to '{path}'");
                 eprintln!("Wrote {width}×{height} PNG to '{path}'");
             }
             None => {
@@ -558,14 +595,14 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
                     return 1;
                 }
                 log::info!(
-                    "app_render[{id}]: wrote {width}×{height} PNG to stdout ({} bytes)",
+                    "app_render[{app_id}]: wrote {width}×{height} PNG to stdout ({} bytes)",
                     png_bytes.len()
                 );
             }
         }
     } else {
         // JSON mode (default): return raw frame commands
-        let json = match crate::render::app_render::render_app_to_json(id, &app_bin, width, height, seed_state) {
+        let json = match crate::render::app_render::render_app_to_json(&app_id, &app_bin, width, height, seed_state) {
             Ok(j) => j,
             Err(e) => {
                 eprintln!("error: render failed: {e}");
@@ -578,12 +615,12 @@ pub fn app_render(id: &str, size: &str, state: Option<&str>, output: Option<&str
                     eprintln!("error: could not write output to '{path}': {e}");
                     return 1;
                 }
-                log::info!("app_render[{id}]: wrote JSON frame to '{path}'");
+                log::info!("app_render[{app_id}]: wrote JSON frame to '{path}'");
                 eprintln!("Wrote JSON frame to '{path}'");
             }
             None => {
                 println!("{json}");
-                log::info!("app_render[{id}]: wrote JSON frame to stdout");
+                log::info!("app_render[{app_id}]: wrote JSON frame to stdout");
             }
         }
     }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -522,10 +522,13 @@ pub fn app_render(app: &str, size: &str, state: Option<&str>, output: Option<&st
 
     // Resolve (app_id, bin_path): path argument takes priority over registry lookup.
     // A path is detected by prefix (./  ../  /) or by existing as a directory.
-    let (app_id, app_bin) = if app.starts_with("./") || app.starts_with("../") || app.starts_with('/') || std::path::Path::new(app).is_dir() {
+    // Path: more than one component (./foo, ../foo, /abs/path) OR an existing directory.
+    // Using components() instead of prefix checks is portable across platforms.
+    let (app_id, app_bin) = if std::path::Path::new(app).components().count() > 1 || std::path::Path::new(app).is_dir() {
         let app_dir = match std::path::Path::new(app).canonicalize() {
             Ok(p) => p,
             Err(e) => {
+                log::warn!("app_render: could not resolve '{app}': {e}");
                 eprintln!("error: could not resolve '{app}': {e}");
                 return 1;
             }
@@ -538,6 +541,7 @@ pub fn app_render(app: &str, size: &str, state: Option<&str>, output: Option<&st
         let manifest_str = match std::fs::read_to_string(&manifest_path) {
             Ok(s) => s,
             Err(e) => {
+                log::warn!("app_render: no manifest.toml in {}: {e}", app_dir.display());
                 eprintln!("error: no manifest.toml in {}: {e}", app_dir.display());
                 eprintln!("  Is this a Plexi app directory? Run `plexi app init <name>` to scaffold one.");
                 return 1;
@@ -546,10 +550,19 @@ pub fn app_render(app: &str, size: &str, state: Option<&str>, output: Option<&st
         let manifest: crate::app::registry::AppManifest = match toml::from_str(&manifest_str) {
             Ok(m) => m,
             Err(e) => {
+                log::warn!("app_render: invalid manifest.toml in {}: {e}", app_dir.display());
                 eprintln!("error: invalid manifest.toml: {e}");
                 return 1;
             }
         };
+        if manifest.schema_version > crate::app::registry::MANIFEST_SCHEMA_VERSION {
+            eprintln!(
+                "error: manifest.toml schema_version {} is newer than supported (max {}); update Plexi to render this app",
+                manifest.schema_version,
+                crate::app::registry::MANIFEST_SCHEMA_VERSION
+            );
+            return 1;
+        }
         let entry = app_dir.join(&manifest.app.entry);
         if !entry.exists() {
             eprintln!("error: app entry '{}' not found in {}", manifest.app.entry, app_dir.display());

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -375,8 +375,8 @@ pub enum AppCmd {
     List,
     /// Render an app headlessly (JSON frame tree by default, or PNG with --png).
     Render {
-        /// App id to render (e.g. "snake")
-        id: String,
+        /// App id or local path to render (e.g. "snake" or "./my-app")
+        app: String,
         /// Image dimensions as WxH (e.g. 500x500)
         #[arg(long, default_value = "800x600")]
         size: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,8 @@ fn main() -> eframe::Result {
                         AppCmd::Init { name, lang, global, no_open, from_pane_id } => std::process::exit(cli::app_init(&name, &lang, global, no_open, from_pane_id)),
                         AppCmd::Uninstall { id, yes } => std::process::exit(cli::app_uninstall(&id, yes)),
                         AppCmd::List => std::process::exit(cli::app_list()),
-                        AppCmd::Render { id, size, state, output, png } => {
-                            std::process::exit(cli::app_render(&id, &size, state.as_deref(), output.as_deref(), png))
+                        AppCmd::Render { app, size, state, output, png } => {
+                            std::process::exit(cli::app_render(&app, &size, state.as_deref(), output.as_deref(), png))
                         }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                         AppCmd::Validate { path } => {

--- a/src/render/app_render.rs
+++ b/src/render/app_render.rs
@@ -50,8 +50,37 @@ fn spawn_and_collect_frame(
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
     // Mirror the env setup from ProcessApp::launch so Python apps can import plexi_sdk.
+    // .py entries are launched via python3 — no shebang or execute bit required (mirrors ProcessApp::launch).
     const ENV_WHITELIST: &[&str] = &["HOME", "PATH", "LANG", "LC_ALL", "TERM", "USER", "SHELL"];
-    let mut cmd = Command::new(bin_path);
+    let bundle_contents = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()));
+    let bundled_py_bin = bundle_contents.as_ref()
+        .map(|c| c.join("Resources").join("assets").join("python").join("bin"));
+    let bundle_sdk = bundle_contents.as_ref()
+        .map(|c| c.join("Resources").join("sdk").join("python"));
+    let is_python = bin_path.extension().and_then(|e| e.to_str()) == Some("py");
+    let mut cmd = if is_python {
+        let venv_python = bin_path
+            .parent()
+            .map(|app_dir| app_dir.join(".venv").join("bin").join("python"))
+            .filter(|p| p.exists());
+        let py = venv_python
+            .map(std::ffi::OsString::from)
+            .or_else(|| {
+                bundled_py_bin.as_ref()
+                    .map(|b| b.join("python3"))
+                    .filter(|p| p.exists())
+                    .map(std::ffi::OsString::from)
+            })
+            .unwrap_or_else(|| std::ffi::OsString::from("python3"));
+        log::info!("app_render[{app_id}]: launching .py entry via {:?}", py);
+        let mut c = Command::new(py);
+        c.arg(bin_path);
+        c
+    } else {
+        Command::new(bin_path)
+    };
     cmd.current_dir(&cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -67,10 +96,6 @@ fn spawn_and_collect_frame(
             cmd.env(k, v);
         }
     }
-    let bundle_sdk = std::env::current_exe()
-        .ok()
-        .and_then(|exe| exe.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
-        .map(|p| p.join("Resources").join("sdk").join("python"));
     let pythonpath = crate::config::build_pythonpath(bundle_sdk.as_deref());
     cmd.env("PYTHONPATH", &pythonpath);
     log::info!("app_render[{app_id}]: PYTHONPATH={pythonpath}");


### PR DESCRIPTION
Closes #1608, Closes #1609

## Summary

**#1608 — feat(cli): plexi app render should accept a path in addition to installed app ID**
- `plexi app render ./my-app` now resolves the app from the directory directly — no install required
- Path detection: argument starting with `./` `../` `/` or resolving as an existing directory triggers path-based loading
- Manifest is parsed from the directory; `bin_path` is resolved from `manifest.app.entry`; ID-based registry lookup is the fallback for plain names

**#1609 — fix(cli): audit and remove spurious workspace preconditions from path-based app commands**
- Confirmed: `app render`, `app validate`, and `app install <path>` do not call `resolve_workspace_root` for their primary path argument
- Tests added in alpha (validate_tests, app_install_workspace_tests) verify these invariants hold

## Done When — #1608
1. `plexi app render ./examples/bluesky --output /tmp/out.png` renders without prior install
2. `plexi app render bluesky` (installed ID) still works unchanged
3. An invalid path produces a clear error, not "app not found"

## Done When — #1609
1. `plexi app render ./examples/bluesky` works from a directory with no `.plexi/` workspace
2. `plexi app validate ./examples/bluesky` works from a directory with no `.plexi/` workspace
3. `plexi app install ./examples/bluesky` works from a directory with no `.plexi/` workspace
4. No spurious "workspace not found" warnings appear for any of the above