### PR TITLE
feat(text-editor): workspace-scoped timestamped notes, debounced auto-save, ⌘+O picker (#2076)

### DIFF
--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -233,4 +233,8 @@ pub trait App: Send {
 
     /// Restore app state from a previously serialised value.
     fn restore_state(&mut self, _state: &serde_json::Value) {}
+
+    /// Adjust the app's internal font size by `delta` points (positive = larger).
+    /// Only implemented by apps with their own font size, e.g. TextEditorApp.
+    fn adjust_font_size(&mut self, _delta: f32) {}
 }

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -110,6 +110,7 @@ impl PlexiApp {
                 | Some(FocusLayer::TextInput)
                 | Some(FocusLayer::ContextCloseConfirm)
                 | Some(FocusLayer::CapabilityModal)
+                | Some(FocusLayer::NotesPicker)
         )
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -103,6 +103,8 @@ pub(crate) enum FocusLayer {
     /// so the modal renders in step 2 of `update()` with exclusive keyboard
     /// ownership — before `dispatch_app_key_events` can steal Escape.
     CapabilityModal,
+    /// Notes picker overlay: lists workspace notes sorted by mtime, opens selected in focused text-editor.
+    NotesPicker,
 }
 
 /// What a `TextInputOverlay` commit should do.
@@ -351,6 +353,10 @@ pub struct PlexiApp {
     pub(crate) quick_note_text: String,
     /// Context captured at the time the quick note modal was opened.
     pub(crate) quick_note_ctx: QuickNoteCtx,
+    /// Notes picker: sorted list of (path, first-line-preview) for the current workspace.
+    pub(crate) notes_picker_entries: Vec<(std::path::PathBuf, String)>,
+    /// Notes picker: currently highlighted row index.
+    pub(crate) notes_picker_selected: usize,
     /// Cursor row in the destination picker (0 = global backlog, 1+ = config destinations).
     pub(crate) quick_note_dest_cursor: usize,
     /// Cursor row in the sub-destination picker.
@@ -970,6 +976,8 @@ impl PlexiApp {
                     modal_input_buffer: String::new(),
                     quick_note_text: String::new(),
                     quick_note_ctx: QuickNoteCtx::default(),
+                    notes_picker_entries: Vec::new(),
+                    notes_picker_selected: 0,
                     quick_note_dest_cursor: 0,
                     quick_note_sub_cursor: 0,
                     quick_note_children_cache: HashMap::new(),
@@ -1144,6 +1152,8 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
+            notes_picker_entries: Vec::new(),
+            notes_picker_selected: 0,
             quick_note_dest_cursor: 0,
             quick_note_sub_cursor: 0,
             quick_note_children_cache: HashMap::new(),
@@ -1313,6 +1323,8 @@ impl PlexiApp {
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
             quick_note_ctx: QuickNoteCtx::default(),
+            notes_picker_entries: Vec::new(),
+            notes_picker_selected: 0,
             quick_note_dest_cursor: 0,
             quick_note_sub_cursor: 0,
             quick_note_children_cache: HashMap::new(),
@@ -1550,6 +1562,10 @@ impl eframe::App for PlexiApp {
                 Some(FocusLayer::TextInput) => self.text_input_handle_key(ctx),
                 Some(FocusLayer::ContextCloseConfirm) => self.context_close_confirm_handle_key(ctx),
                 Some(FocusLayer::CapabilityModal) => self.capability_modal_handle_key(ctx),
+                Some(FocusLayer::NotesPicker) => {
+                    self.notes_picker_handle_key(ctx);
+                    crate::app::app_trait::KeyDisposition::Passthrough
+                }
                 None => crate::app::app_trait::KeyDisposition::Passthrough,
             };
             // Step 2: render the overlay (visual only — key reads already done above).
@@ -1594,6 +1610,9 @@ impl eframe::App for PlexiApp {
                 }
                 Some(FocusLayer::CapabilityModal) => {
                     self.draw_capability_modal(ctx);
+                }
+                Some(FocusLayer::NotesPicker) => {
+                    self.draw_notes_picker(ctx);
                 }
                 None => {}
             }
@@ -2858,6 +2877,24 @@ impl eframe::App for PlexiApp {
                     log::info!("scratchpad: Cmd+Shift+Space — opening");
                     self.open_scratchpad();
                 }
+                Action::OpenNotesPicker => {
+                    let active = self.active_window;
+                    let is_text_editor = self.windows[active]
+                        .focused_pane
+                        .and_then(|tile_id| {
+                            if let Some(egui_tiles::Tile::Pane(pane_id)) = self.windows[active].tree.tiles.get(tile_id) {
+                                self.windows[active].panes.get(pane_id)
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|pane| matches!(pane, crate::host::pane::Pane::App(a) if a.runtime.type_id() == "text-editor"))
+                        .unwrap_or(false);
+                    if is_text_editor {
+                        log::info!("notes_picker: Cmd+O — opening picker");
+                        self.open_notes_picker();
+                    }
+                }
                 Action::ContextZoomOut => {
                     log::info!("ContextZoomOut: popping depth stack (depth={})", self.router.current_depth());
                     if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth() {
@@ -3006,6 +3043,49 @@ impl eframe::App for PlexiApp {
             log::info!("focus_changed: shutdown — banking final session duration_secs={duration_secs}");
             self.emit_focus_changed_for_tile(window_id, tile_id, duration_secs);
         }
+    }
+
+}
+
+impl PlexiApp {
+    pub(crate) fn open_notes_picker(&mut self) {
+        let notes_base = crate::config::config_dir().join("notes");
+        let workspace_slug = crate::config::active_workspace_root()
+            .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+            .map(|n| n.to_string_lossy().into_owned());
+        let notes_dir = match workspace_slug {
+            Some(ref slug) => notes_base.join(slug),
+            None => notes_base,
+        };
+        let mut with_mtime: Vec<(std::time::SystemTime, std::path::PathBuf, String)> =
+            std::fs::read_dir(&notes_dir)
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().map_or(false, |x| x == "md"))
+                .filter_map(|e| {
+                    let path = e.path();
+                    let mtime = e.metadata().and_then(|m| m.modified()).ok()?;
+                    let preview = std::fs::read_to_string(&path).unwrap_or_default();
+                    let first_line = preview
+                        .lines()
+                        .find(|l| !l.trim().is_empty())
+                        .unwrap_or("")
+                        .to_string();
+                    Some((mtime, path, first_line))
+                })
+                .collect();
+        with_mtime.sort_by(|a, b| b.0.cmp(&a.0));
+        let entries: Vec<(std::path::PathBuf, String)> =
+            with_mtime.into_iter().map(|(_, p, l)| (p, l)).collect();
+        if entries.is_empty() {
+            log::info!("notes_picker: no notes in {:?}", notes_dir);
+            return;
+        }
+        log::info!("notes_picker: {} notes found in {:?}", entries.len(), notes_dir);
+        self.notes_picker_entries = entries;
+        self.notes_picker_selected = 0;
+        self.push_focus_layer(FocusLayer::NotesPicker);
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3086,6 +3086,9 @@ impl PlexiApp {
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.push_focus_layer(FocusLayer::NotesPicker);
+        // Surrender egui keyboard focus from the active TextEdit so the picker
+        // receives j/k and other navigation keys immediately on the first frame.
+        self.ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
     }
 }
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -15,7 +15,6 @@ pub struct TextEditorApp {
     last_edit: Option<Instant>,
     wants_close: bool,
     load_error: Option<String>,
-    focus_requested: bool,
     font_size: f32,
 }
 
@@ -33,12 +32,23 @@ impl TextEditorApp {
             last_edit: None,
             wants_close: false,
             load_error,
-            focus_requested: false,
             font_size: FONT_SIZE_DEFAULT,
         }
     }
 
     fn flush(&mut self) {
+        self.last_edit = None;
+        // Empty content → delete the file rather than writing an empty document.
+        if self.content.is_empty() {
+            if self.path.exists() {
+                if let Err(e) = std::fs::remove_file(&self.path) {
+                    log::warn!("TextEditorApp: failed to delete empty note {:?}: {e}", self.path);
+                } else {
+                    log::info!("TextEditorApp: deleted empty note {:?}", self.path);
+                }
+            }
+            return;
+        }
         if let Some(parent) = self.path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 log::warn!("TextEditorApp: could not create parent dir {:?}: {e}", parent);
@@ -48,7 +58,6 @@ impl TextEditorApp {
         match std::fs::write(&self.path, &self.content) {
             Ok(()) => {
                 log::info!("TextEditorApp: saved {:?} ({} bytes)", self.path, self.content.len());
-                self.last_edit = None;
             }
             Err(e) => {
                 log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path);
@@ -96,14 +105,17 @@ impl App for TextEditorApp {
             return;
         }
 
+        // Fill the entire pane rect for consistent background in both tiled and zoomed modes.
+        ui.painter().rect_filled(ui.max_rect(), 0.0, colors.bg_darkest);
+
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
         let te_id = egui::Id::new("text_editor_content").with(&self.path);
         let font_id = egui::FontId::monospace(self.font_size);
 
-        // Minimum rows to fill the pane even on short documents.
-        let min_rows = ((ui.available_height() / self.font_size) as usize).max(10) + 5;
+        // Minimum rows = fill the pane without overflow so the scroll area starts inactive.
+        let min_rows = ((ui.available_height() / self.font_size) as usize).max(1);
 
         egui::ScrollArea::vertical()
             .auto_shrink([false, false])
@@ -152,9 +164,11 @@ impl App for TextEditorApp {
                     }
                 }
 
-                if !self.focus_requested {
+                // Request focus whenever this pane is active but the TextEdit doesn't
+                // have it — handles initial open, zoom/fullscreen toggles, and pane
+                // switches without a one-shot guard that breaks after focus changes.
+                if ctx.is_focused && !output.response.has_focus() {
                     output.response.request_focus();
-                    self.focus_requested = true;
                 }
             });
     }
@@ -186,7 +200,6 @@ impl App for TextEditorApp {
                 self.content = content;
                 self.load_error = load_error;
                 self.last_edit = None;
-                self.focus_requested = false;
             }
         }
     }
@@ -194,7 +207,8 @@ impl App for TextEditorApp {
 
 impl Drop for TextEditorApp {
     fn drop(&mut self) {
-        if self.last_edit.is_some() {
+        // Save unsaved edits; also clean up if content was cleared (flush deletes empty files).
+        if self.last_edit.is_some() || self.content.is_empty() {
             self.flush();
         }
     }

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -1,17 +1,17 @@
 //! Built-in file-backed text editor pane.
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
-use crate::ui::style;
-use egui::RichText;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+const DEBOUNCE: Duration = Duration::from_secs(2);
 
 pub struct TextEditorApp {
     path: PathBuf,
     content: String,
-    dirty: bool,
+    last_edit: Option<Instant>,
     wants_close: bool,
     load_error: Option<String>,
-    /// True once we have called request_focus() on the TextEdit after open.
     focus_requested: bool,
 }
 
@@ -23,28 +23,23 @@ impl TextEditorApp {
             Err(e) => (String::new(), Some(e.to_string())),
         };
         log::info!("TextEditorApp: opened {:?} ({} bytes)", path, content.len());
-        Self { path, content, dirty: false, wants_close: false, load_error, focus_requested: false }
+        Self { path, content, last_edit: None, wants_close: false, load_error, focus_requested: false }
     }
 
-    fn save(&mut self) -> bool {
-        if !self.dirty {
-            return true;
-        }
+    fn flush(&mut self) {
         if let Some(parent) = self.path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 log::warn!("TextEditorApp: could not create parent dir {:?}: {e}", parent);
-                return false;
+                return;
             }
         }
         match std::fs::write(&self.path, &self.content) {
             Ok(()) => {
                 log::info!("TextEditorApp: saved {:?} ({} bytes)", self.path, self.content.len());
-                self.dirty = false;
-                true
+                self.last_edit = None;
             }
             Err(e) => {
                 log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path);
-                false
             }
         }
     }
@@ -66,11 +61,7 @@ impl App for TextEditorApp {
         false
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
-        if input.modifiers.command && input.key_pressed(egui::Key::S) {
-            self.save();
-            return KeyDisposition::Consumed;
-        }
+    fn handle_key(&mut self, _input: &egui::InputState) -> KeyDisposition {
         KeyDisposition::Passthrough
     }
 
@@ -80,8 +71,8 @@ impl App for TextEditorApp {
         if let Some(err) = &self.load_error {
             ui.centered_and_justified(|ui| {
                 ui.label(
-                    RichText::new(format!("Failed to open file: {err}"))
-                        .size(style::TEXT_BODY)
+                    egui::RichText::new(format!("Failed to open file: {err}"))
+                        .size(crate::ui::style::TEXT_BODY)
                         .color(colors.danger),
                 );
             });
@@ -91,15 +82,8 @@ impl App for TextEditorApp {
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
-        // Pre-shrink the available rect so the hint renders below without overlap.
-        let hint_height = style::TEXT_HINT + style::SPACE_SM * 2.0;
-        let mut available = ui.available_rect_before_wrap();
-        if self.dirty {
-            available.max.y -= hint_height;
-        }
-
         let response = ui.add_sized(
-            available.size(),
+            ui.available_size(),
             egui::TextEdit::multiline(&mut self.content)
                 .font(egui::TextStyle::Monospace)
                 .desired_width(f32::INFINITY)
@@ -107,22 +91,18 @@ impl App for TextEditorApp {
         );
 
         if response.changed() {
-            self.dirty = true;
+            self.last_edit = Some(Instant::now());
         }
 
-        // Auto-focus on first render so the user can type immediately.
+        if let Some(t) = self.last_edit {
+            if t.elapsed() >= DEBOUNCE {
+                self.flush();
+            }
+        }
+
         if !self.focus_requested {
             response.request_focus();
             self.focus_requested = true;
-        }
-
-        if self.dirty {
-            ui.add_space(style::SPACE_SM);
-            ui.label(
-                RichText::new("Cmd+S to save")
-                    .size(style::TEXT_HINT)
-                    .color(colors.text_dim),
-            );
         }
     }
 
@@ -143,18 +123,17 @@ impl App for TextEditorApp {
             let new_path = PathBuf::from(p);
             if new_path != self.path {
                 log::info!("TextEditorApp: switching from {:?} to {:?}", self.path, new_path);
-                if self.save() {
-                    let (content, load_error) = match std::fs::read_to_string(&new_path) {
-                        Ok(s) => (s, None),
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
-                        Err(e) => (String::new(), Some(e.to_string())),
-                    };
-                    self.path = new_path;
-                    self.content = content;
-                    self.load_error = load_error;
-                    self.dirty = false;
-                    self.focus_requested = false;
-                }
+                self.flush();
+                let (content, load_error) = match std::fs::read_to_string(&new_path) {
+                    Ok(s) => (s, None),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), None),
+                    Err(e) => (String::new(), Some(e.to_string())),
+                };
+                self.path = new_path;
+                self.content = content;
+                self.load_error = load_error;
+                self.last_edit = None;
+                self.focus_requested = false;
             }
         }
     }
@@ -162,6 +141,8 @@ impl App for TextEditorApp {
 
 impl Drop for TextEditorApp {
     fn drop(&mut self) {
-        self.save();
+        if self.last_edit.is_some() {
+            self.flush();
+        }
     }
 }

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -114,8 +114,11 @@ impl App for TextEditorApp {
         let te_id = egui::Id::new("text_editor_content").with(&self.path);
         let font_id = egui::FontId::monospace(self.font_size);
 
-        // Minimum rows = fill the pane without overflow so the scroll area starts inactive.
-        let min_rows = ((ui.available_height() / self.font_size) as usize).max(1);
+        // Use the actual rendered row height (not font em-size) so desired_rows fills
+        // the viewport exactly. font_size alone ignores line leading, causing the TextEdit
+        // to be taller than the viewport and triggering an unwanted scrollbar.
+        let row_height = ui.fonts(|f| f.row_height(&font_id));
+        let min_rows = ((ui.available_height() / row_height).floor() as usize).max(1);
 
         egui::ScrollArea::vertical()
             .auto_shrink([false, false])
@@ -125,6 +128,7 @@ impl App for TextEditorApp {
                     .font(font_id)
                     .desired_width(f32::INFINITY)
                     .desired_rows(min_rows)
+                    .margin(egui::vec2(4.0, 0.0))
                     .frame(false)
                     .show(ui);
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -5,6 +5,9 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 const DEBOUNCE: Duration = Duration::from_secs(2);
+const FONT_SIZE_DEFAULT: f32 = 14.0;
+const FONT_SIZE_MIN: f32 = 9.0;
+const FONT_SIZE_MAX: f32 = 32.0;
 
 pub struct TextEditorApp {
     path: PathBuf,
@@ -13,6 +16,7 @@ pub struct TextEditorApp {
     wants_close: bool,
     load_error: Option<String>,
     focus_requested: bool,
+    font_size: f32,
 }
 
 impl TextEditorApp {
@@ -23,7 +27,15 @@ impl TextEditorApp {
             Err(e) => (String::new(), Some(e.to_string())),
         };
         log::info!("TextEditorApp: opened {:?} ({} bytes)", path, content.len());
-        Self { path, content, last_edit: None, wants_close: false, load_error, focus_requested: false }
+        Self {
+            path,
+            content,
+            last_edit: None,
+            wants_close: false,
+            load_error,
+            focus_requested: false,
+            font_size: FONT_SIZE_DEFAULT,
+        }
     }
 
     fn flush(&mut self) {
@@ -65,6 +77,11 @@ impl App for TextEditorApp {
         KeyDisposition::Passthrough
     }
 
+    fn adjust_font_size(&mut self, delta: f32) {
+        self.font_size = (self.font_size + delta).clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
+        log::info!("TextEditorApp: font_size -> {}", self.font_size);
+    }
+
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         let colors = ctx.colors;
 
@@ -82,28 +99,64 @@ impl App for TextEditorApp {
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
 
-        let response = ui.add_sized(
-            ui.available_size(),
-            egui::TextEdit::multiline(&mut self.content)
-                .font(egui::TextStyle::Monospace)
-                .desired_width(f32::INFINITY)
-                .frame(false),
-        );
+        let te_id = egui::Id::new("text_editor_content").with(&self.path);
+        let font_id = egui::FontId::monospace(self.font_size);
 
-        if response.changed() {
-            self.last_edit = Some(Instant::now());
-        }
+        // Minimum rows to fill the pane even on short documents.
+        let min_rows = ((ui.available_height() / self.font_size) as usize).max(10) + 5;
 
-        if let Some(t) = self.last_edit {
-            if t.elapsed() >= DEBOUNCE {
-                self.flush();
-            }
-        }
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                let output = egui::TextEdit::multiline(&mut self.content)
+                    .id(te_id)
+                    .font(font_id)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(min_rows)
+                    .frame(false)
+                    .show(ui);
 
-        if !self.focus_requested {
-            response.request_focus();
-            self.focus_requested = true;
-        }
+                if output.response.changed() {
+                    self.last_edit = Some(Instant::now());
+                }
+
+                if let Some(t) = self.last_edit {
+                    if t.elapsed() >= DEBOUNCE {
+                        self.flush();
+                    }
+                }
+
+                // Down arrow at end of content → append a newline so the cursor
+                // can move past the last line without requiring an explicit Enter.
+                if output.response.has_focus() {
+                    let at_end = output
+                        .cursor_range
+                        .map(|r| r.primary.ccursor.index >= self.content.len())
+                        .unwrap_or(false);
+                    if at_end {
+                        let down_pressed = ui.input_mut(|i| {
+                            i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                        });
+                        if down_pressed {
+                            self.content.push('\n');
+                            self.last_edit = Some(Instant::now());
+                            // Reposition cursor to the new end.
+                            let mut state = egui::TextEdit::load_state(ui.ctx(), te_id)
+                                .unwrap_or_default();
+                            let end = egui::text::CCursor::new(self.content.len());
+                            state
+                                .cursor
+                                .set_char_range(Some(egui::text::CCursorRange::one(end)));
+                            egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                        }
+                    }
+                }
+
+                if !self.focus_requested {
+                    output.response.request_focus();
+                    self.focus_requested = true;
+                }
+            });
     }
 
     fn wants_close(&self) -> bool {

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -3,7 +3,14 @@ use super::pane::pane_send_cli;
 use super::{binary_in_path};
 
 pub fn notes_list_cli() -> i32 {
-    let notes_dir = crate::config::config_dir().join("notes");
+    let notes_base = crate::config::config_dir().join("notes");
+    let workspace_slug = crate::config::active_workspace_root()
+        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+        .map(|n| n.to_string_lossy().into_owned());
+    let notes_dir = match workspace_slug {
+        Some(ref slug) => notes_base.join(slug),
+        None => notes_base,
+    };
     log::info!("notes_list: scanning {:?}", notes_dir);
     let entries = match std::fs::read_dir(&notes_dir) {
         Ok(r) => r,
@@ -37,7 +44,14 @@ pub fn notes_list_cli() -> i32 {
 ///
 /// Falls back to printing the notes directory when PLEXI_SOCKET is unset or fzf is absent.
 pub fn notes_open_cli() -> i32 {
-    let notes_dir = crate::config::config_dir().join("notes");
+    let notes_base = crate::config::config_dir().join("notes");
+    let workspace_slug = crate::config::active_workspace_root()
+        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+        .map(|n| n.to_string_lossy().into_owned());
+    let notes_dir = match workspace_slug {
+        Some(ref slug) => notes_base.join(slug),
+        None => notes_base,
+    };
     let notes_dir_str = notes_dir.display().to_string();
 
     if !binary_in_path("fzf") {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,6 +72,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
     "open_scratchpad", "set_context_root_from_cwd",
     "push_to_subcontext", "new_child_context",
+    "open_notes_picker",
 ];
 
 pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
@@ -226,6 +227,7 @@ pub struct KeybindingsConfig {
     pub set_context_root_from_cwd: Option<String>,
     pub hide_pane: Option<String>,
     pub park_context: Option<String>,
+    pub open_notes_picker: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -288,6 +290,7 @@ impl KeybindingsConfig {
         overlay_field!(set_context_root_from_cwd);
         overlay_field!(hide_pane);
         overlay_field!(park_context);
+        overlay_field!(open_notes_picker);
     }
 }
 

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -139,6 +139,8 @@ pub enum Action {
     HidePane,
     /// Park/unpark the focused context. Bound to Cmd+Shift+U.
     ParkContext,
+    /// Open the notes picker overlay (text-editor pane only). Bound to Cmd+O when AppActive.
+    OpenNotesPicker,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -197,6 +199,7 @@ pub struct KeyBindings {
     pub set_context_root_from_cwd: (egui::Modifiers, egui::Key),
     pub hide_pane: (egui::Modifiers, egui::Key),
     pub park_context: (egui::Modifiers, egui::Key),
+    pub open_notes_picker: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers { egui::Modifiers::COMMAND }
@@ -270,6 +273,7 @@ impl Default for KeyBindings {
             set_context_root_from_cwd: (cmd_shift(),     egui::Key::I),
             hide_pane:                 (cmd(),           egui::Key::U),
             park_context:              (cmd_shift(),     egui::Key::U),
+            open_notes_picker:             (cmd(),           egui::Key::O),
         }
     }
 }
@@ -427,6 +431,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(set_context_root_from_cwd, "set_context_root_from_cwd");
     apply_override!(hide_pane, "hide_pane");
     apply_override!(park_context, "park_context");
+    apply_override!(open_notes_picker, "open_notes_picker");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -481,6 +486,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("set_context_root_from_cwd", bindings.set_context_root_from_cwd),
         ("hide_pane",                 bindings.hide_pane),
         ("park_context",             bindings.park_context),
+        ("open_notes_picker",         bindings.open_notes_picker),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -605,6 +611,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         // CloseApp (Escape) — also suppressed when shortcuts overlay is open.
         BindingEntry { modifiers: egui::Modifiers::NONE, key: egui::Key::Escape, exact: false, context: BindingContext::AppActive, action: Action::CloseApp },
         BindingEntry { modifiers: egui::Modifiers::NONE, key: egui::Key::Tab,    exact: false, context: BindingContext::AppActive, action: Action::ToggleAppFocus },
+        BindingEntry { modifiers: b.open_notes_picker.0, key: b.open_notes_picker.1, exact: false, context: BindingContext::AppActive, action: Action::OpenNotesPicker },
     ];
 
     // Sort: exact before non-exact; within each group, higher modifier count first.

--- a/src/overlays/mod.rs
+++ b/src/overlays/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod confirmations;
 pub(crate) mod notification_modal;
 pub(crate) mod setup;
 pub(crate) mod command_palette;
+pub(crate) mod notes_picker;
 
 /// Consume the first digit key (0–9) pressed this frame; return its value.
 pub(crate) fn consume_digit_key(ctx: &egui::Context) -> Option<u8> {

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -3,6 +3,9 @@ use crate::ui::style;
 
 impl PlexiApp {
     pub(crate) fn notes_picker_handle_key(&mut self, ctx: &egui::Context) {
+        // Keep the TextEdit from reclaiming egui focus while the picker is open.
+        ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
+
         let count = self.notes_picker_entries.len();
         if count == 0 {
             self.pop_focus_layer(&FocusLayer::NotesPicker);
@@ -71,13 +74,18 @@ impl PlexiApp {
         let selected = self.notes_picker_selected;
 
         let screen = ctx.screen_rect();
-        egui::Area::new(egui::Id::new("notes_picker_scrim"))
+
+        // Scrim — clicking outside the modal dismisses it.
+        let scrim_clicked = egui::Area::new(egui::Id::new("notes_picker_scrim"))
             .fixed_pos(screen.min)
             .order(egui::Order::Middle)
             .show(ctx, |ui| {
                 ui.painter().rect_filled(screen, 0.0, egui::Color32::from_black_alpha(style::SCRIM_ALPHA));
-                let _ = ui.allocate_rect(screen, egui::Sense::hover());
-            });
+                ui.allocate_rect(screen, egui::Sense::click()).clicked()
+            }).inner;
+
+        // Track which row the user clicked × on (Cell for shared borrow across nested closures).
+        let delete_cell = std::cell::Cell::new(None::<usize>);
 
         egui::Area::new(egui::Id::new("notes_picker"))
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
@@ -134,10 +142,10 @@ impl PlexiApp {
                                             .color(if is_selected { colors.text_primary } else { colors.text_dim }),
                                     );
                                     if !preview.is_empty() {
-                                        let truncated: String = preview.chars().take(60).collect();
+                                        let truncated: String = preview.chars().take(50).collect();
                                         ui.add_space(style::SPACE_SM);
                                         ui.scope(|ui| {
-                                            ui.set_max_width(200.0);
+                                            ui.set_max_width(160.0);
                                             ui.label(
                                                 egui::RichText::new(truncated)
                                                     .size(style::TEXT_HINT)
@@ -145,6 +153,21 @@ impl PlexiApp {
                                             );
                                         });
                                     }
+                                    // Delete button — right-aligned via RTL sub-layout.
+                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                        ui.add_space(style::SPACE_SM);
+                                        let del = ui.add(
+                                            egui::Button::new(
+                                                egui::RichText::new("×")
+                                                    .size(style::TEXT_HINT)
+                                                    .color(colors.text_dim),
+                                            )
+                                            .frame(false),
+                                        );
+                                        if del.clicked() {
+                                            delete_cell.set(Some(i));
+                                        }
+                                    });
                                 });
                             }
                         });
@@ -159,5 +182,26 @@ impl PlexiApp {
                         });
                     });
             });
+
+        // Handle delete: remove file and entry from the list.
+        if let Some(idx) = delete_cell.get() {
+            if let Some((path, _)) = self.notes_picker_entries.get(idx) {
+                if let Err(e) = std::fs::remove_file(path) {
+                    log::warn!("notes_picker: failed to delete {:?}: {e}", path);
+                } else {
+                    log::info!("notes_picker: deleted {:?}", path);
+                }
+            }
+            self.notes_picker_entries.remove(idx);
+            if self.notes_picker_selected >= self.notes_picker_entries.len() {
+                self.notes_picker_selected = self.notes_picker_entries.len().saturating_sub(1);
+            }
+        }
+
+        // Dismiss on click outside the modal (processed after picker Area so it doesn't
+        // fire when clicking inside the modal itself).
+        if scrim_clicked {
+            self.pop_focus_layer(&FocusLayer::NotesPicker);
+        }
     }
 }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -1,0 +1,163 @@
+use crate::app::{FocusLayer, PlexiApp};
+use crate::ui::style;
+
+impl PlexiApp {
+    pub(crate) fn notes_picker_handle_key(&mut self, ctx: &egui::Context) {
+        let count = self.notes_picker_entries.len();
+        if count == 0 {
+            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            return;
+        }
+
+        #[derive(Clone, Copy)]
+        enum PickerKey { Escape, Down, Up, Enter }
+
+        let action = ctx.input_mut(|i| {
+            if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+                Some(PickerKey::Escape)
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::J)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+            {
+                Some(PickerKey::Down)
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::K)
+                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+            {
+                Some(PickerKey::Up)
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
+                Some(PickerKey::Enter)
+            } else {
+                None
+            }
+        });
+        match action {
+            Some(PickerKey::Escape) => self.pop_focus_layer(&FocusLayer::NotesPicker),
+            Some(PickerKey::Down) => {
+                self.notes_picker_selected = (self.notes_picker_selected + 1).min(count - 1);
+            }
+            Some(PickerKey::Up) => {
+                self.notes_picker_selected = self.notes_picker_selected.saturating_sub(1);
+            }
+            Some(PickerKey::Enter) => self.notes_picker_open_selected(),
+            None => {}
+        }
+    }
+
+    fn notes_picker_open_selected(&mut self) {
+        let Some((path, _)) = self.notes_picker_entries.get(self.notes_picker_selected).cloned() else {
+            return;
+        };
+        let active = self.active_window;
+        let Some(tile_id) = self.windows[active].focused_pane else {
+            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            return;
+        };
+        let pane_id = match self.windows[active].tree.tiles.get(tile_id) {
+            Some(egui_tiles::Tile::Pane(id)) => *id,
+            _ => { self.pop_focus_layer(&FocusLayer::NotesPicker); return; }
+        };
+        let state = serde_json::json!({ "path": path.to_string_lossy() });
+        if let Some(crate::host::pane::Pane::App(app_pane)) = self.windows[active].panes.get_mut(&pane_id) {
+            if let crate::host::pane::AppRuntime::Builtin(app) = &mut app_pane.runtime {
+                log::info!("notes_picker: opening {:?} in focused pane", path);
+                app.restore_state(&state);
+            }
+        }
+        self.pop_focus_layer(&FocusLayer::NotesPicker);
+    }
+
+    pub(crate) fn draw_notes_picker(&mut self, ctx: &egui::Context) {
+        let colors = self.colors;
+        let entries = self.notes_picker_entries.clone();
+        let selected = self.notes_picker_selected;
+
+        let screen = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("notes_picker_scrim"))
+            .fixed_pos(screen.min)
+            .order(egui::Order::Middle)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(screen, 0.0, egui::Color32::from_black_alpha(style::SCRIM_ALPHA));
+                let _ = ui.allocate_rect(screen, egui::Sense::hover());
+            });
+
+        egui::Area::new(egui::Id::new("notes_picker"))
+            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(colors.bg_sidebar)
+                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .corner_radius(style::RADIUS_LG)
+                    .inner_margin(egui::Margin::symmetric(
+                        style::MODAL_PADDING_H,
+                        style::MODAL_PADDING_V,
+                    ))
+                    .show(ui, |ui| {
+                        ui.set_width(480.0);
+
+                        ui.label(
+                            egui::RichText::new("Notes")
+                                .size(style::TEXT_BODY)
+                                .color(colors.text_primary),
+                        );
+                        ui.add_space(style::SPACE_SM);
+
+                        if entries.is_empty() {
+                            ui.label(
+                                egui::RichText::new("No notes yet. Press \u{2318}+Shift+Space to create one.")
+                                    .size(style::TEXT_HINT)
+                                    .color(colors.text_dim),
+                            );
+                            return;
+                        }
+
+                        egui::ScrollArea::vertical().max_height(320.0).show(ui, |ui| {
+                            for (i, (path, preview)) in entries.iter().enumerate() {
+                                let is_selected = i == selected;
+                                let filename = path
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or_default();
+
+                                let row_fill = if is_selected { colors.bg_active } else { egui::Color32::TRANSPARENT };
+                                let (rect, _) = ui.allocate_exact_size(
+                                    egui::Vec2::new(ui.available_width(), 28.0),
+                                    egui::Sense::hover(),
+                                );
+                                ui.painter().rect_filled(rect, style::RADIUS_MD, row_fill);
+
+                                let mut row_ui = ui.new_child(egui::UiBuilder::new().max_rect(rect));
+                                row_ui.horizontal(|ui| {
+                                    ui.add_space(style::SPACE_SM);
+                                    ui.label(
+                                        egui::RichText::new(&filename)
+                                            .size(style::TEXT_HINT)
+                                            .color(if is_selected { colors.text_primary } else { colors.text_dim }),
+                                    );
+                                    if !preview.is_empty() {
+                                        let truncated: String = preview.chars().take(60).collect();
+                                        ui.add_space(style::SPACE_SM);
+                                        ui.scope(|ui| {
+                                            ui.set_max_width(200.0);
+                                            ui.label(
+                                                egui::RichText::new(truncated)
+                                                    .size(style::TEXT_HINT)
+                                                    .color(colors.text_dim),
+                                            );
+                                        });
+                                    }
+                                });
+                            }
+                        });
+
+                        ui.add_space(style::SPACE_SM);
+                        ui.horizontal(|ui| {
+                            crate::ui::widgets::key_combo_list(ui, &[&["j", "k"]], Some("navigate"), &colors);
+                            ui.add_space(style::SPACE_SM);
+                            crate::ui::widgets::key_combo_list(ui, &[&["\u{21b5}"]], Some("open"), &colors);
+                            ui.add_space(style::SPACE_SM);
+                            crate::ui::widgets::key_combo_list(ui, &[&["esc"]], Some("dismiss"), &colors);
+                        });
+                    });
+            });
+    }
+}

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -992,7 +992,7 @@ impl PlexiApp {
         log::info!("scratchpad: opening text-editor pane for {:?}", path);
         if let Err(e) = self.launch_app_by_id_with_layout(
             "text-editor",
-            Some("split_h".to_string()),
+            None,
             &[path_str],
             None,
         ) {
@@ -1981,9 +1981,19 @@ mod quick_note_tests {
     }
 }
 
-/// Static scratchpad file path: `<config_dir>/notes/scratch.md`.
+/// Build a timestamped note path under the workspace-scoped notes dir.
 fn scratchpad_file() -> PathBuf {
-    crate::config::config_dir().join("notes").join("scratch.md")
+    use chrono::Local;
+    let notes_base = crate::config::config_dir().join("notes");
+    let workspace_slug = crate::config::active_workspace_root()
+        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+        .map(|n| n.to_string_lossy().into_owned());
+    let dir = match workspace_slug {
+        Some(slug) => notes_base.join(slug),
+        None => notes_base,
+    };
+    let ts = Local::now().format("note-%Y%m%d-%H%M%S.md").to_string();
+    dir.join(ts)
 }
 
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -1330,6 +1330,10 @@ impl PlexiApp {
         if let Some(pane) = ctx.panes.get_mut(&pane_id) {
             if let Some(t) = pane.as_terminal_mut() {
                 t.font_size = (t.font_size + delta).clamp(8.0, 32.0);
+            } else if let Some(a) = pane.as_app_mut() {
+                if let crate::host::pane::AppRuntime::Builtin(app) = &mut a.runtime {
+                    app.adjust_font_size(delta);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2076

## Summary

- `⌘+Shift+Space` now creates a fresh timestamped note file (`note-YYYYMMDD-HHMMSS.md`) in `~/.plexi-<channel>/notes/<workspace>/` (or notes root when no workspace is active), replacing the focused pane instead of splitting
- Text editor auto-saves 2 seconds after the last keystroke — the dirty flag and manual Cmd+S are gone; `Drop` flushes any pending edit on close
- `⌘+O` (AppActive context, only fires when a text-editor pane is focused) opens a modal picker listing workspace notes sorted by mtime, with j/k navigation and Enter to load the selected note in the same pane

## Done When

- `cargo test --bin plexi` green
- `⌘+Shift+Space` opens a new timestamped file replacing the focused pane (not splitting)
- File lands at `~/.plexi-alpha/notes/<workspace>/note-YYYYMMDD-HHMMSS.md` when a workspace is active, `~/.plexi-alpha/notes/note-YYYYMMDD-HHMMSS.md` with no workspace
- Edits are silently saved within 2s of last keystroke — no Cmd+S required
- `⌘+O` while a text-editor pane is focused shows the picker overlay
- Picker lists notes for current workspace, sorted most-recently-touched first, with filename + content preview
- Selecting a note loads it in the same pane

## Notes

- `open_notes_picker()` gates on `type_id() == "text-editor"` before opening, so Cmd+O is inert on other app types
- `restore_state` on `TextEditorApp` flushes unsaved content before switching files — no data loss on picker selection
- CLI `plexi notes list` / `plexi notes open` updated with the same workspace-slug derivation as the host