### PR TITLE
fix(text-editor): harden note integrity

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -1,7 +1,8 @@
 //! Built-in file-backed text editor pane.
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const DEBOUNCE: Duration = Duration::from_secs(2);
@@ -37,33 +38,171 @@ impl TextEditorApp {
     }
 
     fn flush(&mut self) {
-        self.last_edit = None;
         // Empty content → delete the file rather than writing an empty document.
         if self.content.is_empty() {
             if self.path.exists() {
                 if let Err(e) = std::fs::remove_file(&self.path) {
-                    log::warn!("TextEditorApp: failed to delete empty note {:?}: {e}", self.path);
+                    log::warn!(
+                        "TextEditorApp: failed to delete empty note {:?}: {e}",
+                        self.path
+                    );
+                    self.last_edit = Some(Instant::now());
                 } else {
                     log::info!("TextEditorApp: deleted empty note {:?}", self.path);
+                    self.last_edit = None;
                 }
+            } else {
+                self.last_edit = None;
             }
             return;
         }
-        if let Some(parent) = self.path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                log::warn!("TextEditorApp: could not create parent dir {:?}: {e}", parent);
-                return;
-            }
-        }
-        match std::fs::write(&self.path, &self.content) {
+        match write_note_atomically(&self.path, self.content.as_bytes()) {
             Ok(()) => {
-                log::info!("TextEditorApp: saved {:?} ({} bytes)", self.path, self.content.len());
+                self.last_edit = None;
+                log::info!(
+                    "TextEditorApp: saved {:?} ({} bytes)",
+                    self.path,
+                    self.content.len()
+                );
             }
             Err(e) => {
+                self.last_edit = Some(Instant::now());
                 log::warn!("TextEditorApp: save failed for {:?}: {e}", self.path);
             }
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("{name}-{}-{}", std::process::id(), unique_suffix()))
+    }
+
+    fn unique_suffix() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    }
+
+    #[test]
+    fn note_path_identity_matches_existing_file_aliases() {
+        let dir = unique_temp_dir("plexi-note-identity");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("note.md");
+        std::fs::write(&path, "hello").expect("write note");
+        let alias = dir.join(".").join("note.md");
+
+        assert_eq!(note_path_identity(&path), note_path_identity(&alias));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn note_path_identity_matches_missing_file_when_parent_exists() {
+        let dir = unique_temp_dir("plexi-note-missing-identity");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("missing.md");
+        let alias = dir.join(".").join("missing.md");
+
+        assert_eq!(note_path_identity(&path), note_path_identity(&alias));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_note_atomically_replaces_existing_file_contents() {
+        let dir = unique_temp_dir("plexi-note-atomic-write");
+        let path = dir.join("note.md");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        std::fs::write(&path, "old contents").expect("seed note");
+
+        write_note_atomically(&path, b"new contents").expect("atomic write");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read note"),
+            "new contents"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read temp dir")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files should be cleaned up");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+pub(crate) fn note_path_identity(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    let path = normalize_lexically(path);
+    let Some(parent) = path.parent() else {
+        return path;
+    };
+    match parent.canonicalize() {
+        Ok(parent) => path
+            .file_name()
+            .map(|name| parent.join(name))
+            .unwrap_or(path),
+        Err(_) => path,
+    }
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn write_note_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("note");
+    let temp_path = parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+
+    let write_result = (|| {
+        let mut temp_file = std::fs::File::create(&temp_path)?;
+        temp_file.write_all(bytes)?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+        std::fs::rename(&temp_path, path)
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+
+    write_result
 }
 
 impl App for TextEditorApp {
@@ -106,7 +245,8 @@ impl App for TextEditorApp {
         }
 
         // Fill the entire pane rect for consistent background in both tiled and zoomed modes.
-        ui.painter().rect_filled(ui.max_rect(), 0.0, colors.bg_darkest);
+        ui.painter()
+            .rect_filled(ui.max_rect(), 0.0, colors.bg_darkest);
 
         ui.visuals_mut().extreme_bg_color = colors.bg_darkest;
         ui.visuals_mut().override_text_color = Some(colors.text_primary);
@@ -157,8 +297,8 @@ impl App for TextEditorApp {
                             self.content.push('\n');
                             self.last_edit = Some(Instant::now());
                             // Reposition cursor to the new end.
-                            let mut state = egui::TextEdit::load_state(ui.ctx(), te_id)
-                                .unwrap_or_default();
+                            let mut state =
+                                egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
                             let end = egui::text::CCursor::new(self.content.len());
                             state
                                 .cursor
@@ -192,8 +332,12 @@ impl App for TextEditorApp {
     fn restore_state(&mut self, state: &serde_json::Value) {
         if let Some(p) = state.get("path").and_then(|v| v.as_str()) {
             let new_path = PathBuf::from(p);
-            if new_path != self.path {
-                log::info!("TextEditorApp: switching from {:?} to {:?}", self.path, new_path);
+            if note_path_identity(&new_path) != note_path_identity(&self.path) {
+                log::info!(
+                    "TextEditorApp: switching from {:?} to {:?}",
+                    self.path,
+                    new_path
+                );
                 self.flush();
                 let (content, load_error) = match std::fs::read_to_string(&new_path) {
                     Ok(s) => (s, None),

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -1,10 +1,75 @@
+use crate::app::text_editor_app::note_path_identity;
 use crate::app::{FocusLayer, PlexiApp};
 use crate::ui::style;
 
 impl PlexiApp {
+    fn text_editor_path_for_pane(
+        window: &crate::host::context::Window,
+        pane_id: crate::spatial::tiling::PaneId,
+    ) -> Option<std::path::PathBuf> {
+        let pane = window.panes.get(&pane_id)?;
+        let app_pane = pane.as_app()?;
+        if app_pane.runtime.type_id() != "text-editor" {
+            return None;
+        }
+        app_pane.runtime.serialize_state().and_then(|state| {
+            state
+                .get("path")
+                .and_then(|v| v.as_str())
+                .map(std::path::PathBuf::from)
+                .map(|path| note_path_identity(&path))
+        })
+    }
+
+    fn find_open_text_editor_tile(
+        &self,
+        window_idx: usize,
+        path: &std::path::Path,
+    ) -> Option<(egui_tiles::TileId, crate::spatial::tiling::PaneId)> {
+        let window = self.windows.get(window_idx)?;
+        let identity = note_path_identity(path);
+        window.tree.tiles.iter().find_map(|(tile_id, tile)| {
+            let egui_tiles::Tile::Pane(pane_id) = tile else {
+                return None;
+            };
+            (Self::text_editor_path_for_pane(window, *pane_id).as_deref()
+                == Some(identity.as_path()))
+            .then_some((*tile_id, *pane_id))
+        })
+    }
+
+    fn notes_picker_delete_entry(&mut self, idx: usize) {
+        let Some((path, _)) = self.notes_picker_entries.get(idx).cloned() else {
+            return;
+        };
+        let active = self.active_window;
+        if let Some((existing_tile_id, existing_pane_id)) =
+            self.find_open_text_editor_tile(active, &path)
+        {
+            log::info!("notes_picker: refusing to delete open note in pane {existing_pane_id}");
+            self.set_window_focused_pane(active, existing_tile_id);
+            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            return;
+        }
+
+        if let Err(e) = std::fs::remove_file(&path) {
+            log::warn!("notes_picker: failed to delete {:?}: {e}", path);
+        } else {
+            log::info!("notes_picker: deleted {:?}", path);
+        }
+        self.notes_picker_entries.remove(idx);
+        if self.notes_picker_selected >= self.notes_picker_entries.len() {
+            self.notes_picker_selected = self.notes_picker_entries.len().saturating_sub(1);
+        }
+    }
+
     pub(crate) fn notes_picker_handle_key(&mut self, ctx: &egui::Context) {
         // Keep the TextEdit from reclaiming egui focus while the picker is open.
-        ctx.memory_mut(|m| { if let Some(id) = m.focused() { m.surrender_focus(id); } });
+        ctx.memory_mut(|m| {
+            if let Some(id) = m.focused() {
+                m.surrender_focus(id);
+            }
+        });
 
         let count = self.notes_picker_entries.len();
         if count == 0 {
@@ -13,7 +78,12 @@ impl PlexiApp {
         }
 
         #[derive(Clone, Copy)]
-        enum PickerKey { Escape, Down, Up, Enter }
+        enum PickerKey {
+            Escape,
+            Down,
+            Up,
+            Enter,
+        }
 
         let action = ctx.input_mut(|i| {
             if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
@@ -46,20 +116,37 @@ impl PlexiApp {
     }
 
     fn notes_picker_open_selected(&mut self) {
-        let Some((path, _)) = self.notes_picker_entries.get(self.notes_picker_selected).cloned() else {
+        let Some((path, _)) = self
+            .notes_picker_entries
+            .get(self.notes_picker_selected)
+            .cloned()
+        else {
             return;
         };
         let active = self.active_window;
+        if let Some((existing_tile_id, existing_pane_id)) =
+            self.find_open_text_editor_tile(active, &path)
+        {
+            log::info!("notes_picker: already open in pane {existing_pane_id}, focusing");
+            self.set_window_focused_pane(active, existing_tile_id);
+            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            return;
+        }
         let Some(tile_id) = self.windows[active].focused_pane else {
             self.pop_focus_layer(&FocusLayer::NotesPicker);
             return;
         };
         let pane_id = match self.windows[active].tree.tiles.get(tile_id) {
             Some(egui_tiles::Tile::Pane(id)) => *id,
-            _ => { self.pop_focus_layer(&FocusLayer::NotesPicker); return; }
+            _ => {
+                self.pop_focus_layer(&FocusLayer::NotesPicker);
+                return;
+            }
         };
         let state = serde_json::json!({ "path": path.to_string_lossy() });
-        if let Some(crate::host::pane::Pane::App(app_pane)) = self.windows[active].panes.get_mut(&pane_id) {
+        if let Some(crate::host::pane::Pane::App(app_pane)) =
+            self.windows[active].panes.get_mut(&pane_id)
+        {
             if let crate::host::pane::AppRuntime::Builtin(app) = &mut app_pane.runtime {
                 log::info!("notes_picker: opening {:?} in focused pane", path);
                 app.restore_state(&state);
@@ -80,9 +167,14 @@ impl PlexiApp {
             .fixed_pos(screen.min)
             .order(egui::Order::Middle)
             .show(ctx, |ui| {
-                ui.painter().rect_filled(screen, 0.0, egui::Color32::from_black_alpha(style::SCRIM_ALPHA));
+                ui.painter().rect_filled(
+                    screen,
+                    0.0,
+                    egui::Color32::from_black_alpha(style::SCRIM_ALPHA),
+                );
                 ui.allocate_rect(screen, egui::Sense::click()).clicked()
-            }).inner;
+            })
+            .inner;
 
         // Track which row the user clicked × on (Cell for shared borrow across nested closures).
         let delete_cell = std::cell::Cell::new(None::<usize>);
@@ -111,91 +203,113 @@ impl PlexiApp {
 
                         if entries.is_empty() {
                             ui.label(
-                                egui::RichText::new("No notes yet. Press \u{2318}+Shift+Space to create one.")
-                                    .size(style::TEXT_HINT)
-                                    .color(colors.text_dim),
+                                egui::RichText::new(
+                                    "No notes yet. Press \u{2318}+Shift+Space to create one.",
+                                )
+                                .size(style::TEXT_HINT)
+                                .color(colors.text_dim),
                             );
                             return;
                         }
 
-                        egui::ScrollArea::vertical().max_height(320.0).show(ui, |ui| {
-                            for (i, (path, preview)) in entries.iter().enumerate() {
-                                let is_selected = i == selected;
-                                let filename = path
-                                    .file_name()
-                                    .map(|n| n.to_string_lossy().into_owned())
-                                    .unwrap_or_default();
+                        egui::ScrollArea::vertical()
+                            .max_height(320.0)
+                            .show(ui, |ui| {
+                                for (i, (path, preview)) in entries.iter().enumerate() {
+                                    let is_selected = i == selected;
+                                    let filename = path
+                                        .file_name()
+                                        .map(|n| n.to_string_lossy().into_owned())
+                                        .unwrap_or_default();
 
-                                let row_fill = if is_selected { colors.bg_active } else { egui::Color32::TRANSPARENT };
-                                let (rect, _) = ui.allocate_exact_size(
-                                    egui::Vec2::new(ui.available_width(), 28.0),
-                                    egui::Sense::hover(),
-                                );
-                                ui.painter().rect_filled(rect, style::RADIUS_MD, row_fill);
-
-                                let mut row_ui = ui.new_child(egui::UiBuilder::new().max_rect(rect));
-                                row_ui.horizontal(|ui| {
-                                    ui.add_space(style::SPACE_SM);
-                                    ui.label(
-                                        egui::RichText::new(&filename)
-                                            .size(style::TEXT_HINT)
-                                            .color(if is_selected { colors.text_primary } else { colors.text_dim }),
+                                    let row_fill = if is_selected {
+                                        colors.bg_active
+                                    } else {
+                                        egui::Color32::TRANSPARENT
+                                    };
+                                    let (rect, _) = ui.allocate_exact_size(
+                                        egui::Vec2::new(ui.available_width(), 28.0),
+                                        egui::Sense::hover(),
                                     );
-                                    if !preview.is_empty() {
-                                        let truncated: String = preview.chars().take(50).collect();
+                                    ui.painter().rect_filled(rect, style::RADIUS_MD, row_fill);
+
+                                    let mut row_ui =
+                                        ui.new_child(egui::UiBuilder::new().max_rect(rect));
+                                    row_ui.horizontal(|ui| {
                                         ui.add_space(style::SPACE_SM);
-                                        ui.scope(|ui| {
-                                            ui.set_max_width(160.0);
-                                            ui.label(
-                                                egui::RichText::new(truncated)
-                                                    .size(style::TEXT_HINT)
-                                                    .color(colors.text_dim),
-                                            );
-                                        });
-                                    }
-                                    // Delete button — right-aligned via RTL sub-layout.
-                                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                                        ui.add_space(style::SPACE_SM);
-                                        let del = ui.add(
-                                            egui::Button::new(
-                                                egui::RichText::new("×")
-                                                    .size(style::TEXT_HINT)
-                                                    .color(colors.text_dim),
-                                            )
-                                            .frame(false),
+                                        ui.label(
+                                            egui::RichText::new(&filename)
+                                                .size(style::TEXT_HINT)
+                                                .color(if is_selected {
+                                                    colors.text_primary
+                                                } else {
+                                                    colors.text_dim
+                                                }),
                                         );
-                                        if del.clicked() {
-                                            delete_cell.set(Some(i));
+                                        if !preview.is_empty() {
+                                            let truncated: String =
+                                                preview.chars().take(50).collect();
+                                            ui.add_space(style::SPACE_SM);
+                                            ui.scope(|ui| {
+                                                ui.set_max_width(160.0);
+                                                ui.label(
+                                                    egui::RichText::new(truncated)
+                                                        .size(style::TEXT_HINT)
+                                                        .color(colors.text_dim),
+                                                );
+                                            });
                                         }
+                                        // Delete button — right-aligned via RTL sub-layout.
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.add_space(style::SPACE_SM);
+                                                let del = ui.add(
+                                                    egui::Button::new(
+                                                        egui::RichText::new("×")
+                                                            .size(style::TEXT_HINT)
+                                                            .color(colors.text_dim),
+                                                    )
+                                                    .frame(false),
+                                                );
+                                                if del.clicked() {
+                                                    delete_cell.set(Some(i));
+                                                }
+                                            },
+                                        );
                                     });
-                                });
-                            }
-                        });
+                                }
+                            });
 
                         ui.add_space(style::SPACE_SM);
                         ui.horizontal(|ui| {
-                            crate::ui::widgets::key_combo_list(ui, &[&["j", "k"]], Some("navigate"), &colors);
+                            crate::ui::widgets::key_combo_list(
+                                ui,
+                                &[&["j", "k"]],
+                                Some("navigate"),
+                                &colors,
+                            );
                             ui.add_space(style::SPACE_SM);
-                            crate::ui::widgets::key_combo_list(ui, &[&["\u{21b5}"]], Some("open"), &colors);
+                            crate::ui::widgets::key_combo_list(
+                                ui,
+                                &[&["\u{21b5}"]],
+                                Some("open"),
+                                &colors,
+                            );
                             ui.add_space(style::SPACE_SM);
-                            crate::ui::widgets::key_combo_list(ui, &[&["esc"]], Some("dismiss"), &colors);
+                            crate::ui::widgets::key_combo_list(
+                                ui,
+                                &[&["esc"]],
+                                Some("dismiss"),
+                                &colors,
+                            );
                         });
                     });
             });
 
         // Handle delete: remove file and entry from the list.
         if let Some(idx) = delete_cell.get() {
-            if let Some((path, _)) = self.notes_picker_entries.get(idx) {
-                if let Err(e) = std::fs::remove_file(path) {
-                    log::warn!("notes_picker: failed to delete {:?}: {e}", path);
-                } else {
-                    log::info!("notes_picker: deleted {:?}", path);
-                }
-            }
-            self.notes_picker_entries.remove(idx);
-            if self.notes_picker_selected >= self.notes_picker_entries.len() {
-                self.notes_picker_selected = self.notes_picker_entries.len().saturating_sub(1);
-            }
+            self.notes_picker_delete_entry(idx);
         }
 
         // Dismiss on click outside the modal (processed after picker Area so it doesn't
@@ -203,5 +317,179 @@ impl PlexiApp {
         if scrim_clicked {
             self.pop_focus_layer(&FocusLayer::NotesPicker);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::permissions::AppPermissions;
+    use crate::host::pane::{AppPane, AppRuntime, Pane};
+
+    fn replace_with_text_editor(app: &mut PlexiApp, pane_id: u64, path: std::path::PathBuf) {
+        let app_pane = AppPane {
+            id: pane_id,
+            runtime: AppRuntime::Builtin(Box::new(
+                crate::app::text_editor_app::TextEditorApp::new(path),
+            )),
+            workspace_root: std::env::temp_dir(),
+            permissions: AppPermissions::builtin(),
+            manifest_id: "text-editor".to_string(),
+            name: "Text Editor".to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: None,
+            hidden: false,
+        };
+
+        app.windows[0]
+            .panes
+            .insert(pane_id, Pane::App(Box::new(app_pane)));
+    }
+
+    fn state_path(state: &serde_json::Value) -> String {
+        state
+            .get("path")
+            .and_then(|v| v.as_str())
+            .expect("text editor path")
+            .to_string()
+    }
+
+    #[test]
+    fn notes_picker_focuses_existing_text_editor_instead_of_reopening_same_path() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+        let note_path = std::env::temp_dir().join(format!(
+            "plexi-notes-picker-duplicate-{}.md",
+            std::process::id()
+        ));
+        let other_path = std::env::temp_dir().join(format!(
+            "plexi-notes-picker-other-{}.md",
+            std::process::id()
+        ));
+
+        let (existing_tile, existing_pane) = app.add_test_pane();
+        let (focused_tile, focused_pane) = app.add_test_pane();
+        replace_with_text_editor(&mut app, existing_pane, note_path.clone());
+        replace_with_text_editor(&mut app, focused_pane, other_path.clone());
+
+        app.windows[0].focused_pane = Some(focused_tile);
+        app.notes_picker_entries = vec![(note_path.clone(), "note".to_string())];
+        app.notes_picker_selected = 0;
+        app.push_focus_layer(FocusLayer::NotesPicker);
+
+        app.notes_picker_open_selected();
+
+        assert_eq!(app.windows[0].focused_pane, Some(existing_tile));
+        assert_eq!(
+            app.find_open_text_editor_tile(0, &note_path),
+            Some((existing_tile, existing_pane))
+        );
+
+        let focused_state = app.windows[0]
+            .panes
+            .get(&focused_pane)
+            .and_then(|pane| pane.as_app())
+            .and_then(|pane| pane.runtime.serialize_state())
+            .expect("focused text editor state");
+        assert_eq!(
+            state_path(&focused_state),
+            other_path.to_string_lossy().to_string()
+        );
+        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+    }
+
+    #[test]
+    fn notes_picker_focuses_existing_text_editor_for_alias_path() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+        let dir =
+            std::env::temp_dir().join(format!("plexi-notes-picker-alias-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let note_path = dir.join("note.md");
+        let alias_path = dir.join(".").join("note.md");
+
+        let (existing_tile, existing_pane) = app.add_test_pane();
+        let (focused_tile, focused_pane) = app.add_test_pane();
+        replace_with_text_editor(&mut app, existing_pane, note_path.clone());
+        replace_with_text_editor(&mut app, focused_pane, dir.join("other.md"));
+
+        app.windows[0].focused_pane = Some(focused_tile);
+        app.notes_picker_entries = vec![(alias_path, "note".to_string())];
+        app.notes_picker_selected = 0;
+        app.push_focus_layer(FocusLayer::NotesPicker);
+
+        app.notes_picker_open_selected();
+
+        assert_eq!(app.windows[0].focused_pane, Some(existing_tile));
+        assert_eq!(
+            app.find_open_text_editor_tile(0, &note_path),
+            Some((existing_tile, existing_pane))
+        );
+        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+
+        let focused_state = app.windows[0]
+            .panes
+            .get(&focused_pane)
+            .and_then(|pane| pane.as_app())
+            .and_then(|pane| pane.runtime.serialize_state())
+            .expect("focused text editor state");
+        assert!(state_path(&focused_state).ends_with("other.md"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn notes_picker_refuses_to_delete_open_text_editor_note() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+        let note_path = std::env::temp_dir().join(format!(
+            "plexi-notes-picker-delete-open-{}.md",
+            std::process::id()
+        ));
+        std::fs::write(&note_path, "keep").expect("seed note");
+
+        let (existing_tile, existing_pane) = app.add_test_pane();
+        let (focused_tile, _focused_pane) = app.add_test_pane();
+        replace_with_text_editor(&mut app, existing_pane, note_path.clone());
+
+        app.windows[0].focused_pane = Some(focused_tile);
+        app.notes_picker_entries = vec![(note_path.clone(), "keep".to_string())];
+        app.notes_picker_selected = 0;
+        app.push_focus_layer(FocusLayer::NotesPicker);
+
+        app.notes_picker_delete_entry(0);
+
+        assert_eq!(app.windows[0].focused_pane, Some(existing_tile));
+        assert_eq!(app.notes_picker_entries.len(), 1);
+        assert!(note_path.exists());
+        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+
+        let _ = std::fs::remove_file(&note_path);
+    }
+
+    #[test]
+    fn notes_picker_deletes_closed_note_and_bounds_selection() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+        let note_path = std::env::temp_dir().join(format!(
+            "plexi-notes-picker-delete-closed-{}.md",
+            std::process::id()
+        ));
+        std::fs::write(&note_path, "delete").expect("seed note");
+
+        app.notes_picker_entries = vec![(note_path.clone(), "delete".to_string())];
+        app.notes_picker_selected = 0;
+
+        app.notes_picker_delete_entry(0);
+
+        assert!(app.notes_picker_entries.is_empty());
+        assert_eq!(app.notes_picker_selected, 0);
+        assert!(!note_path.exists());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the text editor note integrity bundle across #2088, #2089, and #2090.

- replace direct note saves with same-directory temp-file writes followed by rename
- keep failed saves dirty so the debounce/drop path can retry instead of losing the pending edit
- centralize note path identity for existing files and missing files whose parent exists
- use that identity in text-editor restore and the notes picker
- focus an already-open note instead of reopening it into another pane
- refuse to delete notes that are currently open in a text-editor pane

## Why

The old text editor used direct `std::fs::write`, so a crash or failed write could leave a truncated note. The notes picker also treated serialized path strings as identity, which made alias paths unsafe and allowed duplicate panes or stale in-memory editors to overwrite/delete each other.

## Validation

- `cargo test --bin plexi text_editor_app::tests`
- `cargo test --bin plexi notes_picker`
- `cargo test --bin plexi` (`727 passed`)

Fixes #2088.
Fixes #2089.
Fixes #2090.
