### PR TITLE
fix: harden production footgun guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,8 @@ Every CLI command and feature must work identically on alpha, beta, main, and PR
 
 **Enforcement:** Never hardcode a profile directory path (e.g. `~/.plexi-alpha/`) in CLI code — always use `config_dir()`. Never route around `PLEXI_SOCKET` when it is set. Any new CLI command that communicates with a running instance must follow the socket-first pattern in `open_cli()`.
 
+**Channel-aware workspace paths:** Never hardcode `.plexi/` as a workspace directory name when joining from a workspace root. Always use `crate::config::workspace_channel_dir()` or a helper built on it, such as `workspace_config_path()`. This returns `.plexi`, `.plexi-alpha`, `.plexi-beta`, `.plexi-pr-N`, etc. based on the running binary/profile. Literal `.plexi` is only acceptable for docs, tests that explicitly cover the main channel, or profile-dir class checks that intentionally match `.plexi*`.
+
 **Testing completions on PR builds:** `just pr-install` intentionally skips completion installation — all channels share a single completion file path (e.g. `$(brew --prefix)/share/zsh/site-functions/_plexi`) and a PR build overwriting it would corrupt the active channel's completions. To test a completion change on a PR build, manually run `plexi-pr-<N> completions zsh > <completions-path>` after install and restore the previous file afterward. Completion changes that don't require interactive testing can be merged to alpha and verified there.
 
 ## CLI Namespace Design

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1560,6 +1560,14 @@ def render_tree(ctx, root: Component, fill: Optional[str] = None) -> None:
     if node is not None:
         ctx.render_tree(node)
         return
+    if getattr(ctx._app, "_l0_fallback_warned", False) is not True:
+        setattr(ctx._app, "_l0_fallback_warned", True)
+        ctx.warn(
+            "ctx.render() fell back to L0 draw commands because "
+            f"{type(root).__name__}.to_node() returned None. "
+            "Use UiNode-native components for ordinary app UI; reserve raw "
+            "drawing for games, visualizations, or explicitly documented escape hatches."
+        )
     root.render(ctx, 0.0, 0.0, ctx.w, ctx.h)
 
 

--- a/sdk/python/tests/test_render_tree.py
+++ b/sdk/python/tests/test_render_tree.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from plexi_sdk._render_context import RenderContext
-from plexi_sdk.ui import Clickable, Tabs
+from plexi_sdk.ui import Clickable, Column, Component, Label, Tabs
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -84,6 +84,43 @@ def test_render_tree_with_clickable_component() -> None:
     assert cmd["type"] == "component_tree"
     assert cmd["root"]["type"] == "interactive"
     assert cmd["root"]["node_id"] == "btn-1"
+
+
+def test_ctx_render_native_component_tree_emits_component_tree() -> None:
+    """ctx.render(Column([...])) stays on the host-native ComponentTree path."""
+    ctx = _make_ctx()
+    ctx.render(Column([Label(text="native")]))
+
+    cmds = _buffered(ctx)
+    assert cmds[0]["type"] == "rect"  # clear background
+    assert cmds[1]["type"] == "component_tree"
+    assert cmds[1]["root"]["type"] == "column"
+    assert cmds[1]["root"]["children"][0]["text"] == "native"
+
+
+def test_ctx_render_l0_fallback_warns_once(capsys: pytest.CaptureFixture[str]) -> None:
+    """Raw fallback remains supported, but it is visible in app logs."""
+    class RawOnly(Component):
+        def measure(self, _avail_w: float) -> float:
+            return 12.0
+
+        def to_node(self) -> None:
+            return None
+
+        def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+            ctx.rect(x, y, w, h, fill="#000000")
+
+    ctx = _make_ctx()
+    ctx.render(Column([RawOnly()]))
+    ctx.render(Column([RawOnly()]))
+
+    emitted = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    warnings = [
+        cmd for cmd in emitted
+        if cmd.get("type") == "log" and cmd.get("level") == "warn"
+    ]
+    assert len(warnings) == 1
+    assert "fell back to L0 draw commands" in warnings[0]["message"]
 
 
 def test_render_tree_rejects_invalid_type() -> None:

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -681,7 +681,7 @@ impl PlexiApp {
             };
 
         // Resolve the active workspace (explicit `plexi <path>` arg, then
-        // CWD-walk fallback) and overlay its `.plexi/config.toml` on top of
+        // CWD-walk fallback) and overlay its channel-scoped config on top of
         // the global config. Project values win on a per-field basis; unset
         // project fields preserve the global value.
         let active_workspace = config::active_workspace_root();

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -74,8 +74,8 @@ pub(super) fn app_init_config_dir() -> String {
     crate::config::config_dir()
         .file_name()
         .and_then(|n| n.to_str())
-        .unwrap_or(".plexi")
-        .to_string()
+        .map(str::to_owned)
+        .unwrap_or_else(crate::config::workspace_channel_dir)
 }
 
 /// `plexi app init [--lang python|rust] [--global] [--no-open] <name>`

--- a/src/cli/config_cli.rs
+++ b/src/cli/config_cli.rs
@@ -6,7 +6,7 @@ pub fn config_check() -> i32 {
         let path = crate::config::config_path();
         eprintln!("✓ {} is valid", path.display());
         if let Some(root) = crate::config::active_workspace_root() {
-            let project_path = root.join(".plexi").join("config.toml");
+            let project_path = crate::config::workspace_config_path(&root);
             if project_path.exists() {
                 eprintln!("✓ {} is valid", project_path.display());
             }
@@ -107,7 +107,7 @@ pub fn config_get(key: &str) -> i32 {
 
     // Overlay workspace config on top if one exists.
     if let Some(workspace_root) = crate::config::active_workspace_root() {
-        let project_path = workspace_root.join(".plexi").join("config.toml");
+        let project_path = crate::config::workspace_config_path(&workspace_root);
         if let Ok(data) = std::fs::read_to_string(&project_path) {
             if let Ok(project_val) = toml::from_str::<toml::Value>(&data) {
                 toml_merge(&mut root, project_val);
@@ -195,4 +195,3 @@ pub fn config_reset() -> i32 {
         }
     }
 }
-

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,6 +72,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "open_secrets_manager", "force_reload_app", "toggle_notification_modal",
     "open_scratchpad", "set_context_root_from_cwd",
     "push_to_subcontext", "new_child_context",
+    "hide_pane", "park_context",
     "open_notes_picker",
 ];
 
@@ -160,7 +161,7 @@ fn check_unknown_keys(
 pub fn validate_all() -> Vec<ConfigDiagnostic> {
     let mut diags = validate_from_path(&config_path());
     if let Some(root) = active_workspace_root() {
-        let project_path = root.join(workspace_channel_dir()).join("config.toml");
+        let project_path = workspace_config_path(&root);
         diags.extend(validate_from_path(&project_path));
     }
     diags
@@ -704,6 +705,14 @@ pub fn config_dir() -> PathBuf {
         .join(config_dir_name())
 }
 
+pub fn workspace_config_path(workspace_root: &Path) -> PathBuf {
+    workspace_config_path_for_channel(workspace_root, &workspace_channel_dir())
+}
+
+fn workspace_config_path_for_channel(workspace_root: &Path, channel_dir: &str) -> PathBuf {
+    workspace_root.join(channel_dir).join("config.toml")
+}
+
 /// Dev override: when `PLEXI_SDK_PATH` is set, Python apps import the SDK from
 /// that directory (which must contain the `plexi_sdk` package) instead of the
 /// binary-embedded copy. This enables live SDK iteration — edit
@@ -875,7 +884,7 @@ pub fn open_file_with_fallback(path: &std::path::Path) -> bool {
 impl PlexiConfig {
     /// Load the global config only — no project-level merge. Most call sites
     /// should prefer [`load_with_workspace`] so a workspace's
-    /// `.plexi/config.toml` can override.
+    /// channel-scoped config can override.
     pub fn load() -> Self {
         let path = config_path();
         if !path.exists() {
@@ -912,15 +921,15 @@ impl PlexiConfig {
         }
     }
 
-    /// Load the global config and overlay `<workspace_root>/.plexi/config.toml`
-    /// on top if it exists. Project-level values override globals on a
+    /// Load the global config and overlay the workspace's channel-scoped
+    /// config on top if it exists. Project-level values override globals on a
     /// per-field basis; unset project fields preserve the global value.
     pub fn load_with_workspace(workspace_root: Option<&Path>) -> Self {
         let mut merged = Self::load();
         let Some(root) = workspace_root else {
             return merged;
         };
-        let project_path = root.join(".plexi").join("config.toml");
+        let project_path = workspace_config_path(root);
         if let Some(project) = Self::load_from_path(&project_path) {
             merged.overlay(project);
         }
@@ -1272,6 +1281,19 @@ mod tests {
     }
 
     #[test]
+    fn validate_known_keybindings_cover_pane_hide_and_context_park() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[keybindings]\nhide_pane = \"cmd+u\"\npark_context = \"cmd+shift+u\"\n",
+        )
+        .unwrap();
+        let diags = validate_from_path(&path);
+        assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+    }
+
+    #[test]
     fn validate_parse_error() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -1345,6 +1367,24 @@ mod tests {
     }
 
     #[test]
+    fn workspace_config_path_uses_channel_dir() {
+        let workspace = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            workspace_config_path_for_channel(workspace.path(), ".plexi"),
+            workspace.path().join(".plexi").join("config.toml")
+        );
+        assert_eq!(
+            workspace_config_path_for_channel(workspace.path(), ".plexi-alpha"),
+            workspace.path().join(".plexi-alpha").join("config.toml")
+        );
+        assert_eq!(
+            workspace_config_path_for_channel(workspace.path(), ".plexi-pr-817"),
+            workspace.path().join(".plexi-pr-817").join("config.toml")
+        );
+    }
+
+    #[test]
     fn missing_project_config_keeps_global() {
         let global_dir = tempfile::tempdir().unwrap();
         let global_path = global_dir.path().join("config.toml");
@@ -1353,7 +1393,7 @@ mod tests {
             "font_size = 12.0\n[log]\nlevel = \"warn\"\n[theme]\naccent = \"#bbbbbb\"\n",
         );
 
-        // Workspace exists but has no .plexi/config.toml.
+        // Workspace exists but has no main-channel config.toml.
         let workspace = tempfile::tempdir().unwrap();
         let project_path = workspace.path().join(".plexi").join("config.toml");
         assert!(!project_path.exists());
@@ -1452,4 +1492,3 @@ mod tests {
     }
 
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> eframe::Result {
         }
     }
 
-    // Merge global config with the workspace's `.plexi/config.toml` if a
+    // Merge global config with the workspace's channel-scoped config if a
     // workspace is in scope. The `log` level needs the merged value so a
     // project-level `[log] level = "debug"` actually takes effect.
     let merged_config_root = adopted_root

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -47,6 +47,16 @@ fn auto_init_workspace(root: &std::path::Path) {
     }
 }
 
+fn persisted_next_pane_id(host_next: u64, windows: &[crate::workspace::SavedWindow]) -> u64 {
+    let next_from_saved = windows
+        .iter()
+        .flat_map(|win| win.panes.iter().map(|pane| pane.id))
+        .max()
+        .map(|id| id.saturating_add(1))
+        .unwrap_or(host_next);
+    host_next.max(next_from_saved)
+}
+
 impl PlexiApp {
     /// Create a child context nested inside `parent_name`. Always creates a fresh
     /// terminal in the child (portal model — no pane adoption). Inserts a Portal
@@ -1079,7 +1089,7 @@ impl PlexiApp {
             version: 2,
             active_context: self.router.active_idx(),
             sidebar_visible: self.sidebar_visible,
-            next_pane_id: self.host.next_pane_id(),
+            next_pane_id: persisted_next_pane_id(self.host.next_pane_id(), &saved_windows),
             contexts: saved_contexts,
             windows: saved_windows,
             context_active_window: self.context_active_window.clone(),
@@ -1088,5 +1098,47 @@ impl PlexiApp {
         if let Err(e) = ws.save() {
             log::error!("Failed to save workspace: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn saved_window_with_panes(ids: &[u64]) -> crate::workspace::SavedWindow {
+        crate::workspace::SavedWindow {
+            name: "test".to_string(),
+            path: std::env::temp_dir(),
+            tree: egui_tiles::Tree::empty("test_tree"),
+            panes: ids
+                .iter()
+                .map(|id| crate::workspace::SavedPane {
+                    id: *id,
+                    kind: crate::workspace::SavedPaneKind::App,
+                    cwd: std::env::temp_dir(),
+                    name: None,
+                    app_id: Some("test".to_string()),
+                    app_state: None,
+                    hidden: false,
+                })
+                .collect(),
+            focused_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: 1,
+            context_id: 1,
+        }
+    }
+
+    #[test]
+    fn persisted_next_pane_id_cannot_collide_with_saved_panes() {
+        let windows = vec![
+            saved_window_with_panes(&[1, 4]),
+            saved_window_with_panes(&[9, 12]),
+        ];
+
+        assert_eq!(persisted_next_pane_id(3, &windows), 13);
+        assert_eq!(persisted_next_pane_id(20, &windows), 20);
+        assert_eq!(persisted_next_pane_id(7, &[]), 7);
     }
 }


### PR DESCRIPTION
## Summary
- route workspace config reads through a channel-aware helper instead of hardcoded .plexi paths
- align config keybinding validation with pane hide and context park actions
- make Python SDK L0 render fallback explicit with a one-time warning
- persist next_pane_id above every serialized pane id to prevent restore collisions
- document the channel-aware workspace path rule in CLAUDE.md

## Issues
- Closes #2091
- Closes #2092
- Part of #2093
- Closes #2094
- Part of #2095

This intentionally does not attempt #2096's larger PlexiApp state-machine extraction; that should remain a separate, reviewable refactor.

## Tests
- cargo test --bin plexi config::tests:: --locked
- cargo test --bin plexi pane_ops::workspace::tests:: --locked
- PYTHONPATH=sdk/python uv run pytest sdk/python/tests/test_render_tree.py -q