### PR TITLE
Feat: add app check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ PGAP is the wire protocol that every Plexi app speaks — built-in or third-part
 6. Out-of-frame commands (`notify`, `secret_get`, `capability_request`, etc.) arrive at any time; host processes them immediately.
 7. On close: host sends `shutdown`; app must exit cleanly within a short timeout.
 
-Current protocol version: **pgap/3**. Full reference: [PGAP.md](PGAP.md).
+Current protocol version: **pgap/3**. The Python SDK has its own authoring API version; SDK v2 apps speak PGAP v3. Full reference: [PGAP.md](PGAP.md).
 
 ---
 

--- a/docs/SDK_QUICKSTART.md
+++ b/docs/SDK_QUICKSTART.md
@@ -4,6 +4,8 @@ Audience: a coding agent building its first PGAP app.
 Goal: a running counter app using SDK v2.
 Deeper reference: [`docs/sdk-v2.md`](sdk-v2.md) and [`docs/PGAP_REFERENCE.md`](PGAP_REFERENCE.md).
 
+Naming: SDK v2 is the Python authoring API. PGAP v3 (`pgap/3`) is the host/app protocol it speaks.
+
 ## 1. Create The App
 
 Run this inside a Plexi workspace:
@@ -92,9 +94,12 @@ Python apps are native subprocesses. Capabilities gate PGAP host APIs; they are 
 ## 4. Open And Test
 
 ```bash
+plexi app check ./counter
 plexi app open ./counter
 plexi app render ./counter --state '{"count": 5}'
 ```
+
+`plexi app check` validates the manifest, inspects Python SDK usage without importing app code, and renders the app at small and normal pane sizes.
 
 For a live app pane, agents can drive the UI with:
 

--- a/docs/sdk-v2.md
+++ b/docs/sdk-v2.md
@@ -1,5 +1,9 @@
 # Plexi SDK v2 — Developer Reference
 
+SDK v2 is the Python authoring API. PGAP v3 (`pgap/3`) is the host/app wire
+protocol the SDK speaks. They are different version lines: SDK v2 apps normally
+emit PGAP v3 component trees.
+
 ## The Pattern (memorize this)
 
 ```python

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,6 +2,8 @@
 
 Python SDK v2 for building Plexi PGAP apps.
 
+SDK v2 is the Python authoring API. PGAP v3 (`pgap/3`) is the host/app wire protocol the SDK speaks.
+
 Full API reference: `plexi_sdk/__init__.py` and `docs/sdk-v2.md`.
 
 ## Install For SDK Development

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -1,0 +1,495 @@
+use crate::app::registry::AppManifest;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_CHECK_SIZES: &[(u32, u32)] = &[(320, 240), (480, 320), (800, 600), (1200, 800)];
+
+#[derive(Debug, Default)]
+struct SdkAnalysis {
+    app_classes: Vec<PythonAppClass>,
+    errors: Vec<String>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PythonAstReport {
+    classes: Vec<PythonClassReport>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PythonClassReport {
+    name: String,
+    bases: Vec<String>,
+    methods: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PythonAppClass {
+    name: String,
+    has_view: bool,
+    has_on_render: bool,
+}
+
+pub fn app_check_cli(path: &str, sizes: &[String], png_dir: Option<&str>) -> i32 {
+    let app_dir = Path::new(path);
+    log::info!(
+        "app_check: path={} sizes={sizes:?} png_dir={png_dir:?}",
+        app_dir.display()
+    );
+
+    let render_sizes = match check_sizes(sizes) {
+        Ok(sizes) => sizes,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+
+    let png_dir = match png_dir {
+        Some(raw) => {
+            let dir = PathBuf::from(raw);
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                eprintln!(
+                    "error: could not create PNG output directory {}: {e}",
+                    dir.display()
+                );
+                return 1;
+            }
+            Some(dir)
+        }
+        None => None,
+    };
+
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    let (manifest, entry_path) = match load_local_app(app_dir) {
+        Ok(app) => app,
+        Err(e) => {
+            println!("✗ manifest — {e}");
+            return 1;
+        }
+    };
+
+    println!("✓ manifest — {} ({})", manifest.app.id, manifest.app.name);
+
+    if entry_path.extension().and_then(|ext| ext.to_str()) == Some("py") {
+        match analyze_python_entry(&entry_path) {
+            Ok(analysis) => {
+                if analysis.app_classes.is_empty() {
+                    errors.push(format!(
+                        "SDK — {} does not define a class that subclasses App",
+                        entry_path.display()
+                    ));
+                } else {
+                    for class in analysis.app_classes {
+                        if class.has_view {
+                            println!("✓ SDK — {} uses view()", class.name);
+                        } else if class.has_on_render {
+                            warnings.push(format!(
+                                "SDK — {} uses on_render(ctx); use this only for canvas, games, animation, or visual tools",
+                                class.name
+                            ));
+                        }
+                    }
+                }
+                errors.extend(analysis.errors);
+                warnings.extend(analysis.warnings);
+            }
+            Err(e) => errors.push(format!("SDK — {e}")),
+        }
+    } else {
+        warnings.push(format!(
+            "SDK — {} is not a Python entry; skipping Python SDK checks",
+            entry_path.display()
+        ));
+    }
+
+    for (width, height) in render_sizes {
+        let label = format!("{width}x{height}");
+        match crate::render::app_render::render_app_to_json(
+            &manifest.app.id,
+            &entry_path,
+            width,
+            height,
+            None,
+        ) {
+            Ok(json) => {
+                let frame: serde_json::Value = match serde_json::from_str(&json) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        errors.push(format!("render {label} — invalid JSON frame: {e}"));
+                        continue;
+                    }
+                };
+                let command_count = frame.as_array().map(Vec::len).unwrap_or(0);
+                if command_count == 0 {
+                    errors.push(format!("render {label} — app emitted an empty frame"));
+                    continue;
+                }
+                let bounds = obvious_bounds_errors(&frame, width, height);
+                if bounds.is_empty() {
+                    println!("✓ render {label} — {command_count} command(s)");
+                } else {
+                    for issue in bounds {
+                        errors.push(format!("render {label} — {issue}"));
+                    }
+                }
+                if let Some(dir) = &png_dir {
+                    let png_path = dir.join(format!("{}-{label}.png", manifest.app.id));
+                    match crate::render::app_render::render_app_to_png(
+                        &manifest.app.id,
+                        &entry_path,
+                        width,
+                        height,
+                        None,
+                    ) {
+                        Ok(bytes) => match std::fs::write(&png_path, bytes) {
+                            Ok(()) => println!("✓ png {label} — {}", png_path.display()),
+                            Err(e) => errors.push(format!(
+                                "png {label} — could not write {}: {e}",
+                                png_path.display()
+                            )),
+                        },
+                        Err(e) => errors.push(format!("png {label} — {e}")),
+                    }
+                }
+            }
+            Err(e) => errors.push(format!("render {label} — {e}")),
+        }
+    }
+
+    for warning in &warnings {
+        println!("warning: {warning}");
+    }
+    for error in &errors {
+        println!("error: {error}");
+    }
+
+    if errors.is_empty() {
+        println!("✓ app check passed");
+        log::info!(
+            "app_check[{}]: passed with {} warning(s)",
+            manifest.app.id,
+            warnings.len()
+        );
+        0
+    } else {
+        println!(
+            "✗ app check failed — {} error(s), {} warning(s)",
+            errors.len(),
+            warnings.len()
+        );
+        log::warn!(
+            "app_check[{}]: failed with {} error(s), {} warning(s)",
+            manifest.app.id,
+            errors.len(),
+            warnings.len()
+        );
+        1
+    }
+}
+
+fn check_sizes(raw_sizes: &[String]) -> Result<Vec<(u32, u32)>, String> {
+    if raw_sizes.is_empty() {
+        return Ok(DEFAULT_CHECK_SIZES.to_vec());
+    }
+
+    let mut parsed = Vec::with_capacity(raw_sizes.len());
+    for raw in raw_sizes {
+        let Some((w, h)) = parse_size(raw) else {
+            return Err(format!(
+                "invalid --size '{raw}' — expected WxH, for example 800x600"
+            ));
+        };
+        if !parsed.contains(&(w, h)) {
+            parsed.push((w, h));
+        }
+    }
+    Ok(parsed)
+}
+
+fn parse_size(raw: &str) -> Option<(u32, u32)> {
+    let (w, h) = raw.split_once('x')?;
+    let w = w.parse::<u32>().ok()?;
+    let h = h.parse::<u32>().ok()?;
+    if w == 0 || h == 0 {
+        return None;
+    }
+    Some((w, h))
+}
+
+fn load_local_app(app_dir: &Path) -> Result<(AppManifest, PathBuf), String> {
+    if !app_dir.exists() {
+        return Err(format!("path does not exist: {}", app_dir.display()));
+    }
+    if !app_dir.is_dir() {
+        return Err(format!("path is not a directory: {}", app_dir.display()));
+    }
+
+    let manifest_path = app_dir.join("manifest.toml");
+    let manifest_raw = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("could not read {}: {e}", manifest_path.display()))?;
+    let manifest: AppManifest =
+        toml::from_str(&manifest_raw).map_err(|e| format!("invalid manifest.toml: {e}"))?;
+
+    if manifest.schema_version > crate::app::registry::MANIFEST_SCHEMA_VERSION {
+        return Err(format!(
+            "manifest schema_version {} is newer than this Plexi build supports ({})",
+            manifest.schema_version,
+            crate::app::registry::MANIFEST_SCHEMA_VERSION
+        ));
+    }
+
+    let entry_path = app_dir.join(&manifest.app.entry);
+    if !entry_path.exists() {
+        return Err(format!(
+            "entry file '{}' not found in {}",
+            manifest.app.entry,
+            app_dir.display()
+        ));
+    }
+
+    Ok((manifest, entry_path))
+}
+
+fn analyze_python_entry(entry_path: &Path) -> Result<SdkAnalysis, String> {
+    let script = r#"
+import ast
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    tree = ast.parse(fh.read(), filename=path)
+
+def base_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Subscript):
+        return base_name(node.value)
+    if isinstance(node, ast.Call):
+        return base_name(node.func)
+    return ""
+
+classes = []
+for node in ast.walk(tree):
+    if isinstance(node, ast.ClassDef):
+        methods = [
+            child.name
+            for child in node.body
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        classes.append({
+            "name": node.name,
+            "bases": [base_name(base) for base in node.bases],
+            "methods": methods,
+        })
+
+json.dump({"classes": classes}, sys.stdout)
+"#;
+
+    let output = std::process::Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .arg(entry_path)
+        .output()
+        .map_err(|e| format!("could not run python3 for AST analysis: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Python syntax or AST error in {}: {}",
+            entry_path.display(),
+            stderr.trim()
+        ));
+    }
+
+    let report: PythonAstReport = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("could not parse AST report: {e}"))?;
+
+    let mut analysis = SdkAnalysis::default();
+    for class in report.classes {
+        if !class.bases.iter().any(|base| base == "App") {
+            continue;
+        }
+        let has_view = class.methods.iter().any(|method| method == "view");
+        let has_on_render = class.methods.iter().any(|method| method == "on_render");
+        if has_view && has_on_render {
+            analysis.errors.push(format!(
+                "SDK — {} defines both view() and on_render(ctx); pick one render path",
+                class.name
+            ));
+        }
+        if !has_view && !has_on_render {
+            analysis.errors.push(format!(
+                "SDK — {} defines neither view() nor on_render(ctx)",
+                class.name
+            ));
+        }
+        analysis.app_classes.push(PythonAppClass {
+            name: class.name,
+            has_view,
+            has_on_render,
+        });
+    }
+
+    Ok(analysis)
+}
+
+fn obvious_bounds_errors(frame: &serde_json::Value, width: u32, height: u32) -> Vec<String> {
+    let Some(commands) = frame.as_array() else {
+        return vec!["frame is not a command array".to_string()];
+    };
+
+    let mut errors = Vec::new();
+    for (idx, command) in commands.iter().enumerate() {
+        collect_bounds_errors(
+            command,
+            width as f64,
+            height as f64,
+            &format!("command {idx}"),
+            &mut errors,
+        );
+    }
+    errors
+}
+
+fn collect_bounds_errors(
+    value: &serde_json::Value,
+    viewport_w: f64,
+    viewport_h: f64,
+    label: &str,
+    errors: &mut Vec<String>,
+) {
+    let Some(obj) = value.as_object() else {
+        return;
+    };
+
+    let type_name = obj
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("node");
+
+    let x = obj.get("x").and_then(serde_json::Value::as_f64);
+    let y = obj.get("y").and_then(serde_json::Value::as_f64);
+    let w = obj.get("w").and_then(serde_json::Value::as_f64);
+    let h = obj.get("h").and_then(serde_json::Value::as_f64);
+
+    if let (Some(x), Some(y), Some(w), Some(h)) = (x, y, w, h) {
+        if w < 0.0 || h < 0.0 {
+            errors.push(format!("{label} {type_name} has negative size {w}x{h}"));
+        }
+        if x + w < 0.0 || y + h < 0.0 || x > viewport_w || y > viewport_h {
+            errors.push(format!(
+                "{label} {type_name} is outside the viewport at {x},{y} {w}x{h}"
+            ));
+        }
+        if w > viewport_w * 4.0 || h > viewport_h * 4.0 {
+            errors.push(format!(
+                "{label} {type_name} is far larger than the viewport: {w}x{h}"
+            ));
+        }
+    } else if let (Some(x), Some(y)) = (x, y) {
+        if x < -viewport_w || y < -viewport_h || x > viewport_w * 2.0 || y > viewport_h * 2.0 {
+            errors.push(format!(
+                "{label} {type_name} is far outside the viewport at {x},{y}"
+            ));
+        }
+    }
+
+    for key in ["root", "children", "items", "tiers", "command"] {
+        if let Some(child) = obj.get(key) {
+            match child {
+                serde_json::Value::Array(values) => {
+                    for (idx, nested) in values.iter().enumerate() {
+                        collect_bounds_errors(
+                            nested,
+                            viewport_w,
+                            viewport_h,
+                            &format!("{label}.{key}[{idx}]"),
+                            errors,
+                        );
+                    }
+                }
+                serde_json::Value::Object(_) => {
+                    collect_bounds_errors(
+                        child,
+                        viewport_w,
+                        viewport_h,
+                        &format!("{label}.{key}"),
+                        errors,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod app_check_tests {
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn default_sizes_cover_small_and_normal_panes() {
+        let sizes = super::check_sizes(&[]).expect("default sizes should parse");
+
+        assert!(sizes.contains(&(320, 240)));
+        assert!(sizes.contains(&(480, 320)));
+        assert!(sizes.contains(&(800, 600)));
+    }
+
+    #[test]
+    fn sdk_analysis_accepts_view_only_app() {
+        let dir = TempDir::new().unwrap();
+        let entry = dir.path().join("main.py");
+        fs::write(
+            &entry,
+            r#"
+from plexi_sdk import App
+
+class Good(App):
+    def view(self):
+        return None
+"#,
+        )
+        .unwrap();
+
+        let analysis = super::analyze_python_entry(&entry).expect("analysis should run");
+        assert!(analysis.errors.is_empty(), "{:?}", analysis.errors);
+    }
+
+    #[test]
+    fn sdk_analysis_rejects_app_that_overrides_both_render_paths() {
+        let dir = TempDir::new().unwrap();
+        let entry = dir.path().join("main.py");
+        fs::write(
+            &entry,
+            r#"
+from plexi_sdk import App
+
+class Bad(App):
+    def view(self):
+        return None
+
+    def on_render(self, ctx):
+        pass
+"#,
+        )
+        .unwrap();
+
+        let analysis = super::analyze_python_entry(&entry).expect("analysis should run");
+        assert!(
+            analysis
+                .errors
+                .iter()
+                .any(|error| error.contains("defines both view() and on_render(ctx)")),
+            "{:?}",
+            analysis.errors
+        );
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -390,6 +390,22 @@ pub enum AppCmd {
         #[arg(long)]
         png: bool,
     },
+    /// Check a local app with manifest, SDK, and render-size checks.
+    ///
+    /// This is the compiler-like gate for generated Plexi apps. It checks the
+    /// manifest, inspects Python SDK usage without importing app code, and
+    /// renders the app at small and normal pane sizes.
+    Check {
+        /// Local app directory to check (default: current directory)
+        #[arg(default_value = ".", value_hint = ValueHint::DirPath)]
+        path: String,
+        /// Render size to check as WxH. Repeat to override the default matrix.
+        #[arg(long = "size")]
+        sizes: Vec<String>,
+        /// Write PNG snapshots for each checked size into this directory.
+        #[arg(long, value_hint = ValueHint::DirPath)]
+        png_dir: Option<String>,
+    },
     /// Show details about an installed app: id, name, version, and available tools.
     Info {
         id: String,
@@ -445,6 +461,7 @@ pub enum AppCmd {
     self.emit.ai_query(tier, sys, msgs) LLM queries
 
   Headless testing:
+    plexi app check <path>                             Validate SDK shape + render size matrix
     plexi app render <id>                           JSON frame tree to stdout
     plexi app render <id> --png --output shot.png   PNG image to file
     Use --state file.json to pre-populate app state before on_init.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -104,6 +104,7 @@ pub mod setup;
 pub mod agent;
 pub mod ai;
 pub mod app;
+pub mod app_check;
 pub mod completions;
 pub mod config_cli;
 pub mod context_cli;
@@ -172,6 +173,7 @@ pub(super) fn binary_in_path(name: &str) -> bool {
 
 // ── Public re-exports (preserve crate::cli::fn_name() call sites in main.rs) ──
 pub use app::{app_init, app_uninstall, app_install_with_pin, app_info, app_list, app_render, app_publish, app_update_cli, app_action_cli};
+pub use app_check::app_check_cli;
 pub use completions::{completions_cli, complete_open_cli};
 pub use config_cli::{config_check, config_edit, config_get, config_reset};
 pub use context_cli::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,6 +330,10 @@ fn main() -> eframe::Result {
                         AppCmd::Render { app, size, state, output, png } => {
                             std::process::exit(cli::app_render(&app, &size, state.as_deref(), output.as_deref(), png))
                         }
+                        AppCmd::Check { path, sizes, png_dir } => {
+                            log::info!("app_check:cli: path={path} sizes={sizes:?} png_dir={png_dir:?}");
+                            std::process::exit(cli::app_check_cli(&path, &sizes, png_dir.as_deref()));
+                        }
                         AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
                         AppCmd::Validate { path } => {
                             log::info!("app_validate:cli: path={path}");

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.
-verified_version: "0.0.662"
+verified_version: "0.0.671"
 order: 7
 ---
 
@@ -207,6 +207,7 @@ Manage the active context (the folder and project scope tied to the current pane
 | `zoom` | Zoom into a sub-context by its numeric context_id |
 | `zoom-out` | Zoom out of the current sub-context to the parent |
 | `push` | Push the focused pane into a new sub-context |
+| `list` | List all open contexts as a JSON array |
 
 ### `plexi context new`
 
@@ -266,6 +267,10 @@ Push the focused pane into a new sub-context
 |---|---|---|---|
 | `<name>` | string | no | Name for the new sub-context. Defaults to the pane name |
 
+### `plexi context list`
+
+List all open contexts as a JSON array
+
 ## `plexi app`
 
 Manage your Plexi apps — open, install, list, scaffold, and inspect
@@ -277,6 +282,7 @@ Manage your Plexi apps — open, install, list, scaffold, and inspect
 | `uninstall` | Remove an installed app by id |
 | `list` | Show all installed apps with their versions |
 | `render` | Render an app headlessly (JSON frame tree by default, or PNG with --png) |
+| `check` | Check a local app with manifest, SDK, and render-size checks |
 | `info` | Show details about an installed app: id, name, version, and available tools |
 | `init` | Create a new app from a template |
 | `validate` | Check a Plexi app directory for errors before publishing or installing |
@@ -337,11 +343,23 @@ Render an app headlessly (JSON frame tree by default, or PNG with --png)
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
-| `<id>` | string | yes | App id to render (e.g. "snake") |
+| `<app>` | string | yes | App id or local path to render (e.g. "snake" or "./my-app") |
 | `--size` | string | no | Image dimensions as WxH (e.g. 500x500) Default: `800x600`. |
 | `--state` | string | no | Pre-seed the app's state from a JSON file before rendering |
 | `--output` | string | no | Where to save the output (default: stdout) |
 | `--png` | flag | no | Render to a PNG image instead of JSON (default: JSON) |
+
+### `plexi app check`
+
+Check a local app with manifest, SDK, and render-size checks.
+
+This is the compiler-like gate for generated Plexi apps. It checks the manifest, inspects Python SDK usage without importing app code, and renders the app at small and normal pane sizes.
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | no | Local app directory to check (default: current directory) Default: `.`. |
+| `--size` | string (repeatable) | no | Render size to check as WxH. Repeat to override the default matrix |
+| `--png-dir` | string | no | Write PNG snapshots for each checked size into this directory |
 
 ### `plexi app info`
 
@@ -446,7 +464,7 @@ Control panes — list, focus, send input, capture output, and more
 | `close` | Close a pane. Omit the pane id to close the pane you are currently in |
 | `send` | Type text into another pane as if it came from the keyboard |
 | `self` | Print the id of the pane you are currently in |
-| `info` | Print details about the current pane as JSON |
+| `info` | Print details about the current pane (or the previously focused pane) as JSON |
 | `capture` | Capture the last N lines of a pane's output as a JSON array |
 | `key` | Send a key press to a pane |
 | `command` | Send a shell command to a terminal pane as if typed from the keyboard |
@@ -536,7 +554,11 @@ Useful in scripts: MY_PANE=$(plexi pane self)
 
 ### `plexi pane info`
 
-Print details about the current pane as JSON
+Print details about the current pane (or the previously focused pane) as JSON
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `--previous` | flag | no | Return info for the previously focused pane instead of the current one |
 
 ### `plexi pane capture`
 


### PR DESCRIPTION
## Summary

- Add `plexi app check` for local app validation, Python SDK shape checks, and render-size matrix checks.
- Keep `view()` apps as the clean path while warning, not failing, for explicit `on_render(ctx)` apps.
- Clarify that SDK v2 is the Python authoring API and PGAP v3 is the wire protocol it speaks.

## Verification

- `cargo test --bin plexi app_check_tests`
- `PLEXI_SDK_PATH=.../sdk/python cargo run -- app check apps/kraken --size 320x240 --size 800x600`
- `PLEXI_SDK_PATH=.../sdk/python cargo run -- app check apps/dev/counter-tree --size 320x240`
- `cargo build`
- `npm run build` in `website/`

## Note

`cargo test --bin plexi` hit intermittent connection-reset failures in `process_app::mcp_server::tests::{test_wrong_token_returns_401,test_no_auth_returns_401}`; both failed tests passed when rerun individually.