### PR TITLE
feat(apps): promote GitHub Issues viewer to core app with L1 PGAP rewrite (#1963)

### DIFF
--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""gh-issues — GitHub Issues viewer for the workspace repo.
+
+Two views:
+  - LIST: scrollable issue rows with number badge, title, labels
+  - DETAIL: metadata card + scrollable markdown body
+
+Keys: j/k navigate · Enter open detail · Esc back · o open in browser
+      r refresh · n new issue in terminal
+"""
+import asyncio
+import json
+import subprocess
+
+from plexi_sdk import (
+    App, RenderContext, Arg,
+    theme,
+    BODY, CAPTION, HINT,
+    PAD, PAD_TIGHT,
+)
+from plexi_sdk.ui import (
+    AppBar, FooterKeys, InfoTable, Section,
+    Scrollable, Column, Label, Spacer,
+    ListRow, RowChip, LeadingBadge,
+    Component,
+    TEXT_BODY,
+    SPACE_MD,
+    _markdown_measure_lines,
+)
+
+
+# ── Private markdown component ────────────────────────────────────────────────
+
+class _MarkdownBlock(Component):
+    """Embeds ctx.markdown() in the declarative component tree."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def measure(self, avail_w: float) -> float:
+        if not self.text:
+            return 0.0
+        lines = _markdown_measure_lines(self.text, avail_w, TEXT_BODY, max_lines=400)
+        return max(1, lines) * (TEXT_BODY + 5.0)
+
+    def render(self, ctx, x: float, y: float, w: float, _h: float) -> None:
+        if self.text:
+            ctx.markdown(x, y, w, self.text)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _gh(*args: str, cwd: str | None = None, timeout: float = 15.0) -> tuple[int, str, str]:
+    """Run gh CLI. Returns (returncode, stdout, stderr). Never raises."""
+    try:
+        p = subprocess.run(
+            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        )
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", "timeout after 15s"
+    except Exception as exc:
+        return -1, "", str(exc)
+
+
+def _label_color(name: str) -> str:
+    n = name.lower()
+    if any(w in n for w in ("bug", "error", "p0", "p1")):
+        return theme.danger
+    if any(w in n for w in ("p2", "enhancement", "feat")):
+        return theme.warning
+    if any(w in n for w in ("ready", "done", "p3", "p4")):
+        return theme.success
+    return theme.accent
+
+
+# ── App ───────────────────────────────────────────────────────────────────────
+
+class GhIssues(App):
+    VIEW_LIST   = "list"
+    VIEW_DETAIL = "detail"
+
+    repo_dir: Arg[str | None] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
+
+    async def on_init(self) -> None:
+        self._view           = self.VIEW_LIST
+        self._issues         : list[dict] = []
+        self._sel            = 0
+        self._loading        = True
+        self._detail_loading = False
+        self._error          : str | None = None
+        self._detail         : dict | None = None
+        self._root           = self.repo_dir or ""
+        # Stable Scrollable instance — scroll offset persists across renders.
+        self._body_scroll    = Scrollable(Label(""))
+        self.emit.status_summary("Loading…")
+        self.emit.info(f"gh-issues init workspace={self._root!r}")
+        self._fetch()
+
+    # ── data ──────────────────────────────────────────────────────────────────
+
+    def _fetch(self) -> None:
+        self._loading = True
+        self._error   = None
+        asyncio.get_event_loop().create_task(asyncio.to_thread(self._load_list))
+
+    def _load_list(self) -> None:
+        rc, out, err = _gh(
+            "issue", "list", "--state", "open",
+            "--json", "number,title,state,labels,assignees,createdAt",
+            "--limit", "100",
+            cwd=self._root or None,
+        )
+        if rc != 0:
+            self.emit.warn(f"gh issue list failed rc={rc} stderr={err!r}")
+            self._error   = err.strip() or f"exit {rc}"
+            self._loading = False
+            self.emit.schedule_render()
+            return
+        try:
+            self._issues = json.loads(out)
+            self._sel = max(0, min(self._sel, len(self._issues) - 1)) if self._issues else 0
+        except Exception as exc:
+            self.emit.warn(f"gh issue list json parse error: {exc}")
+            self._error = str(exc)
+        self._loading = False
+        self.emit.info(f"gh-issues loaded {len(self._issues)} open issues")
+        self.emit.schedule_render()
+
+    def _load_detail(self, number: int) -> None:
+        rc, out, err = _gh(
+            "issue", "view", str(number),
+            "--json", "number,title,state,body,labels,assignees,createdAt",
+            cwd=self._root or None,
+        )
+        if rc != 0:
+            self.emit.warn(f"gh issue view {number} failed rc={rc} stderr={err!r}")
+            self._error = err.strip() or f"exit {rc}"
+            self._detail_loading = False
+            self.emit.schedule_render()
+            return
+        try:
+            self._detail = json.loads(out)
+            self.emit.info(f"gh-issues loaded detail #{number}")
+        except Exception as exc:
+            self.emit.warn(f"gh issue view {number} json parse error: {exc}")
+            self._error = str(exc)
+        self._detail_loading = False
+        self.emit.schedule_render()
+
+    # ── render ────────────────────────────────────────────────────────────────
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.clear(theme.bg)
+
+        # No-repo message when context root has no GitHub repo.
+        if not self._root:
+            ctx.render(Column([
+                AppBar("GitHub Issues", accent=theme.accent),
+                Spacer(size=SPACE_MD),
+                Label(
+                    "Set the context root to a directory with a GitHub repo in order to see issues.",
+                    tone="body",
+                    color=theme.muted,
+                ),
+            ], padding_top=0))
+            return
+
+        if self._view == self.VIEW_DETAIL:
+            if self._detail_loading:
+                ctx.render(Column([
+                    AppBar("Issues", accent=theme.accent),
+                    Spacer(size=SPACE_MD),
+                    Label("Loading issue…", tone="body", color=theme.muted),
+                ], padding_top=0))
+            elif self._error:
+                ctx.render(Column([
+                    AppBar("Error", accent=theme.accent),
+                    Spacer(size=SPACE_MD),
+                    Label(f"Error: {self._error}", tone="body", color=theme.danger),
+                    Spacer(grow=True),
+                    FooterKeys([("escape", "back")]),
+                ], padding_top=0))
+            else:
+                self._draw_detail(ctx)
+            return
+
+        # Header: AppBar (title + count). Shortcuts live in a bottom footer.
+        appbar = AppBar(
+            "Issues",
+            subtitle=f"{len(self._issues)} open" if not self._loading else None,
+            accent=theme.accent,
+        )
+        footer = FooterKeys([
+            (["j", "k"], "navigate"),
+            ("↩", "detail"),
+            ("o", "browser"),
+            ("r", "refresh"),
+            ("n", "new"),
+        ])
+        appbar_h  = appbar.measure(ctx.w)
+        footer_h  = footer.measure(ctx.w)
+        list_top  = appbar_h
+        appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)
+        footer.render(ctx, 0.0, ctx.h - footer_h, ctx.w, footer_h)
+
+        if self._loading:
+            ctx.text(PAD, list_top + PAD, "Loading…", size=BODY, color=theme.muted)
+            return
+        if self._error:
+            ctx.text(PAD, list_top + PAD, f"Error: {self._error}",
+                     size=CAPTION, color=theme.danger, max_width=ctx.w - PAD * 2)
+            ctx.text(PAD, list_top + PAD + BODY + PAD_TIGHT,
+                     "r — retry", size=HINT, color=theme.muted)
+            return
+
+        self._draw_list(ctx, list_top, footer_h)
+
+    def _draw_list(self, ctx: RenderContext, list_top: float, footer_h: float) -> None:
+        rows = [
+            ListRow(
+                id=f"issue-{issue['number']}",
+                leading=LeadingBadge(f"#{issue['number']}", color=theme.accent),
+                primary=issue.get("title", ""),
+                chips=[
+                    RowChip(lbl.get("name", ""), _label_color(lbl.get("name", "")))
+                    for lbl in (issue.get("labels") or [])[:2]
+                ],
+            ).to_dict()
+            for issue in self._issues
+        ]
+        list_h = max(0.0, ctx.h - list_top - footer_h)
+        ctx.list_view("issues", rows, selected=self._sel,
+                      y=float(list_top), h=float(list_h))
+
+    def _draw_detail(self, ctx: RenderContext) -> None:
+        if self._detail is None:
+            return
+        d             = self._detail
+        labels_str    = ", ".join(lb.get("name", "") for lb in d.get("labels", []) if lb) or "none"
+        assignees_str = ", ".join(a.get("login", "") for a in d.get("assignees", []) if a) or "unassigned"
+        body_text     = (d.get("body") or "").strip()
+        number        = d.get("number", "")
+        title         = d.get("title", "")
+
+        self._body_scroll.child = (
+            _MarkdownBlock(body_text) if body_text
+            else Label("No body.", tone="caption", color=theme.muted)
+        )
+
+        ctx.render(Column([
+            AppBar(f"← #{number}  {title}", accent=theme.accent),
+            InfoTable([
+                ("number",    f"#{number}"),
+                ("state",     d.get("state", "open")),
+                ("labels",    labels_str),
+                ("assignees", assignees_str),
+                ("opened",    (d.get("createdAt") or "")[:10]),
+            ]),
+            Section("Body"),
+            self._body_scroll,
+            FooterKeys([("o", "open in browser"), ("escape", "back")]),
+        ], padding_top=0))
+
+    # ── input ─────────────────────────────────────────────────────────────────
+
+    def on_key(self, key: str, _mods: dict) -> None:
+        if self._loading:
+            return
+
+        if self._view == self.VIEW_LIST:
+            if key == "o":
+                self._open_browser()
+            elif key == "r":
+                self.emit.info("gh-issues: refresh")
+                self._fetch()
+            elif key == "n":
+                self._new_issue()
+
+        elif self._view == self.VIEW_DETAIL:
+            if key == "escape":
+                self._view   = self.VIEW_LIST
+                self._detail = None
+                self.emit.info("gh-issues: back to list")
+                self.emit.status_summary("Issues")
+                self.emit.schedule_render()
+            elif key == "o":
+                if self._detail:
+                    num = self._detail["number"]
+                    rc, _, _ = _gh("issue", "view", str(num), "--web",
+                                   cwd=self._root or None)
+                    self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
+            else:
+                if self._body_scroll.handle_key(key):
+                    self.emit.schedule_render()
+
+    def on_list_select(self, _id: str, index: int) -> None:
+        self._sel = index
+        if self._issues:
+            self.emit.status_summary(self._issues[self._sel]["title"])
+        self.emit.schedule_render()
+
+    def on_list_activate(self, _id: str, _index: int) -> None:
+        self._open_detail()
+
+    def on_click(self, _x: float, _y: float, _button: str) -> None:
+        pass
+
+    # ── actions ───────────────────────────────────────────────────────────────
+
+    def _open_detail(self) -> None:
+        if not self._issues:
+            return
+        issue = self._issues[self._sel]
+        self.emit.info(f"gh-issues: open detail #{issue['number']}")
+        self._view                      = self.VIEW_DETAIL
+        self._detail                    = None
+        self._detail_loading            = True
+        self._error                     = None
+        self._body_scroll.scroll_offset = 0.0
+        asyncio.get_event_loop().create_task(
+            asyncio.to_thread(self._load_detail, issue["number"])
+        )
+
+    def _open_browser(self) -> None:
+        if not self._issues:
+            return
+        num = self._issues[self._sel]["number"]
+        rc, _, _ = _gh("issue", "view", str(num), "--web", cwd=self._root or None)
+        self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
+
+    def _new_issue(self) -> None:
+        self.emit.info("gh-issues: new issue")
+        self.emit.run_in_terminal("gh issue create")
+
+
+GhIssues().run()

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -102,7 +102,7 @@ class GhIssues(App):
     def _fetch(self) -> None:
         self._loading = True
         self._error   = None
-        asyncio.get_event_loop().create_task(asyncio.to_thread(self._load_list))
+        asyncio.create_task(asyncio.to_thread(self._load_list))
 
     def _load_list(self) -> None:
         rc, out, err = _gh(
@@ -264,13 +264,13 @@ class GhIssues(App):
 
     # ── input ─────────────────────────────────────────────────────────────────
 
-    def on_key(self, key: str, _mods: dict) -> None:
+    async def on_key(self, key: str, _mods: dict) -> None:
         if self._loading:
             return
 
         if self._view == self.VIEW_LIST:
             if key == "o":
-                self._open_browser()
+                await self._open_browser()
             elif key == "r":
                 self.emit.info("gh-issues: refresh")
                 self._fetch()
@@ -281,14 +281,16 @@ class GhIssues(App):
             if key == "escape":
                 self._view   = self.VIEW_LIST
                 self._detail = None
+                self._error  = None
                 self.emit.info("gh-issues: back to list")
                 self.emit.status_summary("Issues")
                 self.emit.schedule_render()
             elif key == "o":
                 if self._detail:
                     num = self._detail["number"]
-                    rc, _, _ = _gh("issue", "view", str(num), "--web",
-                                   cwd=self._root or None)
+                    rc, _, _ = await asyncio.to_thread(
+                        _gh, "issue", "view", str(num), "--web", cwd=self._root or None,
+                    )
                     self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
             else:
                 if self._body_scroll.handle_key(key):
@@ -318,15 +320,17 @@ class GhIssues(App):
         self._detail_loading            = True
         self._error                     = None
         self._body_scroll.scroll_offset = 0.0
-        asyncio.get_event_loop().create_task(
+        asyncio.create_task(
             asyncio.to_thread(self._load_detail, issue["number"])
         )
 
-    def _open_browser(self) -> None:
+    async def _open_browser(self) -> None:
         if not self._issues:
             return
         num = self._issues[self._sel]["number"]
-        rc, _, _ = _gh("issue", "view", str(num), "--web", cwd=self._root or None)
+        rc, _, _ = await asyncio.to_thread(
+            _gh, "issue", "view", str(num), "--web", cwd=self._root or None,
+        )
         self.emit.info(f"gh-issues: open #{num} in browser rc={rc}")
 
     def _new_issue(self) -> None:

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -264,6 +264,17 @@ class GhIssues(App):
 
     # ── input ─────────────────────────────────────────────────────────────────
 
+    def on_escape(self) -> bool:
+        if self._view == self.VIEW_DETAIL:
+            self._view   = self.VIEW_LIST
+            self._detail = None
+            self._error  = None
+            self.emit.info("gh-issues: back to list")
+            self.emit.status_summary("Issues")
+            self.emit.schedule_render()
+            return True
+        return False
+
     async def on_key(self, key: str, _mods: dict) -> None:
         if self._loading:
             return
@@ -278,14 +289,7 @@ class GhIssues(App):
                 self._new_issue()
 
         elif self._view == self.VIEW_DETAIL:
-            if key == "escape":
-                self._view   = self.VIEW_LIST
-                self._detail = None
-                self._error  = None
-                self.emit.info("gh-issues: back to list")
-                self.emit.status_summary("Issues")
-                self.emit.schedule_render()
-            elif key == "o":
+            if key == "o":
                 if self._detail:
                     num = self._detail["number"]
                     rc, _, _ = await asyncio.to_thread(

--- a/apps/github-issues/manifest.toml
+++ b/apps/github-issues/manifest.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+
+[app]
+id = "github-issues"
+type = "app"
+name = "GitHub Issues"
+version = "0.1.0"
+description = "GitHub Issues viewer for the workspace repo."
+entry = "main.py"
+
+[app.capabilities]
+capabilities = []
+
+[launch]


### PR DESCRIPTION
Closes #1963

## Summary

- Creates `apps/github-issues/` with `manifest.toml` and `main.py` as a new core app
- Ports the refined two-view UX (list + detail, j/k nav, markdown body, InfoTable, label colors, AppBar, FooterKeys) from the archived dev POC at commit `00f6cbb4`
- Updates all callback signatures for the current L1 SDK (`on_init`/`on_key`/`on_list_select`/`on_list_activate`/`on_click` no longer take `ctx`; removed `on_render_seed`); uses `self.emit.*` for side effects outside `on_render`
- Adds a rendered no-repo message when `workspace_root` is unset, instead of crashing or printing to stderr

## Done When

1. `plexi-alpha app open github-issues` shows a scrollable list of GitHub issues from the workspace repo
2. Enter on an issue shows metadata InfoTable + scrollable markdown body
3. j/k scrolls the markdown body in detail view
4. Opening the app with no repo in context shows the no-repo message (rendered, not stderr)
5. All keybindings work: j/k navigate list, Enter detail, Esc back, o browser, r refresh
6. Theme colors used throughout (no hardcoded color constants)
7. No L0 imports or deprecated SDK patterns

## Notes

- `_MarkdownBlock` bridge component retained — no L1 Markdown component exists in SDK yet; issue spec explicitly permits this pattern
- `Arg` descriptor Pyright warnings on `cwd=self._root or None` are a known SDK limitation present in all core apps (csv_viewer, snake, backlog) — not fixable without changing `Arg.__get__` typing in the SDK