### PR TITLE
feat(sdk): make TextEdit a normal view() component-tree child (#2102)

### DIFF
--- a/docs/sdk-v2.md
+++ b/docs/sdk-v2.md
@@ -128,7 +128,7 @@ class SnakeApp(App):
 | `FooterKeys(shortcuts)` | Bottom key hint row. `shortcuts`: list of `(key, description)` tuples. |
 | `SelectList(items, selected_idx=0)` | Keyboard-navigable list. |
 | `TextInput(id, placeholder="")` | Single-line text input. |
-| `TextEdit(node_id, placeholder="", multiline=False, height=48.0)` | Host-rendered text editor. Change/submit events via `on_component_event`. |
+| `TextEdit(node_id, placeholder="", value="", multiline=False, max_length=0, height=48.0)` | Host-rendered text editor. Change/submit events via `on_component_event`. |
 | `Divider()` | Horizontal rule. |
 
 ## Agent dev loop (testing and automation)

--- a/docs/sdk-v2.md
+++ b/docs/sdk-v2.md
@@ -128,6 +128,7 @@ class SnakeApp(App):
 | `FooterKeys(shortcuts)` | Bottom key hint row. `shortcuts`: list of `(key, description)` tuples. |
 | `SelectList(items, selected_idx=0)` | Keyboard-navigable list. |
 | `TextInput(id, placeholder="")` | Single-line text input. |
+| `TextEdit(node_id, placeholder="", multiline=False, height=48.0)` | Host-rendered text editor. Change/submit events via `on_component_event`. |
 | `Divider()` | Horizontal rule. |
 
 ## Agent dev loop (testing and automation)

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1181,12 +1181,20 @@ class TextEdit(Component):
     max_length: int = 0
     height: float = 48.0
 
+    _submitted: Optional[str] = field(default=None, init=False, repr=False)
+
     def measure(self, _avail_w: float) -> float:
         return self.height
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.text_input(self.node_id, x=x, y=y, w=w, placeholder=self.placeholder,
-                       h=h, multiline=self.multiline)
+        self._submitted = ctx.text_input(self.node_id, x=x, y=y, w=w,
+                                         placeholder=self.placeholder,
+                                         h=h, multiline=self.multiline)
+
+    @property
+    def submitted(self) -> Optional[str]:
+        """Text submitted this frame (user pressed Enter) during L0 fallback, else None."""
+        return self._submitted
 
     def to_node(self) -> dict:
         return {

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -1154,34 +1154,39 @@ class TextInput(Component):
         return self._submitted
 
 
-class TextEdit:
-    """Host-rendered text editor node for component trees (PGAP v3.5+).
+@dataclass
+class TextEdit(Component):
+    """Host-rendered text editor. Use inside ``view()`` like any other component.
 
-    Produces a ``UiNode::TextEdit`` wire dict. The host maintains a persistent
-    buffer keyed on ``node_id``. Typing fires ``ComponentEvent`` with
-    ``event_type="change"`` and ``payload={"value": "..."}``; Enter (single-line)
-    or Cmd+Enter (multiline) fires ``event_type="submit"``.
+    The host maintains a persistent buffer keyed on ``node_id``. Typing fires
+    ``ComponentEvent`` with ``event_type="change"`` and ``payload={"value": "..."}``;
+    Enter (single-line) or Cmd+Enter (multiline) fires ``event_type="submit"``.
 
-    Use this in ``ctx.render_tree()`` calls, not inside ``ctx.render(Column([...]))``.
+    ``height`` controls the allocated row height (pixels). Default ``48.0`` suits
+    single-line use; set it larger for multiline (e.g. ``height=120.0``).
 
     Example::
 
-        ctx.render_tree(TextEdit("notes", placeholder="Type here...", multiline=True).to_node())
+        def view(self):
+            return Column([
+                TextEdit("body", multiline=True, height=120.0, placeholder="Type here..."),
+                FooterKeys([("↩", "submit")]),
+            ])
     """
 
-    def __init__(
-        self,
-        node_id: str,
-        placeholder: str = "",
-        value: str = "",
-        multiline: bool = False,
-        max_length: int = 0,
-    ) -> None:
-        self.node_id = node_id
-        self.placeholder = placeholder
-        self.value = value
-        self.multiline = multiline
-        self.max_length = max_length
+    node_id: str
+    placeholder: str = ""
+    value: str = ""
+    multiline: bool = False
+    max_length: int = 0
+    height: float = 48.0
+
+    def measure(self, _avail_w: float) -> float:
+        return self.height
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        ctx.text_input(self.node_id, x=x, y=y, w=w, placeholder=self.placeholder,
+                       h=h, multiline=self.multiline)
 
     def to_node(self) -> dict:
         return {

--- a/sdk/python/tests/test_new_components.py
+++ b/sdk/python/tests/test_new_components.py
@@ -1,6 +1,6 @@
 """Tests for B2 UiNode component classes: Tabs, Grid, Toggle, Clickable, ProgressBar."""
 
-from plexi_sdk.ui import Tabs, Grid, Toggle, Clickable, ProgressBar
+from plexi_sdk.ui import Tabs, Grid, Toggle, Clickable, ProgressBar, TextEdit, Column
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -194,3 +194,39 @@ def test_progress_bar_default_color() -> None:
     node = ProgressBar(0.5).to_node()
     filled = node["children"][0]
     assert filled["color"] == "accent"
+
+
+# ── TextEdit ───────────────────────────────────────────────────────────────
+
+
+def test_textedit_is_component() -> None:
+    from plexi_sdk.ui import Component
+    te = TextEdit("x")
+    assert isinstance(te, Component)
+
+
+def test_textedit_to_node_fields() -> None:
+    te = TextEdit("notes", placeholder="Write here", value="hello", multiline=True, max_length=500)
+    assert te.to_node() == {
+        "type": "text_edit",
+        "node_id": "notes",
+        "placeholder": "Write here",
+        "value": "hello",
+        "multiline": True,
+        "max_length": 500,
+    }
+
+
+def test_textedit_nested_in_column_no_fallback() -> None:
+    te = TextEdit("body", placeholder="Type...", multiline=True, height=120.0)
+    col = Column([te])
+    node = col.to_node()
+    assert node is not None, "Column.to_node() returned None — TextEdit triggered L0 fallback"
+    child_node = node["children"][0]
+    assert child_node["type"] == "text_edit"
+    assert child_node["node_id"] == "body"
+
+
+def test_textedit_measure() -> None:
+    te = TextEdit("x", height=80.0)
+    assert te.measure(400.0) == 80.0


### PR DESCRIPTION
Closes #2102

## Summary

- Promoted `TextEdit` from a plain class to a `@dataclass Component` subclass so it can be returned directly from `view()` inside `Column`, `Card`, or any other container without triggering L0 fallback
- Added `height: float = 48.0` field with `measure()`, and an L0 fallback `render()` that calls `ctx.text_input()` for compatibility
- Updated `docs/sdk-v2.md` component table to list `TextEdit` as a normal component alongside `TextInput`
- Added 4 regression tests: `isinstance(Component)`, `to_node()` fields, Column nesting without fallback, `measure()` return value

## Done When

- A normal SDK app can return `Column([TextEdit("body", multiline=True), FooterKeys([...])])` from `view()` and emit a ComponentTree without fallback.
- TextEdit change and submit events still arrive through `on_component_event` with `payload.value`.
- `docs/sdk-v2.md` teaches TextEdit as a normal view() component.
- Focused SDK tests pass for TextEdit nesting/event behavior.

## Notes

- `render()` L0 fallback delegates to `ctx.text_input()` — only reached if something else in the tree returns `None` from `to_node()`. Normal path is the L1 ComponentTree route.
- Multiline height sizing left to caller (`height=120.0` recommended in docstring) per the open question in the issue — richer sizing is a follow-up.