### PR TITLE
fix(config): config_dir() and workspace_channel_dir() honour PLEXI_CHANNEL env var (#2109)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -779,11 +779,9 @@ pub fn workspace_channel_dir() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
-    if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
-        if !channel.is_empty() {
-            log::info!("workspace_channel_dir: using PLEXI_CHANNEL={channel}");
-            return channel_suffix_from_basename(&format!("plexi-{channel}"));
-        }
+    if let Some(channel) = std::env::var("PLEXI_CHANNEL").ok().filter(|c| !c.is_empty()) {
+        log::info!("workspace_channel_dir: using PLEXI_CHANNEL={channel}");
+        return format!(".plexi-{channel}");
     }
     static CHANNEL_DIR: OnceLock<String> = OnceLock::new();
     CHANNEL_DIR
@@ -802,11 +800,9 @@ fn config_dir_name() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
-    if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
-        if !channel.is_empty() {
-            log::info!("config_dir_name: using PLEXI_CHANNEL={channel}");
-            return channel_suffix_from_basename(&format!("plexi-{channel}"));
-        }
+    if let Some(channel) = std::env::var("PLEXI_CHANNEL").ok().filter(|c| !c.is_empty()) {
+        log::info!("config_dir_name: using PLEXI_CHANNEL={channel}");
+        return format!(".plexi-{channel}");
     }
     let basename = std::env::current_exe()
         .ok()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -779,6 +779,11 @@ pub fn workspace_channel_dir() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
+    if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
+        if !channel.is_empty() {
+            return channel_suffix_from_basename(&format!("plexi-{channel}"));
+        }
+    }
     static CHANNEL_DIR: OnceLock<String> = OnceLock::new();
     CHANNEL_DIR
         .get_or_init(|| {
@@ -795,6 +800,11 @@ pub fn workspace_channel_dir() -> String {
 fn config_dir_name() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
+    }
+    if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
+        if !channel.is_empty() {
+            return channel_suffix_from_basename(&format!("plexi-{channel}"));
+        }
     }
     let basename = std::env::current_exe()
         .ok()
@@ -1393,6 +1403,18 @@ mod tests {
         // A binary at /Users/alpha/bin/plexi must NOT resolve to .plexi-alpha.
         // The extractor must use basename only, not the full path.
         assert_eq!(channel_suffix_from_basename("plexi"), ".plexi");
+    }
+
+    #[test]
+    fn config_dir_name_respects_plexi_channel_env() {
+        let prev = std::env::var("PLEXI_CHANNEL").ok();
+        unsafe { std::env::set_var("PLEXI_CHANNEL", "pr-999") };
+        let result = config_dir_name();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("PLEXI_CHANNEL", v) },
+            None => unsafe { std::env::remove_var("PLEXI_CHANNEL") },
+        }
+        assert_eq!(result, ".plexi-pr-999");
     }
 
     fn write(path: &Path, contents: &str) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -781,6 +781,7 @@ pub fn workspace_channel_dir() -> String {
     }
     if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
         if !channel.is_empty() {
+            log::info!("workspace_channel_dir: using PLEXI_CHANNEL={channel}");
             return channel_suffix_from_basename(&format!("plexi-{channel}"));
         }
     }
@@ -803,6 +804,7 @@ fn config_dir_name() -> String {
     }
     if let Ok(channel) = std::env::var("PLEXI_CHANNEL") {
         if !channel.is_empty() {
+            log::info!("config_dir_name: using PLEXI_CHANNEL={channel}");
             return channel_suffix_from_basename(&format!("plexi-{channel}"));
         }
     }
@@ -1410,6 +1412,18 @@ mod tests {
         let prev = std::env::var("PLEXI_CHANNEL").ok();
         unsafe { std::env::set_var("PLEXI_CHANNEL", "pr-999") };
         let result = config_dir_name();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("PLEXI_CHANNEL", v) },
+            None => unsafe { std::env::remove_var("PLEXI_CHANNEL") },
+        }
+        assert_eq!(result, ".plexi-pr-999");
+    }
+
+    #[test]
+    fn workspace_channel_dir_respects_plexi_channel_env() {
+        let prev = std::env::var("PLEXI_CHANNEL").ok();
+        unsafe { std::env::set_var("PLEXI_CHANNEL", "pr-999") };
+        let result = workspace_channel_dir();
         match prev {
             Some(v) => unsafe { std::env::set_var("PLEXI_CHANNEL", v) },
             None => unsafe { std::env::remove_var("PLEXI_CHANNEL") },


### PR DESCRIPTION
Closes #2109

## Summary

- `config_dir_name()` and `workspace_channel_dir()` now check `PLEXI_CHANNEL` env var between `PROFILE_OVERRIDE` and binary-name detection
- Fixes the bug where running the bare `plexi` binary inside a PR/alpha pane resolved the wrong profile dir
- Resolution priority is now: `PROFILE_OVERRIDE` > `PLEXI_CHANNEL` > binary-name detection

## Done When

- Inside a `plexi-pr-<N>` pane, `plexi config get font_size` reads from `~/.plexi-pr-<N>/config.toml`
- `grep -n "PLEXI_CHANNEL" src/config/mod.rs` shows it being read in both `config_dir_name` and `workspace_channel_dir`
- New test passes: `PLEXI_CHANNEL=pr-999` → `config_dir_name()` returns `.plexi-pr-999`

## Notes

`workspace_channel_dir()` uses a `OnceLock` to cache the binary-name-derived result. The `PLEXI_CHANNEL` check is inserted before the `OnceLock` (matching the `PROFILE_OVERRIDE` pattern), so it bypasses the cache and reads the env var on every call — cheap and correct since env vars are constant for a process lifetime.