### PR TITLE
fix(host/context): dissolve portals in place instead of flattening child layouts (#2108)

### DIFF
--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1,7 +1,5 @@
 use super::super::*;
-use crate::app::app_trait::AppCommand;
 use crate::host::context::Window;
-use crate::testing::HostHarness;
 
 /// Issue #1392: creating a child context must NOT remove or replace the parent's
 /// focused pane (adoption branch was removed). The parent should have:
@@ -914,5 +912,433 @@ fn delete_context_keeps_all_empty_windows_when_no_nonempty_sibling() {
     assert_eq!(
         root_windows, 2,
         "both portal-only windows must survive when no non-empty sibling exists"
+    );
+}
+
+fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
+    use crate::app::permissions::AppPermissions;
+    use crate::host::pane::{AppPane, AppRuntime};
+    use crate::process_app::ProcessApp;
+
+    let permissions = AppPermissions::builtin();
+    let (process_app, _draw_tx) = ProcessApp::new_for_test(pane_id, permissions.clone());
+    crate::host::pane::Pane::App(Box::new(AppPane {
+        id: pane_id,
+        runtime: AppRuntime::Process(Box::new(process_app)),
+        workspace_root: std::env::temp_dir(),
+        permissions,
+        manifest_id: format!("test-{pane_id}"),
+        name: format!("Test App {pane_id}"),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden: false,
+    }))
+}
+
+fn test_context(id: u64, parent_id: u64, name: &str) -> crate::host::context::Context {
+    crate::host::context::Context {
+        name: name.to_string(),
+        path: std::path::PathBuf::from(format!("/tmp/{name}")),
+        root: None,
+        description: None,
+        context_id: id,
+        parent_id: Some(parent_id),
+        depth: 1,
+        parked: false,
+    }
+}
+
+/// Issue #2108: dissolving a one-window sub-context should graft that child's
+/// tile tree into the exact Portal slot instead of flattening child panes into
+/// the parent container.
+#[test]
+fn dissolve_portal_grafts_single_child_window_tree_in_place() {
+    use egui_tiles::{Container, LinearDir, Tile};
+    use std::collections::HashMap;
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let parent_ctx_id = app.router.active().context_id;
+    let parent_win_id = app.windows[0].window_id;
+    let child_ctx_id = 210810u64;
+    let child_win_id = 210811u64;
+
+    let parent_left = 210801u64;
+    let parent_top_right = 210802u64;
+    let portal_pane_id = 210803u64;
+    let child_left = 210804u64;
+    let child_right = 210805u64;
+
+    let mut parent_tiles = egui_tiles::Tiles::default();
+    let parent_left_tile = parent_tiles.insert_pane(parent_left);
+    let parent_top_right_tile = parent_tiles.insert_pane(parent_top_right);
+    let portal_tile = parent_tiles.insert_pane(portal_pane_id);
+    let right_col = parent_tiles.insert_vertical_tile(vec![parent_top_right_tile, portal_tile]);
+    let parent_root = parent_tiles.insert_horizontal_tile(vec![parent_left_tile, right_col]);
+    let mut parent_panes = HashMap::new();
+    parent_panes.insert(parent_left, test_app_pane(parent_left));
+    parent_panes.insert(parent_top_right, test_app_pane(parent_top_right));
+    parent_panes.insert(
+        portal_pane_id,
+        crate::host::pane::Pane::Portal(Box::new(crate::host::pane::PortalPane {
+            pane_id: portal_pane_id,
+            target_context_id: child_ctx_id,
+            context_state: None,
+            hidden: false,
+        })),
+    );
+    app.windows[0].tree =
+        egui_tiles::Tree::new("dissolve_single_parent", parent_root, parent_tiles);
+    app.windows[0].panes = parent_panes;
+    app.windows[0].focused_pane = Some(portal_tile);
+    app.windows[0].zoomed_pane = Some(portal_tile);
+
+    app.router.push(test_context(
+        child_ctx_id,
+        parent_ctx_id,
+        "dissolve_single_child",
+    ));
+    app.context_active_window.insert(child_ctx_id, child_win_id);
+
+    let mut child_tiles = egui_tiles::Tiles::default();
+    let child_left_tile = child_tiles.insert_pane(child_left);
+    let child_right_tile = child_tiles.insert_pane(child_right);
+    let child_root = child_tiles.insert_horizontal_tile(vec![child_left_tile, child_right_tile]);
+    let mut child_panes = HashMap::new();
+    child_panes.insert(child_left, test_app_pane(child_left));
+    child_panes.insert(child_right, test_app_pane(child_right));
+    app.windows.push(Window {
+        name: "child".to_string(),
+        path: std::path::PathBuf::from("/tmp/dissolve_single_child"),
+        tree: egui_tiles::Tree::new("dissolve_single_child", child_root, child_tiles),
+        panes: child_panes,
+        focused_pane: Some(child_right_tile),
+        zoomed_pane: Some(child_right_tile),
+        grid_x: 0,
+        grid_y: 0,
+        window_id: child_win_id,
+        context_id: child_ctx_id,
+    });
+    app.router
+        .push_depth(child_ctx_id, child_win_id, Some(child_right_tile));
+
+    app.dissolve_portal(child_ctx_id);
+
+    assert!(
+        app.router.iter().all(|ctx| ctx.context_id != child_ctx_id),
+        "dissolved child context must be removed from router"
+    );
+    assert!(
+        !app.context_active_window.contains_key(&child_ctx_id),
+        "dissolved child context must not keep an active-window entry"
+    );
+    assert!(
+        app.router
+            .depth_stack
+            .iter()
+            .all(|(ctx_id, _, _)| *ctx_id != child_ctx_id),
+        "dissolved child context must be removed from depth stack"
+    );
+    assert!(
+        app.windows.iter().all(|w| w.context_id != child_ctx_id),
+        "no window should still belong to the dissolved child context"
+    );
+
+    let parent = app
+        .windows
+        .iter()
+        .find(|w| w.window_id == parent_win_id)
+        .expect("parent window should survive");
+    assert!(parent.panes.contains_key(&parent_left));
+    assert!(parent.panes.contains_key(&parent_top_right));
+    assert!(parent.panes.contains_key(&child_left));
+    assert!(parent.panes.contains_key(&child_right));
+    assert!(
+        !parent.panes.contains_key(&portal_pane_id),
+        "Portal pane must be removed after dissolve"
+    );
+    assert!(
+        parent
+            .panes
+            .values()
+            .all(|pane| pane.portal_target() != Some(child_ctx_id)),
+        "no surviving PortalPane may point at the dissolved context"
+    );
+
+    let grafted_tile = match parent.tree.tiles.get(right_col) {
+        Some(Tile::Container(Container::Linear(linear))) => {
+            assert_eq!(
+                linear.dir,
+                LinearDir::Vertical,
+                "portal lived in the lower half of the right column"
+            );
+            assert_eq!(
+                linear.children.len(),
+                2,
+                "child split should replace the portal slot, not become extra siblings"
+            );
+            linear.children[1]
+        }
+        other => panic!("expected right column linear container, got {other:?}"),
+    };
+
+    match parent.tree.tiles.get(grafted_tile) {
+        Some(Tile::Container(Container::Linear(linear))) => {
+            assert_eq!(linear.dir, LinearDir::Horizontal);
+            let grafted_panes: Vec<_> = linear
+                .children
+                .iter()
+                .map(|tile| match parent.tree.tiles.get(*tile) {
+                    Some(Tile::Pane(pane_id)) => *pane_id,
+                    other => panic!("expected child pane tile, got {other:?}"),
+                })
+                .collect();
+            assert_eq!(
+                grafted_panes,
+                vec![child_left, child_right],
+                "grafted tile must preserve the child split order"
+            );
+        }
+        other => panic!("expected child split grafted into portal slot, got {other:?}"),
+    }
+
+    let mapped_child_focus = parent
+        .tree
+        .tiles
+        .find_pane(&child_right)
+        .expect("focused child pane should be present in graft");
+    assert_eq!(
+        parent.focused_pane,
+        Some(mapped_child_focus),
+        "child focus should map to the grafted tile"
+    );
+    assert_eq!(
+        parent.zoomed_pane,
+        Some(mapped_child_focus),
+        "child zoom should map to the grafted tile"
+    );
+}
+
+/// Issue #2108: a multi-window child context must not be flattened into the
+/// active parent window. The active child window is grafted into the Portal
+/// slot; the remaining child windows are promoted to parent-context windows.
+#[test]
+fn dissolve_portal_preserves_multi_window_child_boundaries() {
+    use egui_tiles::{Container, Tile};
+    use std::collections::{HashMap, HashSet};
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let parent_ctx_id = app.router.active().context_id;
+    let parent_win_id = app.windows[0].window_id;
+    let child_ctx_id = 210860u64;
+    let child_win_a = 210861u64;
+    let child_win_primary = 210862u64;
+    let child_win_c = 210863u64;
+
+    let parent_pane = 210850u64;
+    let portal_pane_id = 210851u64;
+    let secondary_a_pane = 210852u64;
+    let primary_left = 210853u64;
+    let primary_right = 210854u64;
+    let secondary_c_pane = 210855u64;
+
+    let mut parent_tiles = egui_tiles::Tiles::default();
+    let parent_tile = parent_tiles.insert_pane(parent_pane);
+    let portal_tile = parent_tiles.insert_pane(portal_pane_id);
+    let parent_root = parent_tiles.insert_horizontal_tile(vec![parent_tile, portal_tile]);
+    let mut parent_panes = HashMap::new();
+    parent_panes.insert(parent_pane, test_app_pane(parent_pane));
+    parent_panes.insert(
+        portal_pane_id,
+        crate::host::pane::Pane::Portal(Box::new(crate::host::pane::PortalPane {
+            pane_id: portal_pane_id,
+            target_context_id: child_ctx_id,
+            context_state: None,
+            hidden: false,
+        })),
+    );
+    app.windows[0].tree = egui_tiles::Tree::new("dissolve_multi_parent", parent_root, parent_tiles);
+    app.windows[0].panes = parent_panes;
+    app.windows[0].focused_pane = Some(portal_tile);
+    app.windows[0].grid_x = 0;
+    app.windows[0].grid_y = 0;
+
+    app.router.push(test_context(
+        child_ctx_id,
+        parent_ctx_id,
+        "dissolve_multi_child",
+    ));
+    app.context_active_window
+        .insert(child_ctx_id, child_win_primary);
+
+    let mut tiles_a = egui_tiles::Tiles::default();
+    let tile_a = tiles_a.insert_pane(secondary_a_pane);
+    let mut panes_a = HashMap::new();
+    panes_a.insert(secondary_a_pane, test_app_pane(secondary_a_pane));
+    app.windows.push(Window {
+        name: "secondary-a".to_string(),
+        path: std::path::PathBuf::from("/tmp/dissolve_multi_a"),
+        tree: egui_tiles::Tree::new("dissolve_multi_a", tile_a, tiles_a),
+        panes: panes_a,
+        focused_pane: Some(tile_a),
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: child_win_a,
+        context_id: child_ctx_id,
+    });
+
+    let mut tiles_primary = egui_tiles::Tiles::default();
+    let primary_left_tile = tiles_primary.insert_pane(primary_left);
+    let primary_right_tile = tiles_primary.insert_pane(primary_right);
+    let primary_root =
+        tiles_primary.insert_horizontal_tile(vec![primary_left_tile, primary_right_tile]);
+    let mut panes_primary = HashMap::new();
+    panes_primary.insert(primary_left, test_app_pane(primary_left));
+    panes_primary.insert(primary_right, test_app_pane(primary_right));
+    app.windows.push(Window {
+        name: "primary".to_string(),
+        path: std::path::PathBuf::from("/tmp/dissolve_multi_primary"),
+        tree: egui_tiles::Tree::new("dissolve_multi_primary", primary_root, tiles_primary),
+        panes: panes_primary,
+        focused_pane: Some(primary_right_tile),
+        zoomed_pane: Some(primary_right_tile),
+        grid_x: 1,
+        grid_y: 0,
+        window_id: child_win_primary,
+        context_id: child_ctx_id,
+    });
+
+    let mut tiles_c = egui_tiles::Tiles::default();
+    let tile_c = tiles_c.insert_pane(secondary_c_pane);
+    let mut panes_c = HashMap::new();
+    panes_c.insert(secondary_c_pane, test_app_pane(secondary_c_pane));
+    app.windows.push(Window {
+        name: "secondary-c".to_string(),
+        path: std::path::PathBuf::from("/tmp/dissolve_multi_c"),
+        tree: egui_tiles::Tree::new("dissolve_multi_c", tile_c, tiles_c),
+        panes: panes_c,
+        focused_pane: Some(tile_c),
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: child_win_c,
+        context_id: child_ctx_id,
+    });
+
+    app.dissolve_portal(child_ctx_id);
+
+    assert!(
+        app.router.iter().all(|ctx| ctx.context_id != child_ctx_id),
+        "dissolved child context must be removed from router"
+    );
+    assert!(
+        !app.context_active_window.contains_key(&child_ctx_id),
+        "dissolved child context must not keep an active-window entry"
+    );
+    assert!(
+        app.windows.iter().all(|w| w.context_id != child_ctx_id),
+        "all child windows should be reparented or removed"
+    );
+
+    let active_parent = app
+        .windows
+        .iter()
+        .find(|w| w.window_id == parent_win_id)
+        .expect("parent window should survive");
+    assert!(active_parent.panes.contains_key(&parent_pane));
+    assert!(active_parent.panes.contains_key(&primary_left));
+    assert!(active_parent.panes.contains_key(&primary_right));
+    assert!(
+        !active_parent.panes.contains_key(&secondary_a_pane)
+            && !active_parent.panes.contains_key(&secondary_c_pane),
+        "secondary child windows must not be flattened into the active parent window"
+    );
+    assert!(
+        !active_parent.panes.contains_key(&portal_pane_id),
+        "Portal pane must be removed after dissolve"
+    );
+    let portal_slot = match active_parent
+        .tree
+        .root
+        .and_then(|root| active_parent.tree.tiles.get(root))
+    {
+        Some(Tile::Container(Container::Linear(linear))) => {
+            assert_eq!(
+                linear.children.len(),
+                2,
+                "primary child tree should replace the portal slot"
+            );
+            linear.children[1]
+        }
+        other => panic!("expected parent root split, got {other:?}"),
+    };
+    assert!(
+        matches!(
+            active_parent.tree.tiles.get(portal_slot),
+            Some(Tile::Container(Container::Linear(_)))
+        ),
+        "primary child split should be grafted as a container"
+    );
+
+    let promoted_a = app
+        .windows
+        .iter()
+        .find(|w| w.window_id == child_win_a)
+        .expect("secondary child window A should be promoted");
+    let promoted_c = app
+        .windows
+        .iter()
+        .find(|w| w.window_id == child_win_c)
+        .expect("secondary child window C should be promoted");
+    assert_eq!(promoted_a.context_id, parent_ctx_id);
+    assert_eq!(promoted_c.context_id, parent_ctx_id);
+    assert!(promoted_a.panes.contains_key(&secondary_a_pane));
+    assert!(promoted_c.panes.contains_key(&secondary_c_pane));
+    assert!(
+        promoted_a
+            .tree
+            .root
+            .and_then(|root| promoted_a.tree.tiles.get(root))
+            .is_some(),
+        "promoted window A should keep its tile tree"
+    );
+    assert!(
+        promoted_c
+            .tree
+            .root
+            .and_then(|root| promoted_c.tree.tiles.get(root))
+            .is_some(),
+        "promoted window C should keep its tile tree"
+    );
+
+    let parent_window_coords: HashSet<_> = app
+        .windows
+        .iter()
+        .filter(|w| w.context_id == parent_ctx_id)
+        .map(|w| (w.grid_x, w.grid_y))
+        .collect();
+    let parent_window_count = app
+        .windows
+        .iter()
+        .filter(|w| w.context_id == parent_ctx_id)
+        .count();
+    assert_eq!(
+        parent_window_coords.len(),
+        parent_window_count,
+        "promoted child windows should have deterministic non-colliding grid coordinates"
+    );
+    assert!(
+        app.windows
+            .iter()
+            .flat_map(|w| w.panes.values())
+            .all(|pane| pane.portal_target() != Some(child_ctx_id)),
+        "no surviving PortalPane may point at the dissolved context"
     );
 }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1232,6 +1232,9 @@ fn dissolve_portal_preserves_multi_window_child_boundaries() {
         context_id: child_ctx_id,
     });
 
+    app.minimap.visible = false;
+    app.minimap_visible_per_context.insert(parent_ctx_id, false);
+
     app.dissolve_portal(child_ctx_id);
 
     assert!(
@@ -1333,6 +1336,15 @@ fn dissolve_portal_preserves_multi_window_child_boundaries() {
         parent_window_coords.len(),
         parent_window_count,
         "promoted child windows should have deterministic non-colliding grid coordinates"
+    );
+    assert!(
+        app.minimap.visible,
+        "dissolving a multi-window child context should show the parent minimap"
+    );
+    assert_eq!(
+        app.minimap_visible_per_context.get(&parent_ctx_id),
+        Some(&true),
+        "parent minimap state should be saved as visible after promoted child windows"
     );
     assert!(
         app.windows

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1196,6 +1196,7 @@ impl PlexiApp {
             self.router.retain_depth_stack(|cid| cid != child_ctx_id);
             return;
         };
+        let promoted_child_window_count = child_windows.len().saturating_sub(1);
 
         let Some(primary_idx) = self
             .windows
@@ -1216,7 +1217,7 @@ impl PlexiApp {
 
         log::info!(
             "dissolve_portal: ctx={child_ctx_id} parent_ctx={parent_ctx_id} graft_primary_window={primary_child_window_id} promote_windows={}",
-            child_windows.len().saturating_sub(1)
+            promoted_child_window_count
         );
 
         {
@@ -1364,11 +1365,19 @@ impl PlexiApp {
             .iter()
             .filter(|w| w.context_id == parent_ctx_id)
             .count();
-        self.minimap.visible = self
+        let restored_minimap_visible = self
             .minimap_visible_per_context
             .get(&parent_ctx_id)
             .copied()
             .unwrap_or(page_count > 1);
+        let show_promoted_windows = promoted_child_window_count > 0 && page_count > 1;
+        self.minimap.visible = restored_minimap_visible || show_promoted_windows;
+        if show_promoted_windows {
+            self.minimap_visible_per_context.insert(parent_ctx_id, true);
+            log::info!(
+                "dissolve_portal: parent ctx={parent_ctx_id} now has {page_count} windows; showing minimap"
+            );
+        }
     }
 
     pub(crate) fn save_workspace(&self) {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -4,7 +4,9 @@
 use crate::app::PlexiApp;
 use crate::host::context::Window;
 use crate::host::shell;
+use crate::spatial::tiling::PaneId;
 use crate::workspace::WorkspaceFile;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 /// Auto-initialize a project workspace at `root` if one does not already exist.
@@ -65,6 +67,129 @@ fn persisted_next_pane_id(host_next: u64, windows: &[crate::workspace::SavedWind
         .map(|id| id.saturating_add(1))
         .unwrap_or(host_next);
     host_next.max(next_from_saved)
+}
+
+fn two_windows_mut(
+    windows: &mut [Window],
+    first: usize,
+    second: usize,
+) -> (&mut Window, &mut Window) {
+    debug_assert_ne!(first, second, "cannot borrow the same window twice");
+    if first < second {
+        let (left, right) = windows.split_at_mut(second);
+        (&mut left[first], &mut right[0])
+    } else {
+        let (left, right) = windows.split_at_mut(first);
+        (&mut right[0], &mut left[second])
+    }
+}
+
+fn clone_tile_subtree(
+    source_tiles: &egui_tiles::Tiles<PaneId>,
+    source_id: egui_tiles::TileId,
+    dest_tiles: &mut egui_tiles::Tiles<PaneId>,
+    tile_map: &mut HashMap<egui_tiles::TileId, egui_tiles::TileId>,
+) -> Option<egui_tiles::TileId> {
+    if let Some(mapped) = tile_map.get(&source_id) {
+        return Some(*mapped);
+    }
+
+    let tile = source_tiles.get(source_id)?;
+    let new_id = match tile {
+        egui_tiles::Tile::Pane(pane_id) => dest_tiles.insert_pane(*pane_id),
+        egui_tiles::Tile::Container(egui_tiles::Container::Linear(linear)) => {
+            let child_pairs: Option<Vec<_>> = linear
+                .children
+                .iter()
+                .map(|&child| {
+                    clone_tile_subtree(source_tiles, child, dest_tiles, tile_map)
+                        .map(|new_child| (child, new_child))
+                })
+                .collect();
+            let child_pairs = child_pairs?;
+            let new_children: Vec<_> = child_pairs
+                .iter()
+                .map(|(_, new_child)| *new_child)
+                .collect();
+            let mut new_linear = egui_tiles::Linear::new(linear.dir, new_children);
+            for (old_child, new_child) in child_pairs {
+                new_linear
+                    .shares
+                    .set_share(new_child, linear.shares[old_child]);
+            }
+            dest_tiles.insert_container(new_linear)
+        }
+        egui_tiles::Tile::Container(egui_tiles::Container::Tabs(tabs)) => {
+            let child_pairs: Option<Vec<_>> = tabs
+                .children
+                .iter()
+                .map(|&child| {
+                    clone_tile_subtree(source_tiles, child, dest_tiles, tile_map)
+                        .map(|new_child| (child, new_child))
+                })
+                .collect();
+            let child_pairs = child_pairs?;
+            let new_children: Vec<_> = child_pairs
+                .iter()
+                .map(|(_, new_child)| *new_child)
+                .collect();
+            let mut new_tabs = egui_tiles::Tabs::new(new_children);
+            new_tabs.active = tabs.active.and_then(|active| {
+                child_pairs
+                    .iter()
+                    .find_map(|(old_child, new_child)| (*old_child == active).then_some(*new_child))
+            });
+            dest_tiles.insert_container(new_tabs)
+        }
+        egui_tiles::Tile::Container(egui_tiles::Container::Grid(grid)) => {
+            let child_pairs: Option<Vec<_>> = grid
+                .children()
+                .copied()
+                .map(|child| {
+                    clone_tile_subtree(source_tiles, child, dest_tiles, tile_map)
+                        .map(|new_child| (child, new_child))
+                })
+                .collect();
+            let child_pairs = child_pairs?;
+            let new_children: Vec<_> = child_pairs
+                .iter()
+                .map(|(_, new_child)| *new_child)
+                .collect();
+            let mut new_grid = egui_tiles::Grid::new(new_children);
+            new_grid.layout = grid.layout.clone();
+            new_grid.col_shares = grid.col_shares.clone();
+            new_grid.row_shares = grid.row_shares.clone();
+            dest_tiles.insert_container(new_grid)
+        }
+    };
+
+    tile_map.insert(source_id, new_id);
+    Some(new_id)
+}
+
+fn map_focus_tile(
+    tile_map: &HashMap<egui_tiles::TileId, egui_tiles::TileId>,
+    source_tile: Option<egui_tiles::TileId>,
+) -> Option<egui_tiles::TileId> {
+    source_tile.and_then(|tile| tile_map.get(&tile).copied())
+}
+
+fn reserve_grid_slot(
+    occupied: &mut HashSet<(u32, u32)>,
+    preferred_x: u32,
+    preferred_y: u32,
+) -> (u32, u32) {
+    if occupied.insert((preferred_x, preferred_y)) {
+        return (preferred_x, preferred_y);
+    }
+
+    let mut x = 0;
+    loop {
+        if occupied.insert((x, preferred_y)) {
+            return (x, preferred_y);
+        }
+        x += 1;
+    }
 }
 
 impl PlexiApp {
@@ -999,17 +1124,16 @@ impl PlexiApp {
         }
     }
 
-    /// Dissolve a portal: reparent all its panes into the parent window (the active
-    /// window that contains the Portal tile), replace the Portal tile with the
-    /// adopted panes, then delete the now-empty child context.
-    ///
-    /// Only promotes one level. Nested portals inside the dissolved context remain
-    /// intact — their tiles are moved to the parent window alongside the regular panes.
+    /// Dissolve a portal: remove the context boundary while preserving the child
+    /// layout. The active child window is grafted into the Portal tile's exact
+    /// position; any remaining child windows are promoted as parent-context windows.
     pub(crate) fn dissolve_portal(&mut self, child_ctx_id: u64) {
-        use egui_tiles::{Container, Tile};
+        use egui_tiles::Tile;
 
         // Find the Portal tile in the active (parent) window.
         let parent_idx = self.active_window;
+        let parent_ctx_id = self.windows[parent_idx].context_id;
+        let parent_window_id = self.windows[parent_idx].window_id;
         let portal_pane_id = {
             let win = &self.windows[parent_idx];
             win.panes
@@ -1039,116 +1163,212 @@ impl PlexiApp {
             }
         };
 
-        // Collect panes from all child windows — extract them so we can move ownership.
-        let child_win_indices: Vec<usize> = self
+        let mut child_windows: Vec<(u64, u32, u32)> = self
             .windows
             .iter()
-            .enumerate()
-            .filter(|(_, w)| w.context_id == child_ctx_id)
-            .map(|(i, _)| i)
+            .filter(|w| w.context_id == child_ctx_id)
+            .map(|w| (w.window_id, w.grid_y, w.grid_x))
             .collect();
+        child_windows.sort_by_key(|(window_id, grid_y, grid_x)| (*grid_y, *grid_x, *window_id));
 
-        // Drain panes from child windows into a staging list (sorted by ID for deterministic order).
-        let mut adopted: Vec<(crate::spatial::tiling::PaneId, crate::host::pane::Pane)> =
-            Vec::new();
-        for &win_idx in &child_win_indices {
-            let mut pane_ids: Vec<crate::spatial::tiling::PaneId> =
-                self.windows[win_idx].panes.keys().copied().collect();
-            pane_ids.sort();
-            for pane_id in pane_ids {
-                if let Some(pane) = self.windows[win_idx].panes.remove(&pane_id) {
-                    adopted.push((pane_id, pane));
-                }
+        let Some(primary_child_window_id) = self
+            .context_active_window
+            .get(&child_ctx_id)
+            .copied()
+            .filter(|active_id| {
+                child_windows
+                    .iter()
+                    .any(|(window_id, _, _)| window_id == active_id)
+            })
+            .or_else(|| child_windows.first().map(|(window_id, _, _)| *window_id))
+        else {
+            log::warn!(
+                "dissolve_portal: ctx={child_ctx_id} has no child windows; removing portal only"
+            );
+            self.windows[parent_idx].panes.remove(&portal_pane_id);
+            self.windows[parent_idx]
+                .tree
+                .remove_recursively(portal_tile_id);
+            if let Some(idx) = self.router.position(|c| c.context_id == child_ctx_id) {
+                self.router.remove_at(idx);
             }
+            self.context_active_window.remove(&child_ctx_id);
+            self.router.retain_depth_stack(|cid| cid != child_ctx_id);
+            return;
+        };
+
+        let Some(primary_idx) = self
+            .windows
+            .iter()
+            .position(|w| w.window_id == primary_child_window_id && w.context_id == child_ctx_id)
+        else {
+            log::warn!(
+                "dissolve_portal: primary child window {primary_child_window_id} missing for ctx={child_ctx_id}"
+            );
+            return;
+        };
+        if primary_idx == parent_idx {
+            log::warn!(
+                "dissolve_portal: primary child window matches parent window idx={parent_idx}"
+            );
+            return;
         }
 
         log::info!(
-            "dissolve_portal: ctx={child_ctx_id} adopting {} panes into parent win={parent_idx}",
-            adopted.len()
+            "dissolve_portal: ctx={child_ctx_id} parent_ctx={parent_ctx_id} graft_primary_window={primary_child_window_id} promote_windows={}",
+            child_windows.len().saturating_sub(1)
         );
 
-        // Insert adopted panes into the parent window.
-        // Strategy: add each new tile alongside the Portal tile.
-        // After all siblings are added, remove the Portal tile.
-        for (pane_id, pane) in adopted {
-            let new_tile = self.windows[parent_idx].tree.tiles.insert_pane(pane_id);
-            self.windows[parent_idx].panes.insert(pane_id, pane);
+        {
+            let (parent_win, primary_child_win) =
+                two_windows_mut(&mut self.windows, parent_idx, primary_idx);
+            let Some(child_root) = primary_child_win.tree.root else {
+                log::warn!(
+                    "dissolve_portal: primary child window {primary_child_window_id} has no root"
+                );
+                return;
+            };
 
-            // Add the new tile as a sibling of the Portal tile.
-            let parent_of_portal = self.windows[parent_idx]
-                .tree
-                .tiles
-                .parent_of(portal_tile_id);
-            if let Some(parent_tile) = parent_of_portal {
-                if let Some(Tile::Container(Container::Linear(lin))) =
-                    self.windows[parent_idx].tree.tiles.get_mut(parent_tile)
+            let child_focus = primary_child_win.focused_pane;
+            let child_zoom = primary_child_win.zoomed_pane;
+            let mut tile_map = HashMap::new();
+            let Some(grafted_root) = clone_tile_subtree(
+                &primary_child_win.tree.tiles,
+                child_root,
+                &mut parent_win.tree.tiles,
+                &mut tile_map,
+            ) else {
+                log::warn!("dissolve_portal: failed to clone child tree for ctx={child_ctx_id}");
+                return;
+            };
+
+            parent_win.panes.remove(&portal_pane_id);
+            parent_win
+                .panes
+                .extend(std::mem::take(&mut primary_child_win.panes));
+            if let Some(parent_tile) = parent_win.tree.tiles.parent_of(portal_tile_id) {
+                if let Some(Tile::Container(parent_container)) =
+                    parent_win.tree.tiles.get_mut(parent_tile)
                 {
-                    if let Some(pos) = lin.children.iter().position(|&c| c == portal_tile_id) {
-                        lin.children.insert(pos, new_tile);
-                    } else {
-                        lin.children.push(new_tile);
-                    }
-                } else {
-                    // Parent is Tabs or another container — append via a new horizontal split at root.
-                    let existing_root = self.windows[parent_idx].tree.root;
-                    if let Some(root) = existing_root {
-                        let new_root = self.windows[parent_idx]
-                            .tree
-                            .tiles
-                            .insert_horizontal_tile(vec![root, new_tile]);
-                        self.windows[parent_idx].tree.root = Some(new_root);
-                    } else {
-                        self.windows[parent_idx].tree.root = Some(new_tile);
-                    }
+                    crate::host::context::replace_child(
+                        parent_container,
+                        portal_tile_id,
+                        grafted_root,
+                    );
                 }
             } else {
-                // Portal tile is the root — wrap everything in a horizontal container.
-                let new_root = self.windows[parent_idx]
-                    .tree
-                    .tiles
-                    .insert_horizontal_tile(vec![new_tile, portal_tile_id]);
-                self.windows[parent_idx].tree.root = Some(new_root);
+                parent_win.tree.root = Some(grafted_root);
             }
+            parent_win.tree.tiles.remove(portal_tile_id);
+
+            parent_win.focused_pane = map_focus_tile(&tile_map, child_focus)
+                .or_else(|| parent_win.find_first_pane_in(grafted_root));
+            parent_win.zoomed_pane = map_focus_tile(&tile_map, child_zoom);
+            parent_win.reconcile_stale_tiles();
         }
 
-        // Remove the Portal tile from the parent window.
-        {
-            let win = &mut self.windows[parent_idx];
-            win.panes.remove(&portal_pane_id);
-            if let Some(parent_tile) = win.tree.tiles.parent_of(portal_tile_id) {
-                if let Some(Tile::Container(parent_container)) = win.tree.tiles.get_mut(parent_tile)
-                {
-                    parent_container.remove_child(portal_tile_id);
-                }
-            }
-            win.tree.tiles.remove(portal_tile_id);
-            win.tree.simplify(&egui_tiles::SimplificationOptions {
-                all_panes_must_have_tabs: true,
-                ..egui_tiles::SimplificationOptions::default()
-            });
-        }
-
-        // Fix up active_window index BEFORE the retain shifts indices.
-        // Count how many child windows sit before parent_idx — each removal shifts the index down by 1.
-        let removed_before = child_win_indices
+        let mut occupied: HashSet<(u32, u32)> = self
+            .windows
             .iter()
-            .filter(|&&i| i < parent_idx)
-            .count();
+            .filter(|w| w.context_id == parent_ctx_id)
+            .map(|w| (w.grid_x, w.grid_y))
+            .collect();
+        for (window_id, _grid_y, _grid_x) in child_windows
+            .iter()
+            .filter(|(window_id, _, _)| *window_id != primary_child_window_id)
+        {
+            let Some(win) = self
+                .windows
+                .iter_mut()
+                .find(|w| w.window_id == *window_id && w.context_id == child_ctx_id)
+            else {
+                continue;
+            };
+            let (grid_x, grid_y) = reserve_grid_slot(&mut occupied, win.grid_x, win.grid_y);
+            win.context_id = parent_ctx_id;
+            win.grid_x = grid_x;
+            win.grid_y = grid_y;
+            log::info!(
+                "dissolve_portal: promoted child window {} to parent ctx={} grid=({}, {})",
+                win.window_id,
+                parent_ctx_id,
+                grid_x,
+                grid_y
+            );
+        }
 
-        // Remove child context windows and router entry.
-        self.windows.retain(|w| w.context_id != child_ctx_id);
+        self.windows
+            .retain(|w| w.window_id != primary_child_window_id && w.context_id != child_ctx_id);
         if let Some(idx) = self.router.position(|c| c.context_id == child_ctx_id) {
             self.router.remove_at(idx);
         }
 
-        self.active_window = parent_idx - removed_before;
+        self.context_active_window.remove(&child_ctx_id);
+        self.context_active_window
+            .insert(parent_ctx_id, parent_window_id);
 
-        // Focus the first pane in the parent window.
-        let new_focus = self.windows[self.active_window]
-            .tree
-            .root
-            .and_then(|root| self.windows[self.active_window].find_first_pane_in(root));
-        self.windows[self.active_window].focused_pane = new_focus;
+        let before_depth = self.router.depth_stack.len();
+        self.router.retain_depth_stack(|cid| cid != child_ctx_id);
+        let cleaned_depth = before_depth - self.router.depth_stack.len();
+        if cleaned_depth > 0 {
+            log::info!(
+                "dissolve_portal: removed {cleaned_depth} stale depth_stack entries for ctx={child_ctx_id}"
+            );
+        }
+
+        for win in &mut self.windows {
+            let stale_portal_ids: Vec<_> = win
+                .panes
+                .iter()
+                .filter(|(_, pane)| pane.portal_target() == Some(child_ctx_id))
+                .map(|(pane_id, _)| *pane_id)
+                .collect();
+            for pane_id in stale_portal_ids {
+                win.panes.remove(&pane_id);
+                if let Some(tile_id) = win.tree.tiles.find_pane(&pane_id) {
+                    win.tree.remove_recursively(tile_id);
+                }
+                log::warn!(
+                    "dissolve_portal: removed stale PortalPane {pane_id} targeting dissolved ctx={child_ctx_id}"
+                );
+            }
+            win.reconcile_stale_tiles();
+        }
+
+        self.active_window = self
+            .windows
+            .iter()
+            .position(|w| w.window_id == parent_window_id && w.context_id == parent_ctx_id)
+            .unwrap_or(0);
+        if let Some(parent_ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
+            self.router.set_active(parent_ctx_idx);
+        }
+
+        self.pending_notifications.retain(|n| {
+            !(matches!(n.scope, crate::app_protocol::NotifyScope::Context)
+                && n.source_context_id == child_ctx_id)
+        });
+        self.save_notifications();
+        if let Some(ref id) = self.current_notify_id.clone() {
+            let still_present = self
+                .pending_notifications
+                .iter()
+                .any(|n| &n.notify_id == id);
+            if !still_present {
+                self.current_notify_id = None;
+            }
+        }
+
+        let page_count = self
+            .windows
+            .iter()
+            .filter(|w| w.context_id == parent_ctx_id)
+            .count();
+        self.minimap.visible = self
+            .minimap_visible_per_context
+            .get(&parent_ctx_id)
+            .copied()
+            .unwrap_or(page_count > 1);
     }
 
     pub(crate) fn save_workspace(&self) {


### PR DESCRIPTION
Closes #2108

## Summary

- Replaces dissolve's pane-drain logic with tile-tree grafting so the active child window replaces the Portal slot in place.
- Promotes non-primary child windows into the parent context with deterministic non-colliding grid coordinates instead of flattening them into the active parent window.
- Adds PTY-free regressions for single-window grafting, multi-window boundary preservation, and stale dissolve cleanup.

## Done When

- `cargo test --bin plexi dissolve_portal_grafts_single_child_window_tree_in_place` passes.
- `cargo test --bin plexi dissolve_portal_preserves_multi_window_child_boundaries` passes.
- Existing context tests for `delete_context_portal_resets_stale_focused_pane`, `delete_context_collapses_empty_portal_window`, and `delete_context_keeps_all_empty_windows_when_no_nonempty_sibling` still pass.
- Manual alpha behavior: dissolving a one-window sub-context with a 50/50 split inside a bottom-right Portal leaves that bottom-right region as the same 50/50 split, not as panes inserted at the beginning of the parent layout.

## Notes

- Child `TileId`s are recreated in the destination arena; `PaneId`s and pane ownership are preserved.
- Multi-window policy grafts the child context's active window into the Portal slot and promotes the remaining child windows as separate parent-context windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented portal dissolution functionality that allows dissolving portals by grafting child window layouts into the parent context at the portal position, while automatically promoting remaining child windows as separate windows.

* **Tests**
  * Added integration tests verifying portal dissolution behavior for single-window and multi-window child contexts, ensuring proper layout grafting and window promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->