### PR TITLE
feat(agents): Claude Code hook integration — per-pane agent state + plexi agent status (#2083)

### DIFF
--- a/assets/hooks/claude-code-agent-state.sh
+++ b/assets/hooks/claude-code-agent-state.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Claude Code agent state hook for PLEXI.
+# Registered in ~/.claude/settings.json by `plexi agent hook install --claude-code`.
+# Fires on lifecycle events and reports working/blocked/idle state to the host.
+
+set -euo pipefail
+
+# Exit silently if not inside a PLEXI pane.
+if [ -z "${PLEXI_SOCKET:-}" ] || [ -z "${PLEXI_PANE_ID:-}" ]; then
+    exit 0
+fi
+
+# Read JSON from stdin; extract hook_event_name.
+INPUT=$(cat)
+EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+
+case "$EVENT" in
+    SessionStart|UserPromptSubmit)    STATE="working" ;;
+    PermissionRequest)                STATE="blocked" ;;
+    Stop|StopFailure|SessionEnd)      STATE="idle" ;;
+    SubagentStop)                     exit 0 ;;  # skip — avoid false idle
+    *)                                exit 0 ;;  # unknown event, skip
+esac
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+
+# Build plexi binary name from the socket path channel suffix.
+BINARY="plexi"
+if [[ "$PLEXI_SOCKET" =~ plexi-([^/]+)/notify\.sock ]]; then
+    SUFFIX="${BASH_REMATCH[1]}"
+    BINARY="plexi-${SUFFIX}"
+fi
+
+ARGS=("agent" "report" "--state" "$STATE" "--agent" "claude-code")
+if [ -n "$SESSION_ID" ]; then
+    ARGS+=("--session-id" "$SESSION_ID")
+fi
+
+"$BINARY" "${ARGS[@]}" >/dev/null 2>&1 || true
+exit 0

--- a/assets/hooks/claude-code-agent-state.sh
+++ b/assets/hooks/claude-code-agent-state.sh
@@ -12,7 +12,7 @@ fi
 
 # Read JSON from stdin; extract hook_event_name.
 INPUT=$(cat)
-EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+EVENT=$(jq -r '.hook_event_name // empty' <<< "$INPUT" 2>/dev/null || true)
 
 case "$EVENT" in
     SessionStart|UserPromptSubmit)    STATE="working" ;;
@@ -22,7 +22,7 @@ case "$EVENT" in
     *)                                exit 0 ;;  # unknown event, skip
 esac
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+SESSION_ID=$(jq -r '.session_id // empty' <<< "$INPUT" 2>/dev/null || true)
 
 # Build plexi binary name from the socket path channel suffix.
 BINARY="plexi"

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -317,6 +317,7 @@ impl PlexiApp {
                     if before == after {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
+                    self.pane_agent_states.remove(pane_id);
                 }
                 crate::app_protocol::AppRequest::SpawnPane {
                     type_id,
@@ -1335,6 +1336,7 @@ impl PlexiApp {
         }
 
         for pane_id in panes_to_close {
+            self.pane_agent_states.remove(&pane_id);
             self.close_pane_by_id(pane_id);
         }
     }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -838,6 +838,41 @@ impl PlexiApp {
                         }
                     }
                 }
+                crate::app_protocol::AppRequest::SetAgentState {
+                    pane_id,
+                    state,
+                    agent,
+                    session_id,
+                } => {
+                    log::info!(
+                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?}"
+                    );
+                    self.pane_agent_states.insert(
+                        *pane_id,
+                        crate::app_protocol::PaneAgentState {
+                            pane_id: *pane_id,
+                            state: state.clone(),
+                            agent: agent.clone(),
+                            session_id: session_id.clone(),
+                        },
+                    );
+                }
+                crate::app_protocol::AppRequest::GetAgentStates { response_file } => {
+                    log::info!("pane_ipc: kind=get_agent_states response_file={response_file:?}");
+                    let states: Vec<&crate::app_protocol::PaneAgentState> =
+                        self.pane_agent_states.values().collect();
+                    let json_str =
+                        serde_json::to_string(&states).unwrap_or_else(|_| "[]".to_string());
+                    let temp = format!("{response_file}.tmp");
+                    if let Err(e) = std::fs::write(&temp, &json_str) {
+                        log::error!(
+                            "pane_ipc: get_agent_states: could not write temp file: {e}"
+                        );
+                    } else if let Err(e) = std::fs::rename(&temp, response_file) {
+                        log::error!("pane_ipc: get_agent_states: rename failed: {e}");
+                        let _ = std::fs::remove_file(&temp);
+                    }
+                }
                 crate::app_protocol::AppRequest::Notify {
                     level,
                     title,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -325,6 +325,8 @@ pub struct PlexiApp {
     /// Only overlay-unsafe side effects are held here; safe commands (ShowNotification,
     /// pipes, queries) are dispatched immediately even during overlay ownership.
     pub(crate) overlay_held_cmds: Vec<crate::app::app_trait::AppCommand>,
+    /// Per-pane agent state reported via hook scripts. Keyed by pane_id.
+    pub(crate) pane_agent_states: std::collections::HashMap<u64, crate::app_protocol::PaneAgentState>,
 }
 
 #[cfg(test)]
@@ -799,6 +801,7 @@ impl PlexiApp {
                     focus_started_at: None,
                     last_system_theme: None,
                     overlay_held_cmds: Vec::new(),
+                    pane_agent_states: std::collections::HashMap::new(),
                 };
                 app.apply_context_transition_effects();
                 return app;
@@ -976,6 +979,7 @@ impl PlexiApp {
             focus_started_at: None,
             last_system_theme: None,
             overlay_held_cmds: Vec::new(),
+            pane_agent_states: std::collections::HashMap::new(),
         };
         app.apply_context_transition_effects();
         app
@@ -1162,6 +1166,7 @@ impl PlexiApp {
                 focus_started_at: None,
                 last_system_theme: None,
                 overlay_held_cmds: Vec::new(),
+                pane_agent_states: std::collections::HashMap::new(),
             },
             pane_ipc_tx,
         )

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -209,6 +209,314 @@ fn install_agent(global_agent_md: &Path, ws_agent_dir: &Path) -> Result<(), Stri
     Ok(())
 }
 
+/// `plexi agent report --state <state>` — report agent state to host via socket.
+pub fn agent_report_cli(state: &str, agent: &str, session_id: Option<&str>) -> i32 {
+    log::info!("agent_report:cli: state={state} agent={agent}");
+    let normalized = match state.to_lowercase().as_str() {
+        "working" => "working",
+        "blocked" => "blocked",
+        "idle" => "idle",
+        other => {
+            eprintln!("error: unknown state '{other}'; expected working, blocked, or idle");
+            return 1;
+        }
+    };
+    let pane_id: u64 = match std::env::var("PLEXI_PANE_ID")
+        .ok()
+        .and_then(|v| v.parse().ok())
+    {
+        Some(id) => id,
+        None => {
+            eprintln!(
+                "error: PLEXI_PANE_ID is not set — run this inside a Plexi terminal pane"
+            );
+            return 1;
+        }
+    };
+    let mut payload = serde_json::json!({
+        "type": "set_agent_state",
+        "pane_id": pane_id,
+        "state": normalized,
+        "agent": agent,
+    });
+    if let Some(sid) = session_id {
+        payload["session_id"] = serde_json::Value::String(sid.to_string());
+    }
+    super::send_to_socket(payload)
+}
+
+/// `plexi agent status` — query agent states for all panes.
+pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
+    log::info!("agent_status:cli: blocked={blocked} working={working} idle={idle}");
+    let tmp_path = std::env::temp_dir().join(format!(
+        "plexi-agent-states-{}.json",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let tmp_path_str = tmp_path.to_string_lossy().to_string();
+    let code = super::send_to_socket(serde_json::json!({
+        "type": "get_agent_states",
+        "response_file": tmp_path_str,
+    }));
+    if code != 0 {
+        return code;
+    }
+    // Poll for response (host writes async)
+    let response = (|| {
+        for _ in 0..50 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            if let Ok(content) = std::fs::read_to_string(&tmp_path) {
+                if !content.is_empty() {
+                    return Some(content);
+                }
+            }
+        }
+        None
+    })();
+    // Clean up temp file.
+    let _ = std::fs::remove_file(&tmp_path);
+    let content = match response {
+        Some(c) => c,
+        None => {
+            eprintln!("error: timed out waiting for agent states response");
+            return 1;
+        }
+    };
+    let states: Vec<serde_json::Value> = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: could not parse agent states: {e}");
+            return 1;
+        }
+    };
+    let filter_active = blocked || working || idle;
+    let filtered: Vec<&serde_json::Value> = states
+        .iter()
+        .filter(|s| {
+            if !filter_active {
+                return true;
+            }
+            let st = s["state"].as_str().unwrap_or("");
+            (blocked && st == "blocked") || (working && st == "working") || (idle && st == "idle")
+        })
+        .collect();
+    if filtered.is_empty() {
+        println!("No agent states tracked.");
+        return 0;
+    }
+    println!("{:<12} {:<16} {:<12} {}", "PANE_ID", "AGENT", "STATE", "SESSION_ID");
+    for s in &filtered {
+        let pane_id = s["pane_id"].as_u64().unwrap_or(0);
+        let agent = s["agent"].as_str().unwrap_or("unknown");
+        let state = s["state"].as_str().unwrap_or("unknown");
+        let session_id = s
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        println!("{:<12} {:<16} {:<12} {}", pane_id, agent, state, session_id);
+    }
+    0
+}
+
+/// `plexi agent hook install --claude-code` — patch ~/.claude/settings.json.
+pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
+    if !claude_code {
+        eprintln!("error: specify --claude-code");
+        return 1;
+    }
+    log::info!("agent_hook_install:cli: claude-code");
+
+    // Locate the binary to build the hook command.
+    let binary = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| "plexi".to_string());
+
+    let settings_path = claude_settings_path();
+    let mut settings = read_claude_settings(&settings_path);
+
+    // Each event maps to a specific state.
+    let event_state_map: &[(&str, &str)] = &[
+        ("SessionStart", "working"),
+        ("UserPromptSubmit", "working"),
+        ("PermissionRequest", "blocked"),
+        ("Stop", "idle"),
+        ("StopFailure", "idle"),
+        ("SessionEnd", "idle"),
+    ];
+
+    if settings.get("hooks").is_none() {
+        settings["hooks"] = serde_json::json!({});
+    }
+
+    for (event, state) in event_state_map {
+        let event_hooks = settings["hooks"][*event].as_array().cloned().unwrap_or_default();
+
+        // Idempotency: skip if already registered.
+        let already_registered = event_hooks.iter().any(|h| {
+            h.get("hooks")
+                .and_then(|arr| arr.as_array())
+                .map(|arr| {
+                    arr.iter().any(|entry| {
+                        entry
+                            .get("command")
+                            .and_then(|c| c.as_str())
+                            .map(|c| c.contains("plexi agent report"))
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if already_registered {
+            continue;
+        }
+
+        let cmd = format!("{binary} agent report --state {state} --agent claude-code");
+        let new_entry = serde_json::json!({
+            "matcher": "",
+            "hooks": [{"type": "command", "command": cmd}]
+        });
+        match settings["hooks"][*event].as_array_mut() {
+            Some(a) => {
+                a.push(new_entry);
+            }
+            None => {
+                settings["hooks"][*event] = serde_json::json!([new_entry]);
+            }
+        }
+    }
+
+    let code = write_claude_settings(&settings_path, &settings);
+    if code == 0 {
+        println!("Installed Claude Code hooks into {}.", settings_path.display());
+    }
+    code
+}
+
+/// `plexi agent hook uninstall --claude-code` — remove PLEXI hook entries from ~/.claude/settings.json.
+pub fn agent_hook_uninstall_cli(claude_code: bool) -> i32 {
+    if !claude_code {
+        eprintln!("error: specify --claude-code");
+        return 1;
+    }
+    log::info!("agent_hook_uninstall:cli: claude-code");
+
+    let settings_path = claude_settings_path();
+    if !settings_path.exists() {
+        println!("Nothing to uninstall — {} does not exist.", settings_path.display());
+        return 0;
+    }
+
+    let mut settings = read_claude_settings(&settings_path);
+
+    let events = [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PermissionRequest",
+        "Stop",
+        "StopFailure",
+        "SessionEnd",
+    ];
+    let mut removed = 0usize;
+
+    if let Some(hooks_map) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+        for event in &events {
+            if let Some(event_arr) = hooks_map.get_mut(*event).and_then(|v| v.as_array_mut()) {
+                let before = event_arr.len();
+                event_arr.retain(|entry| {
+                    !entry
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|arr| {
+                            arr.iter().any(|h| {
+                                h.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(|c| c.contains("plexi agent report"))
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false)
+                });
+                removed += before - event_arr.len();
+            }
+        }
+    }
+
+    if removed == 0 {
+        println!(
+            "No PLEXI hook entries found in {}.",
+            settings_path.display()
+        );
+        return 0;
+    }
+
+    let code = write_claude_settings(&settings_path, &settings);
+    if code == 0 {
+        println!(
+            "Removed {removed} PLEXI hook entr{} from {}.",
+            if removed == 1 { "y" } else { "ies" },
+            settings_path.display()
+        );
+    }
+    code
+}
+
+fn claude_settings_path() -> std::path::PathBuf {
+    std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("~"))
+        .join(".claude")
+        .join("settings.json")
+}
+
+fn read_claude_settings(path: &std::path::Path) -> serde_json::Value {
+    if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_else(|e| {
+                log::warn!(
+                    "agent_hook: could not parse {}: {e} — treating as empty",
+                    path.display()
+                );
+                serde_json::json!({})
+            }),
+            Err(e) => {
+                log::warn!("agent_hook: could not read {}: {e}", path.display());
+                serde_json::json!({})
+            }
+        }
+    } else {
+        serde_json::json!({})
+    }
+}
+
+fn write_claude_settings(path: &std::path::Path, settings: &serde_json::Value) -> i32 {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("error: could not create {}: {e}", parent.display());
+            return 1;
+        }
+    }
+    let json = match serde_json::to_string_pretty(settings) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not serialize settings: {e}");
+            return 1;
+        }
+    };
+    match std::fs::write(path, json) {
+        Ok(()) => {
+            log::info!("agent_hook: wrote {}", path.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: could not write {}: {e}", path.display());
+            1
+        }
+    }
+}
+
 #[cfg(test)]
 mod agent_tests {
     use std::fs;

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -250,10 +250,7 @@ pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
     log::info!("agent_status:cli: blocked={blocked} working={working} idle={idle}");
     let tmp_path = std::env::temp_dir().join(format!(
         "plexi-agent-states-{}.json",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
+        uuid::Uuid::new_v4()
     ));
     let tmp_path_str = tmp_path.to_string_lossy().to_string();
     let code = super::send_to_socket(serde_json::json!({
@@ -263,15 +260,15 @@ pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
     if code != 0 {
         return code;
     }
-    // Poll for response (host writes async)
+    // Poll for response (host writes async); check before sleeping to avoid artificial latency
     let response = (|| {
-        for _ in 0..50 {
-            std::thread::sleep(std::time::Duration::from_millis(50));
+        for _ in 0..250 {
             if let Ok(content) = std::fs::read_to_string(&tmp_path) {
                 if !content.is_empty() {
                     return Some(content);
                 }
             }
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
         None
     })();
@@ -464,9 +461,8 @@ pub fn agent_hook_uninstall_cli(claude_code: bool) -> i32 {
 }
 
 fn claude_settings_path() -> std::path::PathBuf {
-    std::env::var("HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::path::PathBuf::from("~"))
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join(".claude")
         .join("settings.json")
 }
@@ -505,16 +501,18 @@ fn write_claude_settings(path: &std::path::Path, settings: &serde_json::Value) -
             return 1;
         }
     };
-    match std::fs::write(path, json) {
-        Ok(()) => {
-            log::info!("agent_hook: wrote {}", path.display());
-            0
-        }
-        Err(e) => {
-            eprintln!("error: could not write {}: {e}", path.display());
-            1
-        }
+    let tmp_path = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp_path, &json) {
+        eprintln!("error: could not write temp settings: {e}");
+        return 1;
     }
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        eprintln!("error: could not rename temp settings: {e}");
+        let _ = std::fs::remove_file(&tmp_path);
+        return 1;
+    }
+    log::info!("agent_hook: wrote {}", path.display());
+    0
 }
 
 #[cfg(test)]

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -317,7 +317,7 @@ pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
     0
 }
 
-/// `plexi agent hook install --claude-code` — patch ~/.claude/settings.json.
+/// `plexi agent hook install --claude-code` — write hook script + patch ~/.claude/settings.json.
 pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
     if !claude_code {
         eprintln!("error: specify --claude-code");
@@ -325,33 +325,78 @@ pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
     }
     log::info!("agent_hook_install:cli: claude-code");
 
-    // Locate the binary to build the hook command.
     let binary = std::env::current_exe()
         .ok()
         .and_then(|p| p.to_str().map(|s| s.to_string()))
         .unwrap_or_else(|| "plexi".to_string());
 
+    // Write a dynamic hook script that reads event name + session_id from stdin.
+    // Static per-event commands can't surface session_id; the script approach can.
+    let hooks_dir = crate::config::config_dir().join("hooks");
+    if let Err(e) = std::fs::create_dir_all(&hooks_dir) {
+        eprintln!("error: could not create hooks dir: {e}");
+        return 1;
+    }
+    let script_path = hooks_dir.join("claude-code-agent-state.sh");
+    let script_content = format!(
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ -z "${{PLEXI_SOCKET:-}}" ] || [ -z "${{PLEXI_PANE_ID:-}}" ]; then
+    exit 0
+fi
+INPUT=$(cat)
+EVENT=$(jq -r '.hook_event_name // empty' <<< "$INPUT" 2>/dev/null || true)
+case "$EVENT" in
+    SessionStart|UserPromptSubmit) STATE="working" ;;
+    PermissionRequest)             STATE="blocked" ;;
+    Stop|StopFailure|SessionEnd)   STATE="idle" ;;
+    SubagentStop)                  exit 0 ;;
+    *)                             exit 0 ;;
+esac
+SESSION_ID=$(jq -r '.session_id // empty' <<< "$INPUT" 2>/dev/null || true)
+ARGS=(agent report --state "$STATE" --agent claude-code)
+[ -n "$SESSION_ID" ] && ARGS+=(--session-id "$SESSION_ID")
+"{binary}" "${{ARGS[@]}}" >/dev/null 2>&1 || true
+exit 0
+"#
+    );
+    if let Err(e) = std::fs::write(&script_path, &script_content) {
+        eprintln!("error: could not write hook script: {e}");
+        return 1;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+        {
+            eprintln!("error: could not chmod hook script: {e}");
+            return 1;
+        }
+    }
+    let script_str = script_path.to_string_lossy().to_string();
+    log::info!("agent_hook_install: wrote hook script to {script_str}");
+
     let settings_path = claude_settings_path();
     let mut settings = read_claude_settings(&settings_path);
-
-    // Each event maps to a specific state.
-    let event_state_map: &[(&str, &str)] = &[
-        ("SessionStart", "working"),
-        ("UserPromptSubmit", "working"),
-        ("PermissionRequest", "blocked"),
-        ("Stop", "idle"),
-        ("StopFailure", "idle"),
-        ("SessionEnd", "idle"),
-    ];
 
     if settings.get("hooks").is_none() {
         settings["hooks"] = serde_json::json!({});
     }
 
-    for (event, state) in event_state_map {
+    let events = [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PermissionRequest",
+        "Stop",
+        "StopFailure",
+        "SessionEnd",
+    ];
+
+    for event in &events {
         let event_hooks = settings["hooks"][*event].as_array().cloned().unwrap_or_default();
 
-        // Idempotency: skip if already registered.
+        // Idempotency: skip if this script or any PLEXI agent-report command is already registered.
         let already_registered = event_hooks.iter().any(|h| {
             h.get("hooks")
                 .and_then(|arr| arr.as_array())
@@ -360,7 +405,10 @@ pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
                         entry
                             .get("command")
                             .and_then(|c| c.as_str())
-                            .map(|c| c.contains("plexi agent report"))
+                            .map(|c| {
+                                c.contains("claude-code-agent-state.sh")
+                                    || c.contains("plexi agent report")
+                            })
                             .unwrap_or(false)
                     })
                 })
@@ -370,10 +418,9 @@ pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
             continue;
         }
 
-        let cmd = format!("{binary} agent report --state {state} --agent claude-code");
         let new_entry = serde_json::json!({
             "matcher": "",
-            "hooks": [{"type": "command", "command": cmd}]
+            "hooks": [{"type": "command", "command": script_str}]
         });
         match settings["hooks"][*event].as_array_mut() {
             Some(a) => {
@@ -387,7 +434,8 @@ pub fn agent_hook_install_cli(claude_code: bool) -> i32 {
 
     let code = write_claude_settings(&settings_path, &settings);
     if code == 0 {
-        println!("Installed Claude Code hooks into {}.", settings_path.display());
+        println!("Hook script: {script_str}");
+        println!("Registered in {} for 6 lifecycle events.", settings_path.display());
     }
     code
 }
@@ -430,7 +478,10 @@ pub fn agent_hook_uninstall_cli(claude_code: bool) -> i32 {
                             arr.iter().any(|h| {
                                 h.get("command")
                                     .and_then(|c| c.as_str())
-                                    .map(|c| c.contains("plexi agent report"))
+                                    .map(|c| {
+                                        c.contains("claude-code-agent-state.sh")
+                                            || c.contains("plexi agent report")
+                                    })
                                     .unwrap_or(false)
                             })
                         })

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -844,6 +844,70 @@ pub enum AgentCmd {
     },
     /// List agents installed in the current workspace.
     List,
+    /// Report agent state for this pane to the host.
+    ///
+    /// Called internally by hook scripts. Requires PLEXI_SOCKET and PLEXI_PANE_ID
+    /// to be set in the environment.
+    ///
+    /// Example: plexi agent report --state working --agent claude-code
+    Report {
+        /// State to report: working, blocked, or idle
+        #[arg(long)]
+        state: String,
+        /// Agent name (e.g. "claude-code")
+        #[arg(long, default_value = "unknown")]
+        agent: String,
+        /// Session ID (optional, from hook event JSON)
+        #[arg(long)]
+        session_id: Option<String>,
+    },
+    /// Show current agent state for all panes.
+    ///
+    /// Queries the host for all panes that have reported agent state via hooks.
+    /// Formats as a table with pane ID, agent name, state, and session ID.
+    ///
+    /// Example: plexi agent status
+    /// Example: plexi agent status --blocked
+    Status {
+        /// Show only blocked panes
+        #[arg(long)]
+        blocked: bool,
+        /// Show only working panes
+        #[arg(long)]
+        working: bool,
+        /// Show only idle panes
+        #[arg(long)]
+        idle: bool,
+    },
+    /// Install or uninstall Claude Code hook integration.
+    ///
+    /// install: patches ~/.claude/settings.json with hook registrations for all
+    /// Claude Code lifecycle events, routing them to plexi agent report.
+    ///
+    /// uninstall: removes all PLEXI hook entries from ~/.claude/settings.json.
+    ///
+    /// Example: plexi agent hook install --claude-code
+    /// Example: plexi agent hook uninstall --claude-code
+    Hook {
+        #[command(subcommand)]
+        action: HookAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum HookAction {
+    /// Install the PLEXI hook script into ~/.claude/settings.json.
+    Install {
+        /// Install Claude Code hooks (SessionStart, UserPromptSubmit, PermissionRequest, Stop, StopFailure, SessionEnd)
+        #[arg(long = "claude-code")]
+        claude_code: bool,
+    },
+    /// Remove PLEXI hook entries from ~/.claude/settings.json.
+    Uninstall {
+        /// Remove Claude Code hooks
+        #[arg(long = "claude-code")]
+        claude_code: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -197,5 +197,5 @@ pub use routine::{routine_list, routine_run};
 pub use run::{run_list_commands, run_command};
 pub use validate::validate_cli;
 pub use workspace::{workspace_init, workspace_secret_set, workspace_secret_get, workspace_secret_list, workspace_secret_delete};
-pub use agent::{agent_init, agent_add, agent_update, agent_list};
+pub use agent::{agent_init, agent_add, agent_update, agent_list, agent_report_cli, agent_status_cli, agent_hook_install_cli, agent_hook_uninstall_cli};
 pub use ai::{ai_doctor_cli, ai_setup_cli};

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> eframe::Result {
             Some(a.clone())
         })
         .collect();
-    use crate::cli::args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd, NotesCmd, AgentCmd, AiCmd};
+    use crate::cli::args::{Cli, Commands, WorkspaceCmd, SecretCmd, AppCmd, UpdateCmd, PaneCmd, DescriptorCmd, RegistryCmd, ContextCmd, ConfigCmd, RoutineCmd, NotesCmd, AgentCmd, HookAction, AiCmd};
     use clap::Parser;
 
     match Cli::try_parse_from(&args) {
@@ -199,6 +199,12 @@ fn main() -> eframe::Result {
                         AgentCmd::Add { name } => std::process::exit(cli::agent_add(&name)),
                         AgentCmd::Update { name } => std::process::exit(cli::agent_update(&name)),
                         AgentCmd::List => std::process::exit(cli::agent_list()),
+                        AgentCmd::Report { state, agent, session_id } => std::process::exit(cli::agent_report_cli(state.as_str(), agent.as_str(), session_id.as_deref())),
+                        AgentCmd::Status { blocked, working, idle } => std::process::exit(cli::agent_status_cli(blocked, working, idle)),
+                        AgentCmd::Hook { action } => match action {
+                            HookAction::Install { claude_code } => std::process::exit(cli::agent_hook_install_cli(claude_code)),
+                            HookAction::Uninstall { claude_code } => std::process::exit(cli::agent_hook_uninstall_cli(claude_code)),
+                        },
                     },
                     Commands::Secret { cmd } => match cmd {
                         SecretCmd::Set { friendly_name, from_env, global, alias } => std::process::exit(cli::workspace_secret_set(&friendly_name, from_env, global, alias.as_deref())),

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1860,6 +1860,27 @@ impl ProcessApp {
                     context_id,
                 });
             }
+            AppRequest::SetAgentState {
+                pane_id,
+                state,
+                agent,
+                session_id: _,
+            } => {
+                // SetAgentState is a CLI/hook-only command routed through the host socket.
+                // Apps should not send this; log and ignore.
+                log::warn!(
+                    "ProcessApp[{}]: SetAgentState ignored — pane_id={pane_id} agent={agent} state={state:?}",
+                    self.type_id
+                );
+            }
+            AppRequest::GetAgentStates { response_file } => {
+                // GetAgentStates is a CLI-only command routed through the host socket.
+                // Apps should not send this; log and ignore.
+                log::warn!(
+                    "ProcessApp[{}]: GetAgentStates ignored — response_file={response_file:?}",
+                    self.type_id
+                );
+            }
         }
     }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -432,6 +432,24 @@ pub struct ResponsiveTier {
     pub gap: f32,
 }
 
+/// Agent state reported by a hook script.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentState {
+    Working,
+    Blocked,
+    Idle,
+}
+
+/// Per-pane agent state stored in PlexiApp.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PaneAgentState {
+    pub pane_id: u64,
+    pub state: AgentState,
+    pub agent: String,
+    pub session_id: Option<String>,
+}
+
 /// App-to-host requests — go to `route_command`.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -520,6 +538,18 @@ pub enum AppRequest {
         /// Omit for backwards-compatible global behaviour.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         scope: Option<NotifyScope>,
+    },
+    /// Report agent state for a pane. Called by hook scripts via `plexi agent report`.
+    SetAgentState {
+        pane_id: u64,
+        state: AgentState,
+        agent: String,
+        #[serde(default)]
+        session_id: Option<String>,
+    },
+    /// Get all tracked pane agent states. Writes JSON array to response_file.
+    GetAgentStates {
+        response_file: String,
     },
     /// Open a typed pipe.
     /// mode: "json" | "binary"
@@ -3228,7 +3258,6 @@ mod tests {
 mod ui_node_tests {
     use super::*;
     use crate::protocol::events::PlexiEvent;
-    use crate::protocol::ui_nodes::*;
 
     #[test]
     fn stack_with_text_child_serializes_correctly() {


### PR DESCRIPTION
Closes #2083

## Summary

- Adds `AgentState` (Working/Blocked/Idle), `PaneAgentState`, and `SetAgentState`/`GetAgentStates` AppRequest variants; host stores per-pane agent state drained each frame
- `plexi agent report --state <state>` — internal CLI command called by hook scripts via PLEXI_SOCKET
- `plexi agent status [--blocked|--working|--idle]` — queries all tracked pane states, prints a table
- `plexi agent hook install --claude-code` / `uninstall` — patches `~/.claude/settings.json` with 6 lifecycle hook registrations (idempotent); reference hook script at `assets/hooks/claude-code-agent-state.sh`

## Done When

- `plexi agent hook install --claude-code` patches `~/.claude/settings.json` with the 6 hook registrations
- `plexi agent hook uninstall --claude-code` removes those entries and prints confirmation; re-running is a no-op
- Running Claude Code in a PLEXI terminal pane and submitting a prompt causes `plexi agent status` to show that pane as `working`
- Triggering a permission dialog causes it to show as `blocked`
- After the agent turn ends, it shows as `idle`
- `plexi agent status --blocked` filters to only blocked panes
- Hook script exits 0 silently when `PLEXI_SOCKET` is not set
- `cargo test --bin plexi` green

## Notes

- `SetAgentState` and `GetAgentStates` are CLI-only commands — `process_app/routing.rs` has log+warn no-op arms so apps can't accidentally trigger them
- `GetAgentStates` uses atomic rename (write `.tmp` then rename) to avoid race between CLI poll and host write
- Hook install builds the command string from `std::env::current_exe()` so it's channel-agnostic
- `SubagentStop` events are intentionally skipped to avoid false idle signals from subagent recaps