### PR TITLE
refactor(cli): remove top-level `plexi terminal` command (#2116)

### DIFF
--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -79,13 +79,6 @@ context zoom-out         Zoom out to parent context.
 context push [NAME]      Push focused pane into a new sub-context.
 ```
 
-### terminal -- shorthand for pane new
-
-```
-terminal [CMD]           Same as pane new. Flags: -e, --layout LAYOUT, --from-pane-id ID,
-                         --cwd DIR, --no-focus.
-```
-
 ### notify -- surface information to the user
 
 ```
@@ -143,7 +136,7 @@ uninstall                Remove app bundle, CLI, completions. --keep-data, -y.
 
 ## Non-Obvious Translation Rules
 
-- `pane new` is primary; `terminal` is a shorthand alias -- prefer `pane new`
+- `pane new` is the canonical way to open a terminal pane
 - `app open TYPE_ID` opens installed apps -- never `pane send ID "app\n"`
 - `app render` takes an installed app **ID** (not a path) -- run `app list` first
 - `agent init` replaces the former `app init --agent` form

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -109,26 +109,6 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PaneCmd,
     },
-    /// Open a plain terminal pane.
-    Terminal {
-        /// Optional shell command to run inside the new terminal
-        cmd: Option<String>,
-        /// Close the pane automatically when the command finishes
-        #[arg(long, short = 'e')]
-        ephemeral: bool,
-        /// Where to place the new pane: split_h (right), split_left (left), split_v (below), split_right, split_below, split_above, tab, or new_window
-        #[arg(long, value_parser = ["split_h", "split_left", "split_right", "split_v", "split_below", "split_above", "tab", "new_window"])]
-        layout: Option<String>,
-        /// Open the new pane relative to this pane ID instead of the focused pane
-        #[arg(long)]
-        from_pane_id: Option<u64>,
-        /// Directory to open the terminal in
-        #[arg(long, value_hint = ValueHint::DirPath)]
-        cwd: Option<String>,
-        /// Keep focus on the current pane instead of jumping to the new one
-        #[arg(long)]
-        no_focus: bool,
-    },
     /// Send a notification to the Plexi UI.
     Notify {
         /// Notification title (required)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -187,7 +187,7 @@ pub use install::{install_cli, install_pack_cli, install_workspace_pack_cli, ple
 pub use list::{freeze_cli, parse_notify_choice};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
-pub use open::{open_cli, terminal_cli, pane_new_cli, mcp_pane_title, parse_prefix, open_cli_by_name, open_mcp_by_name, OpenPrefix};
+pub use open::{open_cli, pane_new_cli, mcp_pane_title, parse_prefix, open_cli_by_name, open_mcp_by_name, OpenPrefix};
 pub use pane::{
     pane_set_title_cli, pane_list_cli, pane_self_cli, pane_info_cli,
     pane_focus_cli, pane_close_cli, pane_send_cli, pane_key_cli, pane_capture_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -414,9 +414,9 @@ pub fn open_cli(
 
     if type_id == "terminal" {
         log::warn!(
-            "open:cli: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead"
+            "open:cli: 'plexi app open terminal' is deprecated, use 'plexi pane new' instead"
         );
-        eprintln!("warning: 'plexi app open terminal' is deprecated, use 'plexi terminal' instead");
+        eprintln!("warning: 'plexi app open terminal' is deprecated, use 'plexi pane new' instead");
     }
 
     // If type_id looks like a path to an app directory (contains manifest.toml), open by path.
@@ -502,30 +502,6 @@ fn open_app_by_path(abs_path: &str, layout: Option<&str>, from_pane_id: Option<u
     0
 }
 
-/// Thin wrapper preserving the existing `plexi terminal` call site.
-pub fn terminal_cli(
-    cmd: Option<&str>,
-    ephemeral: bool,
-    layout: Option<&str>,
-    from_pane_id: Option<u64>,
-    cwd: Option<&str>,
-    no_focus: bool,
-) -> i32 {
-    let layout_str = layout.unwrap_or("split_h");
-    pane_new_cli(
-        cmd,
-        None,
-        layout_str,
-        from_pane_id,
-        cwd,
-        ephemeral,
-        no_focus,
-        None,
-        &[],
-        None,
-        &[],
-    )
-}
 
 /// Read a line from stdin with echo disabled (for password-style input).
 pub(super) fn read_secret_from_stdin() -> io::Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,9 +529,6 @@ fn main() -> eframe::Result {
                             ));
                         }
                     },
-                    Commands::Terminal { cmd, ephemeral, layout, from_pane_id, cwd, no_focus } => {
-                        std::process::exit(cli::terminal_cli(cmd.as_deref(), ephemeral, layout.as_deref(), from_pane_id, cwd.as_deref(), no_focus));
-                    }
                     Commands::CompleteOpen { prefix } => {
                         std::process::exit(cli::complete_open_cli(&prefix));
                     },

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1556,7 +1556,7 @@ mod tests {
         );
     }
 
-    /// `plexi terminal --layout tab` must create a new tab pane alongside the
+    /// `plexi pane new --tab` must create a new tab pane alongside the
     /// focused pane (wrapping both in a Tabs container) rather than splitting.
     #[test]
     fn spawn_pane_tab_creates_tab_not_split() {
@@ -1613,7 +1613,7 @@ mod tests {
         );
     }
 
-    /// `plexi terminal --layout new_window` must create a new spatial grid window
+    /// `plexi pane new --window` must create a new spatial grid window
     /// in the current context rather than splitting the active pane.
     #[test]
     fn spawn_pane_new_window_creates_separate_window() {


### PR DESCRIPTION
Closes #2116

## Summary

- Deletes `Commands::Terminal` variant, `terminal_cli()`, and its match arm — `plexi terminal` is now an unrecognised subcommand
- Fixes stale deprecation warning in `plexi app open terminal` to point to `plexi pane new` instead of the now-removed `plexi terminal`
- Removes `terminal` section and alias note from `skills/plexi-cli/SKILL.md`; updates two test doc-comments in `create.rs`

## Done When

- `plexi terminal` returns a clap "unrecognized subcommand" error
- `plexi pane new "echo hi" -d` works identically to what `plexi terminal "echo hi" --layout split_v` did
- `cargo test --bin plexi` passes
- `skills/plexi-cli/SKILL.md` has no mention of `terminal` as a command
- No `terminal_cli` symbol remaining in source

## Notes

`terminal_cli()` was a thin wrapper that immediately delegated to `pane_new_cli()` — no logic was lost. The `plexi app open terminal` deprecation warning was updated in the same pass since it pointed to the removed command.