### PR TITLE
feat(ui): add host UI primitives for NotesPicker (#2122, #2123)

### DIFF
--- a/docs/prm/host-ui-kit.md
+++ b/docs/prm/host-ui-kit.md
@@ -15,8 +15,8 @@ When a PRD-backed issue lands, update its row in this table before treating the 
 
 | Step | Issue | Status | Completion note |
 |---|---|---|---|
-| 1. ListRow + NotesPicker | [#2122](https://github.com/ianjamesburke/PLEXI/issues/2122) | Ready | Not started |
-| 2. ModalShell + HintBar | [#2123](https://github.com/ianjamesburke/PLEXI/issues/2123) | Blocked | Blocked by #2122 |
+| 1. ListRow + NotesPicker | [#2122](https://github.com/ianjamesburke/PLEXI/issues/2122) | In progress | Bundle branch `feature/bundle-2122-2123` adds ListRow and migrates NotesPicker |
+| 2. ModalShell + HintBar | [#2123](https://github.com/ianjamesburke/PLEXI/issues/2123) | In progress | Bundle branch `feature/bundle-2122-2123` adds ModalShell and HintBar for NotesPicker |
 | 3. TextField focus registration | [#2124](https://github.com/ianjamesburke/PLEXI/issues/2124) | Blocked | Blocked by #2123 |
 | 4. CommandPalette migration | [#2125](https://github.com/ianjamesburke/PLEXI/issues/2125) | Blocked | Blocked by #2122, #2123, #2124 |
 | 5. QuickNote menu migration | [#2126](https://github.com/ianjamesburke/PLEXI/issues/2126) | Blocked | Blocked by #2122, #2123, #2124 |

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -1,6 +1,11 @@
 use crate::app::text_editor_app::note_path_identity;
 use crate::app::{FocusLayer, PlexiApp};
 use crate::ui::style;
+use crate::ui::{
+    hints::{HintBar, HintGroup},
+    list::ListRow,
+    overlay::ModalShell,
+};
 
 impl PlexiApp {
     fn text_editor_path_for_pane(
@@ -160,151 +165,59 @@ impl PlexiApp {
         let entries = self.notes_picker_entries.clone();
         let selected = self.notes_picker_selected;
 
-        let screen = ctx.screen_rect();
-
-        // Scrim — clicking outside the modal dismisses it.
-        let scrim_clicked = egui::Area::new(egui::Id::new("notes_picker_scrim"))
-            .fixed_pos(screen.min)
-            .order(egui::Order::Middle)
-            .show(ctx, |ui| {
-                ui.painter().rect_filled(
-                    screen,
-                    0.0,
-                    egui::Color32::from_black_alpha(style::SCRIM_ALPHA),
-                );
-                ui.allocate_rect(screen, egui::Sense::click()).clicked()
-            })
-            .inner;
-
         // Track which row the user clicked × on (Cell for shared borrow across nested closures).
         let delete_cell = std::cell::Cell::new(None::<usize>);
 
-        egui::Area::new(egui::Id::new("notes_picker"))
-            .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(colors.bg_sidebar)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
-                    .corner_radius(style::RADIUS_LG)
-                    .inner_margin(egui::Margin::symmetric(
-                        style::MODAL_PADDING_H,
-                        style::MODAL_PADDING_V,
-                    ))
+        let modal_response = ModalShell::centered("notes_picker")
+            .title("Notes")
+            .width(480.0)
+            .escape(true)
+            .show(ctx, &colors, |ui| {
+                if entries.is_empty() {
+                    ui.label(
+                        egui::RichText::new(
+                            "No notes yet. Press \u{2318}+Shift+Space to create one.",
+                        )
+                        .size(style::TEXT_HINT)
+                        .color(colors.text_dim),
+                    );
+                    return;
+                }
+
+                egui::ScrollArea::vertical()
+                    .max_height(320.0)
                     .show(ui, |ui| {
-                        ui.set_width(480.0);
-
-                        ui.label(
-                            egui::RichText::new("Notes")
-                                .size(style::TEXT_BODY)
-                                .color(colors.text_primary),
-                        );
-                        ui.add_space(style::SPACE_SM);
-
-                        if entries.is_empty() {
-                            ui.label(
-                                egui::RichText::new(
-                                    "No notes yet. Press \u{2318}+Shift+Space to create one.",
-                                )
-                                .size(style::TEXT_HINT)
-                                .color(colors.text_dim),
-                            );
-                            return;
+                        for (i, (path, preview)) in entries.iter().enumerate() {
+                            let is_selected = i == selected;
+                            let filename = path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().into_owned())
+                                .unwrap_or_default();
+                            let truncated: String = preview.chars().take(50).collect();
+                            let row_response = ListRow::new(&filename)
+                                .leading_chip("note")
+                                .secondary(&truncated)
+                                .trailing_action("×")
+                                .danger_trailing(true)
+                                .selected(is_selected)
+                                .show(ui, &colors);
+                            if row_response.row_clicked() && !row_response.trailing_clicked() {
+                                self.notes_picker_selected = i;
+                                self.notes_picker_open_selected();
+                            }
+                            if row_response.trailing_clicked() {
+                                delete_cell.set(Some(i));
+                            }
                         }
-
-                        egui::ScrollArea::vertical()
-                            .max_height(320.0)
-                            .show(ui, |ui| {
-                                for (i, (path, preview)) in entries.iter().enumerate() {
-                                    let is_selected = i == selected;
-                                    let filename = path
-                                        .file_name()
-                                        .map(|n| n.to_string_lossy().into_owned())
-                                        .unwrap_or_default();
-
-                                    let row_fill = if is_selected {
-                                        colors.bg_active
-                                    } else {
-                                        egui::Color32::TRANSPARENT
-                                    };
-                                    let (rect, _) = ui.allocate_exact_size(
-                                        egui::Vec2::new(ui.available_width(), 28.0),
-                                        egui::Sense::hover(),
-                                    );
-                                    ui.painter().rect_filled(rect, style::RADIUS_MD, row_fill);
-
-                                    let mut row_ui =
-                                        ui.new_child(egui::UiBuilder::new().max_rect(rect));
-                                    row_ui.horizontal(|ui| {
-                                        ui.add_space(style::SPACE_SM);
-                                        ui.label(
-                                            egui::RichText::new(&filename)
-                                                .size(style::TEXT_HINT)
-                                                .color(if is_selected {
-                                                    colors.text_primary
-                                                } else {
-                                                    colors.text_dim
-                                                }),
-                                        );
-                                        if !preview.is_empty() {
-                                            let truncated: String =
-                                                preview.chars().take(50).collect();
-                                            ui.add_space(style::SPACE_SM);
-                                            ui.scope(|ui| {
-                                                ui.set_max_width(160.0);
-                                                ui.label(
-                                                    egui::RichText::new(truncated)
-                                                        .size(style::TEXT_HINT)
-                                                        .color(colors.text_dim),
-                                                );
-                                            });
-                                        }
-                                        // Delete button — right-aligned via RTL sub-layout.
-                                        ui.with_layout(
-                                            egui::Layout::right_to_left(egui::Align::Center),
-                                            |ui| {
-                                                ui.add_space(style::SPACE_SM);
-                                                let del = ui.add(
-                                                    egui::Button::new(
-                                                        egui::RichText::new("×")
-                                                            .size(style::TEXT_HINT)
-                                                            .color(colors.text_dim),
-                                                    )
-                                                    .frame(false),
-                                                );
-                                                if del.clicked() {
-                                                    delete_cell.set(Some(i));
-                                                }
-                                            },
-                                        );
-                                    });
-                                }
-                            });
-
-                        ui.add_space(style::SPACE_SM);
-                        ui.horizontal(|ui| {
-                            crate::ui::widgets::key_combo_list(
-                                ui,
-                                &[&["j", "k"]],
-                                Some("navigate"),
-                                &colors,
-                            );
-                            ui.add_space(style::SPACE_SM);
-                            crate::ui::widgets::key_combo_list(
-                                ui,
-                                &[&["\u{21b5}"]],
-                                Some("open"),
-                                &colors,
-                            );
-                            ui.add_space(style::SPACE_SM);
-                            crate::ui::widgets::key_combo_list(
-                                ui,
-                                &[&["esc"]],
-                                Some("dismiss"),
-                                &colors,
-                            );
-                        });
                     });
+
+                ui.add_space(style::SPACE_SM);
+                let hints = [
+                    HintGroup::new(&["j", "k"], "navigate"),
+                    HintGroup::new(&["\u{21b5}"], "open"),
+                    HintGroup::new(&["esc"], "dismiss"),
+                ];
+                HintBar::new(&hints).show(ui, &colors);
             });
 
         // Handle delete: remove file and entry from the list.
@@ -314,7 +227,7 @@ impl PlexiApp {
 
         // Dismiss on click outside the modal (processed after picker Area so it doesn't
         // fire when clicking inside the modal itself).
-        if scrim_clicked {
+        if modal_response.dismissed {
             self.pop_focus_layer(&FocusLayer::NotesPicker);
         }
     }

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -1,0 +1,33 @@
+use crate::ui::style;
+use crate::ui::theme::Colors;
+use crate::ui::widgets;
+
+pub(crate) struct HintGroup<'a> {
+    keys: &'a [&'a str],
+    label: &'a str,
+}
+
+impl<'a> HintGroup<'a> {
+    pub(crate) fn new(keys: &'a [&'a str], label: &'a str) -> Self {
+        Self { keys, label }
+    }
+}
+
+pub(crate) struct HintBar<'a> {
+    groups: &'a [HintGroup<'a>],
+}
+
+impl<'a> HintBar<'a> {
+    pub(crate) fn new(groups: &'a [HintGroup<'a>]) -> Self {
+        Self { groups }
+    }
+
+    pub(crate) fn show(self, ui: &mut egui::Ui, colors: &Colors) {
+        ui.horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing.x = style::SPACE_MD;
+            for group in self.groups {
+                widgets::key_combo_list(ui, &[group.keys], Some(group.label), colors);
+            }
+        });
+    }
+}

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -174,7 +174,44 @@ fn elided_galley(
     color: Color32,
     max_width: f32,
 ) -> std::sync::Arc<egui::Galley> {
-    ui.fonts(|f| f.layout(text.to_string(), font_id, color, max_width))
+    let text = elide_to_width(ui, text, font_id.clone(), max_width);
+    ui.fonts(|f| f.layout_no_wrap(text, font_id, color))
+}
+
+fn elide_to_width(ui: &egui::Ui, text: &str, font_id: egui::FontId, max_width: f32) -> String {
+    if max_width <= 0.0 {
+        return String::new();
+    }
+
+    let width = |s: &str| {
+        ui.fonts(|f| {
+            f.layout_no_wrap(s.to_string(), font_id.clone(), Color32::WHITE)
+                .size()
+                .x
+        })
+    };
+
+    if width(text) <= max_width {
+        return text.to_string();
+    }
+
+    const ELLIPSIS: &str = "...";
+    if width(ELLIPSIS) > max_width {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    for ch in text.chars() {
+        let mut candidate = out.clone();
+        candidate.push(ch);
+        candidate.push_str(ELLIPSIS);
+        if width(&candidate) > max_width {
+            break;
+        }
+        out.push(ch);
+    }
+    out.push_str(ELLIPSIS);
+    out
 }
 
 fn trailing_size(ui: &egui::Ui, label: &str) -> Vec2 {
@@ -231,5 +268,19 @@ mod tests {
         assert!(row.secondary.is_none());
         assert_eq!(row.leading_chip, Some("app"));
         assert!(!row.selected);
+    }
+
+    #[test]
+    fn elide_to_width_keeps_text_single_line_within_width() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let font = egui::FontId::proportional(style::TEXT_HINT);
+            let elided = elide_to_width(ui, "a very long note filename.md", font.clone(), 40.0);
+            let galley = ui.fonts(|f| f.layout_no_wrap(elided, font, Color32::WHITE));
+            assert!(galley.size().x <= 40.0);
+            assert_eq!(galley.rows.len(), 1);
+        });
+        let _ = ctx.end_pass();
     }
 }

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -1,0 +1,235 @@
+use egui::{Align2, Color32, CornerRadius, Pos2, Response, Stroke, StrokeKind, Vec2};
+
+use crate::ui::style;
+use crate::ui::theme::Colors;
+
+pub struct ListRow<'a> {
+    body: &'a str,
+    secondary: Option<&'a str>,
+    leading_chip: Option<&'a str>,
+    trailing: Option<&'a str>,
+    selected: bool,
+    danger_trailing: bool,
+}
+
+impl<'a> ListRow<'a> {
+    pub fn new(body: &'a str) -> Self {
+        Self {
+            body,
+            secondary: None,
+            leading_chip: None,
+            trailing: None,
+            selected: false,
+            danger_trailing: false,
+        }
+    }
+
+    pub fn secondary(mut self, secondary: &'a str) -> Self {
+        self.secondary = (!secondary.is_empty()).then_some(secondary);
+        self
+    }
+
+    pub fn leading_chip(mut self, label: &'a str) -> Self {
+        self.leading_chip = Some(label);
+        self
+    }
+
+    pub fn trailing_action(mut self, label: &'a str) -> Self {
+        self.trailing = Some(label);
+        self
+    }
+
+    pub fn danger_trailing(mut self, danger: bool) -> Self {
+        self.danger_trailing = danger;
+        self
+    }
+
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    pub fn show(self, ui: &mut egui::Ui, colors: &Colors) -> ListRowResponse {
+        let (rect, response) = ui.allocate_exact_size(
+            Vec2::new(ui.available_width(), style::LIST_ROW_H),
+            egui::Sense::click(),
+        );
+        if response.hovered() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        }
+
+        let fill = if self.selected {
+            colors.bg_active
+        } else if response.hovered() {
+            colors.bg_hover
+        } else {
+            Color32::TRANSPARENT
+        };
+        ui.painter().rect_filled(rect, style::RADIUS_MD, fill);
+
+        let mut x = rect.left() + style::LIST_ROW_PAD_H;
+        let center_y = rect.center().y;
+
+        if let Some(label) = self.leading_chip {
+            let chip = chip_rect(ui, label, colors, x, center_y);
+            x = chip.right() + style::LIST_ROW_GAP;
+        }
+
+        let trailing_response = self.trailing.map(|label| {
+            let size = trailing_size(ui, label);
+            let trailing_rect = egui::Rect::from_center_size(
+                Pos2::new(
+                    rect.right() - style::LIST_ROW_PAD_H - size.x / 2.0,
+                    center_y,
+                ),
+                size,
+            );
+            let id = response.id.with("_trailing_action");
+            let trailing_response = ui.interact(trailing_rect, id, egui::Sense::click());
+            let color = if self.danger_trailing && trailing_response.hovered() {
+                colors.danger
+            } else {
+                colors.text_dim
+            };
+            ui.painter().text(
+                trailing_rect.center(),
+                Align2::CENTER_CENTER,
+                label,
+                egui::FontId::proportional(style::TEXT_BODY),
+                color,
+            );
+            trailing_response
+        });
+
+        let text_right = self
+            .trailing
+            .map(|label| {
+                rect.right()
+                    - style::LIST_ROW_PAD_H
+                    - trailing_size(ui, label).x
+                    - style::LIST_ROW_GAP
+            })
+            .unwrap_or_else(|| rect.right() - style::LIST_ROW_PAD_H);
+        let max_text_width = (text_right - x).max(0.0);
+        draw_text_block(ui, &self, colors, x, center_y, max_text_width);
+
+        ListRowResponse {
+            row: response,
+            trailing: trailing_response,
+        }
+    }
+}
+
+pub struct ListRowResponse {
+    row: Response,
+    trailing: Option<Response>,
+}
+
+impl ListRowResponse {
+    pub fn row_clicked(&self) -> bool {
+        self.row.clicked()
+    }
+
+    pub fn trailing_clicked(&self) -> bool {
+        self.trailing.as_ref().is_some_and(Response::clicked)
+    }
+}
+
+fn draw_text_block(
+    ui: &mut egui::Ui,
+    row: &ListRow<'_>,
+    colors: &Colors,
+    x: f32,
+    center_y: f32,
+    max_width: f32,
+) {
+    let primary_color = if row.selected {
+        colors.text_primary
+    } else {
+        colors.text_dim
+    };
+    let primary_font = egui::FontId::proportional(style::TEXT_HINT);
+    let primary = elided_galley(ui, row.body, primary_font, primary_color, max_width);
+
+    if let Some(secondary) = row.secondary {
+        let secondary_font = egui::FontId::proportional(style::TEXT_HINT);
+        let secondary_galley =
+            elided_galley(ui, secondary, secondary_font, colors.text_dim, max_width);
+        let total_h = primary.size().y + 2.0 + secondary_galley.size().y;
+        let primary_pos = Pos2::new(x, center_y - total_h / 2.0);
+        let secondary_pos = Pos2::new(x, primary_pos.y + primary.size().y + 2.0);
+        ui.painter().galley(primary_pos, primary, primary_color);
+        ui.painter()
+            .galley(secondary_pos, secondary_galley, colors.text_dim);
+    } else {
+        let pos = Pos2::new(x, center_y - primary.size().y / 2.0);
+        ui.painter().galley(pos, primary, primary_color);
+    }
+}
+
+fn elided_galley(
+    ui: &egui::Ui,
+    text: &str,
+    font_id: egui::FontId,
+    color: Color32,
+    max_width: f32,
+) -> std::sync::Arc<egui::Galley> {
+    ui.fonts(|f| f.layout(text.to_string(), font_id, color, max_width))
+}
+
+fn trailing_size(ui: &egui::Ui, label: &str) -> Vec2 {
+    let galley = ui.fonts(|f| {
+        f.layout_no_wrap(
+            label.to_string(),
+            egui::FontId::proportional(style::TEXT_BODY),
+            Color32::WHITE,
+        )
+    });
+    Vec2::new(galley.size().x.max(24.0), style::LIST_ROW_H)
+}
+
+fn chip_rect(ui: &egui::Ui, label: &str, colors: &Colors, x: f32, center_y: f32) -> egui::Rect {
+    let galley = ui.fonts(|f| {
+        f.layout_no_wrap(
+            label.to_string(),
+            egui::FontId::proportional(style::TEXT_HINT),
+            colors.text_primary,
+        )
+    });
+    let size = Vec2::new(
+        galley.size().x + style::SPACE_SM,
+        galley.size().y + style::SPACE_XS,
+    );
+    let rect = egui::Rect::from_min_size(Pos2::new(x, center_y - size.y / 2.0), size);
+    ui.painter()
+        .rect_filled(rect, CornerRadius::same(4), colors.bg_active);
+    ui.painter().rect_stroke(
+        rect,
+        CornerRadius::same(4),
+        Stroke::new(1.0, colors.border),
+        StrokeKind::Inside,
+    );
+    ui.painter().galley(
+        Pos2::new(
+            rect.center().x - galley.size().x / 2.0,
+            rect.center().y - galley.size().y / 2.0,
+        ),
+        galley,
+        colors.text_primary,
+    );
+    rect
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_row_builder_keeps_optional_secondary_empty_by_default() {
+        let row = ListRow::new("note").secondary("").leading_chip("app");
+        assert_eq!(row.body, "note");
+        assert!(row.secondary.is_none());
+        assert_eq!(row.leading_chip, Some("app"));
+        assert!(!row.selected);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,6 @@
+pub mod hints;
+pub mod list;
+pub mod overlay;
 pub mod sidebar;
 pub mod sidebar_row;
 pub mod style;

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -1,0 +1,102 @@
+use egui::{Align2, Color32, Vec2};
+
+use crate::ui::style;
+use crate::ui::theme::Colors;
+
+pub(crate) struct ModalShell<'a> {
+    id: egui::Id,
+    title: Option<&'a str>,
+    width: f32,
+    anchor: Align2,
+    offset: Vec2,
+    click_away: bool,
+    escape: bool,
+}
+
+impl<'a> ModalShell<'a> {
+    pub(crate) fn centered(id: impl std::hash::Hash) -> Self {
+        Self {
+            id: egui::Id::new(id),
+            title: None,
+            width: style::MODAL_WIDTH_MD,
+            anchor: Align2::CENTER_CENTER,
+            offset: Vec2::ZERO,
+            click_away: true,
+            escape: false,
+        }
+    }
+
+    pub(crate) fn title(mut self, title: &'a str) -> Self {
+        self.title = Some(title);
+        self
+    }
+
+    pub(crate) fn width(mut self, width: f32) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub(crate) fn escape(mut self, enabled: bool) -> Self {
+        self.escape = enabled;
+        self
+    }
+
+    pub(crate) fn show<R>(
+        self,
+        ctx: &egui::Context,
+        colors: &Colors,
+        add_body: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> ModalResponse {
+        let mut dismissed = self.escape
+            && ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+
+        let screen = ctx.screen_rect();
+        egui::Area::new(self.id.with("scrim"))
+            .fixed_pos(screen.min)
+            .order(egui::Order::Middle)
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(
+                    screen,
+                    0.0,
+                    Color32::from_black_alpha(style::SCRIM_ALPHA),
+                );
+                let clicked = ui.allocate_rect(screen, egui::Sense::click()).clicked();
+                if self.click_away && clicked {
+                    dismissed = true;
+                }
+            });
+
+        egui::Area::new(self.id.with("overlay"))
+            .anchor(self.anchor, self.offset)
+            .order(egui::Order::Foreground)
+            .show(ctx, |ui| {
+                egui::Frame::new()
+                    .fill(colors.bg_sidebar)
+                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .corner_radius(style::RADIUS_LG)
+                    .inner_margin(egui::Margin::symmetric(
+                        style::MODAL_PADDING_H,
+                        style::MODAL_PADDING_V,
+                    ))
+                    .show(ui, |ui| {
+                        ui.set_width(self.width);
+                        if let Some(title) = self.title {
+                            ui.label(
+                                egui::RichText::new(title)
+                                    .size(style::TEXT_BODY)
+                                    .color(colors.text_primary),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                        }
+                        add_body(ui)
+                    })
+                    .inner
+            });
+
+        ModalResponse { dismissed }
+    }
+}
+
+pub(crate) struct ModalResponse {
+    pub(crate) dismissed: bool,
+}

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -59,6 +59,11 @@ pub const MODAL_WIDTH_NOTIFY: f32 = 760.0; // Notification modal — wider for b
 pub const BUTTON_H_MD: f32 = 40.0; // Standard form buttons.
 pub const BUTTON_H_LG: f32 = 52.0; // Primary action buttons in modals.
 
+// ── List rows ──────────────────────────────────────────────────────────────
+pub const LIST_ROW_H: f32 = 36.0;
+pub const LIST_ROW_PAD_H: f32 = 10.0;
+pub const LIST_ROW_GAP: f32 = 8.0;
+
 // ── Overlay / modal chrome ─────────────────────────────────────────────────
 /// Alpha (0-255) of the black scrim drawn behind modals. Higher = more of the
 /// workspace is dimmed.


### PR DESCRIPTION
<!-- coderabbitai:ignore -->
Closes #2122, Closes #2123

## Summary

**#2122 — feat(ui): add host ListRow primitives and migrate NotesPicker**
- Added a host `ListRow` primitive that owns row height, padding, selection/hover fill, vertical centering, leading chips, secondary text, trailing actions, and click targets.
- Migrated NotesPicker rows off hand-built fixed rects and child UIs.

**#2123 — feat(ui): add ModalShell and HintBar for host overlays**
- Added `ModalShell` for scrim, centered modal frame, padding, click-away, and Escape dismissal.
- Added `HintBar` for semantic footer shortcut groups and migrated NotesPicker footer hints.

## Verification

- `cargo build`
- `cargo test --bin plexi notes_picker`
