### PR TITLE
refactor(ui): add host TextField focus registration for overlays (#2124)

### DIFF
--- a/docs/prm/host-ui-kit.md
+++ b/docs/prm/host-ui-kit.md
@@ -17,7 +17,7 @@ When a PRD-backed issue lands, update its row in this table before treating the 
 |---|---|---|---|
 | 1. ListRow + NotesPicker | [#2122](https://github.com/ianjamesburke/PLEXI/issues/2122) | Done | Landed in PR #2129; NotesPicker rows use host ListRow |
 | 2. ModalShell + HintBar | [#2123](https://github.com/ianjamesburke/PLEXI/issues/2123) | Done | Landed in PR #2129; NotesPicker uses ModalShell and HintBar |
-| 3. TextField focus registration | [#2124](https://github.com/ianjamesburke/PLEXI/issues/2124) | Blocked | Blocked by #2123 |
+| 3. TextField focus registration | [#2124](https://github.com/ianjamesburke/PLEXI/issues/2124) | Done | CommandPalette search uses host TextField focus registration |
 | 4. CommandPalette migration | [#2125](https://github.com/ianjamesburke/PLEXI/issues/2125) | Blocked | Blocked by #2122, #2123, #2124 |
 | 5. QuickNote menu migration | [#2126](https://github.com/ianjamesburke/PLEXI/issues/2126) | Blocked | Blocked by #2122, #2123, #2124 |
 | 6. Host UI gallery | [#2127](https://github.com/ianjamesburke/PLEXI/issues/2127) | Blocked | Blocked by #2122, #2123, #2124 |

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -892,13 +892,13 @@ impl PlexiApp {
 
         self.draw_feature_effects(ctx);
 
-        // Re-request focus for the palette search field after all pane rendering.
-        // App panes call request_focus() on their TextInput widgets during
-        // CentralPanel rendering, and egui focus is last-write-wins — without
-        // this, a keyboard-capture app pane steals focus from the palette every
-        // frame, making the search field non-typeable even though it's visible.
-        if self.show_command_palette {
-            ctx.memory_mut(|m| m.request_focus(egui::Id::new("palette_search")));
+        // Re-request registered overlay fields after all pane rendering. App panes
+        // call request_focus() on their TextInput widgets during CentralPanel, and
+        // egui focus is last-write-wins; host TextField registrations reclaim focus
+        // for migrated overlays without another hard-coded ID path.
+        let registered_overlay_focus = crate::ui::focus::drain_overlay_focus(ctx);
+        for id in registered_overlay_focus {
+            ctx.memory_mut(|m| m.request_focus(id));
         }
 
         // Same pattern: QuickNote compose mode needs re-focus every frame so

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -2,7 +2,7 @@ use egui::{Align2, Color32, CornerRadius, RichText, Stroke, Vec2};
 
 use crate::app::PlexiApp;
 use crate::overlays::MODAL_WIDTH;
-use crate::ui::widgets::selectable_row;
+use crate::ui::widgets::{selectable_row, TextField};
 
 enum PaletteEntry {
     Context {
@@ -360,28 +360,10 @@ impl PlexiApp {
                         ui.set_width(MODAL_WIDTH);
 
                         let te_id = egui::Id::new("palette_search");
-                        let te = ui
-                            .scope(|ui| {
-                                ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                                ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
-                                ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
-                                ui.visuals_mut().widgets.active.bg_stroke =
-                                    egui::Stroke::new(1.0, self.colors.accent);
-                                ui.visuals_mut().widgets.inactive.bg_stroke =
-                                    egui::Stroke::new(1.0, self.colors.border);
-                                ui.add(
-                                    egui::TextEdit::singleline(&mut self.palette_query)
-                                        .id(te_id)
-                                        .desired_width(MODAL_WIDTH)
-                                        .hint_text("Jump to context or launch app...")
-                                        .font(egui::TextStyle::Body)
-                                        .margin(egui::Margin::symmetric(8, 5)),
-                                )
-                            })
-                            .inner;
-                        if !te.has_focus() {
-                            te.request_focus();
-                        }
+                        let te = TextField::singleline(te_id, "Jump to context or launch app...")
+                            .focused(true)
+                            .log_name("command_palette")
+                            .show(ui, &mut self.palette_query, &self.colors);
                         if te.changed() {
                             self.palette_selected = 0;
                         }

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -559,6 +559,26 @@ fn steal_focus(h: &HostHarness) -> egui::Id {
     steal_id
 }
 
+/// Regression guard for #2124: migrated host TextField overlays must register
+/// their focus intent with the UI-kit registry, and the post-CentralPanel drain
+/// must re-claim focus after a pane TextInput steals it.
+#[test]
+fn command_palette_text_field_registry_wins_after_central_panel_steal() {
+    let mut h = HostHarness::new();
+    h.app.show_command_palette = true;
+    h.app.sync_command_palette_focus();
+
+    h.run_frames(1);
+    steal_focus(&h);
+    h.run_frames(1);
+
+    assert_eq!(
+        h.ctx.memory(|m| m.focused()),
+        Some(egui::Id::new("palette_search")),
+        "palette_search must win focus back through the host TextField registry"
+    );
+}
+
 /// Regression guard for #1601: rename-pane TextEdit must retain egui focus
 /// after CentralPanel renders. The between-frame steal simulates a pane TextInput
 /// calling request_focus during CentralPanel — the post-CentralPanel block must

--- a/src/ui/focus.rs
+++ b/src/ui/focus.rs
@@ -1,0 +1,49 @@
+use egui::Id;
+
+const OVERLAY_FOCUS_REGISTRY_ID: &str = "plexi_overlay_focus_registry";
+
+/// Register an overlay field that should reclaim focus after CentralPanel.
+///
+/// Text-owning overlays render before panes, while app panes render during
+/// CentralPanel and may call `request_focus()` later in the same frame. The
+/// renderer drains this registry after CentralPanel so host overlay fields win
+/// egui's last-writer-wins focus contest without every overlay hard-coding a
+/// second focus path.
+pub(crate) fn register_overlay_focus(ctx: &egui::Context, id: Id) {
+    let registry_id = Id::new(OVERLAY_FOCUS_REGISTRY_ID);
+    ctx.memory_mut(|memory| {
+        let mut ids: Vec<Id> = memory.data.get_temp(registry_id).unwrap_or_default();
+        if !ids.contains(&id) {
+            ids.push(id);
+        }
+        memory.data.insert_temp(registry_id, ids);
+    });
+}
+
+pub(crate) fn drain_overlay_focus(ctx: &egui::Context) -> Vec<Id> {
+    let registry_id = Id::new(OVERLAY_FOCUS_REGISTRY_ID);
+    ctx.memory_mut(|memory| {
+        let ids = memory.data.get_temp(registry_id).unwrap_or_default();
+        memory.data.remove::<Vec<Id>>(registry_id);
+        ids
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_focus_registry_dedupes_and_drains_in_order() {
+        let ctx = egui::Context::default();
+        let first = Id::new("first_overlay_field");
+        let second = Id::new("second_overlay_field");
+
+        register_overlay_focus(&ctx, first);
+        register_overlay_focus(&ctx, first);
+        register_overlay_focus(&ctx, second);
+
+        assert_eq!(drain_overlay_focus(&ctx), vec![first, second]);
+        assert!(drain_overlay_focus(&ctx).is_empty());
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod focus;
 pub mod hints;
 pub mod list;
 pub mod overlay;

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -210,6 +210,51 @@ pub(crate) fn styled_text_input(
     .inner
 }
 
+pub(crate) struct TextField<'a> {
+    id: egui::Id,
+    hint: egui::WidgetText,
+    focused: bool,
+    log_name: &'a str,
+}
+
+impl<'a> TextField<'a> {
+    pub(crate) fn singleline(id: egui::Id, hint: impl Into<egui::WidgetText>) -> Self {
+        Self {
+            id,
+            hint: hint.into(),
+            focused: false,
+            log_name: "text_field",
+        }
+    }
+
+    pub(crate) fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    pub(crate) fn log_name(mut self, log_name: &'a str) -> Self {
+        self.log_name = log_name;
+        self
+    }
+
+    pub(crate) fn show(
+        self,
+        ui: &mut egui::Ui,
+        buf: &mut String,
+        colors: &Colors,
+    ) -> egui::Response {
+        let response = styled_text_input(ui, buf, self.hint, self.id, colors);
+        if self.focused {
+            crate::ui::focus::register_overlay_focus(ui.ctx(), self.id);
+            if !response.has_focus() {
+                response.request_focus();
+                log::info!("{}: focus requested for host TextField", self.log_name);
+            }
+        }
+        response
+    }
+}
+
 /// 📋 / ✓ copy-to-clipboard button. Shows the clipboard icon normally; switches
 /// to ✓ for 2 seconds after a successful copy. `id` must be unique per call site.
 pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::Response {


### PR DESCRIPTION
Closes #2124

## Summary

- Adds a host overlay focus registry under `src/ui` so migrated text fields can declare focus intent once.
- Wraps the existing styled single-line input in a host `TextField` primitive that registers post-CentralPanel focus ownership.
- Migrates command palette search to the host `TextField` path while preserving legacy hard-coded focus paths for unmigrated overlays.

## Done When

- At least one text-owning overlay uses the host TextField registration path.
- The post-CentralPanel focus pass consumes registered overlay focus IDs instead of only hard-coded IDs.
- Existing focus regression tests pass, and the migrated overlay still accepts keyboard input when an app pane contains a focused TextInput.
- `cargo build` passes.

## Verification

- `cargo test --bin plexi`
- `cargo build`
