### PR TITLE
feat(file-explorer): column model sorting resizing and persistence (#2136)

### DIFF
--- a/.stint/tasks/0002-file-explorer-column-model-sorting-resizing-and-persistence.md
+++ b/.stint/tasks/0002-file-explorer-column-model-sorting-resizing-and-persistence.md
@@ -1,15 +1,23 @@
 ---
 id: "0002"
 title: "File Explorer: column model sorting resizing and persistence"
-status: backlog
-estimate: 16h
+status: in-progress
+estimate: "16h"
+started_at: "2026-06-10T22:26:31Z"
 sprint: "s1"
 blocked_by:
   - 1
-gh_issue: ["2136"]
-area: ["apps/file-browser", "ui/widgets"]
-tags: ["file-explorer", "details-table", "metadata"]
+gh_issue:
+  - "2136"
+area:
+  - "apps/file-browser"
+  - "ui/widgets"
+tags:
+  - "file-explorer"
+  - "details-table"
+  - "metadata"
 ---
+
 
 Add a real File Explorer column model on top of the adaptive shell.
 

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::path::Path;
 use std::time::SystemTime;
 
@@ -57,12 +58,327 @@ pub(crate) struct Entry {
     pub is_image: bool,
     pub size_bytes: Option<u64>,
     pub modified: Option<SystemTime>,
+    pub created: Option<SystemTime>,
+    pub extension: Option<String>,
+    pub permissions: String,
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SortMode {
-    RecentlyTouched,
+pub(crate) enum ColumnId {
     Name,
+    Kind,
+    Size,
+    Modified,
+    Created,
+    Extension,
+    Permissions,
+    Tags,
+}
+
+impl ColumnId {
+    pub(crate) const ALL: [Self; 8] = [
+        Self::Name,
+        Self::Kind,
+        Self::Size,
+        Self::Modified,
+        Self::Created,
+        Self::Extension,
+        Self::Permissions,
+        Self::Tags,
+    ];
+
+    pub(crate) fn key(self) -> &'static str {
+        match self {
+            Self::Name => "name",
+            Self::Kind => "kind",
+            Self::Size => "size",
+            Self::Modified => "modified",
+            Self::Created => "created",
+            Self::Extension => "extension",
+            Self::Permissions => "permissions",
+            Self::Tags => "tags",
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Name => "Name",
+            Self::Kind => "Kind",
+            Self::Size => "Size",
+            Self::Modified => "Modified",
+            Self::Created => "Created",
+            Self::Extension => "Ext",
+            Self::Permissions => "Perms",
+            Self::Tags => "Tags",
+        }
+    }
+
+    pub(crate) fn default_width(self) -> f32 {
+        match self {
+            Self::Name => 260.0,
+            Self::Kind => 92.0,
+            Self::Size => 96.0,
+            Self::Modified => 116.0,
+            Self::Created => 116.0,
+            Self::Extension => 72.0,
+            Self::Permissions => 76.0,
+            Self::Tags => 120.0,
+        }
+    }
+
+    pub(crate) fn min_width(self) -> f32 {
+        match self {
+            Self::Name => 160.0,
+            Self::Kind => 72.0,
+            Self::Size => 72.0,
+            Self::Modified | Self::Created => 92.0,
+            Self::Extension | Self::Permissions => 60.0,
+            Self::Tags => 88.0,
+        }
+    }
+
+    pub(crate) fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "name" => Some(Self::Name),
+            "kind" => Some(Self::Kind),
+            "size" => Some(Self::Size),
+            "modified" => Some(Self::Modified),
+            "created" => Some(Self::Created),
+            "extension" => Some(Self::Extension),
+            "permissions" => Some(Self::Permissions),
+            "tags" => Some(Self::Tags),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    pub(crate) fn toggled(self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+
+    pub(crate) fn key(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+
+    pub(crate) fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "asc" => Some(Self::Asc),
+            "desc" => Some(Self::Desc),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SortDescriptor {
+    pub column: ColumnId,
+    pub direction: SortDirection,
+}
+
+impl Default for SortDescriptor {
+    fn default() -> Self {
+        Self {
+            column: ColumnId::Modified,
+            direction: SortDirection::Desc,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ColumnConfig {
+    pub id: ColumnId,
+    pub width: f32,
+    pub visible: bool,
+}
+
+impl ColumnConfig {
+    pub(crate) fn new(id: ColumnId, visible: bool) -> Self {
+        Self {
+            id,
+            width: id.default_width(),
+            visible,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ColumnModel {
+    pub columns: Vec<ColumnConfig>,
+    pub sort: SortDescriptor,
+    pub folders_on_top: bool,
+}
+
+impl Default for ColumnModel {
+    fn default() -> Self {
+        Self {
+            columns: vec![
+                ColumnConfig::new(ColumnId::Name, true),
+                ColumnConfig::new(ColumnId::Kind, true),
+                ColumnConfig::new(ColumnId::Size, true),
+                ColumnConfig::new(ColumnId::Modified, true),
+                ColumnConfig::new(ColumnId::Created, false),
+                ColumnConfig::new(ColumnId::Extension, false),
+                ColumnConfig::new(ColumnId::Permissions, false),
+                ColumnConfig::new(ColumnId::Tags, false),
+            ],
+            sort: SortDescriptor::default(),
+            folders_on_top: true,
+        }
+    }
+}
+
+impl ColumnModel {
+    pub(crate) fn visible_columns(&self) -> impl Iterator<Item = &ColumnConfig> {
+        self.columns.iter().filter(|column| column.visible)
+    }
+
+    pub(crate) fn visible_column_count(&self) -> usize {
+        self.columns.iter().filter(|column| column.visible).count()
+    }
+
+    pub(crate) fn set_column_visible(&mut self, id: ColumnId, visible: bool) {
+        if id == ColumnId::Name {
+            return;
+        }
+        if let Some(column) = self.columns.iter_mut().find(|column| column.id == id) {
+            column.visible = visible;
+        }
+        if self.visible_column_count() == 0 {
+            if let Some(name) = self
+                .columns
+                .iter_mut()
+                .find(|column| column.id == ColumnId::Name)
+            {
+                name.visible = true;
+            }
+        }
+    }
+
+    pub(crate) fn resize_column(&mut self, id: ColumnId, width: f32) {
+        if let Some(column) = self.columns.iter_mut().find(|column| column.id == id) {
+            column.width = width.max(id.min_width());
+        }
+    }
+
+    pub(crate) fn move_column(&mut self, id: ColumnId, offset: isize) {
+        let Some(index) = self.columns.iter().position(|column| column.id == id) else {
+            return;
+        };
+        let new_index = if offset.is_negative() {
+            index.saturating_sub(offset.unsigned_abs())
+        } else {
+            (index + offset as usize).min(self.columns.len().saturating_sub(1))
+        };
+        if index != new_index {
+            self.columns.swap(index, new_index);
+        }
+    }
+
+    pub(crate) fn toggle_sort(&mut self, column: ColumnId) {
+        if self.sort.column == column {
+            self.sort.direction = self.sort.direction.toggled();
+        } else {
+            self.sort = SortDescriptor {
+                column,
+                direction: default_direction_for(column),
+            };
+        }
+    }
+
+    pub(crate) fn toggle_legacy_sort(&mut self) {
+        self.sort = match (self.sort.column, self.sort.direction) {
+            (ColumnId::Name, SortDirection::Asc) => SortDescriptor::default(),
+            _ => SortDescriptor {
+                column: ColumnId::Name,
+                direction: SortDirection::Asc,
+            },
+        };
+    }
+
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "sort": {
+                "column": self.sort.column.key(),
+                "direction": self.sort.direction.key(),
+            },
+            "folders_on_top": self.folders_on_top,
+            "columns": self.columns.iter().map(|column| {
+                serde_json::json!({
+                    "id": column.id.key(),
+                    "width": column.width,
+                    "visible": column.visible,
+                })
+            }).collect::<Vec<_>>(),
+        })
+    }
+
+    pub(crate) fn from_json(value: &serde_json::Value) -> Self {
+        let mut model = Self::default();
+        if let Some(column) = value["sort"]["column"]
+            .as_str()
+            .and_then(ColumnId::from_key)
+        {
+            model.sort.column = column;
+        }
+        if let Some(direction) = value["sort"]["direction"]
+            .as_str()
+            .and_then(SortDirection::from_key)
+        {
+            model.sort.direction = direction;
+        }
+        if let Some(folders_on_top) = value["folders_on_top"].as_bool() {
+            model.folders_on_top = folders_on_top;
+        }
+        if let Some(columns) = value["columns"].as_array() {
+            let mut restored = Vec::new();
+            for item in columns {
+                let Some(id) = item["id"].as_str().and_then(ColumnId::from_key) else {
+                    continue;
+                };
+                if restored.iter().any(|column: &ColumnConfig| column.id == id) {
+                    continue;
+                }
+                restored.push(ColumnConfig {
+                    id,
+                    width: item["width"]
+                        .as_f64()
+                        .map(|width| width as f32)
+                        .unwrap_or_else(|| id.default_width())
+                        .max(id.min_width()),
+                    visible: item["visible"].as_bool().unwrap_or(true),
+                });
+            }
+            for id in ColumnId::ALL {
+                if !restored.iter().any(|column| column.id == id) {
+                    restored.push(ColumnConfig::new(id, id == ColumnId::Name));
+                }
+            }
+            if !restored.iter().any(|column| column.visible) {
+                if let Some(name) = restored
+                    .iter_mut()
+                    .find(|column| column.id == ColumnId::Name)
+                {
+                    name.visible = true;
+                }
+            }
+            model.columns = restored;
+        }
+        model
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -71,6 +387,57 @@ pub(crate) struct DirStats {
     pub dir_count: usize,
     pub total_bytes: u64,
     pub truncated: bool,
+}
+
+fn default_direction_for(column: ColumnId) -> SortDirection {
+    match column {
+        ColumnId::Name
+        | ColumnId::Kind
+        | ColumnId::Extension
+        | ColumnId::Permissions
+        | ColumnId::Tags => SortDirection::Asc,
+        ColumnId::Size | ColumnId::Modified | ColumnId::Created => SortDirection::Desc,
+    }
+}
+
+fn kind_value(entry: &Entry) -> &'static str {
+    if entry.is_dir {
+        "folder"
+    } else if entry.is_image {
+        "image"
+    } else {
+        "file"
+    }
+}
+
+pub(crate) fn sort_entries(entries: &mut [Entry], sort: SortDescriptor, folders_on_top: bool) {
+    entries.sort_by(|a, b| {
+        if folders_on_top {
+            let folder_order = b.is_dir.cmp(&a.is_dir);
+            if folder_order != Ordering::Equal {
+                return folder_order;
+            }
+        }
+        let ordering = compare_entry_column(a, b, sort.column)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        match sort.direction {
+            SortDirection::Asc => ordering,
+            SortDirection::Desc => ordering.reverse(),
+        }
+    });
+}
+
+fn compare_entry_column(a: &Entry, b: &Entry, column: ColumnId) -> Ordering {
+    match column {
+        ColumnId::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        ColumnId::Kind => kind_value(a).cmp(kind_value(b)),
+        ColumnId::Size => a.size_bytes.unwrap_or(0).cmp(&b.size_bytes.unwrap_or(0)),
+        ColumnId::Modified => a.modified.cmp(&b.modified),
+        ColumnId::Created => a.created.cmp(&b.created),
+        ColumnId::Extension => a.extension.cmp(&b.extension),
+        ColumnId::Permissions => a.permissions.cmp(&b.permissions),
+        ColumnId::Tags => a.tags.join(",").cmp(&b.tags.join(",")),
+    }
 }
 
 pub(crate) fn format_size(bytes: Option<u64>) -> String {
@@ -172,5 +539,121 @@ mod media_bridge_tests {
                 "{path} should not route to an in-app player"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod column_model_tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn entry(name: &str, is_dir: bool, size_bytes: Option<u64>, modified_secs: u64) -> Entry {
+        let path = PathBuf::from(name);
+        Entry {
+            name: name.to_string(),
+            extension: path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.to_ascii_lowercase()),
+            path,
+            is_dir,
+            is_image: false,
+            size_bytes,
+            modified: Some(UNIX_EPOCH + Duration::from_secs(modified_secs)),
+            created: None,
+            permissions: "rw".to_string(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn sort_entries_uses_descriptor_and_keeps_folders_on_top() {
+        let mut entries = vec![
+            entry("tiny.txt", false, Some(1), 10),
+            entry("z-folder", true, None, 1),
+            entry("large.bin", false, Some(900), 20),
+        ];
+        sort_entries(
+            &mut entries,
+            SortDescriptor {
+                column: ColumnId::Size,
+                direction: SortDirection::Desc,
+            },
+            true,
+        );
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["z-folder", "large.bin", "tiny.txt"]);
+    }
+
+    #[test]
+    fn sort_entries_can_disable_folders_on_top() {
+        let mut entries = vec![
+            entry("tiny.txt", false, Some(1), 10),
+            entry("z-folder", true, None, 1),
+            entry("large.bin", false, Some(900), 20),
+        ];
+        sort_entries(
+            &mut entries,
+            SortDescriptor {
+                column: ColumnId::Name,
+                direction: SortDirection::Asc,
+            },
+            false,
+        );
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["large.bin", "tiny.txt", "z-folder"]);
+    }
+
+    #[test]
+    fn column_model_round_trips_preferences() {
+        let mut model = ColumnModel::default();
+        model.toggle_sort(ColumnId::Extension);
+        model.resize_column(ColumnId::Name, 333.0);
+        model.set_column_visible(ColumnId::Created, true);
+        model.move_column(ColumnId::Created, -1);
+        model.folders_on_top = false;
+
+        let restored = ColumnModel::from_json(&model.to_json());
+
+        assert_eq!(restored.sort.column, ColumnId::Extension);
+        assert_eq!(restored.sort.direction, SortDirection::Asc);
+        assert!(!restored.folders_on_top);
+        assert_eq!(
+            restored
+                .columns
+                .iter()
+                .find(|column| column.id == ColumnId::Name)
+                .map(|column| column.width),
+            Some(333.0)
+        );
+        assert_eq!(
+            restored
+                .columns
+                .iter()
+                .find(|column| column.id == ColumnId::Created)
+                .map(|column| column.visible),
+            Some(true)
+        );
+        let created_index = restored
+            .columns
+            .iter()
+            .position(|column| column.id == ColumnId::Created)
+            .expect("created column");
+        let modified_index = restored
+            .columns
+            .iter()
+            .position(|column| column.id == ColumnId::Modified)
+            .expect("modified column");
+        assert!(
+            created_index < modified_index,
+            "column order should survive serialization"
+        );
     }
 }

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -418,12 +418,12 @@ pub(crate) fn sort_entries(entries: &mut [Entry], sort: SortDescriptor, folders_
                 return folder_order;
             }
         }
-        let ordering = compare_entry_column(a, b, sort.column)
-            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-        match sort.direction {
-            SortDirection::Asc => ordering,
-            SortDirection::Desc => ordering.reverse(),
-        }
+        let primary = compare_entry_column(a, b, sort.column);
+        let directed_primary = match sort.direction {
+            SortDirection::Asc => primary,
+            SortDirection::Desc => primary.reverse(),
+        };
+        directed_primary.then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
     });
 }
 
@@ -609,6 +609,28 @@ mod column_model_tests {
             .map(|entry| entry.name.as_str())
             .collect::<Vec<_>>();
         assert_eq!(names, ["large.bin", "tiny.txt", "z-folder"]);
+    }
+
+    #[test]
+    fn descending_metadata_sort_keeps_name_tiebreaker_ascending() {
+        let mut entries = vec![
+            entry("zeta.txt", false, Some(10), 20),
+            entry("alpha.txt", false, Some(10), 20),
+            entry("middle.txt", false, Some(1), 10),
+        ];
+        sort_entries(
+            &mut entries,
+            SortDescriptor {
+                column: ColumnId::Modified,
+                direction: SortDirection::Desc,
+            },
+            true,
+        );
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["alpha.txt", "zeta.txt", "middle.txt"]);
     }
 
     #[test]

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -11,7 +11,10 @@ use image::imageops::FilterType;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use helpers::{format_modified, format_size, DirStats, Entry, MediaKind, SortMode};
+use helpers::{
+    format_modified, format_size, sort_entries, ColumnConfig, ColumnId, ColumnModel, DirStats,
+    Entry, MediaKind, SortDirection,
+};
 use icons::paint_entry_icon;
 
 const DETAILS_TABLE_MIN_WIDTH: f32 = 560.0;
@@ -149,7 +152,7 @@ pub struct FileBrowserApp {
     pub cwd: PathBuf,
     entries: Vec<Entry>,
     selected: usize,
-    sort_mode: SortMode,
+    columns: ColumnModel,
     error: Option<String>,
     // Image preview
     preview_texture: Option<egui::TextureHandle>,
@@ -181,7 +184,7 @@ impl FileBrowserApp {
             cwd,
             entries: Vec::new(),
             selected: 0,
-            sort_mode: SortMode::RecentlyTouched,
+            columns: ColumnModel::default(),
             error: None,
             preview_texture: None,
             preview_texture_path: None,
@@ -222,10 +225,21 @@ impl FileBrowserApp {
                             meta.as_ref()
                                 .and_then(|m| if is_dir { None } else { Some(m.len()) });
                         let modified = meta.as_ref().and_then(|m| m.modified().ok());
+                        let created = meta.as_ref().and_then(|m| m.created().ok());
                         let ext = path
                             .extension()
                             .and_then(|e| e.to_str())
                             .map(|e| e.to_ascii_lowercase());
+                        let permissions = meta
+                            .as_ref()
+                            .map(|m| {
+                                if m.permissions().readonly() {
+                                    "ro"
+                                } else {
+                                    "rw"
+                                }
+                            })
+                            .unwrap_or("?");
                         let is_image = ext
                             .as_deref()
                             .map(|e| {
@@ -242,22 +256,15 @@ impl FileBrowserApp {
                             is_image,
                             size_bytes,
                             modified,
+                            created,
+                            extension: ext,
+                            permissions: permissions.to_string(),
+                            tags: Vec::new(),
                         })
                     })
                     .collect();
 
-                match self.sort_mode {
-                    SortMode::Name => {
-                        entries.sort_by(|a, b| b.is_dir.cmp(&a.is_dir).then(a.name.cmp(&b.name)));
-                    }
-                    SortMode::RecentlyTouched => {
-                        entries.sort_by(|a, b| {
-                            b.is_dir
-                                .cmp(&a.is_dir)
-                                .then(b.modified.cmp(&a.modified).then(a.name.cmp(&b.name)))
-                        });
-                    }
-                }
+                sort_entries(&mut entries, self.columns.sort, self.columns.folders_on_top);
                 self.entries = entries;
                 self.selected = self.selected.min(self.entries.len().saturating_sub(1));
             }
@@ -540,6 +547,28 @@ impl FileBrowserApp {
         }
     }
 
+    fn entry_cell_text(entry: &Entry, column: ColumnId) -> String {
+        match column {
+            ColumnId::Name => Self::entry_title(entry),
+            ColumnId::Kind => Self::entry_kind(entry).to_string(),
+            ColumnId::Size => format_size(entry.size_bytes),
+            ColumnId::Modified => format_modified(entry.modified),
+            ColumnId::Created => format_modified(entry.created),
+            ColumnId::Extension => entry
+                .extension
+                .clone()
+                .unwrap_or_else(|| "\u{2014}".to_string()),
+            ColumnId::Permissions => entry.permissions.clone(),
+            ColumnId::Tags => {
+                if entry.tags.is_empty() {
+                    "\u{2014}".to_string()
+                } else {
+                    entry.tags.join(", ")
+                }
+            }
+        }
+    }
+
     fn entry_chip(entry: &Entry) -> &'static str {
         if entry.is_dir {
             "dir"
@@ -630,7 +659,7 @@ impl FileBrowserApp {
         navigate_to
     }
 
-    fn draw_details_header(&self, ui: &mut egui::Ui, colors: &Colors) {
+    fn draw_details_header(&mut self, ui: &mut egui::Ui, colors: &Colors) {
         let (rect, _) = ui.allocate_exact_size(
             egui::vec2(ui.available_width(), DETAILS_HEADER_H),
             egui::Sense::hover(),
@@ -643,19 +672,84 @@ impl FileBrowserApp {
             Stroke::new(1.0, colors.border),
             StrokeKind::Inside,
         );
-        let cols = self.details_columns(rect);
-        for (label, cell) in [
-            ("Name", cols.0),
-            ("Kind", cols.1),
-            ("Size", cols.2),
-            ("Modified", cols.3),
-        ] {
+        for (column, cell) in self.details_columns(rect) {
+            let handle_rect = egui::Rect::from_min_max(
+                egui::pos2(cell.right() - 5.0, cell.top()),
+                egui::pos2(cell.right() + 5.0, cell.bottom()),
+            );
+            let header_response = ui.interact(
+                cell,
+                ui.id().with(("file-browser-header", column.id.key())),
+                egui::Sense::click_and_drag(),
+            );
+            let resize_response = ui.interact(
+                handle_rect,
+                ui.id().with(("file-browser-resize", column.id.key())),
+                egui::Sense::drag(),
+            );
+            if header_response.clicked() {
+                self.columns.toggle_sort(column.id);
+                self.refresh();
+                log::info!(
+                    "file_browser: sort changed to {} {}",
+                    self.columns.sort.column.key(),
+                    self.columns.sort.direction.key()
+                );
+            }
+            if header_response.drag_stopped() {
+                let delta = header_response.drag_delta().x;
+                let offset = if delta < -cell.width() * 0.35 {
+                    Some(-1)
+                } else if delta > cell.width() * 0.35 {
+                    Some(1)
+                } else {
+                    None
+                };
+                if let Some(offset) = offset {
+                    self.columns.move_column(column.id, offset);
+                    log::info!(
+                        "file_browser: moved column {} by {}",
+                        column.id.key(),
+                        offset
+                    );
+                }
+            }
+            if resize_response.dragged() {
+                let frame_delta = ui.input(|input| input.pointer.delta().x);
+                self.columns
+                    .resize_column(column.id, column.width + frame_delta);
+                log::info!(
+                    "file_browser: resized column {} to {:.1}",
+                    column.id.key(),
+                    self.columns
+                        .columns
+                        .iter()
+                        .find(|candidate| candidate.id == column.id)
+                        .map(|candidate| candidate.width)
+                        .unwrap_or(column.width)
+                );
+            }
+            let sort_suffix = if self.columns.sort.column == column.id {
+                match self.columns.sort.direction {
+                    SortDirection::Asc => " \u{2191}",
+                    SortDirection::Desc => " \u{2193}",
+                }
+            } else {
+                ""
+            };
             ui.painter().text(
                 egui::pos2(cell.left() + style::SPACE_SM, cell.center().y),
                 egui::Align2::LEFT_CENTER,
-                label,
+                format!("{}{}", column.id.label(), sort_suffix),
                 egui::FontId::proportional(style::TEXT_HINT),
                 colors.text_dim,
+            );
+            ui.painter().line_segment(
+                [
+                    egui::pos2(cell.right(), cell.top() + 5.0),
+                    egui::pos2(cell.right(), cell.bottom() - 5.0),
+                ],
+                Stroke::new(1.0, colors.border),
             );
         }
     }
@@ -668,56 +762,62 @@ impl FileBrowserApp {
         entry: &Entry,
         selected: bool,
     ) {
-        let cols = self.details_columns(rect);
         let primary = if selected {
             colors.text_primary
         } else {
             colors.text_dim
         };
         let font = egui::FontId::proportional(style::TEXT_HINT);
-        let icon_rect = egui::Rect::from_min_size(
-            egui::pos2(cols.0.left() + style::SPACE_SM, cols.0.center().y - 9.0),
-            egui::vec2(18.0, 18.0),
-        );
-        paint_entry_icon(ui.painter(), icon_rect, entry, colors);
-        let name_cell = cols.0.shrink2(egui::vec2(28.0, 0.0));
-
-        for (text, cell, color) in [
-            (Self::entry_title(entry), name_cell, primary),
-            (Self::entry_kind(entry).to_string(), cols.1, colors.text_dim),
-            (format_size(entry.size_bytes), cols.2, colors.text_dim),
-            (format_modified(entry.modified), cols.3, colors.text_dim),
-        ] {
+        for (column, mut cell) in self.details_columns(rect) {
+            if column.id == ColumnId::Name {
+                let icon_rect = egui::Rect::from_min_size(
+                    egui::pos2(cell.left() + style::SPACE_SM, cell.center().y - 9.0),
+                    egui::vec2(18.0, 18.0),
+                );
+                paint_entry_icon(ui.painter(), icon_rect, entry, colors);
+                cell = cell.shrink2(egui::vec2(28.0, 0.0));
+            }
             let text_pos = egui::pos2(cell.left() + style::SPACE_SM, cell.center().y);
             ui.painter().text(
                 text_pos,
                 egui::Align2::LEFT_CENTER,
-                text,
+                Self::entry_cell_text(entry, column.id),
                 font.clone(),
-                color,
+                if column.id == ColumnId::Name {
+                    primary
+                } else {
+                    colors.text_dim
+                },
             );
         }
     }
 
-    fn details_columns(
-        &self,
-        rect: egui::Rect,
-    ) -> (egui::Rect, egui::Rect, egui::Rect, egui::Rect) {
-        let w = rect.width();
-        let name_w = (w * 0.48).clamp(180.0, 420.0);
-        let kind_w = 92.0;
-        let size_w = 96.0;
-        let name = egui::Rect::from_min_size(rect.min, egui::vec2(name_w, rect.height()));
-        let kind = egui::Rect::from_min_size(
-            egui::pos2(name.right(), rect.top()),
-            egui::vec2(kind_w, rect.height()),
-        );
-        let size = egui::Rect::from_min_size(
-            egui::pos2(kind.right(), rect.top()),
-            egui::vec2(size_w, rect.height()),
-        );
-        let modified = egui::Rect::from_min_max(egui::pos2(size.right(), rect.top()), rect.max);
-        (name, kind, size, modified)
+    fn details_columns(&self, rect: egui::Rect) -> Vec<(ColumnConfig, egui::Rect)> {
+        let mut x = rect.left();
+        let visible = self.columns.visible_columns().copied().collect::<Vec<_>>();
+        let total_config_width = visible
+            .iter()
+            .map(|column| column.width.max(column.id.min_width()))
+            .sum::<f32>()
+            .max(1.0);
+        let scale = (rect.width() / total_config_width).max(1.0);
+        let mut columns = Vec::with_capacity(visible.len());
+        for (idx, column) in visible.iter().enumerate() {
+            let right = if idx + 1 == visible.len() {
+                rect.right()
+            } else {
+                (x + column.width * scale).min(rect.right())
+            };
+            columns.push((
+                *column,
+                egui::Rect::from_min_max(
+                    egui::pos2(x, rect.top()),
+                    egui::pos2(right, rect.bottom()),
+                ),
+            ));
+            x = right;
+        }
+        columns
     }
 
     fn draw_sidebar_preview(&mut self, ui: &mut egui::Ui, colors: &Colors) {
@@ -901,25 +1001,48 @@ impl FileBrowserApp {
                     .monospace(),
             );
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                let name_label = if self.sort_mode == SortMode::Name {
-                    "Name \u{2713}"
+                let folders_label = if self.columns.folders_on_top {
+                    "Folders \u{2713}"
                 } else {
-                    "Name"
+                    "Folders"
                 };
-                let recent_label = if self.sort_mode == SortMode::RecentlyTouched {
-                    "Recent \u{2713}"
-                } else {
-                    "Recent"
-                };
-                if ui.small_button(name_label).clicked() {
-                    self.sort_mode = SortMode::Name;
+                if ui.small_button(folders_label).clicked() {
+                    self.columns.folders_on_top = !self.columns.folders_on_top;
                     self.refresh();
-                    log::info!("file_browser: sort changed to name");
+                    log::info!(
+                        "file_browser: folders_on_top changed to {}",
+                        self.columns.folders_on_top
+                    );
                 }
-                if ui.small_button(recent_label).clicked() {
-                    self.sort_mode = SortMode::RecentlyTouched;
-                    self.refresh();
-                    log::info!("file_browser: sort changed to recent");
+                for id in [
+                    ColumnId::Tags,
+                    ColumnId::Permissions,
+                    ColumnId::Extension,
+                    ColumnId::Created,
+                    ColumnId::Modified,
+                    ColumnId::Size,
+                    ColumnId::Kind,
+                ] {
+                    let visible = self
+                        .columns
+                        .columns
+                        .iter()
+                        .find(|column| column.id == id)
+                        .map(|column| column.visible)
+                        .unwrap_or(false);
+                    let label = if visible {
+                        format!("{} \u{2713}", id.label())
+                    } else {
+                        id.label().to_string()
+                    };
+                    if ui.small_button(label).clicked() {
+                        self.columns.set_column_visible(id, !visible);
+                        log::info!(
+                            "file_browser: column {} visibility changed to {}",
+                            id.key(),
+                            !visible
+                        );
+                    }
                 }
                 ui.label(
                     egui::RichText::new(match layout {
@@ -1193,11 +1316,13 @@ impl App for FileBrowserApp {
                 KeyDisposition::Consumed
             }
             (Mode::Normal, Some(FileBrowserAction::ToggleSort)) => {
-                self.sort_mode = match self.sort_mode {
-                    SortMode::RecentlyTouched => SortMode::Name,
-                    SortMode::Name => SortMode::RecentlyTouched,
-                };
+                self.columns.toggle_legacy_sort();
                 self.refresh();
+                log::info!(
+                    "file_browser: sort changed to {} {}",
+                    self.columns.sort.column.key(),
+                    self.columns.sort.direction.key()
+                );
                 KeyDisposition::Consumed
             }
             (Mode::Normal, Some(FileBrowserAction::Refresh)) => {
@@ -1228,6 +1353,7 @@ impl App for FileBrowserApp {
         Some(serde_json::json!({
             "cwd": self.cwd.display().to_string(),
             "selected": self.selected,
+            "columns": self.columns.to_json(),
         }))
     }
 
@@ -1241,6 +1367,10 @@ impl App for FileBrowserApp {
         }
         if let Some(sel) = state["selected"].as_u64() {
             self.selected = (sel as usize).min(self.entries.len().saturating_sub(1));
+        }
+        if state.get("columns").is_some() {
+            self.columns = ColumnModel::from_json(&state["columns"]);
+            self.refresh();
         }
     }
 }
@@ -1666,7 +1796,7 @@ mod tests {
     #[test]
     fn search_mode_s_does_not_toggle_sort() {
         let (mut app, _dir) = make_populated_dir_app();
-        let original_sort = app.sort_mode;
+        let original_sort = app.columns.sort;
         app.in_search = true;
         app.refilter();
         run_handle_key(
@@ -1677,13 +1807,62 @@ mod tests {
             ],
         );
         assert_eq!(
-            app.sort_mode, original_sort,
+            app.columns.sort, original_sort,
             "S in search mode must not toggle sort"
         );
         assert_eq!(
             app.search_query, "s",
             "S in search mode must append to query"
         );
+    }
+
+    #[test]
+    fn serialized_state_persists_column_preferences() {
+        let (mut app, _dir) = make_populated_dir_app();
+        app.columns.toggle_sort(ColumnId::Size);
+        app.columns.resize_column(ColumnId::Name, 344.0);
+        app.columns.set_column_visible(ColumnId::Created, true);
+        app.columns.move_column(ColumnId::Created, -1);
+        app.columns.folders_on_top = false;
+
+        let state = app.serialize_state().expect("state");
+        let mut restored = FileBrowserApp::new(app.cwd.clone());
+        restored.restore_state(&state);
+
+        assert_eq!(restored.columns.sort.column, ColumnId::Size);
+        assert_eq!(restored.columns.sort.direction, SortDirection::Desc);
+        assert!(!restored.columns.folders_on_top);
+        assert_eq!(
+            restored
+                .columns
+                .columns
+                .iter()
+                .find(|column| column.id == ColumnId::Name)
+                .map(|column| column.width),
+            Some(344.0)
+        );
+        assert_eq!(
+            restored
+                .columns
+                .columns
+                .iter()
+                .find(|column| column.id == ColumnId::Created)
+                .map(|column| column.visible),
+            Some(true)
+        );
+        let created_index = restored
+            .columns
+            .columns
+            .iter()
+            .position(|column| column.id == ColumnId::Created)
+            .expect("created column");
+        let modified_index = restored
+            .columns
+            .columns
+            .iter()
+            .position(|column| column.id == ColumnId::Modified)
+            .expect("modified column");
+        assert!(created_index < modified_index);
     }
 
     #[test]

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -274,6 +274,13 @@ impl FileBrowserApp {
         }
     }
 
+    fn refresh_preserving_filter(&mut self) {
+        self.refresh();
+        if self.in_search {
+            self.refilter();
+        }
+    }
+
     fn navigate_into(&mut self, path: PathBuf) {
         if let Some(entry) = self.selected_entry() {
             self.directory_selection_memory
@@ -689,7 +696,7 @@ impl FileBrowserApp {
             );
             if header_response.clicked() {
                 self.columns.toggle_sort(column.id);
-                self.refresh();
+                self.refresh_preserving_filter();
                 log::info!(
                     "file_browser: sort changed to {} {}",
                     self.columns.sort.column.key(),
@@ -800,7 +807,11 @@ impl FileBrowserApp {
             .map(|column| column.width.max(column.id.min_width()))
             .sum::<f32>()
             .max(1.0);
-        let scale = (rect.width() / total_config_width).max(1.0);
+        let scale = if total_config_width > rect.width() {
+            rect.width() / total_config_width
+        } else {
+            1.0
+        };
         let mut columns = Vec::with_capacity(visible.len());
         for (idx, column) in visible.iter().enumerate() {
             let right = if idx + 1 == visible.len() {
@@ -1008,7 +1019,7 @@ impl FileBrowserApp {
                 };
                 if ui.small_button(folders_label).clicked() {
                     self.columns.folders_on_top = !self.columns.folders_on_top;
-                    self.refresh();
+                    self.refresh_preserving_filter();
                     log::info!(
                         "file_browser: folders_on_top changed to {}",
                         self.columns.folders_on_top
@@ -1379,6 +1390,7 @@ impl App for FileBrowserApp {
 mod tests {
     use super::*;
     use egui::{Event, Key, Modifiers, RawInput};
+    use helpers::SortDescriptor;
 
     fn key_event(key: Key, modifiers: Modifiers) -> Event {
         Event::Key {
@@ -1863,6 +1875,60 @@ mod tests {
             .position(|column| column.id == ColumnId::Modified)
             .expect("modified column");
         assert!(created_index < modified_index);
+    }
+
+    #[test]
+    fn refresh_preserving_filter_rebuilds_search_indices_after_sort_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("aaa.txt"), b"a").expect("write a");
+        std::fs::write(dir.path().join("bbb.txt"), b"b").expect("write b");
+        let mut app = FileBrowserApp::new(dir.path().to_path_buf());
+        app.columns.sort = SortDescriptor {
+            column: ColumnId::Name,
+            direction: SortDirection::Asc,
+        };
+        app.refresh();
+        app.in_search = true;
+        app.search_query = "b".to_string();
+        app.refilter();
+        assert_eq!(
+            app.selected_entry().map(|entry| entry.name.as_str()),
+            Some("bbb.txt")
+        );
+
+        app.columns.sort = SortDescriptor {
+            column: ColumnId::Name,
+            direction: SortDirection::Desc,
+        };
+        app.refresh_preserving_filter();
+
+        assert_eq!(
+            app.selected_entry().map(|entry| entry.name.as_str()),
+            Some("bbb.txt"),
+            "search indices must follow the refreshed entry order"
+        );
+    }
+
+    #[test]
+    fn details_columns_keep_enabled_columns_reachable_at_breakpoint_width() {
+        let (mut app, _dir) = make_populated_dir_app();
+        for id in ColumnId::ALL {
+            app.columns.set_column_visible(id, true);
+        }
+        let rect = egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(DETAILS_TABLE_MIN_WIDTH, DETAILS_HEADER_H),
+        );
+        let columns = app.details_columns(rect);
+
+        assert_eq!(columns.len(), ColumnId::ALL.len());
+        for (column, cell) in columns {
+            assert!(
+                cell.width() > 0.0,
+                "{} column should remain reachable",
+                column.id.key()
+            );
+        }
     }
 
     #[test]

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -22,7 +22,7 @@ const INSPECTOR_MIN_WIDTH: f32 = 920.0;
 const DIR_PREVIEW_CAP: usize = 500;
 const DETAILS_HEADER_H: f32 = 28.0;
 const DETAILS_ROW_H: f32 = style::LIST_ROW_H;
-const STATUS_BAR_H: f32 = 28.0;
+const STATUS_BAR_H: f32 = 44.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FileBrowserLayout {
@@ -1166,7 +1166,7 @@ impl App for FileBrowserApp {
                 }
 
                 let mut navigate_to: Option<(PathBuf, bool)> = None;
-                let body_height = (ui.available_height() - STATUS_BAR_H).max(120.0);
+                let body_height = (ui.available_height() - STATUS_BAR_H).max(0.0);
 
                 if layout.shows_inspector() {
                     ui.columns(2, |columns| {

--- a/website/src/content/docs/file-explorer.md
+++ b/website/src/content/docs/file-explorer.md
@@ -22,7 +22,7 @@ Press `⌘E` from any focused terminal pane. The overlay opens over your current
 | Open file / enter directory | `Enter`, `l`, or `→` |
 | Go up one directory | `h`, `Backspace`, or `←` |
 | Search by name | `/` |
-| Toggle sort order | `s` |
+| Toggle recent/name sort | `s` |
 | Refresh listing | `r` |
 | Close | `Escape` |
 
@@ -32,6 +32,10 @@ Files open in the focused terminal pane. Directories are entered in place — th
 
 Press `/` to enter search mode. Type to filter the current directory listing by filename. Press `Escape` to exit search and return to normal navigation, or `Enter` to open the highlighted match.
 
-## Sort Order
+## Details Columns
 
-Press `s` to toggle between recent-first and name sort. The sort persists for the current session.
+Medium and wide panes show a details table. Click a column header to sort by that metadata, click the same header again to reverse direction, drag the header sideways to reorder columns, and drag the right edge of a header to resize it.
+
+The toolbar can show or hide metadata columns for kind, size, modified time, creation time, extension, permissions, and tags. The folders-on-top toggle keeps directories grouped above files. Column widths, visibility, sort order, and the folders-on-top setting persist with the File Explorer pane state.
+
+Press `s` to toggle quickly between recent-first and name sort.


### PR DESCRIPTION
Closes #2136

## Summary

- Adds a File Explorer column model with descriptors for name, kind, size, modified, created, extension, permissions, and tags.
- Wires details-table headers for click sorting, drag resizing, header-drag reordering, visibility toggles, and folders-on-top.
- Persists column order, widths, visibility, sort, and folders-on-top in pane state without a separate file metadata store.

## Done When

Details view supports configurable columns, sortable headers, folders-on-top, persisted widths/visibility, `cargo build` passes, and focused file browser tests cover the sort and persistence behavior.

## Verification

- `cargo test --bin plexi file_browser`
- `cargo build`
