### PR TITLE
refactor(host/agents): move agent state onto pane structs (#2119)

### DIFF
--- a/.stint/tasks/0033-host-agent-state-on-pane-structs.md
+++ b/.stint/tasks/0033-host-agent-state-on-pane-structs.md
@@ -1,14 +1,23 @@
 ---
 id: "0033"
 title: "Host agents: pane-native agent state"
-status: backlog
+status: in-progress
+estimate: "8h"
+started_at: "2026-06-10T22:26:58Z"
 sprint: "s6"
-estimate: 8h
 blocked_by: []
-gh_issue: ["2119"]
-area: ["host/pane-ops", "cli/commands", "agents"]
-tags: ["agents", "host", "state"]
+gh_issue:
+  - "2119"
+area:
+  - "host/pane-ops"
+  - "cli/commands"
+  - "agents"
+tags:
+  - "agents"
+  - "host"
+  - "state"
 ---
+
 
 Move agent state onto pane structs so `pane info`, `pane list`, portals, and orchestration surfaces can read it without a side-channel join.
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -169,6 +169,7 @@ impl PlexiApp {
                         if let Some(pane) = win.panes.get(pane_id) {
                             let focused =
                                 win_idx == active_win && focused_pane_id == Some(*pane_id);
+                            let agent = pane.agent();
                             let info = match pane {
                                 crate::host::pane::Pane::Terminal(t) => {
                                     let cwd =
@@ -182,7 +183,7 @@ impl PlexiApp {
                                         "context_id": win.context_id,
                                         "window_id": win.window_id,
                                         "cwd": cwd,
-                                        "agent": t.agent.as_ref(),
+                                        "agent": agent,
                                     })
                                 }
                                 crate::host::pane::Pane::App(a) => {
@@ -195,7 +196,7 @@ impl PlexiApp {
                                         "window_id": win.window_id,
                                         "cwd": a.workspace_root.to_string_lossy().as_ref(),
                                         "manifest_id": a.manifest_id.clone(),
-                                        "agent": a.agent.as_ref(),
+                                        "agent": agent,
                                     })
                                 }
                                 crate::host::pane::Pane::Portal(p) => {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -103,6 +103,7 @@ impl PlexiApp {
                                 "context_name": context_name,
                                 "window_id": win.window_id,
                                 "cwd": cwd,
+                                "agent": pane.agent(),
                             }));
                         }
                     }
@@ -181,6 +182,7 @@ impl PlexiApp {
                                         "context_id": win.context_id,
                                         "window_id": win.window_id,
                                         "cwd": cwd,
+                                        "agent": t.agent.as_ref(),
                                     })
                                 }
                                 crate::host::pane::Pane::App(a) => {
@@ -193,6 +195,7 @@ impl PlexiApp {
                                         "window_id": win.window_id,
                                         "cwd": a.workspace_root.to_string_lossy().as_ref(),
                                         "manifest_id": a.manifest_id.clone(),
+                                        "agent": a.agent.as_ref(),
                                     })
                                 }
                                 crate::host::pane::Pane::Portal(p) => {
@@ -317,7 +320,6 @@ impl PlexiApp {
                     if before == after {
                         log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
                     }
-                    self.pane_agent_states.remove(pane_id);
                 }
                 crate::app_protocol::AppRequest::SpawnPane {
                     type_id,
@@ -848,20 +850,34 @@ impl PlexiApp {
                     log::info!(
                         "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?}"
                     );
-                    self.pane_agent_states.insert(
-                        *pane_id,
-                        crate::app_protocol::PaneAgentState {
-                            pane_id: *pane_id,
-                            state: state.clone(),
-                            agent: agent.clone(),
-                            session_id: session_id.clone(),
-                        },
-                    );
+                    let mut found = false;
+                    for win in &mut self.windows {
+                        if let Some(pane) = win.panes.get_mut(pane_id) {
+                            found = pane.set_agent(Some(crate::app_protocol::PaneAgentState {
+                                pane_id: *pane_id,
+                                state: state.clone(),
+                                agent: agent.clone(),
+                                session_id: session_id.clone(),
+                            }));
+                            break;
+                        }
+                    }
+                    if found {
+                        log::info!("pane_ipc: set_agent_state: pane_id={pane_id} stored on pane");
+                    } else {
+                        log::warn!(
+                            "pane_ipc: set_agent_state: pane_id={pane_id} not found or not agent-addressable"
+                        );
+                    }
                 }
                 crate::app_protocol::AppRequest::GetAgentStates { response_file } => {
                     log::info!("pane_ipc: kind=get_agent_states response_file={response_file:?}");
-                    let states: Vec<&crate::app_protocol::PaneAgentState> =
-                        self.pane_agent_states.values().collect();
+                    let states: Vec<&crate::app_protocol::PaneAgentState> = self
+                        .windows
+                        .iter()
+                        .flat_map(|win| win.panes.values())
+                        .filter_map(|pane| pane.agent())
+                        .collect();
                     let json_str =
                         serde_json::to_string(&states).unwrap_or_else(|_| "[]".to_string());
                     let temp = format!("{response_file}.tmp");
@@ -1434,7 +1450,6 @@ impl PlexiApp {
         }
 
         for pane_id in panes_to_close {
-            self.pane_agent_states.remove(&pane_id);
             self.close_pane_by_id(pane_id);
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -332,9 +332,6 @@ pub struct PlexiApp {
     /// Only overlay-unsafe side effects are held here; safe commands (ShowNotification,
     /// pipes, queries) are dispatched immediately even during overlay ownership.
     pub(crate) overlay_held_cmds: Vec<crate::app::app_trait::AppCommand>,
-    /// Per-pane agent state reported via hook scripts. Keyed by pane_id.
-    pub(crate) pane_agent_states:
-        std::collections::HashMap<u64, crate::app_protocol::PaneAgentState>,
 }
 
 #[cfg(test)]
@@ -549,6 +546,7 @@ impl PlexiApp {
                                         linked_pane_id: None,
                                         overlay_replaced: None,
                                         hidden: false,
+                                        agent: None,
                                     })));
                             }
                             "secrets_manager" => {
@@ -572,6 +570,7 @@ impl PlexiApp {
                                         linked_pane_id: None,
                                         overlay_replaced: None,
                                         hidden: false,
+                                        agent: None,
                                     })));
                             }
                             other => {
@@ -591,6 +590,7 @@ impl PlexiApp {
                                             linked_pane_id: None,
                                             overlay_replaced: None,
                                             hidden: false,
+                                            agent: None,
                                         })));
                                 }
                             }
@@ -812,7 +812,6 @@ impl PlexiApp {
                     focus_started_at: None,
                     last_system_theme: None,
                     overlay_held_cmds: Vec::new(),
-                    pane_agent_states: std::collections::HashMap::new(),
                 };
                 app.apply_context_transition_effects();
                 return app;
@@ -993,7 +992,6 @@ impl PlexiApp {
             focus_started_at: None,
             last_system_theme: None,
             overlay_held_cmds: Vec::new(),
-            pane_agent_states: std::collections::HashMap::new(),
         };
         app.apply_context_transition_effects();
         app
@@ -1183,7 +1181,6 @@ impl PlexiApp {
                 focus_started_at: None,
                 last_system_theme: None,
                 overlay_held_cmds: Vec::new(),
-                pane_agent_states: std::collections::HashMap::new(),
             },
             pane_ipc_tx,
         )
@@ -1214,6 +1211,7 @@ impl PlexiApp {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         };
 
         let win = &mut self.windows[0];

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -947,6 +947,7 @@ fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
         linked_pane_id: None,
         overlay_replaced: None,
         hidden: false,
+        agent: None,
     }))
 }
 

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -351,6 +351,76 @@ fn get_agent_states_collects_state_from_panes() {
     let _ = std::fs::remove_file(&states_file);
 }
 
+#[test]
+fn overlay_panes_preserve_replaced_pane_agent_state() {
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+
+    h.inject_ipc(crate::app_protocol::AppRequest::SetAgentState {
+        pane_id,
+        state: crate::app_protocol::AgentState::Working,
+        agent: "claude-code".to_string(),
+        session_id: Some("overlay-session".to_string()),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let replaced = h.app.windows[0]
+        .panes
+        .remove(&pane_id)
+        .expect("test pane exists before overlay");
+    let (overlay_app, _draw_tx) = crate::process_app::ProcessApp::new_for_test(
+        pane_id,
+        crate::app::permissions::AppPermissions::builtin(),
+    );
+    h.app.windows[0].panes.insert(
+        pane_id,
+        crate::host::pane::Pane::App(Box::new(crate::host::pane::AppPane {
+            id: pane_id,
+            runtime: crate::host::pane::AppRuntime::Process(Box::new(overlay_app)),
+            workspace_root: std::env::temp_dir(),
+            permissions: crate::app::permissions::AppPermissions::builtin(),
+            manifest_id: "overlay".to_string(),
+            name: "Overlay".to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: Some(Box::new(replaced)),
+            hidden: false,
+            agent: None,
+        })),
+    );
+
+    let states_file = std::env::temp_dir().join("plexi_test_overlay_agent_states_2119.json");
+    h.inject_ipc(crate::app_protocol::AppRequest::GetAgentStates {
+        response_file: states_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let states_json =
+        std::fs::read_to_string(&states_file).expect("GetAgentStates must write response file");
+    let states: Vec<serde_json::Value> = serde_json::from_str(&states_json).expect("valid JSON");
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0]["pane_id"], pane_id);
+    assert_eq!(states[0]["state"], "working");
+    assert_eq!(states[0]["session_id"], "overlay-session");
+
+    let info_file = std::env::temp_dir().join("plexi_test_overlay_pane_info_agent_2119.json");
+    h.inject_ipc(crate::app_protocol::AppRequest::GetPaneInfo {
+        pane_id,
+        response_file: info_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let info_json =
+        std::fs::read_to_string(&info_file).expect("GetPaneInfo must write response file");
+    let info: serde_json::Value = serde_json::from_str(&info_json).expect("valid pane info JSON");
+    assert_eq!(info["agent"]["pane_id"], pane_id);
+    assert_eq!(info["agent"]["state"], "working");
+    assert_eq!(info["agent"]["session_id"], "overlay-session");
+
+    let _ = std::fs::remove_file(&states_file);
+    let _ = std::fs::remove_file(&info_file);
+}
+
 /// #1074: navigate(Down) at the vertical pane boundary jumps to the LAST
 /// window in the workspace list — skipping intermediate windows entirely.
 #[test]

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -158,6 +158,7 @@ fn send_to_pane_searches_all_windows() {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         }
     };
     win1.panes.insert(
@@ -230,6 +231,7 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
         linked_pane_id: None,
         overlay_replaced: None,
         hidden: false,
+        agent: None,
     }));
     h.app.windows[0].panes.insert(orphan_id, orphan_pane);
     assert!(
@@ -265,6 +267,88 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
     }
 
     let _ = std::fs::remove_file(&resp_file);
+}
+
+#[test]
+fn pane_info_and_list_include_agent_state() {
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+
+    h.inject_ipc(crate::app_protocol::AppRequest::SetAgentState {
+        pane_id,
+        state: crate::app_protocol::AgentState::Working,
+        agent: "claude-code".to_string(),
+        session_id: Some("session-33".to_string()),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let info_file = std::env::temp_dir().join("plexi_test_pane_info_agent_2119.json");
+    h.inject_ipc(crate::app_protocol::AppRequest::GetPaneInfo {
+        pane_id,
+        response_file: info_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let info_json =
+        std::fs::read_to_string(&info_file).expect("GetPaneInfo must write response file");
+    let info: serde_json::Value = serde_json::from_str(&info_json).expect("valid pane info JSON");
+    assert_eq!(info["agent"]["pane_id"], pane_id);
+    assert_eq!(info["agent"]["state"], "working");
+    assert_eq!(info["agent"]["agent"], "claude-code");
+    assert_eq!(info["agent"]["session_id"], "session-33");
+
+    let list_file = std::env::temp_dir().join("plexi_test_pane_list_agent_2119.json");
+    h.inject_ipc(crate::app_protocol::AppRequest::ListPanes {
+        response_file: list_file.to_string_lossy().to_string(),
+        context_id: None,
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let list_json =
+        std::fs::read_to_string(&list_file).expect("ListPanes must write response file");
+    let panes: Vec<serde_json::Value> = serde_json::from_str(&list_json).expect("valid JSON");
+    let pane = panes
+        .iter()
+        .find(|pane| pane["id"].as_u64() == Some(pane_id))
+        .expect("pane must be present in pane list");
+    assert_eq!(pane["agent"]["pane_id"], pane_id);
+    assert_eq!(pane["agent"]["state"], "working");
+    assert_eq!(pane["agent"]["agent"], "claude-code");
+    assert_eq!(pane["agent"]["session_id"], "session-33");
+
+    let _ = std::fs::remove_file(&info_file);
+    let _ = std::fs::remove_file(&list_file);
+}
+
+#[test]
+fn get_agent_states_collects_state_from_panes() {
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+
+    h.inject_ipc(crate::app_protocol::AppRequest::SetAgentState {
+        pane_id,
+        state: crate::app_protocol::AgentState::Blocked,
+        agent: "claude-code".to_string(),
+        session_id: None,
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let states_file = std::env::temp_dir().join("plexi_test_agent_states_2119.json");
+    h.inject_ipc(crate::app_protocol::AppRequest::GetAgentStates {
+        response_file: states_file.to_string_lossy().to_string(),
+    });
+    h.app.drain_pane_cmd_channel();
+
+    let states_json =
+        std::fs::read_to_string(&states_file).expect("GetAgentStates must write response file");
+    let states: Vec<serde_json::Value> = serde_json::from_str(&states_json).expect("valid JSON");
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0]["pane_id"], pane_id);
+    assert_eq!(states[0]["state"], "blocked");
+    assert_eq!(states[0]["agent"], "claude-code");
+    assert!(states[0]["session_id"].is_null());
+
+    let _ = std::fs::remove_file(&states_file);
 }
 
 /// #1074: navigate(Down) at the vertical pane boundary jumps to the LAST

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -98,7 +98,10 @@ impl Pane {
     pub fn agent(&self) -> Option<&crate::app_protocol::PaneAgentState> {
         match self {
             Pane::Terminal(t) => t.agent.as_ref(),
-            Pane::App(a) => a.agent.as_ref(),
+            Pane::App(a) => a
+                .agent
+                .as_ref()
+                .or_else(|| a.overlay_replaced.as_deref().and_then(Pane::agent)),
             Pane::Portal(_) => None,
         }
     }
@@ -110,8 +113,12 @@ impl Pane {
                 true
             }
             Pane::App(a) => {
-                a.agent = agent;
-                true
+                if let Some(replaced) = a.overlay_replaced.as_deref_mut() {
+                    replaced.set_agent(agent)
+                } else {
+                    a.agent = agent;
+                    true
+                }
             }
             Pane::Portal(_) => false,
         }

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -95,6 +95,28 @@ impl Pane {
         }
     }
 
+    pub fn agent(&self) -> Option<&crate::app_protocol::PaneAgentState> {
+        match self {
+            Pane::Terminal(t) => t.agent.as_ref(),
+            Pane::App(a) => a.agent.as_ref(),
+            Pane::Portal(_) => None,
+        }
+    }
+
+    pub fn set_agent(&mut self, agent: Option<crate::app_protocol::PaneAgentState>) -> bool {
+        match self {
+            Pane::Terminal(t) => {
+                t.agent = agent;
+                true
+            }
+            Pane::App(a) => {
+                a.agent = agent;
+                true
+            }
+            Pane::Portal(_) => false,
+        }
+    }
+
     /// Returns the target context_id if this is a Portal pane.
     pub fn portal_target(&self) -> Option<u64> {
         match self {
@@ -130,6 +152,7 @@ pub struct TerminalPane {
     pub(crate) outside_workspace_root: Option<PathBuf>,
     /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
     pub hidden: bool,
+    pub agent: Option<crate::app_protocol::PaneAgentState>,
 }
 
 impl TerminalPane {
@@ -160,6 +183,7 @@ impl TerminalPane {
             outside_workspace_checked_at: None,
             outside_workspace_root: None,
             hidden: false,
+            agent: None,
         })
     }
 }
@@ -316,4 +340,5 @@ pub struct AppPane {
     pub overlay_replaced: Option<Box<Pane>>,
     /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
     pub hidden: bool,
+    pub agent: Option<crate::app_protocol::PaneAgentState>,
 }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -253,6 +253,7 @@ mod tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         };
 
         app.windows[0]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -159,6 +159,7 @@ impl PlexiApp {
                 linked_pane_id,
                 overlay_replaced,
                 hidden: false,
+                agent: None,
             }))
         };
 
@@ -285,6 +286,7 @@ impl PlexiApp {
                 linked_pane_id: None,
                 overlay_replaced: None,
                 hidden: false,
+                agent: None,
             })),
         );
         if self.windows[active].focused_pane.is_none() {
@@ -520,6 +522,7 @@ impl PlexiApp {
                 linked_pane_id,
                 overlay_replaced,
                 hidden: false,
+                agent: None,
             }))
         };
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -1945,6 +1945,7 @@ mod move_to_adjacent_window_tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         }))
     }
 
@@ -2079,6 +2080,7 @@ mod pop_pane_to_new_window_tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         }))
     }
 
@@ -2261,6 +2263,7 @@ mod move_to_row_boundary_tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         }))
     }
 
@@ -2467,6 +2470,7 @@ mod context_root_cwd_tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         };
         let tile = app.windows[0].tree.tiles.insert_pane(pane_id);
         app.windows[0].tree.root = Some(tile);
@@ -2594,6 +2598,7 @@ mod navigate_boundary_tests {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         }))
     }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -441,7 +441,7 @@ pub enum AgentState {
     Idle,
 }
 
-/// Per-pane agent state stored in PlexiApp.
+/// Per-pane agent state stored on the pane struct.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaneAgentState {
     pub pane_id: u64,

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -120,6 +120,7 @@ impl HostHarness {
             linked_pane_id: None,
             overlay_replaced: None,
             hidden: false,
+            agent: None,
         };
 
         let win = &mut self.app.windows[0];

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -142,6 +142,7 @@ mod tests {
                 linked_pane_id: None,
                 overlay_replaced: None,
                 hidden: false,
+                agent: None,
             };
             let win = &mut app.windows[app.active_window];
             win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));


### PR DESCRIPTION
Closes #2119

## Summary

- Moves `PaneAgentState` from the `PlexiApp` side-channel map onto `TerminalPane` and `AppPane`.
- Adds `agent` to `pane info` and `pane list --json` responses while keeping `plexi agent status` backed by the same data.
- Covers the pane metadata and agent status paths with HostHarness regression tests.

## Done When

- `plexi pane info <id>` JSON includes `agent` for panes.
- `plexi pane list --json` includes `agent` on each entry.
- `plexi agent status` still works through pane-collected state.
- `cargo test --bin plexi` is green.

## Verification

- `cargo build`
- `cargo test --bin plexi`