### PR TITLE
feat(cli): add non-blocking choice notifications for validation handoffs (#2151)

### DIFF
--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -242,7 +242,7 @@ VALIDATION_STATE="/tmp/plexi-validate-${PLEXI_PANE_ID:-unknown}.env"
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 # Route reply to PM pane if PM dispatched this skill, otherwise this pane
 REPLY_PANE="${PM_PANE_ID:-$PLEXI_PANE_ID}"
-plexi notify --no-wait \
+plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} notify --no-wait \
   --title "PR #<n> quality checks done (attempt $((ATTEMPT_COUNT+1))/3)" \
   --body "<title>. Review the [TESTING] block, then reply pass/fail/modify." \
   --choice "talk:Talk to Claude:pane_focus:$REPLY_PANE"

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -223,7 +223,7 @@ Reply: "pass" | "fail: <description>" | "modify: <bounded change>"
 
 After printing the testing block in the final response, send a best-effort notification. The notification is only an attention cue; the testing block is the source of truth.
 
-Until `plexi notify --no-wait` is available, do not use `plexi notify --choice` in this handoff path. A blocking choice notification keeps the agent process alive and can corrupt the final validation handoff. Use a plain fire-and-forget notification instead:
+Use a non-blocking choice notification so the user can focus the reply pane without leaving the agent process blocked on a response file:
 ```bash
 # Persist enough state for a later user reply to survive context compaction.
 ALPHA_ROOT=$(git worktree list --porcelain | awk '
@@ -242,13 +242,6 @@ VALIDATION_STATE="/tmp/plexi-validate-${PLEXI_PANE_ID:-unknown}.env"
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 # Route reply to PM pane if PM dispatched this skill, otherwise this pane
 REPLY_PANE="${PM_PANE_ID:-$PLEXI_PANE_ID}"
-plexi notify \
-  --title "PR #<n> quality checks done (attempt $((ATTEMPT_COUNT+1))/3)" \
-  --body "<title>. Review the [TESTING] block in pane $REPLY_PANE, then reply pass/fail/modify."
-```
-
-After `plexi notify --no-wait` lands, use this non-blocking choice notification:
-```bash
 plexi notify --no-wait \
   --title "PR #<n> quality checks done (attempt $((ATTEMPT_COUNT+1))/3)" \
   --body "<title>. Review the [TESTING] block, then reply pass/fail/modify." \

--- a/.stint/tasks/0147-cli-nonblocking-choice-notifications.md
+++ b/.stint/tasks/0147-cli-nonblocking-choice-notifications.md
@@ -1,14 +1,24 @@
 ---
 id: "0147"
 title: "CLI: non-blocking choice notifications for validation handoffs"
-status: backlog
+status: in-progress
+estimate: "4h"
+started_at: "2026-06-10T23:48:39Z"
 sprint: "s6"
-estimate: 4h
 blocked_by: []
-gh_issue: ["2151"]
-area: ["host/notifications", "cli/commands", "infra/skills"]
-tags: ["v1", "workflow", "dispatch", "validation"]
+gh_issue:
+  - "2151"
+area:
+  - "host/notifications"
+  - "cli/commands"
+  - "infra/skills"
+tags:
+  - "v1"
+  - "workflow"
+  - "dispatch"
+  - "validation"
 ---
+
 
 Add a `plexi notify --no-wait` path so choice notifications can run host actions like `pane_focus:<id>` without keeping the sender process blocked on a response file.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -129,6 +129,9 @@ pub enum Commands {
         /// Repeatable. The host runs this even after the process that sent the notification has exited.
         #[arg(long = "host-action")]
         host_actions: Vec<String>,
+        /// Queue choice buttons without waiting for a selected value
+        #[arg(long)]
+        no_wait: bool,
         /// How many seconds before the notification disappears (0 = stays until dismissed)
         #[arg(long, default_value = "0")]
         timeout: u64,

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -3,6 +3,7 @@ pub fn notify_cli(
     body: &str,
     level: &str,
     choices: &[(String, String, Option<String>)],
+    wait_for_response: bool,
     timeout_secs: u64,
     scope: Option<crate::app_protocol::NotifyScope>,
 ) -> i32 {
@@ -27,14 +28,19 @@ pub fn notify_cli(
         })
         .collect();
 
-    let (kind, response_file_str) = if choices.is_empty() {
-        ("message".to_string(), None)
+    let kind = if choices.is_empty() {
+        "message".to_string()
     } else {
+        "choice".to_string()
+    };
+    let response_file_str = if !choices.is_empty() && wait_for_response {
         let rf = crate::config::config_dir()
             .join(format!("notify-response-{id}.txt"))
             .to_string_lossy()
             .into_owned();
-        ("choice".to_string(), Some(rf))
+        Some(rf)
+    } else {
+        None
     };
 
     let mut payload = serde_json::json!({
@@ -59,8 +65,9 @@ pub fn notify_cli(
     }
 
     log::info!(
-        "notify:cli: sending via socket choices={} scope={:?} response_file={:?}",
+        "notify:cli: sending via socket choices={} wait_for_response={} scope={:?} response_file={:?}",
         choices.len(),
+        wait_for_response,
         scope,
         response_file_str
     );
@@ -83,7 +90,9 @@ pub fn notify_cli(
     // Fire-and-forget path — command is delivered, nothing to wait for.
     let Some(response_file) = response_file_str else {
         if timeout_secs > 0 {
-            eprintln!("warning: --timeout has no effect without --choice (notification queued without auto-dismiss)");
+            eprintln!(
+                "warning: --timeout only limits waiting for a choice response; notification queued"
+            );
         }
         println!("notification queued");
         return 0;
@@ -127,13 +136,112 @@ pub fn notify_cli(
 mod notify_tests {
     use super::notify_cli;
     use crate::cli::parse_notify_choice;
+    use serde_json::Value;
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::net::UnixListener;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn capture_notify_payload<F>(run_cli: F) -> (i32, Value)
+    where
+        F: FnOnce() -> i32,
+    {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("notify.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind notify socket");
+        std::env::set_var("PLEXI_SOCKET", &socket_path);
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept notify connection");
+            let mut line = String::new();
+            BufReader::new(stream)
+                .read_line(&mut line)
+                .expect("read notify payload");
+            serde_json::from_str::<Value>(&line).expect("notify payload json")
+        });
+
+        let code = run_cli();
+        std::env::remove_var("PLEXI_SOCKET");
+        let payload = handle.join().expect("payload thread");
+        (code, payload)
+    }
 
     /// Without PLEXI_SOCKET set, notify_cli must fail fast (exit 1) rather than panic.
     #[test]
     fn notify_cli_no_socket_returns_one() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var("PLEXI_SOCKET");
-        let code = notify_cli("Test title", "Test body", "info", &[], 0, None);
+        let code = notify_cli("Test title", "Test body", "info", &[], true, 0, None);
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn notify_cli_nonblocking_choice_omits_response_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let choices = vec![(
+            "talk".to_string(),
+            "Talk to Claude".to_string(),
+            Some("pane_focus:188".to_string()),
+        )];
+
+        let (code, payload) = capture_notify_payload(|| {
+            notify_cli("Ready", "Review tests", "info", &choices, false, 0, None)
+        });
+
+        assert_eq!(code, 0);
+        assert_eq!(payload["kind"], "choice");
+        assert!(
+            payload.get("response_file").is_none(),
+            "non-blocking choice must not create a response file: {payload}"
+        );
+        assert_eq!(payload["options"][0]["value"], "talk");
+        assert_eq!(payload["options"][0]["label"], "Talk to Claude");
+        assert_eq!(payload["options"][0]["host_action"], "pane_focus:188");
+    }
+
+    #[test]
+    fn notify_cli_blocking_choice_sends_response_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("notify.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind notify socket");
+        std::env::set_var("PLEXI_SOCKET", &socket_path);
+        std::env::set_var("PLEXI_CHANNEL", "notify-test");
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept notify connection");
+            let mut line = String::new();
+            BufReader::new(stream)
+                .read_line(&mut line)
+                .expect("read notify payload");
+            let payload: Value = serde_json::from_str(&line).expect("notify payload json");
+            let response_file = payload["response_file"]
+                .as_str()
+                .expect("blocking choice response_file")
+                .to_string();
+            std::fs::create_dir_all(
+                std::path::Path::new(&response_file)
+                    .parent()
+                    .expect("response file parent"),
+            )
+            .expect("create response dir");
+            std::fs::write(&response_file, "talk").expect("write response");
+            payload
+        });
+
+        let choices = vec![("talk".to_string(), "Talk to Claude".to_string(), None)];
+        let code = notify_cli("Ready", "Review tests", "info", &choices, true, 1, None);
+        std::env::remove_var("PLEXI_SOCKET");
+        std::env::remove_var("PLEXI_CHANNEL");
+        let payload = handle.join().expect("payload thread");
+
+        assert_eq!(code, 0);
+        assert_eq!(payload["kind"], "choice");
+        assert!(
+            payload["response_file"].as_str().is_some(),
+            "blocking choice must include a response file: {payload}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,6 +520,7 @@ fn main() -> eframe::Result {
                         level,
                         choices,
                         host_actions,
+                        no_wait,
                         timeout,
                         scope,
                     } => {
@@ -599,6 +600,7 @@ fn main() -> eframe::Result {
                             &body,
                             &level,
                             &parsed_choices,
+                            !no_wait,
                             timeout,
                             parsed_scope,
                         ));


### PR DESCRIPTION
Closes #2151

## Summary

- Adds `plexi notify --no-wait` so choice notifications can be queued without a response file.
- Preserves the default blocking `--choice` path for scripts that need a selected value.
- Updates validate-pr handoff instructions to use the non-blocking Talk to Claude notification.

## Done When

- [x] `plexi notify --choice "talk:Talk to Claude:pane_focus:<pane>" --no-wait` exits immediately after queuing the notification.
- [x] Clicking `Talk to Claude` focuses the target pane.
- [x] Existing blocking `plexi notify --choice ...` still prints the selected value and exits only after a choice or timeout.
- [x] `validate-pr` uses the non-blocking notification path and still surfaces the official `[TESTING]` block as the final handoff.
- [x] `cargo build` passes.
- [x] Focused tests cover blocking choices, non-blocking choices, and host-action delivery without a response file.

## Verification

- `cargo test --bin plexi notify_tests`
- `cargo build`