### PR TITLE
fix(apps/stats): overhaul UI and ignore idle focus segments (#2144)

### DIFF
--- a/.stint/tasks/0048-app-refresh-stats-idle-aware-overhaul.md
+++ b/.stint/tasks/0048-app-refresh-stats-idle-aware-overhaul.md
@@ -1,9 +1,11 @@
 ---
 id: "0048"
 title: "App refresh: Stats idle-aware overhaul"
-status: in-progress
+status: done
 estimate: "8h"
+actual: "8m"
 started_at: "2026-06-10T23:58:36Z"
+completed_at: "2026-06-11T00:06:06Z"
 sprint: "s7"
 blocked_by: []
 gh_issue:
@@ -19,6 +21,7 @@ tags:
 ---
 
 
+
 Refresh the Stats app UI and make its time calculations ignore or clamp idle focus segments caused by leaving a pane open while away.
 
 Use the 15-minute pane-switch heuristic from issue #2144: if no pane switch happens for at least 15 minutes, truncate that stale segment to 1 minute and ignore further stale time until pane switches resume faster than the 15-minute window.
@@ -31,3 +34,7 @@ Stats should report active use, not passive focus ownership. Fake multi-hour pan
 
 - `focus_changed.duration_secs` is focus ownership, not proof of user activity.
 - Do not add new global activity monitoring for this task; use the existing focus event `reason` and duration fields unless implementation proves they are insufficient.
+
+## Variance
+
+Completed under estimate because the fix stayed local to the existing Stats app: host focus events already carried the needed `reason` and `duration_secs` fields, so no host event schema or activity-monitoring work was required.

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -22,6 +22,8 @@ STATS_BAR_H = 34.0
 TIMELINE_H = 50.0
 MIN_CELL_W = 60.0
 MIN_CELL_H = 40.0
+IDLE_THRESHOLD_SECS = 15 * 60
+IDLE_CLAMP_SECS = 60
 HOME = str(Path.home())
 UNKNOWN_CONTEXT = "Unknown"
 
@@ -101,6 +103,80 @@ def _fmt_duration(secs: float) -> str:
     if h > 0:
         return f"{h}h {m:02d}m"
     return f"{m}m"
+
+
+def _event_duration(ev: dict, key: str = "duration_secs") -> float:
+    try:
+        return max(0.0, float(ev.get(key, 0) or 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _event_ts(ev: dict) -> datetime:
+    ts = ev.get("_ts")
+    if isinstance(ts, datetime):
+        return ts
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _normalize_focus_events(events: list[dict]) -> tuple[list[dict], dict[str, float | int]]:
+    normalized: list[dict] = []
+    stats: dict[str, float | int] = {
+        "raw_secs": 0.0,
+        "counted_secs": 0.0,
+        "clamped_secs": 0.0,
+        "skipped_secs": 0.0,
+        "counted_events": 0,
+        "clamped_events": 0,
+        "skipped_events": 0,
+    }
+    idle_stream = False
+
+    for ev in sorted(events, key=_event_ts):
+        raw = _event_duration(ev)
+        reason = ev.get("reason") or ""
+        counted = raw
+        idle_state = "active"
+        clamped = 0.0
+        skipped = 0.0
+
+        if reason == "pane_switch" and raw < IDLE_THRESHOLD_SECS:
+            idle_stream = False
+        elif raw >= IDLE_THRESHOLD_SECS:
+            if idle_stream:
+                counted = 0.0
+                skipped = raw
+                idle_state = "skipped"
+            else:
+                counted = min(raw, float(IDLE_CLAMP_SECS))
+                clamped = max(0.0, raw - counted)
+                idle_state = "clamped"
+                idle_stream = True
+        elif idle_stream and reason != "pane_switch":
+            counted = 0.0
+            skipped = raw
+            idle_state = "skipped"
+
+        normalized_ev = dict(ev)
+        normalized_ev["_raw_duration_secs"] = raw
+        normalized_ev["_clamped_secs"] = clamped
+        normalized_ev["_skipped_secs"] = skipped
+        normalized_ev["_idle_state"] = idle_state
+        normalized_ev["duration_secs"] = counted
+        normalized.append(normalized_ev)
+
+        stats["raw_secs"] = float(stats["raw_secs"]) + raw
+        stats["counted_secs"] = float(stats["counted_secs"]) + counted
+        stats["clamped_secs"] = float(stats["clamped_secs"]) + clamped
+        stats["skipped_secs"] = float(stats["skipped_secs"]) + skipped
+        if counted > 0:
+            stats["counted_events"] = int(stats["counted_events"]) + 1
+        if clamped > 0:
+            stats["clamped_events"] = int(stats["clamped_events"]) + 1
+        if skipped > 0:
+            stats["skipped_events"] = int(stats["skipped_events"]) + 1
+
+    return normalized, stats
 
 
 def _resolve_events_path() -> Path | None:
@@ -385,16 +461,28 @@ class _StatsCanvas(Component):
                  color=dim(ctx.theme.muted, 60), width=1.0)
 
         stats_text_y = stats_y + (STATS_BAR_H - TEXT_CAPTION) / 2
-        third = w / 3
-        ctx.text(x + third * 0.5, stats_text_y,
-                 f"{_fmt_duration(app.total_time)} active",
+        quarter = w / 4
+        compact = w < 620
+        active_label = f"{_fmt_duration(app.total_time)} {'act' if compact else 'active'}"
+        idle_label = f"{_fmt_duration(app.idle_skipped_time)} {'idle' if compact else 'idle skipped'}"
+        clamped_label = f"{_fmt_duration(app.idle_clamped_time)} {'clamp' if compact else 'clamped'}"
+        visits_label = (
+            f"{app.total_visits}v · {app.total_projects}p"
+            if compact
+            else f"{app.total_visits} visits · {app.total_projects} projects"
+        )
+        ctx.text(x + quarter * 0.5, stats_text_y,
+                 active_label,
                  size=TEXT_CAPTION, color=ctx.theme.accent, bold=True, align="center")
-        ctx.text(x + third * 1.5, stats_text_y,
-                 f"{app.total_visits} visits",
-                 size=TEXT_CAPTION, color=ctx.theme.success, bold=True, align="center")
-        ctx.text(x + third * 2.5, stats_text_y,
-                 f"{app.total_projects} projects",
+        ctx.text(x + quarter * 1.5, stats_text_y,
+                 idle_label,
+                 size=TEXT_CAPTION, color=ctx.theme.muted, bold=True, align="center")
+        ctx.text(x + quarter * 2.5, stats_text_y,
+                 clamped_label,
                  size=TEXT_CAPTION, color=ctx.theme.warning, bold=True, align="center")
+        ctx.text(x + quarter * 3.5, stats_text_y,
+                 visits_label,
+                 size=TEXT_CAPTION, color=ctx.theme.success, bold=True, align="center")
 
         # timeline strip
         tl_y = stats_y + STATS_BAR_H
@@ -402,7 +490,16 @@ class _StatsCanvas(Component):
 
         bar_y = tl_y + 4
         bar_h = TIMELINE_H - 20
-        for start_frac, end_frac, _, _, color_idx in app.timeline:
+        idle_y = bar_y + bar_h * 0.58
+        idle_h = max(4.0, bar_h * 0.32)
+        for raw_start, raw_end, start_frac, end_frac, _, _, color_idx, state in app.timeline:
+            if state in {"clamped", "skipped"} and raw_end > raw_start:
+                bx = x + raw_start * w
+                bw = max(2.0, (raw_end - raw_start) * w)
+                fill = ctx.theme.warning if state == "clamped" else ctx.theme.muted
+                ctx.rect(bx, idle_y, bw, idle_h, fill=dim(fill, 90), radius=2.0)
+            if end_frac <= start_frac:
+                continue
             bx = x + start_frac * w
             bw = max(2.0, (end_frac - start_frac) * w)
             color = PALETTE[color_idx % len(PALETTE)]
@@ -439,8 +536,11 @@ class StatsApp(App):
         self.view_root: TreeNode | None = None
         self.view_stack: list[TreeNode] = []
         self.cells: list[tuple[TreeNode, float, float, float, float]] = []
-        self.timeline: list[tuple[float, float, str, str, int]] = []
+        self.timeline: list[tuple[float, float, float, float, str, str, int, str]] = []
         self.total_time = 0.0
+        self.raw_time = 0.0
+        self.idle_skipped_time = 0.0
+        self.idle_clamped_time = 0.0
         self.total_visits = 0
         self.total_projects = 0
         self.events_path: Path | None = None
@@ -459,20 +559,37 @@ class StatsApp(App):
             self.view_stack = []
             self.timeline = []
             self.total_time = 0.0
+            self.raw_time = 0.0
+            self.idle_skipped_time = 0.0
+            self.idle_clamped_time = 0.0
             self.total_visits = 0
             self.total_projects = 0
             return
 
         events = _parse_events(self.events_path)
         self.emit.info(f"stats: loaded {len(events)} focus events from {self.events_path}")
+        normalized_events, idle_stats = _normalize_focus_events(events)
+        counted_events = [ev for ev in normalized_events if _event_duration(ev) > 0]
+        self.emit.info(
+            "stats: normalized focus events "
+            f"raw={len(events)} counted={idle_stats['counted_events']} "
+            f"clamped={idle_stats['clamped_events']} skipped={idle_stats['skipped_events']} "
+            f"raw_secs={idle_stats['raw_secs']:.0f} "
+            f"counted_secs={idle_stats['counted_secs']:.0f} "
+            f"clamped_secs={idle_stats['clamped_secs']:.0f} "
+            f"skipped_secs={idle_stats['skipped_secs']:.0f}"
+        )
 
-        self.root = _build_tree(events)
+        self.root = _build_tree(counted_events)
         self.view_root = self.root
         self.view_stack = []
 
-        self.total_time = sum(ev.get("duration_secs", 0) for ev in events)
-        self.total_visits = len(events)
-        self.total_projects = len({_event_context_identity(ev)[0] for ev in events})
+        self.total_time = float(idle_stats["counted_secs"])
+        self.raw_time = float(idle_stats["raw_secs"])
+        self.idle_clamped_time = float(idle_stats["clamped_secs"])
+        self.idle_skipped_time = float(idle_stats["skipped_secs"])
+        self.total_visits = int(idle_stats["counted_events"])
+        self.total_projects = len({_event_context_identity(ev)[0] for ev in counted_events})
 
         now = datetime.now(timezone.utc)
         start_window = now - timedelta(hours=24)
@@ -480,25 +597,39 @@ class StatsApp(App):
         context_colors = {}
         if self.root:
             context_colors = {child.path: i for i, child in enumerate(self.root.children)}
-        for ev in events:
+        for ev in normalized_events:
             ts = ev["_ts"]
-            dur = ev.get("duration_secs", 0)
+            dur = _event_duration(ev)
+            raw_dur = _event_duration(ev, "_raw_duration_secs")
             cwd = _clean_text(ev.get("cwd")) or ""
             context_path, _ = _event_context_identity(ev)
             end_frac = (ts - start_window).total_seconds() / 86400.0
             start_frac = ((ts - timedelta(seconds=dur)) - start_window).total_seconds() / 86400.0
+            raw_start_frac = ((ts - timedelta(seconds=raw_dur)) - start_window).total_seconds() / 86400.0
+            raw_end_frac = end_frac
             start_frac = max(0.0, min(1.0, start_frac))
             end_frac = max(0.0, min(1.0, end_frac))
+            raw_start_frac = max(0.0, min(1.0, raw_start_frac))
+            raw_end_frac = max(0.0, min(1.0, raw_end_frac))
             color_idx = context_colors.get(context_path, 0)
-            self.timeline.append((start_frac, end_frac, context_path, cwd, color_idx))
+            self.timeline.append((
+                raw_start_frac,
+                raw_end_frac,
+                start_frac,
+                end_frac,
+                context_path,
+                cwd,
+                color_idx,
+                str(ev.get("_idle_state") or "active"),
+            ))
 
         self.emit.status_summary(f"{_fmt_duration(self.total_time)} active")
 
     def on_render(self, ctx) -> None:
         subtitle = (
             f"{_fmt_duration(self.total_time)} active · "
-            f"{self.total_visits} visits · "
-            f"{self.total_projects} projects"
+            f"{_fmt_duration(self.idle_skipped_time)} idle skipped · "
+            f"{self.total_visits} visits"
         )
         ctx.render(Column(
             [
@@ -544,7 +675,9 @@ class StatsApp(App):
             bar_h = TIMELINE_H - 20
             if bar_local_y <= local_y <= bar_local_y + bar_h:
                 frac = x / w if w > 0 else 0
-                for start_frac, end_frac, context_path, cwd, _ in self.timeline:
+                for _, _, start_frac, end_frac, context_path, cwd, _, state in self.timeline:
+                    if state == "skipped":
+                        continue
                     if start_frac <= frac <= end_frac:
                         if self.view_root and self.view_root.path == context_path and cwd:
                             self.highlight_path = cwd

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -179,6 +179,28 @@ def _normalize_focus_events(events: list[dict]) -> tuple[list[dict], dict[str, f
     return normalized, stats
 
 
+def _timeline_fractions(
+    ts: datetime,
+    counted_secs: float,
+    raw_secs: float,
+    idle_state: str,
+    start_window: datetime,
+) -> tuple[float, float, float, float]:
+    raw_start = ts - timedelta(seconds=raw_secs)
+    raw_end = ts
+    if idle_state == "clamped":
+        counted_start = raw_start
+        counted_end = raw_start + timedelta(seconds=counted_secs)
+    else:
+        counted_start = ts - timedelta(seconds=counted_secs)
+        counted_end = ts
+
+    def frac(moment: datetime) -> float:
+        return max(0.0, min(1.0, (moment - start_window).total_seconds() / 86400.0))
+
+    return frac(raw_start), frac(raw_end), frac(counted_start), frac(counted_end)
+
+
 def _resolve_events_path() -> Path | None:
     sock = os.environ.get("PLEXI_SOCKET", "")
     if sock:
@@ -603,14 +625,14 @@ class StatsApp(App):
             raw_dur = _event_duration(ev, "_raw_duration_secs")
             cwd = _clean_text(ev.get("cwd")) or ""
             context_path, _ = _event_context_identity(ev)
-            end_frac = (ts - start_window).total_seconds() / 86400.0
-            start_frac = ((ts - timedelta(seconds=dur)) - start_window).total_seconds() / 86400.0
-            raw_start_frac = ((ts - timedelta(seconds=raw_dur)) - start_window).total_seconds() / 86400.0
-            raw_end_frac = end_frac
-            start_frac = max(0.0, min(1.0, start_frac))
-            end_frac = max(0.0, min(1.0, end_frac))
-            raw_start_frac = max(0.0, min(1.0, raw_start_frac))
-            raw_end_frac = max(0.0, min(1.0, raw_end_frac))
+            idle_state = str(ev.get("_idle_state") or "active")
+            raw_start_frac, raw_end_frac, start_frac, end_frac = _timeline_fractions(
+                ts,
+                dur,
+                raw_dur,
+                idle_state,
+                start_window,
+            )
             color_idx = context_colors.get(context_path, 0)
             self.timeline.append((
                 raw_start_frac,
@@ -620,7 +642,7 @@ class StatsApp(App):
                 context_path,
                 cwd,
                 color_idx,
-                str(ev.get("_idle_state") or "active"),
+                idle_state,
             ))
 
         self.emit.status_summary(f"{_fmt_duration(self.total_time)} active")

--- a/apps/stats/tests/test_idle_normalization.py
+++ b/apps/stats/tests/test_idle_normalization.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "sdk", "python"),
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from stats import _normalize_focus_events  # noqa: E402
+
+
+def _event(duration: int, reason: str, pane_id: int = 1) -> dict:
+    return {
+        "kind": "focus_changed",
+        "timestamp": datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc).isoformat(),
+        "_ts": datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc),
+        "duration_secs": duration,
+        "reason": reason,
+        "pane_id": pane_id,
+        "context_name": "PLEXI",
+        "context_root": "/Users/ianburke/Documents/GitHub/PLEXI",
+        "cwd": "/Users/ianburke/Documents/GitHub/PLEXI",
+    }
+
+
+def test_idle_normalization_clamps_first_stale_segment_and_skips_until_switch():
+    events = [
+        _event(120, "pane_switch"),
+        _event(1800, "heartbeat"),
+        _event(900, "heartbeat"),
+        _event(300, "shutdown"),
+        _event(240, "pane_switch", pane_id=2),
+    ]
+
+    normalized, stats = _normalize_focus_events(events)
+
+    assert [ev["duration_secs"] for ev in normalized] == [120, 60, 0, 0, 240]
+    assert [ev["_idle_state"] for ev in normalized] == [
+        "active",
+        "clamped",
+        "skipped",
+        "skipped",
+        "active",
+    ]
+    assert stats["raw_secs"] == 3360
+    assert stats["counted_secs"] == 420
+    assert stats["clamped_secs"] == 1740
+    assert stats["skipped_secs"] == 1200
+    assert stats["counted_events"] == 3
+    assert stats["clamped_events"] == 1
+    assert stats["skipped_events"] == 2
+
+
+def test_idle_normalization_keeps_short_active_sessions():
+    events = [
+        _event(60, "pane_switch"),
+        _event(300, "heartbeat"),
+        _event(480, "shutdown"),
+    ]
+
+    normalized, stats = _normalize_focus_events(events)
+
+    assert [ev["duration_secs"] for ev in normalized] == [60, 300, 480]
+    assert [ev["_idle_state"] for ev in normalized] == ["active", "active", "active"]
+    assert stats["raw_secs"] == 840
+    assert stats["counted_secs"] == 840
+    assert stats["clamped_secs"] == 0
+    assert stats["skipped_secs"] == 0

--- a/apps/stats/tests/test_idle_normalization.py
+++ b/apps/stats/tests/test_idle_normalization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 sys.path.insert(
@@ -11,7 +11,7 @@ sys.path.insert(
 )
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from stats import _normalize_focus_events  # noqa: E402
+from stats import _normalize_focus_events, _timeline_fractions  # noqa: E402
 
 
 def _event(duration: int, reason: str, pane_id: int = 1) -> dict:
@@ -71,3 +71,20 @@ def test_idle_normalization_keeps_short_active_sessions():
     assert stats["counted_secs"] == 840
     assert stats["clamped_secs"] == 0
     assert stats["skipped_secs"] == 0
+
+
+def test_clamped_timeline_counted_slice_starts_at_raw_segment_start():
+    ts = datetime(2026, 6, 10, 12, 30, tzinfo=timezone.utc)
+    window_start = ts - timedelta(hours=12, minutes=30)
+
+    raw_start, raw_end, counted_start, counted_end = _timeline_fractions(
+        ts,
+        counted_secs=60,
+        raw_secs=1800,
+        idle_state="clamped",
+        start_window=window_start,
+    )
+
+    assert abs((raw_end - raw_start) - (1800 / 86400)) < 0.000001
+    assert counted_start == raw_start
+    assert abs((counted_end - counted_start) - (60 / 86400)) < 0.000001


### PR DESCRIPTION
Closes #2144

## Summary

- Adds an idle-aware Stats normalization pass that clamps the first stale focus segment to 60s and skips continuing idle time until short pane switches resume.
- Routes totals, treemap cells, visits, projects, and timeline bars through the normalized focus data so views cannot diverge.
- Refreshes the Stats dashboard counters and timeline to show active, skipped idle, clamped time, visits, and projects.

## Done When

- [x] Leaving a pane focused while away no longer creates a fake multi-hour active block in Stats.
- [x] A stale segment of 15 minutes or more contributes at most 1 minute before subsequent idle time is ignored.
- [x] Counting resumes when pane-switch events return under the 15-minute threshold.
- [x] Stats shows or logs how much time was counted versus skipped/clamped as idle.
- [x] The Stats dashboard has a cleaner, more readable layout with clear active time, idle/skipped time, visits, projects, and timeline sections.
- [x] Existing valid short focus sessions still appear in the correct context/project.
- [x] Headless render validation confirms the refreshed UI is visually usable.

## Validation

- `uv run pytest apps/stats/tests/test_idle_normalization.py -q`
- `cargo build`
- `cargo test --bin plexi`
- `target/debug/plexi app render apps/stats --png --output /tmp/plexi-stats-refresh.png --size 1000x700`
- `target/debug/plexi app render apps/stats --png --output /tmp/plexi-stats-refresh-small.png --size 420x320`

## Note

A broader Python suite run passed the new Stats tests but exposed an existing `apps/backlog/tests/test_text_input.py` failure where no draw command was emitted.