### PR TITLE
feat(apps/github-issues): sorting and label filtering (#2110)

### DIFF
--- a/.stint/tasks/0036-app-refresh-github-issues-filtering-and-sorting.md
+++ b/.stint/tasks/0036-app-refresh-github-issues-filtering-and-sorting.md
@@ -1,9 +1,11 @@
 ---
 id: "0036"
 title: "App refresh: GitHub Issues filtering and sorting"
-status: in-progress
+status: done
 estimate: "6h"
+actual: "6m"
 started_at: "2026-06-11T03:36:22Z"
+completed_at: "2026-06-11T03:41:32Z"
 sprint: "s7"
 blocked_by: []
 gh_issue:
@@ -15,9 +17,12 @@ tags:
   - "app-refresh"
 ---
 
-
 Add label filtering and sort modes to the GitHub Issues app so large issue lists are navigable in-app.
 
 ## Why
 
 The issues app is useful only if it can reduce a large list to the subset the user is actually trying to inspect.
+
+## Variance
+
+Actual was below estimate because the work stayed app-local and did not require host protocol or GitHub backend changes.

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -75,6 +75,7 @@ def _label_color(name: str) -> str:
 
 
 SORT_MODES = ("created_desc", "created_asc", "number_desc", "number_asc")
+ISSUE_LIST_LIMIT = "500"
 
 SORT_LABELS = {
     "created_desc": "created ↓",
@@ -158,7 +159,7 @@ class GhIssues(App):
         rc, out, err = _gh(
             "issue", "list", "--state", "open",
             "--json", "number,title,state,labels,assignees,createdAt",
-            "--limit", "100",
+            "--limit", ISSUE_LIST_LIMIT,
             cwd=self._root or None,
         )
         if rc != 0:
@@ -407,17 +408,12 @@ class GhIssues(App):
     # ── actions ───────────────────────────────────────────────────────────────
 
     def _cycle_sort(self) -> None:
-        issue = self._selected_issue()
-        keep_number = issue.get("number") if issue else None
         self._sort_mode = _next_sort_mode(self._sort_mode)
-        self._select_issue_number(keep_number)
+        self._clamp_selection()
         self.emit.info(f"gh-issues: sort {SORT_LABELS[self._sort_mode]}")
         self.emit.schedule_render()
 
     def _toggle_filter_from_selection(self) -> None:
-        if self._filter_label:
-            self._clear_filter()
-            return
         issue = self._selected_issue()
         if not issue:
             return
@@ -425,8 +421,20 @@ class GhIssues(App):
         if not labels:
             self.emit.info("gh-issues: selected issue has no labels to filter")
             return
-        self._filter_label = labels[0]
-        self._select_issue_number(issue.get("number"))
+        keep_number = issue.get("number")
+        if self._filter_label in labels:
+            idx = labels.index(self._filter_label)
+            if idx == len(labels) - 1:
+                cleared = self._filter_label
+                self._filter_label = None
+                self._select_issue_number(keep_number)
+                self.emit.info(f"gh-issues: cleared filter label:{cleared}")
+                self.emit.schedule_render()
+                return
+            self._filter_label = labels[idx + 1]
+        else:
+            self._filter_label = labels[0]
+        self._select_issue_number(keep_number)
         self.emit.info(f"gh-issues: filter label:{self._filter_label}")
         self.emit.schedule_render()
 

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -6,7 +6,7 @@ Two views:
   - DETAIL: metadata card + scrollable markdown body
 
 Keys: j/k navigate · Enter open detail · Esc back · o open in browser
-      r refresh · n new issue in terminal
+      s sort · f filter · c clear filter · r refresh · n new issue in terminal
 """
 import asyncio
 import json
@@ -74,6 +74,53 @@ def _label_color(name: str) -> str:
     return theme.accent
 
 
+SORT_MODES = ("created_desc", "created_asc", "number_desc", "number_asc")
+
+SORT_LABELS = {
+    "created_desc": "created ↓",
+    "created_asc": "created ↑",
+    "number_desc": "number ↓",
+    "number_asc": "number ↑",
+}
+
+
+def _issue_labels(issue: dict) -> list[str]:
+    return [
+        str(label.get("name", ""))
+        for label in (issue.get("labels") or [])
+        if label and label.get("name")
+    ]
+
+
+def _next_sort_mode(mode: str) -> str:
+    try:
+        idx = SORT_MODES.index(mode)
+    except ValueError:
+        idx = 0
+    return SORT_MODES[(idx + 1) % len(SORT_MODES)]
+
+
+def _sort_key(issue: dict, mode: str) -> tuple:
+    if mode.startswith("number"):
+        return (int(issue.get("number") or 0),)
+    return (str(issue.get("createdAt") or ""), int(issue.get("number") or 0))
+
+
+def _filter_and_sort_issues(
+    issues: list[dict],
+    filter_label: str | None,
+    sort_mode: str,
+) -> list[dict]:
+    visible = list(issues)
+    if filter_label:
+        visible = [
+            issue for issue in visible
+            if any(label == filter_label for label in _issue_labels(issue))
+        ]
+    reverse = sort_mode in ("created_desc", "number_desc")
+    return sorted(visible, key=lambda issue: _sort_key(issue, sort_mode), reverse=reverse)
+
+
 # ── App ───────────────────────────────────────────────────────────────────────
 
 class GhIssues(App):
@@ -91,6 +138,8 @@ class GhIssues(App):
         self._error          : str | None = None
         self._detail         : dict | None = None
         self._root           = self.repo_dir or ""
+        self._filter_label   : str | None = None
+        self._sort_mode      = "created_desc"
         # Stable Scrollable instance — scroll offset persists across renders.
         self._body_scroll    = Scrollable(Label(""))
         self.emit.status_summary("Loading…")
@@ -100,8 +149,9 @@ class GhIssues(App):
     # ── data ──────────────────────────────────────────────────────────────────
 
     def _fetch(self) -> None:
-        self._loading = True
-        self._error   = None
+        self._loading      = True
+        self._error        = None
+        self._filter_label = None
         asyncio.create_task(asyncio.to_thread(self._load_list))
 
     def _load_list(self) -> None:
@@ -119,13 +169,44 @@ class GhIssues(App):
             return
         try:
             self._issues = json.loads(out)
-            self._sel = max(0, min(self._sel, len(self._issues) - 1)) if self._issues else 0
+            self._clamp_selection()
         except Exception as exc:
             self.emit.warn(f"gh issue list json parse error: {exc}")
             self._error = str(exc)
         self._loading = False
         self.emit.info(f"gh-issues loaded {len(self._issues)} open issues")
         self.emit.schedule_render()
+
+    def _visible_issues(self) -> list[dict]:
+        return _filter_and_sort_issues(self._issues, self._filter_label, self._sort_mode)
+
+    def _clamp_selection(self) -> None:
+        visible = self._visible_issues()
+        self._sel = max(0, min(self._sel, len(visible) - 1)) if visible else 0
+
+    def _selected_issue(self) -> dict | None:
+        visible = self._visible_issues()
+        if not visible:
+            return None
+        self._sel = max(0, min(self._sel, len(visible) - 1))
+        return visible[self._sel]
+
+    def _select_issue_number(self, number: int | None) -> None:
+        visible = self._visible_issues()
+        if number is not None:
+            for idx, issue in enumerate(visible):
+                if issue.get("number") == number:
+                    self._sel = idx
+                    return
+        self._clamp_selection()
+
+    def _list_subtitle(self) -> str:
+        count = len(self._visible_issues())
+        parts = [f"{count} open"]
+        if self._filter_label:
+            parts.append(f"label:{self._filter_label}")
+        parts.append(SORT_LABELS.get(self._sort_mode, SORT_LABELS["created_desc"]))
+        return " · ".join(parts)
 
     def _load_detail(self, number: int) -> None:
         rc, out, err = _gh(
@@ -188,12 +269,14 @@ class GhIssues(App):
         # Header: AppBar (title + count). Shortcuts live in a bottom footer.
         appbar = AppBar(
             "Issues",
-            subtitle=f"{len(self._issues)} open" if not self._loading else None,
+            subtitle=self._list_subtitle() if not self._loading else None,
             accent=theme.accent,
         )
         footer = FooterKeys([
-            (["j", "k"], "navigate"),
             ("↩", "detail"),
+            ("s", "sort"),
+            ("f", "filter"),
+            ("c", "clear"),
             ("o", "browser"),
             ("r", "refresh"),
             ("n", "new"),
@@ -217,6 +300,8 @@ class GhIssues(App):
         self._draw_list(ctx, list_top, footer_h)
 
     def _draw_list(self, ctx: RenderContext, list_top: float, footer_h: float) -> None:
+        visible = self._visible_issues()
+        self._clamp_selection()
         rows = [
             ListRow(
                 id=f"issue-{issue['number']}",
@@ -227,7 +312,7 @@ class GhIssues(App):
                     for lbl in (issue.get("labels") or [])[:2]
                 ],
             ).to_dict()
-            for issue in self._issues
+            for issue in visible
         ]
         list_h = max(0.0, ctx.h - list_top - footer_h)
         ctx.list_view("issues", rows, selected=self._sel,
@@ -282,6 +367,12 @@ class GhIssues(App):
         if self._view == self.VIEW_LIST:
             if key == "o":
                 await self._open_browser()
+            elif key == "s":
+                self._cycle_sort()
+            elif key == "f":
+                self._toggle_filter_from_selection()
+            elif key == "c":
+                self._clear_filter()
             elif key == "r":
                 self.emit.info("gh-issues: refresh")
                 self._fetch()
@@ -302,8 +393,9 @@ class GhIssues(App):
 
     def on_list_select(self, _id: str, index: int) -> None:
         self._sel = index
-        if self._issues:
-            self.emit.status_summary(self._issues[self._sel]["title"])
+        issue = self._selected_issue()
+        if issue:
+            self.emit.status_summary(issue["title"])
         self.emit.schedule_render()
 
     def on_list_activate(self, _id: str, _index: int) -> None:
@@ -314,10 +406,45 @@ class GhIssues(App):
 
     # ── actions ───────────────────────────────────────────────────────────────
 
-    def _open_detail(self) -> None:
-        if not self._issues:
+    def _cycle_sort(self) -> None:
+        issue = self._selected_issue()
+        keep_number = issue.get("number") if issue else None
+        self._sort_mode = _next_sort_mode(self._sort_mode)
+        self._select_issue_number(keep_number)
+        self.emit.info(f"gh-issues: sort {SORT_LABELS[self._sort_mode]}")
+        self.emit.schedule_render()
+
+    def _toggle_filter_from_selection(self) -> None:
+        if self._filter_label:
+            self._clear_filter()
             return
-        issue = self._issues[self._sel]
+        issue = self._selected_issue()
+        if not issue:
+            return
+        labels = _issue_labels(issue)
+        if not labels:
+            self.emit.info("gh-issues: selected issue has no labels to filter")
+            return
+        self._filter_label = labels[0]
+        self._select_issue_number(issue.get("number"))
+        self.emit.info(f"gh-issues: filter label:{self._filter_label}")
+        self.emit.schedule_render()
+
+    def _clear_filter(self) -> None:
+        if not self._filter_label:
+            return
+        issue = self._selected_issue()
+        keep_number = issue.get("number") if issue else None
+        cleared = self._filter_label
+        self._filter_label = None
+        self._select_issue_number(keep_number)
+        self.emit.info(f"gh-issues: cleared filter label:{cleared}")
+        self.emit.schedule_render()
+
+    def _open_detail(self) -> None:
+        issue = self._selected_issue()
+        if not issue:
+            return
         self.emit.info(f"gh-issues: open detail #{issue['number']}")
         self._view                      = self.VIEW_DETAIL
         self._detail                    = None
@@ -329,9 +456,10 @@ class GhIssues(App):
         )
 
     async def _open_browser(self) -> None:
-        if not self._issues:
+        issue = self._selected_issue()
+        if not issue:
             return
-        num = self._issues[self._sel]["number"]
+        num = issue["number"]
         rc, _, _ = await asyncio.to_thread(
             _gh, "issue", "view", str(num), "--web", cwd=self._root or None,
         )
@@ -342,4 +470,5 @@ class GhIssues(App):
         self.emit.run_in_terminal("gh issue create")
 
 
-GhIssues().run()
+if __name__ == "__main__":
+    GhIssues().run()

--- a/apps/github-issues/tests/test_filter_sort.py
+++ b/apps/github-issues/tests/test_filter_sort.py
@@ -1,0 +1,94 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SDK = ROOT / "sdk" / "python"
+APP = ROOT / "apps" / "github-issues" / "main.py"
+
+sys.path.insert(0, str(SDK))
+
+
+def _load_app_module():
+    spec = importlib.util.spec_from_file_location("github_issues_app", APP)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _issues():
+    return [
+        {
+            "number": 1,
+            "title": "old bug",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "labels": [{"name": "bug"}],
+        },
+        {
+            "number": 9,
+            "title": "new docs",
+            "createdAt": "2026-03-01T00:00:00Z",
+            "labels": [{"name": "docs"}],
+        },
+        {
+            "number": 5,
+            "title": "middle bug",
+            "createdAt": "2026-02-01T00:00:00Z",
+            "labels": [{"name": "bug"}, {"name": "P1"}],
+        },
+    ]
+
+
+def test_filter_and_sort_defaults_to_newest_created_first():
+    app = _load_app_module()
+
+    visible = app._filter_and_sort_issues(_issues(), None, "created_desc")
+
+    assert [issue["number"] for issue in visible] == [9, 5, 1]
+
+
+def test_filter_and_sort_composes_label_filter_with_number_sort():
+    app = _load_app_module()
+
+    visible = app._filter_and_sort_issues(_issues(), "bug", "number_asc")
+
+    assert [issue["number"] for issue in visible] == [1, 5]
+
+
+def test_sort_cycle_uses_documented_order():
+    app = _load_app_module()
+
+    mode = "created_desc"
+    order = []
+    for _ in range(4):
+        order.append(app.SORT_LABELS[mode])
+        mode = app._next_sort_mode(mode)
+
+    assert order == ["created ↓", "created ↑", "number ↓", "number ↑"]
+
+
+def test_app_filter_and_sort_preserve_selected_issue():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._sel = 1
+    gh._filter_label = None
+    gh._sort_mode = "created_desc"
+
+    gh._cycle_sort()
+
+    assert gh._sort_mode == "created_asc"
+    assert gh._selected_issue()["number"] == 5
+
+    gh._toggle_filter_from_selection()
+
+    assert gh._filter_label == "bug"
+    assert [issue["number"] for issue in gh._visible_issues()] == [1, 5]
+    assert gh._selected_issue()["number"] == 5
+
+    gh._clear_filter()
+
+    assert gh._filter_label is None
+    assert gh._selected_issue()["number"] == 5

--- a/apps/github-issues/tests/test_filter_sort.py
+++ b/apps/github-issues/tests/test_filter_sort.py
@@ -69,7 +69,34 @@ def test_sort_cycle_uses_documented_order():
     assert order == ["created ↓", "created ↑", "number ↓", "number ↑"]
 
 
-def test_app_filter_and_sort_preserve_selected_issue():
+def test_issue_list_limit_is_large_enough_for_active_repos():
+    app = _load_app_module()
+
+    assert app.ISSUE_LIST_LIMIT == "500"
+
+
+def test_app_sort_preserves_selected_index():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._sel = 0
+    gh._filter_label = None
+    gh._sort_mode = "created_desc"
+
+    gh._cycle_sort()
+
+    assert gh._sort_mode == "created_asc"
+    assert gh._sel == 0
+    assert gh._selected_issue()["number"] == 1
+
+    gh._cycle_sort()
+
+    assert gh._sort_mode == "number_desc"
+    assert gh._sel == 0
+    assert gh._selected_issue()["number"] == 9
+
+
+def test_app_filter_cycles_selected_issue_labels_then_clears():
     app = _load_app_module()
     gh = app.GhIssues()
     gh._issues = _issues()
@@ -77,18 +104,19 @@ def test_app_filter_and_sort_preserve_selected_issue():
     gh._filter_label = None
     gh._sort_mode = "created_desc"
 
-    gh._cycle_sort()
+    gh._toggle_filter_from_selection()
 
-    assert gh._sort_mode == "created_asc"
+    assert gh._filter_label == "bug"
+    assert [issue["number"] for issue in gh._visible_issues()] == [5, 1]
     assert gh._selected_issue()["number"] == 5
 
     gh._toggle_filter_from_selection()
 
-    assert gh._filter_label == "bug"
-    assert [issue["number"] for issue in gh._visible_issues()] == [1, 5]
+    assert gh._filter_label == "P1"
+    assert [issue["number"] for issue in gh._visible_issues()] == [5]
     assert gh._selected_issue()["number"] == 5
 
-    gh._clear_filter()
+    gh._toggle_filter_from_selection()
 
     assert gh._filter_label is None
     assert gh._selected_issue()["number"] == 5


### PR DESCRIPTION
Closes #2110

## Summary

- Adds session-local sort modes for created date and issue number.
- Adds label filtering from the selected issue via `f`, plus `c`/`f` clearing.
- Updates the AppBar subtitle/footer hints and adds focused app tests.

## Done When

1. Pressing `s` cycles through sort modes; AppBar subtitle reflects current sort.
2. Pressing `f` filters to a label on the selected issue.
3. Pressing `f` or `c` clears the active filter.
4. Footer no longer shows `j k navigate`; shows `s sort` instead.
5. Filter + sort compose correctly.