### PR TITLE
feat(host/agents): add tool detail to agent state — surface active tool name and input from PreToolUse hook (#2120)

### DIFF
--- a/assets/hooks/claude-code-agent-state.sh
+++ b/assets/hooks/claude-code-agent-state.sh
@@ -14,10 +14,72 @@ fi
 INPUT=$(cat)
 EVENT=$(jq -r '.hook_event_name // empty' <<< "$INPUT" 2>/dev/null || true)
 
+truncate_detail() {
+    local max="$1"
+    local value="$2"
+    if [ "${#value}" -gt "$max" ]; then
+        printf '%s' "${value:0:$max}"
+    else
+        printf '%s' "$value"
+    fi
+}
+
+basename_detail() {
+    local value="$1"
+    if [ -n "$value" ]; then
+        basename "$value"
+    fi
+}
+
+tool_detail() {
+    local tool_name value base
+    tool_name=$(jq -r '.tool_name // empty' <<< "$INPUT" 2>/dev/null || true)
+    case "$tool_name" in
+        Bash)
+            value=$(jq -r '.tool_input.command // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'Bash: %s' "$(truncate_detail 60 "$value")" || printf 'Bash'
+            ;;
+        Edit)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Edit: %s' "$base" || printf 'Edit'
+            ;;
+        Write)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Write: %s' "$base" || printf 'Write'
+            ;;
+        Read)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Read: %s' "$base" || printf 'Read'
+            ;;
+        WebSearch)
+            value=$(jq -r '.tool_input.query // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'WebSearch: %s' "$(truncate_detail 50 "$value")" || printf 'WebSearch'
+            ;;
+        WebFetch)
+            value=$(jq -r '.tool_input.url // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'WebFetch: %s' "$(truncate_detail 60 "$value")" || printf 'WebFetch'
+            ;;
+        Agent)
+            value=$(jq -r '.tool_input.description // .tool_input.prompt // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'Agent: %s' "$(truncate_detail 60 "$value")" || printf 'Agent'
+            ;;
+        "")
+            ;;
+        *)
+            printf '%s' "$tool_name"
+            ;;
+    esac
+}
+
+DETAIL=""
 case "$EVENT" in
+    PreToolUse)                       STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit)    STATE="working" ;;
     PermissionRequest)                STATE="blocked" ;;
-    Stop|StopFailure|SessionEnd)      STATE="idle" ;;
+    PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
     SubagentStop)                     exit 0 ;;  # skip — avoid false idle
     *)                                exit 0 ;;  # unknown event, skip
 esac
@@ -34,6 +96,9 @@ fi
 ARGS=("agent" "report" "--state" "$STATE" "--agent" "claude-code")
 if [ -n "$SESSION_ID" ]; then
     ARGS+=("--session-id" "$SESSION_ID")
+fi
+if [ -n "$DETAIL" ]; then
+    ARGS+=("--detail" "$DETAIL")
 fi
 
 "$BINARY" "${ARGS[@]}" >/dev/null 2>&1 || true

--- a/assets/hooks/claude-code-agent-state.sh
+++ b/assets/hooks/claude-code-agent-state.sh
@@ -79,7 +79,7 @@ case "$EVENT" in
     PreToolUse)                       STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit)    STATE="working" ;;
     PermissionRequest)                STATE="blocked" ;;
-    PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
+    PostToolUse|PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
     SubagentStop)                     exit 0 ;;  # skip — avoid false idle
     *)                                exit 0 ;;  # unknown event, skip
 esac

--- a/assets/hooks/claude-code-agent-state.sh
+++ b/assets/hooks/claude-code-agent-state.sh
@@ -79,7 +79,8 @@ case "$EVENT" in
     PreToolUse)                       STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit)    STATE="working" ;;
     PermissionRequest)                STATE="blocked" ;;
-    PostToolUse|PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
+    PostToolUse|PostToolBatch)          STATE="working" ;;
+    Stop|StopFailure|SessionEnd)        STATE="idle" ;;
     SubagentStop)                     exit 0 ;;  # skip — avoid false idle
     *)                                exit 0 ;;  # unknown event, skip
 esac

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -104,6 +104,9 @@ agent init NAME          Scaffold agent app (ai.query + chat UI). --from-pane-id
 agent add NAME           Install from global registry into workspace.
 agent update NAME        Re-install from registry, preserving memory/logs.
 agent list               List workspace agents.
+agent report             Hook-only state report. --state working|blocked|idle, --agent NAME,
+                         --session-id ID, --detail TEXT.
+agent status             Table of pane agent state. Adds DETAIL when any pane reports it.
 ```
 
 ### workspace, run, routine

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -846,10 +846,11 @@ impl PlexiApp {
                     pane_id,
                     state,
                     agent,
+                    detail,
                     session_id,
                 } => {
                     log::info!(
-                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?}"
+                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?} detail={detail:?}"
                     );
                     let mut found = false;
                     for win in &mut self.windows {
@@ -858,6 +859,7 @@ impl PlexiApp {
                                 pane_id: *pane_id,
                                 state: state.clone(),
                                 agent: agent.clone(),
+                                detail: detail.clone(),
                                 session_id: session_id.clone(),
                             }));
                             break;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -850,7 +850,8 @@ impl PlexiApp {
                     session_id,
                 } => {
                     log::info!(
-                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?} detail={detail:?}"
+                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?} detail_present={}",
+                        detail.is_some()
                     );
                     let mut found = false;
                     for win in &mut self.windows {

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -278,6 +278,7 @@ fn pane_info_and_list_include_agent_state() {
         pane_id,
         state: crate::app_protocol::AgentState::Working,
         agent: "claude-code".to_string(),
+        detail: Some("Bash: cargo test".to_string()),
         session_id: Some("session-33".to_string()),
     });
     h.app.drain_pane_cmd_channel();
@@ -295,6 +296,7 @@ fn pane_info_and_list_include_agent_state() {
     assert_eq!(info["agent"]["pane_id"], pane_id);
     assert_eq!(info["agent"]["state"], "working");
     assert_eq!(info["agent"]["agent"], "claude-code");
+    assert_eq!(info["agent"]["detail"], "Bash: cargo test");
     assert_eq!(info["agent"]["session_id"], "session-33");
 
     let list_file = std::env::temp_dir().join("plexi_test_pane_list_agent_2119.json");
@@ -314,6 +316,7 @@ fn pane_info_and_list_include_agent_state() {
     assert_eq!(pane["agent"]["pane_id"], pane_id);
     assert_eq!(pane["agent"]["state"], "working");
     assert_eq!(pane["agent"]["agent"], "claude-code");
+    assert_eq!(pane["agent"]["detail"], "Bash: cargo test");
     assert_eq!(pane["agent"]["session_id"], "session-33");
 
     let _ = std::fs::remove_file(&info_file);
@@ -329,6 +332,7 @@ fn get_agent_states_collects_state_from_panes() {
         pane_id,
         state: crate::app_protocol::AgentState::Blocked,
         agent: "claude-code".to_string(),
+        detail: None,
         session_id: None,
     });
     h.app.drain_pane_cmd_channel();
@@ -346,6 +350,7 @@ fn get_agent_states_collects_state_from_panes() {
     assert_eq!(states[0]["pane_id"], pane_id);
     assert_eq!(states[0]["state"], "blocked");
     assert_eq!(states[0]["agent"], "claude-code");
+    assert!(states[0]["detail"].is_null());
     assert!(states[0]["session_id"].is_null());
 
     let _ = std::fs::remove_file(&states_file);
@@ -360,6 +365,7 @@ fn overlay_panes_preserve_replaced_pane_agent_state() {
         pane_id,
         state: crate::app_protocol::AgentState::Working,
         agent: "claude-code".to_string(),
+        detail: Some("Edit: main.rs".to_string()),
         session_id: Some("overlay-session".to_string()),
     });
     h.app.drain_pane_cmd_channel();
@@ -401,6 +407,7 @@ fn overlay_panes_preserve_replaced_pane_agent_state() {
     assert_eq!(states.len(), 1);
     assert_eq!(states[0]["pane_id"], pane_id);
     assert_eq!(states[0]["state"], "working");
+    assert_eq!(states[0]["detail"], "Edit: main.rs");
     assert_eq!(states[0]["session_id"], "overlay-session");
 
     let info_file = std::env::temp_dir().join("plexi_test_overlay_pane_info_agent_2119.json");
@@ -415,6 +422,7 @@ fn overlay_panes_preserve_replaced_pane_agent_state() {
     let info: serde_json::Value = serde_json::from_str(&info_json).expect("valid pane info JSON");
     assert_eq!(info["agent"]["pane_id"], pane_id);
     assert_eq!(info["agent"]["state"], "working");
+    assert_eq!(info["agent"]["detail"], "Edit: main.rs");
     assert_eq!(info["agent"]["session_id"], "overlay-session");
 
     let _ = std::fs::remove_file(&states_file);

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -210,8 +210,13 @@ fn install_agent(global_agent_md: &Path, ws_agent_dir: &Path) -> Result<(), Stri
 }
 
 /// `plexi agent report --state <state>` — report agent state to host via socket.
-pub fn agent_report_cli(state: &str, agent: &str, session_id: Option<&str>) -> i32 {
-    log::info!("agent_report:cli: state={state} agent={agent}");
+pub fn agent_report_cli(
+    state: &str,
+    agent: &str,
+    detail: Option<&str>,
+    session_id: Option<&str>,
+) -> i32 {
+    log::info!("agent_report:cli: state={state} agent={agent} detail={detail:?}");
     let normalized = match state.to_lowercase().as_str() {
         "working" => "working",
         "blocked" => "blocked",
@@ -237,6 +242,9 @@ pub fn agent_report_cli(state: &str, agent: &str, session_id: Option<&str>) -> i
         "state": normalized,
         "agent": agent,
     });
+    if let Some(active_tool) = detail.and_then(non_empty_string) {
+        payload["detail"] = serde_json::Value::String(active_tool.to_string());
+    }
     if let Some(sid) = session_id {
         payload["session_id"] = serde_json::Value::String(sid.to_string());
     }
@@ -299,18 +307,45 @@ pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
         println!("No agent states tracked.");
         return 0;
     }
-    println!(
-        "{:<12} {:<16} {:<12} {}",
-        "PANE_ID", "AGENT", "STATE", "SESSION_ID"
-    );
+    let show_detail = filtered
+        .iter()
+        .any(|s| s.get("detail").and_then(|v| v.as_str()).is_some());
+    if show_detail {
+        println!(
+            "{:<12} {:<16} {:<12} {:<20} {}",
+            "PANE_ID", "AGENT", "STATE", "SESSION_ID", "DETAIL"
+        );
+    } else {
+        println!(
+            "{:<12} {:<16} {:<12} {}",
+            "PANE_ID", "AGENT", "STATE", "SESSION_ID"
+        );
+    }
     for s in &filtered {
         let pane_id = s["pane_id"].as_u64().unwrap_or(0);
         let agent = s["agent"].as_str().unwrap_or("unknown");
         let state = s["state"].as_str().unwrap_or("unknown");
         let session_id = s.get("session_id").and_then(|v| v.as_str()).unwrap_or("-");
-        println!("{:<12} {:<16} {:<12} {}", pane_id, agent, state, session_id);
+        if show_detail {
+            let detail = s.get("detail").and_then(|v| v.as_str()).unwrap_or("-");
+            println!(
+                "{:<12} {:<16} {:<12} {:<20} {}",
+                pane_id, agent, state, session_id, detail
+            );
+        } else {
+            println!("{:<12} {:<16} {:<12} {}", pane_id, agent, state, session_id);
+        }
     }
     0
+}
+
+fn non_empty_string(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 /// `plexi agent hook install --claude-code` — write hook script + patch ~/.claude/settings.json.
@@ -342,16 +377,79 @@ if [ -z "${{PLEXI_SOCKET:-}}" ] || [ -z "${{PLEXI_PANE_ID:-}}" ]; then
 fi
 INPUT=$(cat)
 EVENT=$(jq -r '.hook_event_name // empty' <<< "$INPUT" 2>/dev/null || true)
+truncate_detail() {{
+    local max="$1"
+    local value="$2"
+    if [ "${{#value}}" -gt "$max" ]; then
+        printf '%s' "${{value:0:$max}}"
+    else
+        printf '%s' "$value"
+    fi
+}}
+
+basename_detail() {{
+    local value="$1"
+    if [ -n "$value" ]; then
+        basename "$value"
+    fi
+}}
+
+tool_detail() {{
+    local tool_name value base
+    tool_name=$(jq -r '.tool_name // empty' <<< "$INPUT" 2>/dev/null || true)
+    case "$tool_name" in
+        Bash)
+            value=$(jq -r '.tool_input.command // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'Bash: %s' "$(truncate_detail 60 "$value")" || printf 'Bash'
+            ;;
+        Edit)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Edit: %s' "$base" || printf 'Edit'
+            ;;
+        Write)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Write: %s' "$base" || printf 'Write'
+            ;;
+        Read)
+            value=$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$INPUT" 2>/dev/null || true)
+            base=$(basename_detail "$value")
+            [ -n "$base" ] && printf 'Read: %s' "$base" || printf 'Read'
+            ;;
+        WebSearch)
+            value=$(jq -r '.tool_input.query // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'WebSearch: %s' "$(truncate_detail 50 "$value")" || printf 'WebSearch'
+            ;;
+        WebFetch)
+            value=$(jq -r '.tool_input.url // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'WebFetch: %s' "$(truncate_detail 60 "$value")" || printf 'WebFetch'
+            ;;
+        Agent)
+            value=$(jq -r '.tool_input.description // .tool_input.prompt // empty' <<< "$INPUT" 2>/dev/null || true)
+            [ -n "$value" ] && printf 'Agent: %s' "$(truncate_detail 60 "$value")" || printf 'Agent'
+            ;;
+        "")
+            ;;
+        *)
+            printf '%s' "$tool_name"
+            ;;
+    esac
+}}
+
+DETAIL=""
 case "$EVENT" in
+    PreToolUse)                    STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit) STATE="working" ;;
     PermissionRequest)             STATE="blocked" ;;
-    Stop|StopFailure|SessionEnd)   STATE="idle" ;;
+    PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
     SubagentStop)                  exit 0 ;;
     *)                             exit 0 ;;
 esac
 SESSION_ID=$(jq -r '.session_id // empty' <<< "$INPUT" 2>/dev/null || true)
 ARGS=(agent report --state "$STATE" --agent claude-code)
 [ -n "$SESSION_ID" ] && ARGS+=(--session-id "$SESSION_ID")
+[ -n "$DETAIL" ] && ARGS+=(--detail "$DETAIL")
 "{binary}" "${{ARGS[@]}}" >/dev/null 2>&1 || true
 exit 0
 "#
@@ -381,9 +479,11 @@ exit 0
     }
 
     let events = [
+        "PreToolUse",
         "SessionStart",
         "UserPromptSubmit",
         "PermissionRequest",
+        "PostToolBatch",
         "Stop",
         "StopFailure",
         "SessionEnd",
@@ -435,8 +535,9 @@ exit 0
     if code == 0 {
         println!("Hook script: {script_str}");
         println!(
-            "Registered in {} for 6 lifecycle events.",
-            settings_path.display()
+            "Registered in {} for {} lifecycle events.",
+            settings_path.display(),
+            events.len()
         );
     }
     code

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -457,7 +457,8 @@ case "$EVENT" in
     PreToolUse)                    STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit) STATE="working" ;;
     PermissionRequest)             STATE="blocked" ;;
-    PostToolUse|PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
+    PostToolUse|PostToolBatch)       STATE="working" ;;
+    Stop|StopFailure|SessionEnd)     STATE="idle" ;;
     SubagentStop)                  exit 0 ;;
     *)                             exit 0 ;;
 esac

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,5 +1,16 @@
 use std::path::Path;
 
+const CLAUDE_CODE_HOOK_EVENTS: &[&str] = &[
+    "PreToolUse",
+    "SessionStart",
+    "UserPromptSubmit",
+    "PermissionRequest",
+    "PostToolBatch",
+    "Stop",
+    "StopFailure",
+    "SessionEnd",
+];
+
 /// `plexi agent init <name>` — scaffold an agent app with ai.query capability.
 pub fn agent_init(name: &str, from_pane_id: Option<u64>) -> i32 {
     log::info!("agent_init:cli: name={name}");
@@ -216,7 +227,10 @@ pub fn agent_report_cli(
     detail: Option<&str>,
     session_id: Option<&str>,
 ) -> i32 {
-    log::info!("agent_report:cli: state={state} agent={agent} detail={detail:?}");
+    log::info!(
+        "agent_report:cli: state={state} agent={agent} detail_present={}",
+        detail.and_then(non_empty_string).is_some()
+    );
     let normalized = match state.to_lowercase().as_str() {
         "working" => "working",
         "blocked" => "blocked",
@@ -478,18 +492,7 @@ exit 0
         settings["hooks"] = serde_json::json!({});
     }
 
-    let events = [
-        "PreToolUse",
-        "SessionStart",
-        "UserPromptSubmit",
-        "PermissionRequest",
-        "PostToolBatch",
-        "Stop",
-        "StopFailure",
-        "SessionEnd",
-    ];
-
-    for event in &events {
+    for event in CLAUDE_CODE_HOOK_EVENTS {
         let event_hooks = settings["hooks"][*event]
             .as_array()
             .cloned()
@@ -537,7 +540,7 @@ exit 0
         println!(
             "Registered in {} for {} lifecycle events.",
             settings_path.display(),
-            events.len()
+            CLAUDE_CODE_HOOK_EVENTS.len()
         );
     }
     code
@@ -562,18 +565,10 @@ pub fn agent_hook_uninstall_cli(claude_code: bool) -> i32 {
 
     let mut settings = read_claude_settings(&settings_path);
 
-    let events = [
-        "SessionStart",
-        "UserPromptSubmit",
-        "PermissionRequest",
-        "Stop",
-        "StopFailure",
-        "SessionEnd",
-    ];
     let mut removed = 0usize;
 
     if let Some(hooks_map) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
-        for event in &events {
+        for event in CLAUDE_CODE_HOOK_EVENTS {
             if let Some(event_arr) = hooks_map.get_mut(*event).and_then(|v| v.as_array_mut()) {
                 let before = event_arr.len();
                 event_arr.retain(|entry| {

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -5,6 +5,7 @@ const CLAUDE_CODE_HOOK_EVENTS: &[&str] = &[
     "SessionStart",
     "UserPromptSubmit",
     "PermissionRequest",
+    "PostToolUse",
     "PostToolBatch",
     "Stop",
     "StopFailure",
@@ -456,7 +457,7 @@ case "$EVENT" in
     PreToolUse)                    STATE="working"; DETAIL=$(tool_detail) ;;
     SessionStart|UserPromptSubmit) STATE="working" ;;
     PermissionRequest)             STATE="blocked" ;;
-    PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
+    PostToolUse|PostToolBatch|Stop|StopFailure|SessionEnd) STATE="idle" ;;
     SubagentStop)                  exit 0 ;;
     *)                             exit 0 ;;
 esac

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -929,7 +929,7 @@ pub enum AgentCmd {
 pub enum HookAction {
     /// Install the PLEXI hook script into ~/.claude/settings.json.
     Install {
-        /// Install Claude Code hooks (SessionStart, UserPromptSubmit, PermissionRequest, Stop, StopFailure, SessionEnd)
+        /// Install Claude Code hooks (PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, PermissionRequest, Stop, StopFailure, SessionEnd)
         #[arg(long = "claude-code")]
         claude_code: bool,
     },

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -885,6 +885,9 @@ pub enum AgentCmd {
         /// Agent name (e.g. "claude-code")
         #[arg(long, default_value = "unknown")]
         agent: String,
+        /// Active tool detail (optional, from hook event JSON)
+        #[arg(long)]
+        detail: Option<String>,
         /// Session ID (optional, from hook event JSON)
         #[arg(long)]
         session_id: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,10 +220,12 @@ fn main() -> eframe::Result {
                         AgentCmd::Report {
                             state,
                             agent,
+                            detail,
                             session_id,
                         } => std::process::exit(cli::agent_report_cli(
                             state.as_str(),
                             agent.as_str(),
+                            detail.as_deref(),
                             session_id.as_deref(),
                         )),
                         AgentCmd::Status {

--- a/src/process_app/mcp_server.rs
+++ b/src/process_app/mcp_server.rs
@@ -334,7 +334,7 @@ fn generate_call_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Read, Write};
+    use std::io::{ErrorKind, Read, Write};
     use std::net::TcpStream;
 
     fn post_mcp(port: u16, token: Option<&str>, body: &[u8]) -> (u16, Vec<u8>) {
@@ -352,7 +352,11 @@ mod tests {
         stream.flush().unwrap();
 
         let mut response = Vec::new();
-        stream.read_to_end(&mut response).unwrap();
+        match stream.read_to_end(&mut response) {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::ConnectionReset && !response.is_empty() => {}
+            Err(e) => panic!("read response from MCP server: {e}"),
+        }
         let response_str = String::from_utf8_lossy(&response);
         let status: u16 = response_str
             .lines()

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1864,12 +1864,13 @@ impl ProcessApp {
                 pane_id,
                 state,
                 agent,
+                detail,
                 session_id: _,
             } => {
                 // SetAgentState is a CLI/hook-only command routed through the host socket.
                 // Apps should not send this; log and ignore.
                 log::warn!(
-                    "ProcessApp[{}]: SetAgentState ignored — pane_id={pane_id} agent={agent} state={state:?}",
+                    "ProcessApp[{}]: SetAgentState ignored — pane_id={pane_id} agent={agent} state={state:?} detail={detail:?}",
                     self.type_id
                 );
             }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1870,8 +1870,9 @@ impl ProcessApp {
                 // SetAgentState is a CLI/hook-only command routed through the host socket.
                 // Apps should not send this; log and ignore.
                 log::warn!(
-                    "ProcessApp[{}]: SetAgentState ignored — pane_id={pane_id} agent={agent} state={state:?} detail={detail:?}",
-                    self.type_id
+                    "ProcessApp[{}]: SetAgentState ignored — pane_id={pane_id} agent={agent} state={state:?} detail_present={}",
+                    self.type_id,
+                    detail.is_some()
                 );
             }
             AppRequest::GetAgentStates { response_file } => {

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -447,6 +447,9 @@ pub struct PaneAgentState {
     pub pane_id: u64,
     pub state: AgentState,
     pub agent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
 }
 
@@ -544,6 +547,8 @@ pub enum AppRequest {
         pane_id: u64,
         state: AgentState,
         agent: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
         #[serde(default)]
         session_id: Option<String>,
     },
@@ -3542,6 +3547,55 @@ mod ai_stream_chunk_tests {
         assert!(
             serde_json::from_str::<AppRequest>(json).is_err(),
             "missing required response_file must fail"
+        );
+    }
+
+    #[test]
+    fn set_agent_state_detail_round_trips_serde() {
+        let json = r#"{"type":"set_agent_state","pane_id":7,"state":"working","agent":"claude-code","detail":"Bash: cargo test","session_id":"abc"}"#;
+        let req: AppRequest = serde_json::from_str(json).expect("deserialise");
+        match &req {
+            AppRequest::SetAgentState {
+                pane_id,
+                state,
+                agent,
+                detail,
+                session_id,
+            } => {
+                assert_eq!(*pane_id, 7);
+                assert_eq!(*state, AgentState::Working);
+                assert_eq!(agent, "claude-code");
+                assert_eq!(detail.as_deref(), Some("Bash: cargo test"));
+                assert_eq!(session_id.as_deref(), Some("abc"));
+            }
+            other => panic!("expected SetAgentState, got {other:?}"),
+        }
+
+        let serialised = serde_json::to_string(&req).expect("serialise");
+        assert!(
+            serialised.contains(r#""detail":"Bash: cargo test""#),
+            "detail must be emitted when present: {serialised}"
+        );
+    }
+
+    #[test]
+    fn set_agent_state_missing_detail_defaults_to_none() {
+        let json = r#"{"type":"set_agent_state","pane_id":7,"state":"idle","agent":"claude-code"}"#;
+        let req: AppRequest = serde_json::from_str(json).expect("deserialise");
+        match &req {
+            AppRequest::SetAgentState {
+                detail, session_id, ..
+            } => {
+                assert!(detail.is_none());
+                assert!(session_id.is_none());
+            }
+            other => panic!("expected SetAgentState, got {other:?}"),
+        }
+
+        let serialised = serde_json::to_string(&req).expect("serialise");
+        assert!(
+            !serialised.contains("detail"),
+            "empty detail should not add wire noise: {serialised}"
         );
     }
 }

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -245,7 +245,7 @@ Install the PLEXI hook script into ~/.claude/settings.json
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
-| `--claude-code` | flag | no | Install Claude Code hooks (SessionStart, UserPromptSubmit, PermissionRequest, Stop, StopFailure, SessionEnd) |
+| `--claude-code` | flag | no | Install Claude Code hooks (PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, PermissionRequest, Stop, StopFailure, SessionEnd) |
 
 #### `plexi agent hook uninstall`
 
@@ -845,4 +845,3 @@ Example: plexi uninstall
 |---|---|---|---|
 | `--keep-data` | flag | no | Keep your profile directory (~/.plexi/) — your settings, secrets, and app data stay on disk |
 | `--yes` / `-y` | flag | no | Skip the confirmation prompt and proceed immediately (removes data unless --keep-data is set) |
-

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.
-verified_version: "0.0.689"
+verified_version: "0.0.699"
 order: 7
 ---
 
@@ -208,6 +208,7 @@ Example: plexi agent report --state working --agent claude-code
 |---|---|---|---|
 | `--state` | string | yes | State to report: working, blocked, or idle |
 | `--agent` | string | no | Agent name (e.g. "claude-code") Default: `unknown`. |
+| `--detail` | string | no | Active tool detail (optional, from hook event JSON) |
 | `--session-id` | string | no | Session ID (optional, from hook event JSON) |
 
 ### `plexi agent status`
@@ -699,6 +700,7 @@ Send a notification to the Plexi UI
 | `--level` | string | no | Severity level: info, warn, or error Default: `info`. |
 | `--choice` | string (repeatable) | no | Add a clickable button to the notification. Format: `key:Label` (returns key when clicked) or `Label:pane_focus:<pane_id>` (switches focus to that pane when clicked). Repeatable |
 | `--host-action` | string (repeatable) | no | Action to perform on the host when a button is clicked. Format: `key:action_type:action_arg`. Repeatable. The host runs this even after the process that sent the notification has exited |
+| `--no-wait` | flag | no | Queue choice buttons without waiting for a selected value |
 | `--timeout` | string | no | How many seconds before the notification disappears (0 = stays until dismissed) Default: `0`. |
 | `--scope` | string | no | Which panes see this notification: window, context, or global (default: global) Default: `global`. |
 
@@ -845,3 +847,4 @@ Example: plexi uninstall
 |---|---|---|---|
 | `--keep-data` | flag | no | Keep your profile directory (~/.plexi/) — your settings, secrets, and app data stay on disk |
 | `--yes` / `-y` | flag | no | Skip the confirmation prompt and proceed immediately (removes data unless --keep-data is set) |
+


### PR DESCRIPTION
Closes #2120

## Summary

- Adds optional active-tool detail to pane-native agent state and `agent report` / `agent status`.
- Extracts Claude Code `PreToolUse` details in the hook installer and packaged hook script.
- Keeps detail clearing on idle/batch lifecycle events and covers serde plus host propagation tests.

## Done When

- `plexi agent status` shows a DETAIL column: `Bash: cargo test` while agent is running that command, cleared when agent goes idle.
- Hook fires on `PreToolUse` and updates the host — verify with `plexi agent status` during an active Claude Code session.
