### PR TITLE
perf(host): instrument repaint causes and idle frame rate (#2019)

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -234,6 +234,7 @@ impl TerminalBackend {
                     {
                         break;
                     }
+                    crate::diag::diag_note("terminal_pty_output");
                     app_context.clone().request_repaint();
                     if let Event::Exit = event {
                         break;

--- a/deps/egui_term/src/diag.rs
+++ b/deps/egui_term/src/diag.rs
@@ -1,0 +1,52 @@
+//! Repaint-cause diagnostics hook.
+//!
+//! egui_term cannot depend on the host crate, so the host installs a function
+//! pointer at startup and each recurring repaint site reports a stable label
+//! through it. With no hook installed, `diag_note` is a no-op.
+
+use std::sync::OnceLock;
+
+static REPAINT_DIAG_HOOK: OnceLock<fn(&'static str)> = OnceLock::new();
+
+/// Install the host's repaint diagnostics hook. First call wins; later calls
+/// are ignored.
+pub fn set_repaint_diag_hook(hook: fn(&'static str)) {
+    let _ = REPAINT_DIAG_HOOK.set(hook);
+}
+
+/// Report a repaint cause label to the host hook, if one is installed.
+/// Callable from any thread (PTY reader threads report output repaints).
+pub(crate) fn diag_note(cause: &'static str) {
+    if let Some(hook) = REPAINT_DIAG_HOOK.get() {
+        hook(cause);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static CALLS: AtomicU32 = AtomicU32::new(0);
+
+    fn test_hook(label: &'static str) {
+        assert_eq!(label, "terminal_pty_output");
+        CALLS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn installed_hook_receives_diag_note_calls() {
+        // No hook installed yet: must be a silent no-op.
+        diag_note("terminal_pty_output");
+        assert_eq!(CALLS.load(Ordering::Relaxed), 0);
+
+        set_repaint_diag_hook(test_hook);
+        diag_note("terminal_pty_output");
+        assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+
+        // Second install is ignored; the first hook keeps receiving calls.
+        set_repaint_diag_hook(|_| panic!("second hook must not be installed"));
+        diag_note("terminal_pty_output");
+        assert_eq!(CALLS.load(Ordering::Relaxed), 2);
+    }
+}

--- a/deps/egui_term/src/lib.rs
+++ b/deps/egui_term/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod bindings;
+mod diag;
 mod font;
 mod graphics;
 mod theme;
@@ -9,6 +10,7 @@ mod view;
 pub use backend::settings::BackendSettings;
 pub use backend::{BackendCommand, PtyEvent, TerminalBackend, TerminalMode};
 pub use bindings::{Binding, BindingAction, InputKind, KeyboardBinding};
+pub use diag::set_repaint_diag_hook;
 pub use font::{FontSettings, TerminalFont};
 pub use theme::{ColorPalette, TerminalTheme};
 pub use view::TerminalView;

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -518,6 +518,7 @@ impl<'a> TerminalView<'a> {
                 if scroll_lines != 0 {
                     self.backend
                         .process_command(BackendCommand::Scroll(scroll_lines));
+                    crate::diag::diag_note("pointer_tracking");
                     layout
                         .ctx
                         .request_repaint_after(Duration::from_millis(150));
@@ -726,6 +727,7 @@ impl<'a> TerminalView<'a> {
                     }
                     let remaining = blink_interval
                         .saturating_sub(state.last_cursor_toggle.elapsed());
+                    crate::diag::diag_note("terminal_cursor_blink");
                     painter.ctx().request_repaint_after(remaining);
                 } else {
                     // Unfocused: hollow outline, no blink
@@ -1008,6 +1010,7 @@ impl<'a> TerminalView<'a> {
                     ),
                 );
             }
+            crate::diag::diag_note("terminal_search_blink");
             painter
                 .ctx()
                 .request_repaint_after(Duration::from_millis(530));

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1072,6 +1072,9 @@ impl PlexiApp {
                         y += 3.0;
                     }
 
+                    crate::platform::frame_diag::note(
+                        crate::platform::frame_diag::RepaintCause::CrtEffect,
+                    );
                     ctx.request_repaint_after(std::time::Duration::from_millis(16));
                 });
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -149,6 +149,9 @@ pub struct PlexiApp {
     pub(crate) welcome_delete_press_count: u8,
     pub(crate) welcome_delete_last_press: Option<std::time::Instant>,
     pub(crate) frame_tick: crate::platform::logging::FrameTick,
+    /// Repaint-cause diagnostics sample window (#2019): start instant and
+    /// frame count. `None` until the first frame opens a window.
+    pub(crate) frame_diag_window: Option<(std::time::Instant, u32)>,
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
@@ -391,6 +394,23 @@ impl PlexiApp {
         crate::platform::macos_menu::customize_app_menu();
         #[cfg(target_os = "macos")]
         crate::platform::finder_service::register();
+
+        // Repaint-cause diagnostics (#2019): route egui_term's repaint labels
+        // into the host counters; `update()` flushes a summary every 10s.
+        egui_term::set_repaint_diag_hook(|label| {
+            use crate::platform::frame_diag::{note, RepaintCause};
+            match label {
+                "terminal_cursor_blink" => note(RepaintCause::TerminalCursorBlink),
+                "terminal_search_blink" => note(RepaintCause::TerminalSearchBlink),
+                "terminal_pty_output" => note(RepaintCause::TerminalPtyOutput),
+                "pointer_tracking" => note(RepaintCause::PointerTracking),
+                other => log::warn!(
+                    target: "plexi::frame_diag",
+                    "unknown egui_term repaint cause label: {other}"
+                ),
+            }
+        });
+        log::info!(target: "plexi::frame_diag", "frame diagnostics active; summary every 10s");
 
         theme::setup_fonts(&cc.egui_ctx);
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
@@ -740,6 +760,7 @@ impl PlexiApp {
                     pending_close: false,
                     pending_context_close: None,
                     frame_tick: frame_tick.clone(),
+                    frame_diag_window: None,
                     renaming_window: None,
                     rename_buffer: String::new(),
                     editing_description: None,
@@ -920,6 +941,7 @@ impl PlexiApp {
             pending_close: false,
             pending_context_close: None,
             frame_tick,
+            frame_diag_window: None,
             renaming_window: None,
             rename_buffer: String::new(),
             editing_description: None,
@@ -1110,6 +1132,7 @@ impl PlexiApp {
                 pending_close: false,
                 pending_context_close: None,
                 frame_tick,
+                frame_diag_window: None,
                 renaming_window: None,
                 rename_buffer: String::new(),
                 editing_description: None,
@@ -1350,6 +1373,35 @@ impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.frame_tick
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Repaint-cause diagnostics (#2019): count this frame, attribute
+        // input-carrying frames to UserInput, and flush one summary per
+        // 10s sample window.
+        {
+            let (started, frames) = self
+                .frame_diag_window
+                .get_or_insert_with(|| (std::time::Instant::now(), 0));
+            *frames += 1;
+            let frames = *frames;
+            let elapsed = started.elapsed();
+            if ctx.input(|i| !i.raw.events.is_empty()) {
+                crate::platform::frame_diag::note(
+                    crate::platform::frame_diag::RepaintCause::UserInput,
+                );
+            }
+            if elapsed >= std::time::Duration::from_secs(10) {
+                let counts = crate::platform::frame_diag::snapshot_and_reset();
+                log::info!(
+                    target: "plexi::frame_diag",
+                    "{}",
+                    crate::platform::frame_diag::summary_line(
+                        frames,
+                        elapsed.as_secs_f32(),
+                        &counts
+                    )
+                );
+                self.frame_diag_window = Some((std::time::Instant::now(), 0));
+            }
+        }
         let _frame_start = std::time::Instant::now();
         self.update_preamble(ctx);
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -191,6 +191,10 @@ impl PlexiApp {
                             self.welcome_delete_last_press = None;
                         } else {
                             self.draw_welcome_delete_overlay(ctx);
+                            // Same 100ms confirm-timeout poll as the quit overlay.
+                            crate::platform::frame_diag::note(
+                                crate::platform::frame_diag::RepaintCause::QuitConfirm,
+                            );
                             ctx.request_repaint_after(std::time::Duration::from_millis(100));
                         }
                     }
@@ -381,6 +385,9 @@ impl PlexiApp {
                         !i.raw.hovered_files.is_empty() || !i.raw.dropped_files.is_empty()
                     });
                     if has_drag {
+                        crate::platform::frame_diag::note(
+                            crate::platform::frame_diag::RepaintCause::FileDragPoll,
+                        );
                         ui.ctx()
                             .request_repaint_after(std::time::Duration::from_millis(100));
                         use objc2_app_kit::NSApplication;
@@ -792,6 +799,9 @@ impl PlexiApp {
                             egui::CornerRadius::same(4),
                             self.colors.accent.gamma_multiply(0.25),
                         );
+                        crate::platform::frame_diag::note(
+                            crate::platform::frame_diag::RepaintCause::PaneSwapAnim,
+                        );
                         self.ctx.request_repaint();
                     }
 
@@ -819,6 +829,9 @@ impl PlexiApp {
                                 ),
                             };
                             ui.painter().line_segment([p1, p2], egui::Stroke::new(3.0, edge_color));
+                            crate::platform::frame_diag::note(
+                                crate::platform::frame_diag::RepaintCause::EdgePulse,
+                            );
                             self.ctx.request_repaint();
                         }
                     }
@@ -889,6 +902,9 @@ impl PlexiApp {
             } else {
                 self.draw_quit_confirm_overlay(ctx);
                 // Keep repainting so the timeout dismissal fires promptly
+                crate::platform::frame_diag::note(
+                    crate::platform::frame_diag::RepaintCause::QuitConfirm,
+                );
                 ctx.request_repaint_after(std::time::Duration::from_millis(100));
             }
         }

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -555,6 +555,9 @@ impl PlexiApp {
                         path_for_log
                     );
                     self.quick_note_children_rx = Some((node_path, rx));
+                    crate::platform::frame_diag::note(
+                        crate::platform::frame_diag::RepaintCause::WidgetPulse,
+                    );
                     ctx.request_repaint_after(std::time::Duration::from_millis(100));
                 }
             }

--- a/src/platform/frame_diag.rs
+++ b/src/platform/frame_diag.rs
@@ -1,0 +1,221 @@
+//! Frame repaint-cause diagnostics (#2019).
+//!
+//! Plexi has many independent `request_repaint()` / `request_repaint_after()`
+//! paths. Each recurring/timed/background repaint site calls [`note`] with its
+//! [`RepaintCause`] so the per-window summary in `PlexiApp::update` can report
+//! the top repaint causes and the observed frame cadence under the
+//! `plexi::frame_diag` log target. One-shot input-driven repaints are covered
+//! by [`RepaintCause::UserInput`], noted once per frame that carries raw input
+//! events.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Why a repaint was requested. Every variant maps to a stable snake_case
+/// label via [`RepaintCause::label`] for grep-able log output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepaintCause {
+    /// ProcessApp 100ms idle poll for async responses (per visible pane).
+    AppIdlePoll,
+    /// ProcessApp click forwarding (immediate repaint + awaiting-frame echo).
+    AppClick,
+    /// App-requested `ScheduleRender { after_ms }`.
+    AppScheduleRender,
+    /// Pointer-tracking apps at ~60fps while the pointer moves; also terminal
+    /// drag-selection auto-scroll.
+    PointerTracking,
+    /// Focused terminal cursor blink.
+    TerminalCursorBlink,
+    /// Terminal search pill query-cursor blink.
+    TerminalSearchBlink,
+    /// PTY output event from a terminal backend thread.
+    TerminalPtyOutput,
+    /// Skeleton loader animation (~20fps).
+    SkeletonLoader,
+    /// Pane swap animation.
+    PaneSwapAnim,
+    /// Directional edge pulse after focus move.
+    EdgePulse,
+    /// CRT feature effect (~60fps while enabled).
+    CrtEffect,
+    /// Image cache load completion (background thread).
+    ImageCacheCompletion,
+    /// 100ms poll while a file drag hovers the window.
+    FileDragPoll,
+    /// 100ms widget pulse/poll animations (copy feedback, quick-note loading).
+    WidgetPulse,
+    /// Quit/delete confirm overlay 100ms timeout poll.
+    QuitConfirm,
+    /// Frame carried raw input events (covers one-shot event-driven repaints).
+    UserInput,
+}
+
+/// All variants, in declaration order. Indexes into [`COUNTERS`].
+const ALL_CAUSES: [RepaintCause; 16] = [
+    RepaintCause::AppIdlePoll,
+    RepaintCause::AppClick,
+    RepaintCause::AppScheduleRender,
+    RepaintCause::PointerTracking,
+    RepaintCause::TerminalCursorBlink,
+    RepaintCause::TerminalSearchBlink,
+    RepaintCause::TerminalPtyOutput,
+    RepaintCause::SkeletonLoader,
+    RepaintCause::PaneSwapAnim,
+    RepaintCause::EdgePulse,
+    RepaintCause::CrtEffect,
+    RepaintCause::ImageCacheCompletion,
+    RepaintCause::FileDragPoll,
+    RepaintCause::WidgetPulse,
+    RepaintCause::QuitConfirm,
+    RepaintCause::UserInput,
+];
+
+static COUNTERS: [AtomicU32; ALL_CAUSES.len()] =
+    [const { AtomicU32::new(0) }; ALL_CAUSES.len()];
+
+impl RepaintCause {
+    /// Stable snake_case label for log output.
+    pub fn label(self) -> &'static str {
+        match self {
+            RepaintCause::AppIdlePoll => "app_idle_poll",
+            RepaintCause::AppClick => "app_click",
+            RepaintCause::AppScheduleRender => "app_schedule_render",
+            RepaintCause::PointerTracking => "pointer_tracking",
+            RepaintCause::TerminalCursorBlink => "terminal_cursor_blink",
+            RepaintCause::TerminalSearchBlink => "terminal_search_blink",
+            RepaintCause::TerminalPtyOutput => "terminal_pty_output",
+            RepaintCause::SkeletonLoader => "skeleton_loader",
+            RepaintCause::PaneSwapAnim => "pane_swap_anim",
+            RepaintCause::EdgePulse => "edge_pulse",
+            RepaintCause::CrtEffect => "crt_effect",
+            RepaintCause::ImageCacheCompletion => "image_cache_completion",
+            RepaintCause::FileDragPoll => "file_drag_poll",
+            RepaintCause::WidgetPulse => "widget_pulse",
+            RepaintCause::QuitConfirm => "quit_confirm",
+            RepaintCause::UserInput => "user_input",
+        }
+    }
+}
+
+/// Record one repaint request for `cause`. Callable from any thread
+/// (image cache and PTY readers note from background threads).
+pub fn note(cause: RepaintCause) {
+    COUNTERS[cause as usize].fetch_add(1, Ordering::Relaxed);
+}
+
+/// Returns all nonzero counts sorted descending and zeroes every counter.
+/// Ties keep variant declaration order (stable sort).
+pub fn snapshot_and_reset() -> Vec<(RepaintCause, u32)> {
+    let mut counts: Vec<(RepaintCause, u32)> = ALL_CAUSES
+        .iter()
+        .map(|&cause| (cause, COUNTERS[cause as usize].swap(0, Ordering::Relaxed)))
+        .filter(|&(_, n)| n > 0)
+        .collect();
+    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    counts
+}
+
+/// Formats one summary line, e.g.
+/// `frames=102 window=10.0s fps=10.2 causes: app_idle_poll=95 user_input=12`.
+pub fn summary_line(frames: u32, elapsed_secs: f32, counts: &[(RepaintCause, u32)]) -> String {
+    let fps = if elapsed_secs > 0.0 {
+        frames as f32 / elapsed_secs
+    } else {
+        0.0
+    };
+    let mut line = format!("frames={frames} window={elapsed_secs:.1}s fps={fps:.1} causes:");
+    if counts.is_empty() {
+        line.push_str(" none");
+    } else {
+        for (cause, n) in counts {
+            line.push_str(&format!(" {}={n}", cause.label()));
+        }
+    }
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    /// Counters are process-global and harness tests drive real frames in
+    /// parallel, so: (1) frame_diag tests serialize against each other, and
+    /// (2) assertions only touch causes no harness frame ever notes
+    /// (EdgePulse, CrtEffect, SkeletonLoader).
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn count_of(counts: &[(RepaintCause, u32)], cause: RepaintCause) -> Option<u32> {
+        counts.iter().find(|(c, _)| *c == cause).map(|&(_, n)| n)
+    }
+
+    #[test]
+    fn note_increments_and_snapshot_resets() {
+        let _guard = SERIAL.lock().unwrap();
+        snapshot_and_reset();
+
+        note(RepaintCause::EdgePulse);
+        note(RepaintCause::EdgePulse);
+        note(RepaintCause::EdgePulse);
+
+        let counts = snapshot_and_reset();
+        assert_eq!(count_of(&counts, RepaintCause::EdgePulse), Some(3));
+
+        // Counter was zeroed by the snapshot.
+        let counts = snapshot_and_reset();
+        assert_eq!(count_of(&counts, RepaintCause::EdgePulse), None);
+    }
+
+    #[test]
+    fn snapshot_sorted_descending() {
+        let _guard = SERIAL.lock().unwrap();
+        snapshot_and_reset();
+
+        for _ in 0..5 {
+            note(RepaintCause::SkeletonLoader);
+        }
+        for _ in 0..2 {
+            note(RepaintCause::EdgePulse);
+        }
+        note(RepaintCause::CrtEffect);
+
+        let counts = snapshot_and_reset();
+        for pair in counts.windows(2) {
+            assert!(pair[0].1 >= pair[1].1, "not descending: {counts:?}");
+        }
+        let pos = |cause| counts.iter().position(|(c, _)| *c == cause).unwrap();
+        assert!(pos(RepaintCause::SkeletonLoader) < pos(RepaintCause::EdgePulse));
+        assert!(pos(RepaintCause::EdgePulse) < pos(RepaintCause::CrtEffect));
+        assert_eq!(count_of(&counts, RepaintCause::SkeletonLoader), Some(5));
+        assert_eq!(count_of(&counts, RepaintCause::EdgePulse), Some(2));
+        assert_eq!(count_of(&counts, RepaintCause::CrtEffect), Some(1));
+    }
+
+    #[test]
+    fn summary_line_format() {
+        let counts = vec![
+            (RepaintCause::AppIdlePoll, 95),
+            (RepaintCause::UserInput, 12),
+        ];
+        assert_eq!(
+            summary_line(102, 10.0, &counts),
+            "frames=102 window=10.0s fps=10.2 causes: app_idle_poll=95 user_input=12"
+        );
+        assert_eq!(summary_line(0, 10.0, &[]), "frames=0 window=10.0s fps=0.0 causes: none");
+        // Zero-length window must not divide by zero.
+        assert_eq!(summary_line(5, 0.0, &[]), "frames=5 window=0.0s fps=0.0 causes: none");
+    }
+
+    #[test]
+    fn labels_unique_and_complete() {
+        let labels: HashSet<&'static str> = ALL_CAUSES.iter().map(|c| c.label()).collect();
+        assert_eq!(labels.len(), ALL_CAUSES.len());
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(
+                label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'),
+                "label not snake_case: {label}"
+            );
+        }
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "macos")]
 pub mod finder_service;
+pub mod frame_diag;
 pub mod logging;
 #[cfg(target_os = "macos")]
 pub mod macos_menu;

--- a/src/process_app/image_cache.rs
+++ b/src/process_app/image_cache.rs
@@ -188,6 +188,9 @@ impl ImageCache {
                         log::info!("ImageCache: loaded '{key}'");
                     }
                     self.cache.insert(key, CachedImage::Loaded(handle));
+                    crate::platform::frame_diag::note(
+                        crate::platform::frame_diag::RepaintCause::ImageCacheCompletion,
+                    );
                     egui_ctx.request_repaint();
                 }
                 Err(e) => {
@@ -199,6 +202,9 @@ impl ImageCache {
                         self.warned.insert(key.clone());
                     }
                     self.cache.insert(key, CachedImage::Error(e));
+                    crate::platform::frame_diag::note(
+                        crate::platform::frame_diag::RepaintCause::ImageCacheCompletion,
+                    );
                     egui_ctx.request_repaint();
                 }
             }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1272,6 +1272,9 @@ impl ProcessApp {
                 }
             }
             ControlCommand::ScheduleRender { after_ms } => {
+                crate::platform::frame_diag::note(
+                    crate::platform::frame_diag::RepaintCause::AppScheduleRender,
+                );
                 ui.ctx()
                     .request_repaint_after(std::time::Duration::from_millis(after_ms as u64));
             }
@@ -1907,15 +1910,20 @@ impl App for ProcessApp {
         // Pointer-tracking apps are a special case: while the pointer is actively
         // moving we keep the repaint cadence near 60 FPS so host->app hover state
         // does not feel sticky.
+        use crate::platform::frame_diag::{self, RepaintCause};
         if needs_click_repaint {
             self.click_awaiting_frame = true;
+            frame_diag::note(RepaintCause::AppClick);
             ui.ctx().request_repaint();
         } else if self.click_awaiting_frame {
+            frame_diag::note(RepaintCause::AppClick);
             ui.ctx().request_repaint();
         } else if needs_tracking_repaint {
+            frame_diag::note(RepaintCause::PointerTracking);
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(16));
         } else {
+            frame_diag::note(RepaintCause::AppIdlePoll);
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(100));
         }

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -1077,6 +1077,9 @@ pub(crate) fn render_draw_commands(
                     fill,
                 );
                 // Drive animation — request repaint at ~20fps while skeleton is visible
+                crate::platform::frame_diag::note(
+                    crate::platform::frame_diag::RepaintCause::SkeletonLoader,
+                );
                 ui.ctx()
                     .request_repaint_after(std::time::Duration::from_millis(50));
             }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -271,6 +271,7 @@ pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::
         ui.ctx().memory_mut(|m| m.data.insert_temp(id, now));
     }
     if just_copied {
+        crate::platform::frame_diag::note(crate::platform::frame_diag::RepaintCause::WidgetPulse);
         ui.ctx()
             .request_repaint_after(std::time::Duration::from_millis(100));
     }


### PR DESCRIPTION
Closes #2019

Stint task: 0049 (sprint s13 — v1 PGAP performance hardening)

## Summary

- New `src/platform/frame_diag.rs`: `RepaintCause` enum (16 causes), lock-free atomic counters callable from any thread, and a 10s sample window flushed from `PlexiApp::update` as one info line under target `plexi::frame_diag` (`frames=102 window=10.0s fps=10.2 causes: app_idle_poll=95 user_input=12`).
- `deps/egui_term` gets a `set_repaint_diag_hook(fn(&'static str))` so terminal cursor blink, search blink, drag auto-scroll, and PTY output repaints are attributable without the vendored crate depending on the host.
- Annotates every recurring repaint source: ProcessApp 100ms idle poll, click echo, ScheduleRender, pointer tracking, skeleton loader, pane swap, edge pulse, CRT effect, image cache completions, file-drag poll, widget pulses, quit/delete confirm polls; frames carrying raw input are attributed to `user_input`.
- Instrumentation only — no scheduling behavior changes (those are stint 0050/0051/0052, blocked on this data).

## Done When

With a normal idle Plexi window open, logs or a debug overlay identify the top repaint cause and observed frame cadence over a short sample window.

Verified: `cargo build` clean, `cargo test --bin plexi` 782 passed (778 baseline + 4 new), `cargo test -p egui_term --lib` 5 passed.