### PR TITLE
perf(host): make visible PGAP app rendering event-driven instead of idle-polled (#2020)

### DIFF
--- a/apps/balls/balls.py
+++ b/apps/balls/balls.py
@@ -162,7 +162,7 @@ class BallsApp(App):
             ball.y = random.uniform(ball.r, h * 0.6)
             self.balls.append(ball)
         self._canvas = _BallCanvas(self)
-        self.emit.continuous(60)
+        self.emit.continuous(120)
         self.emit.info(f"balls: init complete, spawned {count} balls")
 
     def on_render(self, ctx: RenderContext) -> None:

--- a/apps/balls/balls.py
+++ b/apps/balls/balls.py
@@ -162,7 +162,7 @@ class BallsApp(App):
             ball.y = random.uniform(ball.r, h * 0.6)
             self.balls.append(ball)
         self._canvas = _BallCanvas(self)
-        self.emit.continuous(120)
+        self.emit.continuous(60)
         self.emit.info(f"balls: init complete, spawned {count} balls")
 
     def on_render(self, ctx: RenderContext) -> None:

--- a/apps/balls/balls.py
+++ b/apps/balls/balls.py
@@ -147,8 +147,6 @@ class _BallCanvas(Component):
             hi_y = ball.y - ball.r * 0.28
             ctx.circle(hi_x, hi_y, hi_r, dim("#ffffff", 90))
 
-        ctx.emit.schedule_render(16)   # 60 fps
-
 
 class BallsApp(App):
     default_background = "#0d0d1a"
@@ -164,6 +162,7 @@ class BallsApp(App):
             ball.y = random.uniform(ball.r, h * 0.6)
             self.balls.append(ball)
         self._canvas = _BallCanvas(self)
+        self.emit.continuous(60)
         self.emit.info(f"balls: init complete, spawned {count} balls")
 
     def on_render(self, ctx: RenderContext) -> None:

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -70,7 +70,7 @@ class _SnakeCanvas(Component):
 class SnakeApp(App):
     pipe_id: Arg[str | None] = Arg("--pipe", default=None)
 
-    def on_init(self, _ctx: RenderContext) -> None:
+    def on_init(self) -> None:
         self._pipe: "Pipe | None" = None
         if self.pipe_id:
             self._pipe = self.emit.pipe_open(self.pipe_id, mode="json", direction="out")
@@ -126,7 +126,7 @@ class SnakeApp(App):
         else:
             self._snake.pop()
 
-    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_key(self, key: str, _mods: dict) -> None:
         if self._dead and key in ("r", "Enter", " "):
             self._reset()
             return

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -145,6 +145,7 @@ class SnakeApp(App):
             self._canvas,
             FooterKeys(shortcuts),
         ]))
+        ctx.emit.schedule_render(int(TICK * 1000) if not self._dead else 250)
 
     def on_shutdown(self) -> None:
         self._running = False

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -6,8 +6,6 @@ separate Rust sub-project. The spec allows either; Python is 80 lines vs a
 new cargo crate + cross-compile setup. This is the intentional choice.
 """
 
-import threading
-import time
 from plexi_sdk import App, RenderContext, Arg, Pipe
 from plexi_sdk.ui import Column, AppBar, FooterKeys, Component
 
@@ -77,10 +75,6 @@ class SnakeApp(App):
             self.emit.info(f"snake: pipe open pipe_id={self.pipe_id}")
         self._reset()
         self._canvas = _SnakeCanvas(self)
-        self._timer_thread = threading.Thread(
-            target=self._tick_loop, daemon=True
-        )
-        self._timer_thread.start()
 
     def _reset(self) -> None:
         mid_r, mid_c = ROWS // 2, COLS // 2
@@ -92,13 +86,17 @@ class SnakeApp(App):
         self._food = (COLS - 3, ROWS // 2)
         self._score = 0
         self._dead = False
-        self._running = True
+        self._tick_accum = 0.0
 
-    def _tick_loop(self) -> None:
-        while self._running:
-            time.sleep(TICK)
-            if not self._dead:
-                self._step()
+    def _advance(self, elapsed: float) -> None:
+        if self._dead:
+            return
+        self._tick_accum += min(elapsed, TICK * 2.0)
+        steps = 0
+        while self._tick_accum >= TICK and steps < 2:
+            self._step()
+            self._tick_accum -= TICK
+            steps += 1
 
     def _step(self) -> None:
         dx, dy = self._next_dir
@@ -134,6 +132,7 @@ class SnakeApp(App):
             self._next_dir = DIR_MAP[key]
 
     def on_render(self, ctx: RenderContext) -> None:
+        self._advance(ctx.elapsed)
         subtitle = "GAME OVER" if self._dead else f"Score: {self._score}"
         shortcuts = (
             [("h/j/k/l", "move"), ("r", "restart")]
@@ -145,10 +144,11 @@ class SnakeApp(App):
             self._canvas,
             FooterKeys(shortcuts),
         ]))
-        ctx.emit.schedule_render(int(TICK * 1000) if not self._dead else 250)
-
-    def on_shutdown(self) -> None:
-        self._running = False
+        if self._dead:
+            ctx.emit.schedule_render(250)
+        else:
+            next_tick_ms = max(1, int((TICK - self._tick_accum) * 1000))
+            ctx.emit.schedule_render(next_tick_ms)
 
 
 if __name__ == "__main__":

--- a/apps/tetris/tetris.py
+++ b/apps/tetris/tetris.py
@@ -257,7 +257,7 @@ def _draw_cell(ctx: RenderContext, x: float, y: float, size: float, color: str) 
 
 
 class TetrisApp(App):
-    def on_init(self, _ctx: RenderContext) -> None:
+    def on_init(self) -> None:
         self._canvas = _TetrisCanvas(self)
         self._new_game()
 
@@ -382,7 +382,7 @@ class TetrisApp(App):
 
     # ── Input ─────────────────────────────────────────────────────────────────
 
-    def on_key(self, _ctx: RenderContext, key: str, _mods: dict) -> None:
+    def on_key(self, key: str, _mods: dict) -> None:
         if self.game_over:
             if key == "r":
                 self._new_game()

--- a/justfile
+++ b/justfile
@@ -110,12 +110,16 @@ install: fetch-python-runtime regen-if-stale
 sdk-dev:
     uv pip install -e sdk/python
 
+# Headless SDK/app contract smoke: Init -> Ready -> Render -> FrameDone.
+sdk-smoke:
+    uv run --project sdk/python pytest sdk/python/tests/test_app_harness.py -q
+
 # Build and install the current worktree as a testable PR build.
 # Installs as "Plexi PR<number>.app" with isolated profile ~/.plexi-pr-<number>/.
 # Run from inside the feature worktree: just pr-install 123
 # Always cleans the previous PR build first for a fully fresh install.
 # Alias for: just channel-install pr-<number>
-pr-install number: fetch-python-runtime
+pr-install number: fetch-python-runtime sdk-smoke
     #!/usr/bin/env bash
     set -euo pipefail
     # Preflight: confirm we're running from a valid repo worktree with Cargo.toml present.

--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -3,6 +3,15 @@
   "definitions": {
     "AppRequest": {
       "$defs": {
+        "AgentState": {
+          "description": "Agent state reported by a hook script.",
+          "enum": [
+            "working",
+            "blocked",
+            "idle"
+          ],
+          "type": "string"
+        },
         "AiMessage": {
           "description": "One message in an `AiQuery` conversation. Wire shape mirrors Anthropic\nMessages API: `role` ∈ {\"user\", \"assistant\"}, `content` is plain text.\n(Multimodal content blocks are future-scope.)",
           "properties": {
@@ -477,6 +486,63 @@
           "type": "object"
         },
         {
+          "description": "Report agent state for a pane. Called by hook scripts via `plexi agent report`.",
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "detail": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "session_id": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "state": {
+              "$ref": "#/$defs/AgentState"
+            },
+            "type": {
+              "const": "set_agent_state",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "pane_id",
+            "state",
+            "agent"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Get all tracked pane agent states. Writes JSON array to response_file.",
+          "properties": {
+            "response_file": {
+              "type": "string"
+            },
+            "type": {
+              "const": "get_agent_states",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "response_file"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Open a typed pipe.\nmode: \"json\" | \"binary\"\ndirection: \"in\" | \"out\" | \"duplex\"",
           "properties": {
             "direction": {
@@ -741,6 +807,23 @@
           "type": "object"
         },
         {
+          "description": "List all open contexts. Host writes a JSON array to `response_file`.\nSent by `plexi context list`.",
+          "properties": {
+            "response_file": {
+              "type": "string"
+            },
+            "type": {
+              "const": "list_contexts",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "response_file"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Query info for a specific pane by ID. Host writes JSON object to `response_file`.\nSent by `plexi pane info`.",
           "properties": {
             "pane_id": {
@@ -759,6 +842,23 @@
           "required": [
             "type",
             "pane_id",
+            "response_file"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Query info for the previously focused pane. Host walks `pane_focus_history`\nfrom the end, finds the last entry whose tile resolves to a live pane, and\nwrites the same JSON shape as `GetPaneInfo` to `response_file`.\nReturns `{\"error\":\"...\"}` if history is empty or no valid pane found.\nSent by `plexi pane info --previous`.",
+          "properties": {
+            "response_file": {
+              "type": "string"
+            },
+            "type": {
+              "const": "get_previous_pane_info",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
             "response_file"
           ],
           "type": "object"
@@ -965,6 +1065,11 @@
         {
           "description": "Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.",
           "properties": {
+            "focus": {
+              "default": false,
+              "description": "Zoom into the new sub-context after creation. Default false (stay in parent).",
+              "type": "boolean"
+            },
             "name": {
               "type": [
                 "string",
@@ -972,6 +1077,20 @@
               ]
             },
             "parent_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "portal_direction": {
+              "description": "Direction the portal tile splits in the parent window: \"right\" | \"down\" | \"left\" | \"up\".",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "response_file": {
+              "description": "If set, the host writes a JSON response (context_id, windows) to this path.",
               "type": [
                 "string",
                 "null"
@@ -986,6 +1105,12 @@
             "type": {
               "const": "create_context",
               "type": "string"
+            },
+            "windows": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "required": [
@@ -1914,6 +2039,27 @@
           "type": "object"
         },
         {
+          "description": "Terminal SDK failure with traceback text. Sent before the app exits\nnonzero so the host never has to infer Python hook failures from EOF.",
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "traceback": {
+              "type": "string"
+            },
+            "type": {
+              "const": "fatal_error",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "message",
+            "traceback"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Ask the host to trigger a new Render event after `after_ms` milliseconds.\nIntended for game loops and animations — emit once per frame to sustain a\ntick rate without relying on egui's unconditional repaint cadence.\nApps that do not emit this will still repaint on keyboard/inject events.",
           "properties": {
             "after_ms": {
@@ -1929,6 +2075,31 @@
           "required": [
             "type",
             "after_ms"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Declare app render cadence so the host owns recurring animation ticks.\n`mode=\"idle\"` disables recurring renders, `mode=\"scheduled\"` means the\napp will emit ScheduleRender manually, and `mode=\"continuous\"` asks the\nhost to render at `fps`.",
+          "properties": {
+            "fps": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "mode": {
+              "type": "string"
+            },
+            "type": {
+              "const": "set_scheduler_mode",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "mode"
           ],
           "type": "object"
         },
@@ -2306,6 +2477,9 @@
               "default": 480.0,
               "format": "float",
               "type": "number"
+            },
+            "state": {
+              "description": "Pre-seeded app state for headless rendering (--state flag).\nWhen present, the SDK populates self.state before calling on_init.\nOmitted in live (non-headless) Init events."
             },
             "theme": {
               "additionalProperties": {
@@ -2880,7 +3054,7 @@
           "type": "object"
         },
         {
-          "description": "Sent by the headless renderer to seed app state before the first render.\nUnlike InjectState (which fires on_inject as a background task and is a live\nprotocol event), RenderSeed fires on_render_seed awaited, so state is applied\nbefore the Render event arrives. Live app behavior is completely unaffected.",
+          "description": "DEPRECATED: superseded by the `state` field on Init.\nKept for backwards compatibility with older SDK versions. The headless\nrenderer no longer sends this event.",
           "properties": {
             "payload": true,
             "type": {
@@ -3748,6 +3922,25 @@
     },
     "RenderCommand": {
       "$defs": {
+        "FooterKeyEntry": {
+          "description": "Single shortcut entry for `UiNode::FooterKeys`.",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "keys": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "keys",
+            "description"
+          ],
+          "type": "object"
+        },
         "LayoutChild": {},
         "LayoutDirection": {
           "description": "Direction of a flex layout node.",
@@ -3959,6 +4152,16 @@
           ],
           "type": "object"
         },
+        "PinnedEdge": {
+          "description": "Which edge to pin a child against within a vertical Stack.",
+          "enum": [
+            "bottom",
+            "top",
+            "left",
+            "right"
+          ],
+          "type": "string"
+        },
         "Rect": {
           "description": "A simple rectangle (logical coordinates).",
           "properties": {
@@ -4019,6 +4222,30 @@
           ],
           "type": "object"
         },
+        "SelectListItem": {
+          "description": "Item in a `UiNode::SelectList`.",
+          "properties": {
+            "description": {
+              "default": "",
+              "type": "string"
+            },
+            "leading": {
+              "default": "",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "trailing": {
+              "default": "",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
         "ShortcutPair": {
           "description": "One group inside a `DrawCommand::Shortcuts`. Renders as `keys` chips\nfollowed by `description` text.",
           "properties": {
@@ -4037,6 +4264,14 @@
             "description"
           ],
           "type": "object"
+        },
+        "StackDirection": {
+          "description": "Flex direction for a `UiNode::Stack`.",
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string"
         },
         "TextRowItem": {
           "description": "One text segment inside a `DrawCommand::TextRow`.",
@@ -4063,7 +4298,621 @@
           ],
           "type": "object"
         },
-        "UiNode": {}
+        "UiNode": {
+          "description": "Component tree node. L0 primitives compose into rich UI; L1 sugar variants\nare rendered natively by the host.",
+          "oneOf": [
+            {
+              "description": "Flex container — vertical or horizontal.",
+              "properties": {
+                "children": {
+                  "items": {
+                    "$ref": "#/$defs/UiNode"
+                  },
+                  "type": "array"
+                },
+                "direction": {
+                  "$ref": "#/$defs/StackDirection",
+                  "default": "vertical"
+                },
+                "gap": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "padding": {
+                  "$ref": "#/$defs/UiPadding",
+                  "default": {
+                    "bottom": 0.0,
+                    "left": 0.0,
+                    "right": 0.0,
+                    "top": 0.0
+                  }
+                },
+                "type": {
+                  "const": "stack",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "children"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Scrollable single-child container.",
+              "properties": {
+                "child": {
+                  "$ref": "#/$defs/UiNode"
+                },
+                "horizontal": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "scroll",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "child"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Z-stack overlay — children rendered back-to-front at the same position.",
+              "properties": {
+                "children": {
+                  "items": {
+                    "$ref": "#/$defs/UiNode"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "layer",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "children"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Inline text node.",
+              "properties": {
+                "bold": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "color": {
+                  "default": "",
+                  "type": "string"
+                },
+                "monospace": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "size": {
+                  "default": 0.0,
+                  "description": "0.0 means inherit from context.",
+                  "format": "float",
+                  "type": "number"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "text",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "text"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Interaction wrapper — host fires `ComponentEvent` for click/hover.",
+              "properties": {
+                "child": {
+                  "$ref": "#/$defs/UiNode"
+                },
+                "node_id": {
+                  "type": "string"
+                },
+                "on_click": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "on_hover": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "interactive",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "node_id",
+                "child"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Escape hatch: embed a flat `RenderCommand` inside the tree.",
+              "properties": {
+                "command": {
+                  "$ref": "#"
+                },
+                "type": {
+                  "const": "raw",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "command"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Future GPU surface placeholder — reserved, not yet rendered.",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "surface",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "id"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Pinned layout wrapper. In a vertical Stack, `Pinned { edge: Bottom }` children\nare rendered flush to the available rect bottom regardless of body content height.",
+              "properties": {
+                "child": {
+                  "$ref": "#/$defs/UiNode"
+                },
+                "edge": {
+                  "$ref": "#/$defs/PinnedEdge"
+                },
+                "type": {
+                  "const": "pinned",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "edge",
+                "child"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Semantic column container with sticky-footer host contract.\n`padding` sets left/right/bottom margins (default SPACE_XL); `padding_top`\nsets the top margin independently. Emitted by `Column.to_node()` in the SDK.",
+              "properties": {
+                "children": {
+                  "items": {
+                    "$ref": "#/$defs/UiNode"
+                  },
+                  "type": "array"
+                },
+                "gap": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "padding": {
+                  "default": 24.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "padding_top": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "type": {
+                  "const": "column",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "children"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Host-rendered button.",
+              "properties": {
+                "disabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "node_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "button",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "node_id",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Host-rendered text input.",
+              "properties": {
+                "node_id": {
+                  "type": "string"
+                },
+                "placeholder": {
+                  "default": "",
+                  "type": "string"
+                },
+                "type": {
+                  "const": "input",
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "node_id",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Host-rendered text editor with multiline and max_length support.\n\nThe host maintains a persistent buffer keyed on `node_id`. On each\nframe the app sends its last-known `value`; the host seeds the buffer\nfrom it only when a new `node_id` appears. Typing fires\n`ComponentEvent { event_type: \"change\", payload: { value } }` and\nEnter (single-line) or Cmd+Enter (multiline) fires\n`ComponentEvent { event_type: \"submit\", payload: { value } }`.",
+              "properties": {
+                "max_length": {
+                  "default": 0,
+                  "description": "0 means no limit.",
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "multiline": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "node_id": {
+                  "type": "string"
+                },
+                "placeholder": {
+                  "default": "",
+                  "type": "string"
+                },
+                "type": {
+                  "const": "text_edit",
+                  "type": "string"
+                },
+                "value": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "node_id"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Host-rendered pill badge.",
+              "properties": {
+                "fg": {
+                  "default": "",
+                  "type": "string"
+                },
+                "fill": {
+                  "default": "",
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "badge",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Coloured dot indicator.",
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "size": {
+                  "default": 0.0,
+                  "description": "0.0 means default size.",
+                  "format": "float",
+                  "type": "number"
+                },
+                "type": {
+                  "const": "dot",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "color"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "App title bar with optional subtitle.",
+              "properties": {
+                "subtitle": {
+                  "default": "",
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "app_bar",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "title"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Keyboard shortcut hints row at bottom of pane.",
+              "properties": {
+                "divider": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "entries": {
+                  "items": {
+                    "$ref": "#/$defs/FooterKeyEntry"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "footer_keys",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "entries"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Single-line status footer with optional color.",
+              "properties": {
+                "color": {
+                  "default": "",
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "footer",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "text"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Section header label (small, uppercase, with rule below).",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "section",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "title"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Themed text label with semantic tone.",
+              "properties": {
+                "bold": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "color": {
+                  "default": "",
+                  "type": "string"
+                },
+                "max_lines": {
+                  "default": 0,
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "monospace": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "size": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "tone": {
+                  "default": "",
+                  "type": "string"
+                },
+                "type": {
+                  "const": "label",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "text"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Flexible space between siblings.",
+              "properties": {
+                "grow": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "size": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "type": {
+                  "const": "spacer",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Horizontal divider rule.",
+              "properties": {
+                "color": {
+                  "default": "",
+                  "type": "string"
+                },
+                "type": {
+                  "const": "divider",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Bordered card container.",
+              "properties": {
+                "children": {
+                  "items": {
+                    "$ref": "#/$defs/UiNode"
+                  },
+                  "type": "array"
+                },
+                "padding": {
+                  "default": 0.0,
+                  "format": "float",
+                  "type": "number"
+                },
+                "type": {
+                  "const": "card",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "children"
+              ],
+              "type": "object"
+            },
+            {
+              "description": "Keyboard-navigable scrollable list (selection managed by app).",
+              "properties": {
+                "items": {
+                  "items": {
+                    "$ref": "#/$defs/SelectListItem"
+                  },
+                  "type": "array"
+                },
+                "selected_idx": {
+                  "default": 0,
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "select_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "items"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "UiPadding": {
+          "description": "Per-side padding for a `UiNode::Stack`.",
+          "properties": {
+            "bottom": {
+              "default": 0.0,
+              "format": "float",
+              "type": "number"
+            },
+            "left": {
+              "default": 0.0,
+              "format": "float",
+              "type": "number"
+            },
+            "right": {
+              "default": 0.0,
+              "format": "float",
+              "type": "number"
+            },
+            "top": {
+              "default": 0.0,
+              "format": "float",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Render primitives — go to `pending_frame` → drawn to screen.",

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import json
 import sys
+import traceback
 from typing import Any, Coroutine
 
 from ._protocol import PROTOCOL_VERSION
@@ -63,6 +64,17 @@ def _log_task_exception(task: asyncio.Task) -> None:
         return
     if exc is not None:
         sys.stderr.write(f"plexi_sdk: unhandled exception in background task: {exc}\n")
+
+
+def _emit_fatal_error(exc: BaseException) -> None:
+    """Report an unrecoverable SDK/app exception over PGAP before exiting."""
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    message = f"{type(exc).__name__}: {exc}"
+    try:
+        _emit({"type": "fatal_error", "message": message, "traceback": tb})
+    finally:
+        sys.stderr.write(tb)
+        sys.stderr.flush()
 
 
 # Map egui's Debug-format key names to the documented canonical SDK names.
@@ -1287,8 +1299,16 @@ class App:
                     self._dispatch_hook_task(self._handle_mcp_tool_call, ev)
 
         reader_task = asyncio.create_task(_reader())
+        exit_code = 0
         try:
             await _dispatcher()
+        except SystemExit as e:
+            exit_code = int(e.code) if isinstance(e.code, int) else 1
+            if exit_code != 0:
+                _emit_fatal_error(e)
+        except BaseException as e:
+            exit_code = 1
+            _emit_fatal_error(e)
         finally:
             reader_task.cancel()
             for p in self._pipes.values():
@@ -1299,7 +1319,7 @@ class App:
             # the 2s shutdown window. os._exit() terminates immediately without
             # waiting for threads, avoiding the SIGTERM that would otherwise fire.
             import os as _os
-            _os._exit(0)
+            _os._exit(exit_code)
 
     async def _dispatch_hook(self, hook: "Any", *args: Any) -> None:
         """Dispatch a lifecycle hook and await its completion.

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -835,6 +835,25 @@ class Emitter:
         16 ms ≈ 60 fps.  32 ms ≈ 30 fps."""
         _emit({"type": "schedule_render", "after_ms": after_ms})
 
+    def set_scheduler_mode(self, mode: str, fps: int | None = None) -> None:
+        """Declare how the host should schedule recurring renders.
+
+        Modes:
+          - ``"idle"``: no recurring renders
+          - ``"scheduled"``: app emits schedule_render manually
+          - ``"continuous"``: host renders at ``fps`` after each FrameDone
+        """
+        if mode not in ("idle", "scheduled", "continuous"):
+            raise ValueError("scheduler mode must be idle, scheduled, or continuous")
+        payload: dict[str, Any] = {"type": "set_scheduler_mode", "mode": mode}
+        if fps is not None:
+            payload["fps"] = int(fps)
+        _emit(payload)
+
+    def continuous(self, fps: int = 60) -> None:
+        """Render continuously at ``fps``. Intended for animations/games."""
+        self.set_scheduler_mode("continuous", fps=fps)
+
     # Runs
     def run_get(self, intent: str, payload: Any = None) -> str:
         run_id = str(uuid.uuid4())

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -323,6 +323,7 @@ class AppHarness:
         self._draw_commands: "list[dict]" = []
         self._frame_id = 0
         self._stdout_q: "queue.Queue[str | None]" = queue.Queue()
+        self._events_seen: "list[dict]" = []
 
         import os
         import subprocess as _subprocess
@@ -347,9 +348,16 @@ class AppHarness:
         ev = self._wait_for(lambda e: e.get("type") == "ready")
         if ev is None:
             stderr = self._proc.stderr.read() if self._proc.stderr else ""
+            fatal = next((e for e in reversed(self._events_seen) if e.get("type") == "fatal_error"), None)
+            fatal_msg = ""
+            if fatal is not None:
+                fatal_msg = (
+                    f" fatal_error={fatal.get('message', '')!r} "
+                    f"traceback={fatal.get('traceback', '')[:500]!r}"
+                )
             raise RuntimeError(
                 f"AppHarness: app did not send 'ready' within {timeout}s. "
-                f"stderr: {stderr[:500]!r}"
+                f"stderr: {stderr[:500]!r}{fatal_msg}"
             )
 
     def _read_stdout(self) -> None:
@@ -372,19 +380,52 @@ class AppHarness:
         except json.JSONDecodeError:
             return None
 
+    def _fatal_event(self) -> "dict | None":
+        while True:
+            try:
+                line = self._stdout_q.get_nowait()
+            except queue.Empty:
+                break
+            if line is None:
+                break
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            self._events_seen.append(ev)
+            if ev.get("type") == "fatal_error":
+                return ev
+        return next((e for e in reversed(self._events_seen) if e.get("type") == "fatal_error"), None)
+
+    def _raise_fatal(self, ev: dict) -> None:
+        raise RuntimeError(
+            f"AppHarness: fatal_error: {ev.get('message', '')}\n"
+            f"{ev.get('traceback', '')}"
+        )
+
     def _wait_for(self, predicate, timeout=None) -> "dict | None":
         deadline = time.monotonic() + (timeout if timeout is not None else self._timeout)
         while time.monotonic() < deadline:
             remaining = deadline - time.monotonic()
             ev = self._next_event(timeout=max(0.05, remaining))
-            if ev is not None and predicate(ev):
-                return ev
+            if ev is not None:
+                self._events_seen.append(ev)
+                if ev.get("type") == "fatal_error":
+                    return ev if predicate(ev) else None
+                if predicate(ev):
+                    return ev
         return None
 
     def _send(self, event: dict) -> None:
         assert self._proc.stdin is not None
-        self._proc.stdin.write(json.dumps(event) + "\n")
-        self._proc.stdin.flush()
+        try:
+            self._proc.stdin.write(json.dumps(event) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError):
+            fatal = self._fatal_event()
+            if fatal is not None:
+                self._raise_fatal(fatal)
+            raise
 
     def run(self, n_frames: int = 1) -> "list[dict]":
         """Step N render frames. Returns draw commands from the last frame."""
@@ -398,14 +439,37 @@ class AppHarness:
             })
             cmds = []
             deadline = time.monotonic() + self._timeout
+            saw_frame_done = False
             while time.monotonic() < deadline:
                 remaining = deadline - time.monotonic()
                 ev = self._next_event(timeout=max(0.05, remaining))
                 if ev is None:
+                    if self._proc.poll() is not None:
+                        fatal = self._fatal_event()
+                        if fatal is not None:
+                            self._raise_fatal(fatal)
+                        stderr = self._proc.stderr.read() if self._proc.stderr else ""
+                        raise RuntimeError(
+                            f"AppHarness: app exited before frame_done. "
+                            f"returncode={self._proc.returncode} stderr={stderr[:500]!r}"
+                        )
                     continue
+                self._events_seen.append(ev)
+                if ev.get("type") == "fatal_error":
+                    self._raise_fatal(ev)
                 if ev.get("type") == "frame_done":
+                    saw_frame_done = True
                     break
                 cmds.append(ev)
+            if not saw_frame_done:
+                fatal = self._fatal_event()
+                if fatal is not None:
+                    self._raise_fatal(fatal)
+                stderr = self._proc.stderr.read() if self._proc.stderr and self._proc.poll() is not None else ""
+                raise RuntimeError(
+                    f"AppHarness: app did not emit frame_done within {self._timeout}s. "
+                    f"stderr={stderr[:500]!r}"
+                )
         self._draw_commands = cmds
         return cmds
 

--- a/sdk/python/tests/test_app_harness.py
+++ b/sdk/python/tests/test_app_harness.py
@@ -1,6 +1,11 @@
 """Integration tests for AppHarness — headless Python app subprocess runner."""
 
+import json
+import os
+import subprocess
+import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -67,3 +72,69 @@ def test_appharness_context_manager_closes_cleanly(counter_app: Path) -> None:
         proc = h._proc
     # After __exit__, process should be terminated
     assert proc.poll() is not None, "Subprocess should have exited after close()"
+
+
+def test_appharness_reports_sdk_fatal_errors(tmp_path: Path) -> None:
+    """Hook contract mismatches surface as fatal_error instead of silent EOF."""
+    bad_app = tmp_path / "bad_app.py"
+    bad_app.write_text(textwrap.dedent("""
+        from plexi_sdk import App
+
+        class BadApp(App):
+            def on_init(self, stale_ctx):
+                pass
+
+        BadApp().run()
+    """).lstrip())
+
+    repo_root = Path(__file__).resolve().parents[3]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(repo_root / "sdk/python")
+    proc = subprocess.Popen(
+        [sys.executable, str(bad_app)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    proc.stdin.write(json.dumps({
+        "type": "init",
+        "protocol": "pgap/3",
+        "app_id": "fatal-test",
+        "workspace_root": "/tmp",
+        "capabilities": [],
+        "feature_flags": [],
+    }) + "\n")
+    proc.stdin.flush()
+
+    deadline = time.monotonic() + 2.0
+    seen = []
+    try:
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            ev = json.loads(line)
+            seen.append(ev)
+            if ev.get("type") == "fatal_error":
+                assert "BadApp.on_init" in ev.get("traceback", "")
+                return
+    finally:
+        proc.kill()
+    pytest.fail(f"expected fatal_error, saw {seen}")
+
+
+@pytest.mark.parametrize("relative_path", [
+    "apps/balls/balls.py",
+    "apps/snake/snake.py",
+    "apps/tetris/tetris.py",
+])
+def test_core_game_apps_boot_and_render(relative_path: str) -> None:
+    """Core game apps must satisfy Init -> Ready -> Render -> FrameDone."""
+    repo_root = Path(__file__).resolve().parents[3]
+    with AppHarness(repo_root / relative_path, timeout=2.0) as h:
+        cmds = h.run(1)
+    assert cmds, f"{relative_path} should emit draw/control commands for first frame"

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1,6 +1,7 @@
 //! App command dispatch — keyboard routing + command drain from app panes.
 
 use crate::app::app_trait::{App, AppCommand};
+use crate::host::pane::AppRuntime;
 
 use super::PlexiApp;
 
@@ -65,6 +66,25 @@ mod tests {
         assert_eq!(
             *source_context_id, park_context_id,
             "source_context_id should be the park-time context_id ({park_context_id}), not hardcoded 0"
+        );
+    }
+
+    #[test]
+    fn parked_process_with_pending_headless_work_requests_host_wake() {
+        let mut h = HostHarness::new();
+        let (mut process_app, _draw_tx) = ProcessApp::new_for_test(999, AppPermissions::builtin());
+        process_app.pending_timers.insert(
+            "timer-1".to_string(),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        );
+
+        h.app
+            .background_apps
+            .insert("test-app".to_string(), (42, Box::new(process_app)));
+
+        assert!(
+            h.app.background_processes_need_wake(),
+            "parked process apps with pending timers/async work must keep the host wake loop alive"
         );
     }
 
@@ -177,6 +197,28 @@ impl PlexiApp {
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
             });
         }
+    }
+
+    pub(crate) fn background_processes_need_wake(&self) -> bool {
+        let active = self.active_window;
+        let inactive_context_needs_wake =
+            self.windows.iter().enumerate().any(|(ctx_idx, context)| {
+                ctx_idx != active
+                    && context.panes.values().any(|pane| {
+                        pane.as_app()
+                            .and_then(|app_pane| match &app_pane.runtime {
+                                AppRuntime::Process(app) => Some(app.needs_headless_wake_poll()),
+                                AppRuntime::Builtin(_) => None,
+                            })
+                            .unwrap_or(false)
+                    })
+            });
+
+        inactive_context_needs_wake
+            || self
+                .background_apps
+                .values()
+                .any(|(_, app)| app.needs_headless_wake_poll())
     }
 
     /// Drain `pending_commands` from **every** app pane in **every** context,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1551,6 +1551,12 @@ impl eframe::App for PlexiApp {
         // must reach the queue *now*, not be buffered until the modal
         // closes (which caused the "ghost queue appears on reopen" bug).
         let fresh_cmds = self.drain_all_app_commands();
+        if self.background_processes_need_wake() {
+            crate::platform::frame_diag::note(
+                crate::platform::frame_diag::RepaintCause::AppIdlePoll,
+            );
+            ctx.request_repaint_after(std::time::Duration::from_millis(100));
+        }
         // When the overlay releases, prepend any held unsafe commands so they
         // execute before new commands this frame (FIFO order preserved).
         let deferred_app_cmds: Vec<_> =

--- a/src/platform/frame_diag.rs
+++ b/src/platform/frame_diag.rs
@@ -69,8 +69,7 @@ const ALL_CAUSES: [RepaintCause; 16] = [
     RepaintCause::UserInput,
 ];
 
-static COUNTERS: [AtomicU32; ALL_CAUSES.len()] =
-    [const { AtomicU32::new(0) }; ALL_CAUSES.len()];
+static COUNTERS: [AtomicU32; ALL_CAUSES.len()] = [const { AtomicU32::new(0) }; ALL_CAUSES.len()];
 
 impl RepaintCause {
     /// Stable snake_case label for log output.
@@ -201,9 +200,15 @@ mod tests {
             summary_line(102, 10.0, &counts),
             "frames=102 window=10.0s fps=10.2 causes: app_idle_poll=95 user_input=12"
         );
-        assert_eq!(summary_line(0, 10.0, &[]), "frames=0 window=10.0s fps=0.0 causes: none");
+        assert_eq!(
+            summary_line(0, 10.0, &[]),
+            "frames=0 window=10.0s fps=0.0 causes: none"
+        );
         // Zero-length window must not divide by zero.
-        assert_eq!(summary_line(5, 0.0, &[]), "frames=5 window=0.0s fps=0.0 causes: none");
+        assert_eq!(
+            summary_line(5, 0.0, &[]),
+            "frames=5 window=0.0s fps=0.0 causes: none"
+        );
     }
 
     #[test]

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -1,0 +1,139 @@
+//! UI-thread bridge for PGAP control commands.
+
+use super::{FrameDoneOutcome, ProcessApp};
+use crate::app_protocol::ControlCommand;
+
+impl ProcessApp {
+    /// Dispatch a `ControlCommand` that arrived during `ui()`. Called inline
+    /// from the `ui()` dispatch loop; has access to `egui::Ui` for operations
+    /// that require UI-thread context (font metrics, clipboard, repaint).
+    pub(crate) fn handle_control_command(&mut self, ui: &mut egui::Ui, cmd: ControlCommand) {
+        match cmd {
+            ControlCommand::Ready { sdk, features_used } => {
+                self.sdk = Some(sdk);
+                self.features_used = features_used;
+                self.runtime.mark_ready();
+                ui.ctx().request_repaint();
+            }
+            ControlCommand::FrameDone { frame_id: done_id } => {
+                let frame_ok = match self.runtime.complete_frame(done_id) {
+                    FrameDoneOutcome::Matched => true,
+                    FrameDoneOutcome::Unexpected { expected, got } => {
+                        log::error!(
+                            "ProcessApp[{}]: FrameDone frame_id={got} expected={expected:?}",
+                            self.type_id,
+                        );
+                        self.lifecycle.on_parse_error();
+                        false
+                    }
+                };
+                if !frame_ok {
+                    self.pending_frame.clear();
+                    return;
+                }
+                std::mem::swap(&mut self.frame, &mut self.pending_frame);
+                self.pending_frame.clear();
+                self.click_awaiting_frame = false;
+                self.lifecycle.on_frame_done();
+                self.arm_scheduler_after_frame();
+                if self.runtime.has_pending_render() {
+                    ui.ctx().request_repaint();
+                }
+            }
+            ControlCommand::Log { level, message } => {
+                let target = format!("app::{}", self.type_id);
+                match level.as_str() {
+                    "error" => log::error!(target: &target, "{message}"),
+                    "warn" => log::warn!(target: &target, "{message}"),
+                    "debug" => log::debug!(target: &target, "{message}"),
+                    _ => log::info!(target: &target, "{message}"),
+                }
+            }
+            ControlCommand::FatalError { message, traceback } => {
+                self.record_fatal_error(message, traceback);
+            }
+            ControlCommand::SetSchedulerMode { mode, fps } => {
+                self.set_scheduler_mode(&mode, fps);
+            }
+            ControlCommand::ScheduleRender { after_ms } => {
+                crate::platform::frame_diag::note(
+                    crate::platform::frame_diag::RepaintCause::AppScheduleRender,
+                );
+                let delay = std::time::Duration::from_millis(after_ms as u64);
+                self.mark_render_needed_after("schedule_render", delay);
+                ui.ctx().request_repaint_after(delay);
+            }
+            ControlCommand::CopyToClipboard { text } => {
+                let preview = text.chars().take(80).collect::<String>();
+                log::info!(target: &format!("app::{}", self.type_id), "copy_to_clipboard: {} chars: {:?}", text.len(), preview);
+                ui.ctx().copy_text(text);
+            }
+            ControlCommand::MeasureText {
+                request_id,
+                text,
+                font_size,
+                monospace,
+            } => {
+                let family = if monospace {
+                    egui::FontFamily::Monospace
+                } else {
+                    egui::FontFamily::Proportional
+                };
+                let font_id = egui::FontId::new(font_size, family);
+                let galley = ui.fonts(|f| f.layout_no_wrap(text, font_id, egui::Color32::WHITE));
+                let sz = galley.size();
+                self.outbound_events
+                    .push_back(crate::app_protocol::PlexiEvent::TextMeasured {
+                        request_id,
+                        width: sz.x,
+                        height: sz.y,
+                    });
+            }
+            ControlCommand::MeasureTextWrapped {
+                request_id,
+                text,
+                font_size,
+                max_width,
+                max_lines,
+            } => {
+                let font_id = egui::FontId::proportional(font_size);
+                let galley =
+                    ui.fonts(|f| f.layout(text.clone(), font_id, egui::Color32::WHITE, max_width));
+                let n_rows = max_lines
+                    .map(|n| (n as usize).min(galley.rows.len()))
+                    .unwrap_or(galley.rows.len());
+                let height = if n_rows == 0 {
+                    0.0
+                } else {
+                    galley.rows[n_rows - 1].rect.max.y
+                };
+                log::debug!(
+                    "ProcessApp[{}]: MeasureTextWrapped request_id={} max_width={:.1} max_lines={:?} rows={} height={:.1}",
+                    self.type_id, request_id, max_width, max_lines, n_rows, height
+                );
+                self.outbound_events.push_back(
+                    crate::app_protocol::PlexiEvent::TextWrappedMeasured {
+                        request_id: request_id.clone(),
+                        height,
+                    },
+                );
+            }
+            ControlCommand::SetMinSize { width, height } => {
+                self.live_min_size = Some((width, height));
+                log::info!(
+                    "ProcessApp[{}]: live min size set to {:.0}×{:.0}",
+                    self.type_id,
+                    width,
+                    height
+                );
+            }
+            ControlCommand::CloseSelf => {
+                log::info!(
+                    "ProcessApp[{}]: CloseSelf — pane will close on next frame",
+                    self.type_id
+                );
+                self.wants_close_self = true;
+            }
+        }
+    }
+}

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -35,6 +35,12 @@ impl ProcessApp {
                 self.pending_frame.clear();
                 self.click_awaiting_frame = false;
                 self.lifecycle.on_frame_done();
+                self.render_diag.record_frame_committed(
+                    &self.type_id,
+                    done_id,
+                    self.scheduler_mode.next_frame_delay(),
+                    std::time::Instant::now(),
+                );
                 if self.runtime.has_pending_render() {
                     ui.ctx().request_repaint();
                 }

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -35,7 +35,6 @@ impl ProcessApp {
                 self.pending_frame.clear();
                 self.click_awaiting_frame = false;
                 self.lifecycle.on_frame_done();
-                self.arm_scheduler_after_frame();
                 if self.runtime.has_pending_render() {
                     ui.ctx().request_repaint();
                 }

--- a/src/process_app/image_cache.rs
+++ b/src/process_app/image_cache.rs
@@ -212,6 +212,14 @@ impl ImageCache {
         completed
     }
 
+    pub(crate) fn has_pending(&self) -> bool {
+        !self.immediate_completions.is_empty()
+            || self
+                .cache
+                .values()
+                .any(|entry| matches!(entry, CachedImage::Loading))
+    }
+
     /// Returns the texture handle if the image is loaded; None otherwise.
     pub(crate) fn get(&self, src: &str) -> Option<&egui::TextureHandle> {
         match self.cache.get(src) {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2032,6 +2032,10 @@ impl App for ProcessApp {
             } else {
                 ui.ctx().request_repaint();
             }
+        } else if self.render_in_flight_frame_id.is_some() {
+            frame_diag::note(RepaintCause::AppIdlePoll);
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(100));
         } else if self.needs_async_wake_poll() {
             frame_diag::note(RepaintCause::AppIdlePoll);
             ui.ctx()

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -76,6 +76,14 @@ pub(crate) struct DeferredAiQuery {
     pub(crate) tools: Vec<AiTool>,
 }
 
+fn request_repaint_from_thread(repaint_ctx: &Arc<Mutex<Option<egui::Context>>>) {
+    if let Ok(ctx) = repaint_ctx.lock() {
+        if let Some(ctx) = ctx.as_ref() {
+            ctx.request_repaint();
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // StdinItem — typed messages for the stdin-writer channel
 // ---------------------------------------------------------------------------
@@ -311,6 +319,10 @@ pub struct ProcessApp {
     /// Key = call_id, value = channel to the blocked HTTP handler thread.
     pub(crate) mcp_pending:
         std::collections::HashMap<String, std::sync::mpsc::SyncSender<mcp_server::McpToolResponse>>,
+    /// Last egui context seen by `ui()`. Background stdout/stderr/reaper
+    /// threads use this to wake the host when they enqueue work or flip
+    /// lifecycle state.
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
     /// Set to true when the app emits ControlCommand::CloseSelf. The host
     /// checks wants_close() each frame and calls close_pane gracefully,
     /// avoiding the crash-restart path that sys.exit() would trigger.
@@ -579,7 +591,9 @@ impl ProcessApp {
         let recent_stderr_capture = Arc::new(Mutex::new(VecDeque::<String>::new()));
         let recent_stderr_thread = Arc::clone(&recent_stderr_capture);
         let lifecycle_tracker = Arc::new(LifecycleTracker::new());
+        let repaint_ctx = Arc::new(Mutex::new(None));
         let lifecycle_stderr = Arc::clone(&lifecycle_tracker);
+        let repaint_stderr = Arc::clone(&repaint_ctx);
         thread::Builder::new()
             .name(format!("app-stderr-{stderr_type_id}"))
             .spawn(move || {
@@ -591,6 +605,7 @@ impl ProcessApp {
                             let target = format!("app::{stderr_type_id}");
                             log::warn!(target: &target, "stderr: {l}");
                             lifecycle_stderr.observe_stderr_line(&l);
+                            request_repaint_from_thread(&repaint_stderr);
                             if let Ok(mut buf) = recent_stderr_thread.lock() {
                                 if buf.len() >= STDERR_RING_CAP {
                                     buf.pop_front();
@@ -611,6 +626,7 @@ impl ProcessApp {
         //   - Stdout EOF / read error → on_stdout_closed() (sticky Crashed).
         let (draw_tx, draw_rx) = mpsc::channel::<DrawCommand>();
         let lifecycle_stdout = Arc::clone(&lifecycle_tracker);
+        let repaint_stdout = Arc::clone(&repaint_ctx);
         let stdout_type_id = type_id.clone();
         thread::Builder::new()
             .name(format!("app-stdout-{stdout_type_id}"))
@@ -624,6 +640,7 @@ impl ProcessApp {
                                 if draw_tx.send(cmd).is_err() {
                                     break;
                                 }
+                                request_repaint_from_thread(&repaint_stdout);
                             }
                             Err(e) => {
                                 log::warn!(
@@ -633,6 +650,7 @@ impl ProcessApp {
                                     log::error!(
                                         "ProcessApp[{stdout_type_id}]: protocol-error threshold reached — flipping pane state"
                                     );
+                                    request_repaint_from_thread(&repaint_stdout);
                                 }
                             }
                         }
@@ -640,6 +658,7 @@ impl ProcessApp {
                     Err(e) => {
                         log::debug!("ProcessApp[{stdout_type_id}] stdout closed: {e}");
                         lifecycle_stdout.on_stdout_closed();
+                        request_repaint_from_thread(&repaint_stdout);
                         break;
                     }
                     _ => {}
@@ -649,6 +668,7 @@ impl ProcessApp {
             // subprocess closed its stdout — flip Crashed unless already
             // terminal.
             lifecycle_stdout.on_stdout_closed();
+            request_repaint_from_thread(&repaint_stdout);
         }).expect("failed to spawn app-stdout thread");
 
         // Background reaper: blocks on waitpid so the UI thread never polls try_wait.
@@ -656,6 +676,7 @@ impl ProcessApp {
         // per-frame try_wait() poll that was causing 600 syscalls/sec with 10 panes open.
         let reaper_pid = child.id();
         let lifecycle_reaper = Arc::clone(&lifecycle_tracker);
+        let repaint_reaper = Arc::clone(&repaint_ctx);
         let reaper_type_id = type_id.clone();
         thread::Builder::new()
             .name(format!("app-reaper-{reaper_type_id}"))
@@ -672,6 +693,7 @@ impl ProcessApp {
                     "ProcessApp[{reaper_type_id}]: child exited — reaper signaling lifecycle"
                 );
                 lifecycle_reaper.on_process_exited();
+                request_repaint_from_thread(&repaint_reaper);
             })
             .expect("failed to spawn app-reaper thread");
 
@@ -774,6 +796,7 @@ impl ProcessApp {
             active_stream_threads: Arc::new(AtomicUsize::new(0)),
             mcp_server: mcp_server_handle,
             mcp_pending: std::collections::HashMap::new(),
+            repaint_ctx,
             wants_close_self: false,
             click_awaiting_frame: false,
             launch_args: args.to_vec(),
@@ -931,6 +954,7 @@ impl ProcessApp {
             file_picker_rx,
             mcp_server: None,
             mcp_pending: std::collections::HashMap::new(),
+            repaint_ctx: Arc::new(Mutex::new(None)),
             wants_close_self: false,
             click_awaiting_frame: false,
             launch_args: Vec::new(),
@@ -1102,7 +1126,8 @@ impl ProcessApp {
                 PlexiEvent::Timer { timer_id } => {
                     self.pending_timers.remove(timer_id);
                 }
-                PlexiEvent::AiStreamChunk { .. } => {}
+                PlexiEvent::AiStreamChunk { .. } | PlexiEvent::StreamChunk { .. } => {}
+                PlexiEvent::StreamEnd { .. } => self.complete_async_wake(),
                 _ => self.complete_async_wake(),
             }
             self.outbound_events.push_back(event);
@@ -1119,6 +1144,7 @@ impl ProcessApp {
         self.pending_async_completions > 0
             || !self.pending_timers.is_empty()
             || self.active_stream_threads.load(Ordering::Relaxed) > 0
+            || self.mcp_server.is_some()
             || self.image_cache.has_pending()
     }
 
@@ -1492,6 +1518,9 @@ impl App for ProcessApp {
 
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         let size = ui.available_size();
+        if let Ok(mut repaint_ctx) = self.repaint_ctx.lock() {
+            *repaint_ctx = Some(ui.ctx().clone());
+        }
 
         self.poll_mcp_calls();
         self.flush_outbound_events();

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -150,6 +150,10 @@ pub struct ProcessApp {
     last_size: egui::Vec2,
     initialized: bool,
     frame_counter: u64,
+    render_needed: bool,
+    render_in_flight_frame_id: Option<u64>,
+    render_not_before: Option<std::time::Instant>,
+    idle_render_poll_logged: bool,
     sdk: Option<String>,
     features_used: Vec<String>,
     /// workspace_root sent in Init — scopes all SecretGet calls.
@@ -706,6 +710,10 @@ impl ProcessApp {
             last_size: egui::Vec2::ZERO,
             initialized: false,
             frame_counter: 0,
+            render_needed: true,
+            render_in_flight_frame_id: None,
+            render_not_before: None,
+            idle_render_poll_logged: false,
             sdk: None,
             features_used: Vec::new(),
             workspace_root,
@@ -861,6 +869,10 @@ impl ProcessApp {
             last_size: egui::Vec2::ZERO,
             initialized: true,
             frame_counter: 0,
+            render_needed: true,
+            render_in_flight_frame_id: None,
+            render_not_before: None,
+            idle_render_poll_logged: false,
             sdk: None,
             features_used: Vec::new(),
             workspace_root: std::env::temp_dir(),
@@ -1018,6 +1030,56 @@ impl ProcessApp {
         }
     }
 
+    fn mark_render_needed(&mut self, reason: &'static str) {
+        if !self.render_needed {
+            log::info!("ProcessApp[{}]: render requested ({reason})", self.type_id);
+        }
+        self.render_needed = true;
+        self.render_not_before = None;
+    }
+
+    fn mark_render_needed_after(&mut self, reason: &'static str, delay: std::time::Duration) {
+        let scheduled_at = std::time::Instant::now() + delay;
+        if !self.render_needed {
+            log::info!(
+                "ProcessApp[{}]: render requested ({reason}, after {}ms)",
+                self.type_id,
+                delay.as_millis()
+            );
+            self.render_needed = true;
+            self.render_not_before = Some(scheduled_at);
+        } else if let Some(existing) = self.render_not_before {
+            self.render_not_before = Some(existing.min(scheduled_at));
+        }
+    }
+
+    fn send_render_if_needed(&mut self, size: egui::Vec2) -> Option<u64> {
+        if !self.render_needed || self.render_in_flight_frame_id.is_some() {
+            return None;
+        }
+        if let Some(not_before) = self.render_not_before {
+            if std::time::Instant::now() < not_before {
+                return None;
+            }
+        }
+
+        self.frame_counter += 1;
+        let frame_id = self.frame_counter;
+        self.send_event(&PlexiEvent::Render {
+            frame_id,
+            rect: crate::app_protocol::Rect {
+                x: 0.0,
+                y: 0.0,
+                w: size.x,
+                h: size.y,
+            },
+        });
+        self.render_needed = false;
+        self.render_not_before = None;
+        self.render_in_flight_frame_id = Some(frame_id);
+        Some(frame_id)
+    }
+
     /// Drain the MCP call queue and forward each request to the app as a
     /// `PlexiEvent::McpToolCall`. Called each frame (both `ui()` and
     /// `background_tick()`) so tool calls are processed even for background apps.
@@ -1052,8 +1114,13 @@ impl ProcessApp {
     }
 
     fn flush_outbound_events(&mut self) {
+        let mut flushed = false;
         while let Some(event) = self.outbound_events.pop_front() {
             self.send_event(&event);
+            flushed = true;
+        }
+        if flushed {
+            self.mark_render_needed("outbound_event");
         }
     }
 
@@ -1243,17 +1310,18 @@ impl ProcessApp {
     /// Dispatch a `ControlCommand` that arrived during `ui()`. Called inline
     /// from the `ui()` dispatch loop; has access to `egui::Ui` for operations
     /// that require UI-thread context (font metrics, clipboard, repaint).
-    fn handle_control_command(&mut self, ui: &mut egui::Ui, frame_id: u64, cmd: ControlCommand) {
+    fn handle_control_command(&mut self, ui: &mut egui::Ui, cmd: ControlCommand) {
         match cmd {
             ControlCommand::Ready { sdk, features_used } => {
                 self.sdk = Some(sdk);
                 self.features_used = features_used;
             }
             ControlCommand::FrameDone { frame_id: done_id } => {
-                if done_id != frame_id {
+                let expected_frame_id = self.render_in_flight_frame_id.take();
+                if expected_frame_id != Some(done_id) {
                     log::debug!(
-                        "ProcessApp[{}]: FrameDone frame_id={done_id} expected={frame_id}",
-                        self.type_id
+                        "ProcessApp[{}]: FrameDone frame_id={done_id} expected={expected_frame_id:?}",
+                        self.type_id,
                     );
                 }
                 std::mem::swap(&mut self.frame, &mut self.pending_frame);
@@ -1261,6 +1329,9 @@ impl ProcessApp {
                 self.click_awaiting_frame = false;
                 // Lifecycle: a frame just landed → Running (unless terminal).
                 self.lifecycle.on_frame_done();
+                if self.render_needed {
+                    ui.ctx().request_repaint();
+                }
             }
             ControlCommand::Log { level, message } => {
                 let target = format!("app::{}", self.type_id);
@@ -1275,8 +1346,9 @@ impl ProcessApp {
                 crate::platform::frame_diag::note(
                     crate::platform::frame_diag::RepaintCause::AppScheduleRender,
                 );
-                ui.ctx()
-                    .request_repaint_after(std::time::Duration::from_millis(after_ms as u64));
+                let delay = std::time::Duration::from_millis(after_ms as u64);
+                self.mark_render_needed_after("schedule_render", delay);
+                ui.ctx().request_repaint_after(delay);
             }
             // CopyToClipboard is handled here (not in routing.rs) because
             // `egui::Context::copy_text` is a UI-context method. The host
@@ -1378,6 +1450,7 @@ impl App for ProcessApp {
 
     fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
         self.outbound_events.push_back(event);
+        self.mark_render_needed("queued_outbound_event");
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
@@ -1445,6 +1518,7 @@ impl App for ProcessApp {
                 width: size.x,
                 height: size.y,
             });
+            self.mark_render_needed("resize");
         }
 
         // Size-class guard: if the pane is below the effective minimum, render a
@@ -1479,17 +1553,7 @@ impl App for ProcessApp {
             return;
         }
 
-        self.frame_counter += 1;
-        let frame_id = self.frame_counter;
-        self.send_event(&PlexiEvent::Render {
-            frame_id,
-            rect: crate::app_protocol::Rect {
-                x: 0.0,
-                y: 0.0,
-                w: size.x,
-                h: size.y,
-            },
-        });
+        self.send_render_if_needed(size);
 
         // Drain async HTTP responses from background request threads.
         while let Ok(event) = self.http_rx.try_recv() {
@@ -1540,7 +1604,7 @@ impl App for ProcessApp {
 
         for cmd in new_cmds {
             match cmd {
-                DrawCommand::Control(c) => self.handle_control_command(ui, frame_id, c),
+                DrawCommand::Control(c) => self.handle_control_command(ui, c),
                 DrawCommand::Host(h) => self.route_command(h),
                 DrawCommand::Render(r) => self.pending_frame.push(r),
             }
@@ -1816,6 +1880,7 @@ impl App for ProcessApp {
                         button: crate::app_protocol::MouseButton::Primary,
                         modifiers: frame_mods.clone(),
                     });
+                    self.mark_render_needed("mouse_down");
                     needs_click_repaint = true;
                 }
                 if is_secondary_down {
@@ -1825,6 +1890,7 @@ impl App for ProcessApp {
                         button: crate::app_protocol::MouseButton::Secondary,
                         modifiers: frame_mods.clone(),
                     });
+                    self.mark_render_needed("mouse_down");
                     needs_click_repaint = true;
                 }
             }
@@ -1851,6 +1917,7 @@ impl App for ProcessApp {
                         y,
                         button: crate::app_protocol::MouseButton::Primary,
                     });
+                    self.mark_render_needed("mouse_up");
                     needs_click_repaint = true;
                 }
                 if secondary_up {
@@ -1865,6 +1932,7 @@ impl App for ProcessApp {
                         y,
                         button: crate::app_protocol::MouseButton::Secondary,
                     });
+                    self.mark_render_needed("mouse_up");
                     needs_click_repaint = true;
                 }
             }
@@ -1893,6 +1961,7 @@ impl App for ProcessApp {
                             buttons,
                             modifiers: frame_mods.clone(),
                         });
+                        self.mark_render_needed("mouse_move");
                         needs_tracking_repaint = true;
                     }
                 }
@@ -1922,10 +1991,25 @@ impl App for ProcessApp {
             frame_diag::note(RepaintCause::PointerTracking);
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(16));
+        } else if self.render_needed && self.render_in_flight_frame_id.is_none() {
+            if let Some(not_before) = self.render_not_before {
+                let now = std::time::Instant::now();
+                if not_before > now {
+                    ui.ctx().request_repaint_after(not_before - now);
+                } else {
+                    ui.ctx().request_repaint();
+                }
+            } else {
+                ui.ctx().request_repaint();
+            }
         } else {
-            frame_diag::note(RepaintCause::AppIdlePoll);
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(100));
+            if !self.idle_render_poll_logged {
+                log::info!(
+                    "ProcessApp[{}]: idle render polling disabled; waiting for input, dirty state, or ScheduleRender",
+                    self.type_id
+                );
+                self.idle_render_poll_logged = true;
+            }
         }
     }
 
@@ -2080,6 +2164,7 @@ impl App for ProcessApp {
             }
         }
         if consumed {
+            self.mark_render_needed("keyboard_input");
             KeyDisposition::Consumed
         } else {
             KeyDisposition::Passthrough
@@ -2094,6 +2179,7 @@ impl App for ProcessApp {
         self.outbound_events.push_back(PlexiEvent::PathChanged {
             cwd: new_cwd.to_path_buf(),
         });
+        self.mark_render_needed("path_changed");
     }
 
     fn serialize_state(&self) -> Option<serde_json::Value> {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1068,11 +1068,13 @@ impl ProcessApp {
     fn mark_render_needed_after(&mut self, reason: &'static str, delay: std::time::Duration) {
         let scheduled_at = std::time::Instant::now() + delay;
         if !self.render_needed {
-            log::info!(
-                "ProcessApp[{}]: render requested ({reason}, after {}ms)",
-                self.type_id,
-                delay.as_millis()
-            );
+            if reason != "schedule_render" {
+                log::info!(
+                    "ProcessApp[{}]: render requested ({reason}, after {}ms)",
+                    self.type_id,
+                    delay.as_millis()
+                );
+            }
             self.render_needed = true;
             self.render_not_before = Some(scheduled_at);
         } else if let Some(existing) = self.render_not_before {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1148,6 +1148,10 @@ impl ProcessApp {
             || self.image_cache.has_pending()
     }
 
+    pub(crate) fn needs_headless_wake_poll(&self) -> bool {
+        self.render_in_flight_frame_id.is_some() || self.needs_async_wake_poll()
+    }
+
     /// Drain the MCP call queue and forward each request to the app as a
     /// `PlexiEvent::McpToolCall`. Called each frame (both `ui()` and
     /// `background_tick()`) so tool calls are processed even for background apps.
@@ -1364,7 +1368,19 @@ impl ProcessApp {
                         _ => log::info!(target: &target, "{message}"),
                     }
                 }
-                DrawCommand::Control(_) => {} // Ready/FrameDone/etc. irrelevant without a pane
+                DrawCommand::Control(ControlCommand::FrameDone { frame_id }) => {
+                    let expected_frame_id = self.render_in_flight_frame_id.take();
+                    if expected_frame_id != Some(frame_id) {
+                        log::debug!(
+                            "ProcessApp[{}]: background FrameDone frame_id={frame_id} expected={expected_frame_id:?}",
+                            self.type_id,
+                        );
+                    }
+                    self.pending_frame.clear();
+                    self.click_awaiting_frame = false;
+                    self.lifecycle.on_frame_done();
+                }
+                DrawCommand::Control(_) => {} // Ready/etc. irrelevant without a pane
                 DrawCommand::Render(_) => {}  // No pane to render into
             }
         }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -6,11 +6,15 @@
 //! would — the rest of Plexi doesn't know or care that it's an external process.
 //!
 //! Internal layout:
-//! - `mod.rs`      — struct, lifecycle (launch/drop), App trait impl
-//! - `routing.rs`  — `route_command()`: dispatch DrawCommands to subsystems
-//! - `render.rs`   — `render_draw_commands()`: paint committed frames into egui
-//! - `prompts.rs`  — `show_prompt_modal()`: capability/secret grant UI
+//! - `mod.rs`          — struct, launch/drop, App trait impl
+//! - `transport.rs`    — stdin/stdout/stderr/reaper threads
+//! - `runtime_state.rs` — PGAP render transaction state machine
+//! - `scheduler.rs`    — host repaint policy
+//! - `routing.rs`      — `route_command()`: dispatch DrawCommands to subsystems
+//! - `render.rs`       — `render_draw_commands()`: paint committed frames into egui
+//! - `prompts.rs`      — `show_prompt_modal()`: capability/secret grant UI
 
+mod host_bridge;
 pub(crate) mod image_cache;
 mod lifecycle;
 pub(crate) mod mcp_server;
@@ -18,9 +22,14 @@ pub(crate) mod prompts;
 pub(crate) mod render;
 mod render_session;
 mod routing;
+mod runtime_state;
+mod scheduler;
+mod transport;
 
 pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 use render_session::RenderSession;
+use runtime_state::{FrameDoneOutcome, PgapRuntime, RenderPoll};
+pub(crate) use transport::StdinItem;
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext};
 use crate::app::permissions::{AppPermissions, Capability};
@@ -36,15 +45,13 @@ use crate::media::midi::{MidiDevice, MidiInputSession, MidiOutputHandle};
 use crate::media::video::{VideoDecoder, VideoHandle};
 use crate::plexi_ai::broker::{AiBroker, LiveAiBroker};
 use std::collections::{HashMap, VecDeque};
-use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdout, Stdio};
+use std::process::{Child, Stdio};
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, Receiver, Sender, TryRecvError},
     Arc, Mutex,
 };
-use std::thread;
 
 // ---------------------------------------------------------------------------
 // PendingPrompt — capability / secret prompts queued for modal presentation
@@ -74,30 +81,6 @@ pub(crate) struct DeferredAiQuery {
     pub(crate) system: String,
     pub(crate) messages: Vec<AiMessage>,
     pub(crate) tools: Vec<AiTool>,
-}
-
-fn request_repaint_from_thread(repaint_ctx: &Arc<Mutex<Option<egui::Context>>>) {
-    if let Ok(ctx) = repaint_ctx.lock() {
-        if let Some(ctx) = ctx.as_ref() {
-            ctx.request_repaint();
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// StdinItem — typed messages for the stdin-writer channel
-// ---------------------------------------------------------------------------
-
-/// Messages sent from the GUI thread to the stdin-writer background thread.
-///
-/// `Render` events are coalesced: only the latest matters, so we store it in
-/// `render_slot` and send a single `FlushRender` token. Non-render events are
-/// queued in order and never dropped.
-pub(crate) enum StdinItem {
-    /// A non-render event serialised as a newline-terminated JSON string.
-    Event(String),
-    /// Consume and write the latest render payload from the render slot.
-    FlushRender,
 }
 
 // ---------------------------------------------------------------------------
@@ -157,10 +140,8 @@ pub struct ProcessApp {
     pub(crate) pending_commands: Vec<AppCommand>,
     last_size: egui::Vec2,
     initialized: bool,
-    frame_counter: u64,
-    render_needed: bool,
-    render_in_flight_frame_id: Option<u64>,
-    render_not_before: Option<std::time::Instant>,
+    runtime: PgapRuntime,
+    scheduler_mode: scheduler::AppSchedulerMode,
     pending_async_completions: usize,
     idle_render_poll_logged: bool,
     sdk: Option<String>,
@@ -535,7 +516,7 @@ impl ProcessApp {
         let mut child = cmd.spawn()?;
 
         let stdin = child.stdin.take().expect("stdin piped");
-        let stdout: ChildStdout = child.stdout.take().expect("stdout piped");
+        let stdout = child.stdout.take().expect("stdout piped");
         let stderr = child.stderr.take().expect("stderr piped");
 
         // Stdin writer thread — owns the pipe and blocks on write_all.
@@ -547,155 +528,52 @@ impl ProcessApp {
         let render_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let render_in_queue: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let (event_tx, event_rx) = mpsc::channel::<StdinItem>();
-        let stdin_type_id = type_id.clone();
-        {
-            use std::io::Write as _;
-            let render_slot_writer = Arc::clone(&render_slot);
-            let render_in_queue_writer = Arc::clone(&render_in_queue);
-            thread::Builder::new()
-                .name(format!("app-stdin-{stdin_type_id}"))
-                .spawn(move || {
-                let mut stdin = stdin;
-                for item in event_rx {
-                    match item {
-                        StdinItem::Event(line) => {
-                            if stdin.write_all(line.as_bytes()).is_err() {
-                                log::debug!("ProcessApp[{stdin_type_id}]: stdin write failed — writer thread exiting");
-                                break;
-                            }
-                        }
-                        StdinItem::FlushRender => {
-                            // Clear the flag *before* reading the slot so that
-                            // a concurrent send_event can enqueue a new token
-                            // if a fresh Render arrives while we're writing.
-                            render_in_queue_writer.store(false, Ordering::Relaxed);
-                            let line = render_slot_writer.lock().unwrap().take();
-                            if let Some(line) = line {
-                                if stdin.write_all(line.as_bytes()).is_err() {
-                                    log::debug!("ProcessApp[{stdin_type_id}]: stdin write failed — writer thread exiting");
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }).expect("failed to spawn app-stdin thread");
-        }
+        transport::spawn_stdin_writer(
+            type_id.clone(),
+            stdin,
+            event_rx,
+            Arc::clone(&render_slot),
+            Arc::clone(&render_in_queue),
+        );
 
         // Background thread: forward subprocess stderr to Plexi's logger,
         // capture into the recent-stderr ring buffer used by the in-pane
         // error fallback, AND scan each line for `Traceback` / `PANIC` /
         // `panicked at` so the lifecycle pill flips to Crashed without
         // waiting for `try_wait` to observe the eventual exit.
-        let stderr_type_id = type_id.clone();
         let recent_stderr_capture = Arc::new(Mutex::new(VecDeque::<String>::new()));
-        let recent_stderr_thread = Arc::clone(&recent_stderr_capture);
         let lifecycle_tracker = Arc::new(LifecycleTracker::new());
         let repaint_ctx = Arc::new(Mutex::new(None));
-        let lifecycle_stderr = Arc::clone(&lifecycle_tracker);
-        let repaint_stderr = Arc::clone(&repaint_ctx);
-        thread::Builder::new()
-            .name(format!("app-stderr-{stderr_type_id}"))
-            .spawn(move || {
-                const STDERR_RING_CAP: usize = 32;
-                let reader = std::io::BufReader::new(stderr);
-                for line in std::io::BufRead::lines(reader) {
-                    match line {
-                        Ok(l) if !l.trim().is_empty() => {
-                            let target = format!("app::{stderr_type_id}");
-                            log::warn!(target: &target, "stderr: {l}");
-                            lifecycle_stderr.observe_stderr_line(&l);
-                            request_repaint_from_thread(&repaint_stderr);
-                            if let Ok(mut buf) = recent_stderr_thread.lock() {
-                                if buf.len() >= STDERR_RING_CAP {
-                                    buf.pop_front();
-                                }
-                                buf.push_back(l);
-                            }
-                        }
-                        Err(_) => break,
-                        _ => {}
-                    }
-                }
-            })
-            .expect("failed to spawn app-stderr thread");
+        transport::spawn_stderr_reader(
+            type_id.clone(),
+            stderr,
+            Arc::clone(&recent_stderr_capture),
+            Arc::clone(&lifecycle_tracker),
+            Arc::clone(&repaint_ctx),
+        );
 
         // Background thread: read draw commands line-by-line and forward via channel.
         // Also feeds the lifecycle tracker:
         //   - Malformed JSON → on_parse_error() (counts toward ProtocolError).
         //   - Stdout EOF / read error → on_stdout_closed() (sticky Crashed).
         let (draw_tx, draw_rx) = mpsc::channel::<DrawCommand>();
-        let lifecycle_stdout = Arc::clone(&lifecycle_tracker);
-        let repaint_stdout = Arc::clone(&repaint_ctx);
-        let stdout_type_id = type_id.clone();
-        thread::Builder::new()
-            .name(format!("app-stdout-{stdout_type_id}"))
-            .spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) if !l.trim().is_empty() => {
-                        match serde_json::from_str::<DrawCommand>(&l) {
-                            Ok(cmd) => {
-                                if draw_tx.send(cmd).is_err() {
-                                    break;
-                                }
-                                request_repaint_from_thread(&repaint_stdout);
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "ProcessApp[{stdout_type_id}]: malformed draw command: {e} — line: {l}"
-                                );
-                                if lifecycle_stdout.on_parse_error() {
-                                    log::error!(
-                                        "ProcessApp[{stdout_type_id}]: protocol-error threshold reached — flipping pane state"
-                                    );
-                                    request_repaint_from_thread(&repaint_stdout);
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        log::debug!("ProcessApp[{stdout_type_id}] stdout closed: {e}");
-                        lifecycle_stdout.on_stdout_closed();
-                        request_repaint_from_thread(&repaint_stdout);
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-            // Natural EOF (loop exit without an Err) also signals the
-            // subprocess closed its stdout — flip Crashed unless already
-            // terminal.
-            lifecycle_stdout.on_stdout_closed();
-            request_repaint_from_thread(&repaint_stdout);
-        }).expect("failed to spawn app-stdout thread");
+        transport::spawn_stdout_reader(
+            type_id.clone(),
+            stdout,
+            draw_tx,
+            Arc::clone(&lifecycle_tracker),
+            Arc::clone(&repaint_ctx),
+        );
 
         // Background reaper: blocks on waitpid so the UI thread never polls try_wait.
         // Fires on_process_exited() exactly once when the child exits — replaces the
         // per-frame try_wait() poll that was causing 600 syscalls/sec with 10 panes open.
-        let reaper_pid = child.id();
-        let lifecycle_reaper = Arc::clone(&lifecycle_tracker);
-        let repaint_reaper = Arc::clone(&repaint_ctx);
-        let reaper_type_id = type_id.clone();
-        thread::Builder::new()
-            .name(format!("app-reaper-{reaper_type_id}"))
-            .spawn(move || {
-                let mut status = 0i32;
-                // SAFETY: reaper_pid is a valid child PID obtained from Command::spawn().
-                // We block until the child exits. The shutdown path's child.wait() may
-                // race and get ECHILD if we win — that's harmless since shutdown discards
-                // the result with `let _ = child.wait()`.
-                unsafe {
-                    libc::waitpid(reaper_pid as libc::pid_t, &mut status, 0);
-                }
-                log::info!(
-                    "ProcessApp[{reaper_type_id}]: child exited — reaper signaling lifecycle"
-                );
-                lifecycle_reaper.on_process_exited();
-                request_repaint_from_thread(&repaint_reaper);
-            })
-            .expect("failed to spawn app-reaper thread");
+        transport::spawn_reaper(
+            type_id.clone(),
+            child.id(),
+            Arc::clone(&lifecycle_tracker),
+            Arc::clone(&repaint_ctx),
+        );
 
         let config_dir = crate::config::config_dir();
         let store = crate::app::permissions::PermissionStore::load_or_default(&config_dir);
@@ -732,10 +610,8 @@ impl ProcessApp {
             pending_commands: Vec::new(),
             last_size: egui::Vec2::ZERO,
             initialized: false,
-            frame_counter: 0,
-            render_needed: true,
-            render_in_flight_frame_id: None,
-            render_not_before: None,
+            runtime: PgapRuntime::spawned_with_initial_render(),
+            scheduler_mode: scheduler::AppSchedulerMode::default(),
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
@@ -893,10 +769,8 @@ impl ProcessApp {
             pending_commands: Vec::new(),
             last_size: egui::Vec2::ZERO,
             initialized: true,
-            frame_counter: 0,
-            render_needed: true,
-            render_in_flight_frame_id: None,
-            render_not_before: None,
+            runtime: PgapRuntime::ready_for_test_with_initial_render(),
+            scheduler_mode: scheduler::AppSchedulerMode::default(),
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
@@ -1058,16 +932,13 @@ impl ProcessApp {
     }
 
     fn mark_render_needed(&mut self, reason: &'static str) {
-        if !self.render_needed {
+        if self.runtime.request_render_now() {
             log::info!("ProcessApp[{}]: render requested ({reason})", self.type_id);
         }
-        self.render_needed = true;
-        self.render_not_before = None;
     }
 
     fn mark_render_needed_after(&mut self, reason: &'static str, delay: std::time::Duration) {
-        let scheduled_at = std::time::Instant::now() + delay;
-        if !self.render_needed {
+        if self.runtime.request_render_after(delay) {
             if reason != "schedule_render" {
                 log::info!(
                     "ProcessApp[{}]: render requested ({reason}, after {}ms)",
@@ -1075,38 +946,29 @@ impl ProcessApp {
                     delay.as_millis()
                 );
             }
-            self.render_needed = true;
-            self.render_not_before = Some(scheduled_at);
-        } else if let Some(existing) = self.render_not_before {
-            self.render_not_before = Some(existing.min(scheduled_at));
         }
     }
 
     fn send_render_if_needed(&mut self, size: egui::Vec2) -> Option<u64> {
-        if !self.render_needed || self.render_in_flight_frame_id.is_some() {
-            return None;
-        }
-        if let Some(not_before) = self.render_not_before {
-            if std::time::Instant::now() < not_before {
-                return None;
+        match self.runtime.poll_render(std::time::Instant::now()) {
+            RenderPoll::Send { frame_id } => {
+                self.send_event(&PlexiEvent::Render {
+                    frame_id,
+                    rect: crate::app_protocol::Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        w: size.x,
+                        h: size.y,
+                    },
+                });
+                Some(frame_id)
             }
+            RenderPoll::Waiting { .. }
+            | RenderPoll::InFlight
+            | RenderPoll::NotReady
+            | RenderPoll::Idle
+            | RenderPoll::Terminal => None,
         }
-
-        self.frame_counter += 1;
-        let frame_id = self.frame_counter;
-        self.send_event(&PlexiEvent::Render {
-            frame_id,
-            rect: crate::app_protocol::Rect {
-                x: 0.0,
-                y: 0.0,
-                w: size.x,
-                h: size.y,
-            },
-        });
-        self.render_needed = false;
-        self.render_not_before = None;
-        self.render_in_flight_frame_id = Some(frame_id);
-        Some(frame_id)
     }
 
     fn arm_async_completion_wake(&mut self, reason: &'static str) {
@@ -1151,7 +1013,7 @@ impl ProcessApp {
     }
 
     pub(crate) fn needs_headless_wake_poll(&self) -> bool {
-        self.render_in_flight_frame_id.is_some() || self.needs_async_wake_poll()
+        self.runtime.is_rendering() || self.needs_async_wake_poll()
     }
 
     /// Drain the MCP call queue and forward each request to the app as a
@@ -1208,9 +1070,10 @@ impl ProcessApp {
                 Ok(cmd) => cmds.push(cmd),
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
+                    let reason = self.runtime.mark_stdout_closed();
                     log::error!(
-                        "ProcessApp[{}]: subprocess stdout closed — process crashed or exited",
-                        self.type_id
+                        "ProcessApp[{}]: subprocess stdout closed — {reason:?}",
+                        self.type_id,
                     );
                     self.draw_rx = None;
                     break;
@@ -1218,6 +1081,51 @@ impl ProcessApp {
             }
         }
         cmds
+    }
+
+    fn record_fatal_error(&mut self, message: String, traceback: String) {
+        log::error!(
+            "ProcessApp[{}]: fatal SDK error: {message}\n{traceback}",
+            self.type_id
+        );
+        self.runtime.mark_fatal_error();
+        self.lifecycle.on_process_exited();
+        if let Ok(mut buf) = self.recent_stderr.lock() {
+            const STDERR_RING_CAP: usize = 32;
+            if buf.len() >= STDERR_RING_CAP {
+                buf.pop_front();
+            }
+            buf.push_back(format!("fatal_error: {message}"));
+            for line in traceback.lines().take(STDERR_RING_CAP) {
+                if buf.len() >= STDERR_RING_CAP {
+                    buf.pop_front();
+                }
+                buf.push_back(line.to_string());
+            }
+        }
+    }
+
+    fn arm_scheduler_after_frame(&mut self) {
+        if let Some(delay) = self.scheduler_mode.next_frame_delay() {
+            self.mark_render_needed_after("continuous_scheduler", delay);
+        }
+    }
+
+    fn set_scheduler_mode(&mut self, mode: &str, fps: Option<u32>) {
+        match scheduler::AppSchedulerMode::from_wire(mode, fps) {
+            Ok(parsed) => {
+                self.scheduler_mode = parsed;
+                log::info!(
+                    "ProcessApp[{}]: scheduler mode set to {parsed:?}",
+                    self.type_id
+                );
+            }
+            Err(e) => {
+                log::error!("ProcessApp[{}]: {e}", self.type_id);
+                self.runtime.mark_protocol_error(e);
+                self.lifecycle.on_parse_error();
+            }
+        }
     }
 
     /// Draw the lifecycle pill in the top-right corner of `pane_rect` and
@@ -1370,143 +1278,35 @@ impl ProcessApp {
                         _ => log::info!(target: &target, "{message}"),
                     }
                 }
+                DrawCommand::Control(ControlCommand::FatalError { message, traceback }) => {
+                    self.record_fatal_error(message, traceback);
+                }
                 DrawCommand::Control(ControlCommand::FrameDone { frame_id }) => {
-                    let expected_frame_id = self.render_in_flight_frame_id.take();
-                    if expected_frame_id != Some(frame_id) {
-                        log::debug!(
-                            "ProcessApp[{}]: background FrameDone frame_id={frame_id} expected={expected_frame_id:?}",
-                            self.type_id,
-                        );
+                    match self.runtime.complete_frame(frame_id) {
+                        FrameDoneOutcome::Matched => {}
+                        FrameDoneOutcome::Unexpected { expected, got } => {
+                            log::error!(
+                                "ProcessApp[{}]: background FrameDone frame_id={got} expected={expected:?}",
+                                self.type_id,
+                            );
+                            self.lifecycle.on_parse_error();
+                        }
                     }
                     self.pending_frame.clear();
                     self.click_awaiting_frame = false;
                     self.lifecycle.on_frame_done();
+                    self.arm_scheduler_after_frame();
+                }
+                DrawCommand::Control(ControlCommand::Ready { sdk, features_used }) => {
+                    self.sdk = Some(sdk);
+                    self.features_used = features_used;
+                    self.runtime.mark_ready();
+                }
+                DrawCommand::Control(ControlCommand::SetSchedulerMode { mode, fps }) => {
+                    self.set_scheduler_mode(&mode, fps);
                 }
                 DrawCommand::Control(_) => {} // Ready/etc. irrelevant without a pane
                 DrawCommand::Render(_) => {}  // No pane to render into
-            }
-        }
-    }
-
-    /// Dispatch a `ControlCommand` that arrived during `ui()`. Called inline
-    /// from the `ui()` dispatch loop; has access to `egui::Ui` for operations
-    /// that require UI-thread context (font metrics, clipboard, repaint).
-    fn handle_control_command(&mut self, ui: &mut egui::Ui, cmd: ControlCommand) {
-        match cmd {
-            ControlCommand::Ready { sdk, features_used } => {
-                self.sdk = Some(sdk);
-                self.features_used = features_used;
-            }
-            ControlCommand::FrameDone { frame_id: done_id } => {
-                let expected_frame_id = self.render_in_flight_frame_id.take();
-                if expected_frame_id != Some(done_id) {
-                    log::debug!(
-                        "ProcessApp[{}]: FrameDone frame_id={done_id} expected={expected_frame_id:?}",
-                        self.type_id,
-                    );
-                }
-                std::mem::swap(&mut self.frame, &mut self.pending_frame);
-                self.pending_frame.clear();
-                self.click_awaiting_frame = false;
-                // Lifecycle: a frame just landed → Running (unless terminal).
-                self.lifecycle.on_frame_done();
-                if self.render_needed {
-                    ui.ctx().request_repaint();
-                }
-            }
-            ControlCommand::Log { level, message } => {
-                let target = format!("app::{}", self.type_id);
-                match level.as_str() {
-                    "error" => log::error!(target: &target, "{message}"),
-                    "warn" => log::warn!(target: &target, "{message}"),
-                    "debug" => log::debug!(target: &target, "{message}"),
-                    _ => log::info!(target: &target, "{message}"),
-                }
-            }
-            ControlCommand::ScheduleRender { after_ms } => {
-                crate::platform::frame_diag::note(
-                    crate::platform::frame_diag::RepaintCause::AppScheduleRender,
-                );
-                let delay = std::time::Duration::from_millis(after_ms as u64);
-                self.mark_render_needed_after("schedule_render", delay);
-                ui.ctx().request_repaint_after(delay);
-            }
-            // CopyToClipboard is handled here (not in routing.rs) because
-            // `egui::Context::copy_text` is a UI-context method. The host
-            // owns the clipboard backend selection (pasteboard / X11 /
-            // Wayland / Win32) — we just hand egui the string.
-            ControlCommand::CopyToClipboard { text } => {
-                let preview = text.chars().take(80).collect::<String>();
-                log::info!(target: &format!("app::{}", self.type_id), "copy_to_clipboard: {} chars: {:?}", text.len(), preview);
-                ui.ctx().copy_text(text);
-            }
-            // MeasureText is handled here (not in routing.rs) because it
-            // needs `ui` to access egui font metrics on the UI thread.
-            ControlCommand::MeasureText {
-                request_id,
-                text,
-                font_size,
-                monospace,
-            } => {
-                let family = if monospace {
-                    egui::FontFamily::Monospace
-                } else {
-                    egui::FontFamily::Proportional
-                };
-                let font_id = egui::FontId::new(font_size, family);
-                let galley = ui.fonts(|f| f.layout_no_wrap(text, font_id, egui::Color32::WHITE));
-                let sz = galley.size();
-                self.outbound_events
-                    .push_back(crate::app_protocol::PlexiEvent::TextMeasured {
-                        request_id,
-                        width: sz.x,
-                        height: sz.y,
-                    });
-            }
-            ControlCommand::MeasureTextWrapped {
-                request_id,
-                text,
-                font_size,
-                max_width,
-                max_lines,
-            } => {
-                let font_id = egui::FontId::proportional(font_size);
-                let galley =
-                    ui.fonts(|f| f.layout(text.clone(), font_id, egui::Color32::WHITE, max_width));
-                let n_rows = max_lines
-                    .map(|n| (n as usize).min(galley.rows.len()))
-                    .unwrap_or(galley.rows.len());
-                let height = if n_rows == 0 {
-                    0.0
-                } else {
-                    galley.rows[n_rows - 1].rect.max.y
-                };
-                log::debug!(
-                    "ProcessApp[{}]: MeasureTextWrapped request_id={} max_width={:.1} max_lines={:?} rows={} height={:.1}",
-                    self.type_id, request_id, max_width, max_lines, n_rows, height
-                );
-                self.outbound_events.push_back(
-                    crate::app_protocol::PlexiEvent::TextWrappedMeasured {
-                        request_id: request_id.clone(),
-                        height,
-                    },
-                );
-            }
-            ControlCommand::SetMinSize { width, height } => {
-                self.live_min_size = Some((width, height));
-                log::info!(
-                    "ProcessApp[{}]: live min size set to {:.0}×{:.0}",
-                    self.type_id,
-                    width,
-                    height
-                );
-            }
-            ControlCommand::CloseSelf => {
-                log::info!(
-                    "ProcessApp[{}]: CloseSelf — pane will close on next frame",
-                    self.type_id
-                );
-                self.wants_close_self = true;
             }
         }
     }
@@ -2056,44 +1856,28 @@ impl App for ProcessApp {
         // Pointer-tracking apps are a special case: while the pointer is actively
         // moving we keep the repaint cadence near 60 FPS so host->app hover state
         // does not feel sticky.
-        use crate::platform::frame_diag::{self, RepaintCause};
         if needs_click_repaint {
             self.click_awaiting_frame = true;
-            frame_diag::note(RepaintCause::AppClick);
-            ui.ctx().request_repaint();
-        } else if self.click_awaiting_frame {
-            frame_diag::note(RepaintCause::AppClick);
-            ui.ctx().request_repaint();
-        } else if needs_tracking_repaint {
-            frame_diag::note(RepaintCause::PointerTracking);
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(16));
-        } else if self.render_needed && self.render_in_flight_frame_id.is_none() {
-            if let Some(not_before) = self.render_not_before {
-                let now = std::time::Instant::now();
-                if not_before > now {
-                    ui.ctx().request_repaint_after(not_before - now);
-                } else {
-                    ui.ctx().request_repaint();
+        }
+
+        match scheduler::decide_repaint(scheduler::RepaintInputs {
+            click_now: needs_click_repaint,
+            click_awaiting_frame: self.click_awaiting_frame,
+            pointer_tracking: needs_tracking_repaint,
+            render_delay: self.runtime.pending_repaint_delay(),
+            render_in_flight: self.runtime.is_rendering(),
+            async_wake: self.needs_async_wake_poll(),
+        }) {
+            scheduler::RepaintDecision::Now => ui.ctx().request_repaint(),
+            scheduler::RepaintDecision::After(delay) => ui.ctx().request_repaint_after(delay),
+            scheduler::RepaintDecision::None => {
+                if !self.idle_render_poll_logged {
+                    log::info!(
+                        "ProcessApp[{}]: idle render polling disabled; waiting for input, dirty state, or ScheduleRender",
+                        self.type_id
+                    );
+                    self.idle_render_poll_logged = true;
                 }
-            } else {
-                ui.ctx().request_repaint();
-            }
-        } else if self.render_in_flight_frame_id.is_some() {
-            frame_diag::note(RepaintCause::AppIdlePoll);
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(100));
-        } else if self.needs_async_wake_poll() {
-            frame_diag::note(RepaintCause::AppIdlePoll);
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(100));
-        } else {
-            if !self.idle_render_poll_logged {
-                log::info!(
-                    "ProcessApp[{}]: idle render polling disabled; waiting for input, dirty state, or ScheduleRender",
-                    self.type_id
-                );
-                self.idle_render_poll_logged = true;
             }
         }
     }
@@ -2629,6 +2413,7 @@ mod tests;
 
 impl Drop for ProcessApp {
     fn drop(&mut self) {
+        self.runtime.mark_closing();
         // Cancel active StreamProcess children (#675) — same escalation as
         // CancelProcess: SIGTERM, then SIGKILL after 1s on a background thread.
         for (corr_id, handle) in self.stream_handles.drain() {
@@ -2684,6 +2469,7 @@ impl Drop for ProcessApp {
             while std::time::Instant::now() < shutdown_deadline {
                 match child.try_wait() {
                     Ok(Some(_)) => {
+                        self.runtime.mark_process_exited();
                         exited = true;
                         break;
                     }
@@ -2693,6 +2479,7 @@ impl Drop for ProcessApp {
                     Err(e) if e.raw_os_error() == Some(libc::ECHILD) => {
                         // Background reaper already called waitpid and won the
                         // race — ECHILD means the child is gone. Treat as clean exit.
+                        self.runtime.mark_process_exited();
                         exited = true;
                         break;
                     }
@@ -2714,7 +2501,10 @@ impl Drop for ProcessApp {
                 let kill_deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
                 while std::time::Instant::now() < kill_deadline {
                     match child.try_wait() {
-                        Ok(Some(_)) => break,
+                        Ok(Some(_)) => {
+                            self.runtime.mark_process_exited();
+                            break;
+                        }
                         Ok(None) => {
                             std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
                         }
@@ -2726,6 +2516,7 @@ impl Drop for ProcessApp {
                 // `Child::kill` already SIGKILL-equivalents in `std`, so
                 // the process should be dead.
                 let _ = child.wait();
+                self.runtime.mark_process_exited();
             }
         }
     }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -20,6 +20,7 @@ mod lifecycle;
 pub(crate) mod mcp_server;
 pub(crate) mod prompts;
 pub(crate) mod render;
+mod render_diag;
 mod render_session;
 mod routing;
 mod runtime_state;
@@ -27,6 +28,7 @@ mod scheduler;
 mod transport;
 
 pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
+use render_diag::RenderDiagnostics;
 use render_session::RenderSession;
 use runtime_state::{FrameDoneOutcome, PgapRuntime, RenderPoll};
 pub(crate) use transport::StdinItem;
@@ -142,6 +144,9 @@ pub struct ProcessApp {
     initialized: bool,
     runtime: PgapRuntime,
     scheduler_mode: scheduler::AppSchedulerMode,
+    /// Absolute frame clock — `Some` iff `scheduler_mode` is `Continuous`.
+    animation_clock: Option<scheduler::AnimationClock>,
+    render_diag: RenderDiagnostics,
     pending_async_completions: usize,
     idle_render_poll_logged: bool,
     sdk: Option<String>,
@@ -612,6 +617,8 @@ impl ProcessApp {
             initialized: false,
             runtime: PgapRuntime::spawned_with_initial_render(),
             scheduler_mode: scheduler::AppSchedulerMode::default(),
+            animation_clock: None,
+            render_diag: RenderDiagnostics::new(),
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
@@ -771,6 +778,8 @@ impl ProcessApp {
             initialized: true,
             runtime: PgapRuntime::ready_for_test_with_initial_render(),
             scheduler_mode: scheduler::AppSchedulerMode::default(),
+            animation_clock: None,
+            render_diag: RenderDiagnostics::new(),
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
@@ -939,7 +948,7 @@ impl ProcessApp {
 
     fn mark_render_needed_after(&mut self, reason: &'static str, delay: std::time::Duration) {
         if self.runtime.request_render_after(delay) {
-            if reason != "schedule_render" && reason != "continuous_scheduler" {
+            if reason != "schedule_render" {
                 log::info!(
                     "ProcessApp[{}]: render requested ({reason}, after {}ms)",
                     self.type_id,
@@ -950,7 +959,8 @@ impl ProcessApp {
     }
 
     fn send_render_if_needed(&mut self, size: egui::Vec2) -> Option<u64> {
-        match self.runtime.poll_render(std::time::Instant::now()) {
+        let now = std::time::Instant::now();
+        match self.runtime.poll_render(now) {
             RenderPoll::Send { frame_id } => {
                 self.send_event(&PlexiEvent::Render {
                     frame_id,
@@ -961,8 +971,14 @@ impl ProcessApp {
                         h: size.y,
                     },
                 });
-                if let Some(delay) = self.scheduler_mode.next_frame_delay() {
-                    self.mark_render_needed_after("continuous_scheduler", delay);
+                self.render_diag.record_render_sent(
+                    frame_id,
+                    self.scheduler_mode.next_frame_delay(),
+                    now,
+                );
+                if let Some(clock) = self.animation_clock.as_mut() {
+                    self.runtime
+                        .request_render_at(clock.deadline_after_send(now));
                 }
                 Some(frame_id)
             }
@@ -1112,6 +1128,21 @@ impl ProcessApp {
         match scheduler::AppSchedulerMode::from_wire(mode, fps) {
             Ok(parsed) => {
                 self.scheduler_mode = parsed;
+                self.animation_clock = match parsed {
+                    scheduler::AppSchedulerMode::Continuous { interval } => {
+                        // Anchor the clock and kick the cadence — switching to
+                        // continuous while Idle must start animating without
+                        // waiting for an unrelated render request.
+                        self.mark_render_needed("continuous_mode");
+                        Some(scheduler::AnimationClock::new(
+                            interval,
+                            std::time::Instant::now(),
+                        ))
+                    }
+                    scheduler::AppSchedulerMode::Idle | scheduler::AppSchedulerMode::Scheduled => {
+                        None
+                    }
+                };
                 log::info!(
                     "ProcessApp[{}]: scheduler mode set to {parsed:?}",
                     self.type_id
@@ -1482,6 +1513,12 @@ impl App for ProcessApp {
                 DrawCommand::Render(r) => self.pending_frame.push(r),
             }
         }
+
+        // A continuous app often completes its render transaction during this
+        // drain. Send the next due Render immediately instead of waiting for a
+        // separate host repaint; otherwise a 60Hz host loop can only drive
+        // one app frame every two host frames.
+        self.send_render_if_needed(size);
 
         // Render the current committed frame.
         //
@@ -2409,6 +2446,12 @@ mod tests;
 
 impl Drop for ProcessApp {
     fn drop(&mut self) {
+        self.render_diag.flush_if_nonempty(
+            &self.type_id,
+            self.scheduler_mode.next_frame_delay(),
+            std::time::Instant::now(),
+            "drop",
+        );
         self.runtime.mark_closing();
         // Cancel active StreamProcess children (#675) — same escalation as
         // CancelProcess: SIGTERM, then SIGKILL after 1s on a background thread.

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -939,7 +939,7 @@ impl ProcessApp {
 
     fn mark_render_needed_after(&mut self, reason: &'static str, delay: std::time::Duration) {
         if self.runtime.request_render_after(delay) {
-            if reason != "schedule_render" {
+            if reason != "schedule_render" && reason != "continuous_scheduler" {
                 log::info!(
                     "ProcessApp[{}]: render requested ({reason}, after {}ms)",
                     self.type_id,
@@ -961,6 +961,9 @@ impl ProcessApp {
                         h: size.y,
                     },
                 });
+                if let Some(delay) = self.scheduler_mode.next_frame_delay() {
+                    self.mark_render_needed_after("continuous_scheduler", delay);
+                }
                 Some(frame_id)
             }
             RenderPoll::Waiting { .. }
@@ -1102,12 +1105,6 @@ impl ProcessApp {
                 }
                 buf.push_back(line.to_string());
             }
-        }
-    }
-
-    fn arm_scheduler_after_frame(&mut self) {
-        if let Some(delay) = self.scheduler_mode.next_frame_delay() {
-            self.mark_render_needed_after("continuous_scheduler", delay);
         }
     }
 
@@ -1295,7 +1292,6 @@ impl ProcessApp {
                     self.pending_frame.clear();
                     self.click_awaiting_frame = false;
                     self.lifecycle.on_frame_done();
-                    self.arm_scheduler_after_frame();
                 }
                 DrawCommand::Control(ControlCommand::Ready { sdk, features_used }) => {
                     self.sdk = Some(sdk);

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -153,6 +153,7 @@ pub struct ProcessApp {
     render_needed: bool,
     render_in_flight_frame_id: Option<u64>,
     render_not_before: Option<std::time::Instant>,
+    pending_async_completions: usize,
     idle_render_poll_logged: bool,
     sdk: Option<String>,
     features_used: Vec<String>,
@@ -713,6 +714,7 @@ impl ProcessApp {
             render_needed: true,
             render_in_flight_frame_id: None,
             render_not_before: None,
+            pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
             features_used: Vec::new(),
@@ -872,6 +874,7 @@ impl ProcessApp {
             render_needed: true,
             render_in_flight_frame_id: None,
             render_not_before: None,
+            pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
             features_used: Vec::new(),
@@ -1080,6 +1083,45 @@ impl ProcessApp {
         Some(frame_id)
     }
 
+    fn arm_async_completion_wake(&mut self, reason: &'static str) {
+        self.pending_async_completions = self.pending_async_completions.saturating_add(1);
+        log::info!(
+            "ProcessApp[{}]: async wake armed ({reason}); pending={}",
+            self.type_id,
+            self.pending_async_completions
+        );
+    }
+
+    fn complete_async_wake(&mut self) {
+        self.pending_async_completions = self.pending_async_completions.saturating_sub(1);
+    }
+
+    fn drain_async_events(&mut self) {
+        while let Ok(event) = self.http_rx.try_recv() {
+            match &event {
+                PlexiEvent::Timer { timer_id } => {
+                    self.pending_timers.remove(timer_id);
+                }
+                PlexiEvent::AiStreamChunk { .. } => {}
+                _ => self.complete_async_wake(),
+            }
+            self.outbound_events.push_back(event);
+            self.mark_render_needed("async_completion");
+        }
+        while let Ok(event) = self.file_picker_rx.try_recv() {
+            self.complete_async_wake();
+            self.outbound_events.push_back(event);
+            self.mark_render_needed("async_completion");
+        }
+    }
+
+    fn needs_async_wake_poll(&self) -> bool {
+        self.pending_async_completions > 0
+            || !self.pending_timers.is_empty()
+            || self.active_stream_threads.load(Ordering::Relaxed) > 0
+            || self.image_cache.has_pending()
+    }
+
     /// Drain the MCP call queue and forward each request to the app as a
     /// `PlexiEvent::McpToolCall`. Called each frame (both `ui()` and
     /// `background_tick()`) so tool calls are processed even for background apps.
@@ -1281,12 +1323,7 @@ impl ProcessApp {
     ///
     /// Visual draw commands are discarded — there is no pane to render into.
     pub(crate) fn background_tick(&mut self) {
-        while let Ok(event) = self.http_rx.try_recv() {
-            self.outbound_events.push_back(event);
-        }
-        while let Ok(event) = self.file_picker_rx.try_recv() {
-            self.outbound_events.push_back(event);
-        }
+        self.drain_async_events();
         self.poll_mcp_calls();
         self.flush_outbound_events();
         for cmd in self.drain_draw_commands() {
@@ -1555,14 +1592,7 @@ impl App for ProcessApp {
 
         self.send_render_if_needed(size);
 
-        // Drain async HTTP responses from background request threads.
-        while let Ok(event) = self.http_rx.try_recv() {
-            self.outbound_events.push_back(event);
-        }
-        // Drain file picker results from background dialog threads.
-        while let Ok(event) = self.file_picker_rx.try_recv() {
-            self.outbound_events.push_back(event);
-        }
+        self.drain_async_events();
 
         // Per-frame: detect audio capture pipes whose drain thread exited due
         // to a write error (e.g. Broken pipe when the app-side socket closed
@@ -2002,6 +2032,10 @@ impl App for ProcessApp {
             } else {
                 ui.ctx().request_repaint();
             }
+        } else if self.needs_async_wake_poll() {
+            frame_diag::note(RepaintCause::AppIdlePoll);
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(100));
         } else {
             if !self.idle_render_poll_logged {
                 log::info!(

--- a/src/process_app/render_diag.rs
+++ b/src/process_app/render_diag.rs
@@ -1,0 +1,225 @@
+//! Process-app render transaction diagnostics.
+//!
+//! Host repaint FPS alone does not prove that a PGAP app is receiving and
+//! committing frames at a steady cadence. This tracks the Render -> FrameDone
+//! transaction boundary per pane so animation regressions have a concrete log
+//! signal.
+
+use std::time::{Duration, Instant};
+
+const FIRST_SUMMARY_WINDOW: Duration = Duration::from_secs(1);
+const STEADY_SUMMARY_WINDOW: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub(crate) struct RenderDiagnostics {
+    window_started_at: Instant,
+    current_frame: Option<InFlightFrame>,
+    last_sent_at: Option<Instant>,
+    last_committed_at: Option<Instant>,
+    summaries_logged: u32,
+    sent: u32,
+    committed: u32,
+    total_send_gap: Duration,
+    max_send_gap: Duration,
+    slow_send_gaps: u32,
+    total_rtt: Duration,
+    max_rtt: Duration,
+    total_commit_gap: Duration,
+    max_commit_gap: Duration,
+    slow_commit_gaps: u32,
+}
+
+#[derive(Debug)]
+struct InFlightFrame {
+    frame_id: u64,
+    sent_at: Instant,
+}
+
+impl RenderDiagnostics {
+    pub(crate) fn new() -> Self {
+        Self {
+            window_started_at: Instant::now(),
+            current_frame: None,
+            last_sent_at: None,
+            last_committed_at: None,
+            summaries_logged: 0,
+            sent: 0,
+            committed: 0,
+            total_send_gap: Duration::ZERO,
+            max_send_gap: Duration::ZERO,
+            slow_send_gaps: 0,
+            total_rtt: Duration::ZERO,
+            max_rtt: Duration::ZERO,
+            total_commit_gap: Duration::ZERO,
+            max_commit_gap: Duration::ZERO,
+            slow_commit_gaps: 0,
+        }
+    }
+
+    pub(crate) fn record_render_sent(
+        &mut self,
+        frame_id: u64,
+        target_interval: Option<Duration>,
+        now: Instant,
+    ) {
+        self.sent = self.sent.saturating_add(1);
+        if let Some(last_sent_at) = self.last_sent_at {
+            let gap = now.saturating_duration_since(last_sent_at);
+            self.total_send_gap += gap;
+            self.max_send_gap = self.max_send_gap.max(gap);
+            if target_interval.is_some_and(|interval| gap > interval.mul_f32(1.5)) {
+                self.slow_send_gaps = self.slow_send_gaps.saturating_add(1);
+            }
+        }
+        self.last_sent_at = Some(now);
+        self.current_frame = Some(InFlightFrame {
+            frame_id,
+            sent_at: now,
+        });
+    }
+
+    pub(crate) fn record_frame_committed(
+        &mut self,
+        app_id: &str,
+        frame_id: u64,
+        target_interval: Option<Duration>,
+        now: Instant,
+    ) {
+        self.committed = self.committed.saturating_add(1);
+
+        if let Some(in_flight) = self.current_frame.take() {
+            if in_flight.frame_id == frame_id {
+                let rtt = now.saturating_duration_since(in_flight.sent_at);
+                self.total_rtt += rtt;
+                self.max_rtt = self.max_rtt.max(rtt);
+            }
+        }
+
+        if let Some(last_committed_at) = self.last_committed_at {
+            let gap = now.saturating_duration_since(last_committed_at);
+            self.total_commit_gap += gap;
+            self.max_commit_gap = self.max_commit_gap.max(gap);
+            if target_interval.is_some_and(|interval| gap > interval.mul_f32(1.5)) {
+                self.slow_commit_gaps = self.slow_commit_gaps.saturating_add(1);
+            }
+        }
+        self.last_committed_at = Some(now);
+
+        if now.saturating_duration_since(self.window_started_at) >= self.current_window() {
+            self.log_summary(app_id, target_interval, now, "interval");
+            self.reset_window(now);
+        }
+    }
+
+    pub(crate) fn flush_if_nonempty(
+        &mut self,
+        app_id: &str,
+        target_interval: Option<Duration>,
+        now: Instant,
+        reason: &'static str,
+    ) {
+        if self.sent == 0 && self.committed == 0 {
+            return;
+        }
+        self.log_summary(app_id, target_interval, now, reason);
+        self.reset_window(now);
+    }
+
+    fn current_window(&self) -> Duration {
+        if self.summaries_logged == 0 {
+            FIRST_SUMMARY_WINDOW
+        } else {
+            STEADY_SUMMARY_WINDOW
+        }
+    }
+
+    fn log_summary(
+        &self,
+        app_id: &str,
+        target_interval: Option<Duration>,
+        now: Instant,
+        reason: &'static str,
+    ) {
+        let elapsed = now
+            .saturating_duration_since(self.window_started_at)
+            .as_secs_f64();
+        let app_fps = if elapsed > 0.0 {
+            self.committed as f64 / elapsed
+        } else {
+            0.0
+        };
+        let send_gap_count = self.sent.saturating_sub(1);
+        let avg_send_gap_ms = avg_ms(self.total_send_gap, send_gap_count);
+        let avg_rtt_ms = avg_ms(self.total_rtt, self.committed);
+        let commit_gap_count = self.committed.saturating_sub(1);
+        let avg_gap_ms = avg_ms(self.total_commit_gap, commit_gap_count);
+        let target_ms = target_interval
+            .map(|interval| format!("{:.1}", interval.as_secs_f64() * 1000.0))
+            .unwrap_or_else(|| "none".to_string());
+
+        log::info!(
+            "ProcessApp[{app_id}]: render_diag reason={reason} sent={} committed={} window={elapsed:.1}s app_fps={app_fps:.1} target_ms={} avg_send_gap_ms={avg_send_gap_ms:.1} max_send_gap_ms={:.1} slow_send_gaps={} avg_rtt_ms={avg_rtt_ms:.1} max_rtt_ms={:.1} avg_commit_gap_ms={avg_gap_ms:.1} max_commit_gap_ms={:.1} slow_commit_gaps={}",
+            self.sent,
+            self.committed,
+            target_ms,
+            self.max_send_gap.as_secs_f64() * 1000.0,
+            self.slow_send_gaps,
+            self.max_rtt.as_secs_f64() * 1000.0,
+            self.max_commit_gap.as_secs_f64() * 1000.0,
+            self.slow_commit_gaps,
+        );
+    }
+
+    fn reset_window(&mut self, now: Instant) {
+        self.window_started_at = now;
+        self.summaries_logged = self.summaries_logged.saturating_add(1);
+        self.sent = 0;
+        self.committed = 0;
+        self.total_send_gap = Duration::ZERO;
+        self.max_send_gap = Duration::ZERO;
+        self.slow_send_gaps = 0;
+        self.total_rtt = Duration::ZERO;
+        self.max_rtt = Duration::ZERO;
+        self.total_commit_gap = Duration::ZERO;
+        self.max_commit_gap = Duration::ZERO;
+        self.slow_commit_gaps = 0;
+    }
+}
+
+fn avg_ms(total: Duration, count: u32) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        total.as_secs_f64() * 1000.0 / f64::from(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_committed_frame_cadence() {
+        let start = Instant::now();
+        let mut diag = RenderDiagnostics::new();
+
+        diag.record_render_sent(1, Some(Duration::from_millis(16)), start);
+        diag.record_frame_committed("test", 1, Some(Duration::from_millis(16)), start);
+        diag.record_render_sent(
+            2,
+            Some(Duration::from_millis(16)),
+            start + Duration::from_millis(16),
+        );
+        diag.record_frame_committed(
+            "test",
+            2,
+            Some(Duration::from_millis(16)),
+            start + Duration::from_millis(50),
+        );
+
+        assert_eq!(diag.sent, 2);
+        assert_eq!(diag.committed, 2);
+        assert_eq!(diag.slow_commit_gaps, 1);
+        assert_eq!(diag.max_commit_gap, Duration::from_millis(50));
+    }
+}

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -705,6 +705,7 @@ impl ProcessApp {
                     "ProcessApp[{}]: OpenFilePicker {request_id} filter={filter:?} multiple={multiple}",
                     self.type_id
                 );
+                self.arm_async_completion_wake("file_picker");
                 let tx = self.file_picker_tx.clone();
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
@@ -879,6 +880,7 @@ impl ProcessApp {
                     self.type_id
                 );
 
+                self.arm_async_completion_wake("http_request");
                 let allowed_hosts = normalized_allowed_hosts;
                 let net = std::sync::Arc::clone(&self.net);
                 let tx = self.http_tx.clone();
@@ -1080,6 +1082,7 @@ impl ProcessApp {
 
                 let broker = self.ai_broker.clone();
                 let app_id = self.type_id.clone();
+                self.arm_async_completion_wake("ai_query");
                 let tx = self.http_tx.clone();
                 let workspace_root = self.workspace_root.clone();
                 let open_panes = crate::plexi_ai::broker::get_pane_snapshot();
@@ -1262,6 +1265,7 @@ impl ProcessApp {
                 // Offload to a background thread: cpal device enumeration can
                 // block for hundreds of milliseconds on macOS (Bluetooth scan).
                 let audio = std::sync::Arc::clone(&self.audio_device);
+                self.arm_async_completion_wake("list_audio_devices");
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
@@ -1292,6 +1296,7 @@ impl ProcessApp {
                 // already visible in Audio MIDI Setup.app, no privacy gate.
                 // Offload to a background thread for the same reason as audio.
                 let midi = std::sync::Arc::clone(&self.midi_device);
+                self.arm_async_completion_wake("list_midi_devices");
                 let tx = self.http_tx.clone();
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -616,6 +616,7 @@ impl ProcessApp {
                     });
                     return;
                 }
+                self.arm_async_completion_wake("stream_process");
                 let thread_name = format!("stream-reader-{}-{}", type_id, corr_id);
                 std::thread::Builder::new()
                     .name(thread_name)

--- a/src/process_app/runtime_state.rs
+++ b/src/process_app/runtime_state.rs
@@ -1,0 +1,329 @@
+//! PGAP app runtime state machine.
+//!
+//! This module owns the render transaction contract for a process app. The
+//! host code asks for state transitions; it does not carry separate booleans
+//! for "dirty", "in flight", and "deadline".
+
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExitReason {
+    StdoutClosed,
+    ProcessExited,
+    ExitedDuringRender { frame_id: u64 },
+    FatalError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeState {
+    Spawned {
+        pending_deadline: Option<Instant>,
+    },
+    Ready,
+    Waiting {
+        next_deadline: Instant,
+    },
+    Idle,
+    Rendering {
+        frame_id: u64,
+        followup_deadline: Option<Instant>,
+    },
+    Closing,
+    Exited {
+        reason: ExitReason,
+    },
+    ProtocolError {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FrameDoneOutcome {
+    Matched,
+    Unexpected { expected: Option<u64>, got: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderPoll {
+    Send { frame_id: u64 },
+    Waiting { remaining: Duration },
+    InFlight,
+    NotReady,
+    Idle,
+    Terminal,
+}
+
+#[derive(Debug)]
+pub(crate) struct PgapRuntime {
+    state: RuntimeState,
+    frame_counter: u64,
+}
+
+impl PgapRuntime {
+    pub(crate) fn spawned_with_initial_render() -> Self {
+        Self {
+            state: RuntimeState::Spawned {
+                pending_deadline: Some(Instant::now()),
+            },
+            frame_counter: 0,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ready_for_test_with_initial_render() -> Self {
+        Self {
+            state: RuntimeState::Waiting {
+                next_deadline: Instant::now(),
+            },
+            frame_counter: 0,
+        }
+    }
+
+    pub(crate) fn mark_ready(&mut self) {
+        let deadline = match &self.state {
+            RuntimeState::Spawned { pending_deadline } => *pending_deadline,
+            RuntimeState::Ready
+            | RuntimeState::Waiting { .. }
+            | RuntimeState::Idle
+            | RuntimeState::Rendering { .. } => return,
+            RuntimeState::Closing
+            | RuntimeState::Exited { .. }
+            | RuntimeState::ProtocolError { .. } => {
+                return;
+            }
+        };
+        self.state = match deadline {
+            Some(next_deadline) => RuntimeState::Waiting { next_deadline },
+            None => RuntimeState::Ready,
+        };
+    }
+
+    pub(crate) fn request_render_now(&mut self) -> bool {
+        self.request_render_at(Instant::now())
+    }
+
+    pub(crate) fn request_render_after(&mut self, delay: Duration) -> bool {
+        self.request_render_at(Instant::now() + delay)
+    }
+
+    fn request_render_at(&mut self, deadline: Instant) -> bool {
+        match &mut self.state {
+            RuntimeState::Spawned { pending_deadline } => {
+                let was_idle = pending_deadline.is_none();
+                *pending_deadline =
+                    Some(pending_deadline.map_or(deadline, |old| old.min(deadline)));
+                was_idle
+            }
+            RuntimeState::Ready | RuntimeState::Idle => {
+                self.state = RuntimeState::Waiting {
+                    next_deadline: deadline,
+                };
+                true
+            }
+            RuntimeState::Waiting { next_deadline } => {
+                *next_deadline = (*next_deadline).min(deadline);
+                false
+            }
+            RuntimeState::Rendering {
+                followup_deadline, ..
+            } => {
+                let was_idle = followup_deadline.is_none();
+                *followup_deadline =
+                    Some(followup_deadline.map_or(deadline, |old| old.min(deadline)));
+                was_idle
+            }
+            RuntimeState::Closing
+            | RuntimeState::Exited { .. }
+            | RuntimeState::ProtocolError { .. } => false,
+        }
+    }
+
+    pub(crate) fn poll_render(&mut self, now: Instant) -> RenderPoll {
+        match &self.state {
+            RuntimeState::Waiting { next_deadline } if *next_deadline <= now => {
+                self.frame_counter = self.frame_counter.saturating_add(1);
+                let frame_id = self.frame_counter;
+                self.state = RuntimeState::Rendering {
+                    frame_id,
+                    followup_deadline: None,
+                };
+                RenderPoll::Send { frame_id }
+            }
+            RuntimeState::Waiting { next_deadline } => RenderPoll::Waiting {
+                remaining: next_deadline.saturating_duration_since(now),
+            },
+            RuntimeState::Rendering { .. } => RenderPoll::InFlight,
+            RuntimeState::Spawned { .. } | RuntimeState::Ready => RenderPoll::NotReady,
+            RuntimeState::Idle => RenderPoll::Idle,
+            RuntimeState::Closing
+            | RuntimeState::Exited { .. }
+            | RuntimeState::ProtocolError { .. } => RenderPoll::Terminal,
+        }
+    }
+
+    pub(crate) fn complete_frame(&mut self, frame_id: u64) -> FrameDoneOutcome {
+        let RuntimeState::Rendering {
+            frame_id: expected,
+            followup_deadline,
+        } = &self.state
+        else {
+            let expected = self.in_flight_frame_id();
+            self.state = RuntimeState::ProtocolError {
+                reason: format!("FrameDone({frame_id}) arrived while no render was in flight"),
+            };
+            return FrameDoneOutcome::Unexpected {
+                expected,
+                got: frame_id,
+            };
+        };
+
+        if *expected != frame_id {
+            let expected_frame_id = *expected;
+            self.state = RuntimeState::ProtocolError {
+                reason: format!(
+                    "FrameDone({frame_id}) did not match in-flight Render({expected_frame_id})"
+                ),
+            };
+            return FrameDoneOutcome::Unexpected {
+                expected: Some(expected_frame_id),
+                got: frame_id,
+            };
+        }
+
+        self.state = match followup_deadline {
+            Some(next_deadline) => RuntimeState::Waiting {
+                next_deadline: *next_deadline,
+            },
+            None => RuntimeState::Idle,
+        };
+        FrameDoneOutcome::Matched
+    }
+
+    pub(crate) fn in_flight_frame_id(&self) -> Option<u64> {
+        match self.state {
+            RuntimeState::Rendering { frame_id, .. } => Some(frame_id),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn has_pending_render(&self) -> bool {
+        matches!(
+            self.state,
+            RuntimeState::Waiting { .. }
+                | RuntimeState::Rendering {
+                    followup_deadline: Some(_),
+                    ..
+                }
+                | RuntimeState::Spawned {
+                    pending_deadline: Some(_)
+                }
+        )
+    }
+
+    pub(crate) fn is_rendering(&self) -> bool {
+        matches!(self.state, RuntimeState::Rendering { .. })
+    }
+
+    pub(crate) fn pending_repaint_delay(&self) -> Option<Duration> {
+        match self.state {
+            RuntimeState::Waiting { next_deadline } => {
+                Some(next_deadline.saturating_duration_since(Instant::now()))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn mark_closing(&mut self) {
+        self.state = RuntimeState::Closing;
+    }
+
+    pub(crate) fn mark_stdout_closed(&mut self) -> ExitReason {
+        let reason = match self.state {
+            RuntimeState::Rendering { frame_id, .. } => ExitReason::ExitedDuringRender { frame_id },
+            _ => ExitReason::StdoutClosed,
+        };
+        self.state = RuntimeState::Exited {
+            reason: reason.clone(),
+        };
+        reason
+    }
+
+    pub(crate) fn mark_process_exited(&mut self) {
+        if matches!(self.state, RuntimeState::Exited { .. }) {
+            return;
+        }
+        self.state = RuntimeState::Exited {
+            reason: ExitReason::ProcessExited,
+        };
+    }
+
+    pub(crate) fn mark_fatal_error(&mut self) {
+        self.state = RuntimeState::Exited {
+            reason: ExitReason::FatalError,
+        };
+    }
+
+    pub(crate) fn mark_protocol_error(&mut self, reason: impl Into<String>) {
+        self.state = RuntimeState::ProtocolError {
+            reason: reason.into(),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_waits_for_ready_handshake() {
+        let mut runtime = PgapRuntime::spawned_with_initial_render();
+        assert_eq!(runtime.poll_render(Instant::now()), RenderPoll::NotReady);
+
+        runtime.mark_ready();
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 1 }
+        );
+    }
+
+    #[test]
+    fn render_is_a_strict_transaction() {
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 1 }
+        );
+        assert_eq!(runtime.poll_render(Instant::now()), RenderPoll::InFlight);
+        assert_eq!(runtime.complete_frame(1), FrameDoneOutcome::Matched);
+        assert_eq!(runtime.poll_render(Instant::now()), RenderPoll::Idle);
+    }
+
+    #[test]
+    fn schedule_during_render_becomes_followup_frame() {
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 1 }
+        );
+        assert!(runtime.request_render_after(Duration::from_millis(0)));
+        assert_eq!(runtime.poll_render(Instant::now()), RenderPoll::InFlight);
+        assert_eq!(runtime.complete_frame(1), FrameDoneOutcome::Matched);
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 2 }
+        );
+    }
+
+    #[test]
+    fn eof_during_render_is_classified() {
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 1 }
+        );
+        assert_eq!(
+            runtime.mark_stdout_closed(),
+            ExitReason::ExitedDuringRender { frame_id: 1 }
+        );
+    }
+}

--- a/src/process_app/runtime_state.rs
+++ b/src/process_app/runtime_state.rs
@@ -229,6 +229,17 @@ impl PgapRuntime {
             RuntimeState::Waiting { next_deadline } => {
                 Some(next_deadline.saturating_duration_since(Instant::now()))
             }
+            RuntimeState::Rendering {
+                followup_deadline: Some(next_deadline),
+                ..
+            } => {
+                let delay = next_deadline.saturating_duration_since(Instant::now());
+                if delay.is_zero() {
+                    None
+                } else {
+                    Some(delay)
+                }
+            }
             _ => None,
         }
     }

--- a/src/process_app/runtime_state.rs
+++ b/src/process_app/runtime_state.rs
@@ -106,7 +106,10 @@ impl PgapRuntime {
         self.request_render_at(Instant::now() + delay)
     }
 
-    fn request_render_at(&mut self, deadline: Instant) -> bool {
+    /// Request a render at an absolute deadline. Used by the continuous
+    /// `AnimationClock`, whose deadlines are phase-anchored — converting to a
+    /// relative delay and back would reintroduce send-time rebasing.
+    pub(crate) fn request_render_at(&mut self, deadline: Instant) -> bool {
         match &mut self.state {
             RuntimeState::Spawned { pending_deadline } => {
                 let was_idle = pending_deadline.is_none();
@@ -321,6 +324,25 @@ mod tests {
         assert_eq!(runtime.complete_frame(1), FrameDoneOutcome::Matched);
         assert_eq!(
             runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 2 }
+        );
+    }
+
+    #[test]
+    fn absolute_followup_deadline_due_at_commit_sends_in_same_pass() {
+        // Regression: a continuous app's followup armed via an absolute
+        // deadline must produce an immediate Send when FrameDone commits at
+        // or after that deadline — no extra host repaint in between.
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        let t0 = Instant::now();
+        assert_eq!(runtime.poll_render(t0), RenderPoll::Send { frame_id: 1 });
+        let deadline = t0 + Duration::from_micros(16_667);
+        runtime.request_render_at(deadline);
+        // FrameDone commits one host frame later — past the deadline.
+        let commit = t0 + Duration::from_micros(21_000);
+        assert_eq!(runtime.complete_frame(1), FrameDoneOutcome::Matched);
+        assert_eq!(
+            runtime.poll_render(commit),
             RenderPoll::Send { frame_id: 2 }
         );
     }

--- a/src/process_app/scheduler.rs
+++ b/src/process_app/scheduler.rs
@@ -1,0 +1,83 @@
+//! Host repaint scheduling for PGAP panes.
+
+use crate::platform::frame_diag::{self, RepaintCause};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppSchedulerMode {
+    Idle,
+    Scheduled,
+    Continuous { interval: Duration },
+}
+
+impl Default for AppSchedulerMode {
+    fn default() -> Self {
+        Self::Scheduled
+    }
+}
+
+impl AppSchedulerMode {
+    pub(crate) fn from_wire(mode: &str, fps: Option<u32>) -> Result<Self, String> {
+        match mode {
+            "idle" => Ok(Self::Idle),
+            "scheduled" => Ok(Self::Scheduled),
+            "continuous" => {
+                let fps = fps.unwrap_or(60).clamp(1, 240);
+                Ok(Self::Continuous {
+                    interval: Duration::from_secs_f64(1.0 / fps as f64),
+                })
+            }
+            other => Err(format!("unknown scheduler mode {other:?}")),
+        }
+    }
+
+    pub(crate) fn next_frame_delay(self) -> Option<Duration> {
+        match self {
+            Self::Continuous { interval } => Some(interval),
+            Self::Idle | Self::Scheduled => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepaintDecision {
+    Now,
+    After(Duration),
+    None,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RepaintInputs {
+    pub(crate) click_now: bool,
+    pub(crate) click_awaiting_frame: bool,
+    pub(crate) pointer_tracking: bool,
+    pub(crate) render_delay: Option<Duration>,
+    pub(crate) render_in_flight: bool,
+    pub(crate) async_wake: bool,
+}
+
+pub(crate) fn decide_repaint(input: RepaintInputs) -> RepaintDecision {
+    if input.click_now || input.click_awaiting_frame {
+        frame_diag::note(RepaintCause::AppClick);
+        return RepaintDecision::Now;
+    }
+
+    if input.pointer_tracking {
+        frame_diag::note(RepaintCause::PointerTracking);
+        return RepaintDecision::After(Duration::from_millis(16));
+    }
+
+    if let Some(delay) = input.render_delay {
+        if delay.is_zero() {
+            return RepaintDecision::Now;
+        }
+        return RepaintDecision::After(delay);
+    }
+
+    if input.render_in_flight || input.async_wake {
+        frame_diag::note(RepaintCause::AppIdlePoll);
+        return RepaintDecision::After(Duration::from_millis(100));
+    }
+
+    RepaintDecision::None
+}

--- a/src/process_app/scheduler.rs
+++ b/src/process_app/scheduler.rs
@@ -3,6 +3,9 @@
 use crate::platform::frame_diag::{self, RepaintCause};
 use std::time::Duration;
 
+const RENDER_IN_FLIGHT_POLL: Duration = Duration::from_millis(16);
+const ASYNC_WAKE_POLL: Duration = Duration::from_millis(100);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AppSchedulerMode {
     Idle,
@@ -74,10 +77,62 @@ pub(crate) fn decide_repaint(input: RepaintInputs) -> RepaintDecision {
         return RepaintDecision::After(delay);
     }
 
-    if input.render_in_flight || input.async_wake {
+    if input.render_in_flight {
         frame_diag::note(RepaintCause::AppIdlePoll);
-        return RepaintDecision::After(Duration::from_millis(100));
+        return RepaintDecision::After(RENDER_IN_FLIGHT_POLL);
+    }
+
+    if input.async_wake {
+        frame_diag::note(RepaintCause::AppIdlePoll);
+        return RepaintDecision::After(ASYNC_WAKE_POLL);
     }
 
     RepaintDecision::None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn idle_inputs() -> RepaintInputs {
+        RepaintInputs {
+            click_now: false,
+            click_awaiting_frame: false,
+            pointer_tracking: false,
+            render_delay: None,
+            render_in_flight: false,
+            async_wake: false,
+        }
+    }
+
+    #[test]
+    fn render_delay_takes_precedence_over_in_flight_poll() {
+        let mut input = idle_inputs();
+        input.render_delay = Some(Duration::from_millis(8));
+        input.render_in_flight = true;
+        assert_eq!(
+            decide_repaint(input),
+            RepaintDecision::After(Duration::from_millis(8))
+        );
+    }
+
+    #[test]
+    fn in_flight_render_polls_at_frame_cadence() {
+        let mut input = idle_inputs();
+        input.render_in_flight = true;
+        assert_eq!(
+            decide_repaint(input),
+            RepaintDecision::After(RENDER_IN_FLIGHT_POLL)
+        );
+    }
+
+    #[test]
+    fn generic_async_wake_uses_idle_poll_cadence() {
+        let mut input = idle_inputs();
+        input.async_wake = true;
+        assert_eq!(
+            decide_repaint(input),
+            RepaintDecision::After(ASYNC_WAKE_POLL)
+        );
+    }
 }

--- a/src/process_app/scheduler.rs
+++ b/src/process_app/scheduler.rs
@@ -1,7 +1,7 @@
 //! Host repaint scheduling for PGAP panes.
 
 use crate::platform::frame_diag::{self, RepaintCause};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const RENDER_IN_FLIGHT_POLL: Duration = Duration::from_millis(16);
 const ASYNC_WAKE_POLL: Duration = Duration::from_millis(100);
@@ -39,6 +39,46 @@ impl AppSchedulerMode {
             Self::Continuous { interval } => Some(interval),
             Self::Idle | Self::Scheduled => None,
         }
+    }
+}
+
+/// Absolute frame clock for `Continuous` scheduler mode.
+///
+/// Deadlines advance by exactly `interval` from the *previous deadline*, never
+/// from the send timestamp. Rebasing to `send + interval` phase-locks a 60Hz
+/// host to ~30fps: FrameDone commits one vsync (~16.6ms) after the send, the
+/// rebased deadline (send + 16.7ms) misses being due by a hair, and the next
+/// Render waits for another full host frame.
+///
+/// If the cadence falls more than one interval behind (slow app, hidden pane),
+/// the clock rebases to `now` instead of bursting to catch up — the strict
+/// Render/FrameDone transaction means there is never more than one frame in
+/// flight, so debt must be dropped, not repaid.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AnimationClock {
+    interval: Duration,
+    next_deadline: Instant,
+}
+
+impl AnimationClock {
+    pub(crate) fn new(interval: Duration, now: Instant) -> Self {
+        Self {
+            interval,
+            next_deadline: now,
+        }
+    }
+
+    /// Record that a Render was sent at `now`; returns the absolute deadline
+    /// for the frame after it. A send before the scheduled tick (e.g. a
+    /// click-driven render) does not advance the phase.
+    pub(crate) fn deadline_after_send(&mut self, now: Instant) -> Instant {
+        if now >= self.next_deadline {
+            self.next_deadline += self.interval;
+            if self.next_deadline < now {
+                self.next_deadline = now;
+            }
+        }
+        self.next_deadline
     }
 }
 
@@ -124,6 +164,54 @@ mod tests {
             decide_repaint(input),
             RepaintDecision::After(RENDER_IN_FLIGHT_POLL)
         );
+    }
+
+    const FRAME: Duration = Duration::from_micros(16_667);
+
+    #[test]
+    fn animation_clock_keeps_absolute_phase() {
+        let t0 = Instant::now();
+        let mut clock = AnimationClock::new(FRAME, t0);
+        // The send fires a few ms after the deadline (host vsync
+        // quantization) — the next deadline must stay anchored to the
+        // previous deadline, not the send timestamp.
+        let d1 = clock.deadline_after_send(t0 + Duration::from_millis(5));
+        assert_eq!(d1, t0 + FRAME);
+    }
+
+    #[test]
+    fn deadline_is_due_when_frame_done_commits_one_vsync_after_a_late_send() {
+        // Regression: rebasing the followup to send + interval phase-locked a
+        // 60Hz host to ~30-37fps — FrameDone (send + ~16.6ms) missed the
+        // deadline (send + 16.7ms) by ~0.1ms every frame.
+        let t0 = Instant::now();
+        let mut clock = AnimationClock::new(FRAME, t0);
+        let send = t0 + Duration::from_millis(5);
+        let d1 = clock.deadline_after_send(send);
+        let frame_done = send + Duration::from_micros(16_600);
+        assert!(
+            d1 <= frame_done,
+            "followup deadline must already be due when FrameDone commits"
+        );
+    }
+
+    #[test]
+    fn early_send_does_not_advance_phase() {
+        let t0 = Instant::now();
+        let mut clock = AnimationClock::new(FRAME, t0);
+        let d1 = clock.deadline_after_send(t0);
+        // A click-driven render fires mid-tick; the scheduled tick stands.
+        let d2 = clock.deadline_after_send(t0 + Duration::from_millis(4));
+        assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn falling_behind_rebases_instead_of_bursting() {
+        let t0 = Instant::now();
+        let mut clock = AnimationClock::new(FRAME, t0);
+        // Pane hidden for 500ms — next deadline rebases to now, no burst.
+        let late = t0 + Duration::from_millis(500);
+        assert_eq!(clock.deadline_after_send(late), late);
     }
 
     #[test]

--- a/src/process_app/transport.rs
+++ b/src/process_app/transport.rs
@@ -1,0 +1,171 @@
+//! PGAP process transport: stdin writer, stdout reader, stderr capture, reaper.
+
+use super::lifecycle::LifecycleTracker;
+use crate::app_protocol::DrawCommand;
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{ChildStderr, ChildStdin, ChildStdout};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc::Sender,
+    Arc, Mutex,
+};
+use std::thread;
+
+/// Messages sent from the GUI thread to the stdin-writer background thread.
+///
+/// `Render` events are coalesced outside the writer by storing the latest JSON
+/// payload in `render_slot` and sending one `FlushRender` token.
+pub(crate) enum StdinItem {
+    Event(String),
+    FlushRender,
+}
+
+pub(crate) fn request_repaint_from_thread(repaint_ctx: &Arc<Mutex<Option<egui::Context>>>) {
+    if let Ok(ctx) = repaint_ctx.lock() {
+        if let Some(ctx) = ctx.as_ref() {
+            ctx.request_repaint();
+        }
+    }
+}
+
+pub(crate) fn spawn_stdin_writer(
+    type_id: String,
+    stdin: ChildStdin,
+    event_rx: std::sync::mpsc::Receiver<StdinItem>,
+    render_slot: Arc<Mutex<Option<String>>>,
+    render_in_queue: Arc<AtomicBool>,
+) {
+    thread::Builder::new()
+        .name(format!("app-stdin-{type_id}"))
+        .spawn(move || {
+            let mut stdin = stdin;
+            for item in event_rx {
+                match item {
+                    StdinItem::Event(line) => {
+                        if stdin.write_all(line.as_bytes()).is_err() {
+                            log::debug!(
+                                "ProcessApp[{type_id}]: stdin write failed — writer thread exiting"
+                            );
+                            break;
+                        }
+                    }
+                    StdinItem::FlushRender => {
+                        render_in_queue.store(false, Ordering::Relaxed);
+                        let line = render_slot.lock().unwrap().take();
+                        if let Some(line) = line {
+                            if stdin.write_all(line.as_bytes()).is_err() {
+                                log::debug!(
+                                    "ProcessApp[{type_id}]: stdin write failed — writer thread exiting"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .expect("failed to spawn app-stdin thread");
+}
+
+pub(crate) fn spawn_stderr_reader(
+    type_id: String,
+    stderr: ChildStderr,
+    recent_stderr: Arc<Mutex<VecDeque<String>>>,
+    lifecycle: Arc<LifecycleTracker>,
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+) {
+    thread::Builder::new()
+        .name(format!("app-stderr-{type_id}"))
+        .spawn(move || {
+            const STDERR_RING_CAP: usize = 32;
+            let reader = BufReader::new(stderr);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) if !l.trim().is_empty() => {
+                        let target = format!("app::{type_id}");
+                        log::warn!(target: &target, "stderr: {l}");
+                        lifecycle.observe_stderr_line(&l);
+                        request_repaint_from_thread(&repaint_ctx);
+                        if let Ok(mut buf) = recent_stderr.lock() {
+                            if buf.len() >= STDERR_RING_CAP {
+                                buf.pop_front();
+                            }
+                            buf.push_back(l);
+                        }
+                    }
+                    Err(_) => break,
+                    _ => {}
+                }
+            }
+        })
+        .expect("failed to spawn app-stderr thread");
+}
+
+pub(crate) fn spawn_stdout_reader(
+    type_id: String,
+    stdout: ChildStdout,
+    draw_tx: Sender<DrawCommand>,
+    lifecycle: Arc<LifecycleTracker>,
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+) {
+    thread::Builder::new()
+        .name(format!("app-stdout-{type_id}"))
+        .spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) if !l.trim().is_empty() => match serde_json::from_str::<DrawCommand>(&l) {
+                        Ok(cmd) => {
+                            if draw_tx.send(cmd).is_err() {
+                                break;
+                            }
+                            request_repaint_from_thread(&repaint_ctx);
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "ProcessApp[{type_id}]: malformed draw command: {e} — line: {l}"
+                            );
+                            if lifecycle.on_parse_error() {
+                                log::error!(
+                                    "ProcessApp[{type_id}]: protocol-error threshold reached — flipping pane state"
+                                );
+                                request_repaint_from_thread(&repaint_ctx);
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        log::debug!("ProcessApp[{type_id}] stdout closed: {e}");
+                        lifecycle.on_stdout_closed();
+                        request_repaint_from_thread(&repaint_ctx);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            lifecycle.on_stdout_closed();
+            request_repaint_from_thread(&repaint_ctx);
+        })
+        .expect("failed to spawn app-stdout thread");
+}
+
+pub(crate) fn spawn_reaper(
+    type_id: String,
+    pid: u32,
+    lifecycle: Arc<LifecycleTracker>,
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+) {
+    thread::Builder::new()
+        .name(format!("app-reaper-{type_id}"))
+        .spawn(move || {
+            let mut status = 0i32;
+            // SAFETY: pid is a valid child PID obtained from Command::spawn().
+            unsafe {
+                libc::waitpid(pid as libc::pid_t, &mut status, 0);
+            }
+            log::info!("ProcessApp[{type_id}]: child exited — reaper signaling lifecycle");
+            lifecycle.on_process_exited();
+            request_repaint_from_thread(&repaint_ctx);
+        })
+        .expect("failed to spawn app-reaper thread");
+}

--- a/src/process_app/transport.rs
+++ b/src/process_app/transport.rs
@@ -29,6 +29,10 @@ pub(crate) fn request_repaint_from_thread(repaint_ctx: &Arc<Mutex<Option<egui::C
     }
 }
 
+fn stdout_command_wakes_host(cmd: &DrawCommand) -> bool {
+    !matches!(cmd, DrawCommand::Render(_))
+}
+
 pub(crate) fn spawn_stdin_writer(
     type_id: String,
     stdin: ChildStdin,
@@ -117,10 +121,13 @@ pub(crate) fn spawn_stdout_reader(
                 match line {
                     Ok(l) if !l.trim().is_empty() => match serde_json::from_str::<DrawCommand>(&l) {
                         Ok(cmd) => {
+                            let wakes_host = stdout_command_wakes_host(&cmd);
                             if draw_tx.send(cmd).is_err() {
                                 break;
                             }
-                            request_repaint_from_thread(&repaint_ctx);
+                            if wakes_host {
+                                request_repaint_from_thread(&repaint_ctx);
+                            }
                         }
                         Err(e) => {
                             log::warn!(
@@ -168,4 +175,29 @@ pub(crate) fn spawn_reaper(
             request_repaint_from_thread(&repaint_ctx);
         })
         .expect("failed to spawn app-reaper thread");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_protocol::{ControlCommand, RenderCommand};
+
+    #[test]
+    fn render_primitives_do_not_wake_host_before_frame_done() {
+        let cmd = DrawCommand::Render(RenderCommand::Circle {
+            cx: 10.0,
+            cy: 10.0,
+            r: 4.0,
+            fill: "#ffffff".to_string(),
+        });
+
+        assert!(!stdout_command_wakes_host(&cmd));
+    }
+
+    #[test]
+    fn frame_done_wakes_host_at_transaction_boundary() {
+        let cmd = DrawCommand::Control(ControlCommand::FrameDone { frame_id: 7 });
+
+        assert!(stdout_command_wakes_host(&cmd));
+    }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1164,11 +1164,23 @@ pub enum ControlCommand {
         level: String,
         message: String,
     },
+    /// Terminal SDK failure with traceback text. Sent before the app exits
+    /// nonzero so the host never has to infer Python hook failures from EOF.
+    FatalError { message: String, traceback: String },
     /// Ask the host to trigger a new Render event after `after_ms` milliseconds.
     /// Intended for game loops and animations — emit once per frame to sustain a
     /// tick rate without relying on egui's unconditional repaint cadence.
     /// Apps that do not emit this will still repaint on keyboard/inject events.
     ScheduleRender { after_ms: u32 },
+    /// Declare app render cadence so the host owns recurring animation ticks.
+    /// `mode="idle"` disables recurring renders, `mode="scheduled"` means the
+    /// app will emit ScheduleRender manually, and `mode="continuous"` asks the
+    /// host to render at `fps`.
+    SetSchedulerMode {
+        mode: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fps: Option<u32>,
+    },
     /// Write `text` to the OS clipboard.
     ///
     /// Routed through `egui::Context::copy_text`, which handles platform-

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::app_protocol::PlexiEvent;
 
 // -- DrawCommand routing --------------------------------------------------
 
@@ -74,6 +73,81 @@ fn add_test_pane_appears_in_snapshot() {
     assert_eq!(
         snap.pane_titles.get(&pane).map(|s| s.as_str()),
         Some("Test App")
+    );
+}
+
+#[test]
+fn visible_idle_process_app_does_not_emit_recurring_render_events() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    let first = h
+        .render_payload_take(pane)
+        .expect("first visible frame must request an app Render");
+    assert!(
+        first.contains("\"frame_id\":1"),
+        "first Render should use frame_id=1, got {first}"
+    );
+
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::FrameDone { frame_id: 1 }),
+    );
+    h.run_frames(1);
+    let second = h.render_payload_take(pane);
+    assert_eq!(
+        second, None,
+        "an idle visible app with a committed frame must not receive another Render just because the host repainted"
+    );
+
+    h.run_frames(2);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "idle host repaint cycles must not restart visible app rendering"
+    );
+}
+
+#[test]
+fn schedule_render_requests_next_process_app_render() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    assert!(
+        h.render_payload_take(pane).is_some(),
+        "first visible frame must request an app Render"
+    );
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::FrameDone { frame_id: 1 }),
+    );
+    h.run_frames(1);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "stable idle frame should not render before ScheduleRender"
+    );
+
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::ScheduleRender { after_ms: 0 }),
+    );
+    h.run_frames(1);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "ScheduleRender is handled after the render slot for this host frame"
+    );
+
+    h.run_frames(1);
+    let scheduled = h
+        .render_payload_take(pane)
+        .expect("ScheduleRender must request the next app Render");
+    assert!(
+        scheduled.contains("\"frame_id\":2"),
+        "scheduled Render should use the next frame_id, got {scheduled}"
     );
 }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -110,6 +110,25 @@ fn visible_idle_process_app_does_not_emit_recurring_render_events() {
 }
 
 #[test]
+fn in_flight_process_app_render_is_not_duplicated_while_host_polls() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    assert!(
+        h.render_payload_take(pane).is_some(),
+        "first visible frame must request an app Render"
+    );
+
+    h.run_frames(3);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "host wake polling while awaiting FrameDone must not send duplicate Render events"
+    );
+}
+
+#[test]
 fn schedule_render_requests_next_process_app_render() {
     let mut h = HostHarness::new();
     let pane = h.add_test_pane();

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -129,6 +129,46 @@ fn in_flight_process_app_render_is_not_duplicated_while_host_polls() {
 }
 
 #[test]
+fn background_frame_done_clears_in_flight_render() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    assert!(
+        h.render_payload_take(pane).is_some(),
+        "first visible frame must request an app Render"
+    );
+
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::FrameDone { frame_id: 1 }),
+    );
+    {
+        let win = &mut h.app.windows[0];
+        let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane) else {
+            panic!("expected App pane");
+        };
+        let AppRuntime::Process(proc) = &mut app_pane.runtime else {
+            panic!("expected Process runtime");
+        };
+        proc.background_tick();
+    }
+
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::ScheduleRender { after_ms: 0 }),
+    );
+    h.run_frames(2);
+    let scheduled = h
+        .render_payload_take(pane)
+        .expect("a background-drained FrameDone must allow the next Render");
+    assert!(
+        scheduled.contains("\"frame_id\":2"),
+        "next Render should use frame_id=2 after background FrameDone, got {scheduled}"
+    );
+}
+
+#[test]
 fn schedule_render_requests_next_process_app_render() {
     let mut h = HostHarness::new();
     let pane = h.add_test_pane();

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -152,6 +152,61 @@ fn schedule_render_requests_next_process_app_render() {
 }
 
 #[test]
+fn pending_async_completion_keeps_host_wake_without_idle_render() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    assert!(
+        h.render_payload_take(pane).is_some(),
+        "first visible frame must request an app Render"
+    );
+    h.inject(
+        pane,
+        DrawCommand::Control(crate::app_protocol::ControlCommand::FrameDone { frame_id: 1 }),
+    );
+    h.run_frames(1);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "stable app must not render before async work starts"
+    );
+
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::HttpRequest {
+            request_id: "http-1".to_string(),
+            url: "https://example.com/".to_string(),
+            method: "GET".to_string(),
+            headers: std::collections::HashMap::new(),
+            body: None,
+        }),
+    );
+    h.run_frames(1);
+    assert_eq!(
+        h.render_payload_take(pane),
+        None,
+        "arming async work must wake the host without sending an app Render"
+    );
+
+    let mut scheduled_render = None;
+    for _ in 0..20 {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        h.run_frames(1);
+        if let Some(payload) = h.render_payload_take(pane) {
+            scheduled_render = Some(payload);
+            break;
+        }
+    }
+
+    let scheduled = scheduled_render.expect("async completion must trigger the next app Render");
+    assert!(
+        scheduled.contains("\"frame_id\":2"),
+        "async-triggered Render should use the next frame_id, got {scheduled}"
+    );
+}
+
+#[test]
 fn two_test_panes_have_distinct_ids() {
     let mut h = HostHarness::new();
     let p1 = h.add_test_pane();

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -194,16 +194,9 @@ fn schedule_render_requests_next_process_app_render() {
         DrawCommand::Control(crate::app_protocol::ControlCommand::ScheduleRender { after_ms: 0 }),
     );
     h.run_frames(1);
-    assert_eq!(
-        h.render_payload_take(pane),
-        None,
-        "ScheduleRender is handled after the render slot for this host frame"
-    );
-
-    h.run_frames(1);
     let scheduled = h
         .render_payload_take(pane)
-        .expect("ScheduleRender must request the next app Render");
+        .expect("a due ScheduleRender drained this pass must send the Render in the same pass");
     assert!(
         scheduled.contains("\"frame_id\":2"),
         "scheduled Render should use the next frame_id, got {scheduled}"

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -282,6 +282,25 @@ impl HostHarness {
         };
         process_app.outbound_events.drain(..).collect()
     }
+
+    /// Take the latest Render payload queued for a test `ProcessApp`.
+    ///
+    /// Test apps do not spawn the stdin writer thread, so this helper also
+    /// resets `render_in_queue` to simulate that writer consuming the slot.
+    pub fn render_payload_take(&mut self, pane_id: PaneId) -> Option<String> {
+        let win = &mut self.app.windows[0];
+        let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane_id) else {
+            return None;
+        };
+        let AppRuntime::Process(process_app) = &mut app_pane.runtime else {
+            return None;
+        };
+        let payload = process_app.render_slot.lock().unwrap().take();
+        process_app
+            .render_in_queue
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        payload
+    }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2020

## Summary

- Added per-ProcessApp render-needed and in-flight tracking so visible idle PGAP panes do not receive Render events on unrelated host repaints.
- Marked resize, keyboard/mouse input, outbound protocol events, async completions, image completions, and explicit ScheduleRender as causes for the next app render.
- Added HostHarness coverage for idle no-repeat behavior and ScheduleRender-driven follow-up renders.

## Done When

A visible idle PGAP app receives no recurring Render events after it has committed a stable frame, while Tetris/Snake-style apps using ScheduleRender still animate at their requested cadence.

## Tests

- cargo build
- cargo test --bin plexi testing::harness_tests
- cargo test --bin plexi
