### PR TITLE
feat(panes): pane slot system (#1994)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -30,6 +30,26 @@ fn slot_error(response_file: &str, message: impl Into<String>) {
     );
 }
 
+fn slot_read_error(response_file: &str, message: impl Into<String>) {
+    write_json_response(
+        &format!("{response_file}.err"),
+        serde_json::json!({
+            "ok": false,
+            "error": message.into(),
+        }),
+    );
+}
+
+fn write_bytes_response_atomic(response_file: &str, bytes: &[u8]) {
+    let temp_file = format!("{response_file}.tmp");
+    if let Err(e) = std::fs::write(&temp_file, bytes) {
+        log::error!("pane_ipc: could not write temp response file {temp_file:?}: {e}");
+    } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
+        log::error!("pane_ipc: could not rename temp response file to {response_file:?}: {e}");
+        let _ = std::fs::remove_file(&temp_file);
+    }
+}
+
 fn validate_slot_name(slot_name: &str) -> Result<(), String> {
     if slot_name.is_empty() {
         return Err("slot name cannot be empty".to_string());
@@ -537,7 +557,7 @@ impl PlexiApp {
                 } => {
                     log::info!("pane_ipc: kind=slot_read pane_id={pane_id} slot={slot_name:?}");
                     if let Err(msg) = validate_slot_name(slot_name) {
-                        slot_error(response_file, msg);
+                        slot_read_error(response_file, msg);
                         continue;
                     }
                     let path = self
@@ -547,19 +567,13 @@ impl PlexiApp {
                         .and_then(|pane| pane.slots())
                         .and_then(|slots| slots.get(slot_name).cloned());
                     let Some(path) = path else {
-                        slot_error(response_file, format!("slot '{slot_name}' not found"));
+                        slot_read_error(response_file, format!("slot '{slot_name}' not found"));
                         continue;
                     };
                     match std::fs::read(&path) {
-                        Ok(bytes) => {
-                            if let Err(e) = std::fs::write(response_file, bytes) {
-                                log::error!(
-                                    "pane_ipc: slot_read: could not write response file {response_file:?}: {e}"
-                                );
-                            }
-                        }
+                        Ok(bytes) => write_bytes_response_atomic(response_file, &bytes),
                         Err(e) => {
-                            slot_error(
+                            slot_read_error(
                                 response_file,
                                 format!("could not read slot '{slot_name}': {e}"),
                             );

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -482,7 +482,13 @@ impl PlexiApp {
                         );
                         continue;
                     };
-                    let existing_path = slots.get(slot_name).cloned().unwrap_or(slot_path.clone());
+                    let tracked_path = slots.get(slot_name).cloned();
+                    let existing_path = tracked_path.clone().unwrap_or(slot_path.clone());
+                    let write_path = if *append {
+                        tracked_path.clone().unwrap_or(slot_path.clone())
+                    } else {
+                        slot_path.clone()
+                    };
                     let exists = existing_path.exists();
                     if exists && !*append && !*replace {
                         slot_error(
@@ -508,12 +514,13 @@ impl PlexiApp {
                             continue;
                         }
                     }
-                    if let Err(e) = std::fs::create_dir_all(&slot_dir) {
+                    let write_dir = write_path.parent().unwrap_or(slot_dir.as_path());
+                    if let Err(e) = std::fs::create_dir_all(write_dir) {
                         slot_error(
                             response_file,
                             format!(
                                 "could not create slot directory {}: {e}",
-                                slot_dir.display()
+                                write_dir.display()
                             ),
                         );
                         continue;
@@ -523,10 +530,10 @@ impl PlexiApp {
                         std::fs::OpenOptions::new()
                             .create(true)
                             .append(true)
-                            .open(&slot_path)
+                            .open(&write_path)
                             .and_then(|mut f| f.write_all(content).map(|_| ()))
                     } else {
-                        std::fs::write(&slot_path, content)
+                        std::fs::write(&write_path, content)
                     };
                     if let Err(e) = write_result {
                         slot_error(
@@ -535,9 +542,9 @@ impl PlexiApp {
                         );
                         continue;
                     }
-                    let absolute = slot_path
+                    let absolute = write_path
                         .canonicalize()
-                        .unwrap_or_else(|_| slot_path.clone());
+                        .unwrap_or_else(|_| write_path.clone());
                     slots.insert(slot_name.clone(), absolute.clone());
                     let size = std::fs::metadata(&absolute).map(|m| m.len()).unwrap_or(0);
                     write_json_response(

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -5,6 +5,97 @@ use egui_term::PtyEvent;
 use super::PendingNotification;
 use super::PlexiApp;
 
+const MAX_SLOT_CONTENT_SIZE: usize = 10 * 1024 * 1024;
+
+fn write_json_response(response_file: &str, value: serde_json::Value) {
+    match serde_json::to_string(&value) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(response_file, json) {
+                log::error!("pane_ipc: could not write response file {response_file:?}: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!("pane_ipc: could not serialize response for {response_file:?}: {e}");
+        }
+    }
+}
+
+fn slot_error(response_file: &str, message: impl Into<String>) {
+    write_json_response(
+        response_file,
+        serde_json::json!({
+            "ok": false,
+            "error": message.into(),
+        }),
+    );
+}
+
+fn validate_slot_name(slot_name: &str) -> Result<(), String> {
+    if slot_name.is_empty() {
+        return Err("slot name cannot be empty".to_string());
+    }
+    if slot_name == "." || slot_name == ".." || slot_name.contains('/') || slot_name.contains('\\')
+    {
+        return Err(format!("invalid slot name '{slot_name}'"));
+    }
+    Ok(())
+}
+
+fn slot_base_dir(context_root: Option<&std::path::Path>) -> std::path::PathBuf {
+    match context_root {
+        Some(root) => root
+            .join(crate::config::workspace_channel_dir())
+            .join("slots"),
+        None => crate::config::config_dir().join("slots"),
+    }
+}
+
+fn pane_slots_json(pane: &crate::host::pane::Pane) -> serde_json::Value {
+    match pane.slots() {
+        Some(slots) => {
+            let obj = slots
+                .iter()
+                .map(|(name, path)| {
+                    (
+                        name.clone(),
+                        serde_json::Value::String(path.to_string_lossy().into_owned()),
+                    )
+                })
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        None => serde_json::Value::Object(serde_json::Map::new()),
+    }
+}
+
+fn slot_list_entries(
+    slots: &std::collections::HashMap<String, std::path::PathBuf>,
+) -> Vec<serde_json::Value> {
+    let mut entries: Vec<serde_json::Value> = slots
+        .iter()
+        .map(|(name, path)| {
+            let metadata = std::fs::metadata(path).ok();
+            let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+            let modified = metadata
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs());
+            serde_json::json!({
+                "name": name,
+                "path": path.to_string_lossy(),
+                "size": size,
+                "modified": modified,
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        a.get("name")
+            .and_then(|v| v.as_str())
+            .cmp(&b.get("name").and_then(|v| v.as_str()))
+    });
+    entries
+}
+
 impl PlexiApp {
     pub(super) fn drain_pane_cmd_channel(&mut self) {
         while let Ok(cmd) = self.pane_ipc_rx.try_recv() {
@@ -104,6 +195,7 @@ impl PlexiApp {
                                 "window_id": win.window_id,
                                 "cwd": cwd,
                                 "agent": pane.agent(),
+                                "slots": pane_slots_json(pane),
                             }));
                         }
                     }
@@ -184,6 +276,7 @@ impl PlexiApp {
                                         "window_id": win.window_id,
                                         "cwd": cwd,
                                         "agent": agent,
+                                        "slots": pane_slots_json(pane),
                                     })
                                 }
                                 crate::host::pane::Pane::App(a) => {
@@ -197,6 +290,7 @@ impl PlexiApp {
                                         "cwd": a.workspace_root.to_string_lossy().as_ref(),
                                         "manifest_id": a.manifest_id.clone(),
                                         "agent": agent,
+                                        "slots": pane_slots_json(pane),
                                     })
                                 }
                                 crate::host::pane::Pane::Portal(p) => {
@@ -253,6 +347,7 @@ impl PlexiApp {
                                                 "context_id": win.context_id,
                                                 "window_id": win.window_id,
                                                 "cwd": cwd,
+                                                "slots": pane_slots_json(pane),
                                             })
                                         }
                                         crate::host::pane::Pane::App(a) => {
@@ -265,6 +360,7 @@ impl PlexiApp {
                                                 "window_id": win.window_id,
                                                 "cwd": a.workspace_root.to_string_lossy().as_ref(),
                                                 "manifest_id": a.manifest_id.clone(),
+                                                "slots": pane_slots_json(pane),
                                             })
                                         }
                                         crate::host::pane::Pane::Portal(p) => {
@@ -306,6 +402,317 @@ impl PlexiApp {
                             let _ = std::fs::remove_file(&temp_file);
                         }
                     }
+                }
+                crate::app_protocol::AppRequest::SlotWrite {
+                    pane_id,
+                    slot_name,
+                    content,
+                    append,
+                    replace,
+                    response_file,
+                } => {
+                    log::info!(
+                        "pane_ipc: kind=slot_write pane_id={pane_id} slot={slot_name:?} bytes={} append={append} replace={replace}",
+                        content.len()
+                    );
+                    if let Err(msg) = validate_slot_name(slot_name) {
+                        slot_error(response_file, msg);
+                        continue;
+                    }
+                    if *append && *replace {
+                        slot_error(response_file, "use only one of append or replace");
+                        continue;
+                    }
+                    if content.len() > MAX_SLOT_CONTENT_SIZE {
+                        slot_error(
+                            response_file,
+                            format!(
+                                "slot '{slot_name}' content size {} exceeds 10485760 bytes",
+                                content.len()
+                            ),
+                        );
+                        continue;
+                    }
+                    let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
+                        if win.panes.contains_key(pane_id) {
+                            Some((idx, win.context_id))
+                        } else {
+                            None
+                        }
+                    });
+                    let Some((win_idx, context_id)) = target else {
+                        slot_error(response_file, format!("pane {pane_id} not found"));
+                        continue;
+                    };
+                    let context_root = self
+                        .router
+                        .iter()
+                        .find(|ctx| ctx.context_id == context_id)
+                        .and_then(|ctx| ctx.root.clone());
+                    let slot_dir = slot_base_dir(context_root.as_deref()).join(pane_id.to_string());
+                    let slot_path = slot_dir.join(slot_name);
+                    let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
+                        slot_error(response_file, format!("pane {pane_id} not found"));
+                        continue;
+                    };
+                    let Some(slots) = pane.slots_mut() else {
+                        slot_error(
+                            response_file,
+                            format!("pane {pane_id} does not support slots"),
+                        );
+                        continue;
+                    };
+                    let existing_path = slots.get(slot_name).cloned().unwrap_or(slot_path.clone());
+                    let exists = existing_path.exists();
+                    if exists && !*append && !*replace {
+                        slot_error(
+                            response_file,
+                            format!(
+                                "slot '{slot_name}' already exists — use --append to add to it or --replace to overwrite it"
+                            ),
+                        );
+                        continue;
+                    }
+                    if *append {
+                        let existing_size = std::fs::metadata(&existing_path)
+                            .map(|m| m.len())
+                            .unwrap_or(0);
+                        let final_size = existing_size.saturating_add(content.len() as u64);
+                        if final_size > MAX_SLOT_CONTENT_SIZE as u64 {
+                            slot_error(
+                                response_file,
+                                format!(
+                                    "slot '{slot_name}' content size {final_size} exceeds 10485760 bytes"
+                                ),
+                            );
+                            continue;
+                        }
+                    }
+                    if let Err(e) = std::fs::create_dir_all(&slot_dir) {
+                        slot_error(
+                            response_file,
+                            format!(
+                                "could not create slot directory {}: {e}",
+                                slot_dir.display()
+                            ),
+                        );
+                        continue;
+                    }
+                    let write_result = if *append {
+                        use std::io::Write as _;
+                        std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(&slot_path)
+                            .and_then(|mut f| f.write_all(content).map(|_| ()))
+                    } else {
+                        std::fs::write(&slot_path, content)
+                    };
+                    if let Err(e) = write_result {
+                        slot_error(
+                            response_file,
+                            format!("could not write slot '{slot_name}': {e}"),
+                        );
+                        continue;
+                    }
+                    let absolute = slot_path
+                        .canonicalize()
+                        .unwrap_or_else(|_| slot_path.clone());
+                    slots.insert(slot_name.clone(), absolute.clone());
+                    let size = std::fs::metadata(&absolute).map(|m| m.len()).unwrap_or(0);
+                    write_json_response(
+                        response_file,
+                        serde_json::json!({
+                            "ok": true,
+                            "name": slot_name,
+                            "path": absolute.to_string_lossy(),
+                            "size": size,
+                        }),
+                    );
+                }
+                crate::app_protocol::AppRequest::SlotRead {
+                    pane_id,
+                    slot_name,
+                    response_file,
+                } => {
+                    log::info!("pane_ipc: kind=slot_read pane_id={pane_id} slot={slot_name:?}");
+                    if let Err(msg) = validate_slot_name(slot_name) {
+                        slot_error(response_file, msg);
+                        continue;
+                    }
+                    let path = self
+                        .windows
+                        .iter()
+                        .find_map(|win| win.panes.get(pane_id))
+                        .and_then(|pane| pane.slots())
+                        .and_then(|slots| slots.get(slot_name).cloned());
+                    let Some(path) = path else {
+                        slot_error(response_file, format!("slot '{slot_name}' not found"));
+                        continue;
+                    };
+                    match std::fs::read(&path) {
+                        Ok(bytes) => {
+                            if let Err(e) = std::fs::write(response_file, bytes) {
+                                log::error!(
+                                    "pane_ipc: slot_read: could not write response file {response_file:?}: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            slot_error(
+                                response_file,
+                                format!("could not read slot '{slot_name}': {e}"),
+                            );
+                        }
+                    }
+                }
+                crate::app_protocol::AppRequest::SlotList {
+                    pane_id,
+                    response_file,
+                } => {
+                    log::info!("pane_ipc: kind=slot_list pane_id={pane_id}");
+                    let slots = self
+                        .windows
+                        .iter()
+                        .find_map(|win| win.panes.get(pane_id))
+                        .and_then(|pane| pane.slots());
+                    match slots {
+                        Some(slots) => {
+                            write_json_response(
+                                response_file,
+                                serde_json::Value::Array(slot_list_entries(slots)),
+                            );
+                        }
+                        None => slot_error(response_file, format!("pane {pane_id} not found")),
+                    }
+                }
+                crate::app_protocol::AppRequest::SlotDelete {
+                    pane_id,
+                    slot_name,
+                    response_file,
+                } => {
+                    log::info!("pane_ipc: kind=slot_delete pane_id={pane_id} slot={slot_name:?}");
+                    if let Err(msg) = validate_slot_name(slot_name) {
+                        slot_error(response_file, msg);
+                        continue;
+                    }
+                    let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
+                        if win.panes.contains_key(pane_id) {
+                            Some((idx, win.context_id))
+                        } else {
+                            None
+                        }
+                    });
+                    let Some((win_idx, context_id)) = target else {
+                        slot_error(response_file, format!("pane {pane_id} not found"));
+                        continue;
+                    };
+                    let context_root = self
+                        .router
+                        .iter()
+                        .find(|ctx| ctx.context_id == context_id)
+                        .and_then(|ctx| ctx.root.clone());
+                    let fallback_path = slot_base_dir(context_root.as_deref())
+                        .join(pane_id.to_string())
+                        .join(slot_name);
+                    let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
+                        slot_error(response_file, format!("pane {pane_id} not found"));
+                        continue;
+                    };
+                    let Some(slots) = pane.slots_mut() else {
+                        slot_error(
+                            response_file,
+                            format!("pane {pane_id} does not support slots"),
+                        );
+                        continue;
+                    };
+                    let path = slots.remove(slot_name).unwrap_or(fallback_path);
+                    let removed = if path.exists() {
+                        match std::fs::remove_file(&path) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                slot_error(
+                                    response_file,
+                                    format!("could not delete slot '{slot_name}': {e}"),
+                                );
+                                continue;
+                            }
+                        }
+                    } else {
+                        false
+                    };
+                    write_json_response(
+                        response_file,
+                        serde_json::json!({
+                            "ok": true,
+                            "name": slot_name,
+                            "removed": removed,
+                        }),
+                    );
+                }
+                crate::app_protocol::AppRequest::WorkspaceCleanSlots {
+                    dry_run,
+                    response_file,
+                } => {
+                    log::info!("pane_ipc: kind=workspace_clean_slots dry_run={dry_run}");
+                    let live_panes: std::collections::HashSet<u64> = self
+                        .windows
+                        .iter()
+                        .flat_map(|win| win.panes.keys().copied())
+                        .collect();
+                    let mut roots = vec![crate::config::config_dir().join("slots")];
+                    for root in self.router.iter().filter_map(|ctx| ctx.root.as_ref()) {
+                        roots.push(slot_base_dir(Some(root)));
+                    }
+                    roots.sort();
+                    roots.dedup();
+
+                    let mut paths = Vec::new();
+                    for root in roots {
+                        let Ok(entries) = std::fs::read_dir(&root) else {
+                            continue;
+                        };
+                        for entry in entries.flatten() {
+                            let path = entry.path();
+                            if !path.is_dir() {
+                                continue;
+                            }
+                            let Some(pane_id) =
+                                entry.file_name().to_string_lossy().parse::<u64>().ok()
+                            else {
+                                continue;
+                            };
+                            if live_panes.contains(&pane_id) {
+                                continue;
+                            }
+                            paths.push(path);
+                        }
+                    }
+                    paths.sort();
+                    let mut cleaned = Vec::new();
+                    for path in paths {
+                        if !*dry_run {
+                            if let Err(e) = std::fs::remove_dir_all(&path) {
+                                slot_error(
+                                    response_file,
+                                    format!(
+                                        "could not remove slot directory {}: {e}",
+                                        path.display()
+                                    ),
+                                );
+                                continue;
+                            }
+                        }
+                        cleaned.push(path.to_string_lossy().into_owned());
+                    }
+                    write_json_response(
+                        response_file,
+                        serde_json::json!({
+                            "ok": true,
+                            "dry_run": dry_run,
+                            "paths": cleaned,
+                        }),
+                    );
                 }
                 crate::app_protocol::AppRequest::FocusPane { pane_id } => {
                     log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -489,7 +489,7 @@ impl PlexiApp {
                     } else {
                         slot_path.clone()
                     };
-                    let exists = existing_path.exists();
+                    let exists = tracked_path.as_ref().is_some_and(|path| path.exists());
                     if exists && !*append && !*replace {
                         slot_error(
                             response_file,
@@ -681,6 +681,13 @@ impl PlexiApp {
                         .iter()
                         .flat_map(|win| win.panes.keys().copied())
                         .collect();
+                    let live_slot_paths: std::collections::HashSet<std::path::PathBuf> = self
+                        .windows
+                        .iter()
+                        .flat_map(|win| win.panes.values())
+                        .filter_map(|pane| pane.slots())
+                        .flat_map(|slots| slots.values().cloned())
+                        .collect();
                     let mut roots = vec![crate::config::config_dir().join("slots")];
                     for root in self.router.iter().filter_map(|ctx| ctx.root.as_ref()) {
                         roots.push(slot_base_dir(Some(root)));
@@ -703,10 +710,26 @@ impl PlexiApp {
                             else {
                                 continue;
                             };
-                            if live_panes.contains(&pane_id) {
+                            if !live_panes.contains(&pane_id) {
+                                paths.push(path);
                                 continue;
                             }
-                            paths.push(path);
+                            let has_live_slots = live_slot_paths
+                                .iter()
+                                .any(|slot_path| slot_path.parent() == Some(path.as_path()));
+                            if !has_live_slots {
+                                paths.push(path);
+                                continue;
+                            }
+                            let Ok(slot_entries) = std::fs::read_dir(&path) else {
+                                continue;
+                            };
+                            for slot_entry in slot_entries.flatten() {
+                                let slot_path = slot_entry.path();
+                                if !live_slot_paths.contains(&slot_path) {
+                                    paths.push(slot_path);
+                                }
+                            }
                         }
                     }
                     paths.sort();
@@ -714,9 +737,14 @@ impl PlexiApp {
                     let mut clean_error = None;
                     for path in paths {
                         if !*dry_run {
-                            if let Err(e) = std::fs::remove_dir_all(&path) {
+                            let remove_result = if path.is_dir() {
+                                std::fs::remove_dir_all(&path)
+                            } else {
+                                std::fs::remove_file(&path)
+                            };
+                            if let Err(e) = remove_result {
                                 clean_error = Some(format!(
-                                    "could not remove slot directory {}: {e}",
+                                    "could not remove slot path {}: {e}",
                                     path.display()
                                 ));
                                 break;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -711,20 +711,22 @@ impl PlexiApp {
                     }
                     paths.sort();
                     let mut cleaned = Vec::new();
+                    let mut clean_error = None;
                     for path in paths {
                         if !*dry_run {
                             if let Err(e) = std::fs::remove_dir_all(&path) {
-                                slot_error(
-                                    response_file,
-                                    format!(
-                                        "could not remove slot directory {}: {e}",
-                                        path.display()
-                                    ),
-                                );
-                                continue;
+                                clean_error = Some(format!(
+                                    "could not remove slot directory {}: {e}",
+                                    path.display()
+                                ));
+                                break;
                             }
                         }
                         cleaned.push(path.to_string_lossy().into_owned());
+                    }
+                    if let Some(error) = clean_error {
+                        slot_error(response_file, error);
+                        continue;
                     }
                     write_json_response(
                         response_file,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -567,6 +567,7 @@ impl PlexiApp {
                                         overlay_replaced: None,
                                         hidden: false,
                                         agent: None,
+                                        slots: std::collections::HashMap::new(),
                                     })));
                             }
                             "secrets_manager" => {
@@ -591,6 +592,7 @@ impl PlexiApp {
                                         overlay_replaced: None,
                                         hidden: false,
                                         agent: None,
+                                        slots: std::collections::HashMap::new(),
                                     })));
                             }
                             other => {
@@ -611,6 +613,7 @@ impl PlexiApp {
                                             overlay_replaced: None,
                                             hidden: false,
                                             agent: None,
+                                            slots: std::collections::HashMap::new(),
                                         })));
                                 }
                             }
@@ -1235,6 +1238,7 @@ impl PlexiApp {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         };
 
         let win = &mut self.windows[0];

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -948,6 +948,7 @@ fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
         overlay_replaced: None,
         hidden: false,
         agent: None,
+        slots: std::collections::HashMap::new(),
     }))
 }
 

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -159,6 +159,7 @@ fn send_to_pane_searches_all_windows() {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         }
     };
     win1.panes.insert(
@@ -232,6 +233,7 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
         overlay_replaced: None,
         hidden: false,
         agent: None,
+        slots: std::collections::HashMap::new(),
     }));
     h.app.windows[0].panes.insert(orphan_id, orphan_pane);
     assert!(
@@ -392,6 +394,7 @@ fn overlay_panes_preserve_replaced_pane_agent_state() {
             overlay_replaced: Some(Box::new(replaced)),
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         })),
     );
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -719,9 +719,12 @@ pub enum PaneSlotCmd {
     Write {
         /// Slot name
         name: String,
-        /// Optional content and optional pane id: `name [content] [pane_id]`.
-        #[arg(num_args = 0..=2, allow_hyphen_values = true)]
-        args: Vec<String>,
+        /// Optional content. If omitted, stdin is read fully.
+        #[arg(allow_hyphen_values = true)]
+        content: Option<String>,
+        /// Pane id. Defaults to PLEXI_PANE_ID.
+        #[arg(long)]
+        pane_id: Option<u64>,
         /// Append to an existing slot instead of replacing it.
         #[arg(long, conflicts_with = "replace")]
         append: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -231,6 +231,12 @@ pub enum WorkspaceCmd {
     /// Run this once inside your project folder. It creates a .plexi/workspace.toml
     /// so that secrets and commands are scoped to this project.
     Init,
+    /// Remove pane slot files for panes that are no longer open.
+    Clean {
+        /// Print slot directories that would be removed without deleting them.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -699,6 +705,48 @@ pub enum PaneCmd {
     State {
         /// Pane id to query (from `plexi pane list`)
         pane_id: u64,
+    },
+    /// Manage host-managed named file slots for a pane.
+    Slot {
+        #[command(subcommand)]
+        cmd: PaneSlotCmd,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum PaneSlotCmd {
+    /// Write bytes to a named pane slot. If content is omitted, stdin is read fully.
+    Write {
+        /// Slot name
+        name: String,
+        /// Optional content and optional pane id: `name [content] [pane_id]`.
+        #[arg(num_args = 0..=2, allow_hyphen_values = true)]
+        args: Vec<String>,
+        /// Append to an existing slot instead of replacing it.
+        #[arg(long, conflicts_with = "replace")]
+        append: bool,
+        /// Replace an existing slot.
+        #[arg(long, conflicts_with = "append")]
+        replace: bool,
+    },
+    /// Print raw bytes from a named pane slot.
+    Read {
+        /// Slot name
+        name: String,
+        /// Pane id. Defaults to PLEXI_PANE_ID.
+        pane_id: Option<u64>,
+    },
+    /// List slots for a pane as JSON.
+    List {
+        /// Pane id. Defaults to PLEXI_PANE_ID.
+        pane_id: Option<u64>,
+    },
+    /// Delete a named pane slot.
+    Delete {
+        /// Slot name
+        name: String,
+        /// Pane id. Defaults to PLEXI_PANE_ID.
+        pane_id: Option<u64>,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -202,12 +202,13 @@ pub use open::{
 };
 pub use pane::{
     pane_capture_cli, pane_close_cli, pane_focus_cli, pane_info_cli, pane_key_cli, pane_list_cli,
-    pane_self_cli, pane_send_cli, pane_set_title_cli, pane_state_cli,
+    pane_self_cli, pane_send_cli, pane_set_title_cli, pane_slot_delete_cli, pane_slot_list_cli,
+    pane_slot_read_cli, pane_slot_write_cli, pane_state_cli,
 };
 pub use routine::{routine_list, routine_run};
 pub use run::{run_command, run_list_commands};
 pub use validate::validate_cli;
 pub use workspace::{
-    workspace_init, workspace_secret_delete, workspace_secret_get, workspace_secret_list,
-    workspace_secret_set,
+    workspace_clean_cli, workspace_init, workspace_secret_delete, workspace_secret_get,
+    workspace_secret_list, workspace_secret_set,
 };

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -98,6 +98,213 @@ fn print_json_output(json_str: &str) -> i32 {
     }
 }
 
+fn resolve_pane_id(pane_id: Option<u64>) -> Result<u64, i32> {
+    match pane_id {
+        Some(id) => Ok(id),
+        None => {
+            let raw = match std::env::var("PLEXI_PANE_ID") {
+                Ok(v) => v,
+                Err(_) => {
+                    eprintln!("error: pane_id not provided and PLEXI_PANE_ID is not set — run inside a Plexi pane or pass a pane ID");
+                    return Err(1);
+                }
+            };
+            match raw.parse::<u64>() {
+                Ok(id) => Ok(id),
+                Err(_) => {
+                    eprintln!("error: PLEXI_PANE_ID is not a valid number: {raw}");
+                    Err(1)
+                }
+            }
+        }
+    }
+}
+
+fn response_file(prefix: &str) -> String {
+    let id = uuid::Uuid::new_v4();
+    crate::config::config_dir()
+        .join(format!("{prefix}-{id}.json"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn wait_for_response_bytes(response_file: &str, label: &str) -> Result<Vec<u8>, i32> {
+    let response_path = std::path::PathBuf::from(response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            match std::fs::read(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    return Ok(content);
+                }
+                Err(e) => {
+                    log::warn!("{label}:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return Err(1);
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for {label} response");
+            return Err(1);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn response_error(content: &[u8]) -> Option<String> {
+    let value = serde_json::from_slice::<serde_json::Value>(content).ok()?;
+    if value.get("ok").and_then(|v| v.as_bool()) != Some(false) {
+        return None;
+    }
+    value.get("error")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// `plexi pane slot write <name> [content] [pane_id]`
+pub fn pane_slot_write_cli(
+    name: &str,
+    content: Option<&str>,
+    append: bool,
+    replace: bool,
+    pane_id: Option<u64>,
+) -> i32 {
+    let resolved_pane_id = match resolve_pane_id(pane_id) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let mut bytes = Vec::new();
+    if let Some(content) = content {
+        bytes.extend_from_slice(content.as_bytes());
+    } else {
+        use std::io::Read as _;
+        if let Err(e) = std::io::stdin().read_to_end(&mut bytes) {
+            eprintln!("error: could not read stdin: {e}");
+            return 1;
+        }
+    }
+    let response_file = response_file("pane-slot-write-response");
+    log::info!(
+        "pane_slot_write:cli: pane_id={resolved_pane_id} slot={name:?} bytes={} append={append} replace={replace} response_file={response_file:?}",
+        bytes.len()
+    );
+    let code = send_to_socket(serde_json::json!({
+        "type": "slot_write",
+        "pane_id": resolved_pane_id,
+        "slot_name": name,
+        "content": bytes,
+        "append": append,
+        "replace": replace,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let content = match wait_for_response_bytes(&response_file, "pane slot write") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Some(err) = response_error(&content) {
+        eprintln!("error: {err}");
+        return 1;
+    }
+    0
+}
+
+/// `plexi pane slot read <name> [pane_id]`
+pub fn pane_slot_read_cli(name: &str, pane_id: Option<u64>) -> i32 {
+    let resolved_pane_id = match resolve_pane_id(pane_id) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let response_file = response_file("pane-slot-read-response");
+    log::info!(
+        "pane_slot_read:cli: pane_id={resolved_pane_id} slot={name:?} response_file={response_file:?}"
+    );
+    let code = send_to_socket(serde_json::json!({
+        "type": "slot_read",
+        "pane_id": resolved_pane_id,
+        "slot_name": name,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let content = match wait_for_response_bytes(&response_file, "pane slot read") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Some(err) = response_error(&content) {
+        eprintln!("error: {err}");
+        return 1;
+    }
+    use std::io::Write as _;
+    if let Err(e) = std::io::stdout().write_all(&content) {
+        eprintln!("error: could not write stdout: {e}");
+        return 1;
+    }
+    0
+}
+
+/// `plexi pane slot list [pane_id]`
+pub fn pane_slot_list_cli(pane_id: Option<u64>) -> i32 {
+    let resolved_pane_id = match resolve_pane_id(pane_id) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let response_file = response_file("pane-slot-list-response");
+    log::info!("pane_slot_list:cli: pane_id={resolved_pane_id} response_file={response_file:?}");
+    let code = send_to_socket(serde_json::json!({
+        "type": "slot_list",
+        "pane_id": resolved_pane_id,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let content = match wait_for_response_bytes(&response_file, "pane slot list") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Some(err) = response_error(&content) {
+        eprintln!("error: {err}");
+        return 1;
+    }
+    print_json_output(&String::from_utf8_lossy(&content))
+}
+
+/// `plexi pane slot delete <name> [pane_id]`
+pub fn pane_slot_delete_cli(name: &str, pane_id: Option<u64>) -> i32 {
+    let resolved_pane_id = match resolve_pane_id(pane_id) {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let response_file = response_file("pane-slot-delete-response");
+    log::info!(
+        "pane_slot_delete:cli: pane_id={resolved_pane_id} slot={name:?} response_file={response_file:?}"
+    );
+    let code = send_to_socket(serde_json::json!({
+        "type": "slot_delete",
+        "pane_id": resolved_pane_id,
+        "slot_name": name,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+    let content = match wait_for_response_bytes(&response_file, "pane slot delete") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Some(err) = response_error(&content) {
+        eprintln!("error: {err}");
+        return 1;
+    }
+    0
+}
+
 /// `plexi pane list`
 ///
 /// Sends a `list_panes` command to PLEXI_SOCKET. The host writes a JSON array

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -153,6 +153,51 @@ fn wait_for_response_bytes(response_file: &str, label: &str) -> Result<Vec<u8>, 
     }
 }
 
+fn wait_for_slot_read_response(response_file: &str) -> Result<Vec<u8>, i32> {
+    let response_path = std::path::PathBuf::from(response_file);
+    let error_path = std::path::PathBuf::from(format!("{response_file}.err"));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if error_path.exists() {
+            let content = match std::fs::read(&error_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&error_path);
+                    content
+                }
+                Err(e) => {
+                    log::warn!("pane_slot_read:cli: could not read error response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return Err(1);
+                }
+            };
+            if let Some(err) = response_error(&content) {
+                eprintln!("error: {err}");
+                return Err(1);
+            }
+            eprintln!("error: invalid slot read error response");
+            return Err(1);
+        }
+        if response_path.exists() {
+            match std::fs::read(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    return Ok(content);
+                }
+                Err(e) => {
+                    log::warn!("pane_slot_read:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return Err(1);
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for pane slot read response");
+            return Err(1);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 fn response_error(content: &[u8]) -> Option<String> {
     let value = serde_json::from_slice::<serde_json::Value>(content).ok()?;
     if value.get("ok").and_then(|v| v.as_bool()) != Some(false) {
@@ -232,14 +277,10 @@ pub fn pane_slot_read_cli(name: &str, pane_id: Option<u64>) -> i32 {
     if code != 0 {
         return code;
     }
-    let content = match wait_for_response_bytes(&response_file, "pane slot read") {
+    let content = match wait_for_slot_read_response(&response_file) {
         Ok(content) => content,
         Err(code) => return code,
     };
-    if let Some(err) = response_error(&content) {
-        eprintln!("error: {err}");
-        return 1;
-    }
     use std::io::Write as _;
     if let Err(e) = std::io::stdout().write_all(&content) {
         eprintln!("error: could not write stdout: {e}");

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -108,6 +108,10 @@ pub fn workspace_clean_cli(dry_run: bool) -> i32 {
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
+            if paths.is_empty() {
+                println!("No stale pane slot files found.");
+                return 0;
+            }
             for path in paths {
                 if let Some(path) = path.as_str() {
                     println!("{path}");

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -61,6 +61,68 @@ pub fn workspace_init() -> i32 {
     }
 }
 
+pub fn workspace_clean_cli(dry_run: bool) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let response_file = crate::config::config_dir()
+        .join(format!("workspace-clean-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+    log::info!("workspace_clean:cli: dry_run={dry_run} response_file={response_file:?}");
+    let code = super::send_to_socket(serde_json::json!({
+        "type": "workspace_clean_slots",
+        "dry_run": dry_run,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if response_path.exists() {
+            let content = match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    let _ = std::fs::remove_file(&response_path);
+                    content
+                }
+                Err(e) => {
+                    log::warn!("workspace_clean:cli: could not read response file: {e}");
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            };
+            let value = match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(value) => value,
+                Err(e) => {
+                    eprintln!("error: invalid workspace clean response: {e}");
+                    return 1;
+                }
+            };
+            if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
+                eprintln!("error: {err}");
+                return 1;
+            }
+            let paths = value
+                .get("paths")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            for path in paths {
+                if let Some(path) = path.as_str() {
+                    println!("{path}");
+                }
+            }
+            return 0;
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for workspace clean response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 // ── plexi secret subcommands (workspace-aware, issue #322) ───────────────────
 
 /// Resolve the current workspace and config. Errors out with a helpful

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -2,6 +2,7 @@ use crate::app::app_trait::{App, AppCommand, AppRenderContext};
 use crate::app::permissions::AppPermissions;
 use crate::spatial::tiling::PaneId;
 use egui_term::{BackendSettings, PtyEvent, TerminalBackend};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
@@ -124,6 +125,22 @@ impl Pane {
         }
     }
 
+    pub fn slots(&self) -> Option<&HashMap<String, PathBuf>> {
+        match self {
+            Pane::Terminal(t) => Some(&t.slots),
+            Pane::App(a) => Some(&a.slots),
+            Pane::Portal(_) => None,
+        }
+    }
+
+    pub fn slots_mut(&mut self) -> Option<&mut HashMap<String, PathBuf>> {
+        match self {
+            Pane::Terminal(t) => Some(&mut t.slots),
+            Pane::App(a) => Some(&mut a.slots),
+            Pane::Portal(_) => None,
+        }
+    }
+
     /// Returns the target context_id if this is a Portal pane.
     pub fn portal_target(&self) -> Option<u64> {
         match self {
@@ -160,6 +177,7 @@ pub struct TerminalPane {
     /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
     pub hidden: bool,
     pub agent: Option<crate::app_protocol::PaneAgentState>,
+    pub slots: HashMap<String, PathBuf>,
 }
 
 impl TerminalPane {
@@ -191,6 +209,7 @@ impl TerminalPane {
             outside_workspace_root: None,
             hidden: false,
             agent: None,
+            slots: HashMap::new(),
         })
     }
 }
@@ -348,4 +367,5 @@ pub struct AppPane {
     /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
     pub hidden: bool,
     pub agent: Option<crate::app_protocol::PaneAgentState>,
+    pub slots: HashMap<String, PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -723,30 +723,17 @@ fn main() -> eframe::Result {
                             PaneCmd::Slot { cmd } => match cmd {
                                 PaneSlotCmd::Write {
                                     name,
-                                    args,
+                                    content,
+                                    pane_id,
                                     append,
                                     replace,
                                 } => {
-                                    let (content, pane_id) = match args.as_slice() {
-                                        [] => (None, None),
-                                        [content] => (Some(content.as_str()), None),
-                                        [content, pane] => {
-                                            let pane_id = match pane.parse::<u64>() {
-                                                Ok(id) => id,
-                                                Err(_) => {
-                                                    eprintln!("error: pane_id must be a number, got {pane:?}");
-                                                    std::process::exit(1);
-                                                }
-                                            };
-                                            (Some(content.as_str()), Some(pane_id))
-                                        }
-                                        _ => {
-                                            eprintln!("error: usage: plexi pane slot write <name> [content] [pane_id]");
-                                            std::process::exit(2);
-                                        }
-                                    };
                                     std::process::exit(cli::pane_slot_write_cli(
-                                        &name, content, append, replace, pane_id,
+                                        &name,
+                                        content.as_deref(),
+                                        append,
+                                        replace,
+                                        pane_id,
                                     ));
                                 }
                                 PaneSlotCmd::Read { name, pane_id } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,8 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd, HookAction,
-        NotesCmd, PaneCmd, RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd, WorkspaceCmd,
+        NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd,
+        WorkspaceCmd,
     };
     use clap::Parser;
 
@@ -205,6 +206,9 @@ fn main() -> eframe::Result {
                     },
                     Commands::Workspace { cmd } => match cmd {
                         WorkspaceCmd::Init => std::process::exit(cli::workspace_init()),
+                        WorkspaceCmd::Clean { dry_run } => {
+                            std::process::exit(cli::workspace_clean_cli(dry_run))
+                        }
                     },
                     Commands::Routine { cmd } => match cmd {
                         RoutineCmd::List => std::process::exit(cli::routine_list()),
@@ -716,6 +720,45 @@ fn main() -> eframe::Result {
                             PaneCmd::State { pane_id } => {
                                 std::process::exit(cli::pane_state_cli(pane_id))
                             }
+                            PaneCmd::Slot { cmd } => match cmd {
+                                PaneSlotCmd::Write {
+                                    name,
+                                    args,
+                                    append,
+                                    replace,
+                                } => {
+                                    let (content, pane_id) = match args.as_slice() {
+                                        [] => (None, None),
+                                        [content] => (Some(content.as_str()), None),
+                                        [content, pane] => {
+                                            let pane_id = match pane.parse::<u64>() {
+                                                Ok(id) => id,
+                                                Err(_) => {
+                                                    eprintln!("error: pane_id must be a number, got {pane:?}");
+                                                    std::process::exit(1);
+                                                }
+                                            };
+                                            (Some(content.as_str()), Some(pane_id))
+                                        }
+                                        _ => {
+                                            eprintln!("error: usage: plexi pane slot write <name> [content] [pane_id]");
+                                            std::process::exit(2);
+                                        }
+                                    };
+                                    std::process::exit(cli::pane_slot_write_cli(
+                                        &name, content, append, replace, pane_id,
+                                    ));
+                                }
+                                PaneSlotCmd::Read { name, pane_id } => {
+                                    std::process::exit(cli::pane_slot_read_cli(&name, pane_id))
+                                }
+                                PaneSlotCmd::List { pane_id } => {
+                                    std::process::exit(cli::pane_slot_list_cli(pane_id))
+                                }
+                                PaneSlotCmd::Delete { name, pane_id } => {
+                                    std::process::exit(cli::pane_slot_delete_cli(&name, pane_id))
+                                }
+                            },
                             PaneCmd::New {
                                 cmd,
                                 name,

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -265,6 +265,7 @@ mod tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         };
 
         app.windows[0]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -160,6 +160,7 @@ impl PlexiApp {
                 overlay_replaced,
                 hidden: false,
                 agent: None,
+                slots: std::collections::HashMap::new(),
             }))
         };
 
@@ -287,6 +288,7 @@ impl PlexiApp {
                 overlay_replaced: None,
                 hidden: false,
                 agent: None,
+                slots: std::collections::HashMap::new(),
             })),
         );
         if self.windows[active].focused_pane.is_none() {
@@ -523,6 +525,7 @@ impl PlexiApp {
                 overlay_replaced,
                 hidden: false,
                 agent: None,
+                slots: std::collections::HashMap::new(),
             }))
         };
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -1946,6 +1946,7 @@ mod move_to_adjacent_window_tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         }))
     }
 
@@ -2081,6 +2082,7 @@ mod pop_pane_to_new_window_tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         }))
     }
 
@@ -2264,6 +2266,7 @@ mod move_to_row_boundary_tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         }))
     }
 
@@ -2471,6 +2474,7 @@ mod context_root_cwd_tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         };
         let tile = app.windows[0].tree.tiles.insert_pane(pane_id);
         app.windows[0].tree.root = Some(tile);
@@ -2599,6 +2603,7 @@ mod navigate_boundary_tests {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: std::collections::HashMap::new(),
         }))
     }
 

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1883,6 +1883,32 @@ impl ProcessApp {
                     self.type_id
                 );
             }
+            AppRequest::SlotWrite {
+                pane_id, slot_name, ..
+            }
+            | AppRequest::SlotRead {
+                pane_id, slot_name, ..
+            }
+            | AppRequest::SlotDelete {
+                pane_id, slot_name, ..
+            } => {
+                log::warn!(
+                    "ProcessApp[{}]: pane slot command ignored — pane_id={pane_id} slot={slot_name:?} (host socket only)",
+                    self.type_id
+                );
+            }
+            AppRequest::SlotList { pane_id, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: SlotList ignored — pane_id={pane_id} (host socket only)",
+                    self.type_id
+                );
+            }
+            AppRequest::WorkspaceCleanSlots { dry_run, .. } => {
+                log::warn!(
+                    "ProcessApp[{}]: WorkspaceCleanSlots ignored — dry_run={dry_run} (host socket only)",
+                    self.type_id
+                );
+            }
         }
     }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -686,6 +686,39 @@ pub enum AppRequest {
     /// Sent by `plexi pane info --previous`.
     GetPreviousPaneInfo { response_file: String },
 
+    /// Write bytes to a named host-managed pane file slot.
+    SlotWrite {
+        pane_id: u64,
+        slot_name: String,
+        content: Vec<u8>,
+        append: bool,
+        replace: bool,
+        response_file: String,
+    },
+
+    /// Read raw bytes from a named host-managed pane file slot.
+    SlotRead {
+        pane_id: u64,
+        slot_name: String,
+        response_file: String,
+    },
+
+    /// List named host-managed pane file slots.
+    SlotList { pane_id: u64, response_file: String },
+
+    /// Delete a named host-managed pane file slot.
+    SlotDelete {
+        pane_id: u64,
+        slot_name: String,
+        response_file: String,
+    },
+
+    /// Remove slot files for pane ids that are no longer live in any window.
+    WorkspaceCleanSlots {
+        dry_run: bool,
+        response_file: String,
+    },
+
     /// Move UI focus to a pane by PaneId. Sent by `plexi pane focus`. Fire-and-forget.
     FocusPane { pane_id: u64 },
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -169,6 +169,70 @@ fn pane_slots_write_read_list_delete() {
 }
 
 #[test]
+fn pane_slot_read_preserves_error_like_json_content() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+    let raw_json = br#"{"ok":false,"error":"stored artifact"}"#;
+
+    let write_file = temp_response(tmp.path(), "slot-json-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: raw_json.to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&write_file)["ok"].as_bool(), Some(true));
+
+    let read_file = temp_response(tmp.path(), "slot-json-read");
+    h.inject_ipc(AppRequest::SlotRead {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        response_file: read_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(std::fs::read(&read_file).expect("read response"), raw_json);
+    assert!(
+        !std::path::PathBuf::from(format!("{read_file}.err")).exists(),
+        "successful raw reads must not write the error sidecar"
+    );
+}
+
+#[test]
+fn pane_slot_read_errors_use_sidecar_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let read_file = temp_response(tmp.path(), "slot-missing-read");
+    h.inject_ipc(AppRequest::SlotRead {
+        pane_id: pane,
+        slot_name: "missing".to_string(),
+        response_file: read_file.clone(),
+    });
+    h.run_frames(1);
+
+    assert!(
+        !std::path::Path::new(&read_file).exists(),
+        "read error must not occupy the raw response path"
+    );
+    let error_file = format!("{read_file}.err");
+    let response = read_json_response(&error_file);
+    assert_eq!(response["ok"].as_bool(), Some(false));
+    assert!(
+        response["error"]
+            .as_str()
+            .expect("error")
+            .contains("slot 'missing' not found")
+    );
+}
+
+#[test]
 fn pane_slot_write_requires_replace_or_append_for_existing_slot() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -343,6 +343,50 @@ fn pane_slot_append_rejects_final_file_over_10_mib() {
 }
 
 #[test]
+fn pane_slot_append_uses_tracked_path_after_context_root_changes() {
+    let first_root = tempfile::tempdir().expect("first root");
+    let second_root = tempfile::tempdir().expect("second root");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(first_root.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let write_file = temp_response(first_root.path(), "slot-root-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"hello".to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    let original_path = read_json_response(&write_file)["path"]
+        .as_str()
+        .expect("slot path")
+        .to_string();
+
+    h.app
+        .set_active_context_root(second_root.path().to_path_buf());
+    let append_file = temp_response(second_root.path(), "slot-root-append");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b" world".to_vec(),
+        append: true,
+        replace: false,
+        response_file: append_file.clone(),
+    });
+    h.run_frames(1);
+    let append = read_json_response(&append_file);
+    assert_eq!(append["ok"].as_bool(), Some(true));
+    assert_eq!(append["path"].as_str(), Some(original_path.as_str()));
+    assert_eq!(
+        std::fs::read(&original_path).expect("original slot contents"),
+        b"hello world"
+    );
+}
+
+#[test]
 fn pane_info_and_list_include_slots_object() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -489,6 +489,47 @@ fn workspace_clean_slots_lists_and_removes_dead_pane_slot_dirs() {
     assert!(!slot_dir.exists(), "clean should remove dead pane slot dir");
 }
 
+#[test]
+fn workspace_clean_slots_removes_unregistered_files_for_reused_pane_ids() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let slot_dir = tmp
+        .path()
+        .join(crate::config::workspace_channel_dir())
+        .join("slots")
+        .join(pane.to_string());
+    std::fs::create_dir_all(&slot_dir).expect("create stale slot dir");
+    let stale_slot = slot_dir.join("artifact");
+    std::fs::write(&stale_slot, b"stale").expect("write stale slot");
+
+    let clean_file = temp_response(tmp.path(), "slot-clean-reused-pane");
+    h.inject_ipc(AppRequest::WorkspaceCleanSlots {
+        dry_run: false,
+        response_file: clean_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&clean_file)["ok"].as_bool(), Some(true));
+    assert!(
+        !stale_slot.exists(),
+        "unregistered stale slot file should be removed for live pane id"
+    );
+
+    let write_file = temp_response(tmp.path(), "slot-reused-pane-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"fresh".to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&write_file)["ok"].as_bool(), Some(true));
+}
+
 // -- Nav stack ------------------------------------------------------------
 
 /// Regression guard for PR #392: `push_nav` and `pop_nav` commands must be

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -87,6 +87,300 @@ fn two_test_panes_have_distinct_ids() {
     assert_eq!(snap.open_panes.len(), 2);
 }
 
+fn temp_response(dir: &std::path::Path, name: &str) -> String {
+    dir.join(format!("{name}-{}.json", uuid::Uuid::new_v4()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn read_json_response(path: &str) -> serde_json::Value {
+    let content = std::fs::read_to_string(path).expect("response file must exist");
+    serde_json::from_str(&content).expect("response must be valid JSON")
+}
+
+// -- Pane file slots ------------------------------------------------------
+
+#[test]
+fn pane_slots_write_read_list_delete() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let write_file = temp_response(tmp.path(), "slot-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"hello".to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    let write = read_json_response(&write_file);
+    assert_eq!(write["ok"].as_bool(), Some(true));
+
+    let append_file = temp_response(tmp.path(), "slot-append");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b" world".to_vec(),
+        append: true,
+        replace: false,
+        response_file: append_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&append_file)["ok"].as_bool(), Some(true));
+
+    let read_file = temp_response(tmp.path(), "slot-read");
+    h.inject_ipc(AppRequest::SlotRead {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        response_file: read_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(
+        std::fs::read(&read_file).expect("read response"),
+        b"hello world"
+    );
+
+    let list_file = temp_response(tmp.path(), "slot-list");
+    h.inject_ipc(AppRequest::SlotList {
+        pane_id: pane,
+        response_file: list_file.clone(),
+    });
+    h.run_frames(1);
+    let list = read_json_response(&list_file);
+    let entries = list.as_array().expect("slot list must be an array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "artifact");
+    assert_eq!(entries[0]["size"], 11);
+
+    let delete_file = temp_response(tmp.path(), "slot-delete");
+    h.inject_ipc(AppRequest::SlotDelete {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        response_file: delete_file.clone(),
+    });
+    h.run_frames(1);
+    let deleted = read_json_response(&delete_file);
+    assert_eq!(deleted["ok"].as_bool(), Some(true));
+    assert_eq!(deleted["removed"].as_bool(), Some(true));
+}
+
+#[test]
+fn pane_slot_write_requires_replace_or_append_for_existing_slot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let first_file = temp_response(tmp.path(), "slot-first");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"first".to_vec(),
+        append: false,
+        replace: false,
+        response_file: first_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&first_file)["ok"].as_bool(), Some(true));
+
+    let second_file = temp_response(tmp.path(), "slot-second");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"second".to_vec(),
+        append: false,
+        replace: false,
+        response_file: second_file.clone(),
+    });
+    h.run_frames(1);
+    let second = read_json_response(&second_file);
+    assert_eq!(second["ok"].as_bool(), Some(false));
+    assert!(
+        second["error"]
+            .as_str()
+            .expect("error")
+            .contains("already exists"),
+        "unexpected error: {second}"
+    );
+
+    let read_file = temp_response(tmp.path(), "slot-read-after-reject");
+    h.inject_ipc(AppRequest::SlotRead {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        response_file: read_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(std::fs::read(&read_file).expect("read response"), b"first");
+}
+
+#[test]
+fn pane_slot_write_rejects_content_over_10_mib() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let response_file = temp_response(tmp.path(), "slot-too-large");
+    let too_large = vec![b'x'; 10 * 1024 * 1024 + 1];
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "big".to_string(),
+        content: too_large,
+        append: false,
+        replace: false,
+        response_file: response_file.clone(),
+    });
+    h.run_frames(1);
+    let response = read_json_response(&response_file);
+    assert_eq!(response["ok"].as_bool(), Some(false));
+    let error = response["error"].as_str().expect("error");
+    assert!(error.contains("slot 'big'"), "unexpected error: {error}");
+    assert!(error.contains("10485761"), "unexpected error: {error}");
+}
+
+#[test]
+fn pane_slot_append_rejects_final_file_over_10_mib() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let first_file = temp_response(tmp.path(), "slot-first");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: vec![b'a'; 10 * 1024 * 1024],
+        append: false,
+        replace: false,
+        response_file: first_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&first_file)["ok"].as_bool(), Some(true));
+
+    let append_file = temp_response(tmp.path(), "slot-too-large-append");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"!".to_vec(),
+        append: true,
+        replace: false,
+        response_file: append_file.clone(),
+    });
+    h.run_frames(1);
+    let response = read_json_response(&append_file);
+    assert_eq!(response["ok"].as_bool(), Some(false));
+    let error = response["error"].as_str().expect("error");
+    assert!(error.contains("slot 'artifact'"), "unexpected error: {error}");
+    assert!(error.contains("10485761"), "unexpected error: {error}");
+}
+
+#[test]
+fn pane_info_and_list_include_slots_object() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let write_file = temp_response(tmp.path(), "slot-info-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"{} ".to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    let slot_path = read_json_response(&write_file)["path"]
+        .as_str()
+        .expect("slot path")
+        .to_string();
+
+    let info_file = temp_response(tmp.path(), "slot-info");
+    h.inject_ipc(AppRequest::GetPaneInfo {
+        pane_id: pane,
+        response_file: info_file.clone(),
+    });
+    h.run_frames(1);
+    let info = read_json_response(&info_file);
+    assert_eq!(info["slots"]["artifact"].as_str(), Some(slot_path.as_str()));
+
+    let list_file = temp_response(tmp.path(), "slot-pane-list");
+    h.inject_ipc(AppRequest::ListPanes {
+        response_file: list_file.clone(),
+        context_id: None,
+    });
+    h.run_frames(1);
+    let list = read_json_response(&list_file);
+    let pane_entry = list
+        .as_array()
+        .expect("pane list array")
+        .iter()
+        .find(|entry| entry["id"].as_u64() == Some(pane))
+        .expect("pane entry");
+    assert_eq!(
+        pane_entry["slots"]["artifact"].as_str(),
+        Some(slot_path.as_str())
+    );
+}
+
+#[test]
+fn workspace_clean_slots_lists_and_removes_dead_pane_slot_dirs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.set_active_context_root(tmp.path().to_path_buf());
+    let pane = h.add_test_pane();
+
+    let write_file = temp_response(tmp.path(), "slot-clean-write");
+    h.inject_ipc(AppRequest::SlotWrite {
+        pane_id: pane,
+        slot_name: "artifact".to_string(),
+        content: b"done".to_vec(),
+        append: false,
+        replace: false,
+        response_file: write_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&write_file)["ok"].as_bool(), Some(true));
+
+    let slot_dir = tmp
+        .path()
+        .join(crate::config::workspace_channel_dir())
+        .join("slots")
+        .join(pane.to_string());
+    assert!(slot_dir.exists(), "slot dir should exist before clean");
+
+    h.app.windows[0].panes.remove(&pane);
+
+    let dry_run_file = temp_response(tmp.path(), "slot-clean-dry-run");
+    h.inject_ipc(AppRequest::WorkspaceCleanSlots {
+        dry_run: true,
+        response_file: dry_run_file.clone(),
+    });
+    h.run_frames(1);
+    let dry_run = read_json_response(&dry_run_file);
+    assert_eq!(dry_run["ok"].as_bool(), Some(true));
+    let dry_run_paths = dry_run["paths"].as_array().expect("paths array");
+    assert!(dry_run_paths.iter().any(|path| {
+        path.as_str()
+            .is_some_and(|path| path == slot_dir.to_string_lossy())
+    }));
+    assert!(slot_dir.exists(), "dry-run must not remove slot dir");
+
+    let clean_file = temp_response(tmp.path(), "slot-clean");
+    h.inject_ipc(AppRequest::WorkspaceCleanSlots {
+        dry_run: false,
+        response_file: clean_file.clone(),
+    });
+    h.run_frames(1);
+    assert_eq!(read_json_response(&clean_file)["ok"].as_bool(), Some(true));
+    assert!(!slot_dir.exists(), "clean should remove dead pane slot dir");
+}
+
 // -- Nav stack ------------------------------------------------------------
 
 /// Regression guard for PR #392: `push_nav` and `pop_nav` commands must be

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -121,6 +121,7 @@ impl HostHarness {
             overlay_replaced: None,
             hidden: false,
             agent: None,
+            slots: HashMap::new(),
         };
 
         let win = &mut self.app.windows[0];

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -143,6 +143,7 @@ mod tests {
                 overlay_replaced: None,
                 hidden: false,
                 agent: None,
+                slots: std::collections::HashMap::new(),
             };
             let win = &mut app.windows[app.active_window];
             win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));


### PR DESCRIPTION
Closes #1994

## Summary

- Adds host-owned named pane slots with deterministic workspace/profile storage and per-pane slot maps.
- Adds `plexi pane slot write/read/list/delete` plus `plexi workspace clean --dry-run`.
- Exposes `slots` in `pane info`/`pane list` JSON and covers write/read/list/delete, clobber protection, size caps, and cleanup with HostHarness tests.

## Done When

- [x] `plexi pane slot write task "analyze logs"` stores a file and registers the path on the pane
- [x] `plexi pane slot write artifact --replace < output.json` replaces an existing slot
- [x] `plexi pane slot write artifact --append` appends to an existing slot without error
- [x] `plexi pane slot write artifact` with an existing slot, no flags, returns a clear error
- [x] `plexi pane slot read artifact` cats the file contents
- [x] `plexi pane slot list` returns JSON with name, path, size, modified
- [x] `plexi pane slot delete artifact` removes the file and map entry
- [x] `plexi pane info` and `plexi pane list` include `slots`
- [x] `plexi workspace clean --dry-run` lists dead pane slot dirs; without `--dry-run` it deletes them
- [x] Slot writes over 10 MiB return a clear error naming the slot and size
- [x] Info-level traces added for slot operations
- [x] `cargo test --bin plexi` green
