### PR TITLE
feat(notes-picker): x key deletes selected note (#2165)

### DIFF
--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -88,6 +88,7 @@ impl PlexiApp {
             Down,
             Up,
             Enter,
+            Delete,
         }
 
         let action = ctx.input_mut(|i| {
@@ -103,6 +104,8 @@ impl PlexiApp {
                 Some(PickerKey::Up)
             } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
                 Some(PickerKey::Enter)
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::X) {
+                Some(PickerKey::Delete)
             } else {
                 None
             }
@@ -116,6 +119,13 @@ impl PlexiApp {
                 self.notes_picker_selected = self.notes_picker_selected.saturating_sub(1);
             }
             Some(PickerKey::Enter) => self.notes_picker_open_selected(),
+            Some(PickerKey::Delete) => {
+                log::info!(
+                    "notes_picker: x key — deleting entry at index {}",
+                    self.notes_picker_selected
+                );
+                self.notes_picker_delete_entry(self.notes_picker_selected);
+            }
             None => {}
         }
     }
@@ -215,6 +225,7 @@ impl PlexiApp {
                 let hints = [
                     HintGroup::new(&["j", "k"], "navigate"),
                     HintGroup::new(&["\u{21b5}"], "open"),
+                    HintGroup::new(&["x"], "delete"),
                     HintGroup::new(&["esc"], "dismiss"),
                 ];
                 HintBar::new(&hints).show(ui, &colors);


### PR DESCRIPTION
Closes #2165

## Summary

- Adds `Delete` variant to `PickerKey` enum and consumes `egui::Key::X` (no modifiers) in `notes_picker_handle_key`
- Calls `notes_picker_delete_entry(selected)` on `x` press — same logic as the mouse × button
- Adds `HintGroup::new(&["x"], "delete")` to the HintBar so the shortcut is advertised

## Done When

- Pressing `x` while a note is highlighted in the picker deletes it and updates the selection (same behavior as clicking ×)
- The hint bar shows `x  delete` alongside the existing j/k/↵/esc hints
- Existing tests in `notes_picker_refuses_to_delete_open_text_editor_note` and `notes_picker_deletes_closed_note_and_bounds_selection` still pass