### PR TITLE
Agent workflow reliability bundle (#1692)

### DIFF
--- a/.agents/skills/_lib/agent-handoff-summary.sh
+++ b/.agents/skills/_lib/agent-handoff-summary.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLEXI_BIN="plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL}"
+
+read_slot() {
+  local path="${1:-}"
+  if [ -n "$path" ] && [ -f "$path" ]; then
+    tr '\n' ' ' < "$path" | sed 's/[[:space:]]\+$//'
+  fi
+}
+
+PANES_JSON="$($PLEXI_BIN pane list)"
+
+printf 'Agent handoff summary\n'
+printf '=====================\n'
+
+printf '%s\n' "$PANES_JSON" | jq -r '
+  .[]
+  | select(.slots != null)
+  | select((.slots.pipeline_phase // .slots.status // .slots.issue // .slots.pr // "") != "")
+  | [
+      (.id // .pane_id // ""),
+      (.title // .name // ""),
+      (.slots.pipeline_phase // ""),
+      (.slots.issue // ""),
+      (.slots.pr // ""),
+      (.slots.status // ""),
+      (.slots.test_instructions // ""),
+      (.slots.last_error // "")
+    ]
+  | @tsv
+' | while IFS=$'\t' read -r pane_id title phase_path issue_path pr_path status_path test_path error_path; do
+  phase="$(read_slot "$phase_path")"
+  issue="$(read_slot "$issue_path")"
+  pr="$(read_slot "$pr_path")"
+  slot_status="$(read_slot "$status_path")"
+  test_instructions="$(read_slot "$test_path")"
+  last_error="$(read_slot "$error_path")"
+
+  printf '\nPane %s' "$pane_id"
+  if [ -n "$title" ]; then
+    printf ' — %s' "$title"
+  fi
+  printf '\n'
+
+  printf '  doing: %s' "${phase:-unknown}"
+  if [ -n "$issue" ]; then
+    printf ' issue #%s' "$issue"
+  fi
+  if [ -n "$pr" ]; then
+    printf ' PR #%s' "$pr"
+  fi
+  printf '\n'
+
+  printf '  waiting: %s\n' "${slot_status:-working}"
+
+  if [ -n "$last_error" ]; then
+    printf '  needs from Ian: inspect error — %s\n' "$last_error"
+  elif printf '%s' "$slot_status" | grep -Eq 'needs-you|waiting|blocked'; then
+    printf '  needs from Ian: %s\n' "${test_instructions:-reply or review the pane}"
+  else
+    printf '  needs from Ian: nothing right now\n'
+  fi
+done

--- a/.agents/skills/_lib/pipeline-slots.sh
+++ b/.agents/skills/_lib/pipeline-slots.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Shared pane-slot publishing for ship-pipeline skills.
+
+pipeline_slots_plexi() {
+  printf 'plexi%s' "${PLEXI_CHANNEL:+-$PLEXI_CHANNEL}"
+}
+
+pipeline_slot_write() {
+  local name="$1"
+  local value="${2:-}"
+
+  if [ -z "${PLEXI_SOCKET:-}" ] || [ -z "${PLEXI_PANE_ID:-}" ]; then
+    return 0
+  fi
+
+  "$(pipeline_slots_plexi)" pane slot write "$name" "$value" --replace >/dev/null 2>&1 || true
+}
+
+pipeline_slots_set() {
+  local phase="${1:-}"
+  local issue="${2:-}"
+  local pr="${3:-}"
+  local slot_status="${4:-}"
+  local test_instructions="${5:-}"
+  local last_error="${6:-}"
+
+  pipeline_slot_write pipeline_phase "$phase"
+  pipeline_slot_write issue "$issue"
+  pipeline_slot_write pr "$pr"
+  pipeline_slot_write status "$slot_status"
+  pipeline_slot_write test_instructions "$test_instructions"
+  pipeline_slot_write last_error "$last_error"
+}

--- a/.agents/skills/agent-handoff-summary/SKILL.md
+++ b/.agents/skills/agent-handoff-summary/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: agent-handoff-summary
+description: "Summarize active agent panes from host-managed pane slots: what each lane is doing, waiting on, and needs from Ian."
+risk: low
+source: local
+date_added: "2026-06-11"
+---
+
+# Agent Handoff Summary
+
+Use when Ian asks what agents are doing, what is waiting, or what needs his attention.
+
+Run:
+
+```bash
+.agents/skills/_lib/agent-handoff-summary.sh
+```
+
+The helper reads `plexi pane list` slot metadata and prints one entry per pane that has pipeline slots.

--- a/.agents/skills/dispatch/SKILL.md
+++ b/.agents/skills/dispatch/SKILL.md
@@ -80,12 +80,12 @@ The pipeline self-orchestrates inline from there:
 implement-issue → open-pr → validate-pr (notify user, wait) → merge-pr
 ```
 
-All phases run in the same window. Each window closes itself at the end of merge-pr and fires a notify.
+All phases run in the same window. Each successful window closes itself at the end of merge-pr without firing a redundant success notification; failures and user-action states still notify.
 
 ---
 
 ## Notes
 
-- Dispatch is fire-and-forget after lanes are open. You will be notified when each pipeline completes via `plexi notify`.
+- Dispatch is fire-and-forget after lanes are open. You will be notified for validation handoffs, failures, and user-action states; successful merge panes close quietly.
 - If a pane crashes mid-pipeline: re-run `/dispatch N` for that issue. implement-issue will detect the in-progress state and ask for takeover confirmation, or open-pr/validate-pr will resume from the Ship Log.
 - To add a lane to an existing dispatch: `bash .claude/skills/dispatch/scripts/add-to-dispatch.sh <pane_id> <issue>`

--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -38,6 +38,12 @@ This skill is not complete when the branch is merely pushed. Completion includes
 
 > **Stint timing is mandatory.** This skill opens linked stint work with `stint start <task-id>`. Do not close stint tasks here; `/merge-pr` runs `stint done <task-id>` after the PR merges and alpha is verified. Use `stint start --help` / `stint done --help` for exact flags instead of manually editing timing fields.
 
+> **Pane slots.** Publish pipeline state with the shared helper whenever phase, issue, PR, status, testing instructions, or last error changes:
+> ```bash
+> . .agents/skills/_lib/pipeline-slots.sh
+> pipeline_slots_set implement <issue-number> "" working "" ""
+> ```
+
 ---
 
 ## Phase 0 — Find the Issue
@@ -113,6 +119,7 @@ If ls-remote is non-empty: another agent owns this branch. Surface it and any ex
 ```bash
 gh issue edit <number> --add-label "in progress" --add-label "pipeline:implement"
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<number> · impl"
+pipeline_slots_set implement <number> "" working "" ""
 IMPL_PANE=$PLEXI_PANE_ID
 wtp add -b feature/<issue-number>-short-description HEAD  # origin/alpha when in sync; local HEAD when ahead
 ```
@@ -292,6 +299,7 @@ gh issue edit <N> \
 Set the pane status to `pushed`, then invoke `/open-pr` inline in the same pane — do not spawn a new pane or wait for PM to dispatch:
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · pushed"   # bundle: "#<n1>+<n2> · pushed"
+pipeline_slots_set implement <n> "" pushed "" ""
 # Next action in this same pane:
 /open-pr <branch-or-issue>
 ```
@@ -315,4 +323,4 @@ plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · pushed"   # bundle: "#
 - `cargo build --manifest-path <worktree>/Cargo.toml` — never rely on CWD
 - Start linked stint tasks here; never mark them done here. `/merge-pr` owns completion timing.
 - After pushing, always invoke `/open-pr` inline before considering this skill complete.
-- On unrecoverable failure: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"`, close PR if open, comment on issue under `## Prior Attempts`, remove `in progress`, add `ready`, exit
+- On unrecoverable failure: set `plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"`, run `pipeline_slots_set implement <n> "" blocked "" "<error summary>"`, close PR if open, comment on issue under `## Prior Attempts`, remove `in progress`, add `ready`, exit

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -42,6 +42,7 @@ This skill is not complete when the worktree exists. Completion means the task w
   ```
 - Worktree path rule: after creation, all implementation reads, edits, tests, and commits run from the worktree path, not the repo root.
 - If the task links a GitHub issue, keep issue labels as the live PR pipeline state. If it does not, still open a PR; just skip issue labels and Ship Log updates.
+- Publish phase handoff state with `. .agents/skills/_lib/pipeline-slots.sh` and `pipeline_slots_set implement <issue-or-task> "" <status> "" ""` whenever pane title state changes.
 
 ## Phase 0 - Resolve Task
 
@@ -164,6 +165,7 @@ Name the pane:
 
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "stint-<task-id> · impl"
+pipeline_slots_set implement <issue-or-task> "" working "" ""
 ```
 
 If the task links a GitHub issue, mark the issue in progress after the worktree exists:
@@ -268,6 +270,7 @@ Rename the pane:
 
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "stint-<task-id> · pushed"
+pipeline_slots_set implement <issue-or-task> "" pushed "" ""
 ```
 
 Then invoke `/open-pr` inline for the branch. Do not run `stint done` here; `/merge-pr` closes the task after the PR merges and alpha is verified.
@@ -282,4 +285,5 @@ Record the blocker in the task body and linked issue if one exists. Rename the p
 
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "stint-<task-id> · blocked"
+pipeline_slots_set implement <issue-or-task> "" blocked "" "<blocker summary>"
 ```

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -13,6 +13,8 @@ Phase 4 of the ship pipeline. Input: approved PR number. Output: clean alpha at 
 > **Labels are the live state.** On success, all `pipeline:*` labels are removed when the issue closes. On failure, remove all `pipeline:*` labels and `in progress`, add `ready`.
 
 > **Stint timing closure.** Close linked stint tasks with `stint done <task-id>` after the script exits 0.
+>
+> **Pane slots.** Source `.agents/skills/_lib/pipeline-slots.sh` and publish `pipeline_slots_set merge "$ISSUE" "$PR_NUMBER" <status> "" <last-error>` at status changes.
 
 **Entry:** `/merge-pr <pr-number>`
 
@@ -23,6 +25,7 @@ Phase 4 of the ship pipeline. Input: approved PR number. Output: clean alpha at 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · merging"
+pipeline_slots_set merge "$ISSUE" "$PR_NUMBER" merging "" ""
 ```
 
 > Labels are already correct when invoked inline from validate-pr. No label edit needed here.
@@ -97,12 +100,7 @@ git status  # must be clean
 
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · done"
-(RESULT=$(plexi notify \
-  --title "Shipped #$ISSUE" \
-  --body "<title> — v$VERSION" \
-  --choice "ok:Dismiss" \
-  --choice "open:Open PR")
- [ "$RESULT" = "open" ] && open "<pr-url>") &
+pipeline_slots_set merge "$ISSUE" "$PR_NUMBER" done "" ""
 plexi pane close
 ```
 
@@ -118,4 +116,4 @@ plexi pane close
 - Never commit directly to alpha, beta, or main
 - Alpha must be clean when this skill exits
 - Never close a linked stint task until `just merge-pr` exits 0
-- On unrecoverable failure: set pane to `blocked`, comment on issue, remove `in progress` + all `pipeline:*` labels, add `ready`, exit
+- On unrecoverable failure: set pane to `blocked`, run `pipeline_slots_set merge "$ISSUE" "$PR_NUMBER" blocked "" "<error summary>"`, comment on issue, remove `in progress` + all `pipeline:*` labels, add `ready`, exit

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -29,6 +29,8 @@ Pipeline: pipeline:validate + ready set — invoking /validate-pr inline
 > plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
 > ```
 > States this skill sets: `pr-open`.
+>
+> **Pane slots.** Source `.agents/skills/_lib/pipeline-slots.sh` and publish `pipeline_slots_set open-pr <issue> <pr> <status> "" ""` at phase boundaries.
 
 ---
 
@@ -117,6 +119,7 @@ PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 Update pane status:
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · pr-open"
+pipeline_slots_set open-pr <n> "$PR_NUMBER" pr-open "" ""
 ```
 
 ---

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -30,6 +30,8 @@ Phase 3 of the ship pipeline. Manages the test loop and all rejection paths.
 > plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · <state>"
 > ```
 > **The status word must never contain a digit** (the PM maps panes to issues via `grep -oE '[0-9]+'` — a PR number in the suffix would corrupt the census). States this skill sets: `validate`, `needs-you` (waiting on the user — the PM surfaces this), `fixing`, `blocked`.
+>
+> **Pane slots.** Source `.agents/skills/_lib/pipeline-slots.sh` and publish `pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" <status> <testing-summary> <last-error>` at every status change.
 
 ---
 
@@ -61,6 +63,7 @@ gh issue edit $ISSUE_NUMBER \
   --remove-label "pipeline:open-pr" \
   --add-label "pipeline:validate" 2>/dev/null || true
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · validate"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" working "" ""
 ```
 
 ---
@@ -245,6 +248,7 @@ VALIDATION_STATE="/tmp/plexi-validate-${PLEXI_PANE_ID:-unknown}.env"
 
 # Flip pane status to needs-you so the PM surfaces this lane as awaiting the user
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the [TESTING] block, then reply pass/fail/modify." ""
 # Route reply to PM pane if PM dispatched this skill, otherwise this pane
 REPLY_PANE="${PM_PANE_ID:-$PLEXI_PANE_ID}"
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} notify --no-wait \
@@ -290,6 +294,7 @@ First run **Step 0b — Resume Guard After User Reply**. Do not inspect or edit 
 Fix the specific change on the feature branch, commit, push:
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · fixing"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" fixing "" ""
 git add <files>
 git commit -m "fix: <description>"
 git push
@@ -324,6 +329,7 @@ First run **Step 0b — Resume Guard After User Reply**. Do not inspect or edit 
 Apply the targeted fix to the feature branch, commit, push:
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · fixing"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" fixing "" "<failure description>"
 git add <files>
 git commit -m "fix: <description from failure>"
 git push
@@ -361,6 +367,7 @@ If `c` → STOP. Leave PR open. Remove attempt limit — user owns it from here.
 1. **Mark the lane blocked and read the PR log:**
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · blocked"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" blocked "" "hard reject after failed validation"
 tail -100 ~/.plexi-pr-$PR_NUMBER/plexi.log
 ```
 
@@ -447,6 +454,7 @@ Reply: "pass" | "fail: <description>" | "modify: <change>"
 Before firing the notification, flip pane status the same as the install path:
 ```bash
 plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
+pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the diff-review [TESTING] block, then reply pass/fail/modify." ""
 ```
 
 ---


### PR DESCRIPTION
Closes #1692

## Summary

- Remove the merge-pr success notification so successful dispatch panes close quietly.
- Add shared pipeline pane-slot publishing guidance for implement, open-pr, validate-pr, and merge-pr.
- Add an agent handoff summary skill/helper that reads pane slot metadata across panes.

## Done When

Running the dispatch flow through merge produces no notification modal or toast after the worktree pane closes.

Additional bundle tasks:
- 0155: pipeline slots publish phase, issue, PR, status, test instructions, and last error.
- 0156: handoff summary helper prints what agents are doing, waiting on, and need from Ian.

## Verification

- bash -n .agents/skills/_lib/pipeline-slots.sh
- bash -n .agents/skills/_lib/agent-handoff-summary.sh
- .agents/skills/_lib/agent-handoff-summary.sh
- cargo build