### PR TITLE
Minimap show/hide state not restored when focus history traversal crosses context boundaries (#2052)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -388,6 +388,9 @@ impl PlexiApp {
                 log::info!("focus_history: skipping stale entry window={window_id} tile={tile_id:?} (tile gone)");
                 continue;
             }
+            let ctx_id = self.windows[idx].context_id;
+            self.save_minimap_before_context_navigation(ctx_id);
+
             // Save current focus to future stack before navigating.
             let current_window_id = self.windows[self.active_window].window_id;
             if let Some(current_tile) = self.windows[self.active_window].focused_pane {
@@ -400,11 +403,16 @@ impl PlexiApp {
             self.windows[idx].navigate_to(tile_id);
             self.active_window = idx;
             // Sync sidebar: router active must match the context of the window we navigated to.
-            let ctx_id = self.windows[idx].context_id;
             if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
                 self.router.set_active(ctx_idx);
             }
-            log::info!("focus_history: back — to window={window_id} tile={tile_id:?} ctx={ctx_id} history_len={}", self.pane_focus_history.len());
+            self.context_active_window.insert(ctx_id, window_id);
+            self.restore_minimap_for_context(ctx_id);
+            log::info!(
+                "focus_history: back — to window={window_id} tile={tile_id:?} ctx={ctx_id} minimap_visible={} history_len={}",
+                self.minimap.visible,
+                self.pane_focus_history.len()
+            );
             break;
         }
         self.navigating_history = false;
@@ -429,6 +437,9 @@ impl PlexiApp {
                 log::info!("focus_history: skipping stale entry window={window_id} tile={tile_id:?} (tile gone)");
                 continue;
             }
+            let ctx_id = self.windows[idx].context_id;
+            self.save_minimap_before_context_navigation(ctx_id);
+
             // Save current focus to history stack before navigating.
             let current_window_id = self.windows[self.active_window].window_id;
             if let Some(current_tile) = self.windows[self.active_window].focused_pane {
@@ -441,14 +452,38 @@ impl PlexiApp {
             self.windows[idx].navigate_to(tile_id);
             self.active_window = idx;
             // Sync sidebar: router active must match the context of the window we navigated to.
-            let ctx_id = self.windows[idx].context_id;
             if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
                 self.router.set_active(ctx_idx);
             }
-            log::info!("focus_history: forward — to window={window_id} tile={tile_id:?} ctx={ctx_id} future_len={}", self.pane_focus_future.len());
+            self.context_active_window.insert(ctx_id, window_id);
+            self.restore_minimap_for_context(ctx_id);
+            log::info!(
+                "focus_history: forward — to window={window_id} tile={tile_id:?} ctx={ctx_id} minimap_visible={} future_len={}",
+                self.minimap.visible,
+                self.pane_focus_future.len()
+            );
             break;
         }
         self.navigating_history = false;
+    }
+
+    fn save_minimap_before_context_navigation(&mut self, target_ctx_id: u64) {
+        let old_ctx_id = self.windows[self.active_window].context_id;
+        if old_ctx_id != target_ctx_id {
+            self.context_active_window
+                .insert(old_ctx_id, self.windows[self.active_window].window_id);
+        }
+        self.minimap_visible_per_context
+            .insert(old_ctx_id, self.minimap.visible);
+    }
+
+    fn restore_minimap_for_context(&mut self, ctx_id: u64) {
+        let page_count = self.windows.iter().filter(|w| w.context_id == ctx_id).count();
+        self.minimap.visible = self
+            .minimap_visible_per_context
+            .get(&ctx_id)
+            .copied()
+            .unwrap_or(page_count > 1);
     }
 
     /// Re-read configuration from disk and apply changes that can take
@@ -844,6 +879,7 @@ impl PlexiApp {
             self.windows[idx].clear_zoom();
             log::info!("notify:action: pane_navigate cleared stale zoom on window={idx}");
         }
+        self.save_minimap_before_context_navigation(ctx_id);
         // navigate_to sets focused_pane and activates the ancestor Tabs container.
         self.windows[idx].navigate_to(tile_id);
         self.push_focus_history(old_window_id, old_focus);
@@ -853,8 +889,12 @@ impl PlexiApp {
         // new active context immediately (router.active_idx() drives the highlight).
         if let Some(ctx_idx) = self.router.position(|ctx| ctx.context_id == ctx_id) {
             self.router.set_active(ctx_idx);
+            self.context_active_window
+                .insert(ctx_id, self.windows[idx].window_id);
+            self.restore_minimap_for_context(ctx_id);
             log::info!(
-                "notify:action: pane_navigate active_window {prev}→{idx} ctx_idx={ctx_idx} pane_id={pane_id}"
+                "notify:action: pane_navigate active_window {prev}→{idx} ctx_idx={ctx_idx} pane_id={pane_id} minimap_visible={}",
+                self.minimap.visible
             );
         } else {
             log::warn!(

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -452,6 +452,124 @@ fn switch_workspace_no_double_push_during_history_navigation() {
     );
 }
 
+/// Regression guard for #2052: focus-history traversal across contexts must
+/// restore the destination context's saved minimap visibility.
+#[test]
+fn focus_history_restores_context_minimap_visibility() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, pane_a_id) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+    let ctx_a_id = app.router.active().context_id;
+
+    let ctx_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    let win_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    app.router.push(crate::host::context::Context {
+        name: "ctx-b".into(),
+        path: std::path::PathBuf::from("/tmp"),
+        root: None,
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp"),
+        tree: egui_tiles::Tree::empty("test_ctx_b_minimap"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+    app.context_active_window.insert(ctx_b_id, win_b_id);
+    let ctx_b_idx = app.router.len() - 1;
+
+    app.minimap.visible = false;
+    app.minimap_visible_per_context.insert(ctx_a_id, false);
+    app.switch_workspace(ctx_b_idx);
+
+    let pane_b_id = 424242;
+    let tile_b = app.windows[app.active_window].tree.tiles.insert_pane(pane_b_id);
+    app.windows[app.active_window].tree.root = Some(tile_b);
+    app.windows[app.active_window].focused_pane = Some(tile_b);
+    app.minimap.visible = true;
+    app.minimap_visible_per_context.insert(ctx_b_id, true);
+
+    app.step_focus_history_back();
+    assert_eq!(app.router.active().context_id, ctx_a_id);
+    assert!(
+        !app.minimap.visible,
+        "history back must restore context A's hidden minimap state"
+    );
+
+    app.step_focus_history_forward();
+    assert_eq!(app.router.active().context_id, ctx_b_id);
+    assert!(
+        app.minimap.visible,
+        "history forward must restore context B's visible minimap state"
+    );
+
+    app.pane_navigate(pane_a_id);
+    assert_eq!(app.router.active().context_id, ctx_a_id);
+    assert!(
+        !app.minimap.visible,
+        "pane_navigate must restore context A's hidden minimap state"
+    );
+
+    app.pane_navigate(pane_b_id);
+    assert_eq!(app.router.active().context_id, ctx_b_id);
+    assert!(
+        app.minimap.visible,
+        "pane_navigate must restore context B's visible minimap state"
+    );
+}
+
+#[test]
+fn pane_navigate_same_context_records_destination_active_window() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, _) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+    let ctx_id = app.router.active().context_id;
+    let win_b_id = app.next_window_id;
+    app.next_window_id += 1;
+    let pane_b_id = 525252;
+    let mut tree = egui_tiles::Tree::empty("same_context_second_window");
+    let tile_b = tree.tiles.insert_pane(pane_b_id);
+    tree.root = Some(tile_b);
+    app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp"),
+        tree,
+        panes: std::collections::HashMap::new(),
+        focused_pane: Some(tile_b),
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_id,
+    });
+
+    assert!(app.pane_navigate(pane_b_id));
+
+    assert_eq!(
+        app.context_active_window.get(&ctx_id),
+        Some(&win_b_id),
+        "same-context pane_navigate must remember the destination window"
+    );
+}
+
 /// Regression guard for #2054: navigate_to activates ancestor Tabs so focused_pane
 /// is never pointing at a tab-hidden tile, and assert_focus_invariants catches
 /// zoom/focus desync.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -975,8 +975,8 @@ impl PlexiApp {
     /// context's minimap state and restoring the target context's saved state.
     /// Falls back to `visible = (page count > 1)` on first visit.
     ///
-    /// This is the **only** place context navigation should be performed —
-    /// calling `router.set_active` directly bypasses the minimap save/restore.
+    /// This is the standard path for context navigation. Focus-history traversal
+    /// has its own save/restore path because it targets a specific pane tile.
     pub(crate) fn switch_workspace(&mut self, new_ctx_idx: usize) {
         // Record the outgoing focus so Cmd+[ can return here from any context.
         if let Some(w) = self.windows.get(self.active_window) {


### PR DESCRIPTION
Closes #2052

## Summary

- Saves the outgoing context minimap visibility before direct focus-navigation context jumps.
- Restores the destination context minimap state for Cmd+[ / Cmd+] history traversal and pane_navigate.
- Adds regression coverage for hidden/visible minimap restoration across both paths.

## Done When

- Cmd+[ to a context where the minimap was visible makes the minimap appear.
- Cmd+] back to a context where the minimap was hidden hides the minimap.
- Existing switch_workspace minimap behavior is unchanged.
- cargo test --bin plexi focus_history passes.
- cargo build passes.