### PR TITLE
refactor(ui): finish host chrome button primitive migration (#2172)

### DIFF
--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -460,17 +460,14 @@ impl PlexiApp {
                         if show_browse {
                             ui.add_space(style::SPACE_SM);
                             ui.horizontal(|ui| {
-                                if ui
-                                    .add(
-                                        egui::Button::new(
-                                            RichText::new("Browse\u{2026}")
-                                                .size(style::TEXT_CAPTION)
-                                                .color(self.colors.text_primary),
-                                        )
-                                        .fill(self.colors.bg_active),
-                                    )
-                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                                    .clicked()
+                                if crate::ui::button::chrome_button(
+                                    ui,
+                                    "Browse\u{2026}",
+                                    crate::ui::button::ButtonKind::Primary,
+                                    &self.colors,
+                                    80.0,
+                                )
+                                .clicked()
                                 {
                                     browse_clicked = true;
                                 }

--- a/src/overlays/toolbar.rs
+++ b/src/overlays/toolbar.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ui::button;
 
 impl PlexiApp {
     pub(crate) fn draw_toolbar(&mut self, ui: &mut egui::Ui) {
@@ -31,17 +32,14 @@ impl PlexiApp {
             // Right side — help button + notification badge
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 if host_ui_gallery_available() {
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                RichText::new("UI").size(12.0).color(self.colors.text_dim),
-                            )
-                            .frame(false)
-                            .min_size(egui::vec2(24.0, 0.0)),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text("Host UI gallery")
-                        .clicked()
+                    if button::toolbar_button(
+                        ui,
+                        RichText::new("UI")
+                            .size(style::TEXT_CAPTION)
+                            .color(self.colors.text_dim),
+                        "Host UI gallery",
+                    )
+                    .clicked()
                     {
                         self.show_ui_gallery = !self.show_ui_gallery;
                         log::info!(
@@ -55,16 +53,7 @@ impl PlexiApp {
                     }
                 }
 
-                if ui
-                    .add(
-                        egui::Button::new(
-                            RichText::new("?").size(12.0).color(self.colors.text_dim),
-                        )
-                        .frame(false)
-                        .min_size(egui::vec2(24.0, 0.0)),
-                    )
-                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .on_hover_text("Keyboard shortcuts (\u{2318}/)")
+                if button::icon_button(ui, "?", "Keyboard shortcuts (\u{2318}/)", &self.colors)
                     .clicked()
                 {
                     self.show_shortcuts = !self.show_shortcuts;
@@ -84,12 +73,7 @@ impl PlexiApp {
                 } else {
                     "Changelog"
                 };
-                if ui
-                    .add(egui::Button::new(version_label).frame(false))
-                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .on_hover_text(hover_text)
-                    .clicked()
-                {
+                if button::toolbar_button(ui, version_label, hover_text).clicked() {
                     self.show_changelog = !self.show_changelog;
                 }
 
@@ -100,17 +84,14 @@ impl PlexiApp {
                     } else {
                         notif_count.to_string()
                     };
-                    let btn = egui::Button::new(
+                    if button::toolbar_button(
+                        ui,
                         RichText::new(format!("\u{1F514} {badge_text}"))
-                            .size(12.0)
+                            .size(style::TEXT_CAPTION)
                             .color(self.colors.accent),
+                        "Notifications (\u{2318}\u{21E7}A)",
                     )
-                    .frame(false);
-                    if ui
-                        .add(btn)
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .on_hover_text("Notifications (\u{2318}\u{21E7}A)")
-                        .clicked()
+                    .clicked()
                     {
                         self.show_notification_modal = !self.show_notification_modal;
                         if self.show_notification_modal && self.current_notify_id.is_none() {

--- a/src/overlays/ui_gallery.rs
+++ b/src/overlays/ui_gallery.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::ui::{
-    button::{chrome_button, ButtonKind},
+    button::{chrome_button, icon_button, toolbar_button, ButtonKind},
     hints::{HintBar, HintGroup},
     labels::{chrome_section, description_label},
     list::ListRow,
@@ -134,6 +134,7 @@ impl PlexiApp {
                                     92.0,
                                 );
                                 chrome_button(ui, "Danger", ButtonKind::Danger, &colors, 80.0);
+                                chrome_button(ui, "Accent", ButtonKind::Accent, &colors, 80.0);
                                 ui.add_enabled_ui(false, |ui| {
                                     chrome_button(
                                         ui,
@@ -143,6 +144,17 @@ impl PlexiApp {
                                         80.0,
                                     );
                                 });
+                            });
+                            ui.add_space(style::SPACE_SM);
+                            ui.horizontal(|ui| {
+                                icon_button(ui, "+", "Icon button", &colors);
+                                toolbar_button(
+                                    ui,
+                                    RichText::new("Toolbar")
+                                        .size(style::TEXT_CAPTION)
+                                        .color(colors.text_dim),
+                                    "Toolbar button",
+                                );
                             });
                             ui.add_space(style::SPACE_SM);
                             ui.horizontal(|ui| {

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -8,8 +8,8 @@
 use crate::app::app_trait::AppRenderContext;
 use crate::app_protocol::PlexiEvent;
 use crate::host::pane::AppPane;
-use crate::ui::style;
 use crate::ui::theme::Colors;
+use crate::ui::{button, style};
 use egui::RichText;
 
 /// Height of the nav bar shown when the app has pushed at least one view.
@@ -88,13 +88,12 @@ pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_foc
                     ui.add_space(NAV_BAR_PAD);
 
                     // Back arrow button — ‹ (single angle quotation mark, U+2039)
-                    let back_btn = ui.add(
-                        egui::Button::new(
-                            RichText::new("‹")
-                                .size(style::TEXT_BODY + 2.0)
-                                .color(colors.accent),
-                        )
-                        .frame(false),
+                    let back_btn = button::toolbar_button(
+                        ui,
+                        RichText::new("‹")
+                            .size(style::TEXT_BODY + 2.0)
+                            .color(colors.accent),
+                        "Back",
                     );
                     if back_btn.clicked() {
                         app_pane.runtime.queue_outbound_event(PlexiEvent::NavBack {

--- a/src/render/cli_renderer_app.rs
+++ b/src/render/cli_renderer_app.rs
@@ -6,7 +6,10 @@
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
 use crate::app::plexi_descriptor::{ArgSpec, ArgType, Command, PlexiDescriptor};
-use crate::ui::style;
+use crate::ui::{
+    button::{self, ButtonKind},
+    style,
+};
 use egui::{self, Color32, RichText, Vec2};
 use std::collections::HashMap;
 
@@ -527,16 +530,14 @@ impl CliRendererApp {
         // Back button
         ui.horizontal(|ui| {
             ui.add_space(style::SPACE_MD);
-            if ui
-                .add(
-                    egui::Button::new(
-                        RichText::new("← Back")
-                            .size(style::TEXT_CAPTION)
-                            .color(colors.text_dim),
-                    )
-                    .frame(false),
-                )
-                .clicked()
+            if button::toolbar_button(
+                ui,
+                RichText::new("← Back")
+                    .size(style::TEXT_CAPTION)
+                    .color(colors.text_dim),
+                "Back",
+            )
+            .clicked()
             {
                 self.navigate_back();
             }
@@ -584,16 +585,7 @@ impl CliRendererApp {
             } else {
                 "▶  Run"
             };
-            let btn = egui::Button::new(
-                RichText::new(run_text)
-                    .size(style::TEXT_BODY)
-                    .color(colors.text_on(colors.accent)),
-            )
-            .fill(colors.accent)
-            .corner_radius(style::RADIUS_MD)
-            .min_size(Vec2::new(120.0, style::BUTTON_H_MD));
-
-            if ui.add(btn).clicked() {
+            if button::chrome_button(ui, run_text, ButtonKind::Accent, colors, 120.0).clicked() {
                 self.execute();
             }
         });

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -6,6 +6,7 @@ use crate::ui::theme::Colors;
 pub(crate) enum ButtonKind {
     Primary,
     Secondary,
+    Accent,
     Danger,
 }
 
@@ -30,6 +31,7 @@ pub(crate) fn chrome_button_sized(
     let (fill, text_color) = match kind {
         ButtonKind::Primary => (colors.bg_active, colors.text_primary),
         ButtonKind::Secondary => (colors.bg_active, colors.text_dim),
+        ButtonKind::Accent => (colors.accent, colors.text_on(colors.accent)),
         ButtonKind::Danger => (colors.danger, colors.text_on(colors.danger)),
     };
 
@@ -43,6 +45,35 @@ pub(crate) fn chrome_button_sized(
         .min_size(egui::vec2(min_width, height)),
     )
     .on_hover_cursor(egui::CursorIcon::PointingHand)
+}
+
+pub(crate) fn toolbar_button(
+    ui: &mut egui::Ui,
+    label: impl Into<egui::WidgetText>,
+    hover_text: &str,
+) -> egui::Response {
+    ui.add(
+        egui::Button::new(label)
+            .frame(false)
+            .min_size(egui::vec2(style::BUTTON_H_MD - style::SPACE_SM, 0.0)),
+    )
+    .on_hover_cursor(egui::CursorIcon::PointingHand)
+    .on_hover_text(hover_text)
+}
+
+pub(crate) fn icon_button(
+    ui: &mut egui::Ui,
+    icon: &str,
+    hover_text: &str,
+    colors: &Colors,
+) -> egui::Response {
+    toolbar_button(
+        ui,
+        RichText::new(icon)
+            .size(style::TEXT_CAPTION)
+            .color(colors.text_dim),
+        hover_text,
+    )
 }
 
 pub(crate) fn copy_button(ui: &mut egui::Ui, id: egui::Id, text: &str) -> egui::Response {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,4 +1,5 @@
 use crate::host::context::WindowMenuAction;
+use crate::ui::button;
 use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
@@ -30,17 +31,7 @@ impl PlexiApp {
             );
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 ui.add_space(12.0);
-                if ui
-                    .add(
-                        egui::Button::new(
-                            RichText::new("+").size(12.0).color(self.colors.text_dim),
-                        )
-                        .frame(false),
-                    )
-                    .on_hover_cursor(egui::CursorIcon::PointingHand)
-                    .on_hover_text("New context")
-                    .clicked()
-                {
+                if button::icon_button(ui, "+", "New context", &self.colors).clicked() {
                     add_clicked = true;
                 }
             });


### PR DESCRIPTION
Closes #2172

## Summary

- Adds focused host chrome button primitives for accent, toolbar, and icon-style buttons.
- Migrates remaining host-owned button callsites in sidebar, toolbar, text input browse, app pane nav, and CLI renderer chrome.
- Leaves app protocol-rendered buttons out of scope; `egui::Button::new` leftovers are now internal to `src/ui/button.rs`.

## Done When

- A grep for host chrome `egui::Button::new` callsites has no unreviewed leftovers in sidebar, toolbar, setup, confirmations, UI gallery, command palette, notification modal, and CLI renderer host chrome.
- `cargo build` passes.
- PR build visual smoke verifies sidebar `+`, toolbar buttons, and CLI renderer Back/Run still look and click correctly.

## Verification

- `cargo build`
- `cargo test --bin plexi` — 826 passed, 0 failed
