### PR TITLE
feat(apps): Flow — node-based workflow canvas POC

### DIFF
--- a/apps/flow/main.py
+++ b/apps/flow/main.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Flow — node-based workflow canvas (n8n-style POC).
+
+Drag nodes on a pannable canvas, wire outputs into inputs, expand any node
+into a full text editor, then run the graph: prompts template into other
+prompts, file nodes read/write the local filesystem, shell nodes pipe text
+through commands. The AI node is a correctly-shaped stub for a later broker.
+
+Graph persists to <workspace_root>/.plexi/flow.json.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import subprocess
+import time
+
+from plexi_sdk import App, dim
+from plexi_sdk.ui import AppBar, Column, Component, FooterKeys, Label, Spacer, TextEdit
+
+FLOW_FILE = ".plexi/flow.json"
+SHELL_TIMEOUT = 15.0
+
+NODE_W = 190.0
+NODE_H = 76.0
+HEADER_H = 26.0
+PORT_R = 6.0
+PORT_HIT_R = 14.0
+EDGE_HIT_DIST = 7.0
+DOUBLE_CLICK_S = 0.35
+CLICK_SLOP = 4.0
+
+BG = "#11111b"
+GRID_DOT = "#313244"
+SURFACE = "#1e1e2e"
+SURFACE_SEL = "#2a2a40"
+BORDER = "#45475a"
+ACCENT = "#89b4fa"
+TEXT = "#cdd6f4"
+TEXT_DIM = "#7f849c"
+OK = "#a6e3a1"
+ERR = "#f38ba8"
+WIRE = "#6c7086"
+
+KINDS = {
+    "prompt":     {"label": "Prompt",     "color": "#89b4fa",
+                   "hint": "Template text. {{input}} is replaced by upstream output."},
+    "file_read":  {"label": "File Read",  "color": "#a6e3a1",
+                   "hint": "Path to read (relative to workspace root or absolute)."},
+    "file_write": {"label": "File Write", "color": "#f9e2af",
+                   "hint": "Path to write. Upstream output becomes the file contents."},
+    "shell":      {"label": "Shell",      "color": "#fab387",
+                   "hint": "Command to run. Upstream output is piped to stdin."},
+    "ai":         {"label": "AI",         "color": "#cba6f7",
+                   "hint": "Prompt template ({{input}} substituted). Stub — no model wired yet."},
+}
+KIND_ORDER = list(KINDS)
+
+
+class Node:
+    def __init__(self, nid: int, kind: str, x: float, y: float,
+                 title: str = "", text: str = "") -> None:
+        self.id = nid
+        self.kind = kind
+        self.x = x
+        self.y = y
+        self.title = title or KINDS[kind]["label"]
+        self.text = text
+        self.status = "idle"   # idle | running | ok | error
+        self.output = ""
+        self.error = ""
+
+    def to_dict(self) -> dict:
+        return {"id": self.id, "kind": self.kind, "x": self.x, "y": self.y,
+                "title": self.title, "text": self.text}
+
+    @staticmethod
+    def from_dict(d: dict) -> "Node":
+        return Node(d["id"], d["kind"], d["x"], d["y"], d["title"], d["text"])
+
+
+def _bezier_points(x1: float, y1: float, x2: float, y2: float,
+                   steps: int = 18) -> list[tuple[float, float]]:
+    """Horizontal-tangent cubic bezier between two ports, as a polyline."""
+    dx = max(40.0, abs(x2 - x1) * 0.5)
+    c1x, c1y = x1 + dx, y1
+    c2x, c2y = x2 - dx, y2
+    pts: list[tuple[float, float]] = []
+    for i in range(steps + 1):
+        t = i / steps
+        mt = 1.0 - t
+        px = (mt ** 3) * x1 + 3 * (mt ** 2) * t * c1x + 3 * mt * (t ** 2) * c2x + (t ** 3) * x2
+        py = (mt ** 3) * y1 + 3 * (mt ** 2) * t * c1y + 3 * mt * (t ** 2) * c2y + (t ** 3) * y2
+        pts.append((px, py))
+    return pts
+
+
+def _dist_to_segment(px: float, py: float, x1: float, y1: float,
+                     x2: float, y2: float) -> float:
+    vx, vy = x2 - x1, y2 - y1
+    seg_sq = vx * vx + vy * vy
+    if seg_sq <= 0.0:
+        return ((px - x1) ** 2 + (py - y1) ** 2) ** 0.5
+    t = max(0.0, min(1.0, ((px - x1) * vx + (py - y1) * vy) / seg_sq))
+    cx, cy = x1 + t * vx, y1 + t * vy
+    return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
+
+
+class _FlowCanvas(Component):
+    """World-space node canvas. Records its layout rect for hit-testing."""
+
+    def __init__(self, app: "FlowApp") -> None:
+        self._app = app
+        self.rect = (0.0, 0.0, 0.0, 0.0)
+
+    def is_grow(self) -> bool:
+        return True
+
+    def measure(self, _avail_w: float) -> float:
+        return 0.0
+
+    # world <-> screen
+    def to_screen(self, wx: float, wy: float) -> tuple[float, float]:
+        x, y, _, _ = self.rect
+        return (wx + self._app.ox + x, wy + self._app.oy + y)
+
+    def to_world(self, sx: float, sy: float) -> tuple[float, float]:
+        x, y, _, _ = self.rect
+        return (sx - x - self._app.ox, sy - y - self._app.oy)
+
+    def out_port(self, n: Node) -> tuple[float, float]:
+        return self.to_screen(n.x + NODE_W, n.y + NODE_H / 2)
+
+    def in_port(self, n: Node) -> tuple[float, float]:
+        return self.to_screen(n.x, n.y + NODE_H / 2)
+
+    def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
+        self.rect = (x, y, w, h)
+        app = self._app
+        ctx.push_clip(x, y, w, h)
+        ctx.rect(x, y, w, h, BG)
+
+        # dot grid, aligned to pan offset
+        step = 28.0
+        gy = y + (app.oy % step)
+        while gy < y + h:
+            gx = x + (app.ox % step)
+            while gx < x + w:
+                ctx.circle(gx, gy, 1.0, GRID_DOT)
+                gx += step
+            gy += step
+
+        # edges
+        for ei, (a_id, b_id) in enumerate(app.edges):
+            a, b = app.nodes.get(a_id), app.nodes.get(b_id)
+            if a is None or b is None:
+                continue
+            x1, y1 = self.out_port(a)
+            x2, y2 = self.in_port(b)
+            color = ACCENT if app.selected_edge == ei else WIRE
+            width = 2.5 if app.selected_edge == ei else 1.8
+            pts = _bezier_points(x1, y1, x2, y2)
+            for (px, py), (qx, qy) in zip(pts, pts[1:]):
+                ctx.line(px, py, qx, qy, color, width)
+
+        # pending wire follows the cursor
+        if app.drag and app.drag["type"] == "wire":
+            src = app.nodes.get(app.drag["node"])
+            if src is not None:
+                mx, my = app.mouse
+                if app.drag["dir"] == "out":
+                    x1, y1 = self.out_port(src)
+                    pts = _bezier_points(x1, y1, mx, my)
+                else:
+                    x2, y2 = self.in_port(src)
+                    pts = _bezier_points(mx, my, x2, y2)
+                for (px, py), (qx, qy) in zip(pts, pts[1:]):
+                    ctx.line(px, py, qx, qy, ACCENT, 1.8)
+
+        # nodes
+        for n in app.nodes.values():
+            sx, sy = self.to_screen(n.x, n.y)
+            if sx + NODE_W < x or sx > x + w or sy + NODE_H < y or sy > y + h:
+                continue
+            kind = KINDS[n.kind]
+            selected = app.selected_node == n.id
+            ctx.rect(sx + 3, sy + 4, NODE_W, NODE_H, dim("#000000", 70), radius=8.0)
+            ctx.rect(sx - 1, sy - 1, NODE_W + 2, NODE_H + 2,
+                     ACCENT if selected else BORDER, radius=9.0)
+            ctx.rect(sx, sy, NODE_W, NODE_H, SURFACE_SEL if selected else SURFACE,
+                     radius=8.0)
+            ctx.rect(sx, sy, NODE_W, HEADER_H, dim(kind["color"], 90), radius=8.0)
+            ctx.rect(sx, sy + HEADER_H - 4, NODE_W, 4, dim(kind["color"], 90))
+            ctx.text(sx + 10, sy + 6, n.title, 12.0, TEXT, bold=True,
+                     max_width=NODE_W - 62)
+            ctx.text(sx + NODE_W - 10, sy + 7, kind["label"].lower(), 9.0,
+                     dim(kind["color"], 220), align="right")
+
+            preview = n.text.strip().splitlines()[0] if n.text.strip() \
+                else "(empty — ⏎ to edit)"
+            ctx.text(sx + 10, sy + HEADER_H + 8, preview, 10.0,
+                     TEXT_DIM if n.text.strip() else dim(TEXT_DIM, 150),
+                     monospace=True, max_width=NODE_W - 20)
+
+            # status row
+            status_color = {"ok": OK, "error": ERR, "running": ACCENT}.get(n.status)
+            if status_color:
+                ctx.circle(sx + 14, sy + NODE_H - 14, 4.0, status_color)
+                msg = n.error if n.status == "error" else \
+                    (n.output.strip().splitlines()[0] if n.output.strip() else n.status)
+                ctx.text(sx + 24, sy + NODE_H - 20, msg, 9.0, status_color,
+                         max_width=NODE_W - 34)
+
+            # ports
+            for px, py in (self.in_port(n), self.out_port(n)):
+                ctx.circle(px, py, PORT_R + 1.5, BORDER)
+                ctx.circle(px, py, PORT_R, BG)
+                ctx.circle(px, py, PORT_R - 2.5, kind["color"])
+
+        if not app.nodes:
+            ctx.text(x + w / 2, y + h / 2, "Press  a  to add your first node",
+                     14.0, TEXT_DIM, align="center")
+        ctx.pop_clip()
+
+
+class FlowApp(App):
+    default_background = BG
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def on_init(self) -> None:
+        self.nodes: dict[int, Node] = {}
+        self.edges: list[tuple[int, int]] = []
+        self.next_id = 1
+        self.ox = 0.0
+        self.oy = 0.0
+        self.mode = "canvas"           # canvas | edit | add
+        self.edit_node: int | None = None
+        self.selected_node: int | None = None
+        self.selected_edge: int | None = None
+        self.drag: dict | None = None
+        self.mouse = (0.0, 0.0)
+        self._down_pos = (0.0, 0.0)
+        self._last_click: tuple[float, int] = (0.0, -1)
+        self._running = False
+        self._run_task: asyncio.Future | None = None
+        self._canvas = _FlowCanvas(self)
+        self.emit.set_mouse_tracking(True)
+        self._load()
+        self.emit.info(f"flow: init — {len(self.nodes)} nodes, {len(self.edges)} edges")
+
+    def _path(self) -> pathlib.Path:
+        return pathlib.Path(self.workspace_root) / FLOW_FILE
+
+    def _load(self) -> None:
+        try:
+            p = self._path()
+            if not p.exists():
+                return
+            data = json.loads(p.read_text())
+            self.nodes = {n["id"]: Node.from_dict(n) for n in data.get("nodes", [])}
+            self.edges = [tuple(e) for e in data.get("edges", [])]
+            self.next_id = max(self.nodes, default=0) + 1
+        except Exception as e:
+            self.emit.error(f"flow: load failed from {self._path()}: {e}")
+
+    def _save(self) -> None:
+        try:
+            p = self._path()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps({
+                "nodes": [n.to_dict() for n in self.nodes.values()],
+                "edges": [list(e) for e in self.edges],
+            }, indent=2))
+        except Exception as e:
+            self.emit.error(f"flow: save failed to {self._path()}: {e}")
+
+    # ── views ────────────────────────────────────────────────────────────────
+    def view(self):
+        if self.mode == "edit":
+            return self._edit_view()
+        if self.mode == "add":
+            return self._add_view()
+        return self._canvas_view()
+
+    def _canvas_view(self):
+        n, e = len(self.nodes), len(self.edges)
+        subtitle = f"{n} node{'s' if n != 1 else ''} · {e} wire{'s' if e != 1 else ''}"
+        if self._running:
+            subtitle += " · running…"
+        return Column([
+            AppBar(title="Flow", subtitle=subtitle),
+            self._canvas,
+            FooterKeys([
+                ("a", "add"), ("⏎", "edit"), ("drag port", "wire"),
+                ("r", "run"), ("⌫", "delete"),
+            ]),
+        ])
+
+    def _add_view(self):
+        rows: list = [AppBar(title="Flow", subtitle="add node"), Spacer(12.0)]
+        for i, kind in enumerate(KIND_ORDER, start=1):
+            k = KINDS[kind]
+            rows.append(Label(f"{i}   {k['label']}  —  {k['hint']}"))
+            rows.append(Spacer(6.0))
+        rows.append(Spacer(grow=True))
+        rows.append(FooterKeys([("1-5", "choose"), ("esc", "back")]))
+        return Column(rows)
+
+    def _edit_view(self):
+        node = self.nodes.get(self.edit_node) if self.edit_node is not None else None
+        if node is None:
+            self.mode = "canvas"
+            return self._canvas_view()
+        kind = KINDS[node.kind]
+        rows: list = [
+            AppBar(title=node.title, subtitle=kind["label"]),
+            Spacer(8.0),
+            Label("Title"),
+            TextEdit(f"title-{node.id}", value=node.title, height=40.0,
+                     placeholder=kind["label"]),
+            Spacer(8.0),
+            Label(kind["hint"]),
+            TextEdit(f"body-{node.id}", value=node.text, multiline=True,
+                     height=220.0, placeholder="…"),
+        ]
+        if node.status == "error":
+            rows += [Spacer(8.0), Label(f"error: {node.error}")]
+        elif node.output:
+            out = node.output if len(node.output) <= 2000 else node.output[:2000] + "…"
+            rows += [Spacer(8.0), Label("Last output"), Label(out)]
+        rows += [Spacer(grow=True),
+                 FooterKeys([("esc", "back to canvas"), ("⌘⏎", "apply")])]
+        return Column(rows)
+
+    # ── input: keyboard ──────────────────────────────────────────────────────
+    def on_key(self, key: str, _mods: dict) -> None:
+        if self.mode == "add":
+            if key in tuple(str(i) for i in range(1, len(KIND_ORDER) + 1)):
+                self._add_node(KIND_ORDER[int(key) - 1])
+            return
+        if self.mode == "edit":
+            return  # TextEdit owns input; esc handled by on_escape
+        if key == "a":
+            self.mode = "add"
+        elif key == "r":
+            if not self._running:
+                self._run_task = asyncio.ensure_future(self._run_graph())
+        elif key == "return" and self.selected_node is not None:
+            self._open_editor(self.selected_node)
+        elif key == "backspace":
+            self._delete_selection()
+        elif key == "s":
+            self._save()
+            self.emit.info("flow: saved")
+        self.emit.schedule_render()
+
+    def on_escape(self) -> bool:
+        if self.mode != "canvas":
+            if self.mode == "edit":
+                self._save()
+            self.mode = "canvas"
+            self.edit_node = None
+            self.emit.schedule_render()
+            return True
+        if self.selected_node is not None or self.selected_edge is not None:
+            self.selected_node = None
+            self.selected_edge = None
+            self.emit.schedule_render()
+            return True
+        return False
+
+    # ── input: mouse ─────────────────────────────────────────────────────────
+    def on_mouse_down(self, x: float, y: float, button: str, _mods: dict = {}) -> None:
+        if self.mode != "canvas" or button not in ("left", "primary"):
+            return
+        self.mouse = (x, y)
+        self._down_pos = (x, y)
+        # ports first
+        for n in self.nodes.values():
+            ox, oy = self._canvas.out_port(n)
+            if (x - ox) ** 2 + (y - oy) ** 2 <= PORT_HIT_R ** 2:
+                self.drag = {"type": "wire", "node": n.id, "dir": "out"}
+                return
+            ix, iy = self._canvas.in_port(n)
+            if (x - ix) ** 2 + (y - iy) ** 2 <= PORT_HIT_R ** 2:
+                self.drag = {"type": "wire", "node": n.id, "dir": "in"}
+                return
+        node = self._node_at(x, y)
+        if node is not None:
+            self.selected_node = node.id
+            self.selected_edge = None
+            nsx, nsy = self._canvas.to_screen(node.x, node.y)
+            self.drag = {"type": "node", "node": node.id, "grab": (x - nsx, y - nsy)}
+            self.emit.schedule_render()
+            return
+        edge = self._edge_at(x, y)
+        if edge is not None:
+            self.selected_edge = edge
+            self.selected_node = None
+            self.emit.schedule_render()
+            return
+        self.drag = {"type": "pan", "start": (x, y), "origin": (self.ox, self.oy)}
+        if self.selected_node is not None or self.selected_edge is not None:
+            self.selected_node = None
+            self.selected_edge = None
+            self.emit.schedule_render()
+
+    def on_mouse_move(self, x: float, y: float, _buttons: list,
+                      _mods: dict = {}) -> None:
+        self.mouse = (x, y)
+        if self.drag is None:
+            return
+        d = self.drag
+        if d["type"] == "node":
+            node = self.nodes.get(d["node"])
+            if node is not None:
+                gx, gy = d["grab"]
+                node.x, node.y = self._canvas.to_world(x - gx, y - gy)
+        elif d["type"] == "pan":
+            sx, sy = d["start"]
+            ox0, oy0 = d["origin"]
+            self.ox = ox0 + (x - sx)
+            self.oy = oy0 + (y - sy)
+        self.emit.schedule_render()
+
+    def on_mouse_up(self, x: float, y: float, button: str, _mods: dict = {}) -> None:
+        if self.mode != "canvas" or button not in ("left", "primary"):
+            return
+        d, self.drag = self.drag, None
+        if d is None:
+            return
+        if d["type"] == "wire":
+            self._finish_wire(d, x, y)
+        elif d["type"] == "node":
+            moved = abs(x - self._down_pos[0]) + abs(y - self._down_pos[1])
+            if moved <= CLICK_SLOP:
+                now = time.monotonic()
+                last_t, last_id = self._last_click
+                if last_id == d["node"] and now - last_t <= DOUBLE_CLICK_S:
+                    self._open_editor(d["node"])
+                self._last_click = (now, d["node"])
+            else:
+                self._save()
+        self.emit.schedule_render()
+
+    def on_scroll_delta(self, delta_y: float) -> None:
+        if self.mode == "canvas":
+            self.oy += delta_y
+            self.emit.schedule_render()
+
+    # ── component events (editor) ────────────────────────────────────────────
+    def on_component_event(self, node_id: str, event_type: str, payload) -> None:
+        if event_type not in ("change", "submit"):
+            return
+        try:
+            field, nid_s = node_id.rsplit("-", 1)
+            node = self.nodes.get(int(nid_s))
+        except ValueError:
+            return
+        if node is None:
+            return
+        value = payload.get("value", "") if isinstance(payload, dict) else str(payload)
+        if field == "title":
+            node.title = value.strip() or KINDS[node.kind]["label"]
+        elif field == "body":
+            node.text = value
+        if event_type == "submit":
+            self._save()
+            self.mode = "canvas"
+            self.edit_node = None
+            self.emit.schedule_render()
+
+    # ── graph mutations ──────────────────────────────────────────────────────
+    def _add_node(self, kind: str) -> None:
+        cx, cy, w, h = self._canvas.rect
+        wx, wy = self._canvas.to_world(cx + max(w, 400) / 2, cy + max(h, 300) / 2)
+        offset = (len(self.nodes) % 5) * 24.0   # stagger stacked adds
+        node = Node(self.next_id, kind,
+                    wx - NODE_W / 2 + offset, wy - NODE_H / 2 + offset)
+        self.nodes[node.id] = node
+        self.next_id += 1
+        self.selected_node = node.id
+        self._save()
+        self.emit.info(f"flow: added {kind} node {node.id}")
+        self._open_editor(node.id)
+
+    def _delete_selection(self) -> None:
+        if self.selected_node is not None:
+            nid = self.selected_node
+            self.nodes.pop(nid, None)
+            self.edges = [e for e in self.edges if nid not in e]
+            self.selected_node = None
+            self.emit.info(f"flow: deleted node {nid}")
+        elif self.selected_edge is not None and 0 <= self.selected_edge < len(self.edges):
+            a, b = self.edges.pop(self.selected_edge)
+            self.selected_edge = None
+            self.emit.info(f"flow: deleted wire {a}->{b}")
+        else:
+            return
+        self._save()
+
+    def _finish_wire(self, d: dict, x: float, y: float) -> None:
+        target = self._node_at(x, y, port_slop=True)
+        src = self.nodes.get(d["node"])
+        if target is None or src is None or target.id == src.id:
+            return
+        a, b = (src.id, target.id) if d["dir"] == "out" else (target.id, src.id)
+        if (a, b) in self.edges:
+            return
+        if self._creates_cycle(a, b):
+            self.emit.warn(f"flow: refused wire {a}->{b} — would create a cycle")
+            return
+        self.edges.append((a, b))
+        self._save()
+        self.emit.info(f"flow: wired {a}->{b}")
+
+    def _creates_cycle(self, a: int, b: int) -> bool:
+        # adding a->b cycles iff a is reachable from b
+        stack, seen = [b], set()
+        while stack:
+            cur = stack.pop()
+            if cur == a:
+                return True
+            if cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(dst for s, dst in self.edges if s == cur)
+        return False
+
+    def _open_editor(self, nid: int) -> None:
+        self.edit_node = nid
+        self.mode = "edit"
+        self.emit.schedule_render()
+
+    # ── hit testing ──────────────────────────────────────────────────────────
+    def _node_at(self, x: float, y: float, port_slop: bool = False) -> Node | None:
+        slop = PORT_HIT_R if port_slop else 0.0
+        for n in reversed(list(self.nodes.values())):
+            sx, sy = self._canvas.to_screen(n.x, n.y)
+            if sx - slop <= x <= sx + NODE_W + slop \
+                    and sy - slop <= y <= sy + NODE_H + slop:
+                return n
+        return None
+
+    def _edge_at(self, x: float, y: float) -> int | None:
+        for ei, (a_id, b_id) in enumerate(self.edges):
+            a, b = self.nodes.get(a_id), self.nodes.get(b_id)
+            if a is None or b is None:
+                continue
+            x1, y1 = self._canvas.out_port(a)
+            x2, y2 = self._canvas.in_port(b)
+            pts = _bezier_points(x1, y1, x2, y2)
+            for (px, py), (qx, qy) in zip(pts, pts[1:]):
+                if _dist_to_segment(x, y, px, py, qx, qy) <= EDGE_HIT_DIST:
+                    return ei
+        return None
+
+    # ── execution ────────────────────────────────────────────────────────────
+    def _topo_order(self) -> list[int] | None:
+        indeg = {nid: 0 for nid in self.nodes}
+        for _, b in self.edges:
+            if b in indeg:
+                indeg[b] += 1
+        queue = sorted(nid for nid, d in indeg.items() if d == 0)
+        order = []
+        while queue:
+            cur = queue.pop(0)
+            order.append(cur)
+            for s, dst in self.edges:
+                if s == cur and dst in indeg:
+                    indeg[dst] -= 1
+                    if indeg[dst] == 0:
+                        queue.append(dst)
+        return order if len(order) == len(self.nodes) else None
+
+    def _inputs_for(self, nid: int) -> str:
+        parts = [self.nodes[a].output for a, b in self.edges
+                 if b == nid and a in self.nodes]
+        return "\n".join(p for p in parts if p)
+
+    def _resolve_path(self, raw: str) -> pathlib.Path:
+        p = pathlib.Path(raw.strip())
+        return p if p.is_absolute() else pathlib.Path(self.workspace_root) / p
+
+    async def _run_graph(self) -> None:
+        order = self._topo_order()
+        if order is None:
+            self.emit.error("flow: run aborted — graph has a cycle")
+            return
+        self._running = True
+        for n in self.nodes.values():
+            n.status = "idle"
+            n.output = ""
+            n.error = ""
+        self.emit.info(f"flow: running {len(order)} nodes")
+        self.emit.schedule_render()
+        try:
+            for nid in order:
+                node = self.nodes[nid]
+                failed_upstream = any(
+                    self.nodes[a].status == "error"
+                    for a, b in self.edges if b == nid and a in self.nodes
+                )
+                if failed_upstream:
+                    node.status = "error"
+                    node.error = "upstream failed"
+                    continue
+                node.status = "running"
+                self.emit.schedule_render()
+                try:
+                    node.output = await self._exec_node(node, self._inputs_for(nid))
+                    node.status = "ok"
+                    self.emit.info(f"flow: node {nid} ({node.kind}) ok "
+                                   f"({len(node.output)} chars)")
+                except Exception as e:
+                    node.status = "error"
+                    node.error = str(e)
+                    self.emit.error(f"flow: node {nid} ({node.kind}) failed: {e}")
+                self.emit.schedule_render()
+        finally:
+            self._running = False
+            self.emit.schedule_render()
+
+    async def _exec_node(self, node: Node, input_text: str) -> str:
+        kind = node.kind
+        if kind == "prompt":
+            return node.text.replace("{{input}}", input_text)
+        if kind == "ai":
+            rendered = node.text.replace("{{input}}", input_text)
+            # stub: a later broker call replaces this return
+            return f"[ai stub — no model wired]\n{rendered}"
+        if kind == "file_read":
+            if not node.text.strip():
+                raise ValueError("no path set")
+            path = self._resolve_path(node.text)
+            return await asyncio.to_thread(path.read_text)
+        if kind == "file_write":
+            if not node.text.strip():
+                raise ValueError("no path set")
+            path = self._resolve_path(node.text)
+
+            def _write() -> None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(input_text)
+            await asyncio.to_thread(_write)
+            return input_text
+        if kind == "shell":
+            if not node.text.strip():
+                raise ValueError("no command set")
+
+            def _run() -> str:
+                proc = subprocess.run(
+                    node.text, shell=True, input=input_text,
+                    capture_output=True, text=True, timeout=SHELL_TIMEOUT,
+                    cwd=self.workspace_root or None,
+                )
+                if proc.returncode != 0:
+                    raise RuntimeError(
+                        (proc.stderr.strip() or f"exit {proc.returncode}")[:200])
+                return proc.stdout
+            return await asyncio.to_thread(_run)
+        raise ValueError(f"unknown node kind: {kind}")
+
+
+if __name__ == "__main__":
+    FlowApp().run()

--- a/apps/flow/manifest.toml
+++ b/apps/flow/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "flow"
+type = "app"
+name = "Flow"
+entry = "main.py"
+version = "0.1.0"
+description = "Node-based workflow canvas (n8n-style POC): wire prompts, files, and shell commands."
+watch = true
+
+[app.capabilities]
+capabilities = ["fs.read", "fs.write"]
+
+[launch]

--- a/apps/flow/tests/test_flow.py
+++ b/apps/flow/tests/test_flow.py
@@ -1,0 +1,295 @@
+"""Tests for the Flow node-canvas app.
+
+Unit tests exercise the pure graph/exec logic directly; e2e tests boot the
+real app subprocess through AppHarness and drive it with key, mouse, and
+component events. The e2e graph state lives at /tmp/.plexi/flow.json (the
+harness handshake pins workspace_root to /tmp), so each test seeds/cleans it.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import pathlib
+import sys
+import time
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+SDK = ROOT / "sdk" / "python"
+APP = ROOT / "apps" / "flow" / "main.py"
+
+sys.path.insert(0, str(SDK))
+
+from plexi_sdk.testing import AppHarness  # noqa: E402
+
+HARNESS_FLOW_FILE = pathlib.Path("/tmp/.plexi/flow.json")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("flow_app", APP)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+flow = _load_module()
+
+
+def _bare_app(workspace_root: str = "/tmp"):
+    """FlowApp with graph state only — skips App.__init__/event loop."""
+    app = flow.FlowApp.__new__(flow.FlowApp)
+    app.nodes = {}
+    app.edges = []
+    app.workspace_root = workspace_root
+    return app
+
+
+def _node(nid: int, kind: str = "prompt", text: str = ""):
+    return flow.Node(nid, kind, 0.0, 0.0, text=text)
+
+
+# ── unit: geometry ───────────────────────────────────────────────────────────
+
+def test_bezier_hits_both_endpoints():
+    pts = flow._bezier_points(10.0, 20.0, 300.0, 200.0)
+    assert pts[0] == (10.0, 20.0)
+    assert pts[-1] == pytest.approx((300.0, 200.0))
+
+
+def test_dist_to_segment():
+    assert flow._dist_to_segment(5, 5, 0, 0, 10, 0) == pytest.approx(5.0)
+    assert flow._dist_to_segment(20, 0, 0, 0, 10, 0) == pytest.approx(10.0)
+    assert flow._dist_to_segment(3, 4, 1, 1, 1, 1) == pytest.approx(((2**2 + 3**2) ** 0.5))
+
+
+# ── unit: graph logic ────────────────────────────────────────────────────────
+
+def test_topo_order_respects_edges():
+    app = _bare_app()
+    app.nodes = {i: _node(i) for i in (1, 2, 3)}
+    app.edges = [(3, 2), (2, 1)]
+    assert app._topo_order() == [3, 2, 1]
+
+
+def test_topo_order_none_on_cycle():
+    app = _bare_app()
+    app.nodes = {1: _node(1), 2: _node(2)}
+    app.edges = [(1, 2), (2, 1)]
+    assert app._topo_order() is None
+
+
+def test_creates_cycle():
+    app = _bare_app()
+    app.nodes = {i: _node(i) for i in (1, 2, 3)}
+    app.nodes[4] = _node(4)
+    app.edges = [(1, 2), (2, 3)]
+    assert app._creates_cycle(3, 1) is True
+    assert app._creates_cycle(3, 2) is True   # 2→3 exists, so 3→2 closes a loop
+    assert app._creates_cycle(1, 3) is False
+    assert app._creates_cycle(4, 1) is False  # disjoint node is always safe
+
+
+def test_inputs_for_joins_upstream_outputs():
+    app = _bare_app()
+    app.nodes = {i: _node(i) for i in (1, 2, 3)}
+    app.nodes[1].output = "alpha"
+    app.nodes[2].output = "beta"
+    app.edges = [(1, 3), (2, 3)]
+    assert app._inputs_for(3) == "alpha\nbeta"
+
+
+def test_save_load_round_trip(tmp_path):
+    app = _bare_app(str(tmp_path))
+    app.nodes = {7: flow.Node(7, "shell", 12.5, -40.0, title="Upper", text="tr a-z A-Z")}
+    app.edges = [(7, 7)]  # shape only; load doesn't validate
+
+    class _Emit:
+        def error(self, msg):
+            raise AssertionError(msg)
+    app.emit = _Emit()
+    app._save()
+
+    app2 = _bare_app(str(tmp_path))
+    app2.emit = _Emit()
+    app2.next_id = 1
+    app2._load()
+    n = app2.nodes[7]
+    assert (n.kind, n.x, n.y, n.title, n.text) == ("shell", 12.5, -40.0, "Upper", "tr a-z A-Z")
+    assert app2.edges == [(7, 7)]
+    assert app2.next_id == 8
+
+
+# ── unit: node execution ─────────────────────────────────────────────────────
+
+def _exec(app, node, input_text=""):
+    return asyncio.run(app._exec_node(node, input_text))
+
+
+def test_exec_prompt_substitutes_input():
+    app = _bare_app()
+    node = _node(1, "prompt", "Summarize: {{input}} — done")
+    assert _exec(app, node, "the report") == "Summarize: the report — done"
+
+
+def test_exec_ai_is_a_marked_stub():
+    app = _bare_app()
+    node = _node(1, "ai", "Improve: {{input}}")
+    out = _exec(app, node, "draft")
+    assert out.startswith("[ai stub")
+    assert "Improve: draft" in out
+
+
+def test_exec_file_read_write_round_trip(tmp_path):
+    app = _bare_app(str(tmp_path))
+    writer = _node(1, "file_write", "sub/out.txt")
+    assert _exec(app, writer, "payload") == "payload"
+    reader = _node(2, "file_read", "sub/out.txt")
+    assert _exec(app, reader) == "payload"
+    assert (tmp_path / "sub" / "out.txt").read_text() == "payload"
+
+
+def test_exec_file_read_missing_path_raises():
+    app = _bare_app()
+    with pytest.raises(ValueError):
+        _exec(app, _node(1, "file_read", "   "))
+
+
+def test_exec_shell_pipes_stdin(tmp_path):
+    app = _bare_app(str(tmp_path))
+    node = _node(1, "shell", "tr a-z A-Z")
+    assert _exec(app, node, "hello") == "HELLO"
+
+
+def test_exec_shell_failure_raises(tmp_path):
+    app = _bare_app(str(tmp_path))
+    node = _node(1, "shell", "false")
+    with pytest.raises(RuntimeError):
+        _exec(app, node)
+
+
+# ── e2e: AppHarness ──────────────────────────────────────────────────────────
+
+@pytest.fixture
+def clean_flow_file():
+    HARNESS_FLOW_FILE.unlink(missing_ok=True)
+    yield
+    HARNESS_FLOW_FILE.unlink(missing_ok=True)
+
+
+def _seed_graph(nodes: list[dict], edges: list[list[int]]) -> None:
+    HARNESS_FLOW_FILE.parent.mkdir(parents=True, exist_ok=True)
+    HARNESS_FLOW_FILE.write_text(json.dumps({"nodes": nodes, "edges": edges}))
+
+
+def _find_text(cmds: list[dict], needle: str) -> dict | None:
+    """Find `needle` in raw text draw commands (L0 canvas path)."""
+    for c in cmds:
+        if c.get("type") == "text" and needle in c.get("text", ""):
+            return c
+    return None
+
+
+def _tree_contains(cmds: list[dict], needle: str) -> bool:
+    """Find `needle` anywhere in a component_tree command (L1 view path)."""
+    return any(c.get("type") == "component_tree" and needle in json.dumps(c)
+               for c in cmds)
+
+
+def test_e2e_boot_shows_empty_hint(clean_flow_file):
+    with AppHarness(APP) as h:
+        cmds = h.run(1)
+    assert _find_text(cmds, "add your first node") is not None
+
+
+def test_e2e_add_node_opens_editor_and_edits(clean_flow_file):
+    with AppHarness(APP) as h:
+        h.key("a")
+        cmds = h.run(1)
+        assert _tree_contains(cmds, "Prompt")  # add menu lists kinds
+
+        h.key("1")  # add Prompt node → jumps straight into the editor
+        cmds = h.run(1)
+        assert _tree_contains(cmds, "{{input}}")  # kind hint visible
+        assert _tree_contains(cmds, "body-1")     # editor TextEdit present
+
+        h._send({"type": "component_event", "node_id": "body-1",
+                 "event_type": "change", "payload": {"value": "hello {{input}}"}})
+        h._send({"type": "component_event", "node_id": "title-1",
+                 "event_type": "change", "payload": {"value": "Greeter"}})
+        h.key("escape")  # back to canvas, saves
+        cmds = h.run(1)
+        assert _find_text(cmds, "Greeter") is not None
+        assert _find_text(cmds, "hello {{input}}") is not None  # body preview
+
+    saved = json.loads(HARNESS_FLOW_FILE.read_text())
+    assert saved["nodes"][0]["title"] == "Greeter"
+    assert saved["nodes"][0]["text"] == "hello {{input}}"
+
+
+def test_e2e_drag_moves_node(clean_flow_file):
+    _seed_graph([{"id": 1, "kind": "prompt", "x": 60.0, "y": 40.0,
+                  "title": "DragMe", "text": ""}], [])
+    with AppHarness(APP) as h:
+        cmds = h.run(1)
+        t = _find_text(cmds, "DragMe")
+        assert t is not None
+        sx, sy = t["x"], t["y"]  # title is drawn at node origin + (10, 6)
+
+        grab = (sx + 30, sy + 40)  # inside the node body
+        h._send({"type": "mouse_down", "x": grab[0], "y": grab[1], "button": "primary"})
+        h._send({"type": "mouse_move", "x": grab[0] + 80, "y": grab[1] + 50,
+                 "buttons": ["primary"]})
+        h._send({"type": "mouse_up", "x": grab[0] + 80, "y": grab[1] + 50,
+                 "button": "primary"})
+        cmds = h.run(1)
+        t2 = _find_text(cmds, "DragMe")
+        assert t2 is not None
+        assert (t2["x"] - sx, t2["y"] - sy) == pytest.approx((80.0, 50.0))
+
+
+def test_e2e_wire_ports_with_mouse(clean_flow_file):
+    _seed_graph([
+        {"id": 1, "kind": "prompt", "x": 40.0, "y": 60.0, "title": "Src", "text": "x"},
+        {"id": 2, "kind": "prompt", "x": 360.0, "y": 200.0, "title": "Dst", "text": "y"},
+    ], [])
+    with AppHarness(APP) as h:
+        cmds = h.run(1)
+        src = _find_text(cmds, "Src")
+        dst = _find_text(cmds, "Dst")
+        assert src is not None and dst is not None
+        # node origin = title pos - (10, 6); ports sit at (±0/W, H/2)
+        out_port = (src["x"] - 10 + flow.NODE_W, src["y"] - 6 + flow.NODE_H / 2)
+        in_port = (dst["x"] - 10, dst["y"] - 6 + flow.NODE_H / 2)
+        h._send({"type": "mouse_down", "x": out_port[0], "y": out_port[1],
+                 "button": "primary"})
+        h._send({"type": "mouse_move", "x": in_port[0], "y": in_port[1],
+                 "buttons": ["primary"]})
+        h._send({"type": "mouse_up", "x": in_port[0], "y": in_port[1],
+                 "button": "primary"})
+        h.run(1)
+
+    saved = json.loads(HARNESS_FLOW_FILE.read_text())
+    assert saved["edges"] == [[1, 2]]
+
+
+def test_e2e_run_pipeline_writes_file(clean_flow_file, tmp_path):
+    out_file = tmp_path / "result.txt"
+    _seed_graph([
+        {"id": 1, "kind": "prompt", "x": 0, "y": 0, "title": "P",
+         "text": "hello flow"},
+        {"id": 2, "kind": "shell", "x": 250, "y": 0, "title": "S",
+         "text": "tr a-z A-Z"},
+        {"id": 3, "kind": "file_write", "x": 500, "y": 0, "title": "W",
+         "text": str(out_file)},
+    ], [[1, 2], [2, 3]])
+    with AppHarness(APP) as h:
+        h.run(1)
+        h.key("r")
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not out_file.exists():
+            h.run(1)
+            time.sleep(0.1)
+    assert out_file.read_text() == "HELLO FLOW"


### PR DESCRIPTION
## Summary

- New `apps/flow` Plexi app: an n8n-style node workflow editor on a custom draw-command canvas — draggable nodes, pannable dot-grid, bezier port-to-port wiring with cycle rejection, click-to-select, double-click/Enter to expand any node into a host `TextEdit` editor.
- Five node kinds: **prompt** (`{{input}}` templating), **file_read**, **file_write**, **shell** (upstream output piped to stdin), and **ai** — a marked stub shaped for a later LLM broker integration.
- Topological graph runner with per-node status (running/ok/error dots + output preview), upstream-failure skip, and graph persistence to `<workspace>/.plexi/flow.json`.

## Testing

18 tests in `apps/flow/tests/test_flow.py` — pure graph/exec unit tests plus `AppHarness` e2e: boot, add/edit nodes via key + component events, mouse-drag node movement, port-to-port wiring via raw mouse events, and a full prompt→shell→file_write pipeline run asserted on disk (`HELLO FLOW`).

Run: `uv run --project sdk/python pytest apps/flow/tests -q`

No Rust changes — app + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)