### PR TITLE
Trust: host-mediated pane control + Assistant capabilities (stint 0013/0014)

### DIFF
--- a/apps/assistant/assistant.py
+++ b/apps/assistant/assistant.py
@@ -14,19 +14,21 @@ Patterns demonstrated:
     can invoke the assistant programmatically (#2034)
   - Tool consumption: ai_query automatically receives tools exposed by
     other panes in the same workspace via the host tool dispatcher
+  - Host-mediated pane tools (stint 0014): the AI sees and drives other
+    panes via capability-gated SDK calls (panes.spawn/read/control) —
+    no subprocess, no ambient plexi CLI access
 """
 
+import asyncio
 import json
 import os
-import subprocess
 import threading
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-PLEXI_BINARY = os.environ.get("PLEXI_BINARY", "plexi-alpha")
-
-from plexi_sdk import App
+from plexi_sdk import App, CapabilityDeniedError
 from plexi_sdk.ui import (
     Column, AppBar, ChatBubble, Scrollable, Spacer,
     FooterKeys, TextInput, Label,
@@ -35,7 +37,11 @@ from plexi_sdk.ui import (
 SYSTEM_PROMPT = (
     "You are a helpful assistant. Be concise and clear. "
     "You have access to tools offered by other running Plexi apps in this workspace — "
-    "use them when they help answer the user's request."
+    "use them when they help answer the user's request. "
+    "You can also see and drive the user's panes: list_panes first, then "
+    "get_pane_state (app panes) or capture_pane (terminal panes) to look inside, "
+    "then send_app_action or send_command to act, then read the state again to "
+    "verify the action worked."
 )
 MODEL_TIERS = ["low", "medium", "high"]
 _THINKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
@@ -51,9 +57,10 @@ class AssistantApp(App):
         self._scroll = Scrollable(child=Spacer())  # replaced each render
         self._session_id = _new_session_id()
         self._sessions_dir: Path | None = _resolve_sessions_dir(self.workspace_root)
+        self._spawn_waiters: dict[str, asyncio.Future] = {}
         self._load_latest_session()
         self._register_tools()
-        self._register_cli_tools()
+        self._register_pane_tools()
         self.emit.info(f"AssistantApp ready — model={self._model_tier} sessions dir: {self._sessions_dir}")
 
     # ── Tool registration (ExposeTools) ────────────────────────────────────────
@@ -102,21 +109,83 @@ class AssistantApp(App):
 
         self.emit.info("AssistantApp: exposed ask_assistant tool to workspace")
 
-    def _register_cli_tools(self) -> None:
-        """Register CLI tools that let the AI agent control the Plexi workspace.
+    # ── Host-mediated pane tools (stint 0014) ──────────────────────────────────
 
-        Tools registered:
-          - open_terminal: spawn a new terminal pane (optionally running a command)
-          - open_app: open a Plexi app by ID in a new pane
-          - list_panes: return the current pane list as structured JSON
-          - send_command: send a text command to a specific pane
+    async def _call_with_capability(self, cap: str, op_name: str, attempt) -> dict:
+        """Run an async pane operation, popping the host grant modal when needed.
+
+        Pane capabilities are sensitive: even when declared in the manifest they
+        are withheld until the user grants them. First use either raises
+        CapabilityDeniedError (awaitable reads) or is silently dropped by the
+        host (fire-and-forget control), so when the capability isn't held yet we
+        request it up front via the host grant modal. A mid-flight denial gets
+        one grant-and-retry; a user denial is returned to the model as an error.
+        """
+        if cap not in self.capabilities:
+            try:
+                await self.emit.capability_request(cap)
+            except CapabilityDeniedError:
+                self.emit.warn(f"{op_name}: user denied {cap}")
+                return {"error": f"user denied {cap}"}
+        try:
+            return await attempt()
+        except CapabilityDeniedError:
+            pass
+        except Exception as exc:
+            self.emit.error(f"{op_name} failed: {exc}")
+            return {"error": str(exc)}
+        try:
+            await self.emit.capability_request(cap)
+        except CapabilityDeniedError:
+            self.emit.warn(f"{op_name}: user denied {cap}")
+            return {"error": f"user denied {cap}"}
+        try:
+            return await attempt()
+        except Exception as exc:
+            self.emit.error(f"{op_name} retry failed: {exc}")
+            return {"error": str(exc)}
+
+    async def _spawn_pane_and_wait(self, type_id: str,
+                                   args: "list[str] | None" = None) -> dict:
+        """spawn_pane + await the on_pane_spawned/on_pane_spawn_error callback."""
+        request_id = str(uuid.uuid4())
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._spawn_waiters[request_id] = fut
+        self.emit.spawn_pane(type_id, args=args, request_id=request_id)
+        try:
+            return await asyncio.wait_for(fut, timeout=10.0)
+        except asyncio.TimeoutError:
+            self.emit.error(f"spawn of {type_id!r} timed out")
+            return {"error": f"spawn of {type_id!r} timed out after 10s"}
+        finally:
+            self._spawn_waiters.pop(request_id, None)
+
+    def on_pane_spawned(self, pane_id: int, request_id: "str | None" = None) -> None:
+        fut = self._spawn_waiters.get(request_id) if request_id else None
+        if fut is not None and not fut.done():
+            fut.set_result({"pane_id": pane_id})
+
+    def on_pane_spawn_error(self, reason: str, request_id: "str | None" = None) -> None:
+        fut = self._spawn_waiters.get(request_id) if request_id else None
+        if fut is not None and not fut.done():
+            fut.set_result({"error": reason})
+
+    def _register_pane_tools(self) -> None:
+        """Register host-mediated tools that let the AI see and drive panes.
+
+        Everything goes through capability-gated PGAP requests — the app has
+        no socket or subprocess route to the host. Capabilities used:
+        panes.spawn (open_terminal, open_app), panes.read (list_panes,
+        get_pane_state, capture_pane), panes.control (send_command,
+        send_app_action, focus_pane).
         """
 
         @self.tool(
             "open_terminal",
             description=(
-                "Spawn a new terminal pane in the Plexi workspace. "
-                "Optionally run a shell command in it."
+                "Spawn a new terminal pane in the Plexi workspace, optionally "
+                "running a shell command in it. Returns the new pane_id — use "
+                "capture_pane on it to read the command's output."
             ),
             schema={
                 "type": "object",
@@ -130,26 +199,21 @@ class AssistantApp(App):
             },
         )
         async def handle_open_terminal(args: dict) -> dict:
-            cmd = [PLEXI_BINARY, "terminal"]
             command_arg = args.get("command", "").strip()
-            if command_arg:
-                cmd += ["--command", command_arg]
-            self.emit.info(f"open_terminal: {cmd}")
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-                if result.returncode != 0:
-                    err = result.stderr.strip() or result.stdout.strip()
-                    self.emit.error(f"open_terminal failed (rc={result.returncode}): {err}")
-                    return {"error": err}
-                pane_id = result.stdout.strip()
-                return {"pane_id": pane_id}
-            except Exception as exc:
-                self.emit.error(f"open_terminal exception: {exc}")
-                return {"error": str(exc)}
+            self.emit.info(f"open_terminal tool: command={command_arg[:60]!r}")
+            return await self._call_with_capability(
+                "panes.spawn", "open_terminal",
+                lambda: self._spawn_pane_and_wait(
+                    "terminal", args=[command_arg] if command_arg else None
+                ),
+            )
 
         @self.tool(
             "open_app",
-            description="Open a Plexi app by its app ID in a new pane.",
+            description=(
+                "Open a Plexi app by its app ID in a new pane. Returns the new "
+                "pane_id — use get_pane_state on it to see the app's UI."
+            ),
             schema={
                 "type": "object",
                 "properties": {
@@ -165,23 +229,20 @@ class AssistantApp(App):
             app_id = args.get("app_id", "").strip()
             if not app_id:
                 return {"error": "app_id must not be empty"}
-            cmd = [PLEXI_BINARY, "app", "open", app_id]
-            self.emit.info(f"open_app: {cmd}")
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-                if result.returncode != 0:
-                    err = result.stderr.strip() or result.stdout.strip()
-                    self.emit.error(f"open_app failed (rc={result.returncode}): {err}")
-                    return {"error": err}
-                pane_id = result.stdout.strip()
-                return {"pane_id": pane_id}
-            except Exception as exc:
-                self.emit.error(f"open_app exception: {exc}")
-                return {"error": str(exc)}
+            self.emit.info(f"open_app tool: app_id={app_id!r}")
+            return await self._call_with_capability(
+                "panes.spawn", "open_app",
+                lambda: self._spawn_pane_and_wait(app_id),
+            )
 
         @self.tool(
             "list_panes",
-            description="Return the current list of open panes in the Plexi workspace.",
+            description=(
+                "List all open panes in the Plexi workspace with their id, "
+                "title, and type. Start here: pick a pane_id, then use "
+                "get_pane_state (app panes) or capture_pane (terminal panes) "
+                "to see what's inside it."
+            ),
             schema={
                 "type": "object",
                 "properties": {},
@@ -189,32 +250,88 @@ class AssistantApp(App):
             },
         )
         async def handle_list_panes(_args: dict) -> dict:
-            cmd = [PLEXI_BINARY, "pane", "list", "--json"]
-            self.emit.info("list_panes: fetching pane list")
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-                if result.returncode != 0:
-                    err = result.stderr.strip() or result.stdout.strip()
-                    self.emit.error(f"list_panes failed (rc={result.returncode}): {err}")
-                    return {"error": err}
-                try:
-                    panes = json.loads(result.stdout)
-                except json.JSONDecodeError:
-                    panes = result.stdout.strip()
-                return {"panes": panes}
-            except Exception as exc:
-                self.emit.error(f"list_panes exception: {exc}")
-                return {"error": str(exc)}
+            self.emit.info("list_panes tool invoked")
+
+            async def attempt() -> dict:
+                return {"panes": await self.emit.list_panes()}
+
+            return await self._call_with_capability(
+                "panes.read", "list_panes", attempt)
 
         @self.tool(
-            "send_command",
-            description="Send a text string as input to a specific pane by ID.",
+            "get_pane_state",
+            description=(
+                "Read the current UI tree of an app pane — every label, button, "
+                "and input it is rendering. Use this to see an app before acting "
+                "on it with send_app_action, and again afterwards to verify the "
+                "action worked."
+            ),
             schema={
                 "type": "object",
                 "properties": {
                     "pane_id": {
-                        "type": "string",
-                        "description": "The target pane ID.",
+                        "type": "integer",
+                        "description": "Target app pane id (from list_panes).",
+                    },
+                },
+                "required": ["pane_id"],
+            },
+        )
+        async def handle_get_pane_state(args: dict) -> dict:
+            pane_id = int(args["pane_id"])
+            self.emit.info(f"get_pane_state tool: pane={pane_id}")
+
+            async def attempt() -> dict:
+                return {"state": await self.emit.get_pane_state(pane_id)}
+
+            return await self._call_with_capability(
+                "panes.read", "get_pane_state", attempt)
+
+        @self.tool(
+            "capture_pane",
+            description=(
+                "Read the last lines of a terminal pane's scrollback. Use this "
+                "to see a terminal's output before and after send_command."
+            ),
+            schema={
+                "type": "object",
+                "properties": {
+                    "pane_id": {
+                        "type": "integer",
+                        "description": "Target terminal pane id (from list_panes).",
+                    },
+                    "lines": {
+                        "type": "integer",
+                        "description": "Number of lines from the end of the scrollback (default 50).",
+                    },
+                },
+                "required": ["pane_id"],
+            },
+        )
+        async def handle_capture_pane(args: dict) -> dict:
+            pane_id = int(args["pane_id"])
+            lines = int(args.get("lines", 50))
+            self.emit.info(f"capture_pane tool: pane={pane_id} lines={lines}")
+
+            async def attempt() -> dict:
+                return {"lines": await self.emit.capture_pane(pane_id, lines=lines)}
+
+            return await self._call_with_capability(
+                "panes.read", "capture_pane", attempt)
+
+        @self.tool(
+            "send_command",
+            description=(
+                "Send text input to a terminal pane's stdin ('\\n' is Enter). "
+                "Verify the result with capture_pane afterwards. For app panes "
+                "use send_app_action instead."
+            ),
+            schema={
+                "type": "object",
+                "properties": {
+                    "pane_id": {
+                        "type": "integer",
+                        "description": "Target terminal pane id (from list_panes).",
                     },
                     "text": {
                         "type": "string",
@@ -225,26 +342,91 @@ class AssistantApp(App):
             },
         )
         async def handle_send_command(args: dict) -> dict:
-            pane_id = args.get("pane_id", "").strip()
+            pane_id = int(args["pane_id"])
             text = args.get("text", "")
-            if not pane_id:
-                return {"error": "pane_id must not be empty"}
             if not text:
                 return {"error": "text must not be empty"}
-            cmd = [PLEXI_BINARY, "pane", "command", pane_id, text]
-            self.emit.info(f"send_command: pane={pane_id!r} text={text[:60]!r}")
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-                if result.returncode != 0:
-                    err = result.stderr.strip() or result.stdout.strip()
-                    self.emit.error(f"send_command failed (rc={result.returncode}): {err}")
-                    return {"ok": False, "error": err}
-                return {"ok": True}
-            except Exception as exc:
-                self.emit.error(f"send_command exception: {exc}")
-                return {"ok": False, "error": str(exc)}
+            self.emit.info(f"send_command tool: pane={pane_id} text={text[:60]!r}")
 
-        self.emit.info("AssistantApp: registered CLI tools (open_terminal, open_app, list_panes, send_command)")
+            async def attempt() -> dict:
+                self.emit.send_to_pane(pane_id, text)
+                return {"ok": True, "pane_id": pane_id}
+
+            return await self._call_with_capability(
+                "panes.control", "send_command", attempt)
+
+        @self.tool(
+            "send_app_action",
+            description=(
+                "Dispatch a semantic action to an app pane (e.g. 'refresh', "
+                "'navigate-to'). Workflow: get_pane_state to see the app, "
+                "send_app_action to drive it, get_pane_state again to verify."
+            ),
+            schema={
+                "type": "object",
+                "properties": {
+                    "pane_id": {
+                        "type": "integer",
+                        "description": "Target app pane id (from list_panes).",
+                    },
+                    "action": {
+                        "type": "string",
+                        "description": "Action name the app understands.",
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional extra arguments for the action.",
+                    },
+                },
+                "required": ["pane_id", "action"],
+            },
+        )
+        async def handle_send_app_action(args: dict) -> dict:
+            pane_id = int(args["pane_id"])
+            action = args.get("action", "").strip()
+            if not action:
+                return {"error": "action must not be empty"}
+            extra = [str(a) for a in args.get("args", [])]
+            self.emit.info(f"send_app_action tool: pane={pane_id} action={action!r} args={extra}")
+
+            async def attempt() -> dict:
+                self.emit.send_app_action(pane_id, action, args=extra or None)
+                return {"ok": True, "pane_id": pane_id, "action": action}
+
+            return await self._call_with_capability(
+                "panes.control", "send_app_action", attempt)
+
+        @self.tool(
+            "focus_pane",
+            description="Move the user's UI focus to a pane by id (from list_panes).",
+            schema={
+                "type": "object",
+                "properties": {
+                    "pane_id": {
+                        "type": "integer",
+                        "description": "The pane id to focus.",
+                    },
+                },
+                "required": ["pane_id"],
+            },
+        )
+        async def handle_focus_pane(args: dict) -> dict:
+            pane_id = int(args["pane_id"])
+            self.emit.info(f"focus_pane tool: pane={pane_id}")
+
+            async def attempt() -> dict:
+                self.emit.focus_pane(pane_id)
+                return {"ok": True, "pane_id": pane_id}
+
+            return await self._call_with_capability(
+                "panes.control", "focus_pane", attempt)
+
+        self.emit.info(
+            "AssistantApp: registered pane tools (open_terminal, open_app, "
+            "list_panes, get_pane_state, capture_pane, send_command, "
+            "send_app_action, focus_pane)"
+        )
 
     # ── Session persistence ────────────────────────────────────────────────────
 

--- a/apps/assistant/manifest.toml
+++ b/apps/assistant/manifest.toml
@@ -4,14 +4,18 @@ schema_version = 1
 id = "assistant"
 type = "app"
 name = "Assistant"
-version = "0.2.0"
-description = "AI chat assistant powered by Plexi's ai.query broker. Exposes an ask_assistant tool so other workspace apps can invoke it programmatically."
+version = "0.3.0"
+description = "AI chat assistant powered by Plexi's ai.query broker. Can see and drive workspace panes through capability-gated host requests, and exposes an ask_assistant tool so other workspace apps can invoke it programmatically."
 entry = "assistant.py"
 
 [app.capabilities]
 # ai.query: issue brokered LLM calls. The host tool dispatcher automatically
-# injects tools exposed by other workspace panes into each ai_query call, so
-# the assistant can invoke them without any additional capability declaration.
-capabilities = ["ai.query"]
+# injects tools exposed by other workspace panes into each ai_query call.
+# panes.spawn: open_terminal / open_app tools (SpawnPane requests).
+# panes.read: list_panes / get_pane_state / capture_pane tools.
+# panes.control: send_command / send_app_action / focus_pane tools.
+# The pane capabilities are sensitive — the host prompts the user before the
+# first use of each, even though they are declared here.
+capabilities = ["ai.query", "panes.spawn", "panes.read", "panes.control"]
 
 [launch]

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -42,6 +42,8 @@ the PGAP wire. The host validates the capability before processing the command.
 | Spawning typed pipes | `pipe.open` |
 | Launching another app | `spawn.app` |
 | Spawning panes | `panes.spawn` |
+| Listing panes / reading pane state and content | `panes.read` |
+| Focusing, closing, or sending input to panes | `panes.control` |
 | Microphone capture | `audio.record` |
 | Audio playback | `audio.playback` |
 | Video decode | `video.playback` |
@@ -55,6 +57,21 @@ Commands that require **no capability**: `ListAudioDevices`, `ListMidiDevices`,
 `CopyToClipboard`, `MeasureText`, `StatusSummary`, `SaveAppState`, `Log`,
 `ScheduleRender`, `SetMinSize`, `CloseSelf`, `PushNav`, `PopNav`,
 `SetMouseTracking`.
+
+### No ambient socket access
+
+App subprocesses do **not** inherit `PLEXI_SOCKET`. Only terminal PTY panes get
+it, because a human is typing there. An app that wants to see or drive other
+panes must go through capability-gated PGAP requests (`panes.read` /
+`panes.control`) — there is no ambient `plexi` CLI route from inside an app
+process.
+
+Be clear about what this is: it removes the **ambient grant**, it is not
+isolation. Apps are still reviewed native processes, not sandboxed ones. A
+malicious native process can find the socket path on disk and connect to it
+directly. The socket file itself is the user's, with the user's permissions —
+removing the env var stops well-behaved apps from quietly acquiring host
+control, nothing more.
 
 ---
 

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import os
 import sys
+import tempfile
 import threading
 import uuid
 from contextlib import contextmanager
@@ -33,6 +35,16 @@ CAPABILITY_REGISTRY: dict[str, str] = {
     "get_secret": "secrets.get",
     "open_file_picker": "fs.pick",
     "spawn_pane": "panes.spawn",
+    "list_panes": "panes.read",
+    "get_pane_info": "panes.read",
+    "get_pane_state": "panes.read",
+    "capture_pane": "panes.read",
+    "send_to_pane": "panes.control",
+    "key_pane": "panes.control",
+    "focus_pane": "panes.control",
+    "close_pane": "panes.control",
+    "set_pane_title": "panes.control",
+    "send_app_action": "panes.control",
     "open_midi_input": "midi.in",
     "send_midi": "midi.out",
     "open_video": "video.playback",
@@ -655,6 +667,220 @@ class Emitter:
             cmd["request_id"] = request_id
         if target_context is not None:
             cmd["target_context"] = target_context
+        _emit(cmd)
+
+    # ── Pane read/control (stint 0013/0014) ─────────────────────────────────
+    #
+    # Host-mediated equivalents of the `plexi pane` CLI commands. The read
+    # methods gate on `panes.read`, the act-on-pane methods on
+    # `panes.control` — both are sensitive capabilities, so first use
+    # triggers the host consent modal unless the user already decided.
+    # Read methods use the pane-IPC response_file pattern: the host writes a
+    # JSON file at a path we choose; we poll for it with a timeout.
+
+    async def _await_pane_response(self, response_file: str, kind: str,
+                                   timeout: float = 10.0) -> Any:
+        """Poll for a host-written pane-IPC JSON response file.
+
+        Raises CapabilityDeniedError when the host answered with the
+        capability-denied error object, and TimeoutError when the host never
+        wrote the file (e.g. the request was dropped).
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        try:
+            while True:
+                if os.path.exists(response_file):
+                    with open(response_file, "r") as f:
+                        data = json.loads(f.read())
+                    if (isinstance(data, dict)
+                            and "capability" in data and "error" in data):
+                        raise CapabilityDeniedError(f"{kind}: {data['error']}")
+                    return data
+                if loop.time() >= deadline:
+                    raise TimeoutError(
+                        f"{kind}: timed out after {timeout}s waiting for the "
+                        f"host response file"
+                    )
+                await asyncio.sleep(0.05)
+        finally:
+            try:
+                os.remove(response_file)
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _pane_response_file(prefix: str) -> str:
+        """Unique response-file path. The host creates the file; we only poll."""
+        return os.path.join(
+            tempfile.gettempdir(), f"plexi-{prefix}-{uuid.uuid4()}.json"
+        )
+
+    @_blocking_emit_method
+    async def list_panes(self, context_id: "int | None" = None) -> "list[dict]":
+        """List all open panes. Requires the ``panes.read`` capability.
+
+        Returns the same JSON array `plexi pane list` prints: one object per
+        pane with ``id``, ``title``, ``type``, ``context_id``, ``cwd``, etc.
+
+        Args:
+            context_id: When set, only panes in this context are returned.
+
+        Raises ``CapabilityDeniedError`` if the manifest doesn't declare
+        ``panes.read``.
+        """
+        response_file = self._pane_response_file("list-panes")
+        cmd: "dict[str, object]" = {
+            "type": "list_panes",
+            "response_file": response_file,
+        }
+        if context_id is not None:
+            cmd["context_id"] = context_id
+        _emit(cmd)
+        return await self._await_pane_response(response_file, "list_panes")
+
+    @_blocking_emit_method
+    async def get_pane_info(self, pane_id: int) -> dict:
+        """Query info for a specific pane. Requires the ``panes.read`` capability.
+
+        Returns the same JSON object `plexi pane info` prints.
+
+        Raises ``CapabilityDeniedError`` if the manifest doesn't declare
+        ``panes.read``.
+        """
+        response_file = self._pane_response_file("pane-info")
+        _emit({
+            "type": "get_pane_info",
+            "pane_id": int(pane_id),
+            "response_file": response_file,
+        })
+        return await self._await_pane_response(response_file, "get_pane_info")
+
+    @_blocking_emit_method
+    async def get_pane_state(self, pane_id: int) -> dict:
+        """Query the last-rendered UI state of a pane. Requires ``panes.read``.
+
+        For app panes the host answers with a ``frame`` array of
+        RenderCommands; for terminal panes a simple status object.
+
+        Raises ``CapabilityDeniedError`` if the manifest doesn't declare
+        ``panes.read``.
+        """
+        response_file = self._pane_response_file("pane-state")
+        _emit({
+            "type": "get_pane_state",
+            "pane_id": int(pane_id),
+            "response_file": response_file,
+        })
+        return await self._await_pane_response(response_file, "get_pane_state")
+
+    @_blocking_emit_method
+    async def capture_pane(self, pane_id: int, lines: int = 50,
+                           full_output: bool = False,
+                           from_cursor: "int | None" = None) -> "list[str]":
+        """Read the last ``lines`` lines of a terminal pane's scrollback.
+        Requires the ``panes.read`` capability.
+
+        Args:
+            pane_id: Target terminal pane.
+            lines: Number of lines from the end of the scrollback.
+            full_output: Preserve trailing empty lines (default strips them).
+            from_cursor: When set, capture from this saved cursor position.
+
+        Raises ``CapabilityDeniedError`` if the manifest doesn't declare
+        ``panes.read``.
+        """
+        response_file = self._pane_response_file("pane-capture")
+        cmd: "dict[str, object]" = {
+            "type": "capture_pane",
+            "pane_id": int(pane_id),
+            "lines": int(lines),
+            "response_file": response_file,
+        }
+        if full_output:
+            cmd["full_output"] = True
+        if from_cursor is not None:
+            cmd["from_cursor"] = int(from_cursor)
+        _emit(cmd)
+        return await self._await_pane_response(response_file, "capture_pane")
+
+    def send_to_pane(self, pane_id: int, text: str) -> None:
+        """Write ``text`` to a terminal pane's PTY stdin. Requires the
+        ``panes.control`` capability. ``\\n`` (literal backslash-n) is
+        interpreted as Enter.
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        _emit({
+            "type": "send_to_pane",
+            "pane_id": int(pane_id),
+            "text": text,
+        })
+
+    def key_pane(self, pane_id: int, key: str) -> None:
+        """Deliver a synthetic key event to any pane. Requires the
+        ``panes.control`` capability.
+
+        Args:
+            pane_id: Target pane.
+            key: Single char ("h"), named key ("enter", "escape", "up",
+                 "down", "left", "right", "space", "backspace"), or chord
+                 ("ctrl+c", "ctrl+d").
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        _emit({
+            "type": "key_pane",
+            "pane_id": int(pane_id),
+            "key": key,
+        })
+
+    def focus_pane(self, pane_id: int) -> None:
+        """Move UI focus to a pane. Requires the ``panes.control`` capability.
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        _emit({"type": "focus_pane", "pane_id": int(pane_id)})
+
+    def close_pane(self, pane_id: int) -> None:
+        """Close a pane. Requires the ``panes.control`` capability.
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        _emit({"type": "close_pane", "pane_id": int(pane_id)})
+
+    def set_pane_title(self, pane_id: int, name: str) -> None:
+        """Set the title shown on a pane's tab. Requires the
+        ``panes.control`` capability.
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        _emit({
+            "type": "set_pane_title",
+            "pane_id": int(pane_id),
+            "name": name,
+        })
+
+    def send_app_action(self, pane_id: int, action: str,
+                        args: "list[str] | None" = None) -> None:
+        """Dispatch a semantic action to an app pane. Requires the
+        ``panes.control`` capability. The host delivers
+        ``PlexiEvent::Action`` to the target app.
+
+        Args:
+            pane_id: Target app pane.
+            action: Action name, e.g. "refresh", "navigate-to".
+            args: Optional extra arguments.
+
+        Fire-and-forget — capability denial drops with a host log line.
+        """
+        cmd: "dict[str, object]" = {
+            "type": "send_app_action",
+            "pane_id": int(pane_id),
+            "action": action,
+        }
+        if args:
+            cmd["args"] = list(args)
         _emit(cmd)
 
     def query_context_state(self, context_id: int) -> None:

--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -38,6 +38,14 @@ pub enum AppCommand {
         request_id: Option<String>,
         target_context: Option<u64>,
     },
+    /// Forward a capability-gated pane read/control `AppRequest` (ListPanes,
+    /// FocusPane, SendToPane, ...) into the host's pane-IPC handler — the
+    /// same code path CLI requests take over PLEXI_SOCKET (stint 0013/0014).
+    /// Emitted by `routing.rs` after the `panes.read` / `panes.control`
+    /// capability check passes.
+    ForwardPaneRequest {
+        request: crate::app_protocol::AppRequest,
+    },
     /// Request the host to cd sibling terminals (same split container) to `cwd`.
     CdRequest { cwd: String, sender_pane_id: u64 },
     /// Deliver a JSON pipe message to all peer panes that have the given

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -341,6 +341,7 @@ impl PlexiApp {
                 match cmd {
                     AppCommand::SpawnApp { .. }
                     | AppCommand::SpawnPane { .. }
+                    | AppCommand::ForwardPaneRequest { .. }
                     | AppCommand::DeliverPipeMessage { .. }
                     | AppCommand::OpenDirectedPipe { .. }
                     | AppCommand::DeliverRunUpdate { .. }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -119,944 +119,922 @@ fn slot_list_entries(
 impl PlexiApp {
     pub(super) fn drain_pane_cmd_channel(&mut self) {
         while let Ok(cmd) = self.pane_ipc_rx.try_recv() {
-            match &cmd {
-                crate::app_protocol::AppRequest::SetPaneTitle { pane_id, name } => {
-                    log::info!("pane_ipc: kind=set_pane_title pane_id={pane_id}");
-                    let mut found = false;
-                    for win in &mut self.windows {
-                        if let Some(pane) = win.panes.get_mut(pane_id) {
-                            if let Some(t) = pane.as_terminal_mut() {
-                                t.name_locked = !name.is_empty();
-                                t.name = if name.is_empty() {
-                                    None
-                                } else {
-                                    Some(name.clone())
-                                };
-                                found = true;
-                                break;
-                            }
-                        }
-                    }
-                    if !found {
-                        log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
-                    }
-                }
-                crate::app_protocol::AppRequest::ListPanes {
-                    response_file,
-                    context_id: filter_context_id,
-                } => {
-                    log::info!(
-                        "pane_ipc: kind=list_panes context_id={:?} response_file={:?}",
-                        filter_context_id,
-                        response_file
-                    );
-                    let active_win = self.active_window;
-                    let mut entries: Vec<serde_json::Value> = Vec::new();
-                    for (win_idx, win) in self.windows.iter().enumerate() {
-                        if let Some(cid) = filter_context_id {
-                            if win.context_id != *cid {
-                                continue;
-                            }
-                        }
-                        let focused_pane_id = win
-                            .focused_pane
-                            .and_then(|t| win.tree.tiles.get(t))
-                            .and_then(|tile| {
-                                if let egui_tiles::Tile::Pane(id) = tile {
-                                    Some(*id)
-                                } else {
-                                    None
-                                }
-                            });
-                        let context_name = self
-                            .router
-                            .iter()
-                            .find(|ctx| ctx.context_id == win.context_id)
-                            .map(|ctx| ctx.name.clone())
-                            .unwrap_or_default();
-                        for (pane_id, pane) in &win.panes {
-                            // Only emit panes that have a corresponding tile in the tree.
-                            // win.panes and the tile tree can desync (e.g. from corrupted
-                            // restore state); omitting orphaned entries ensures every id
-                            // returned here is navigable via pane_focus. (#996)
-                            if win.tree.tiles.find_pane(pane_id).is_none() {
-                                log::warn!(
-                                    "pane_list: pane_id={pane_id} in win.panes but absent \
-                                     from tile tree — skipping (desync)"
-                                );
-                                continue;
-                            }
-                            let (pane_type, title, cwd) = match pane {
-                                crate::host::pane::Pane::Terminal(t) => {
-                                    let name =
-                                        t.name.clone().unwrap_or_else(|| "terminal".to_string());
-                                    let cwd =
-                                        crate::host::shell::get_pid_cwd(t.backend.child_pid())
-                                            .map(|p| p.to_string_lossy().into_owned());
-                                    ("terminal", name, cwd)
-                                }
-                                crate::host::pane::Pane::App(a) => {
-                                    let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
-                                    ("app", a.name.clone(), cwd)
-                                }
-                                crate::host::pane::Pane::Portal(p) => {
-                                    ("portal", format!("portal:{}", p.target_context_id), None)
-                                }
+            self.handle_pane_ipc_request(cmd);
+        }
+    }
+
+    /// Handle a single pane-IPC `AppRequest`. Shared by the socket drain above
+    /// and the PGAP forwarding path (`AppCommand::ForwardPaneRequest`, stint
+    /// 0013/0014) so capability-gated app requests take the identical host
+    /// code path as CLI requests arriving over PLEXI_SOCKET.
+    pub(crate) fn handle_pane_ipc_request(&mut self, cmd: crate::app_protocol::AppRequest) {
+        match &cmd {
+            crate::app_protocol::AppRequest::SetPaneTitle { pane_id, name } => {
+                log::info!("pane_ipc: kind=set_pane_title pane_id={pane_id}");
+                let mut found = false;
+                for win in &mut self.windows {
+                    if let Some(pane) = win.panes.get_mut(pane_id) {
+                        if let Some(t) = pane.as_terminal_mut() {
+                            t.name_locked = !name.is_empty();
+                            t.name = if name.is_empty() {
+                                None
+                            } else {
+                                Some(name.clone())
                             };
-                            let focused =
-                                win_idx == active_win && focused_pane_id == Some(*pane_id);
-                            entries.push(serde_json::json!({
-                                "id": pane_id,
-                                "type": pane_type,
-                                "title": title,
-                                "focused": focused,
-                                "context_id": win.context_id,
-                                "context_name": context_name,
-                                "window_id": win.window_id,
-                                "cwd": cwd,
-                                "agent": pane.agent(),
-                                "slots": pane_slots_json(pane),
-                            }));
+                            found = true;
+                            break;
                         }
                     }
-                    let json_str =
-                        serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
-                    if let Err(e) = std::fs::write(response_file, &json_str) {
-                        log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
-                    }
                 }
-                crate::app_protocol::AppRequest::ListContexts { response_file } => {
-                    log::info!(
-                        "pane_ipc: kind=list_contexts response_file={:?}",
-                        response_file
-                    );
-                    let active_ctx_id = self.router.active().context_id;
-                    let entries: Vec<serde_json::Value> = self
+                if !found {
+                    log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
+                }
+            }
+            crate::app_protocol::AppRequest::ListPanes {
+                response_file,
+                context_id: filter_context_id,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=list_panes context_id={:?} response_file={:?}",
+                    filter_context_id,
+                    response_file
+                );
+                let active_win = self.active_window;
+                let mut entries: Vec<serde_json::Value> = Vec::new();
+                for (win_idx, win) in self.windows.iter().enumerate() {
+                    if let Some(cid) = filter_context_id {
+                        if win.context_id != *cid {
+                            continue;
+                        }
+                    }
+                    let focused_pane_id = win
+                        .focused_pane
+                        .and_then(|t| win.tree.tiles.get(t))
+                        .and_then(|tile| {
+                            if let egui_tiles::Tile::Pane(id) = tile {
+                                Some(*id)
+                            } else {
+                                None
+                            }
+                        });
+                    let context_name = self
                         .router
                         .iter()
-                        .map(|ctx| {
-                            serde_json::json!({
-                                "context_id": ctx.context_id,
-                                "name": ctx.name,
-                                "path": ctx.path.to_string_lossy(),
-                                "root": ctx.root.as_ref().map(|p| p.to_string_lossy().into_owned()),
-                                "description": ctx.description,
-                                "parent_id": ctx.parent_id,
-                                "depth": ctx.depth,
-                                "is_active": ctx.context_id == active_ctx_id,
-                            })
+                        .find(|ctx| ctx.context_id == win.context_id)
+                        .map(|ctx| ctx.name.clone())
+                        .unwrap_or_default();
+                    for (pane_id, pane) in &win.panes {
+                        // Only emit panes that have a corresponding tile in the tree.
+                        // win.panes and the tile tree can desync (e.g. from corrupted
+                        // restore state); omitting orphaned entries ensures every id
+                        // returned here is navigable via pane_focus. (#996)
+                        if win.tree.tiles.find_pane(pane_id).is_none() {
+                            log::warn!(
+                                "pane_list: pane_id={pane_id} in win.panes but absent \
+                                 from tile tree — skipping (desync)"
+                            );
+                            continue;
+                        }
+                        let (pane_type, title, cwd) = match pane {
+                            crate::host::pane::Pane::Terminal(t) => {
+                                let name = t.name.clone().unwrap_or_else(|| "terminal".to_string());
+                                let cwd = crate::host::shell::get_pid_cwd(t.backend.child_pid())
+                                    .map(|p| p.to_string_lossy().into_owned());
+                                ("terminal", name, cwd)
+                            }
+                            crate::host::pane::Pane::App(a) => {
+                                let cwd = Some(a.workspace_root.to_string_lossy().into_owned());
+                                ("app", a.name.clone(), cwd)
+                            }
+                            crate::host::pane::Pane::Portal(p) => {
+                                ("portal", format!("portal:{}", p.target_context_id), None)
+                            }
+                        };
+                        let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
+                        entries.push(serde_json::json!({
+                            "id": pane_id,
+                            "type": pane_type,
+                            "title": title,
+                            "focused": focused,
+                            "context_id": win.context_id,
+                            "context_name": context_name,
+                            "window_id": win.window_id,
+                            "cwd": cwd,
+                            "agent": pane.agent(),
+                            "slots": pane_slots_json(pane),
+                        }));
+                    }
+                }
+                let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                if let Err(e) = std::fs::write(response_file, &json_str) {
+                    log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
+                }
+            }
+            crate::app_protocol::AppRequest::ListContexts { response_file } => {
+                log::info!(
+                    "pane_ipc: kind=list_contexts response_file={:?}",
+                    response_file
+                );
+                let active_ctx_id = self.router.active().context_id;
+                let entries: Vec<serde_json::Value> = self
+                    .router
+                    .iter()
+                    .map(|ctx| {
+                        serde_json::json!({
+                            "context_id": ctx.context_id,
+                            "name": ctx.name,
+                            "path": ctx.path.to_string_lossy(),
+                            "root": ctx.root.as_ref().map(|p| p.to_string_lossy().into_owned()),
+                            "description": ctx.description,
+                            "parent_id": ctx.parent_id,
+                            "depth": ctx.depth,
+                            "is_active": ctx.context_id == active_ctx_id,
                         })
-                        .collect();
-                    let json_str =
-                        serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                    })
+                    .collect();
+                let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+                let temp_file = format!("{}.tmp", response_file);
+                if let Err(e) = std::fs::write(&temp_file, &json_str) {
+                    log::error!("pane_ipc: list_contexts: could not write temp response file {temp_file:?}: {e}");
+                } else if let Err(e) = std::fs::rename(&temp_file, &response_file) {
+                    log::error!("pane_ipc: list_contexts: could not rename temp response file to {response_file:?}: {e}");
+                    let _ = std::fs::remove_file(&temp_file);
+                }
+            }
+            crate::app_protocol::AppRequest::GetPaneInfo {
+                pane_id,
+                response_file,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=get_pane_info pane_id={pane_id} response_file={:?}",
+                    response_file
+                );
+                let active_win = self.active_window;
+                let mut found = false;
+                'outer: for (win_idx, win) in self.windows.iter().enumerate() {
+                    let focused_pane_id = win
+                        .focused_pane
+                        .and_then(|t| win.tree.tiles.get(t))
+                        .and_then(|tile| {
+                            if let egui_tiles::Tile::Pane(id) = tile {
+                                Some(*id)
+                            } else {
+                                None
+                            }
+                        });
+                    if let Some(pane) = win.panes.get(pane_id) {
+                        let focused = win_idx == active_win && focused_pane_id == Some(*pane_id);
+                        let agent = pane.agent();
+                        let info = match pane {
+                            crate::host::pane::Pane::Terminal(t) => {
+                                let cwd = crate::host::shell::get_pid_cwd(t.backend.child_pid())
+                                    .map(|p| p.to_string_lossy().into_owned());
+                                serde_json::json!({
+                                    "id": pane_id,
+                                    "type": "terminal",
+                                    "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
+                                    "focused": focused,
+                                    "context_id": win.context_id,
+                                    "window_id": win.window_id,
+                                    "cwd": cwd,
+                                    "agent": agent,
+                                    "slots": pane_slots_json(pane),
+                                })
+                            }
+                            crate::host::pane::Pane::App(a) => {
+                                serde_json::json!({
+                                    "id": pane_id,
+                                    "type": "app",
+                                    "title": a.name.clone(),
+                                    "focused": focused,
+                                    "context_id": win.context_id,
+                                    "window_id": win.window_id,
+                                    "cwd": a.workspace_root.to_string_lossy().as_ref(),
+                                    "manifest_id": a.manifest_id.clone(),
+                                    "agent": agent,
+                                    "slots": pane_slots_json(pane),
+                                })
+                            }
+                            crate::host::pane::Pane::Portal(p) => {
+                                serde_json::json!({
+                                    "id": pane_id,
+                                    "type": "portal",
+                                    "context_id": p.target_context_id,
+                                    "focused": focused,
+                                })
+                            }
+                        };
+                        let json_str =
+                            serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
+                        if let Err(e) = std::fs::write(response_file, &json_str) {
+                            log::error!(
+                                "pane_ipc: get_pane_info: could not write response file {:?}: {e}",
+                                response_file
+                            );
+                        }
+                        found = true;
+                        break 'outer;
+                    }
+                }
+                if !found {
+                    log::warn!("pane_ipc: get_pane_info: pane_id={pane_id} not found");
+                    let json_str = format!("{{\"error\":\"pane {pane_id} not found\"}}");
+                    if let Err(e) = std::fs::write(response_file, &json_str) {
+                        log::error!("pane_ipc: get_pane_info: could not write error response: {e}");
+                    }
+                }
+            }
+            crate::app_protocol::AppRequest::GetPreviousPaneInfo { response_file } => {
+                log::info!(
+                    "pane_ipc: kind=get_previous_pane_info response_file={:?}",
+                    response_file
+                );
+                let mut found = false;
+                'prev_outer: for (window_id, tile_id) in self.pane_focus_history.iter().rev() {
+                    if let Some(win) = self.windows.iter().find(|w| w.window_id == *window_id) {
+                        if let Some(egui_tiles::Tile::Pane(pane_id)) = win.tree.tiles.get(*tile_id)
+                        {
+                            if let Some(pane) = win.panes.get(pane_id) {
+                                let info = match pane {
+                                    crate::host::pane::Pane::Terminal(t) => {
+                                        let cwd =
+                                            crate::host::shell::get_pid_cwd(t.backend.child_pid())
+                                                .map(|p| p.to_string_lossy().into_owned());
+                                        serde_json::json!({
+                                            "id": pane_id,
+                                            "type": "terminal",
+                                            "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
+                                            "focused": false,
+                                            "context_id": win.context_id,
+                                            "window_id": win.window_id,
+                                            "cwd": cwd,
+                                            "slots": pane_slots_json(pane),
+                                        })
+                                    }
+                                    crate::host::pane::Pane::App(a) => {
+                                        serde_json::json!({
+                                            "id": pane_id,
+                                            "type": "app",
+                                            "title": a.name.clone(),
+                                            "focused": false,
+                                            "context_id": win.context_id,
+                                            "window_id": win.window_id,
+                                            "cwd": a.workspace_root.to_string_lossy().as_ref(),
+                                            "manifest_id": a.manifest_id.clone(),
+                                            "slots": pane_slots_json(pane),
+                                        })
+                                    }
+                                    crate::host::pane::Pane::Portal(p) => {
+                                        serde_json::json!({
+                                            "id": pane_id,
+                                            "type": "portal",
+                                            "context_id": p.target_context_id,
+                                            "focused": false,
+                                        })
+                                    }
+                                };
+                                let json_str = serde_json::to_string(&info)
+                                    .unwrap_or_else(|_| "{}".to_string());
+                                let temp_file = format!("{}.tmp", response_file);
+                                if let Err(e) = std::fs::write(&temp_file, &json_str) {
+                                    log::error!("pane_ipc: get_previous_pane_info: could not write temp response file {temp_file:?}: {e}");
+                                } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
+                                    log::error!("pane_ipc: get_previous_pane_info: could not rename temp response file to {:?}: {e}", response_file);
+                                    let _ = std::fs::remove_file(&temp_file);
+                                }
+                                found = true;
+                                break 'prev_outer;
+                            }
+                        }
+                    }
+                }
+                if !found {
+                    log::warn!(
+                        "pane_ipc: get_previous_pane_info: no previous pane found in history"
+                    );
+                    let json_str = "{\"error\":\"no previous pane in history\"}";
                     let temp_file = format!("{}.tmp", response_file);
-                    if let Err(e) = std::fs::write(&temp_file, &json_str) {
-                        log::error!("pane_ipc: list_contexts: could not write temp response file {temp_file:?}: {e}");
-                    } else if let Err(e) = std::fs::rename(&temp_file, &response_file) {
-                        log::error!("pane_ipc: list_contexts: could not rename temp response file to {response_file:?}: {e}");
+                    if let Err(e) = std::fs::write(&temp_file, json_str) {
+                        log::error!("pane_ipc: get_previous_pane_info: could not write temp error response {temp_file:?}: {e}");
+                    } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
+                        log::error!("pane_ipc: get_previous_pane_info: could not rename temp error response to {:?}: {e}", response_file);
                         let _ = std::fs::remove_file(&temp_file);
                     }
                 }
-                crate::app_protocol::AppRequest::GetPaneInfo {
-                    pane_id,
-                    response_file,
-                } => {
-                    log::info!(
-                        "pane_ipc: kind=get_pane_info pane_id={pane_id} response_file={:?}",
-                        response_file
-                    );
-                    let active_win = self.active_window;
-                    let mut found = false;
-                    'outer: for (win_idx, win) in self.windows.iter().enumerate() {
-                        let focused_pane_id = win
-                            .focused_pane
-                            .and_then(|t| win.tree.tiles.get(t))
-                            .and_then(|tile| {
-                                if let egui_tiles::Tile::Pane(id) = tile {
-                                    Some(*id)
-                                } else {
-                                    None
-                                }
-                            });
-                        if let Some(pane) = win.panes.get(pane_id) {
-                            let focused =
-                                win_idx == active_win && focused_pane_id == Some(*pane_id);
-                            let agent = pane.agent();
-                            let info = match pane {
-                                crate::host::pane::Pane::Terminal(t) => {
-                                    let cwd =
-                                        crate::host::shell::get_pid_cwd(t.backend.child_pid())
-                                            .map(|p| p.to_string_lossy().into_owned());
-                                    serde_json::json!({
-                                        "id": pane_id,
-                                        "type": "terminal",
-                                        "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
-                                        "focused": focused,
-                                        "context_id": win.context_id,
-                                        "window_id": win.window_id,
-                                        "cwd": cwd,
-                                        "agent": agent,
-                                        "slots": pane_slots_json(pane),
-                                    })
-                                }
-                                crate::host::pane::Pane::App(a) => {
-                                    serde_json::json!({
-                                        "id": pane_id,
-                                        "type": "app",
-                                        "title": a.name.clone(),
-                                        "focused": focused,
-                                        "context_id": win.context_id,
-                                        "window_id": win.window_id,
-                                        "cwd": a.workspace_root.to_string_lossy().as_ref(),
-                                        "manifest_id": a.manifest_id.clone(),
-                                        "agent": agent,
-                                        "slots": pane_slots_json(pane),
-                                    })
-                                }
-                                crate::host::pane::Pane::Portal(p) => {
-                                    serde_json::json!({
-                                        "id": pane_id,
-                                        "type": "portal",
-                                        "context_id": p.target_context_id,
-                                        "focused": focused,
-                                    })
-                                }
-                            };
-                            let json_str =
-                                serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
-                            if let Err(e) = std::fs::write(response_file, &json_str) {
-                                log::error!("pane_ipc: get_pane_info: could not write response file {:?}: {e}", response_file);
-                            }
-                            found = true;
-                            break 'outer;
-                        }
-                    }
-                    if !found {
-                        log::warn!("pane_ipc: get_pane_info: pane_id={pane_id} not found");
-                        let json_str = format!("{{\"error\":\"pane {pane_id} not found\"}}");
-                        if let Err(e) = std::fs::write(response_file, &json_str) {
-                            log::error!(
-                                "pane_ipc: get_pane_info: could not write error response: {e}"
-                            );
-                        }
-                    }
+            }
+            crate::app_protocol::AppRequest::SlotWrite {
+                pane_id,
+                slot_name,
+                content,
+                append,
+                replace,
+                response_file,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=slot_write pane_id={pane_id} slot={slot_name:?} bytes={} append={append} replace={replace}",
+                    content.len()
+                );
+                if let Err(msg) = validate_slot_name(slot_name) {
+                    slot_error(response_file, msg);
+                    return;
                 }
-                crate::app_protocol::AppRequest::GetPreviousPaneInfo { response_file } => {
-                    log::info!(
-                        "pane_ipc: kind=get_previous_pane_info response_file={:?}",
-                        response_file
-                    );
-                    let mut found = false;
-                    'prev_outer: for (window_id, tile_id) in self.pane_focus_history.iter().rev() {
-                        if let Some(win) = self.windows.iter().find(|w| w.window_id == *window_id) {
-                            if let Some(egui_tiles::Tile::Pane(pane_id)) =
-                                win.tree.tiles.get(*tile_id)
-                            {
-                                if let Some(pane) = win.panes.get(pane_id) {
-                                    let info = match pane {
-                                        crate::host::pane::Pane::Terminal(t) => {
-                                            let cwd = crate::host::shell::get_pid_cwd(
-                                                t.backend.child_pid(),
-                                            )
-                                            .map(|p| p.to_string_lossy().into_owned());
-                                            serde_json::json!({
-                                                "id": pane_id,
-                                                "type": "terminal",
-                                                "title": t.name.clone().unwrap_or_else(|| "terminal".to_string()),
-                                                "focused": false,
-                                                "context_id": win.context_id,
-                                                "window_id": win.window_id,
-                                                "cwd": cwd,
-                                                "slots": pane_slots_json(pane),
-                                            })
-                                        }
-                                        crate::host::pane::Pane::App(a) => {
-                                            serde_json::json!({
-                                                "id": pane_id,
-                                                "type": "app",
-                                                "title": a.name.clone(),
-                                                "focused": false,
-                                                "context_id": win.context_id,
-                                                "window_id": win.window_id,
-                                                "cwd": a.workspace_root.to_string_lossy().as_ref(),
-                                                "manifest_id": a.manifest_id.clone(),
-                                                "slots": pane_slots_json(pane),
-                                            })
-                                        }
-                                        crate::host::pane::Pane::Portal(p) => {
-                                            serde_json::json!({
-                                                "id": pane_id,
-                                                "type": "portal",
-                                                "context_id": p.target_context_id,
-                                                "focused": false,
-                                            })
-                                        }
-                                    };
-                                    let json_str = serde_json::to_string(&info)
-                                        .unwrap_or_else(|_| "{}".to_string());
-                                    let temp_file = format!("{}.tmp", response_file);
-                                    if let Err(e) = std::fs::write(&temp_file, &json_str) {
-                                        log::error!("pane_ipc: get_previous_pane_info: could not write temp response file {temp_file:?}: {e}");
-                                    } else if let Err(e) =
-                                        std::fs::rename(&temp_file, response_file)
-                                    {
-                                        log::error!("pane_ipc: get_previous_pane_info: could not rename temp response file to {:?}: {e}", response_file);
-                                        let _ = std::fs::remove_file(&temp_file);
-                                    }
-                                    found = true;
-                                    break 'prev_outer;
-                                }
-                            }
-                        }
-                    }
-                    if !found {
-                        log::warn!(
-                            "pane_ipc: get_previous_pane_info: no previous pane found in history"
-                        );
-                        let json_str = "{\"error\":\"no previous pane in history\"}";
-                        let temp_file = format!("{}.tmp", response_file);
-                        if let Err(e) = std::fs::write(&temp_file, json_str) {
-                            log::error!("pane_ipc: get_previous_pane_info: could not write temp error response {temp_file:?}: {e}");
-                        } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
-                            log::error!("pane_ipc: get_previous_pane_info: could not rename temp error response to {:?}: {e}", response_file);
-                            let _ = std::fs::remove_file(&temp_file);
-                        }
-                    }
+                if *append && *replace {
+                    slot_error(response_file, "use only one of append or replace");
+                    return;
                 }
-                crate::app_protocol::AppRequest::SlotWrite {
-                    pane_id,
-                    slot_name,
-                    content,
-                    append,
-                    replace,
-                    response_file,
-                } => {
-                    log::info!(
-                        "pane_ipc: kind=slot_write pane_id={pane_id} slot={slot_name:?} bytes={} append={append} replace={replace}",
-                        content.len()
+                if content.len() > MAX_SLOT_CONTENT_SIZE {
+                    slot_error(
+                        response_file,
+                        format!(
+                            "slot '{slot_name}' content size {} exceeds 10485760 bytes",
+                            content.len()
+                        ),
                     );
-                    if let Err(msg) = validate_slot_name(slot_name) {
-                        slot_error(response_file, msg);
-                        continue;
-                    }
-                    if *append && *replace {
-                        slot_error(response_file, "use only one of append or replace");
-                        continue;
-                    }
-                    if content.len() > MAX_SLOT_CONTENT_SIZE {
-                        slot_error(
-                            response_file,
-                            format!(
-                                "slot '{slot_name}' content size {} exceeds 10485760 bytes",
-                                content.len()
-                            ),
-                        );
-                        continue;
-                    }
-                    let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
-                        if win.panes.contains_key(pane_id) {
-                            Some((idx, win.context_id))
-                        } else {
-                            None
-                        }
-                    });
-                    let Some((win_idx, context_id)) = target else {
-                        slot_error(response_file, format!("pane {pane_id} not found"));
-                        continue;
-                    };
-                    let context_root = self
-                        .router
-                        .iter()
-                        .find(|ctx| ctx.context_id == context_id)
-                        .and_then(|ctx| ctx.root.clone());
-                    let slot_dir = slot_base_dir(context_root.as_deref()).join(pane_id.to_string());
-                    let slot_path = slot_dir.join(slot_name);
-                    let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
-                        slot_error(response_file, format!("pane {pane_id} not found"));
-                        continue;
-                    };
-                    let Some(slots) = pane.slots_mut() else {
-                        slot_error(
-                            response_file,
-                            format!("pane {pane_id} does not support slots"),
-                        );
-                        continue;
-                    };
-                    let tracked_path = slots.get(slot_name).cloned();
-                    let existing_path = tracked_path.clone().unwrap_or(slot_path.clone());
-                    let write_path = if *append {
-                        tracked_path.clone().unwrap_or(slot_path.clone())
+                    return;
+                }
+                let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
+                    if win.panes.contains_key(pane_id) {
+                        Some((idx, win.context_id))
                     } else {
-                        slot_path.clone()
-                    };
-                    let exists = tracked_path.as_ref().is_some_and(|path| path.exists());
-                    if exists && !*append && !*replace {
+                        None
+                    }
+                });
+                let Some((win_idx, context_id)) = target else {
+                    slot_error(response_file, format!("pane {pane_id} not found"));
+                    return;
+                };
+                let context_root = self
+                    .router
+                    .iter()
+                    .find(|ctx| ctx.context_id == context_id)
+                    .and_then(|ctx| ctx.root.clone());
+                let slot_dir = slot_base_dir(context_root.as_deref()).join(pane_id.to_string());
+                let slot_path = slot_dir.join(slot_name);
+                let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
+                    slot_error(response_file, format!("pane {pane_id} not found"));
+                    return;
+                };
+                let Some(slots) = pane.slots_mut() else {
+                    slot_error(
+                        response_file,
+                        format!("pane {pane_id} does not support slots"),
+                    );
+                    return;
+                };
+                let tracked_path = slots.get(slot_name).cloned();
+                let existing_path = tracked_path.clone().unwrap_or(slot_path.clone());
+                let write_path = if *append {
+                    tracked_path.clone().unwrap_or(slot_path.clone())
+                } else {
+                    slot_path.clone()
+                };
+                let exists = tracked_path.as_ref().is_some_and(|path| path.exists());
+                if exists && !*append && !*replace {
+                    slot_error(
+                        response_file,
+                        format!(
+                            "slot '{slot_name}' already exists — use --append to add to it or --replace to overwrite it"
+                        ),
+                    );
+                    return;
+                }
+                if *append {
+                    let existing_size = std::fs::metadata(&existing_path)
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+                    let final_size = existing_size.saturating_add(content.len() as u64);
+                    if final_size > MAX_SLOT_CONTENT_SIZE as u64 {
                         slot_error(
                             response_file,
                             format!(
-                                "slot '{slot_name}' already exists — use --append to add to it or --replace to overwrite it"
+                                "slot '{slot_name}' content size {final_size} exceeds 10485760 bytes"
                             ),
                         );
-                        continue;
+                        return;
                     }
-                    if *append {
-                        let existing_size = std::fs::metadata(&existing_path)
-                            .map(|m| m.len())
-                            .unwrap_or(0);
-                        let final_size = existing_size.saturating_add(content.len() as u64);
-                        if final_size > MAX_SLOT_CONTENT_SIZE as u64 {
+                }
+                let write_dir = write_path.parent().unwrap_or(slot_dir.as_path());
+                if let Err(e) = std::fs::create_dir_all(write_dir) {
+                    slot_error(
+                        response_file,
+                        format!(
+                            "could not create slot directory {}: {e}",
+                            write_dir.display()
+                        ),
+                    );
+                    return;
+                }
+                let write_result = if *append {
+                    use std::io::Write as _;
+                    std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&write_path)
+                        .and_then(|mut f| f.write_all(content).map(|_| ()))
+                } else {
+                    std::fs::write(&write_path, content)
+                };
+                if let Err(e) = write_result {
+                    slot_error(
+                        response_file,
+                        format!("could not write slot '{slot_name}': {e}"),
+                    );
+                    return;
+                }
+                let absolute = write_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| write_path.clone());
+                slots.insert(slot_name.clone(), absolute.clone());
+                let size = std::fs::metadata(&absolute).map(|m| m.len()).unwrap_or(0);
+                write_json_response(
+                    response_file,
+                    serde_json::json!({
+                        "ok": true,
+                        "name": slot_name,
+                        "path": absolute.to_string_lossy(),
+                        "size": size,
+                    }),
+                );
+            }
+            crate::app_protocol::AppRequest::SlotRead {
+                pane_id,
+                slot_name,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=slot_read pane_id={pane_id} slot={slot_name:?}");
+                if let Err(msg) = validate_slot_name(slot_name) {
+                    slot_read_error(response_file, msg);
+                    return;
+                }
+                let path = self
+                    .windows
+                    .iter()
+                    .find_map(|win| win.panes.get(pane_id))
+                    .and_then(|pane| pane.slots())
+                    .and_then(|slots| slots.get(slot_name).cloned());
+                let Some(path) = path else {
+                    slot_read_error(response_file, format!("slot '{slot_name}' not found"));
+                    return;
+                };
+                match std::fs::read(&path) {
+                    Ok(bytes) => write_bytes_response_atomic(response_file, &bytes),
+                    Err(e) => {
+                        slot_read_error(
+                            response_file,
+                            format!("could not read slot '{slot_name}': {e}"),
+                        );
+                    }
+                }
+            }
+            crate::app_protocol::AppRequest::SlotList {
+                pane_id,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=slot_list pane_id={pane_id}");
+                let slots = self
+                    .windows
+                    .iter()
+                    .find_map(|win| win.panes.get(pane_id))
+                    .and_then(|pane| pane.slots());
+                match slots {
+                    Some(slots) => {
+                        write_json_response(
+                            response_file,
+                            serde_json::Value::Array(slot_list_entries(slots)),
+                        );
+                    }
+                    None => slot_error(response_file, format!("pane {pane_id} not found")),
+                }
+            }
+            crate::app_protocol::AppRequest::SlotDelete {
+                pane_id,
+                slot_name,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=slot_delete pane_id={pane_id} slot={slot_name:?}");
+                if let Err(msg) = validate_slot_name(slot_name) {
+                    slot_error(response_file, msg);
+                    return;
+                }
+                let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
+                    if win.panes.contains_key(pane_id) {
+                        Some((idx, win.context_id))
+                    } else {
+                        None
+                    }
+                });
+                let Some((win_idx, context_id)) = target else {
+                    slot_error(response_file, format!("pane {pane_id} not found"));
+                    return;
+                };
+                let context_root = self
+                    .router
+                    .iter()
+                    .find(|ctx| ctx.context_id == context_id)
+                    .and_then(|ctx| ctx.root.clone());
+                let fallback_path = slot_base_dir(context_root.as_deref())
+                    .join(pane_id.to_string())
+                    .join(slot_name);
+                let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
+                    slot_error(response_file, format!("pane {pane_id} not found"));
+                    return;
+                };
+                let Some(slots) = pane.slots_mut() else {
+                    slot_error(
+                        response_file,
+                        format!("pane {pane_id} does not support slots"),
+                    );
+                    return;
+                };
+                let path = slots.remove(slot_name).unwrap_or(fallback_path);
+                let removed = if path.exists() {
+                    match std::fs::remove_file(&path) {
+                        Ok(()) => true,
+                        Err(e) => {
                             slot_error(
                                 response_file,
-                                format!(
-                                    "slot '{slot_name}' content size {final_size} exceeds 10485760 bytes"
-                                ),
+                                format!("could not delete slot '{slot_name}': {e}"),
                             );
+                            return;
+                        }
+                    }
+                } else {
+                    false
+                };
+                write_json_response(
+                    response_file,
+                    serde_json::json!({
+                        "ok": true,
+                        "name": slot_name,
+                        "removed": removed,
+                    }),
+                );
+            }
+            crate::app_protocol::AppRequest::WorkspaceCleanSlots {
+                dry_run,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=workspace_clean_slots dry_run={dry_run}");
+                let live_panes: std::collections::HashSet<u64> = self
+                    .windows
+                    .iter()
+                    .flat_map(|win| win.panes.keys().copied())
+                    .collect();
+                let live_slot_paths: std::collections::HashSet<std::path::PathBuf> = self
+                    .windows
+                    .iter()
+                    .flat_map(|win| win.panes.values())
+                    .filter_map(|pane| pane.slots())
+                    .flat_map(|slots| slots.values().cloned())
+                    .collect();
+                let mut roots = vec![crate::config::config_dir().join("slots")];
+                for root in self.router.iter().filter_map(|ctx| ctx.root.as_ref()) {
+                    roots.push(slot_base_dir(Some(root)));
+                }
+                roots.sort();
+                roots.dedup();
+
+                let mut paths = Vec::new();
+                for root in roots {
+                    let Ok(entries) = std::fs::read_dir(&root) else {
+                        continue;
+                    };
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if !path.is_dir() {
                             continue;
                         }
-                    }
-                    let write_dir = write_path.parent().unwrap_or(slot_dir.as_path());
-                    if let Err(e) = std::fs::create_dir_all(write_dir) {
-                        slot_error(
-                            response_file,
-                            format!(
-                                "could not create slot directory {}: {e}",
-                                write_dir.display()
-                            ),
-                        );
-                        continue;
-                    }
-                    let write_result = if *append {
-                        use std::io::Write as _;
-                        std::fs::OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open(&write_path)
-                            .and_then(|mut f| f.write_all(content).map(|_| ()))
-                    } else {
-                        std::fs::write(&write_path, content)
-                    };
-                    if let Err(e) = write_result {
-                        slot_error(
-                            response_file,
-                            format!("could not write slot '{slot_name}': {e}"),
-                        );
-                        continue;
-                    }
-                    let absolute = write_path
-                        .canonicalize()
-                        .unwrap_or_else(|_| write_path.clone());
-                    slots.insert(slot_name.clone(), absolute.clone());
-                    let size = std::fs::metadata(&absolute).map(|m| m.len()).unwrap_or(0);
-                    write_json_response(
-                        response_file,
-                        serde_json::json!({
-                            "ok": true,
-                            "name": slot_name,
-                            "path": absolute.to_string_lossy(),
-                            "size": size,
-                        }),
-                    );
-                }
-                crate::app_protocol::AppRequest::SlotRead {
-                    pane_id,
-                    slot_name,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=slot_read pane_id={pane_id} slot={slot_name:?}");
-                    if let Err(msg) = validate_slot_name(slot_name) {
-                        slot_read_error(response_file, msg);
-                        continue;
-                    }
-                    let path = self
-                        .windows
-                        .iter()
-                        .find_map(|win| win.panes.get(pane_id))
-                        .and_then(|pane| pane.slots())
-                        .and_then(|slots| slots.get(slot_name).cloned());
-                    let Some(path) = path else {
-                        slot_read_error(response_file, format!("slot '{slot_name}' not found"));
-                        continue;
-                    };
-                    match std::fs::read(&path) {
-                        Ok(bytes) => write_bytes_response_atomic(response_file, &bytes),
-                        Err(e) => {
-                            slot_read_error(
-                                response_file,
-                                format!("could not read slot '{slot_name}': {e}"),
-                            );
-                        }
-                    }
-                }
-                crate::app_protocol::AppRequest::SlotList {
-                    pane_id,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=slot_list pane_id={pane_id}");
-                    let slots = self
-                        .windows
-                        .iter()
-                        .find_map(|win| win.panes.get(pane_id))
-                        .and_then(|pane| pane.slots());
-                    match slots {
-                        Some(slots) => {
-                            write_json_response(
-                                response_file,
-                                serde_json::Value::Array(slot_list_entries(slots)),
-                            );
-                        }
-                        None => slot_error(response_file, format!("pane {pane_id} not found")),
-                    }
-                }
-                crate::app_protocol::AppRequest::SlotDelete {
-                    pane_id,
-                    slot_name,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=slot_delete pane_id={pane_id} slot={slot_name:?}");
-                    if let Err(msg) = validate_slot_name(slot_name) {
-                        slot_error(response_file, msg);
-                        continue;
-                    }
-                    let target = self.windows.iter().enumerate().find_map(|(idx, win)| {
-                        if win.panes.contains_key(pane_id) {
-                            Some((idx, win.context_id))
-                        } else {
-                            None
-                        }
-                    });
-                    let Some((win_idx, context_id)) = target else {
-                        slot_error(response_file, format!("pane {pane_id} not found"));
-                        continue;
-                    };
-                    let context_root = self
-                        .router
-                        .iter()
-                        .find(|ctx| ctx.context_id == context_id)
-                        .and_then(|ctx| ctx.root.clone());
-                    let fallback_path = slot_base_dir(context_root.as_deref())
-                        .join(pane_id.to_string())
-                        .join(slot_name);
-                    let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
-                        slot_error(response_file, format!("pane {pane_id} not found"));
-                        continue;
-                    };
-                    let Some(slots) = pane.slots_mut() else {
-                        slot_error(
-                            response_file,
-                            format!("pane {pane_id} does not support slots"),
-                        );
-                        continue;
-                    };
-                    let path = slots.remove(slot_name).unwrap_or(fallback_path);
-                    let removed = if path.exists() {
-                        match std::fs::remove_file(&path) {
-                            Ok(()) => true,
-                            Err(e) => {
-                                slot_error(
-                                    response_file,
-                                    format!("could not delete slot '{slot_name}': {e}"),
-                                );
-                                continue;
-                            }
-                        }
-                    } else {
-                        false
-                    };
-                    write_json_response(
-                        response_file,
-                        serde_json::json!({
-                            "ok": true,
-                            "name": slot_name,
-                            "removed": removed,
-                        }),
-                    );
-                }
-                crate::app_protocol::AppRequest::WorkspaceCleanSlots {
-                    dry_run,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=workspace_clean_slots dry_run={dry_run}");
-                    let live_panes: std::collections::HashSet<u64> = self
-                        .windows
-                        .iter()
-                        .flat_map(|win| win.panes.keys().copied())
-                        .collect();
-                    let live_slot_paths: std::collections::HashSet<std::path::PathBuf> = self
-                        .windows
-                        .iter()
-                        .flat_map(|win| win.panes.values())
-                        .filter_map(|pane| pane.slots())
-                        .flat_map(|slots| slots.values().cloned())
-                        .collect();
-                    let mut roots = vec![crate::config::config_dir().join("slots")];
-                    for root in self.router.iter().filter_map(|ctx| ctx.root.as_ref()) {
-                        roots.push(slot_base_dir(Some(root)));
-                    }
-                    roots.sort();
-                    roots.dedup();
-
-                    let mut paths = Vec::new();
-                    for root in roots {
-                        let Ok(entries) = std::fs::read_dir(&root) else {
+                        let Some(pane_id) = entry.file_name().to_string_lossy().parse::<u64>().ok()
+                        else {
                             continue;
                         };
-                        for entry in entries.flatten() {
-                            let path = entry.path();
-                            if !path.is_dir() {
-                                continue;
-                            }
-                            let Some(pane_id) =
-                                entry.file_name().to_string_lossy().parse::<u64>().ok()
-                            else {
-                                continue;
-                            };
-                            if !live_panes.contains(&pane_id) {
-                                paths.push(path);
-                                continue;
-                            }
-                            let has_live_slots = live_slot_paths
-                                .iter()
-                                .any(|slot_path| slot_path.parent() == Some(path.as_path()));
-                            if !has_live_slots {
-                                paths.push(path);
-                                continue;
-                            }
-                            let Ok(slot_entries) = std::fs::read_dir(&path) else {
-                                continue;
-                            };
-                            for slot_entry in slot_entries.flatten() {
-                                let slot_path = slot_entry.path();
-                                if !live_slot_paths.contains(&slot_path) {
-                                    paths.push(slot_path);
-                                }
+                        if !live_panes.contains(&pane_id) {
+                            paths.push(path);
+                            continue;
+                        }
+                        let has_live_slots = live_slot_paths
+                            .iter()
+                            .any(|slot_path| slot_path.parent() == Some(path.as_path()));
+                        if !has_live_slots {
+                            paths.push(path);
+                            continue;
+                        }
+                        let Ok(slot_entries) = std::fs::read_dir(&path) else {
+                            continue;
+                        };
+                        for slot_entry in slot_entries.flatten() {
+                            let slot_path = slot_entry.path();
+                            if !live_slot_paths.contains(&slot_path) {
+                                paths.push(slot_path);
                             }
                         }
                     }
-                    paths.sort();
-                    let mut cleaned = Vec::new();
-                    let mut clean_error = None;
-                    for path in paths {
-                        if !*dry_run {
-                            let remove_result = if path.is_dir() {
-                                std::fs::remove_dir_all(&path)
-                            } else {
-                                std::fs::remove_file(&path)
-                            };
-                            if let Err(e) = remove_result {
-                                clean_error = Some(format!(
-                                    "could not remove slot path {}: {e}",
-                                    path.display()
-                                ));
-                                break;
-                            }
-                        }
-                        cleaned.push(path.to_string_lossy().into_owned());
-                    }
-                    if let Some(error) = clean_error {
-                        slot_error(response_file, error);
-                        continue;
-                    }
-                    write_json_response(
-                        response_file,
-                        serde_json::json!({
-                            "ok": true,
-                            "dry_run": dry_run,
-                            "paths": cleaned,
-                        }),
-                    );
                 }
-                crate::app_protocol::AppRequest::FocusPane { pane_id } => {
-                    log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
-                    if !self.pane_navigate(*pane_id) {
-                        log::warn!("pane_ipc: focus_pane: pane_id={pane_id} not found");
-                    }
-                }
-                crate::app_protocol::AppRequest::ClosePane { pane_id } => {
-                    log::info!("pane_ipc: kind=close_pane pane_id={pane_id}");
-                    let before: usize = self.windows.iter().map(|w| w.panes.len()).sum();
-                    self.close_pane_by_id(*pane_id);
-                    let after: usize = self.windows.iter().map(|w| w.panes.len()).sum();
-                    if before == after {
-                        log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
-                    }
-                }
-                crate::app_protocol::AppRequest::SpawnPane {
-                    type_id,
-                    layout,
-                    args,
-                    ephemeral,
-                    response_file,
-                    from_pane_id,
-                    cwd,
-                    no_focus,
-                    path,
-                    workspace_root,
-                    name,
-                    ..
-                } => {
-                    log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} workspace_root={workspace_root:?} response_file={response_file:?}");
-                    let new_pane_id = self.host.next_pane_id();
-
-                    let active = self.active_window;
-                    let cwd_override: Option<std::path::PathBuf> =
-                        cwd.as_deref().map(std::path::PathBuf::from);
-                    let mut launch_result: Result<(), String> = Ok(());
-                    if type_id == "terminal" {
-                        let layout_str = layout.as_deref().unwrap_or("split_h");
-                        let initial_cmd = super::cmd_from_args(args);
-                        if layout_str == "new_window" {
-                            // Create a new spatial grid window to the right of the
-                            // current context row instead of splitting the active pane.
-                            let ws_id = self.router.active().context_id;
-                            let active_y = self.windows[self.active_window].grid_y;
-                            let max_x = self
-                                .windows
-                                .iter()
-                                .filter(|w| w.context_id == ws_id && w.grid_y == active_y)
-                                .map(|w| w.grid_x)
-                                .max();
-                            let new_x = max_x.map(|x| x + 1).unwrap_or(1);
-                            log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                            self.create_page_at(
-                                new_x,
-                                active_y,
-                                initial_cmd.as_deref(),
-                                *ephemeral,
-                            );
-                            if *no_focus {
-                                self.active_window = active;
-                            }
-                        } else if layout_str == "tab" {
-                            log::info!("pane_ipc: spawn_pane terminal layout=tab initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                            let original_focused = self.windows[active].focused_pane;
-                            self.new_tab(initial_cmd.as_deref(), *ephemeral);
-                            if *no_focus {
-                                self.active_window = active;
-                                self.restore_window_focused_pane(active, original_focused);
-                            }
+                paths.sort();
+                let mut cleaned = Vec::new();
+                let mut clean_error = None;
+                for path in paths {
+                    if !*dry_run {
+                        let remove_result = if path.is_dir() {
+                            std::fs::remove_dir_all(&path)
                         } else {
-                            let vertical =
-                                matches!(layout_str, "split_h" | "split_right" | "split_left");
-                            let new_pane_first = matches!(layout_str, "split_above" | "split_left");
-                            // Resolve target window and tile: from_pane_id wins (cross-window),
-                            // then fall back to the active window's focused pane.
-                            let (target_win, target_tile) = if let Some(from_id) = from_pane_id {
-                                match self.find_pane_in_any_window(*from_id) {
-                                    Some(loc) => {
-                                        log::info!("pane_ipc: spawn_pane: targeting from_pane_id={from_id} in win_idx={}", loc.0);
-                                        loc
-                                    }
-                                    None => {
-                                        log::warn!("pane_ipc: spawn_pane: from_pane_id={from_id} not found in any window, using focused pane");
-                                        if let Some(tile) = self.windows[active]
-                                            .focused_pane
-                                            .or(self.windows[active].tree.root)
-                                        {
-                                            (active, tile)
-                                        } else {
-                                            // Window is empty — let split_focused handle it
-                                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} (empty context fallback)");
-                                            self.split_focused(
-                                                vertical,
-                                                initial_cmd.as_deref(),
-                                                *ephemeral,
-                                                new_pane_first,
-                                                cwd_override,
-                                            );
-                                            if *no_focus {
-                                                self.active_window = active;
-                                            }
-                                            if let Some(ref pane_name) = name {
-                                                if !pane_name.is_empty() {
-                                                    self.apply_inline_pane_name(
-                                                        new_pane_id,
-                                                        pane_name,
-                                                    );
-                                                }
-                                            }
-                                            if let Some(rf) = response_file {
-                                                let json = format!("{{\"pane_id\":{new_pane_id}}}");
-                                                if let Err(e) = std::fs::write(rf, &json) {
-                                                    log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
-                                                }
-                                            }
-                                            continue;
+                            std::fs::remove_file(&path)
+                        };
+                        if let Err(e) = remove_result {
+                            clean_error = Some(format!(
+                                "could not remove slot path {}: {e}",
+                                path.display()
+                            ));
+                            break;
+                        }
+                    }
+                    cleaned.push(path.to_string_lossy().into_owned());
+                }
+                if let Some(error) = clean_error {
+                    slot_error(response_file, error);
+                    return;
+                }
+                write_json_response(
+                    response_file,
+                    serde_json::json!({
+                        "ok": true,
+                        "dry_run": dry_run,
+                        "paths": cleaned,
+                    }),
+                );
+            }
+            crate::app_protocol::AppRequest::FocusPane { pane_id } => {
+                log::info!("pane_ipc: kind=focus_pane pane_id={pane_id}");
+                if !self.pane_navigate(*pane_id) {
+                    log::warn!("pane_ipc: focus_pane: pane_id={pane_id} not found");
+                }
+            }
+            crate::app_protocol::AppRequest::ClosePane { pane_id } => {
+                log::info!("pane_ipc: kind=close_pane pane_id={pane_id}");
+                let before: usize = self.windows.iter().map(|w| w.panes.len()).sum();
+                self.close_pane_by_id(*pane_id);
+                let after: usize = self.windows.iter().map(|w| w.panes.len()).sum();
+                if before == after {
+                    log::warn!("pane_ipc: close_pane: pane_id={pane_id} not found");
+                }
+            }
+            crate::app_protocol::AppRequest::SpawnPane {
+                type_id,
+                layout,
+                args,
+                ephemeral,
+                response_file,
+                from_pane_id,
+                cwd,
+                no_focus,
+                path,
+                workspace_root,
+                name,
+                ..
+            } => {
+                log::info!("pane_ipc: kind=spawn_pane type_id={type_id} path={path:?} layout={layout:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} workspace_root={workspace_root:?} response_file={response_file:?}");
+                let new_pane_id = self.host.next_pane_id();
+
+                let active = self.active_window;
+                let cwd_override: Option<std::path::PathBuf> =
+                    cwd.as_deref().map(std::path::PathBuf::from);
+                let mut launch_result: Result<(), String> = Ok(());
+                if type_id == "terminal" {
+                    let layout_str = layout.as_deref().unwrap_or("split_h");
+                    let initial_cmd = super::cmd_from_args(args);
+                    if layout_str == "new_window" {
+                        // Create a new spatial grid window to the right of the
+                        // current context row instead of splitting the active pane.
+                        let ws_id = self.router.active().context_id;
+                        let active_y = self.windows[self.active_window].grid_y;
+                        let max_x = self
+                            .windows
+                            .iter()
+                            .filter(|w| w.context_id == ws_id && w.grid_y == active_y)
+                            .map(|w| w.grid_x)
+                            .max();
+                        let new_x = max_x.map(|x| x + 1).unwrap_or(1);
+                        log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                        self.create_page_at(new_x, active_y, initial_cmd.as_deref(), *ephemeral);
+                        if *no_focus {
+                            self.active_window = active;
+                        }
+                    } else if layout_str == "tab" {
+                        log::info!("pane_ipc: spawn_pane terminal layout=tab initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                        let original_focused = self.windows[active].focused_pane;
+                        self.new_tab(initial_cmd.as_deref(), *ephemeral);
+                        if *no_focus {
+                            self.active_window = active;
+                            self.restore_window_focused_pane(active, original_focused);
+                        }
+                    } else {
+                        let vertical =
+                            matches!(layout_str, "split_h" | "split_right" | "split_left");
+                        let new_pane_first = matches!(layout_str, "split_above" | "split_left");
+                        // Resolve target window and tile: from_pane_id wins (cross-window),
+                        // then fall back to the active window's focused pane.
+                        let (target_win, target_tile) = if let Some(from_id) = from_pane_id {
+                            match self.find_pane_in_any_window(*from_id) {
+                                Some(loc) => {
+                                    log::info!("pane_ipc: spawn_pane: targeting from_pane_id={from_id} in win_idx={}", loc.0);
+                                    loc
+                                }
+                                None => {
+                                    log::warn!("pane_ipc: spawn_pane: from_pane_id={from_id} not found in any window, using focused pane");
+                                    if let Some(tile) = self.windows[active]
+                                        .focused_pane
+                                        .or(self.windows[active].tree.root)
+                                    {
+                                        (active, tile)
+                                    } else {
+                                        // Window is empty — let split_focused handle it
+                                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} (empty context fallback)");
+                                        self.split_focused(
+                                            vertical,
+                                            initial_cmd.as_deref(),
+                                            *ephemeral,
+                                            new_pane_first,
+                                            cwd_override,
+                                        );
+                                        if *no_focus {
+                                            self.active_window = active;
                                         }
+                                        if let Some(ref pane_name) = name {
+                                            if !pane_name.is_empty() {
+                                                self.apply_inline_pane_name(new_pane_id, pane_name);
+                                            }
+                                        }
+                                        if let Some(rf) = response_file {
+                                            let json = format!("{{\"pane_id\":{new_pane_id}}}");
+                                            if let Err(e) = std::fs::write(rf, &json) {
+                                                log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
+                                            }
+                                        }
+                                        return;
                                     }
                                 }
-                            } else if let Some(tile) = self.windows[active]
-                                .focused_pane
-                                .or(self.windows[active].tree.root)
-                            {
-                                (active, tile)
-                            } else {
-                                // Truly empty window — fall back to split_focused
-                                log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
-                                self.split_focused(
-                                    vertical,
-                                    initial_cmd.as_deref(),
-                                    *ephemeral,
-                                    new_pane_first,
-                                    cwd_override,
-                                );
-                                if *no_focus {
-                                    self.active_window = active;
-                                }
-                                if let Some(ref pane_name) = name {
-                                    if !pane_name.is_empty() {
-                                        self.apply_inline_pane_name(new_pane_id, pane_name);
-                                    }
-                                }
-                                // Skip rest of split path
-                                if let Some(rf) = response_file {
-                                    let json = format!("{{\"pane_id\":{new_pane_id}}}");
-                                    if let Err(e) = std::fs::write(rf, &json) {
-                                        log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
-                                    }
-                                }
-                                continue;
-                            };
-                            let keep_focus = *no_focus || from_pane_id.is_some();
-                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={ephemeral} target_win={target_win} keep_focus={keep_focus}");
-                            let _ = self.spawn_terminal_pane_at(
-                                target_win,
-                                target_tile,
+                            }
+                        } else if let Some(tile) = self.windows[active]
+                            .focused_pane
+                            .or(self.windows[active].tree.root)
+                        {
+                            (active, tile)
+                        } else {
+                            // Truly empty window — fall back to split_focused
+                            log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={ephemeral}");
+                            self.split_focused(
                                 vertical,
-                                new_pane_first,
                                 initial_cmd.as_deref(),
                                 *ephemeral,
+                                new_pane_first,
                                 cwd_override,
-                                keep_focus,
                             );
                             if *no_focus {
                                 self.active_window = active;
                             }
-                        }
-                    } else if let Some(path_str) = path {
-                        let ws_root = workspace_root.as_deref().map(std::path::PathBuf::from);
-                        let (target_win, orig_focused_in_target) = if let Some(from_id) =
-                            from_pane_id
-                        {
-                            match self.find_pane_in_any_window(*from_id) {
-                                Some((fw, ft)) => {
-                                    log::info!("pane_ipc: spawn_pane path: targeting from_pane_id={from_id} win_idx={fw}");
-                                    let saved = self.windows[fw].focused_pane;
-                                    self.active_window = fw;
-                                    self.set_window_focused_pane(fw, ft);
-                                    (fw, saved)
-                                }
-                                None => {
-                                    log::warn!("pane_ipc: spawn_pane path: from_pane_id={from_id} not found, using focused pane");
-                                    (active, self.windows[active].focused_pane)
+                            if let Some(ref pane_name) = name {
+                                if !pane_name.is_empty() {
+                                    self.apply_inline_pane_name(new_pane_id, pane_name);
                                 }
                             }
-                        } else {
-                            (active, self.windows[active].focused_pane)
+                            // Skip rest of split path
+                            if let Some(rf) = response_file {
+                                let json = format!("{{\"pane_id\":{new_pane_id}}}");
+                                if let Err(e) = std::fs::write(rf, &json) {
+                                    log::error!(
+                                        "pane_ipc: spawn_pane: could not write response file: {e}"
+                                    );
+                                }
+                            }
+                            return;
                         };
-                        launch_result = self.launch_app_by_path_with_layout(
-                            path_str,
-                            layout.clone(),
-                            ws_root,
-                            &args,
+                        let keep_focus = *no_focus || from_pane_id.is_some();
+                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={ephemeral} target_win={target_win} keep_focus={keep_focus}");
+                        let _ = self.spawn_terminal_pane_at(
+                            target_win,
+                            target_tile,
+                            vertical,
+                            new_pane_first,
+                            initial_cmd.as_deref(),
+                            *ephemeral,
+                            cwd_override,
+                            keep_focus,
                         );
-                        if from_pane_id.is_some() {
-                            self.active_window = active;
-                            // Undo the temporary focus redirect when launch failed.
-                            if launch_result.is_err() {
-                                self.restore_window_focused_pane(
-                                    target_win,
-                                    orig_focused_in_target,
-                                );
-                            }
-                        }
                         if *no_focus {
                             self.active_window = active;
-                            self.restore_window_focused_pane(target_win, orig_focused_in_target);
+                        }
+                    }
+                } else if let Some(path_str) = path {
+                    let ws_root = workspace_root.as_deref().map(std::path::PathBuf::from);
+                    let (target_win, orig_focused_in_target) = if let Some(from_id) = from_pane_id {
+                        match self.find_pane_in_any_window(*from_id) {
+                            Some((fw, ft)) => {
+                                log::info!("pane_ipc: spawn_pane path: targeting from_pane_id={from_id} win_idx={fw}");
+                                let saved = self.windows[fw].focused_pane;
+                                self.active_window = fw;
+                                self.set_window_focused_pane(fw, ft);
+                                (fw, saved)
+                            }
+                            None => {
+                                log::warn!("pane_ipc: spawn_pane path: from_pane_id={from_id} not found, using focused pane");
+                                (active, self.windows[active].focused_pane)
+                            }
                         }
                     } else {
-                        let (target_win, orig_focused_in_target) = if let Some(from_id) =
-                            from_pane_id
-                        {
-                            match self.find_pane_in_any_window(*from_id) {
-                                Some((fw, ft)) => {
-                                    log::info!("pane_ipc: spawn_pane app: targeting from_pane_id={from_id} win_idx={fw}");
-                                    let saved = self.windows[fw].focused_pane;
-                                    self.active_window = fw;
-                                    self.set_window_focused_pane(fw, ft);
-                                    (fw, saved)
-                                }
-                                None => {
-                                    log::warn!("pane_ipc: spawn_pane app: from_pane_id={from_id} not found, using focused pane");
-                                    (active, self.windows[active].focused_pane)
-                                }
-                            }
-                        } else {
-                            (active, self.windows[active].focused_pane)
-                        };
-                        launch_result = self.launch_app_by_id_with_layout(
-                            type_id,
-                            layout.clone(),
-                            args,
-                            cwd_override,
-                        );
-                        if from_pane_id.is_some() {
-                            self.active_window = active;
-                            // Undo the temporary focus redirect when launch failed.
-                            if launch_result.is_err() {
-                                self.restore_window_focused_pane(
-                                    target_win,
-                                    orig_focused_in_target,
-                                );
-                            }
-                        }
-                        if *no_focus {
-                            self.active_window = active;
+                        (active, self.windows[active].focused_pane)
+                    };
+                    launch_result =
+                        self.launch_app_by_path_with_layout(path_str, layout.clone(), ws_root, args);
+                    if from_pane_id.is_some() {
+                        self.active_window = active;
+                        // Undo the temporary focus redirect when launch failed.
+                        if launch_result.is_err() {
                             self.restore_window_focused_pane(target_win, orig_focused_in_target);
                         }
                     }
-                    if type_id == "terminal" && launch_result.is_ok() {
-                        if let Some(ref pane_name) = name {
-                            if !pane_name.is_empty() {
-                                self.apply_inline_pane_name(new_pane_id, pane_name);
+                    if *no_focus {
+                        self.active_window = active;
+                        self.restore_window_focused_pane(target_win, orig_focused_in_target);
+                    }
+                } else {
+                    let (target_win, orig_focused_in_target) = if let Some(from_id) = from_pane_id {
+                        match self.find_pane_in_any_window(*from_id) {
+                            Some((fw, ft)) => {
+                                log::info!("pane_ipc: spawn_pane app: targeting from_pane_id={from_id} win_idx={fw}");
+                                let saved = self.windows[fw].focused_pane;
+                                self.active_window = fw;
+                                self.set_window_focused_pane(fw, ft);
+                                (fw, saved)
+                            }
+                            None => {
+                                log::warn!("pane_ipc: spawn_pane app: from_pane_id={from_id} not found, using focused pane");
+                                (active, self.windows[active].focused_pane)
                             }
                         }
+                    } else {
+                        (active, self.windows[active].focused_pane)
+                    };
+                    launch_result = self.launch_app_by_id_with_layout(
+                        type_id,
+                        layout.clone(),
+                        args,
+                        cwd_override,
+                    );
+                    if from_pane_id.is_some() {
+                        self.active_window = active;
+                        // Undo the temporary focus redirect when launch failed.
+                        if launch_result.is_err() {
+                            self.restore_window_focused_pane(target_win, orig_focused_in_target);
+                        }
                     }
-                    if let Some(rf) = response_file {
-                        let json = match &launch_result {
-                            Ok(()) => format!("{{\"pane_id\":{new_pane_id}}}"),
-                            Err(msg) => {
-                                log::warn!("pane_ipc: spawn_pane: launch failed, returning error to caller: {msg}");
-                                format!(
-                                    "{{\"error\":{}}}",
-                                    serde_json::to_string(msg)
-                                        .unwrap_or_else(|_| format!("\"{msg}\""))
-                                )
-                            }
-                        };
-                        if let Err(e) = std::fs::write(rf, &json) {
-                            log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
+                    if *no_focus {
+                        self.active_window = active;
+                        self.restore_window_focused_pane(target_win, orig_focused_in_target);
+                    }
+                }
+                if type_id == "terminal" && launch_result.is_ok() {
+                    if let Some(ref pane_name) = name {
+                        if !pane_name.is_empty() {
+                            self.apply_inline_pane_name(new_pane_id, pane_name);
                         }
                     }
                 }
-                crate::app_protocol::AppRequest::SendToPane {
-                    pane_id,
-                    text,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=send_to_pane pane_id={pane_id} len={} windows={} response_file={response_file:?}", text.len(), self.windows.len());
-                    let text_with_newlines = text.replace("\\n", "\n");
-                    let result = match self
-                        .windows
-                        .iter_mut()
-                        .find_map(|win| win.panes.get_mut(pane_id))
-                    {
-                        None => {
-                            log::warn!(
-                                "pane_ipc: send_to_pane: pane_id={pane_id} not found in any window"
-                            );
-                            Err(format!("pane {pane_id} not found"))
+                if let Some(rf) = response_file {
+                    let json = match &launch_result {
+                        Ok(()) => format!("{{\"pane_id\":{new_pane_id}}}"),
+                        Err(msg) => {
+                            log::warn!("pane_ipc: spawn_pane: launch failed, returning error to caller: {msg}");
+                            format!(
+                                "{{\"error\":{}}}",
+                                serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))
+                            )
                         }
-                        Some(pane) => match pane.as_terminal_mut() {
+                    };
+                    if let Err(e) = std::fs::write(rf, &json) {
+                        log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
+                    }
+                }
+            }
+            crate::app_protocol::AppRequest::SendToPane {
+                pane_id,
+                text,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=send_to_pane pane_id={pane_id} len={} windows={} response_file={response_file:?}", text.len(), self.windows.len());
+                let text_with_newlines = text.replace("\\n", "\n");
+                let result = match self
+                    .windows
+                    .iter_mut()
+                    .find_map(|win| win.panes.get_mut(pane_id))
+                {
+                    None => {
+                        log::warn!(
+                            "pane_ipc: send_to_pane: pane_id={pane_id} not found in any window"
+                        );
+                        Err(format!("pane {pane_id} not found"))
+                    }
+                    Some(pane) => {
+                        match pane.as_terminal_mut() {
                             None => {
                                 log::warn!("pane_ipc: send_to_pane: pane_id={pane_id} is not a terminal pane");
                                 Err(format!("pane {pane_id} is not a terminal pane"))
@@ -1068,86 +1046,86 @@ impl PlexiApp {
                                     ));
                                 Ok(())
                             }
-                        },
+                        }
+                    }
+                };
+                if let Some(rf) = response_file {
+                    let json = match result {
+                        Ok(()) => r#"{"ok":true}"#.to_string(),
+                        Err(ref msg) => format!(
+                            "{{\"error\":{}}}",
+                            serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))
+                        ),
                     };
-                    if let Some(rf) = response_file {
-                        let json = match result {
-                            Ok(()) => r#"{"ok":true}"#.to_string(),
-                            Err(ref msg) => format!(
-                                "{{\"error\":{}}}",
-                                serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))
-                            ),
-                        };
-                        if let Err(e) = std::fs::write(rf, &json) {
-                            log::error!(
-                                "pane_ipc: send_to_pane: could not write response file: {e}"
+                    if let Err(e) = std::fs::write(rf, &json) {
+                        log::error!("pane_ipc: send_to_pane: could not write response file: {e}");
+                    }
+                }
+            }
+            crate::app_protocol::AppRequest::KeyPane {
+                pane_id,
+                key,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=key_pane pane_id={pane_id} key={key:?}");
+                let result = match self
+                    .windows
+                    .iter_mut()
+                    .find_map(|win| win.panes.get_mut(pane_id))
+                {
+                    None => {
+                        log::warn!("pane_ipc: key_pane: pane_id={pane_id} not found");
+                        Err(format!("pane {pane_id} not found"))
+                    }
+                    Some(pane) => {
+                        if let Some(term) = pane.as_terminal_mut() {
+                            let bytes = super::key_str_to_pty_bytes(key);
+                            term.backend
+                                .process_command(egui_term::BackendCommand::Write(bytes));
+                            Ok(())
+                        } else if let Some(app_pane) = pane.as_app_mut() {
+                            let (key_str, modifiers) = super::parse_key_str_to_event(key);
+                            app_pane.runtime.queue_outbound_event(
+                                crate::app_protocol::PlexiEvent::Key {
+                                    key: key_str,
+                                    modifiers,
+                                },
                             );
+                            Ok(())
+                        } else {
+                            Err(format!("pane {pane_id}: unknown pane type"))
                         }
                     }
-                }
-                crate::app_protocol::AppRequest::KeyPane {
-                    pane_id,
-                    key,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=key_pane pane_id={pane_id} key={key:?}");
-                    let result = match self
-                        .windows
-                        .iter_mut()
-                        .find_map(|win| win.panes.get_mut(pane_id))
-                    {
-                        None => {
-                            log::warn!("pane_ipc: key_pane: pane_id={pane_id} not found");
-                            Err(format!("pane {pane_id} not found"))
-                        }
-                        Some(pane) => {
-                            if let Some(term) = pane.as_terminal_mut() {
-                                let bytes = super::key_str_to_pty_bytes(key);
-                                term.backend
-                                    .process_command(egui_term::BackendCommand::Write(bytes));
-                                Ok(())
-                            } else if let Some(app_pane) = pane.as_app_mut() {
-                                let (key_str, modifiers) = super::parse_key_str_to_event(key);
-                                app_pane.runtime.queue_outbound_event(
-                                    crate::app_protocol::PlexiEvent::Key {
-                                        key: key_str,
-                                        modifiers,
-                                    },
-                                );
-                                Ok(())
-                            } else {
-                                Err(format!("pane {pane_id}: unknown pane type"))
-                            }
-                        }
+                };
+                if let Some(rf) = response_file {
+                    let json = match &result {
+                        Ok(()) => serde_json::json!({"ok": true}).to_string(),
+                        Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Some(rf) = response_file {
-                        let json = match &result {
-                            Ok(()) => serde_json::json!({"ok": true}).to_string(),
-                            Err(msg) => serde_json::json!({"error": msg}).to_string(),
-                        };
-                        if let Err(e) = std::fs::write(rf, &json) {
-                            log::error!("pane_ipc: key_pane: could not write response file: {e}");
-                        }
+                    if let Err(e) = std::fs::write(rf, &json) {
+                        log::error!("pane_ipc: key_pane: could not write response file: {e}");
                     }
                 }
-                crate::app_protocol::AppRequest::CapturePane {
-                    pane_id,
-                    lines,
-                    response_file,
-                    full_output,
-                    from_cursor,
-                } => {
-                    log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} full_output={full_output} from_cursor={from_cursor:?} response_file={:?}", response_file);
-                    let result: Result<serde_json::Value, String> = match self
-                        .windows
-                        .iter()
-                        .find_map(|win| win.panes.get(pane_id))
-                    {
-                        None => {
-                            log::warn!("pane_ipc: capture_pane: pane_id={pane_id} not found");
-                            Err(format!("pane {pane_id} not found"))
-                        }
-                        Some(pane) => match pane.as_terminal() {
+            }
+            crate::app_protocol::AppRequest::CapturePane {
+                pane_id,
+                lines,
+                response_file,
+                full_output,
+                from_cursor,
+            } => {
+                log::info!("pane_ipc: kind=capture_pane pane_id={pane_id} lines={lines} full_output={full_output} from_cursor={from_cursor:?} response_file={:?}", response_file);
+                let result: Result<serde_json::Value, String> = match self
+                    .windows
+                    .iter()
+                    .find_map(|win| win.panes.get(pane_id))
+                {
+                    None => {
+                        log::warn!("pane_ipc: capture_pane: pane_id={pane_id} not found");
+                        Err(format!("pane {pane_id} not found"))
+                    }
+                    Some(pane) => {
+                        match pane.as_terminal() {
                             None => {
                                 log::warn!("pane_ipc: capture_pane: pane_id={pane_id} is not a terminal pane");
                                 Err(format!("pane {pane_id} is not a terminal pane"))
@@ -1165,9 +1143,9 @@ impl PlexiApp {
                                         captured_lines.truncate(trimmed);
                                     }
                                     log::info!(
-                                        "pane_ipc: capture_pane: cursor={cursor} new_cursor={new_cursor} missed={missed} lines={}",
-                                        captured_lines.len()
-                                    );
+                                    "pane_ipc: capture_pane: cursor={cursor} new_cursor={new_cursor} missed={missed} lines={}",
+                                    captured_lines.len()
+                                );
                                     Ok(serde_json::json!({
                                         "lines": captured_lines,
                                         "cursor": new_cursor,
@@ -1184,9 +1162,9 @@ impl PlexiApp {
                                             .unwrap_or(0);
                                         captured.truncate(trimmed);
                                         log::info!(
-                                            "pane_ipc: capture_pane: stripped trailing empty lines, result len={}",
-                                            captured.len()
-                                        );
+                                        "pane_ipc: capture_pane: stripped trailing empty lines, result len={}",
+                                        captured.len()
+                                    );
                                     }
                                     log::info!(
                                         "pane_ipc: capture_pane: lines={} cursor={lw}",
@@ -1199,444 +1177,432 @@ impl PlexiApp {
                                     }))
                                 }
                             }
-                        },
-                    };
-                    let json_str = match result {
-                        Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| {
-                            r#"{"lines":[],"cursor":0,"missed":false}"#.to_string()
-                        }),
+                        }
+                    }
+                };
+                let json_str = match result {
+                    Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| {
+                        r#"{"lines":[],"cursor":0,"missed":false}"#.to_string()
+                    }),
+                    Err(msg) => serde_json::json!({"error": msg}).to_string(),
+                };
+                if let Err(e) = std::fs::write(response_file, &json_str) {
+                    log::error!(
+                        "pane_ipc: capture_pane: could not write response file {response_file:?}: {e}"
+                    );
+                }
+            }
+            crate::app_protocol::AppRequest::GetPaneState {
+                pane_id,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=get_pane_state pane_id={pane_id} response_file={response_file:?}");
+                let json_str = match self.windows.iter().find_map(|win| win.panes.get(pane_id)) {
+                    None => {
+                        log::warn!("pane_ipc: get_pane_state: pane_id={pane_id} not found");
+                        serde_json::json!({"error": format!("pane {pane_id} not found")})
+                            .to_string()
+                    }
+                    Some(pane) => {
+                        if let Some(app_pane) = pane.as_app() {
+                            let frame = app_pane
+                                .runtime
+                                .frame_json()
+                                .unwrap_or(serde_json::Value::Array(vec![]));
+                            serde_json::json!({
+                                "pane_id": pane_id,
+                                "type": "app",
+                                "title": app_pane.name,
+                                "manifest_id": app_pane.manifest_id,
+                                "frame": frame,
+                            })
+                            .to_string()
+                        } else if let Some(term) = pane.as_terminal() {
+                            let title = term.name.clone().unwrap_or_else(|| "terminal".to_string());
+                            serde_json::json!({
+                                "pane_id": pane_id,
+                                "type": "terminal",
+                                "title": title,
+                            })
+                            .to_string()
+                        } else {
+                            serde_json::json!({
+                                "pane_id": pane_id,
+                                "type": "unknown",
+                            })
+                            .to_string()
+                        }
+                    }
+                };
+                if let Err(e) = std::fs::write(response_file, &json_str) {
+                    log::error!("pane_ipc: get_pane_state: could not write response file {response_file:?}: {e}");
+                }
+            }
+            crate::app_protocol::AppRequest::SendAppAction {
+                pane_id,
+                action,
+                args,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=send_app_action pane_id={pane_id} action={action:?} args={args:?}");
+                let result = match self
+                    .windows
+                    .iter_mut()
+                    .find_map(|win| win.panes.get_mut(pane_id))
+                {
+                    None => {
+                        log::warn!("pane_ipc: send_app_action: pane_id={pane_id} not found");
+                        Err(format!("pane {pane_id} not found"))
+                    }
+                    Some(pane) => {
+                        if let Some(app_pane) = pane.as_app_mut() {
+                            app_pane.runtime.queue_outbound_event(
+                                crate::app_protocol::PlexiEvent::Action {
+                                    action: action.clone(),
+                                    args: args.clone(),
+                                },
+                            );
+                            Ok(())
+                        } else {
+                            log::warn!(
+                                "pane_ipc: send_app_action: pane_id={pane_id} is not an app pane"
+                            );
+                            Err(format!("pane {pane_id} is not an app pane"))
+                        }
+                    }
+                };
+                if let Some(rf) = response_file {
+                    let json = match &result {
+                        Ok(()) => serde_json::json!({"ok": true}).to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Err(e) = std::fs::write(response_file, &json_str) {
+                    if let Err(e) = std::fs::write(rf, &json) {
                         log::error!(
-                            "pane_ipc: capture_pane: could not write response file {response_file:?}: {e}"
+                            "pane_ipc: send_app_action: could not write response file: {e}"
                         );
                     }
                 }
-                crate::app_protocol::AppRequest::GetPaneState {
-                    pane_id,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=get_pane_state pane_id={pane_id} response_file={response_file:?}");
-                    let json_str = match self.windows.iter().find_map(|win| win.panes.get(pane_id))
-                    {
-                        None => {
-                            log::warn!("pane_ipc: get_pane_state: pane_id={pane_id} not found");
-                            serde_json::json!({"error": format!("pane {pane_id} not found")})
-                                .to_string()
-                        }
-                        Some(pane) => {
-                            if let Some(app_pane) = pane.as_app() {
-                                let frame = app_pane
-                                    .runtime
-                                    .frame_json()
-                                    .unwrap_or(serde_json::Value::Array(vec![]));
-                                serde_json::json!({
-                                    "pane_id": pane_id,
-                                    "type": "app",
-                                    "title": app_pane.name,
-                                    "manifest_id": app_pane.manifest_id,
-                                    "frame": frame,
-                                })
-                                .to_string()
-                            } else if let Some(term) = pane.as_terminal() {
-                                let title =
-                                    term.name.clone().unwrap_or_else(|| "terminal".to_string());
-                                serde_json::json!({
-                                    "pane_id": pane_id,
-                                    "type": "terminal",
-                                    "title": title,
-                                })
-                                .to_string()
-                            } else {
-                                serde_json::json!({
-                                    "pane_id": pane_id,
-                                    "type": "unknown",
-                                })
-                                .to_string()
-                            }
-                        }
-                    };
-                    if let Err(e) = std::fs::write(response_file, &json_str) {
-                        log::error!("pane_ipc: get_pane_state: could not write response file {response_file:?}: {e}");
+            }
+            crate::app_protocol::AppRequest::SetAgentState {
+                pane_id,
+                state,
+                agent,
+                detail,
+                session_id,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?} detail_present={}",
+                    detail.is_some()
+                );
+                let mut found = false;
+                for win in &mut self.windows {
+                    if let Some(pane) = win.panes.get_mut(pane_id) {
+                        found = pane.set_agent(Some(crate::app_protocol::PaneAgentState {
+                            pane_id: *pane_id,
+                            state: state.clone(),
+                            agent: agent.clone(),
+                            detail: detail.clone(),
+                            session_id: session_id.clone(),
+                        }));
+                        break;
                     }
                 }
-                crate::app_protocol::AppRequest::SendAppAction {
-                    pane_id,
-                    action,
-                    args,
-                    response_file,
-                } => {
-                    log::info!("pane_ipc: kind=send_app_action pane_id={pane_id} action={action:?} args={args:?}");
-                    let result = match self
-                        .windows
-                        .iter_mut()
-                        .find_map(|win| win.panes.get_mut(pane_id))
-                    {
-                        None => {
-                            log::warn!("pane_ipc: send_app_action: pane_id={pane_id} not found");
-                            Err(format!("pane {pane_id} not found"))
-                        }
-                        Some(pane) => {
-                            if let Some(app_pane) = pane.as_app_mut() {
-                                app_pane.runtime.queue_outbound_event(
-                                    crate::app_protocol::PlexiEvent::Action {
-                                        action: action.clone(),
-                                        args: args.clone(),
-                                    },
-                                );
-                                Ok(())
-                            } else {
-                                log::warn!("pane_ipc: send_app_action: pane_id={pane_id} is not an app pane");
-                                Err(format!("pane {pane_id} is not an app pane"))
-                            }
-                        }
-                    };
-                    if let Some(rf) = response_file {
-                        let json = match &result {
-                            Ok(()) => serde_json::json!({"ok": true}).to_string(),
-                            Err(msg) => serde_json::json!({"error": msg}).to_string(),
-                        };
-                        if let Err(e) = std::fs::write(rf, &json) {
-                            log::error!(
-                                "pane_ipc: send_app_action: could not write response file: {e}"
-                            );
-                        }
-                    }
-                }
-                crate::app_protocol::AppRequest::SetAgentState {
-                    pane_id,
-                    state,
-                    agent,
-                    detail,
-                    session_id,
-                } => {
-                    log::info!(
-                        "pane_ipc: kind=set_agent_state pane_id={pane_id} agent={agent} state={state:?} detail_present={}",
-                        detail.is_some()
+                if found {
+                    log::info!("pane_ipc: set_agent_state: pane_id={pane_id} stored on pane");
+                } else {
+                    log::warn!(
+                        "pane_ipc: set_agent_state: pane_id={pane_id} not found or not agent-addressable"
                     );
-                    let mut found = false;
-                    for win in &mut self.windows {
-                        if let Some(pane) = win.panes.get_mut(pane_id) {
-                            found = pane.set_agent(Some(crate::app_protocol::PaneAgentState {
-                                pane_id: *pane_id,
-                                state: state.clone(),
-                                agent: agent.clone(),
-                                detail: detail.clone(),
-                                session_id: session_id.clone(),
-                            }));
-                            break;
-                        }
-                    }
-                    if found {
-                        log::info!("pane_ipc: set_agent_state: pane_id={pane_id} stored on pane");
-                    } else {
-                        log::warn!(
-                            "pane_ipc: set_agent_state: pane_id={pane_id} not found or not agent-addressable"
-                        );
-                    }
                 }
-                crate::app_protocol::AppRequest::GetAgentStates { response_file } => {
-                    log::info!("pane_ipc: kind=get_agent_states response_file={response_file:?}");
-                    let states: Vec<&crate::app_protocol::PaneAgentState> = self
-                        .windows
-                        .iter()
-                        .flat_map(|win| win.panes.values())
-                        .filter_map(|pane| pane.agent())
-                        .collect();
-                    let json_str =
-                        serde_json::to_string(&states).unwrap_or_else(|_| "[]".to_string());
-                    let temp = format!("{response_file}.tmp");
-                    if let Err(e) = std::fs::write(&temp, &json_str) {
-                        log::error!("pane_ipc: get_agent_states: could not write temp file: {e}");
-                    } else if let Err(e) = std::fs::rename(&temp, response_file) {
-                        log::error!("pane_ipc: get_agent_states: rename failed: {e}");
-                        let _ = std::fs::remove_file(&temp);
-                    }
+            }
+            crate::app_protocol::AppRequest::GetAgentStates { response_file } => {
+                log::info!("pane_ipc: kind=get_agent_states response_file={response_file:?}");
+                let states: Vec<&crate::app_protocol::PaneAgentState> = self
+                    .windows
+                    .iter()
+                    .flat_map(|win| win.panes.values())
+                    .filter_map(|pane| pane.agent())
+                    .collect();
+                let json_str = serde_json::to_string(&states).unwrap_or_else(|_| "[]".to_string());
+                let temp = format!("{response_file}.tmp");
+                if let Err(e) = std::fs::write(&temp, &json_str) {
+                    log::error!("pane_ipc: get_agent_states: could not write temp file: {e}");
+                } else if let Err(e) = std::fs::rename(&temp, response_file) {
+                    log::error!("pane_ipc: get_agent_states: rename failed: {e}");
+                    let _ = std::fs::remove_file(&temp);
                 }
-                crate::app_protocol::AppRequest::Notify {
-                    level,
+            }
+            crate::app_protocol::AppRequest::Notify {
+                level,
+                title,
+                body,
+                kind,
+                options,
+                input_prompt,
+                required,
+                priority,
+                image_inline,
+                image_pipe_id,
+                timeout_secs,
+                on_dismiss,
+                response_file,
+                scope,
+                ..
+            } => {
+                if !self.notifications_enabled {
+                    log::info!("pane_ipc: notify dropped — notifications disabled");
+                    return;
+                }
+                let internal_id = format!(
+                    "__host__:{}",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0)
+                );
+                log::info!(
+                    "pane_ipc: kind=notify title={:?} choices={} scope={:?} response_file={:?}",
                     title,
-                    body,
-                    kind,
-                    options,
-                    input_prompt,
-                    required,
-                    priority,
-                    image_inline,
-                    image_pipe_id,
-                    timeout_secs,
-                    on_dismiss,
-                    response_file,
+                    options.len(),
                     scope,
-                    ..
-                } => {
-                    if !self.notifications_enabled {
-                        log::info!("pane_ipc: notify dropped — notifications disabled");
-                        continue;
-                    }
-                    let internal_id = format!(
-                        "__host__:{}",
-                        std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_nanos())
-                            .unwrap_or(0)
-                    );
-                    log::info!(
-                        "pane_ipc: kind=notify title={:?} choices={} scope={:?} response_file={:?}",
-                        title,
-                        options.len(),
-                        scope,
-                        response_file
-                    );
-                    self.pending_notifications.push(PendingNotification {
-                        notify_id: internal_id.clone(),
-                        sender_pane_id: 0,
-                        source_context_id: self.router.active().context_id,
-                        source_window_id: self.windows[self.active_window].window_id,
-                        scope: scope.unwrap_or(crate::app_protocol::NotifyScope::Global),
-                        level: level.clone(),
-                        title: title.clone(),
-                        body: body.clone(),
-                        kind: kind.clone(),
-                        options: options.clone(),
-                        input_prompt: input_prompt.clone(),
-                        required: *required,
-                        priority: *priority,
-                        image_inline: image_inline.clone(),
-                        image_pipe_id: image_pipe_id.clone(),
-                        response_file: response_file.clone(),
-                        timeout_secs: *timeout_secs,
-                        on_dismiss: on_dismiss.clone(),
-                        enqueued_at: std::time::Instant::now(),
-                        tombstoned: false,
-                        deliver_after: None,
-                    });
-                    self.save_notifications();
-                    let should_auto_open = !self.notifications_focus_mode
-                        && *priority >= self.notifications_interrupt_threshold;
-                    if should_auto_open {
-                        self.show_notification_modal = true;
-                        if self.current_notify_id.is_none() {
-                            self.current_notify_id = Some(internal_id);
-                        }
+                    response_file
+                );
+                self.pending_notifications.push(PendingNotification {
+                    notify_id: internal_id.clone(),
+                    sender_pane_id: 0,
+                    source_context_id: self.router.active().context_id,
+                    source_window_id: self.windows[self.active_window].window_id,
+                    scope: scope.unwrap_or(crate::app_protocol::NotifyScope::Global),
+                    level: level.clone(),
+                    title: title.clone(),
+                    body: body.clone(),
+                    kind: kind.clone(),
+                    options: options.clone(),
+                    input_prompt: input_prompt.clone(),
+                    required: *required,
+                    priority: *priority,
+                    image_inline: image_inline.clone(),
+                    image_pipe_id: image_pipe_id.clone(),
+                    response_file: response_file.clone(),
+                    timeout_secs: *timeout_secs,
+                    on_dismiss: on_dismiss.clone(),
+                    enqueued_at: std::time::Instant::now(),
+                    tombstoned: false,
+                    deliver_after: None,
+                });
+                self.save_notifications();
+                let should_auto_open = !self.notifications_focus_mode
+                    && *priority >= self.notifications_interrupt_threshold;
+                if should_auto_open {
+                    self.show_notification_modal = true;
+                    if self.current_notify_id.is_none() {
+                        self.current_notify_id = Some(internal_id);
                     }
                 }
-                crate::app_protocol::AppRequest::CreateContext {
+            }
+            crate::app_protocol::AppRequest::CreateContext {
+                root,
+                name,
+                parent_name,
+                windows,
+                focus,
+                portal_direction,
+                response_file,
+            } => {
+                // Map direction string to insert_split_tile params.
+                // vertical=true  → side-by-side (left/right)
+                // vertical=false → stacked (up/down)
+                // new_pane_first=true → portal appears before the existing pane (left/up)
+                let (portal_vertical, portal_first) =
+                    match portal_direction.as_deref().unwrap_or("right") {
+                        "down" => (false, false),
+                        "up" => (false, true),
+                        "left" => (true, true),
+                        _ => (true, false), // "right" is default
+                    };
+                log::info!(
+                    "pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?} \
+                     windows={} focus={focus} direction={:?}",
                     root,
                     name,
                     parent_name,
-                    windows,
-                    focus,
-                    portal_direction,
-                    response_file,
-                } => {
-                    // Map direction string to insert_split_tile params.
-                    // vertical=true  → side-by-side (left/right)
-                    // vertical=false → stacked (up/down)
-                    // new_pane_first=true → portal appears before the existing pane (left/up)
-                    let (portal_vertical, portal_first) =
-                        match portal_direction.as_deref().unwrap_or("right") {
-                            "down" => (false, false),
-                            "up" => (false, true),
-                            "left" => (true, true),
-                            _ => (true, false), // "right" is default
-                        };
-                    log::info!(
-                        "pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?} \
-                         windows={} focus={focus} direction={:?}",
-                        root,
-                        name,
-                        parent_name,
-                        windows.len(),
-                        portal_direction
-                    );
-                    let mut ctx_ok = true;
-                    // Track which context was active before and which context was just created.
-                    // Windows must be placed in the new context regardless of focus state.
-                    let orig_ctx_id = self.router.active().context_id;
-                    let mut new_ctx_id = orig_ctx_id;
-                    if let Some(pname) = parent_name {
-                        let path = root.as_ref().cloned().unwrap_or_else(|| {
-                            let p = self.router.active().path.clone();
-                            if p.is_absolute() {
-                                p
-                            } else {
-                                dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"))
-                            }
-                        });
-                        let current_ctx_id = self.router.active().context_id;
-                        let current_win_id = self.windows[self.active_window].window_id;
-                        let current_focused = self.windows[self.active_window].focused_pane;
-                        if let Err(e) = self.new_child_context(
-                            pname.as_str(),
-                            path,
-                            portal_vertical,
-                            portal_first,
-                        ) {
-                            log::warn!("pane_ipc: create_context with parent failed: {e}");
-                            ctx_ok = false;
+                    windows.len(),
+                    portal_direction
+                );
+                let mut ctx_ok = true;
+                // Track which context was active before and which context was just created.
+                // Windows must be placed in the new context regardless of focus state.
+                let orig_ctx_id = self.router.active().context_id;
+                let mut new_ctx_id = orig_ctx_id;
+                if let Some(pname) = parent_name {
+                    let path = root.as_ref().cloned().unwrap_or_else(|| {
+                        let p = self.router.active().path.clone();
+                        if p.is_absolute() {
+                            p
                         } else {
-                            if let Some(n) = name {
-                                let idx = self.router.len() - 1;
-                                self.router.get_mut(idx).name = n.clone();
-                            }
-                            let new_ctx_idx = self.router.len() - 1;
-                            new_ctx_id = self.router.get(new_ctx_idx).context_id;
-                            if *focus {
-                                self.router.push_depth(
-                                    current_ctx_id,
-                                    current_win_id,
-                                    current_focused,
-                                );
-                                self.switch_workspace(new_ctx_idx);
-                                log::info!(
-                                    "pane_ipc: zoomed into new child context ctx_id={new_ctx_id}"
-                                );
-                            } else {
-                                log::info!(
-                                    "pane_ipc: created child context ctx_id={new_ctx_id} (no-focus)"
-                                );
-                            }
+                            dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"))
                         }
+                    });
+                    let current_ctx_id = self.router.active().context_id;
+                    let current_win_id = self.windows[self.active_window].window_id;
+                    let current_focused = self.windows[self.active_window].focused_pane;
+                    if let Err(e) =
+                        self.new_child_context(pname.as_str(), path, portal_vertical, portal_first)
+                    {
+                        log::warn!("pane_ipc: create_context with parent failed: {e}");
+                        ctx_ok = false;
                     } else {
-                        if let Some(r) = root {
-                            self.new_context_at_path(r.clone());
-                        } else {
-                            self.new_context();
-                        }
                         if let Some(n) = name {
                             let idx = self.router.len() - 1;
                             self.router.get_mut(idx).name = n.clone();
                         }
-                        new_ctx_id = self.router.get(self.router.len() - 1).context_id;
-                    }
-                    if ctx_ok && !windows.is_empty() {
-                        // When no-focus, active context is still the parent — temporarily switch
-                        // to the new context so create_page_at places windows there, then restore.
-                        let need_restore = self.router.active().context_id != new_ctx_id;
-                        if need_restore {
-                            if let Some(idx) = self.router.position(|c| c.context_id == new_ctx_id)
-                            {
-                                self.switch_workspace(idx);
-                            }
+                        let new_ctx_idx = self.router.len() - 1;
+                        new_ctx_id = self.router.get(new_ctx_idx).context_id;
+                        if *focus {
+                            self.router
+                                .push_depth(current_ctx_id, current_win_id, current_focused);
+                            self.switch_workspace(new_ctx_idx);
+                            log::info!(
+                                "pane_ipc: zoomed into new child context ctx_id={new_ctx_id}"
+                            );
+                        } else {
+                            log::info!(
+                                "pane_ipc: created child context ctx_id={new_ctx_id} (no-focus)"
+                            );
                         }
-                        let active_y = self.windows[self.active_window].grid_y;
-                        let mut new_x = self
+                    }
+                } else {
+                    if let Some(r) = root {
+                        self.new_context_at_path(r.clone());
+                    } else {
+                        self.new_context();
+                    }
+                    if let Some(n) = name {
+                        let idx = self.router.len() - 1;
+                        self.router.get_mut(idx).name = n.clone();
+                    }
+                    new_ctx_id = self.router.get(self.router.len() - 1).context_id;
+                }
+                if ctx_ok && !windows.is_empty() {
+                    // When no-focus, active context is still the parent — temporarily switch
+                    // to the new context so create_page_at places windows there, then restore.
+                    let need_restore = self.router.active().context_id != new_ctx_id;
+                    if need_restore {
+                        if let Some(idx) = self.router.position(|c| c.context_id == new_ctx_id) {
+                            self.switch_workspace(idx);
+                        }
+                    }
+                    let active_y = self.windows[self.active_window].grid_y;
+                    let mut new_x = self
+                        .windows
+                        .iter()
+                        .filter(|w| w.context_id == new_ctx_id && w.grid_y == active_y)
+                        .map(|w| w.grid_x)
+                        .max()
+                        .map(|x| x + 1)
+                        .unwrap_or(1);
+                    for cmd in windows {
+                        log::info!(
+                            "pane_ipc: create_context window ctx_id={new_ctx_id} grid_x={new_x} cmd={cmd:?}"
+                        );
+                        self.create_page_at(new_x, active_y, Some(cmd.as_str()), false);
+                        new_x += 1;
+                    }
+                    if need_restore {
+                        if let Some(idx) = self.router.position(|c| c.context_id == orig_ctx_id) {
+                            self.switch_workspace(idx);
+                        }
+                    }
+                }
+                // Write JSON response for callers that passed a response_file path.
+                if ctx_ok {
+                    if let Some(rf) = response_file {
+                        let windows_info: Vec<serde_json::Value> = self
                             .windows
                             .iter()
-                            .filter(|w| w.context_id == new_ctx_id && w.grid_y == active_y)
-                            .map(|w| w.grid_x)
-                            .max()
-                            .map(|x| x + 1)
-                            .unwrap_or(1);
-                        for cmd in windows {
-                            log::info!(
-                                "pane_ipc: create_context window ctx_id={new_ctx_id} grid_x={new_x} cmd={cmd:?}"
-                            );
-                            self.create_page_at(new_x, active_y, Some(cmd.as_str()), false);
-                            new_x += 1;
-                        }
-                        if need_restore {
-                            if let Some(idx) = self.router.position(|c| c.context_id == orig_ctx_id)
-                            {
-                                self.switch_workspace(idx);
-                            }
-                        }
-                    }
-                    // Write JSON response for callers that passed a response_file path.
-                    if ctx_ok {
-                        if let Some(rf) = response_file {
-                            let windows_info: Vec<serde_json::Value> = self
-                                .windows
-                                .iter()
-                                .filter(|w| w.context_id == new_ctx_id)
-                                .map(|w| {
-                                    serde_json::json!({
-                                        "window_id": w.window_id,
-                                        "grid_x": w.grid_x,
-                                        "grid_y": w.grid_y,
-                                    })
+                            .filter(|w| w.context_id == new_ctx_id)
+                            .map(|w| {
+                                serde_json::json!({
+                                    "window_id": w.window_id,
+                                    "grid_x": w.grid_x,
+                                    "grid_y": w.grid_y,
                                 })
-                                .collect();
-                            let response = serde_json::json!({
-                                "context_id": new_ctx_id,
-                                "windows": windows_info,
-                            });
-                            if let Ok(s) = serde_json::to_string(&response) {
-                                if let Err(e) = std::fs::write(&rf, s) {
-                                    log::warn!(
-                                        "pane_ipc: create_context failed to write response file {rf}: {e}"
-                                    );
-                                }
+                            })
+                            .collect();
+                        let response = serde_json::json!({
+                            "context_id": new_ctx_id,
+                            "windows": windows_info,
+                        });
+                        if let Ok(s) = serde_json::to_string(&response) {
+                            if let Err(e) = std::fs::write(&rf, s) {
+                                log::warn!(
+                                    "pane_ipc: create_context failed to write response file {rf}: {e}"
+                                );
                             }
                         }
                     }
-                    self.save_workspace();
                 }
-                crate::app_protocol::AppRequest::FocusContext { root } => {
-                    log::warn!(
-                        "pane_ipc: FocusContext ignored — CWD-based auto-switch removed (root={})",
-                        root.display()
-                    );
+                self.save_workspace();
+            }
+            crate::app_protocol::AppRequest::FocusContext { root } => {
+                log::warn!(
+                    "pane_ipc: FocusContext ignored — CWD-based auto-switch removed (root={})",
+                    root.display()
+                );
+            }
+            crate::app_protocol::AppRequest::SetContextRoot { root } => {
+                log::info!("pane_ipc: kind=set_context_root root={}", root.display());
+                self.set_active_context_root(root.clone());
+                self.save_workspace();
+            }
+            crate::app_protocol::AppRequest::SetContextDescription { description } => {
+                log::info!("pane_ipc: kind=set_context_description");
+                let idx = self.router.active_idx();
+                let trimmed = description.trim().to_string();
+                self.router.get_mut(idx).description = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                };
+                self.save_workspace();
+            }
+            crate::app_protocol::AppRequest::ZoomIntoContext { context_id } => {
+                log::info!("pane_ipc: kind=zoom_into_context context_id={context_id}");
+                if let Some(ctx_idx) = self.router.position(|c| c.context_id == *context_id) {
+                    let current_ctx_id = self.router.active().context_id;
+                    let current_win_id = self.windows[self.active_window].window_id;
+                    let current_focused = self.windows[self.active_window].focused_pane;
+                    self.router
+                        .push_depth(current_ctx_id, current_win_id, current_focused);
+                    self.switch_workspace(ctx_idx);
                 }
-                crate::app_protocol::AppRequest::SetContextRoot { root } => {
-                    log::info!("pane_ipc: kind=set_context_root root={}", root.display());
-                    self.set_active_context_root(root.clone());
-                    self.save_workspace();
-                }
-                crate::app_protocol::AppRequest::SetContextDescription { description } => {
-                    log::info!("pane_ipc: kind=set_context_description");
-                    let idx = self.router.active_idx();
-                    let trimmed = description.trim().to_string();
-                    self.router.get_mut(idx).description = if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed)
-                    };
-                    self.save_workspace();
-                }
-                crate::app_protocol::AppRequest::ZoomIntoContext { context_id } => {
-                    log::info!("pane_ipc: kind=zoom_into_context context_id={context_id}");
-                    if let Some(ctx_idx) = self.router.position(|c| c.context_id == *context_id) {
-                        let current_ctx_id = self.router.active().context_id;
-                        let current_win_id = self.windows[self.active_window].window_id;
-                        let current_focused = self.windows[self.active_window].focused_pane;
-                        self.router
-                            .push_depth(current_ctx_id, current_win_id, current_focused);
+            }
+            crate::app_protocol::AppRequest::ZoomOutOfContext => {
+                log::info!(
+                    "pane_ipc: kind=zoom_out_of_context depth={}",
+                    self.router.current_depth()
+                );
+                if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth()
+                {
+                    if let Some(ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
                         self.switch_workspace(ctx_idx);
-                    }
-                }
-                crate::app_protocol::AppRequest::ZoomOutOfContext => {
-                    log::info!(
-                        "pane_ipc: kind=zoom_out_of_context depth={}",
-                        self.router.current_depth()
-                    );
-                    if let Some((parent_ctx_id, parent_win_id, focused_tile)) =
-                        self.router.pop_depth()
-                    {
-                        if let Some(ctx_idx) =
-                            self.router.position(|c| c.context_id == parent_ctx_id)
+                        if let Some(win_idx) = self
+                            .windows
+                            .iter()
+                            .position(|w| w.window_id == parent_win_id)
                         {
-                            self.switch_workspace(ctx_idx);
-                            if let Some(win_idx) = self
-                                .windows
-                                .iter()
-                                .position(|w| w.window_id == parent_win_id)
-                            {
-                                self.active_window = win_idx;
-                                self.windows[win_idx].focused_pane = focused_tile;
-                            }
+                            self.active_window = win_idx;
+                            self.windows[win_idx].focused_pane = focused_tile;
                         }
                     }
                 }
-                crate::app_protocol::AppRequest::PushPaneToSubcontext { name } => {
-                    log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);
-                    self.push_pane_to_subcontext(name.clone());
-                }
-                _ => {
-                    log::warn!("pane_ipc: unsupported command kind, dropping");
-                }
+            }
+            crate::app_protocol::AppRequest::PushPaneToSubcontext { name } => {
+                log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);
+                self.push_pane_to_subcontext(name.clone());
+            }
+            _ => {
+                log::warn!("pane_ipc: unsupported command kind, dropping");
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1547,6 +1547,13 @@ impl eframe::App for PlexiApp {
                 continue;
             }
             match cmd {
+                // Capability-gated pane read/control request from a PGAP app
+                // (stint 0013/0014). routing.rs already checked panes.read /
+                // panes.control; execute it through the same handler CLI
+                // requests take over PLEXI_SOCKET.
+                AppCommand::ForwardPaneRequest { request } => {
+                    self.handle_pane_ipc_request(request);
+                }
                 AppCommand::SpawnApp {
                     type_id,
                     layout,

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -83,6 +83,32 @@ impl fmt::Display for Capability {
 }
 
 impl Capability {
+    /// One-line human-readable description shown in the permission grant
+    /// modal under the wire-format capability string.
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::FsRead => "Read files in this workspace",
+            Self::FsWrite => "Write files in this workspace",
+            Self::NetHttp => "Make outbound HTTP requests",
+            Self::SecretsGet => "Read secrets scoped to this workspace",
+            Self::PipeOpen => "Open data pipes to other panes",
+            Self::SpawnApp => "Launch another app in a new pane",
+            Self::AudioRecord => "Capture microphone audio",
+            Self::AudioPlayback => "Play audio",
+            Self::VideoPlayback => "Decode and display video",
+            Self::Llm => "Make LLM API calls using your API key",
+            Self::Timer => "Schedule timers",
+            Self::AiQuery => "Make AI calls through the Plexi broker",
+            Self::MidiIn => "Receive input from MIDI devices",
+            Self::MidiOut => "Send output to MIDI devices",
+            Self::TerminalBindings => "Drive a linked terminal pane",
+            Self::FsPick => "Show a native file picker",
+            Self::PanesSpawn => "Open new panes in your workspace",
+            Self::PanesRead => "See your open panes and read app or terminal pane state",
+            Self::PanesControl => "Control your panes: focus, close, send input, and drive apps",
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::FsRead => "fs.read",

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -64,6 +64,16 @@ pub enum Capability {
     FsPick,
     /// Spawn a new pane via DrawCommand::SpawnPane (#592).
     PanesSpawn,
+    /// Read pane metadata and state across the workspace (stint 0013/0014).
+    /// Gates the PGAP path for `ListPanes`, `GetPaneInfo`, `GetPreviousPaneInfo`,
+    /// `GetPaneState`, `CapturePane`, and `ListContexts` — the same host
+    /// handlers `plexi pane list` / `plexi pane info` use over PLEXI_SOCKET.
+    PanesRead,
+    /// Act on other panes (stint 0013/0014). Gates the PGAP path for
+    /// `FocusPane`, `ClosePane`, `SendToPane`, `KeyPane`, `SetPaneTitle`,
+    /// and `SendAppAction` — the same host handlers the `plexi pane` CLI
+    /// commands use over PLEXI_SOCKET.
+    PanesControl,
 }
 
 impl fmt::Display for Capability {
@@ -92,6 +102,8 @@ impl Capability {
             Self::TerminalBindings => "terminal.bindings",
             Self::FsPick => "fs.pick",
             Self::PanesSpawn => "panes.spawn",
+            Self::PanesRead => "panes.read",
+            Self::PanesControl => "panes.control",
         }
     }
 
@@ -114,6 +126,8 @@ impl Capability {
             "terminal.bindings",
             "fs.pick",
             "panes.spawn",
+            "panes.read",
+            "panes.control",
         ]
     }
 
@@ -142,6 +156,8 @@ impl Capability {
         matches!(
             self,
             Self::PanesSpawn
+                | Self::PanesRead
+                | Self::PanesControl
                 | Self::SpawnApp
                 | Self::AiQuery
                 | Self::Llm
@@ -202,6 +218,8 @@ impl<'a> TryFrom<&'a str> for Capability {
             "terminal.bindings" => Ok(Self::TerminalBindings),
             "fs.pick" => Ok(Self::FsPick),
             "panes.spawn" => Ok(Self::PanesSpawn),
+            "panes.read" => Ok(Self::PanesRead),
+            "panes.control" => Ok(Self::PanesControl),
             other => Err(UnknownCapability(other.to_string())),
         }
     }
@@ -647,6 +665,64 @@ mod tests {
             PermissionCheck::Denied(reason) => {
                 assert!(
                     reason.contains("panes.spawn"),
+                    "denial must name capability: {reason}"
+                );
+            }
+            PermissionCheck::Allowed => panic!("must be denied without declaration"),
+        }
+    }
+
+    #[test]
+    fn panes_read_capability_recognized() {
+        let parsed = Capability::try_from("panes.read").expect("panes.read must parse");
+        assert_eq!(parsed, Capability::PanesRead);
+        assert_eq!(parsed.as_str(), "panes.read");
+        assert!(parsed.is_sensitive(), "panes.read must be sensitive");
+        let perms = AppPermissions::from_capability_strings(&["panes.read".to_string()]);
+        assert!(
+            perms.capabilities.contains(&Capability::PanesRead),
+            "panes.read must end up in granted capabilities"
+        );
+        assert!(matches!(
+            check(&perms, Capability::PanesRead),
+            PermissionCheck::Allowed
+        ));
+        match check(
+            &AppPermissions::from_capability_strings(&[]),
+            Capability::PanesRead,
+        ) {
+            PermissionCheck::Denied(reason) => {
+                assert!(
+                    reason.contains("panes.read"),
+                    "denial must name capability: {reason}"
+                );
+            }
+            PermissionCheck::Allowed => panic!("must be denied without declaration"),
+        }
+    }
+
+    #[test]
+    fn panes_control_capability_recognized() {
+        let parsed = Capability::try_from("panes.control").expect("panes.control must parse");
+        assert_eq!(parsed, Capability::PanesControl);
+        assert_eq!(parsed.as_str(), "panes.control");
+        assert!(parsed.is_sensitive(), "panes.control must be sensitive");
+        let perms = AppPermissions::from_capability_strings(&["panes.control".to_string()]);
+        assert!(
+            perms.capabilities.contains(&Capability::PanesControl),
+            "panes.control must end up in granted capabilities"
+        );
+        assert!(matches!(
+            check(&perms, Capability::PanesControl),
+            PermissionCheck::Allowed
+        ));
+        match check(
+            &AppPermissions::from_capability_strings(&[]),
+            Capability::PanesControl,
+        ) {
+            PermissionCheck::Denied(reason) => {
+                assert!(
+                    reason.contains("panes.control"),
                     "denial must name capability: {reason}"
                 );
             }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -104,6 +104,8 @@ pub fn validate_cli(path: &str) -> i32 {
             "midi.out",
             "ai.query",
             "panes.spawn",
+            "panes.read",
+            "panes.control",
             "video.decode",
         ];
         for cap in caps {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2286,6 +2286,8 @@ fn cap_example_method(cap: &str) -> &'static str {
         "fs.read" => "fs_read",
         "fs.write" => "fs_write",
         "panes.spawn" => "spawn_pane",
+        "panes.read" => "list_panes",
+        "panes.control" => "send_to_pane",
         "midi.in" => "open_midi_input",
         "midi.out" => "send_midi",
         "video.playback" => "open_video",

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -446,17 +446,15 @@ impl ProcessApp {
                 cmd.env(var, v);
             }
         }
-        // Pass through every PLEXI_* var (harness knobs, mock-device selectors).
+        // Pass through every PLEXI_* var (harness knobs, mock-device selectors)
+        // EXCEPT PLEXI_SOCKET: app processes must not inherit socket routing.
+        // Pane read/control flows through capability-gated PGAP requests
+        // (panes.read / panes.control) instead of ambient CLI access.
         for (k, v) in std::env::vars() {
-            if k.starts_with("PLEXI_") {
+            if k.starts_with("PLEXI_") && k != "PLEXI_SOCKET" {
                 cmd.env(k, v);
             }
         }
-        // Set PLEXI_SOCKET so the app can invoke `plexi` CLI commands against
-        // the running host. macOS GUI apps don't inherit shell env, so this
-        // is never present via PLEXI_* passthrough above.
-        let socket_path = crate::config::config_dir().join("notify.sock");
-        cmd.env("PLEXI_SOCKET", &socket_path);
 
         // Start the MCP server when the manifest declares [app.mcp].
         let mcp_server_handle = mcp

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -151,6 +151,16 @@ pub(crate) fn show_prompt_modal(
                         .monospace()
                         .strong(),
                 );
+                if let Ok(cap) =
+                    crate::app::permissions::Capability::try_from(capability.as_str())
+                {
+                    ui.add_space(2.0);
+                    ui.label(
+                        egui::RichText::new(cap.description())
+                            .size(crate::ui::style::TEXT_CAPTION)
+                            .color(colors.text_primary),
+                    );
+                }
                 ui.add_space(4.0);
                 ui.label(
                     egui::RichText::new(format!("Workspace: {}", workspace_root.display()))

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1682,13 +1682,25 @@ impl ProcessApp {
                 }
             }
 
-            // SetPaneTitle is only valid over PLEXI_SOCKET; an app sending it
-            // via PGAP is a protocol error — log and drop.
-            AppRequest::SetPaneTitle { pane_id, .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received SetPaneTitle for pane_id={pane_id} over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
+            // ── Pane read/control over PGAP (stint 0013/0014) ─────────────
+            // Apps may inspect and drive other panes through the same host
+            // pane-IPC handlers the `plexi pane` CLI uses, gated on the
+            // `panes.read` / `panes.control` capabilities.
+            request @ (AppRequest::ListPanes { .. }
+            | AppRequest::ListContexts { .. }
+            | AppRequest::GetPaneInfo { .. }
+            | AppRequest::GetPreviousPaneInfo { .. }
+            | AppRequest::GetPaneState { .. }
+            | AppRequest::CapturePane { .. }) => {
+                self.gate_and_forward_pane_request(request, Capability::PanesRead);
+            }
+            request @ (AppRequest::SetPaneTitle { .. }
+            | AppRequest::FocusPane { .. }
+            | AppRequest::ClosePane { .. }
+            | AppRequest::SendToPane { .. }
+            | AppRequest::KeyPane { .. }
+            | AppRequest::SendAppAction { .. }) => {
+                self.gate_and_forward_pane_request(request, Capability::PanesControl);
             }
 
             // Context commands are only valid over PLEXI_SOCKET; log and drop
@@ -1735,43 +1747,6 @@ impl ProcessApp {
                     self.type_id
                 );
             }
-            AppRequest::ListPanes { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received ListPanes over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::ListContexts { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received ListContexts over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::FocusPane { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received FocusPane over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::ClosePane { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received ClosePane over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::SendToPane { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received SendToPane over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::KeyPane { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: received KeyPane over PGAP — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-
             // ── App state save ─────────────────────────────────────────────
             AppRequest::SaveAppState { payload } => {
                 let filename = format!("{}.json", self.type_id);
@@ -1822,39 +1797,6 @@ impl ProcessApp {
                     }
                 }
             }
-            AppRequest::GetPaneInfo { pane_id, .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: GetPaneInfo pane_id={pane_id} received in app routing — ignored (host-only command)",
-                    self.type_id
-                );
-            }
-            AppRequest::GetPreviousPaneInfo { .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: GetPreviousPaneInfo received in app routing — ignored (host-only command)",
-                    self.type_id
-                );
-            }
-            AppRequest::CapturePane { pane_id, .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: CapturePane pane_id={pane_id} received in app routing — ignored (use PLEXI_SOCKET instead)",
-                    self.type_id
-                );
-            }
-            AppRequest::GetPaneState { pane_id, .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: GetPaneState pane_id={pane_id} received in app routing — ignored (host-only command)",
-                    self.type_id
-                );
-            }
-
-            // ── SendAppAction — host-only, routed via PLEXI_SOCKET ────────
-            AppRequest::SendAppAction { pane_id, .. } => {
-                log::warn!(
-                    "ProcessApp[{}]: SendAppAction pane_id={pane_id} received in app routing — ignored (host-only command)",
-                    self.type_id
-                );
-            }
-
             // ── Query context state (#1518) ───────────────────────────────
             AppRequest::QueryContextState { context_id } => {
                 log::info!(
@@ -1916,6 +1858,44 @@ impl ProcessApp {
                 );
             }
         }
+    }
+
+    /// Capability gate for pane read/control requests arriving over PGAP
+    /// (stint 0013/0014). On grant the original request is forwarded into the
+    /// host's pane-IPC handler — the same path `plexi pane ...` CLI commands
+    /// take over PLEXI_SOCKET. On denial, callers waiting on a response_file
+    /// get a JSON error object so they don't hang until their poll timeout;
+    /// fire-and-forget requests just log.
+    fn gate_and_forward_pane_request(&mut self, request: AppRequest, cap: Capability) {
+        let kind = pane_request_kind(&request);
+        if let PermissionCheck::Denied(reason) = check(&self.permissions, cap) {
+            log::warn!(
+                "ProcessApp[{}]: {kind} denied — missing capability '{}': {reason}",
+                self.type_id,
+                cap.as_str()
+            );
+            if let Some(response_file) = pane_request_response_file(&request) {
+                let body = serde_json::json!({
+                    "error": format!("capability denied: {}", cap.as_str()),
+                    "capability": cap.as_str(),
+                })
+                .to_string();
+                if let Err(e) = std::fs::write(response_file, body) {
+                    log::warn!(
+                        "ProcessApp[{}]: {kind} denial — could not write response file {response_file:?}: {e}",
+                        self.type_id
+                    );
+                }
+            }
+            return;
+        }
+        log::info!(
+            "ProcessApp[{}]: forwarding {kind} to host pane-IPC handler (capability '{}')",
+            self.type_id,
+            cap.as_str()
+        );
+        self.pending_commands
+            .push(AppCommand::ForwardPaneRequest { request });
     }
 
     /// Allocate a binary pipe for `pipe_id`, spin up the audio capture
@@ -2327,6 +2307,42 @@ impl ProcessApp {
                 });
             }
         }
+    }
+}
+
+/// Wire name of a pane read/control request, for capability-gate log lines.
+fn pane_request_kind(request: &AppRequest) -> &'static str {
+    match request {
+        AppRequest::ListPanes { .. } => "ListPanes",
+        AppRequest::ListContexts { .. } => "ListContexts",
+        AppRequest::GetPaneInfo { .. } => "GetPaneInfo",
+        AppRequest::GetPreviousPaneInfo { .. } => "GetPreviousPaneInfo",
+        AppRequest::GetPaneState { .. } => "GetPaneState",
+        AppRequest::CapturePane { .. } => "CapturePane",
+        AppRequest::SetPaneTitle { .. } => "SetPaneTitle",
+        AppRequest::FocusPane { .. } => "FocusPane",
+        AppRequest::ClosePane { .. } => "ClosePane",
+        AppRequest::SendToPane { .. } => "SendToPane",
+        AppRequest::KeyPane { .. } => "KeyPane",
+        AppRequest::SendAppAction { .. } => "SendAppAction",
+        _ => "unknown pane request",
+    }
+}
+
+/// The response_file path a pane read/control request carries, if any.
+/// Used to write a capability-denied error object so callers don't hang.
+fn pane_request_response_file(request: &AppRequest) -> Option<&str> {
+    match request {
+        AppRequest::ListPanes { response_file, .. }
+        | AppRequest::ListContexts { response_file }
+        | AppRequest::GetPaneInfo { response_file, .. }
+        | AppRequest::GetPreviousPaneInfo { response_file }
+        | AppRequest::GetPaneState { response_file, .. }
+        | AppRequest::CapturePane { response_file, .. } => Some(response_file),
+        AppRequest::SendToPane { response_file, .. }
+        | AppRequest::KeyPane { response_file, .. }
+        | AppRequest::SendAppAction { response_file, .. } => response_file.as_deref(),
+        _ => None,
     }
 }
 

--- a/src/process_app/tests/env_isolation_tests.rs
+++ b/src/process_app/tests/env_isolation_tests.rs
@@ -49,3 +49,52 @@ fn user_global_secrets_not_injected_into_subprocess_env() {
         "user-global secret must not appear in subprocess env; got: {stdout:?}"
     );
 }
+
+/// App subprocesses must NOT inherit PLEXI_SOCKET (stint 0013). Pane
+/// read/control flows through capability-gated PGAP requests instead of
+/// ambient `plexi` CLI access. Models ProcessApp::launch's env construction:
+/// env_clear() + whitelist + PLEXI_* passthrough that excludes PLEXI_SOCKET.
+#[test]
+fn plexi_socket_not_injected_into_subprocess_env() {
+    let sh = ["/bin/sh", "/usr/bin/sh"]
+        .iter()
+        .find(|p| std::path::Path::new(p).exists())
+        .copied();
+    let Some(sh) = sh else {
+        eprintln!("skipping: no /bin/sh available");
+        return;
+    };
+
+    // Simulated host env: PLEXI_SOCKET set (host launched from inside a pane)
+    // plus a harness knob that MUST pass through.
+    let host_env = [
+        ("PLEXI_SOCKET", "/tmp/fake-notify.sock"),
+        ("PLEXI_PANE_ID", "42"),
+    ];
+
+    let output = Command::new(sh)
+        .arg("-c")
+        .arg("echo \"${PLEXI_SOCKET:-ABSENT}|${PLEXI_PANE_ID:-ABSENT}\"")
+        .env_clear()
+        .envs(
+            WHITELIST
+                .iter()
+                .filter_map(|k| std::env::var(k).ok().map(|v| (*k, v))),
+        )
+        // The launch passthrough loop: every PLEXI_* var except PLEXI_SOCKET.
+        .envs(
+            host_env
+                .iter()
+                .filter(|(k, _)| k.starts_with("PLEXI_") && *k != "PLEXI_SOCKET")
+                .copied(),
+        )
+        .output()
+        .expect("sh spawn failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "ABSENT|42",
+        "PLEXI_SOCKET must be absent and PLEXI_PANE_ID present in app subprocess env; got: {stdout:?}"
+    );
+}

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1353,3 +1353,139 @@ fn capability_secret_overlay_focus_wins_after_central_panel_steal() {
         "capability_secret_input must win focus back after a CentralPanel pane widget steals it"
     );
 }
+
+// -- Pane read/control over PGAP (stint 0013/0014) --------------------------
+
+/// App WITHOUT `panes.read` sends ListPanes via PGAP: the request must not be
+/// forwarded — instead the capability gate writes a JSON error object to the
+/// response_file so the caller doesn't hang until its poll timeout.
+#[test]
+fn pgap_list_panes_denied_without_panes_read() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-panes.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPanes {
+            response_file: response_file.to_string_lossy().into_owned(),
+            context_id: None,
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("denial must write the response file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    assert_eq!(
+        v["capability"], "panes.read",
+        "denial object must name the missing capability: {content}"
+    );
+    assert!(
+        v["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("capability denied")),
+        "denial object must carry an error message: {content}"
+    );
+}
+
+/// App WITH `panes.read` sends ListPanes via PGAP: the request is forwarded
+/// into the host pane-IPC handler, which writes the pane list JSON array.
+#[test]
+fn pgap_list_panes_forwarded_with_panes_read() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "panes.read".to_string(),
+    ]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-panes.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPanes {
+            response_file: response_file.to_string_lossy().into_owned(),
+            context_id: None,
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("grant must write the response file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    let panes = v
+        .as_array()
+        .expect("ListPanes response must be a JSON array");
+    assert!(
+        panes.iter().any(|p| p["id"].as_u64() == Some(pane)),
+        "pane list must contain the requesting pane: {content}"
+    );
+}
+
+/// App WITHOUT `panes.control` sends SendToPane via PGAP: the gate must write
+/// the capability-denied error object instead of forwarding.
+#[test]
+fn pgap_send_to_pane_denied_without_panes_control() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "panes.read".to_string(), // read alone must NOT grant control
+    ]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("send-to-pane.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::SendToPane {
+            pane_id: pane,
+            text: "echo hi".to_string(),
+            response_file: Some(response_file.to_string_lossy().into_owned()),
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("denial must write the response file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    assert_eq!(
+        v["capability"], "panes.control",
+        "denial object must name the missing capability: {content}"
+    );
+}
+
+/// App WITH `panes.control` sends SendToPane via PGAP: the request reaches the
+/// host pane-IPC handler. The target is the app's own (non-terminal) pane, so
+/// the handler — not the capability gate — answers with its pane-type error,
+/// proving the forward happened.
+#[test]
+fn pgap_send_to_pane_forwarded_with_panes_control() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "panes.control".to_string(),
+    ]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("send-to-pane.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::SendToPane {
+            pane_id: pane,
+            text: "echo hi".to_string(),
+            response_file: Some(response_file.to_string_lossy().into_owned()),
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("forward must write the response file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    assert!(
+        v.get("capability").is_none(),
+        "granted request must not produce a capability denial: {content}"
+    );
+    assert!(
+        v["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("not a terminal pane")),
+        "host handler must answer with its own pane-type error: {content}"
+    );
+}


### PR DESCRIPTION
Stint tasks 0013 + 0014 (no linked GitHub issues — stint is the planning source). Pulled ahead of the S2 chain per the PRM re-order note (2026-06-11).

## Summary

**Host + SDK — capability-gated pane control**
- New sensitive capabilities `panes.read` (ListPanes, GetPaneInfo, GetPreviousPaneInfo, GetPaneState, CapturePane, ListContexts) and `panes.control` (SetPaneTitle, FocusPane, ClosePane, SendToPane, KeyPane, SendAppAction).
- PGAP requests for these variants are now gate-then-forwarded into the same host pane-IPC handlers the CLI uses (extracted as `PlexiApp::handle_pane_ipc_request` — zero duplicated handler logic). Denials write a JSON error to the response_file so callers never hang.
- Ten new async Python SDK wrappers (response-file pattern, `CapabilityDeniedError` on denial).

**Trust — ambient host control removed (stint 0013)**
- App subprocesses no longer inherit `PLEXI_SOCKET`; terminal PTY panes keep it. SECURITY_MODEL.md documents this bluntly: ambient-grant removal, not isolation.

**Assistant — host-mediated tools (stint 0014)**
- CLI-subprocess tools deleted; eight host-mediated tools (open_terminal, open_app, list_panes, get_pane_state, capture_pane, send_command, send_app_action, focus_pane) with a capability-request helper that pops the host grant modal on first use and retries once.
- Manifest declares `ai.query`, `panes.spawn`, `panes.read`, `panes.control`.
- Grant modal now shows a human-readable description per capability.

## Done When

- [x] App without `panes.read`/`panes.control` is denied pane PGAP requests (HostHarness tests)
- [x] App with the capability gets identical results to the CLI socket path
- [x] App subprocess env has no `PLEXI_SOCKET` (env isolation test)
- [x] Assistant has no subprocess/CLI control route; all powers declared in manifest
- [x] cargo test --bin plexi: 836 passed, 0 failed; SDK pytest: 169 passed