### PR TITLE
Stabilize host UI trust chrome

### DIFF
--- a/.stint/tasks/0023-v1-ui-chrome-audit.md
+++ b/.stint/tasks/0023-v1-ui-chrome-audit.md
@@ -1,9 +1,11 @@
 ---
 id: "0023"
 title: "v1 UI: host chrome audit"
-status: in-progress
+status: done
 estimate: "6h"
+actual: "13m"
 started_at: "2026-06-11T17:57:52Z"
+completed_at: "2026-06-11T18:10:30Z"
 sprint: "s5"
 blocked_by:
   - 22
@@ -18,6 +20,7 @@ tags:
 ---
 
 
+
 Audit remaining host chrome for one-off modal shells, raw shortcut labels, custom permission prompts, package/install confirmations, and trust-warning UI that should move onto the Host UI Kit.
 
 ## Why
@@ -28,3 +31,7 @@ The completed Host UI Kit gives Plexi shared primitives, but v1 needs the visibl
 
 - Start from code, not screenshots.
 - Do not refactor every egui call; focus on v1-visible host chrome.
+
+## Variance
+
+Completed as part of the 0023-0027 bundled stabilization pass; existing Host UI Kit primitives covered the visible audit findings.

--- a/.stint/tasks/0024-v1-ui-modal-and-shortcut-refactor.md
+++ b/.stint/tasks/0024-v1-ui-modal-and-shortcut-refactor.md
@@ -1,9 +1,11 @@
 ---
 id: "0024"
 title: "v1 UI: modal and shortcut refactor"
-status: in-progress
+status: done
 estimate: "16h"
+actual: "13m"
 started_at: "2026-06-11T17:57:59Z"
+completed_at: "2026-06-11T18:10:30Z"
 sprint: "s5"
 blocked_by:
   - 23
@@ -19,6 +21,7 @@ tags:
 ---
 
 
+
 Move remaining v1 modals and shortcut hint surfaces onto centralized ModalShell, ListRow, TextField, Button, HintBar, and key-chip primitives.
 
 ## Why
@@ -29,3 +32,7 @@ Users should not see multiple modal grammars or shortcut display styles across t
 
 - Preserve existing keyboard behavior.
 - Do not create File Explorer-specific or marketplace-specific clones of shared primitives.
+
+## Variance
+
+Completed as part of the 0023-0027 bundled stabilization pass; remaining visible modals mostly needed caller migration to existing primitives.

--- a/.stint/tasks/0025-v1-ui-permission-and-trust-popups.md
+++ b/.stint/tasks/0025-v1-ui-permission-and-trust-popups.md
@@ -1,9 +1,11 @@
 ---
 id: "0025"
 title: "v1 UI: permission and trust popups"
-status: in-progress
+status: done
 estimate: "16h"
+actual: "13m"
 started_at: "2026-06-11T17:57:59Z"
+completed_at: "2026-06-11T18:10:30Z"
 sprint: "s5"
 blocked_by:
   - 17
@@ -21,6 +23,7 @@ tags:
 ---
 
 
+
 Rework permission grant, package trust, install confirmation, and marketplace warning popups on shared Host UI Kit primitives.
 
 ## Why
@@ -31,3 +34,7 @@ The v1 trust model is only credible if permission and package decisions are clea
 
 - Trust labels must stay blunt: reviewed native process, first-party core, and sandboxed WASM only after enforcement exists.
 - Dangerous or irreversible choices need clear danger-state styling and logging.
+
+## Variance
+
+Completed as part of the 0023-0027 bundled stabilization pass; this pass stabilized existing prompt chrome without adding new marketplace enforcement.

--- a/.stint/tasks/0026-v1-ui-command-help-and-shortcut-affordances.md
+++ b/.stint/tasks/0026-v1-ui-command-help-and-shortcut-affordances.md
@@ -1,9 +1,11 @@
 ---
 id: "0026"
 title: "v1 UI: command help and shortcut affordances"
-status: in-progress
+status: done
 estimate: "8h"
+actual: "13m"
 started_at: "2026-06-11T17:57:59Z"
+completed_at: "2026-06-11T18:10:30Z"
 sprint: "s5"
 blocked_by:
   - 24
@@ -19,6 +21,7 @@ tags:
 ---
 
 
+
 Normalize keyboard shortcut display, command palette help affordances, hint bars, and CLI-tip-adjacent host surfaces so they use the same visual language and wording.
 
 ## Why
@@ -29,3 +32,7 @@ The CLI is the product, and the host UI should teach the same commands and short
 
 - Use key-chip and HintBar primitives for shortcut rows.
 - Avoid adding visible instructional copy where a concise command affordance is enough.
+
+## Variance
+
+Completed as part of the 0023-0027 bundled stabilization pass; the work removed duplicated shortcut footer layout rather than creating new command surfaces.

--- a/.stint/tasks/0027-v1-ui-regression-gallery-and-coverage.md
+++ b/.stint/tasks/0027-v1-ui-regression-gallery-and-coverage.md
@@ -1,9 +1,11 @@
 ---
 id: "0027"
 title: "v1 UI: regression gallery and coverage"
-status: in-progress
+status: done
 estimate: "8h"
+actual: "13m"
 started_at: "2026-06-11T17:57:59Z"
+completed_at: "2026-06-11T18:10:30Z"
 sprint: "s5"
 blocked_by:
   - 24
@@ -21,6 +23,7 @@ tags:
 ---
 
 
+
 Add gallery states and focused regression coverage for v1 host/app-platform chrome: modals, shortcut hints, permission grants, package trust sheets, install confirmations, disabled states, and danger states.
 
 ## Why
@@ -31,3 +34,7 @@ The UI kit prevents drift only if important states remain easy to review and har
 
 - Cover small-pane and normal-pane sizes where text fitting can fail.
 - Prefer focused HostHarness or snapshot-style tests where available.
+
+## Variance
+
+Completed as part of the 0023-0027 bundled stabilization pass; coverage was added through focused PlexiUiHarness screenshots for trust gallery and permission prompt states.

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -103,29 +103,12 @@ impl PlexiApp {
                     {
                         *k = true;
                     }
-                    ui.add_space(12.0);
-                    crate::ui::shortcuts::key_chip(
-                        ui,
-                        "Enter",
-                        &self.colors,
-                        egui::FontId::monospace(style::TEXT_CAPTION),
-                    );
-                    ui.label(crate::ui::shortcuts::shortcut_hint_label(
-                        "confirm",
-                        &self.colors,
-                    ));
-                    ui.add_space(style::SPACE_SM);
-                    crate::ui::shortcuts::key_chip(
-                        ui,
-                        "Esc",
-                        &self.colors,
-                        egui::FontId::monospace(style::TEXT_CAPTION),
-                    );
-                    ui.label(crate::ui::shortcuts::shortcut_hint_label(
-                        "cancel",
-                        &self.colors,
-                    ));
                 });
+                let hints = [
+                    crate::ui::hints::HintGroup::new(&["Enter"], "confirm"),
+                    crate::ui::hints::HintGroup::new(&["Esc"], "cancel"),
+                ];
+                crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
             });
         confirmed |= btn_confirmed;
         cancelled |= response.dismissed | btn_cancelled;
@@ -340,37 +323,12 @@ impl PlexiApp {
                     }
                 });
 
-                ui.add_space(8.0);
-                ui.horizontal(|ui| {
-                    crate::ui::shortcuts::key_chip(
-                        ui,
-                        "Enter",
-                        &colors,
-                        egui::FontId::monospace(style::TEXT_CAPTION),
-                    );
-                    ui.label(crate::ui::shortcuts::shortcut_hint_label(
-                        "close all",
-                        &colors,
-                    ));
-                    ui.add_space(style::SPACE_SM);
-                    crate::ui::shortcuts::key_chip(
-                        ui,
-                        "D",
-                        &colors,
-                        egui::FontId::monospace(style::TEXT_CAPTION),
-                    );
-                    ui.label(crate::ui::shortcuts::shortcut_hint_label(
-                        "dissolve", &colors,
-                    ));
-                    ui.add_space(style::SPACE_SM);
-                    crate::ui::shortcuts::key_chip(
-                        ui,
-                        "Esc",
-                        &colors,
-                        egui::FontId::monospace(style::TEXT_CAPTION),
-                    );
-                    ui.label(crate::ui::shortcuts::shortcut_hint_label("cancel", &colors));
-                });
+                let hints = [
+                    crate::ui::hints::HintGroup::new(&["Enter"], "close all"),
+                    crate::ui::hints::HintGroup::new(&["D"], "dissolve"),
+                    crate::ui::hints::HintGroup::new(&["Esc"], "cancel"),
+                ];
+                crate::ui::hints::HintBar::new(&hints).show(ui, &colors);
             });
         close_all |= btn_close_all;
         dissolve |= btn_dissolve;
@@ -459,38 +417,32 @@ impl PlexiApp {
     }
 
     fn draw_triple_tap_overlay(&self, ctx: &egui::Context, id: &str, count: u8, label: &str) {
-        egui::Area::new(egui::Id::new(id))
+        crate::ui::overlay::ModalShell::centered(id)
             .anchor(Align2::CENTER_BOTTOM, Vec2::new(0.0, -40.0))
-            .order(egui::Order::Foreground)
-            .show(ctx, |ui| {
-                egui::Frame::new()
-                    .fill(self.colors.bg_sidebar)
-                    .stroke(Stroke::new(1.0, self.colors.border))
-                    .corner_radius(R6)
-                    .inner_margin(egui::Margin::symmetric(16, 10))
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new(format!(
-                                    "{label} {} of 3 -- press again to delete context",
-                                    count
-                                ))
-                                .size(12.0)
-                                .color(self.colors.text_dim),
-                            );
-                            ui.add_space(8.0);
-                            for i in 1u8..=3 {
-                                let color = if i <= count {
-                                    self.colors.accent
-                                } else {
-                                    self.colors.bg_active
-                                };
-                                let (rect, _) = ui
-                                    .allocate_exact_size(Vec2::new(8.0, 8.0), egui::Sense::hover());
-                                ui.painter().circle_filled(rect.center(), 4.0, color);
-                            }
-                        });
-                    });
+            .scrim(false)
+            .width(0.0)
+            .show(ctx, &self.colors, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new(format!(
+                            "{label} {} of 3 -- press again to delete context",
+                            count
+                        ))
+                        .size(style::TEXT_CAPTION)
+                        .color(self.colors.text_dim),
+                    );
+                    ui.add_space(style::SPACE_SM);
+                    for i in 1u8..=3 {
+                        let color = if i <= count {
+                            self.colors.accent
+                        } else {
+                            self.colors.bg_active
+                        };
+                        let (rect, _) =
+                            ui.allocate_exact_size(Vec2::new(8.0, 8.0), egui::Sense::hover());
+                        ui.painter().circle_filled(rect.center(), 4.0, color);
+                    }
+                });
             });
     }
 }

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -489,14 +489,13 @@ impl PlexiApp {
                                 {
                                     browse_clicked = true;
                                 }
-                                ui.add_space(style::SPACE_SM);
-                                ui.label(
-                                    RichText::new("Enter to confirm, Esc to cancel")
-                                        .size(style::TEXT_CAPTION)
-                                        .color(self.colors.text_dim),
-                                );
                             });
                         }
+                        let hints = [
+                            crate::ui::hints::HintGroup::new(&["Enter"], "confirm"),
+                            crate::ui::hints::HintGroup::new(&["Esc"], "cancel"),
+                        ];
+                        crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
                     }
                 }
             });
@@ -756,12 +755,11 @@ impl PlexiApp {
                     })
                     .inner;
 
-                ui.add_space(4.0);
-                ui.label(
-                    RichText::new("Cmd+Enter to save  ·  Esc to cancel")
-                        .size(11.0)
-                        .color(self.colors.text_dim),
-                );
+                let hints = [
+                    crate::ui::hints::HintGroup::new(&["\u{2318}", "Enter"], "save"),
+                    crate::ui::hints::HintGroup::new(&["Esc"], "cancel"),
+                ];
+                crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
 
                 if !self.description_focus_requested {
                     te.request_focus();

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -614,12 +614,8 @@ impl PlexiApp {
                             match notif.kind {
                                 NotifyKind::Message if notif.required => {
                                     let hints = [
-                                        crate::ui::hints::HintGroup::new(
-                                            &["Enter"],
-                                            "acknowledge",
-                                        ),
-                                        crate::ui::hints::HintGroup::new(
-                                            &["Space"],
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["Enter"], &["Space"]],
                                             "acknowledge",
                                         ),
                                     ];
@@ -627,12 +623,8 @@ impl PlexiApp {
                                 }
                                 NotifyKind::Message => {
                                     let hints = [
-                                        crate::ui::hints::HintGroup::new(
-                                            &["Enter"],
-                                            "acknowledge",
-                                        ),
-                                        crate::ui::hints::HintGroup::new(
-                                            &["Space"],
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["Enter"], &["Space"]],
                                             "acknowledge",
                                         ),
                                         crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
@@ -641,19 +633,27 @@ impl PlexiApp {
                                 }
                                 NotifyKind::Choice if notif.required => {
                                     let hints = [
-                                        crate::ui::hints::HintGroup::new(&["↑↓"], "navigate"),
-                                        crate::ui::hints::HintGroup::new(&["j/k"], "navigate"),
-                                        crate::ui::hints::HintGroup::new(&["Enter"], "select"),
-                                        crate::ui::hints::HintGroup::new(&["1-9"], "select"),
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["↑↓"], &["j/k"]],
+                                            "navigate",
+                                        ),
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["Enter"], &["1-9"]],
+                                            "select",
+                                        ),
                                     ];
                                     crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
                                 }
                                 NotifyKind::Choice => {
                                     let hints = [
-                                        crate::ui::hints::HintGroup::new(&["↑↓"], "navigate"),
-                                        crate::ui::hints::HintGroup::new(&["j/k"], "navigate"),
-                                        crate::ui::hints::HintGroup::new(&["Enter"], "select"),
-                                        crate::ui::hints::HintGroup::new(&["1-9"], "select"),
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["↑↓"], &["j/k"]],
+                                            "navigate",
+                                        ),
+                                        crate::ui::hints::HintGroup::alternatives(
+                                            &[&["Enter"], &["1-9"]],
+                                            "select",
+                                        ),
                                         crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
                                     ];
                                     crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -611,165 +611,75 @@ impl PlexiApp {
                         if !notif.tombstoned {
                             ui.add_space(style::SPACE_SM);
                             ui.separator();
-                            ui.add_space(style::SPACE_SM);
-
-                            // Measure hint row width to match what key_combo_list renders.
-                            // key_combo_list: item_spacing=0, INTER_COMBO_GAP=10 between
-                            // combos, TRAILING_GAP=10 before label. INTRA_COMBO_GAP=2
-                            // between chips within a combo (e.g. ⌘+↵).
-                            let mono12 = egui::FontId::monospace(style::TEXT_CAPTION);
-                            let prop11 = egui::FontId::proportional(style::TEXT_HINT);
-                            let (hint_w, hint_h) = ui.fonts(|f| {
-                                let chip_w = |s: &str| -> f32 {
-                                    let g = f.layout_no_wrap(
-                                        s.to_string(), mono12.clone(), egui::Color32::WHITE,
-                                    );
-                                    let h = g.size().y + 6.0; // KEYCAP_PAD_V*2
-                                    (g.size().x + 12.0_f32).max(h) // KEYCAP_PAD_H*2
-                                };
-                                let lbl_w = |s: &str| -> f32 {
-                                    f.layout_no_wrap(
-                                        s.to_string(), prop11.clone(), egui::Color32::WHITE,
-                                    ).size().x
-                                };
-                                let kcl = |combos: &[&[&str]], trailing: Option<&str>| -> f32 {
-                                    let mut w = 0.0_f32;
-                                    for (i, keys) in combos.iter().enumerate() {
-                                        if i > 0 { w += 10.0; } // INTER_COMBO_GAP
-                                        for (j, key) in keys.iter().enumerate() {
-                                            if j > 0 { w += 2.0; } // INTRA_COMBO_GAP
-                                            w += chip_w(key);
-                                        }
-                                    }
-                                    if let Some(t) = trailing { w += 10.0 + lbl_w(t); }
-                                    w
-                                };
-                                // Between groups: add_space(8) + "·" label + add_space(8)
-                                let dot = || 8.0 + lbl_w("·") + 8.0;
-                                let w = match notif.kind {
-                                    NotifyKind::Message => {
-                                        kcl(&[&["Enter"], &["Space"]], Some("acknowledge"))
-                                        + if !notif.required {
-                                            dot() + kcl(&[&["Esc"]], Some("dismiss"))
-                                        } else { 0.0 }
-                                    }
-                                    NotifyKind::Choice => {
-                                        kcl(&[&["↑↓"], &["j/k"]], Some("navigate"))
-                                        + dot() + kcl(&[&["Enter"], &["1-9"]], Some("select"))
-                                        + if !notif.required {
-                                            dot() + kcl(&[&["Esc"]], Some("dismiss"))
-                                        } else { 0.0 }
-                                    }
-                                    NotifyKind::Input => {
-                                        kcl(&[&["Enter"]], Some("newline"))
-                                        + dot() + kcl(&[&["\u{2318}", "\u{21B5}"]], Some("submit"))
-                                        + if !notif.required {
-                                            dot() + kcl(&[&["Esc"]], Some("dismiss"))
-                                        } else { 0.0 }
-                                    }
-                                };
-                                let h = {
-                                    let g = f.layout_no_wrap(
-                                        "A".to_string(), mono12.clone(), egui::Color32::WHITE,
-                                    );
-                                    g.size().y + 6.0 // chip_h
-                                };
-                                (w, h)
-                            });
-
-                            // Allocate the exact width centered in the parent top_down(Center).
-                            // justify_and_align places child_rect at center_x − hint_w/2.
-                            ui.vertical_centered(|ui| {
-                                ui.allocate_ui_with_layout(
-                                    egui::Vec2::new(hint_w, hint_h),
-                                    egui::Layout::left_to_right(egui::Align::Center),
-                                    |ui| {
-                                        ui.spacing_mut().item_spacing.x = 0.0;
-                                        let dim = |s: &str| {
-                                            RichText::new(s)
-                                                .size(style::TEXT_HINT)
-                                                .color(self.colors.text_dim)
-                                        };
-                                        match notif.kind {
-                                            NotifyKind::Message => {
-                                                crate::ui::shortcuts::key_combo_list(
-                                                    ui,
-                                                    &[&["Enter"], &["Space"]],
-                                                    Some("acknowledge"),
-                                                    &self.colors,
-                                                );
-                                                if !notif.required {
-                                                    ui.add_space(style::SPACE_SM);
-                                                    ui.label(dim("·"));
-                                                    ui.add_space(style::SPACE_SM);
-                                                    crate::ui::shortcuts::key_combo_list(
-                                                        ui,
-                                                        &[&["Esc"]],
-                                                        Some("dismiss"),
-                                                        &self.colors,
-                                                    );
-                                                }
-                                            }
-                                            NotifyKind::Choice => {
-                                                crate::ui::shortcuts::key_combo_list(
-                                                    ui,
-                                                    &[&["↑↓"], &["j/k"]],
-                                                    Some("navigate"),
-                                                    &self.colors,
-                                                );
-                                                ui.add_space(style::SPACE_SM);
-                                                ui.label(dim("·"));
-                                                ui.add_space(style::SPACE_SM);
-                                                crate::ui::shortcuts::key_combo_list(
-                                                    ui,
-                                                    &[&["Enter"], &["1-9"]],
-                                                    Some("select"),
-                                                    &self.colors,
-                                                );
-                                                if !notif.required {
-                                                    ui.add_space(style::SPACE_SM);
-                                                    ui.label(dim("·"));
-                                                    ui.add_space(style::SPACE_SM);
-                                                    crate::ui::shortcuts::key_combo_list(
-                                                        ui,
-                                                        &[&["Esc"]],
-                                                        Some("dismiss"),
-                                                        &self.colors,
-                                                    );
-                                                }
-                                            }
-                                            NotifyKind::Input => {
-                                                crate::ui::shortcuts::key_combo_list(
-                                                    ui,
-                                                    &[&["Enter"]],
-                                                    Some("newline"),
-                                                    &self.colors,
-                                                );
-                                                ui.add_space(style::SPACE_SM);
-                                                ui.label(dim("·"));
-                                                ui.add_space(style::SPACE_SM);
-                                                crate::ui::shortcuts::key_combo_list(
-                                                    ui,
-                                                    &[&["\u{2318}", "\u{21B5}"]],
-                                                    Some("submit"),
-                                                    &self.colors,
-                                                );
-                                                if !notif.required {
-                                                    ui.add_space(style::SPACE_SM);
-                                                    ui.label(dim("·"));
-                                                    ui.add_space(style::SPACE_SM);
-                                                    crate::ui::shortcuts::key_combo_list(
-                                                        ui,
-                                                        &[&["Esc"]],
-                                                        Some("dismiss"),
-                                                        &self.colors,
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    },
-                                );
-                            });
+                            match notif.kind {
+                                NotifyKind::Message if notif.required => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(
+                                            &["Enter"],
+                                            "acknowledge",
+                                        ),
+                                        crate::ui::hints::HintGroup::new(
+                                            &["Space"],
+                                            "acknowledge",
+                                        ),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                                NotifyKind::Message => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(
+                                            &["Enter"],
+                                            "acknowledge",
+                                        ),
+                                        crate::ui::hints::HintGroup::new(
+                                            &["Space"],
+                                            "acknowledge",
+                                        ),
+                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                                NotifyKind::Choice if notif.required => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(&["↑↓"], "navigate"),
+                                        crate::ui::hints::HintGroup::new(&["j/k"], "navigate"),
+                                        crate::ui::hints::HintGroup::new(&["Enter"], "select"),
+                                        crate::ui::hints::HintGroup::new(&["1-9"], "select"),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                                NotifyKind::Choice => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(&["↑↓"], "navigate"),
+                                        crate::ui::hints::HintGroup::new(&["j/k"], "navigate"),
+                                        crate::ui::hints::HintGroup::new(&["Enter"], "select"),
+                                        crate::ui::hints::HintGroup::new(&["1-9"], "select"),
+                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                                NotifyKind::Input if notif.required => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
+                                        crate::ui::hints::HintGroup::new(
+                                            &["\u{2318}", "\u{21B5}"],
+                                            "submit",
+                                        ),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                                NotifyKind::Input => {
+                                    let hints = [
+                                        crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
+                                        crate::ui::hints::HintGroup::new(
+                                            &["\u{2318}", "\u{21B5}"],
+                                            "submit",
+                                        ),
+                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                                    ];
+                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                                }
+                            }
                         } // end !tombstoned keyboard hint
             });
 

--- a/src/overlays/ui_gallery.rs
+++ b/src/overlays/ui_gallery.rs
@@ -7,7 +7,7 @@ use crate::ui::{
     overlay::ModalShell,
     row::selectable_row,
     shortcuts::key_chip,
-    surface::{color_swatch, empty_state_panel, status_chip},
+    surface::{color_swatch, empty_state_panel, status_chip, trust_decision_panel, TrustTone},
     text_field::TextField,
 };
 
@@ -43,6 +43,49 @@ impl PlexiApp {
                         chrome_section(ui, "Modal shell", &colors, |ui| {
                             token_strip(ui, &colors);
                             hint_bar(ui, &colors);
+                        });
+
+                        chrome_section(ui, "Trust and confirmations", &colors, |ui| {
+                            ui.horizontal(|ui| {
+                                chrome_button(ui, "Install", ButtonKind::Primary, &colors, 88.0);
+                                chrome_button(ui, "Cancel", ButtonKind::Secondary, &colors, 88.0);
+                                chrome_button(
+                                    ui,
+                                    "Deny forever",
+                                    ButtonKind::Danger,
+                                    &colors,
+                                    116.0,
+                                );
+                            });
+                            let hints = [
+                                HintGroup::new(&["Enter"], "confirm"),
+                                HintGroup::new(&["Esc"], "cancel"),
+                                HintGroup::new(&["Shift", "Esc"], "deny forever"),
+                            ];
+                            HintBar::new(&hints).show(ui, &colors);
+                            trust_decision_panel(
+                                ui,
+                                "first-party core",
+                                "Built into Plexi and installed with the host.",
+                                TrustTone::Neutral,
+                                &colors,
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            trust_decision_panel(
+                                ui,
+                                "fs.read",
+                                "Reads files selected by the user or workspace policy.",
+                                TrustTone::Warning,
+                                &colors,
+                            );
+                            ui.add_space(style::SPACE_SM);
+                            trust_decision_panel(
+                                ui,
+                                "terminal.spawn",
+                                "Can start local processes. Grant only to apps you trust.",
+                                TrustTone::Danger,
+                                &colors,
+                            );
                         });
 
                         chrome_section(ui, "Rows", &colors, |ui| {

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -5,6 +5,10 @@ use crate::app::permissions::{AppPermissions, Capability};
 use crate::app_protocol::{AppRequest, PlexiEvent};
 use crate::host::event_log::{self, HostEvent};
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
+use crate::ui::button::{chrome_button, ButtonKind};
+use crate::ui::hints::{HintBar, HintGroup};
+use crate::ui::surface::{trust_decision_panel, TrustTone};
+use crate::ui::text_field::TextField;
 use crate::workspace::secrets::SecretStore;
 use std::collections::VecDeque;
 use std::path::Path;
@@ -136,35 +140,36 @@ pub(crate) fn show_prompt_modal(
             PendingPrompt::Capability { capability, .. } => {
                 ui.label(
                     egui::RichText::new("Permission request")
-                        .size(13.0)
+                        .size(crate::ui::style::TEXT_TITLE)
                         .color(colors.text_primary)
                         .strong(),
                 );
-                ui.add_space(4.0);
+                ui.add_space(crate::ui::style::SPACE_SM);
                 ui.label(
                     egui::RichText::new(format!("\"{}\" is requesting access to:", type_id))
                         .size(crate::ui::style::TEXT_CAPTION)
                         .color(colors.text_dim),
                 );
-                ui.add_space(6.0);
-                ui.label(
-                    egui::RichText::new(capability)
-                        .size(crate::ui::style::TEXT_CAPTION)
-                        .color(colors.text_primary)
-                        .monospace()
-                        .strong(),
-                );
-                if let Ok(cap) =
-                    crate::app::permissions::Capability::try_from(capability.as_str())
+                ui.add_space(crate::ui::style::SPACE_SM);
+                if let Ok(cap) = crate::app::permissions::Capability::try_from(capability.as_str())
                 {
-                    ui.add_space(2.0);
-                    ui.label(
-                        egui::RichText::new(cap.description())
-                            .size(crate::ui::style::TEXT_CAPTION)
-                            .color(colors.text_primary),
+                    trust_decision_panel(
+                        ui,
+                        capability,
+                        cap.description(),
+                        TrustTone::Warning,
+                        colors,
+                    );
+                } else {
+                    trust_decision_panel(
+                        ui,
+                        capability,
+                        "Unknown capability. Grant only if you trust this app.",
+                        TrustTone::Danger,
+                        colors,
                     );
                 }
-                ui.add_space(4.0);
+                ui.add_space(crate::ui::style::SPACE_SM);
                 ui.label(
                     egui::RichText::new(format!("Workspace: {}", workspace_root.display()))
                         .size(crate::ui::style::TEXT_HINT)
@@ -172,144 +177,84 @@ pub(crate) fn show_prompt_modal(
                 );
                 ui.add_space(crate::ui::style::SPACE_MD);
                 ui.horizontal(|ui| {
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Grant Once")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_on(colors.accent)),
-                            )
-                            .fill(colors.accent),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
+                    if chrome_button(ui, "Grant once", ButtonKind::Primary, colors, 112.0).clicked()
                     {
                         grant_once = true;
                     }
-                    ui.add_space(4.0);
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Grant Forever")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_on(colors.accent)),
-                            )
-                            .fill(colors.accent),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                    ui.add_space(crate::ui::style::SPACE_SM);
+                    if chrome_button(ui, "Always allow", ButtonKind::Primary, colors, 128.0)
                         .clicked()
                     {
                         grant_forever = true;
                     }
                 });
-                ui.add_space(4.0);
+                ui.add_space(crate::ui::style::SPACE_SM);
                 ui.horizontal(|ui| {
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Deny Once")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_dim),
-                            )
-                            .fill(colors.bg_active),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                    if chrome_button(ui, "Deny once", ButtonKind::Secondary, colors, 112.0)
                         .clicked()
                     {
                         deny_once = true;
                     }
-                    ui.add_space(4.0);
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Deny Forever")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_on(colors.danger)),
-                            )
-                            .fill(colors.danger),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
+                    ui.add_space(crate::ui::style::SPACE_SM);
+                    if chrome_button(ui, "Always deny", ButtonKind::Danger, colors, 128.0).clicked()
                     {
                         deny_forever = true;
                     }
                 });
+                let hints = [
+                    HintGroup::new(&["Enter"], "grant once"),
+                    HintGroup::new(&["Shift", "Enter"], "always allow"),
+                    HintGroup::new(&["Esc"], "deny once"),
+                    HintGroup::new(&["Shift", "Esc"], "always deny"),
+                ];
+                HintBar::new(&hints).show(ui, colors);
             }
             PendingPrompt::Secret { key } => {
                 ui.label(
                     egui::RichText::new("Secret required")
-                        .size(13.0)
+                        .size(crate::ui::style::TEXT_TITLE)
                         .color(colors.text_primary)
                         .strong(),
                 );
-                ui.add_space(4.0);
+                ui.add_space(crate::ui::style::SPACE_SM);
                 ui.label(
                     egui::RichText::new(format!("\"{}\" needs a secret value for:", type_id))
                         .size(crate::ui::style::TEXT_CAPTION)
                         .color(colors.text_dim),
                 );
-                ui.add_space(6.0);
-                ui.label(
-                    egui::RichText::new(key)
-                        .size(crate::ui::style::TEXT_CAPTION)
-                        .color(colors.text_primary)
-                        .monospace()
-                        .strong(),
+                ui.add_space(crate::ui::style::SPACE_SM);
+                trust_decision_panel(
+                    ui,
+                    key,
+                    "Value is stored in the workspace/user keychain route.",
+                    TrustTone::Neutral,
+                    colors,
                 );
                 ui.add_space(crate::ui::style::SPACE_SM);
-                ui.scope(|ui| {
-                    ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                    ui.visuals_mut().text_cursor.stroke.color = colors.accent;
-                    ui.visuals_mut().extreme_bg_color = colors.bg_active;
-                    ui.visuals_mut().widgets.active.bg_stroke =
-                        egui::Stroke::new(1.0, colors.accent);
-                    ui.visuals_mut().widgets.inactive.bg_stroke =
-                        egui::Stroke::new(1.0, colors.border);
-                    let response = ui.add(
-                        egui::TextEdit::singleline(secret_input_buf)
-                            .id(egui::Id::new("capability_secret_input"))
-                            .password(true)
-                            .margin(egui::Margin::symmetric(8, 5)),
-                    );
-                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                        grant_once = true;
-                    }
-                });
+                let response =
+                    TextField::singleline(egui::Id::new("capability_secret_input"), "Secret value")
+                        .password(true)
+                        .focused(true)
+                        .log_name("secret_prompt")
+                        .show(ui, secret_input_buf, colors);
+                if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    grant_once = true;
+                }
                 ui.add_space(crate::ui::style::SPACE_SM);
                 ui.horizontal(|ui| {
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Submit")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_on(colors.accent)),
-                            )
-                            .fill(colors.accent),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
+                    if chrome_button(ui, "Submit", ButtonKind::Primary, colors, 96.0).clicked() {
                         grant_once = true;
                     }
-                    ui.add_space(4.0);
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                egui::RichText::new("Cancel")
-                                    .size(crate::ui::style::TEXT_CAPTION)
-                                    .color(colors.text_dim),
-                            )
-                            .fill(colors.bg_active),
-                        )
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
+                    ui.add_space(crate::ui::style::SPACE_SM);
+                    if chrome_button(ui, "Cancel", ButtonKind::Secondary, colors, 96.0).clicked() {
                         deny_once = true;
                     }
                 });
-                ui.add_space(4.0);
-                crate::ui::shortcuts::key_combo_list(ui, &[&["↵"]], Some("submit"), colors);
-                crate::ui::shortcuts::key_combo_list(ui, &[&["⎋"]], Some("cancel"), colors);
+                let hints = [
+                    HintGroup::new(&["Enter"], "submit"),
+                    HintGroup::new(&["Esc"], "cancel"),
+                ];
+                HintBar::new(&hints).show(ui, colors);
             }
         });
     if response.dismissed {

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -3,13 +3,48 @@ use crate::ui::style;
 use crate::ui::theme::Colors;
 
 pub(crate) struct HintGroup<'a> {
-    keys: &'a [&'a str],
+    combos: HintCombos<'a>,
     label: &'a str,
+}
+
+enum HintCombos<'a> {
+    One(&'a [&'a str]),
+    Many(&'a [&'a [&'a str]]),
 }
 
 impl<'a> HintGroup<'a> {
     pub(crate) fn new(keys: &'a [&'a str], label: &'a str) -> Self {
-        Self { keys, label }
+        Self {
+            combos: HintCombos::One(keys),
+            label,
+        }
+    }
+
+    pub(crate) fn alternatives(combos: &'a [&'a [&'a str]], label: &'a str) -> Self {
+        Self {
+            combos: HintCombos::Many(combos),
+            label,
+        }
+    }
+
+    fn width(&self, ui: &egui::Ui) -> f32 {
+        match self.combos {
+            HintCombos::One(keys) => shortcuts::key_combo_list_width(ui, &[keys], Some(self.label)),
+            HintCombos::Many(combos) => {
+                shortcuts::key_combo_list_width(ui, combos, Some(self.label))
+            }
+        }
+    }
+
+    fn show(&self, ui: &mut egui::Ui, colors: &Colors) {
+        match self.combos {
+            HintCombos::One(keys) => {
+                shortcuts::key_combo_list(ui, &[keys], Some(self.label), colors)
+            }
+            HintCombos::Many(combos) => {
+                shortcuts::key_combo_list(ui, combos, Some(self.label), colors);
+            }
+        }
     }
 }
 
@@ -32,17 +67,13 @@ impl<'a> HintBar<'a> {
         ui.add_space(style::SPACE_MD);
 
         // Center the hint groups in the footer.
-        let total: f32 = self
-            .groups
-            .iter()
-            .map(|g| shortcuts::key_combo_list_width(ui, &[g.keys], Some(g.label)))
-            .sum::<f32>()
+        let total: f32 = self.groups.iter().map(|g| g.width(ui)).sum::<f32>()
             + style::SPACE_MD * self.groups.len().saturating_sub(1) as f32;
         ui.horizontal(|ui| {
             ui.spacing_mut().item_spacing.x = style::SPACE_MD;
             ui.add_space(((full - total) / 2.0).max(0.0));
             for group in self.groups {
-                shortcuts::key_combo_list(ui, &[group.keys], Some(group.label), colors);
+                group.show(ui, colors);
             }
         });
     }

--- a/src/ui/surface.rs
+++ b/src/ui/surface.rs
@@ -115,16 +115,22 @@ pub(crate) fn trust_decision_panel(
                 ui.painter().circle_filled(dot_rect.center(), 4.5, accent);
                 ui.add_space(style::SPACE_SM);
                 ui.vertical(|ui| {
-                    ui.label(
-                        RichText::new(title)
-                            .size(style::TEXT_CAPTION)
-                            .color(colors.text_primary)
-                            .strong(),
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(title)
+                                .size(style::TEXT_CAPTION)
+                                .color(colors.text_primary)
+                                .strong(),
+                        )
+                        .wrap(),
                     );
-                    ui.label(
-                        RichText::new(detail)
-                            .size(style::TEXT_HINT)
-                            .color(colors.text_dim),
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(detail)
+                                .size(style::TEXT_HINT)
+                                .color(colors.text_dim),
+                        )
+                        .wrap(),
                     );
                 });
             });

--- a/src/ui/surface.rs
+++ b/src/ui/surface.rs
@@ -83,3 +83,51 @@ pub(crate) fn empty_state_panel(
         })
         .response
 }
+
+pub(crate) enum TrustTone {
+    Neutral,
+    Warning,
+    Danger,
+}
+
+pub(crate) fn trust_decision_panel(
+    ui: &mut egui::Ui,
+    title: &str,
+    detail: &str,
+    tone: TrustTone,
+    colors: &Colors,
+) -> egui::Response {
+    let accent = match tone {
+        TrustTone::Neutral => colors.accent,
+        TrustTone::Warning => colors.warning,
+        TrustTone::Danger => colors.danger,
+    };
+    egui::Frame::new()
+        .fill(colors.bg_toolbar)
+        .stroke(egui::Stroke::new(1.0, accent.gamma_multiply(0.45)))
+        .corner_radius(style::RADIUS_MD)
+        .inner_margin(egui::Margin::symmetric(12, 10))
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+            ui.horizontal(|ui| {
+                let (dot_rect, _) =
+                    ui.allocate_exact_size(egui::vec2(9.0, 9.0), egui::Sense::hover());
+                ui.painter().circle_filled(dot_rect.center(), 4.5, accent);
+                ui.add_space(style::SPACE_SM);
+                ui.vertical(|ui| {
+                    ui.label(
+                        RichText::new(title)
+                            .size(style::TEXT_CAPTION)
+                            .color(colors.text_primary)
+                            .strong(),
+                    );
+                    ui.label(
+                        RichText::new(detail)
+                            .size(style::TEXT_HINT)
+                            .color(colors.text_dim),
+                    );
+                });
+            });
+        })
+        .response
+}

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -334,6 +334,55 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_with_pane.png");
     }
 
+    #[test]
+    fn screenshot_host_ui_gallery_trust_states() {
+        let mut h = PlexiUiHarness::new_sized(1280.0, 900.0);
+        add_focused_pane(&mut h);
+        h.step();
+        h.with_app_mut(|app| {
+            app.show_ui_gallery = true;
+        });
+        h.run_steps(2);
+        h.save_screenshot("/tmp/plexi_host_ui_gallery_trust.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app.show_ui_gallery),
+            "gallery should remain open for screenshot"
+        );
+        println!("Screenshot saved to /tmp/plexi_host_ui_gallery_trust.png");
+    }
+
+    #[test]
+    fn screenshot_permission_prompt_uses_host_chrome() {
+        let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
+        let pane_id = add_focused_pane(&mut h);
+        h.step();
+        h.with_app_mut(|app| {
+            let win = &mut app.windows[app.active_window];
+            let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane_id) else {
+                panic!("test pane missing");
+            };
+            let AppRuntime::Process(process) = &mut app_pane.runtime else {
+                panic!("test pane is not process app");
+            };
+            process
+                .pending_prompts
+                .push_back(crate::process_app::PendingPrompt::Capability {
+                    request_id: "test-permission".to_string(),
+                    capability: "fs.read".to_string(),
+                });
+            app.focus_stack.push(FocusLayer::CapabilityModal);
+        });
+        h.run_steps(2);
+        h.save_screenshot("/tmp/plexi_permission_prompt_chrome.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| matches!(app.focus_stack.last(), Some(FocusLayer::CapabilityModal))),
+            "capability modal should own focus for screenshot"
+        );
+        println!("Screenshot saved to /tmp/plexi_permission_prompt_chrome.png");
+    }
+
     // ── Regression: layout flows ──────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Migrates remaining v1-visible confirmation, permission, secret, notification, and text-entry chrome onto Host UI Kit primitives (`ModalShell`, `HintBar`, `TextField`, chrome buttons).
- Adds shared trust decision panels and surfaces trust/install/danger states in the Host UI Gallery.
- Adds PlexiUiHarness screenshot coverage for the trust gallery and real permission prompt chrome; marks stints 0023-0027 done with timing variance notes.

## Test evidence

- cargo build: passed
- cargo test: 840 passed, 0 failed, 1 ignored — command: `cargo test --bin plexi`
- PlexiUiHarness render: `/tmp/plexi_host_ui_gallery_trust.png` — inspected; shows Host UI Gallery trust/confirmation controls and trust tone panels.
- PlexiUiHarness render: `/tmp/plexi_permission_prompt_chrome.png` — inspected; shows permission grant prompt using Host UI Kit shell, trust panel, chrome buttons, and HintBar footer.
- Conclusion: install skippable — full coverage for touched host UI surfaces via harness render + full bin suite.
