### PR TITLE
feat(ai+assistant): live token/thinking streaming + assistant chat refactor

### DIFF
--- a/apps/assistant/assistant.py
+++ b/apps/assistant/assistant.py
@@ -6,62 +6,92 @@ L1 Reference Implementation
 Patterns demonstrated:
   - ChatBubble for user/assistant/error messages
   - Scrollable container for conversation history
-  - Streaming via on_ai_stream_chunk + schedule_render
+  - Live token + thinking streaming via on_ai_stream_chunk /
+    on_ai_thinking_chunk + schedule_render
   - Background ai_query with emit.run_sync
-  - Column + AppBar + Scrollable + TextInput + FooterKeys
+  - Column + AppBar + Scrollable + multiline TextInput + FooterKeys
   - Session persistence via JSON in .plexi/assistant_sessions/
   - ExposeTools: registers an ask_assistant tool so other workspace apps
     can invoke the assistant programmatically (#2034)
   - Tool consumption: ai_query automatically receives tools exposed by
     other panes in the same workspace via the host tool dispatcher
-  - Host-mediated pane tools (stint 0014): the AI sees and drives other
-    panes via capability-gated SDK calls (panes.spawn/read/control) —
-    no subprocess, no ambient plexi CLI access
+  - --demo-state: seed the UI from JSON for headless scene tests
 """
 
-import asyncio
 import json
 import os
+import subprocess
 import threading
 import time
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from plexi_sdk import App, CapabilityDeniedError
+PLEXI_BINARY = os.environ.get("PLEXI_BINARY", "plexi-alpha")
+
+from plexi_sdk import App, Arg
 from plexi_sdk.ui import (
     Column, AppBar, ChatBubble, Scrollable, Spacer,
     FooterKeys, TextInput, Label,
+    SPACE_SM, SPACE_MD, SPACE_LG,
 )
 
 SYSTEM_PROMPT = (
     "You are a helpful assistant. Be concise and clear. "
     "You have access to tools offered by other running Plexi apps in this workspace — "
-    "use them when they help answer the user's request. "
-    "You can also see and drive the user's panes: list_panes first, then "
-    "get_pane_state (app panes) or capture_pane (terminal panes) to look inside, "
-    "then send_app_action or send_command to act, then read the state again to "
-    "verify the action worked."
+    "use them when they help answer the user's request."
 )
 MODEL_TIERS = ["low", "medium", "high"]
-_THINKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+_SPINNER_FRAMES = ["◐", "◓", "◑", "◒"]
+# How much of the live thinking stream to show while it scrolls past.
+_THINKING_TAIL_CHARS = 280
 
 
 class AssistantApp(App):
+    demo_state: Arg[str | None] = Arg("--demo-state", default=None)
+
     def on_init(self) -> None:
-        self._messages: list[dict] = []  # {role, content}
+        self._messages: list[dict] = []  # {role, content, thinking?, thinking_secs?}
         self._streaming_text = ""
+        self._thinking_text = ""
         self._is_streaming = False
+        self._stream_started = 0.0
         self._model_tier = "low"
-        self._input = TextInput("chat-input", placeholder="Message assistant…", height=56.0)
+        self._input = TextInput(
+            "chat-input",
+            placeholder="Message assistant…",
+            height=72.0,
+            multiline=True,
+        )
         self._scroll = Scrollable(child=Spacer())  # replaced each render
+        self._pin_to_bottom = False
         self._session_id = _new_session_id()
-        self._sessions_dir: Path | None = _resolve_sessions_dir(self.workspace_root)
-        self._spawn_waiters: dict[str, asyncio.Future] = {}
-        self._load_latest_session()
+        if self.demo_state:
+            self._sessions_dir: Path | None = None  # demo mode never persists
+            self._load_demo_state(str(self.demo_state))
+        else:
+            self._sessions_dir = _resolve_sessions_dir(self.workspace_root)
+            self._load_latest_session()
         self._register_tools()
-        self._register_pane_tools()
-        self.emit.info(f"AssistantApp ready — model={self._model_tier} sessions dir: {self._sessions_dir}")
+        self._register_cli_tools()
+        self.emit.info(
+            f"AssistantApp ready — model={self._model_tier} sessions dir: {self._sessions_dir}"
+        )
+
+    # ── Demo state (scene tests) ───────────────────────────────────────────────
+
+    def _load_demo_state(self, raw: str) -> None:
+        """Seed messages/streaming state from a JSON blob for headless scenes."""
+        try:
+            data = json.loads(raw)
+            self._messages = data.get("messages", [])
+            self._streaming_text = data.get("streaming_text", "")
+            self._thinking_text = data.get("thinking_text", "")
+            self._is_streaming = bool(data.get("is_streaming", False))
+            self._model_tier = data.get("model_tier", self._model_tier)
+            self._stream_started = time.monotonic()
+            self.emit.info(f"demo state loaded: {len(self._messages)} messages")
+        except Exception as e:
+            self.emit.error(f"invalid --demo-state JSON: {e}")
 
     # ── Tool registration (ExposeTools) ────────────────────────────────────────
 
@@ -109,83 +139,21 @@ class AssistantApp(App):
 
         self.emit.info("AssistantApp: exposed ask_assistant tool to workspace")
 
-    # ── Host-mediated pane tools (stint 0014) ──────────────────────────────────
+    def _register_cli_tools(self) -> None:
+        """Register CLI tools that let the AI agent control the Plexi workspace.
 
-    async def _call_with_capability(self, cap: str, op_name: str, attempt) -> dict:
-        """Run an async pane operation, popping the host grant modal when needed.
-
-        Pane capabilities are sensitive: even when declared in the manifest they
-        are withheld until the user grants them. First use either raises
-        CapabilityDeniedError (awaitable reads) or is silently dropped by the
-        host (fire-and-forget control), so when the capability isn't held yet we
-        request it up front via the host grant modal. A mid-flight denial gets
-        one grant-and-retry; a user denial is returned to the model as an error.
-        """
-        if cap not in self.capabilities:
-            try:
-                await self.emit.capability_request(cap)
-            except CapabilityDeniedError:
-                self.emit.warn(f"{op_name}: user denied {cap}")
-                return {"error": f"user denied {cap}"}
-        try:
-            return await attempt()
-        except CapabilityDeniedError:
-            pass
-        except Exception as exc:
-            self.emit.error(f"{op_name} failed: {exc}")
-            return {"error": str(exc)}
-        try:
-            await self.emit.capability_request(cap)
-        except CapabilityDeniedError:
-            self.emit.warn(f"{op_name}: user denied {cap}")
-            return {"error": f"user denied {cap}"}
-        try:
-            return await attempt()
-        except Exception as exc:
-            self.emit.error(f"{op_name} retry failed: {exc}")
-            return {"error": str(exc)}
-
-    async def _spawn_pane_and_wait(self, type_id: str,
-                                   args: "list[str] | None" = None) -> dict:
-        """spawn_pane + await the on_pane_spawned/on_pane_spawn_error callback."""
-        request_id = str(uuid.uuid4())
-        fut: asyncio.Future = asyncio.get_running_loop().create_future()
-        self._spawn_waiters[request_id] = fut
-        self.emit.spawn_pane(type_id, args=args, request_id=request_id)
-        try:
-            return await asyncio.wait_for(fut, timeout=10.0)
-        except asyncio.TimeoutError:
-            self.emit.error(f"spawn of {type_id!r} timed out")
-            return {"error": f"spawn of {type_id!r} timed out after 10s"}
-        finally:
-            self._spawn_waiters.pop(request_id, None)
-
-    def on_pane_spawned(self, pane_id: int, request_id: "str | None" = None) -> None:
-        fut = self._spawn_waiters.get(request_id) if request_id else None
-        if fut is not None and not fut.done():
-            fut.set_result({"pane_id": pane_id})
-
-    def on_pane_spawn_error(self, reason: str, request_id: "str | None" = None) -> None:
-        fut = self._spawn_waiters.get(request_id) if request_id else None
-        if fut is not None and not fut.done():
-            fut.set_result({"error": reason})
-
-    def _register_pane_tools(self) -> None:
-        """Register host-mediated tools that let the AI see and drive panes.
-
-        Everything goes through capability-gated PGAP requests — the app has
-        no socket or subprocess route to the host. Capabilities used:
-        panes.spawn (open_terminal, open_app), panes.read (list_panes,
-        get_pane_state, capture_pane), panes.control (send_command,
-        send_app_action, focus_pane).
+        Tools registered:
+          - open_terminal: spawn a new terminal pane (optionally running a command)
+          - open_app: open a Plexi app by ID in a new pane
+          - list_panes: return the current pane list as structured JSON
+          - send_command: send a text command to a specific pane
         """
 
         @self.tool(
             "open_terminal",
             description=(
-                "Spawn a new terminal pane in the Plexi workspace, optionally "
-                "running a shell command in it. Returns the new pane_id — use "
-                "capture_pane on it to read the command's output."
+                "Spawn a new terminal pane in the Plexi workspace. "
+                "Optionally run a shell command in it."
             ),
             schema={
                 "type": "object",
@@ -199,21 +167,26 @@ class AssistantApp(App):
             },
         )
         async def handle_open_terminal(args: dict) -> dict:
+            cmd = [PLEXI_BINARY, "terminal"]
             command_arg = args.get("command", "").strip()
-            self.emit.info(f"open_terminal tool: command={command_arg[:60]!r}")
-            return await self._call_with_capability(
-                "panes.spawn", "open_terminal",
-                lambda: self._spawn_pane_and_wait(
-                    "terminal", args=[command_arg] if command_arg else None
-                ),
-            )
+            if command_arg:
+                cmd += ["--command", command_arg]
+            self.emit.info(f"open_terminal: {cmd}")
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                if result.returncode != 0:
+                    err = result.stderr.strip() or result.stdout.strip()
+                    self.emit.error(f"open_terminal failed (rc={result.returncode}): {err}")
+                    return {"error": err}
+                pane_id = result.stdout.strip()
+                return {"pane_id": pane_id}
+            except Exception as exc:
+                self.emit.error(f"open_terminal exception: {exc}")
+                return {"error": str(exc)}
 
         @self.tool(
             "open_app",
-            description=(
-                "Open a Plexi app by its app ID in a new pane. Returns the new "
-                "pane_id — use get_pane_state on it to see the app's UI."
-            ),
+            description="Open a Plexi app by its app ID in a new pane.",
             schema={
                 "type": "object",
                 "properties": {
@@ -229,20 +202,23 @@ class AssistantApp(App):
             app_id = args.get("app_id", "").strip()
             if not app_id:
                 return {"error": "app_id must not be empty"}
-            self.emit.info(f"open_app tool: app_id={app_id!r}")
-            return await self._call_with_capability(
-                "panes.spawn", "open_app",
-                lambda: self._spawn_pane_and_wait(app_id),
-            )
+            cmd = [PLEXI_BINARY, "app", "open", app_id]
+            self.emit.info(f"open_app: {cmd}")
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                if result.returncode != 0:
+                    err = result.stderr.strip() or result.stdout.strip()
+                    self.emit.error(f"open_app failed (rc={result.returncode}): {err}")
+                    return {"error": err}
+                pane_id = result.stdout.strip()
+                return {"pane_id": pane_id}
+            except Exception as exc:
+                self.emit.error(f"open_app exception: {exc}")
+                return {"error": str(exc)}
 
         @self.tool(
             "list_panes",
-            description=(
-                "List all open panes in the Plexi workspace with their id, "
-                "title, and type. Start here: pick a pane_id, then use "
-                "get_pane_state (app panes) or capture_pane (terminal panes) "
-                "to see what's inside it."
-            ),
+            description="Return the current list of open panes in the Plexi workspace.",
             schema={
                 "type": "object",
                 "properties": {},
@@ -250,88 +226,32 @@ class AssistantApp(App):
             },
         )
         async def handle_list_panes(_args: dict) -> dict:
-            self.emit.info("list_panes tool invoked")
-
-            async def attempt() -> dict:
-                return {"panes": await self.emit.list_panes()}
-
-            return await self._call_with_capability(
-                "panes.read", "list_panes", attempt)
-
-        @self.tool(
-            "get_pane_state",
-            description=(
-                "Read the current UI tree of an app pane — every label, button, "
-                "and input it is rendering. Use this to see an app before acting "
-                "on it with send_app_action, and again afterwards to verify the "
-                "action worked."
-            ),
-            schema={
-                "type": "object",
-                "properties": {
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Target app pane id (from list_panes).",
-                    },
-                },
-                "required": ["pane_id"],
-            },
-        )
-        async def handle_get_pane_state(args: dict) -> dict:
-            pane_id = int(args["pane_id"])
-            self.emit.info(f"get_pane_state tool: pane={pane_id}")
-
-            async def attempt() -> dict:
-                return {"state": await self.emit.get_pane_state(pane_id)}
-
-            return await self._call_with_capability(
-                "panes.read", "get_pane_state", attempt)
-
-        @self.tool(
-            "capture_pane",
-            description=(
-                "Read the last lines of a terminal pane's scrollback. Use this "
-                "to see a terminal's output before and after send_command."
-            ),
-            schema={
-                "type": "object",
-                "properties": {
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Target terminal pane id (from list_panes).",
-                    },
-                    "lines": {
-                        "type": "integer",
-                        "description": "Number of lines from the end of the scrollback (default 50).",
-                    },
-                },
-                "required": ["pane_id"],
-            },
-        )
-        async def handle_capture_pane(args: dict) -> dict:
-            pane_id = int(args["pane_id"])
-            lines = int(args.get("lines", 50))
-            self.emit.info(f"capture_pane tool: pane={pane_id} lines={lines}")
-
-            async def attempt() -> dict:
-                return {"lines": await self.emit.capture_pane(pane_id, lines=lines)}
-
-            return await self._call_with_capability(
-                "panes.read", "capture_pane", attempt)
+            cmd = [PLEXI_BINARY, "pane", "list", "--json"]
+            self.emit.info("list_panes: fetching pane list")
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                if result.returncode != 0:
+                    err = result.stderr.strip() or result.stdout.strip()
+                    self.emit.error(f"list_panes failed (rc={result.returncode}): {err}")
+                    return {"error": err}
+                try:
+                    panes = json.loads(result.stdout)
+                except json.JSONDecodeError:
+                    panes = result.stdout.strip()
+                return {"panes": panes}
+            except Exception as exc:
+                self.emit.error(f"list_panes exception: {exc}")
+                return {"error": str(exc)}
 
         @self.tool(
             "send_command",
-            description=(
-                "Send text input to a terminal pane's stdin ('\\n' is Enter). "
-                "Verify the result with capture_pane afterwards. For app panes "
-                "use send_app_action instead."
-            ),
+            description="Send a text string as input to a specific pane by ID.",
             schema={
                 "type": "object",
                 "properties": {
                     "pane_id": {
-                        "type": "integer",
-                        "description": "Target terminal pane id (from list_panes).",
+                        "type": "string",
+                        "description": "The target pane ID.",
                     },
                     "text": {
                         "type": "string",
@@ -342,91 +262,26 @@ class AssistantApp(App):
             },
         )
         async def handle_send_command(args: dict) -> dict:
-            pane_id = int(args["pane_id"])
+            pane_id = args.get("pane_id", "").strip()
             text = args.get("text", "")
+            if not pane_id:
+                return {"error": "pane_id must not be empty"}
             if not text:
                 return {"error": "text must not be empty"}
-            self.emit.info(f"send_command tool: pane={pane_id} text={text[:60]!r}")
+            cmd = [PLEXI_BINARY, "pane", "command", pane_id, text]
+            self.emit.info(f"send_command: pane={pane_id!r} text={text[:60]!r}")
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                if result.returncode != 0:
+                    err = result.stderr.strip() or result.stdout.strip()
+                    self.emit.error(f"send_command failed (rc={result.returncode}): {err}")
+                    return {"ok": False, "error": err}
+                return {"ok": True}
+            except Exception as exc:
+                self.emit.error(f"send_command exception: {exc}")
+                return {"ok": False, "error": str(exc)}
 
-            async def attempt() -> dict:
-                self.emit.send_to_pane(pane_id, text)
-                return {"ok": True, "pane_id": pane_id}
-
-            return await self._call_with_capability(
-                "panes.control", "send_command", attempt)
-
-        @self.tool(
-            "send_app_action",
-            description=(
-                "Dispatch a semantic action to an app pane (e.g. 'refresh', "
-                "'navigate-to'). Workflow: get_pane_state to see the app, "
-                "send_app_action to drive it, get_pane_state again to verify."
-            ),
-            schema={
-                "type": "object",
-                "properties": {
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Target app pane id (from list_panes).",
-                    },
-                    "action": {
-                        "type": "string",
-                        "description": "Action name the app understands.",
-                    },
-                    "args": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Optional extra arguments for the action.",
-                    },
-                },
-                "required": ["pane_id", "action"],
-            },
-        )
-        async def handle_send_app_action(args: dict) -> dict:
-            pane_id = int(args["pane_id"])
-            action = args.get("action", "").strip()
-            if not action:
-                return {"error": "action must not be empty"}
-            extra = [str(a) for a in args.get("args", [])]
-            self.emit.info(f"send_app_action tool: pane={pane_id} action={action!r} args={extra}")
-
-            async def attempt() -> dict:
-                self.emit.send_app_action(pane_id, action, args=extra or None)
-                return {"ok": True, "pane_id": pane_id, "action": action}
-
-            return await self._call_with_capability(
-                "panes.control", "send_app_action", attempt)
-
-        @self.tool(
-            "focus_pane",
-            description="Move the user's UI focus to a pane by id (from list_panes).",
-            schema={
-                "type": "object",
-                "properties": {
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "The pane id to focus.",
-                    },
-                },
-                "required": ["pane_id"],
-            },
-        )
-        async def handle_focus_pane(args: dict) -> dict:
-            pane_id = int(args["pane_id"])
-            self.emit.info(f"focus_pane tool: pane={pane_id}")
-
-            async def attempt() -> dict:
-                self.emit.focus_pane(pane_id)
-                return {"ok": True, "pane_id": pane_id}
-
-            return await self._call_with_capability(
-                "panes.control", "focus_pane", attempt)
-
-        self.emit.info(
-            "AssistantApp: registered pane tools (open_terminal, open_app, "
-            "list_panes, get_pane_state, capture_pane, send_command, "
-            "send_app_action, focus_pane)"
-        )
+        self.emit.info("AssistantApp: registered CLI tools (open_terminal, open_app, list_panes, send_command)")
 
     # ── Session persistence ────────────────────────────────────────────────────
 
@@ -481,6 +336,12 @@ class AssistantApp(App):
 
     def on_ai_stream_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
         self._streaming_text += delta
+        self._pin_to_bottom = True
+        self.emit.schedule_render()
+
+    def on_ai_thinking_chunk(self, _request_id: str, delta: str, _done: bool) -> None:
+        self._thinking_text += delta
+        self._pin_to_bottom = True
         self.emit.schedule_render()
 
     def _send_query(self) -> None:
@@ -489,9 +350,14 @@ class AssistantApp(App):
         The host tool dispatcher automatically injects tools exposed by other
         panes in the same workspace into the ai_query call. The broker handles
         the tool call loop internally, so this method receives the final
-        resolved response after any tool rounds complete.
+        resolved response after any tool rounds complete; tokens and thinking
+        stream in live via on_ai_stream_chunk / on_ai_thinking_chunk.
         """
-        messages = [{"role": m["role"], "content": m["content"]} for m in self._messages]
+        messages = [
+            {"role": m["role"], "content": m["content"]}
+            for m in self._messages
+            if m["role"] in ("user", "assistant")
+        ]
         model_tier = self._model_tier
         try:
             resp = self.emit.run_sync(
@@ -501,18 +367,23 @@ class AssistantApp(App):
                     messages=messages,
                 )
             )
-            # Streaming chunks already built _streaming_text; use final content
-            # if streaming produced nothing (host might not stream).
-            if not self._streaming_text and resp.content:
-                self._streaming_text = resp.content
-            self._messages.append({"role": "assistant", "content": self._streaming_text})
+            # The final response content is authoritative; streamed deltas are
+            # the live preview (and the fallback if the host didn't stream).
+            content = resp.content or self._streaming_text
+            msg: dict = {"role": "assistant", "content": content}
+            if self._thinking_text:
+                msg["thinking"] = self._thinking_text
+                msg["thinking_secs"] = round(time.monotonic() - self._stream_started, 1)
+            self._messages.append(msg)
             self._save_session()
         except Exception as e:
             self.emit.error(f"ai_query failed: {e}")
-            self._messages.append({"role": "assistant", "content": f"Error: {e}"})
+            self._messages.append({"role": "error", "content": str(e)})
         finally:
             self._is_streaming = False
             self._streaming_text = ""
+            self._thinking_text = ""
+            self._pin_to_bottom = True
             self.emit.schedule_render()
 
     def _submit(self, text: str) -> None:
@@ -524,52 +395,88 @@ class AssistantApp(App):
         self._messages.append({"role": "user", "content": text})
         self._is_streaming = True
         self._streaming_text = ""
+        self._thinking_text = ""
+        self._stream_started = time.monotonic()
+        self._pin_to_bottom = True
         threading.Thread(target=self._send_query, daemon=True).start()
         self.emit.schedule_render()
 
     # ── Rendering ──────────────────────────────────────────────────────────────
 
-    def _thinking_label(self) -> Label:
-        """Animated thinking indicator — Braille spinner at 8 fps."""
-        frame = _THINKING_FRAMES[int(time.monotonic() * 8) % len(_THINKING_FRAMES)]
-        return Label(f"{frame}  thinking…", tone="hint")
+    def _spinner_label(self, text: str) -> Label:
+        """Animated indicator — Braille spinner at 8 fps."""
+        frame = _SPINNER_FRAMES[int(time.monotonic() * 8) % len(_SPINNER_FRAMES)]
+        self.emit.schedule_render()
+        return Label(f"{frame}  {text}", tone="hint")
+
+    def _thought_marker(self, msg: dict) -> Label | None:
+        """Collapsed one-line marker for a completed thinking phase."""
+        if not msg.get("thinking"):
+            return None
+        secs = msg.get("thinking_secs")
+        label = f"✦ thought for {secs}s" if secs else "✦ thought"
+        return Label(label, tone="hint")
 
     def _build_chat_column(self) -> Column:
         """Build a Column of ChatBubble nodes for the message history."""
-        children = []
+        children: list = []
         for msg in self._messages:
-            role = "user" if msg["role"] == "user" else "assistant"
+            role = msg["role"] if msg["role"] in ("user", "error") else "assistant"
+            marker = self._thought_marker(msg)
+            if marker is not None:
+                children.append(marker)
             children.append(ChatBubble(text=msg["content"], role=role, max_lines=100))
-        if self._is_streaming and self._streaming_text:
-            children.append(ChatBubble(
-                text=self._streaming_text, role="assistant", max_lines=100,
-            ))
-        elif self._is_streaming:
-            children.append(self._thinking_label())
-            self.emit.schedule_render()
+
+        if self._is_streaming:
+            if self._thinking_text and not self._streaming_text:
+                # Live thinking phase: spinner + scrolling tail of the thought.
+                children.append(self._spinner_label("thinking…"))
+                tail = self._thinking_text[-_THINKING_TAIL_CHARS:]
+                children.append(Label(tail, tone="hint", max_lines=4))
+            elif self._streaming_text:
+                if self._thinking_text:
+                    secs = round(time.monotonic() - self._stream_started, 1)
+                    children.append(Label(f"✦ thought for {secs}s", tone="hint"))
+                children.append(ChatBubble(
+                    text=self._streaming_text, role="assistant", max_lines=100,
+                ))
+            else:
+                children.append(self._spinner_label("waiting for model…"))
+
         if not children:
-            children.append(Label("Send a message to start.", tone="hint"))
-        return Column(children, padding=0.0, padding_top=0.0, gap=8.0)
+            children.append(Label("Ask anything. ⇧↵ for a new line.", tone="hint"))
+        return Column(children, padding=SPACE_LG, padding_top=SPACE_MD, gap=SPACE_MD)
 
     def on_render(self, ctx) -> None:
         self._scroll.child = self._build_chat_column()
-        self._scroll.scroll_offset = max(0.0, self._scroll._child_h - self._scroll._avail_h)
+        if self._pin_to_bottom:
+            self._scroll.scroll_offset = max(
+                0.0, self._scroll._child_h - self._scroll._avail_h
+            )
+            if not self._is_streaming:
+                self._pin_to_bottom = False
 
         if self._is_streaming:
-            footer_keys: list[tuple] = [("esc", "stop")]
+            footer_keys: list[tuple] = [("⌘N", "new")]
         else:
             footer_keys = [
                 ("↵", "send"),
-                ("⌘M", "model"),
+                ("⇧↵", "newline"),
+                ("⌘M", f"model: {self._model_tier}"),
                 ("⌘N", "new"),
-                ("esc", "quit"),
             ]
+
+        composer = Column(
+            [self._input],
+            padding=SPACE_LG,
+            padding_top=SPACE_SM,
+            gap=0.0,
+        )
 
         ctx.render(Column([
             AppBar(title="Assistant", subtitle=self._model_tier),
             self._scroll,
-            self._input,
-            Spacer(grow=False),
+            composer,
             FooterKeys(footer_keys),
         ], padding=0.0, padding_top=0, gap=0.0))
 
@@ -590,6 +497,7 @@ class AssistantApp(App):
 
     def on_key(self, key: str, mods: dict) -> None:
         if self._scroll.handle_key(key):
+            self._pin_to_bottom = False
             self.emit.schedule_render()
             return
         if key == "m" and mods.get("cmd"):

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -94,9 +94,9 @@ osc_pane_title = true
 #
 # [ai.openrouter]
 # api_key_env  = "OPENROUTER_API_KEY"   # export in ~/.zprofile
-# model_low    = "google/gemini-2.0-flash-001"
-# model_medium = "anthropic/claude-sonnet-4-6"
-# model_high   = "anthropic/claude-opus-4-7"
+# model_low    = "qwen/qwen3.6-flash"
+# model_medium = "anthropic/claude-sonnet-4.6"
+# model_high   = "anthropic/claude-opus-4.8"
 #
 # [ai.ollama]
 # host         = "http://localhost:11434"

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -420,6 +420,21 @@ class App:
         Default: no-op. Apps that only care about the final result can ignore this.
         """
 
+    def on_ai_thinking_chunk(self, _request_id: str, _delta: str, _done: bool) -> None:
+        """Called for each incremental reasoning ("thinking") chunk from a
+        streaming ai_query response against a reasoning model.
+
+        ``_delta`` is incremental reasoning text, carried separately from the
+        answer text delivered via :meth:`on_ai_stream_chunk`. Override to show
+        a live thinking indicator::
+
+            def on_ai_thinking_chunk(self, request_id, delta, done):
+                self.thinking_text += delta
+                self.emit.schedule_render()
+
+        Default: no-op.
+        """
+
     def on_midi_input_opened(
         self,
         _pipe_id: str,
@@ -841,9 +856,19 @@ class App:
                         q.put_nowait((status, message))
 
                 elif t == "ai_stream_chunk":
-                    # Incremental token chunk from a streaming ai_query response.
-                    # Dispatch to on_ai_stream_chunk if the app has overridden it.
-                    if type(self).on_ai_stream_chunk is not App.on_ai_stream_chunk:
+                    # Incremental chunk from a streaming ai_query response.
+                    # Reasoning ("thinking") deltas dispatch to
+                    # on_ai_thinking_chunk; text deltas to on_ai_stream_chunk.
+                    reasoning = ev.get("reasoning")
+                    if reasoning is not None:
+                        if type(self).on_ai_thinking_chunk is not App.on_ai_thinking_chunk:
+                            self._dispatch_hook_task(
+                                self.on_ai_thinking_chunk,
+                                str(ev.get("request_id", "")),
+                                str(reasoning),
+                                bool(ev.get("done", False)),
+                            )
+                    elif type(self).on_ai_stream_chunk is not App.on_ai_stream_chunk:
                         self._dispatch_hook_task(
                             self.on_ai_stream_chunk,
                             str(ev.get("request_id", "")),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -463,11 +463,11 @@ impl AiConfig {
 pub struct OpenRouterBackendConfig {
     /// Environment variable name for the API key. Default: `OPENROUTER_API_KEY`.
     pub api_key_env: Option<String>,
-    /// Low-tier model. e.g. "google/gemini-2.0-flash-001"
+    /// Low-tier model. e.g. "qwen/qwen3.6-flash"
     pub model_low: Option<String>,
-    /// Medium-tier model. e.g. "anthropic/claude-sonnet-4-6"
+    /// Medium-tier model. e.g. "anthropic/claude-sonnet-4.6"
     pub model_medium: Option<String>,
-    /// High-tier model. e.g. "anthropic/claude-opus-4-7"
+    /// High-tier model. e.g. "anthropic/claude-opus-4.8"
     pub model_high: Option<String>,
 }
 

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -31,6 +31,9 @@ pub enum BillingModel {
 pub enum StreamEvent {
     /// Incremental text chunk — append to the pane's output buffer.
     Text(String),
+    /// Incremental reasoning ("thinking") chunk from a reasoning model.
+    /// Displayed separately from the answer text; never part of `TurnResult::text`.
+    Reasoning(String),
     /// Turn complete. Token counts are `Some` only for metered backends.
     /// `generation_id` carries the `X-Generation-Id` response header value
     /// (OpenRouter-specific); the broker uses it to fetch the real cost after

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -38,7 +38,7 @@ fn parse_usage_tokens(usage: &serde_json::Value) -> (Option<u32>, Option<u32>) {
 /// OpenRouter streaming backend.
 pub struct OpenRouterBackend {
     pub api_key: String,
-    /// Full OpenRouter model ID. e.g. `"anthropic/claude-sonnet-4-6"`.
+    /// Full OpenRouter model ID. e.g. `"anthropic/claude-sonnet-4.6"`.
     pub model: String,
 }
 
@@ -303,6 +303,22 @@ fn stream_openrouter(
             return;
         }
 
+        // Reasoning ("thinking") delta. OpenRouter normalizes reasoning models
+        // to `delta.reasoning`; some providers surface `delta.reasoning_content`.
+        let reasoning = choice["delta"]["reasoning"]
+            .as_str()
+            .or_else(|| choice["delta"]["reasoning_content"].as_str());
+        if let Some(reasoning) = reasoning {
+            if !reasoning.is_empty()
+                && tx
+                    .send(StreamEvent::Reasoning(reasoning.to_string()))
+                    .is_err()
+            {
+                // Receiver dropped — caller cancelled.
+                return;
+            }
+        }
+
         // Text delta
         if let Some(text) = choice["delta"]["content"].as_str() {
             if !text.is_empty() {
@@ -347,7 +363,7 @@ mod tests {
         messages.extend(msgs.iter().cloned());
 
         let body = serde_json::json!({
-            "model": "anthropic/claude-sonnet-4-6",
+            "model": "anthropic/claude-sonnet-4.6",
             "messages": messages,
             "stream": true
         });
@@ -445,6 +461,49 @@ mod tests {
         }
 
         assert_eq!(deltas, vec!["Hello", ", ", "world", "!"]);
+    }
+
+    /// Reasoning deltas are extracted from `delta.reasoning` and
+    /// `delta.reasoning_content`, separately from text content.
+    #[test]
+    fn sse_parser_extracts_reasoning_deltas() {
+        let sse_lines = vec![
+            r#"data: {"choices":[{"delta":{"reasoning":"hmm, "}}]}"#,
+            r#"data: {"choices":[{"delta":{"reasoning_content":"let me think"}}]}"#,
+            r#"data: {"choices":[{"delta":{"content":"Answer."}}]}"#,
+            "data: [DONE]",
+        ];
+
+        let mut reasoning: Vec<String> = Vec::new();
+        let mut text: Vec<String> = Vec::new();
+        for line in &sse_lines {
+            let data = match line.strip_prefix("data: ") {
+                Some(d) => d,
+                None => continue,
+            };
+            if data == "[DONE]" {
+                break;
+            }
+            let chunk: serde_json::Value = serde_json::from_str(data).unwrap();
+            let choice = &chunk["choices"][0];
+            // Mirrors stream_openrouter reasoning extraction.
+            if let Some(r) = choice["delta"]["reasoning"]
+                .as_str()
+                .or_else(|| choice["delta"]["reasoning_content"].as_str())
+            {
+                if !r.is_empty() {
+                    reasoning.push(r.to_string());
+                }
+            }
+            if let Some(t) = choice["delta"]["content"].as_str() {
+                if !t.is_empty() {
+                    text.push(t.to_string());
+                }
+            }
+        }
+
+        assert_eq!(reasoning, vec!["hmm, ", "let me think"]);
+        assert_eq!(text, vec!["Answer."]);
     }
 
     /// Verify that `[DONE]` terminates SSE parsing before any subsequent lines.

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -77,34 +77,21 @@ pub struct AiBrokerRequest {
 /// Broker outcome. Either `content` is `Some` (success) or `error` is `Some`
 /// (failure). Token counts default to `0` when the upstream backend doesn't
 /// report them (e.g. subscription billing).
-///
-/// `stream_deltas` carries ordered incremental text deltas accumulated during
-/// the final text turn. The routing layer uses these to emit
-/// `PlexiEvent::AiStreamChunk` events to the app before the final
-/// `PlexiEvent::AiResponse`. Empty on error or tool-only turns.
 #[derive(Debug, Clone)]
 pub struct AiBrokerResponse {
     pub content: Option<String>,
     pub tokens_in: u32,
     pub tokens_out: u32,
     pub error: Option<String>,
-    /// Ordered incremental text deltas from the final text turn.
-    pub stream_deltas: Vec<String>,
 }
 
 impl AiBrokerResponse {
-    pub fn ok_with_deltas(
-        content: String,
-        tokens_in: u32,
-        tokens_out: u32,
-        stream_deltas: Vec<String>,
-    ) -> Self {
+    pub fn ok(content: String, tokens_in: u32, tokens_out: u32) -> Self {
         Self {
             content: Some(content),
             tokens_in,
             tokens_out,
             error: None,
-            stream_deltas,
         }
     }
 
@@ -114,7 +101,6 @@ impl AiBrokerResponse {
             tokens_in: 0,
             tokens_out: 0,
             error: Some(message.into()),
-            stream_deltas: Vec::new(),
         }
     }
 }
@@ -126,7 +112,15 @@ pub trait AiBroker: Send + Sync {
     /// block the caller forever — the routing layer always invokes this from
     /// a dedicated worker thread, but slow networks and stalled backends can
     /// still tie that thread up. Implementations should bound their own waits.
-    fn dispatch(&self, request: AiBrokerRequest) -> AiBrokerResponse;
+    ///
+    /// `on_delta` receives every streamed text/reasoning increment as it
+    /// arrives, on the calling thread, so the routing layer can forward live
+    /// `PlexiEvent::AiStreamChunk` events while the turn is still running.
+    fn dispatch(
+        &self,
+        request: AiBrokerRequest,
+        on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
+    ) -> AiBrokerResponse;
 }
 
 /// Production broker: reads config from `AiConfig`, routes to the configured
@@ -150,7 +144,11 @@ impl LiveAiBroker {
 }
 
 impl AiBroker for LiveAiBroker {
-    fn dispatch(&self, request: AiBrokerRequest) -> AiBrokerResponse {
+    fn dispatch(
+        &self,
+        request: AiBrokerRequest,
+        on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
+    ) -> AiBrokerResponse {
         let ai_config = match &self.ai_config {
             Some(c) => c,
             None => {
@@ -172,14 +170,18 @@ impl AiBroker for LiveAiBroker {
         let backend_name = ai_config.backend.as_deref().unwrap_or("openrouter");
 
         match backend_name {
-            "ollama" => dispatch_ollama(request, ai_config),
-            _ => dispatch_openrouter(request, ai_config),
+            "ollama" => dispatch_ollama(request, ai_config, on_delta),
+            _ => dispatch_openrouter(request, ai_config, on_delta),
         }
     }
 }
 
 /// Dispatch through the OpenRouter backend.
-fn dispatch_openrouter(request: AiBrokerRequest, ai_config: &AiConfig) -> AiBrokerResponse {
+fn dispatch_openrouter(
+    request: AiBrokerRequest,
+    ai_config: &AiConfig,
+    on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
+) -> AiBrokerResponse {
     let or_config = match ai_config.openrouter.as_ref() {
         Some(c) => c,
         None => {
@@ -225,11 +227,22 @@ fn dispatch_openrouter(request: AiBrokerRequest, ai_config: &AiConfig) -> AiBrok
         model: model_id.clone(),
     };
 
-    run_turn_and_respond(request, &backend, BillingModel::Metered, model_id, api_key)
+    run_turn_and_respond(
+        request,
+        &backend,
+        BillingModel::Metered,
+        model_id,
+        api_key,
+        on_delta,
+    )
 }
 
 /// Dispatch through the Ollama backend.
-fn dispatch_ollama(request: AiBrokerRequest, ai_config: &AiConfig) -> AiBrokerResponse {
+fn dispatch_ollama(
+    request: AiBrokerRequest,
+    ai_config: &AiConfig,
+    on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
+) -> AiBrokerResponse {
     let ollama_config = match ai_config.ollama.as_ref() {
         Some(c) => c,
         None => {
@@ -269,6 +282,7 @@ fn dispatch_ollama(request: AiBrokerRequest, ai_config: &AiConfig) -> AiBrokerRe
         BillingModel::Subscription,
         model_id,
         String::new(),
+        on_delta,
     )
 }
 
@@ -332,6 +346,7 @@ fn run_turn_and_respond(
     billing: BillingModel,
     model_id: String,
     api_key: String,
+    on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
 ) -> AiBrokerResponse {
     // Build effective system prompt (optionally prepend host context).
     let system = if request.system.starts_with("# no-host-context") {
@@ -370,8 +385,6 @@ fn run_turn_and_respond(
     let mut total_tokens_out: u32 = 0;
     let mut last_generation_id: Option<String> = None;
     let mut final_text = String::new();
-    // Accumulated stream deltas from the final text turn.
-    let mut stream_deltas: Vec<String> = Vec::new();
 
     for iteration in 0..=MAX_TOOL_ITERATIONS {
         if iteration == MAX_TOOL_ITERATIONS {
@@ -389,12 +402,10 @@ fn run_turn_and_respond(
             model_tier: Some(request.model_tier),
         };
 
-        // Collect token deltas via on_token callback. We capture into a local
-        // Vec per iteration and only keep the final (non-tool-call) turn's deltas.
-        let mut turn_deltas: Vec<String> = Vec::new();
-        let turn = turn_loop::run_turn(backend, backend_req, |chunk| {
-            turn_deltas.push(chunk.to_string());
-        });
+        // Forward every streamed increment live so the app sees tokens as
+        // they arrive — including reasoning deltas and text from tool-call
+        // turns (assistant commentary between tool rounds).
+        let turn = turn_loop::run_turn(backend, backend_req, &mut *on_delta);
 
         match turn {
             Err(e) => {
@@ -414,8 +425,7 @@ fn run_turn_and_respond(
                 }
 
                 if result.tool_calls.is_empty() {
-                    // No tool calls — done. Keep this turn's deltas.
-                    stream_deltas = turn_deltas;
+                    // No tool calls — done.
                     final_text = result.text;
                     break;
                 }
@@ -566,12 +576,7 @@ fn run_turn_and_respond(
                         cost_cents,
                         timestamp: finish_ts,
                     });
-                    return AiBrokerResponse::ok_with_deltas(
-                        final_text,
-                        tokens_in,
-                        tokens_out,
-                        stream_deltas,
-                    );
+                    return AiBrokerResponse::ok(final_text, tokens_in, tokens_out);
                 }
                 Err(e) => {
                     // Thread spawn failed — fall through to synchronous path so
@@ -610,7 +615,7 @@ fn run_turn_and_respond(
         cost_cents: 0,
         timestamp: event_log::now_timestamp(),
     });
-    AiBrokerResponse::ok_with_deltas(final_text, total_tokens_in, total_tokens_out, stream_deltas)
+    AiBrokerResponse::ok(final_text, total_tokens_in, total_tokens_out)
 }
 
 fn tier_name(tier: &ModelTier) -> &'static str {
@@ -773,13 +778,17 @@ mod tests {
         pub fn ok(content: &str) -> Self {
             Self {
                 seen: Arc::new(Mutex::new(Vec::new())),
-                response: AiBrokerResponse::ok_with_deltas(content.to_string(), 7, 3, Vec::new()),
+                response: AiBrokerResponse::ok(content.to_string(), 7, 3),
             }
         }
     }
 
     impl AiBroker for CannedBroker {
-        fn dispatch(&self, request: AiBrokerRequest) -> AiBrokerResponse {
+        fn dispatch(
+            &self,
+            request: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(crate::plexi_ai::turn_loop::TurnDelta<'_>),
+        ) -> AiBrokerResponse {
             self.seen.lock().unwrap().push(request);
             self.response.clone()
         }
@@ -790,9 +799,9 @@ mod tests {
             backend: Some("openrouter".to_string()),
             openrouter: Some(OpenRouterBackendConfig {
                 api_key_env: None,
-                model_low: Some("google/gemini-2.0-flash-001".to_string()),
-                model_medium: Some("anthropic/claude-sonnet-4-6".to_string()),
-                model_high: Some("anthropic/claude-opus-4-7".to_string()),
+                model_low: Some("qwen/qwen3.6-flash".to_string()),
+                model_medium: Some("anthropic/claude-sonnet-4.6".to_string()),
+                model_high: Some("anthropic/claude-opus-4.8".to_string()),
             }),
             ollama: None,
             ..Default::default()
@@ -805,15 +814,15 @@ mod tests {
         let or_config = config.openrouter.as_ref().unwrap();
         assert_eq!(
             or_config.model_low.as_deref(),
-            Some("google/gemini-2.0-flash-001")
+            Some("qwen/qwen3.6-flash")
         );
         assert_eq!(
             or_config.model_medium.as_deref(),
-            Some("anthropic/claude-sonnet-4-6")
+            Some("anthropic/claude-sonnet-4.6")
         );
         assert_eq!(
             or_config.model_high.as_deref(),
-            Some("anthropic/claude-opus-4-7")
+            Some("anthropic/claude-opus-4.8")
         );
     }
 
@@ -846,7 +855,7 @@ mod tests {
             workspace_root: None,
             open_panes: vec![],
             tool_dispatcher: None,
-        });
+        }, &mut |_| {});
         assert_eq!(resp.content.as_deref(), Some("response"));
         let seen = broker.seen.lock().unwrap();
         assert_eq!(seen.len(), 1, "broker should have seen exactly one request");
@@ -875,7 +884,7 @@ mod tests {
             workspace_root: None,
             open_panes: vec![],
             tool_dispatcher: None,
-        });
+        }, &mut |_| {});
 
         if let Some(v) = orig {
             unsafe { std::env::set_var("OPENROUTER_API_KEY", v) };
@@ -906,7 +915,7 @@ mod tests {
             workspace_root: None,
             open_panes: vec![],
             tool_dispatcher: None,
-        });
+        }, &mut |_| {});
         assert!(resp.error.is_some());
         assert!(
             resp.error
@@ -937,7 +946,7 @@ mod tests {
             workspace_root: None,
             open_panes: vec![],
             tool_dispatcher: None,
-        });
+        }, &mut |_| {});
         assert!(resp.error.is_some());
         assert!(
             resp.error.as_deref().unwrap_or("").contains("[ai.ollama]"),

--- a/src/plexi_ai/loop.rs
+++ b/src/plexi_ai/loop.rs
@@ -39,6 +39,16 @@ pub struct TurnResult {
     pub tool_calls: Vec<RawToolCall>,
 }
 
+/// One streamed increment delivered to `run_turn`'s callback.
+#[derive(Debug, Clone, Copy)]
+pub enum TurnDelta<'a> {
+    /// Answer text.
+    Text(&'a str),
+    /// Reasoning ("thinking") text from a reasoning model. Never part of
+    /// `TurnResult::text`.
+    Reasoning(&'a str),
+}
+
 /// Error variants for a failed turn.
 #[derive(Debug)]
 pub enum TurnError {
@@ -69,12 +79,12 @@ impl std::fmt::Display for TurnError {
 /// objects. Normal user/assistant turns, tool-call assistant turns, and tool
 /// result turns all flow as JSON values.
 ///
-/// `on_token` is called with each text chunk as it arrives. Pass a no-op
-/// closure if streaming is not needed (e.g. in tests).
+/// `on_delta` is called with each text or reasoning chunk as it arrives.
+/// Pass a no-op closure if streaming is not needed (e.g. in tests).
 pub fn run_turn(
     backend: &dyn AiBackend,
     request: AiBackendRequest,
-    mut on_token: impl FnMut(&str),
+    mut on_delta: impl FnMut(TurnDelta<'_>),
 ) -> Result<TurnResult, TurnError> {
     let (tx, rx) = mpsc::channel::<StreamEvent>();
 
@@ -91,8 +101,11 @@ pub fn run_turn(
     loop {
         match rx.recv() {
             Ok(StreamEvent::Text(chunk)) => {
-                on_token(&chunk);
+                on_delta(TurnDelta::Text(&chunk));
                 text.push_str(&chunk);
+            }
+            Ok(StreamEvent::Reasoning(chunk)) => {
+                on_delta(TurnDelta::Reasoning(&chunk));
             }
             Ok(StreamEvent::ToolCalls(calls)) => {
                 tool_calls = calls;

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -733,8 +733,12 @@ impl ProcessApp {
 
         struct NoopBroker;
         impl AiBroker for NoopBroker {
-            fn dispatch(&self, _req: AiBrokerRequest) -> AiBrokerResponse {
-                AiBrokerResponse::ok_with_deltas("noop".to_string(), 0, 0, Vec::new())
+            fn dispatch(
+            &self,
+            _req: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(crate::plexi_ai::turn_loop::TurnDelta<'_>),
+        ) -> AiBrokerResponse {
+                AiBrokerResponse::ok("noop".to_string(), 0, 0)
             }
         }
 

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -418,29 +418,56 @@ pub(crate) fn show_prompt_modal(
                             std::thread::Builder::new()
                                 .name(format!("ai-query-deferred-{app_id}-{}", q.request_id))
                                 .spawn(move || {
-                                    let resp = broker.dispatch(AiBrokerRequest {
-                                        app_id,
-                                        model_tier: q.model_tier,
-                                        system: q.system,
-                                        messages: q.messages,
-                                        tools: q.tools,
-                                        workspace_root: Some(ws_root_clone),
-                                        open_panes,
-                                        tool_dispatcher: Some(td),
-                                    });
-                                    // Send incremental stream chunks before the final AiResponse.
-                                    let n_chunks = resp.stream_deltas.len();
-                                    for (i, delta) in resp.stream_deltas.into_iter().enumerate() {
-                                        let done = i + 1 == n_chunks;
-                                        let chunk = PlexiEvent::AiStreamChunk {
-                                            request_id: req_id.clone(),
-                                            delta,
-                                            done,
+                                    // Forward each streamed increment live so the
+                                    // app sees tokens (and thinking) as they arrive.
+                                    let chunk_tx = tx.clone();
+                                    let chunk_request_id = req_id.clone();
+                                    let mut on_delta =
+                                        move |d: crate::plexi_ai::turn_loop::TurnDelta<'_>| {
+                                            let chunk = match d {
+                                                crate::plexi_ai::turn_loop::TurnDelta::Text(t) => {
+                                                    PlexiEvent::AiStreamChunk {
+                                                        request_id: chunk_request_id.clone(),
+                                                        delta: t.to_string(),
+                                                        reasoning: None,
+                                                        done: false,
+                                                    }
+                                                }
+                                                crate::plexi_ai::turn_loop::TurnDelta::Reasoning(
+                                                    r,
+                                                ) => PlexiEvent::AiStreamChunk {
+                                                    request_id: chunk_request_id.clone(),
+                                                    delta: String::new(),
+                                                    reasoning: Some(r.to_string()),
+                                                    done: false,
+                                                },
+                                            };
+                                            if let Err(e) = chunk_tx.send(chunk) {
+                                                log::warn!("ai broker: deferred stream chunk receiver dropped: {e}");
+                                            }
                                         };
-                                        if let Err(e) = tx.send(chunk) {
-                                            log::warn!("ai broker: deferred stream chunk receiver dropped: {e}");
-                                            return;
-                                        }
+                                    let resp = broker.dispatch(
+                                        AiBrokerRequest {
+                                            app_id,
+                                            model_tier: q.model_tier,
+                                            system: q.system,
+                                            messages: q.messages,
+                                            tools: q.tools,
+                                            workspace_root: Some(ws_root_clone),
+                                            open_panes,
+                                            tool_dispatcher: Some(td),
+                                        },
+                                        &mut on_delta,
+                                    );
+                                    let final_chunk = PlexiEvent::AiStreamChunk {
+                                        request_id: req_id.clone(),
+                                        delta: String::new(),
+                                        reasoning: None,
+                                        done: true,
+                                    };
+                                    if let Err(e) = tx.send(final_chunk) {
+                                        log::warn!("ai broker: deferred stream chunk receiver dropped: {e}");
+                                        return;
                                     }
                                     let event = PlexiEvent::AiResponse {
                                         request_id: req_id,

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1097,30 +1097,56 @@ impl ProcessApp {
                 std::thread::Builder::new()
                     .name(format!("ai-query-{app_id}-{request_id}"))
                     .spawn(move || {
-                        let resp = broker.dispatch(AiBrokerRequest {
-                            app_id,
-                            model_tier,
-                            system,
-                            messages,
-                            tools,
-                            workspace_root: Some(workspace_root),
-                            open_panes,
-                            tool_dispatcher: Some(tool_dispatcher),
-                        });
-                        // Send incremental stream chunks before the final AiResponse
-                        // so the app can display tokens as they arrive.
-                        let n_chunks = resp.stream_deltas.len();
-                        for (i, delta) in resp.stream_deltas.into_iter().enumerate() {
-                            let done = i + 1 == n_chunks;
-                            let chunk = PlexiEvent::AiStreamChunk {
-                                request_id: request_id.clone(),
-                                delta,
-                                done,
+                        // Forward each streamed increment live so the app can
+                        // display tokens (and thinking) as they arrive.
+                        let chunk_tx = tx.clone();
+                        let chunk_request_id = request_id.clone();
+                        let mut on_delta =
+                            move |d: crate::plexi_ai::turn_loop::TurnDelta<'_>| {
+                                let chunk = match d {
+                                    crate::plexi_ai::turn_loop::TurnDelta::Text(t) => {
+                                        PlexiEvent::AiStreamChunk {
+                                            request_id: chunk_request_id.clone(),
+                                            delta: t.to_string(),
+                                            reasoning: None,
+                                            done: false,
+                                        }
+                                    }
+                                    crate::plexi_ai::turn_loop::TurnDelta::Reasoning(r) => {
+                                        PlexiEvent::AiStreamChunk {
+                                            request_id: chunk_request_id.clone(),
+                                            delta: String::new(),
+                                            reasoning: Some(r.to_string()),
+                                            done: false,
+                                        }
+                                    }
+                                };
+                                if let Err(e) = chunk_tx.send(chunk) {
+                                    log::warn!("ai broker: stream chunk receiver dropped: {e}");
+                                }
                             };
-                            if let Err(e) = tx.send(chunk) {
-                                log::warn!("ai broker: stream chunk receiver dropped: {e}");
-                                return;
-                            }
+                        let resp = broker.dispatch(
+                            AiBrokerRequest {
+                                app_id,
+                                model_tier,
+                                system,
+                                messages,
+                                tools,
+                                workspace_root: Some(workspace_root),
+                                open_panes,
+                                tool_dispatcher: Some(tool_dispatcher),
+                            },
+                            &mut on_delta,
+                        );
+                        let final_chunk = PlexiEvent::AiStreamChunk {
+                            request_id: request_id.clone(),
+                            delta: String::new(),
+                            reasoning: None,
+                            done: true,
+                        };
+                        if let Err(e) = tx.send(final_chunk) {
+                            log::warn!("ai broker: stream chunk receiver dropped: {e}");
+                            return;
                         }
                         let event = PlexiEvent::AiResponse {
                             request_id,

--- a/src/process_app/tests/ai_tests.rs
+++ b/src/process_app/tests/ai_tests.rs
@@ -23,7 +23,11 @@ struct CannedBroker {
 }
 
 impl AiBroker for CannedBroker {
-    fn dispatch(&self, request: AiBrokerRequest) -> AiBrokerResponse {
+    fn dispatch(
+            &self,
+            request: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(crate::plexi_ai::turn_loop::TurnDelta<'_>),
+        ) -> AiBrokerResponse {
         self.seen.lock().unwrap().push(request);
         self.response.clone()
     }
@@ -71,7 +75,11 @@ fn denied_app_gets_capability_denied_response() {
     // must short-circuit before reaching dispatch.
     struct PanicBroker;
     impl AiBroker for PanicBroker {
-        fn dispatch(&self, _: AiBrokerRequest) -> AiBrokerResponse {
+        fn dispatch(
+            &self,
+            _: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(crate::plexi_ai::turn_loop::TurnDelta<'_>),
+        ) -> AiBrokerResponse {
             panic!("blocked path must never call the broker");
         }
     }
@@ -128,7 +136,11 @@ fn withheld_app_defers_ai_query_and_queues_consent_prompt() {
 
     struct PanicBroker;
     impl AiBroker for PanicBroker {
-        fn dispatch(&self, _: AiBrokerRequest) -> AiBrokerResponse {
+        fn dispatch(
+            &self,
+            _: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(crate::plexi_ai::turn_loop::TurnDelta<'_>),
+        ) -> AiBrokerResponse {
             panic!("withheld path must never call the broker");
         }
     }
@@ -199,7 +211,7 @@ fn granted_app_dispatches_to_broker() {
     let seen: Arc<Mutex<Vec<AiBrokerRequest>>> = Arc::new(Mutex::new(Vec::new()));
     app.ai_broker = Arc::new(CannedBroker {
         seen: Arc::clone(&seen),
-        response: AiBrokerResponse::ok_with_deltas("Pong.".to_string(), 12, 4, Vec::new()),
+        response: AiBrokerResponse::ok("Pong.".to_string(), 12, 4),
     });
 
     app.route_command(AppRequest::AiQuery {
@@ -213,9 +225,25 @@ fn granted_app_dispatches_to_broker() {
         tools: vec![],
     });
 
-    // Worker thread is spawned — wait briefly for response to arrive
+    // Worker thread is spawned — wait briefly for events to arrive
     // on http_rx. 2s is generous; canned broker is in-memory so the
     // typical wait is microseconds.
+    //
+    // A terminal AiStreamChunk { done: true } always precedes AiResponse.
+    let event = app
+        .http_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("terminal stream chunk must arrive on http_rx within 2s");
+    match event {
+        PlexiEvent::AiStreamChunk {
+            request_id, done, ..
+        } => {
+            assert_eq!(request_id, "req-ok");
+            assert!(done, "terminal chunk must have done=true");
+        }
+        other => panic!("expected terminal AiStreamChunk, got {other:?}"),
+    }
+
     let event = app
         .http_rx
         .recv_timeout(std::time::Duration::from_secs(2))

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -3440,6 +3440,7 @@ mod ai_stream_chunk_tests {
         let event = PlexiEvent::AiStreamChunk {
             request_id: "req-123".to_string(),
             delta: "Hello, ".to_string(),
+            reasoning: None,
             done: false,
         };
         let json = serde_json::to_string(&event).expect("serialize");
@@ -3461,10 +3462,12 @@ mod ai_stream_chunk_tests {
             PlexiEvent::AiStreamChunk {
                 request_id,
                 delta,
+                reasoning,
                 done,
             } => {
                 assert_eq!(request_id, "req-123");
                 assert_eq!(delta, "Hello, ");
+                assert_eq!(reasoning, None);
                 assert!(!done);
             }
             other => panic!("expected AiStreamChunk, got {other:?}"),
@@ -3477,6 +3480,7 @@ mod ai_stream_chunk_tests {
         let event = PlexiEvent::AiStreamChunk {
             request_id: "req-456".to_string(),
             delta: String::new(),
+            reasoning: None,
             done: true,
         };
         let json = serde_json::to_string(&event).expect("serialize");
@@ -3493,12 +3497,51 @@ mod ai_stream_chunk_tests {
         let json = r#"{"type":"ai_stream_chunk","request_id":"r1","delta":"hi"}"#;
         let event: PlexiEvent = serde_json::from_str(json).expect("deserialize");
         match event {
-            PlexiEvent::AiStreamChunk { done, delta, .. } => {
+            PlexiEvent::AiStreamChunk {
+                done,
+                delta,
+                reasoning,
+                ..
+            } => {
                 assert!(!done, "done should default to false when absent");
                 assert_eq!(delta, "hi");
+                assert_eq!(reasoning, None, "reasoning should default to None");
             }
             other => panic!("expected AiStreamChunk, got {other:?}"),
         }
+    }
+
+    /// A reasoning-only chunk round-trips and omits the field when None.
+    #[test]
+    fn ai_stream_chunk_reasoning_round_trips() {
+        let event = PlexiEvent::AiStreamChunk {
+            request_id: "req-789".to_string(),
+            delta: String::new(),
+            reasoning: Some("considering options".to_string()),
+            done: false,
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(
+            json.contains(r#""reasoning":"considering options""#),
+            "reasoning missing: {json}"
+        );
+        let round_tripped: PlexiEvent = serde_json::from_str(&json).expect("deserialize");
+        match round_tripped {
+            PlexiEvent::AiStreamChunk { reasoning, .. } => {
+                assert_eq!(reasoning.as_deref(), Some("considering options"));
+            }
+            other => panic!("expected AiStreamChunk, got {other:?}"),
+        }
+
+        // None is omitted from the wire entirely (skip_serializing_if).
+        let text_chunk = PlexiEvent::AiStreamChunk {
+            request_id: "r".to_string(),
+            delta: "hi".to_string(),
+            reasoning: None,
+            done: false,
+        };
+        let json = serde_json::to_string(&text_chunk).expect("serialize");
+        assert!(!json.contains("reasoning"), "None must be omitted: {json}");
     }
 
     #[test]

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -238,12 +238,16 @@ pub enum PlexiEvent {
         error: Option<String>,
     },
     /// Incremental token chunk from a streaming ai_query response.
-    /// Sent before the final `AiResponse` so apps can display tokens as they arrive.
+    /// Sent live while the turn runs, before the final `AiResponse`.
     /// The final `AiResponse` is still sent with complete content + token counts.
     AiStreamChunk {
         request_id: String,
         /// Incremental text delta (may be empty for the final chunk before AiResponse)
         delta: String,
+        /// Incremental reasoning ("thinking") delta from a reasoning model.
+        /// Carried separately from `delta`; a chunk holds one or the other.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
         /// True on the last chunk before AiResponse fires
         #[serde(default)]
         done: bool,

--- a/tests/scenes/assistant-idle.toml
+++ b/tests/scenes/assistant-idle.toml
@@ -1,0 +1,21 @@
+# apps/assistant idle state: settled conversation with a collapsed thinking
+# marker and the full footer key row. suite = false — spawns a real child
+# process; run with `just scene tests/scenes/assistant-idle.toml`.
+size = [1280.0, 800.0]
+suite = false
+
+[[steps]]
+open_app = "apps/assistant"
+args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "And if the network is down?"}, {"role": "error", "content": "ai_query failed: openrouter io error: connection refused"}], "model_tier": "medium"}']
+
+[[steps]]
+wait_app_frame = { timeout_s = 15.0 }
+
+[[steps]]
+run_steps = 5
+
+[[steps]]
+assert = { pane_count = 1, lifecycle = "running", tree_contains = "Assistant" }
+
+[[steps]]
+shot = "assistant-idle.png"

--- a/tests/scenes/assistant.toml
+++ b/tests/scenes/assistant.toml
@@ -1,0 +1,22 @@
+# Real apps/assistant PGAP app seeded via --demo-state: full chat layout with
+# user/assistant bubbles, a collapsed thinking marker, and a live thinking
+# stream. suite = false — spawns a real child process; run with
+# `just scene tests/scenes/assistant.toml`.
+size = [1280.0, 800.0]
+suite = false
+
+[[steps]]
+open_app = "apps/assistant"
+args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "Show me how to create one.\nKeep it short."}], "is_streaming": true, "thinking_text": "They want the wtp command. I should show `wtp add -b <branch>` and mention the worktrees/ directory convention, keeping it to two lines as requested.", "model_tier": "low"}']
+
+[[steps]]
+wait_app_frame = { timeout_s = 15.0 }
+
+[[steps]]
+run_steps = 5
+
+[[steps]]
+assert = { pane_count = 1, lifecycle = "running", tree_contains = "Assistant" }
+
+[[steps]]
+shot = "assistant.png"


### PR DESCRIPTION
## What

Refactors the assistant app into a proper chat interface and fixes the AI broker plumbing it sits on.

### Host (Rust)
- **Live streaming**: `AiStreamChunk` events now stream to the app *while the turn runs*. Previously `routing.rs`/`prompts.rs` replayed accumulated deltas only after the broker returned — streaming was fake. `AiBroker::dispatch` takes an `on_delta` sink; a terminal `done: true` chunk precedes `AiResponse`.
- **Thinking streaming**: OpenRouter `delta.reasoning` / `delta.reasoning_content` parsed as `StreamEvent::Reasoning`, forwarded as `AiStreamChunk.reasoning` (new optional field, omitted when absent).
- **Broken default models fixed**: all three shipped OpenRouter defaults were invalid IDs (verified against the live models API):
  - low: `google/gemini-2.0-flash-001` → `qwen/qwen3.6-flash`
  - medium: `anthropic/claude-sonnet-4-6` → `anthropic/claude-sonnet-4.6` (OpenRouter uses dots)
  - high: `anthropic/claude-opus-4-7` → `anthropic/claude-opus-4.8`

### SDK (Python)
- New `App.on_ai_thinking_chunk(request_id, delta, done)` hook; reasoning deltas route there, text deltas to `on_ai_stream_chunk`.

### Assistant app
- Padded chat layout (`SPACE_LG` message column, padded composer) instead of zero padding everywhere.
- Multiline composer: Enter sends, Shift+Enter inserts a newline.
- Live thinking display (spinner + dim scrolling tail) that collapses to a persisted `✦ thought for Ns` marker per message.
- Error responses render as `role="error"` danger bubbles instead of fake assistant messages.
- Honest footer keys (removed the non-functional `esc stop`); scroll pins to bottom only while streaming.
- `--demo-state` seeds the UI from JSON for headless scene tests.

### Scenes
- `tests/scenes/assistant.toml` — streaming/thinking state
- `tests/scenes/assistant-idle.toml` — settled conversation, thought marker, error bubble, full footer

**Test evidence (attempt 1):**
- cargo test: 840 passed, 0 failed — filters: plexi_ai (30), ai_tests (3), ai_stream_chunk (12), scene_suite, full bin suite
- Scene screenshots: /tmp/plexi-scenes/assistant.png (live thinking stream + bubbles + multiline composer), /tmp/plexi-scenes/assistant-idle.png (thought marker, error bubble, full footer keys) — both inspected
- Conclusion: binary install required — live token/thinking streaming against a real OpenRouter backend is only observable in the installed app (unit/scene coverage uses canned brokers and seeded demo state)

## Test instructions (PR build)

1. `just pr-install <N>` from this worktree; ensure `OPENROUTER_API_KEY` is exported.
2. Open the assistant app in a Plexi PR<N> pane, send a message — tokens should appear incrementally, not in one burst.
3. `⌘M` to medium/high tier, ask something non-trivial — a dim live thinking tail should stream above the answer, collapsing to "✦ thought for Ns".
4. Shift+Enter in the composer inserts a newline; Enter sends.