### PR TITLE
Packages + trust: .plexipkg validator, install trust sheet, permission manager (stints 0015-0017)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,6 +3382,7 @@ dependencies = [
  "egui_term",
  "egui_tiles",
  "fern",
+ "flate2",
  "fontdue",
  "image",
  "include_dir",
@@ -3393,7 +3404,9 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "sha2",
  "taffy",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tiny-skia",
@@ -4053,6 +4066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,6 +4439,17 @@ dependencies = [
  "num-traits",
  "serde",
  "slotmap",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5806,6 +5841,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ wgpu = { version = "24", default-features = false, features = ["wgsl", "metal"] 
 egui-wgpu = "0.31"
 png = "0.17"
 taffy = "0.5"
+# Single-app package artifact `.plexipkg` (stint 0015): gzipped tar + sha256 manifest.
+tar = "0.4"
+flate2 = "1"
+sha2 = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Keychain access via Security.framework C API — no subprocess, distinct error

--- a/apps/permissions/main.py
+++ b/apps/permissions/main.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Permissions — first-party permission manager (stint 0017).
+
+Lists every (app, workspace, capability) permission row the host knows
+about via `list_permissions`, grouped by app, and lets the user flip a
+row to Allow (green) / Ask (yellow) / Block (red) via `set_permission`.
+Both calls gate on the sensitive `permissions.manage` capability.
+"""
+from plexi_sdk import App, CapabilityDeniedError
+from plexi_sdk.ui import AppBar, Column, FooterKeys, Label, SelectList, Spacer
+
+_STATE_BADGE = {"green": "● allow", "yellow": "● ask", "red": "● block"}
+
+
+class Permissions(App):
+    def on_init(self) -> None:
+        self._rows: list[dict] = []
+        self._running: list[str] = []
+        self._loading = True
+        self._denied = False
+        self._error: str | None = None
+        self._list = SelectList([])
+        self.emit.info("Permissions app initialized — fetching permission rows")
+        self.emit.schedule_task(self._refresh())
+
+    # ── Data ──────────────────────────────────────────────────────────────────
+
+    async def _refresh(self) -> None:
+        """Fetch permission rows from the host and rebuild the list."""
+        self._loading = True
+        self._error = None
+        self.emit.schedule_render()
+        try:
+            data = await self.emit.list_permissions()
+            rows = data.get("permissions", [])
+            # Group by app: stable sort by (app_id, capability).
+            rows.sort(key=lambda r: (r.get("app_id", ""), r.get("capability", "")))
+            self._rows = rows
+            self._running = data.get("running", [])
+            self._denied = False
+            self.emit.info(f"Permissions: fetched {len(rows)} rows "
+                           f"({len(self._running)} running apps)")
+        except CapabilityDeniedError as exc:
+            self._denied = True
+            self.emit.warn(f"Permissions: list_permissions denied: {exc}")
+        except Exception as exc:
+            self._error = str(exc)
+            self.emit.error(f"Permissions: list_permissions failed: {exc}")
+        finally:
+            self._loading = False
+            self._rebuild_list()
+            self.emit.schedule_render()
+
+    def _rebuild_list(self) -> None:
+        items = []
+        prev_app = None
+        for row in self._rows:
+            app_id = row.get("app_id", "?")
+            badge = _STATE_BADGE.get(row.get("state", ""), row.get("state", "?"))
+            running = " · running" if app_id in self._running else ""
+            sensitive = " · [sensitive]" if row.get("sensitive") else ""
+            stored = "" if row.get("stored", True) else " · live"
+            group = app_id if app_id != prev_app else " " * len(app_id)
+            prev_app = app_id
+            items.append({
+                "name": f"{group}  {row.get('capability', '?')}",
+                "description": (row.get("description") or "") + running,
+                "trailing": f"{badge}{sensitive}{stored}",
+            })
+        selected = min(self._list.selected_idx, max(0, len(items) - 1))
+        self._list = SelectList(items, selected_idx=selected)
+
+    # ── Mutations ─────────────────────────────────────────────────────────────
+
+    async def _set_selected(self, state: str) -> None:
+        if not self._rows:
+            return
+        row = self._rows[self._list.selected_idx]
+        app_id = row.get("app_id", "")
+        capability = row.get("capability", "")
+        workspace = row.get("workspace")
+        self.emit.info(f"Permissions: set {app_id}/{capability} "
+                       f"@ {workspace} → {state}")
+        try:
+            await self.emit.set_permission(
+                app_id, capability, state, workspace=workspace)
+        except CapabilityDeniedError as exc:
+            self._denied = True
+            self.emit.warn(f"Permissions: set_permission denied: {exc}")
+            self.emit.schedule_render()
+            return
+        except Exception as exc:
+            self._error = str(exc)
+            self.emit.error(f"Permissions: set_permission failed: {exc}")
+            self.emit.schedule_render()
+            return
+        await self._refresh()
+
+    async def _retry_after_denial(self) -> None:
+        """Re-ask for permissions.manage via the host grant modal, then refetch."""
+        try:
+            await self.emit.capability_request("permissions.manage")
+        except CapabilityDeniedError:
+            self.emit.warn("Permissions: user denied permissions.manage again")
+            self.emit.schedule_render()
+            return
+        self._denied = False
+        await self._refresh()
+
+    # ── View ──────────────────────────────────────────────────────────────────
+
+    def view(self):
+        if self._denied:
+            body: list = [
+                Spacer(grow=True),
+                Label("permissions.manage was denied — grant it to manage "
+                      "app permissions", tone="hint"),
+                Spacer(grow=True),
+            ]
+            keys = [("r", "retry"), ("esc", "close")]
+        elif self._loading:
+            body = [Spacer(grow=True),
+                    Label("Loading permissions…", tone="hint"),
+                    Spacer(grow=True)]
+            keys = [("esc", "close")]
+        else:
+            body = []
+            if self._error:
+                body.append(Label(f"Error: {self._error}", tone="hint"))
+            body.append(self._list)
+            keys = [("j/k", "select"), ("g", "allow"), ("y", "ask"),
+                    ("b", "block"), ("r", "refresh"), ("esc", "close")]
+        return Column([
+            AppBar(title="Permissions",
+                   subtitle=f"{len(self._rows)} rows"),
+            *body,
+            FooterKeys(shortcuts=keys),
+        ])
+
+    # ── Keys ──────────────────────────────────────────────────────────────────
+
+    def on_key(self, key: str, _mods: dict) -> None:
+        if self._denied:
+            if key == "r":
+                self.emit.schedule_task(self._retry_after_denial())
+            return
+        if self._list.handle_key(key):
+            self.emit.schedule_render()
+            return
+        if key == "r":
+            self.emit.schedule_task(self._refresh())
+        elif key == "g":
+            self.emit.schedule_task(self._set_selected("green"))
+        elif key == "y":
+            self.emit.schedule_task(self._set_selected("yellow"))
+        elif key == "b":
+            self.emit.schedule_task(self._set_selected("red"))
+
+
+if __name__ == "__main__":
+    Permissions().run()

--- a/apps/permissions/manifest.toml
+++ b/apps/permissions/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "permissions"
+type = "app"
+name = "Permissions"
+entry = "main.py"
+version = "0.1.0"
+description = "View and manage capability permissions for every app"
+watch = true
+
+[app.capabilities]
+capabilities = ["permissions.manage"]
+
+[launch]

--- a/justfile
+++ b/justfile
@@ -216,6 +216,7 @@ merge-pr PR:
 #   just merge-cleanup 2155 feature/2155-foo
 #   just merge-bump
 #   just merge-close 2144 2155
+#   just merge-close-stints 2186 0015 0016
 merge-rebase BRANCH:
     bash scripts/merge-pr.sh rebase {{BRANCH}}
 
@@ -233,6 +234,9 @@ merge-bump:
 
 merge-close ISSUE PR:
     bash scripts/merge-pr.sh close {{ISSUE}} {{PR}}
+
+merge-close-stints PR +STINTS:
+    bash scripts/merge-pr.sh close-stints {{PR}} {{STINTS}}
 
 # Dispatch Claude agents at one or more issues. Labels each "in progress" first
 # to prevent double-claiming when multiple dispatches run close together.

--- a/packs/core.toml
+++ b/packs/core.toml
@@ -25,3 +25,8 @@ version = "bundled"
 id      = "calc"
 source  = "local:calc"
 version = "bundled"
+
+[[app]]
+id      = "permissions"
+source  = "local:permissions"
+version = "bundled"

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -9,6 +9,7 @@
 #   scripts/merge-pr.sh cleanup <PR> <BRANCH>  channel-clean + wtp remove + remote branch delete
 #   scripts/merge-pr.sh bump                   just bump + git push
 #   scripts/merge-pr.sh close <ISSUE> <PR>     strip pipeline labels + close issue + append ship log
+#   scripts/merge-pr.sh close-stints <PR> <ID...>
 #
 # Call sub-steps directly to resume after a failure (e.g. rebase conflict).
 set -euo pipefail
@@ -91,6 +92,60 @@ do_close() {
         "$CURRENT_BODY" "$PR" "$VERSION" "$(date +%Y-%m-%d)")"
 }
 
+task_file_for_stint() {
+    local STINT="$1"
+    find .stint/tasks -maxdepth 1 -name "${STINT}-*.md" -print -quit
+}
+
+resolve_stints() {
+    local BRANCH="$1"
+    local PR_BODY="${2:-}"
+    local STINT
+    {
+        printf '%s\n' "$BRANCH" | grep -Eo 'stint-[0-9-]+' | grep -Eo '[0-9]{4}' || true
+        printf '%s\n' "$PR_BODY" | grep -Ei 'stint' | grep -Eo '[0-9]{4}' || true
+    } | sort -u | while IFS= read -r STINT; do
+        [ -n "$STINT" ] || continue
+        if [ -z "$(task_file_for_stint "$STINT")" ]; then
+            echo "ERROR: PR references stint task $STINT, but no .stint/tasks/${STINT}-*.md exists" >&2
+            return 1
+        fi
+        printf '%s\n' "$STINT"
+    done
+}
+
+join_by() {
+    local IFS="$1"
+    shift
+    printf '%s\n' "$*"
+}
+
+do_close_stints() {
+    local PR="$1"
+    shift
+    local VERSION
+    local STINTS
+    local STINT
+
+    VERSION=$(grep '^version' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+    STINTS=$(join_by ", " "$@")
+
+    echo "==> Closing stint task(s): $STINTS"
+    for STINT in "$@"; do
+        stint done "$STINT"
+    done
+
+    if git diff --quiet -- .stint/tasks; then
+        echo "==> No stint task changes to commit"
+        return
+    fi
+
+    git add .stint/tasks
+    git commit -m "chore(stint): close tasks $STINTS after PR #$PR"
+    git push
+    echo "==> Closed stint task(s) $STINTS on alpha v$VERSION"
+}
+
 resolve_issue() {
     local PR="$1"
     local BRANCH="$2"
@@ -120,8 +175,6 @@ resolve_issue() {
             ;;
     esac
 
-    echo "ERROR: could not resolve GitHub issue for PR #$PR ($BRANCH)" >&2
-    echo "Add a closing keyword like 'Closes #1234' to the PR body or use a numeric feature/fix branch." >&2
     return 1
 }
 
@@ -157,16 +210,48 @@ test_resolve_issue() {
     echo "resolve_issue tests passed"
 }
 
+test_resolve_stints() {
+    local actual
+    actual=$(resolve_stints "feature/stint-0015-0016-0017-packages-trust" "")
+    [ "$actual" = "$(printf '0015\n0016\n0017')" ] || {
+        echo "expected stint ids from branch, got '$actual'" >&2
+        return 1
+    }
+
+    actual=$(resolve_stints "feature/packages-trust" "Stint tasks 0015, 0016, 0017")
+    [ "$actual" = "$(printf '0015\n0016\n0017')" ] || {
+        echo "expected stint ids from PR body, got '$actual'" >&2
+        return 1
+    }
+
+    if resolve_stints "feature/stint-9999-missing" "" >/dev/null 2>&1; then
+        echo "expected missing stint task to fail" >&2
+        return 1
+    fi
+
+    echo "resolve_stints tests passed"
+}
+
 # --- Dispatch ---
 CMD="${1:-}"
 case "$CMD" in
     test-resolve-issue) test_resolve_issue ;;
+    test-resolve-stints) test_resolve_stints ;;
     rebase)   do_rebase "${2:?BRANCH required}" ;;
     squash)   do_squash "${2:?PR required}" ;;
     sync)     do_sync ;;
     cleanup)  do_cleanup "${2:?PR required}" "${3:?BRANCH required}" ;;
     bump)     do_bump ;;
     close)    do_close "${2:?ISSUE required}" "${3:?PR required}" ;;
+    close-stints)
+        PR="${2:?PR required}"
+        shift 2
+        [ "$#" -gt 0 ] || {
+            echo "ERROR: at least one stint task id is required" >&2
+            exit 1
+        }
+        do_close_stints "$PR" "$@"
+        ;;
     *)
         PR="${1:?PR number required}"
 
@@ -174,9 +259,26 @@ case "$CMD" in
         BRANCH=$(echo "$INFO" | jq -r .branch)
         STATE=$(echo "$INFO" | jq -r .state)
         PR_BODY=$(echo "$INFO" | jq -r '.body // ""')
-        ISSUE=$(resolve_issue "$PR" "$BRANCH" "$PR_BODY")
+        ISSUE=$(resolve_issue "$PR" "$BRANCH" "$PR_BODY" || true)
+        STINTS=""
+        STINT_ARGS=()
+        if [ -z "$ISSUE" ]; then
+            STINTS=$(resolve_stints "$BRANCH" "$PR_BODY")
+            if [ -z "$STINTS" ]; then
+                echo "ERROR: could not resolve GitHub issue or stint tasks for PR #$PR ($BRANCH)" >&2
+                echo "Add a closing keyword like 'Closes #1234', use a numeric feature/fix branch, or include stint ids in the branch/body." >&2
+                exit 1
+            fi
+            while IFS= read -r STINT; do
+                [ -n "$STINT" ] && STINT_ARGS+=("$STINT")
+            done <<< "$STINTS"
+        fi
 
-        echo "==> PR #$PR: $BRANCH (issue #$ISSUE, state: $STATE)"
+        if [ -n "$ISSUE" ]; then
+            echo "==> PR #$PR: $BRANCH (issue #$ISSUE, state: $STATE)"
+        else
+            echo "==> PR #$PR: $BRANCH (stint tasks: $(join_by ", " "${STINT_ARGS[@]}"), state: $STATE)"
+        fi
 
         # Fail fast if root worktree has uncommitted changes
         DIRTY=$(git status --porcelain | grep -v "^??" || true)
@@ -196,10 +298,18 @@ case "$CMD" in
         do_sync
         do_cleanup "$PR" "$BRANCH"
         do_bump
-        do_close "$ISSUE" "$PR"
+        if [ -n "$ISSUE" ]; then
+            do_close "$ISSUE" "$PR"
+        else
+            do_close_stints "$PR" "${STINT_ARGS[@]}"
+        fi
 
         VERSION=$(grep '^version' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
         echo ""
-        echo "==> Done: PR #$PR merged → alpha v$VERSION, issue #$ISSUE closed"
+        if [ -n "$ISSUE" ]; then
+            echo "==> Done: PR #$PR merged → alpha v$VERSION, issue #$ISSUE closed"
+        else
+            echo "==> Done: PR #$PR merged → alpha v$VERSION, stint task(s) $(join_by ", " "${STINT_ARGS[@]}") closed"
+        fi
         ;;
 esac

--- a/sdk/python/plexi_sdk/_emitter.py
+++ b/sdk/python/plexi_sdk/_emitter.py
@@ -45,6 +45,8 @@ CAPABILITY_REGISTRY: dict[str, str] = {
     "close_pane": "panes.control",
     "set_pane_title": "panes.control",
     "send_app_action": "panes.control",
+    "list_permissions": "permissions.manage",
+    "set_permission": "permissions.manage",
     "open_midi_input": "midi.in",
     "send_midi": "midi.out",
     "open_video": "video.playback",
@@ -882,6 +884,71 @@ class Emitter:
         if args:
             cmd["args"] = list(args)
         _emit(cmd)
+
+    # ── Permission management (stint 0017) ──────────────────────────────────
+    #
+    # Host-mediated equivalents of the permission manager surface. Both gate
+    # on `permissions.manage` — a sensitive capability, so the host may show
+    # a consent modal before replying. The response-file poll therefore uses
+    # a 60s timeout (vs. the 10s pane-IPC default) to leave room for the
+    # user to answer the modal.
+
+    @_blocking_emit_method
+    async def list_permissions(self) -> dict:
+        """List permission state across apps. Requires ``permissions.manage``.
+
+        Returns ``{"permissions": [...], "running": [...]}`` — one row per
+        stored `permissions.toml` entry plus one row per live capability of a
+        running app with no stored entry. Each row has ``app_id``,
+        ``workspace``, ``capability``, ``state`` ("green"|"yellow"|"red"),
+        ``stored``, ``sensitive``, and ``description``.
+
+        Raises ``CapabilityDeniedError`` if the host denies
+        ``permissions.manage``.
+        """
+        response_file = self._pane_response_file("list-permissions")
+        _emit({
+            "type": "list_permissions",
+            "response_file": response_file,
+        })
+        return await self._await_pane_response(
+            response_file, "list_permissions", timeout=60.0)
+
+    @_blocking_emit_method
+    async def set_permission(self, app_id: str, capability: str, state: str,
+                             workspace: "str | None" = None) -> dict:
+        """Set the stored permission state for an (app, workspace, capability)
+        triple. Requires ``permissions.manage``.
+
+        Args:
+            app_id: Target app id.
+            capability: Capability string, e.g. "panes.read".
+            state: One of "green" (allow), "yellow" (ask), "red" (block).
+            workspace: Workspace root the entry applies to. When omitted, the
+                workspace of a running app with ``app_id`` is used; fails if
+                no such app is running.
+
+        Returns ``{"ok": True}``. Raises ``CapabilityDeniedError`` if the
+        host denies ``permissions.manage``, and ``RuntimeError`` when the
+        host replies with any other error (unknown capability/state strings
+        fail closed).
+        """
+        response_file = self._pane_response_file("set-permission")
+        cmd: "dict[str, object]" = {
+            "type": "set_permission",
+            "app_id": app_id,
+            "capability": capability,
+            "state": state,
+            "response_file": response_file,
+        }
+        if workspace is not None:
+            cmd["workspace"] = workspace
+        _emit(cmd)
+        data = await self._await_pane_response(
+            response_file, "set_permission", timeout=60.0)
+        if isinstance(data, dict) and "error" in data:
+            raise RuntimeError(f"set_permission: {data['error']}")
+        return data
 
     def query_context_state(self, context_id: int) -> None:
         """Query the state of a context (#1518).

--- a/sdk/python/tests/test_permissions_wrappers.py
+++ b/sdk/python/tests/test_permissions_wrappers.py
@@ -1,0 +1,122 @@
+"""Tests for the permissions.manage SDK wrappers (stint 0017).
+
+Fakes the host: patches `plexi_sdk._emitter._emit` to capture the emitted
+command and write the JSON response file the wrapper polls for.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from plexi_sdk._emitter import CAPABILITY_REGISTRY
+from plexi_sdk._types import CapabilityDeniedError
+
+
+def _make_app():
+    from plexi_sdk._app import App
+
+    app = App.__new__(App)
+    App.__init__(app)
+    return app
+
+
+def _fake_host(reply: object):
+    """Return (emitted_commands, _emit side effect) writing `reply` to the
+    response file of every captured command, like the host would."""
+    emitted: list[dict] = []
+
+    def side_effect(cmd: dict) -> None:
+        emitted.append(cmd)
+        with open(cmd["response_file"], "w") as f:
+            f.write(json.dumps(reply))
+
+    return emitted, side_effect
+
+
+# ── list_permissions ──────────────────────────────────────────────────────────
+
+def test_list_permissions_emits_and_returns_host_reply():
+    app = _make_app()
+    reply = {
+        "permissions": [{
+            "app_id": "snake",
+            "workspace": "/tmp/ws",
+            "capability": "panes.read",
+            "state": "green",
+            "stored": True,
+            "sensitive": True,
+            "description": "Read pane state",
+        }],
+        "running": ["snake"],
+    }
+    emitted, side_effect = _fake_host(reply)
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        result = asyncio.run(app.emit.list_permissions())
+
+    assert result == reply
+    assert len(emitted) == 1
+    assert emitted[0]["type"] == "list_permissions"
+    assert emitted[0]["response_file"].endswith(".json")
+
+
+def test_list_permissions_raises_on_capability_denial():
+    app = _make_app()
+    denial = {"capability": "permissions.manage", "error": "denied by user"}
+    _, side_effect = _fake_host(denial)
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        with pytest.raises(CapabilityDeniedError, match="denied by user"):
+            asyncio.run(app.emit.list_permissions())
+
+
+# ── set_permission ────────────────────────────────────────────────────────────
+
+def test_set_permission_ok_with_workspace():
+    app = _make_app()
+    emitted, side_effect = _fake_host({"ok": True})
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        result = asyncio.run(app.emit.set_permission(
+            "snake", "panes.read", "red", workspace="/tmp/ws"))
+
+    assert result == {"ok": True}
+    assert len(emitted) == 1
+    cmd = emitted[0]
+    assert cmd["type"] == "set_permission"
+    assert cmd["app_id"] == "snake"
+    assert cmd["capability"] == "panes.read"
+    assert cmd["state"] == "red"
+    assert cmd["workspace"] == "/tmp/ws"
+
+
+def test_set_permission_omits_workspace_when_none():
+    app = _make_app()
+    emitted, side_effect = _fake_host({"ok": True})
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        asyncio.run(app.emit.set_permission("snake", "panes.read", "green"))
+
+    assert "workspace" not in emitted[0]
+
+
+def test_set_permission_raises_runtime_error_on_host_error():
+    app = _make_app()
+    _, side_effect = _fake_host({"error": "unknown capability 'nope'"})
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        with pytest.raises(RuntimeError, match="unknown capability"):
+            asyncio.run(app.emit.set_permission("snake", "nope", "green"))
+
+
+def test_set_permission_raises_on_capability_denial():
+    app = _make_app()
+    denial = {"capability": "permissions.manage", "error": "denied by user"}
+    _, side_effect = _fake_host(denial)
+    with patch("plexi_sdk._emitter._emit", side_effect=side_effect):
+        with pytest.raises(CapabilityDeniedError, match="denied by user"):
+            asyncio.run(app.emit.set_permission("snake", "panes.read", "red"))
+
+
+# ── registry ──────────────────────────────────────────────────────────────────
+
+def test_capability_registry_maps_permission_wrappers():
+    assert CAPABILITY_REGISTRY["list_permissions"] == "permissions.manage"
+    assert CAPABILITY_REGISTRY["set_permission"] == "permissions.manage"

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1601,9 +1601,217 @@ impl PlexiApp {
                 log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);
                 self.push_pane_to_subcontext(name.clone());
             }
+            crate::app_protocol::AppRequest::ListPermissions { response_file } => {
+                log::info!("pane_ipc: kind=list_permissions response_file={response_file:?}");
+                self.handle_list_permissions(response_file);
+            }
+            crate::app_protocol::AppRequest::SetPermission {
+                app_id,
+                workspace,
+                capability,
+                state,
+                response_file,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=set_permission app_id={app_id} workspace={workspace:?} \
+                     capability={capability} state={state} response_file={response_file:?}"
+                );
+                self.handle_set_permission(
+                    app_id,
+                    workspace.as_deref(),
+                    capability,
+                    state,
+                    response_file,
+                );
+            }
             _ => {
                 log::warn!("pane_ipc: unsupported command kind, dropping");
             }
+        }
+    }
+
+    /// `ListPermissions` host handler (stint 0017). Writes the permission
+    /// inventory JSON documented on the `AppRequest::ListPermissions` variant:
+    /// one row per stored `permissions.toml` entry (`stored: true`) plus one
+    /// row per live granted/blocked capability of a running app that has no
+    /// stored entry (`stored: false`), and the list of running app ids.
+    fn handle_list_permissions(&mut self, response_file: &str) {
+        use crate::app::permissions::PermissionStore;
+        use crate::host::pane::{AppRuntime, Pane};
+
+        let store = PermissionStore::load_or_default(&self.permission_store_dir);
+        let mut rows: Vec<serde_json::Value> = Vec::new();
+        let mut stored_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (app_id, workspace, cap, state) in store.iter_entries() {
+            stored_keys.insert(format!("{app_id}::{workspace}::{}", cap.as_str()));
+            rows.push(serde_json::json!({
+                "app_id": app_id,
+                "workspace": workspace,
+                "capability": cap.as_str(),
+                "state": state.as_str(),
+                "stored": true,
+                "sensitive": cap.is_sensitive(),
+                "description": cap.description(),
+            }));
+        }
+
+        let mut running: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for win in &self.windows {
+            for pane in win.panes.values() {
+                let Pane::App(app_pane) = pane else { continue };
+                let AppRuntime::Process(proc) = &app_pane.runtime else {
+                    continue;
+                };
+                running.insert(proc.type_id.clone());
+                let workspace = proc
+                    .workspace_root
+                    .canonicalize()
+                    .unwrap_or_else(|_| proc.workspace_root.clone())
+                    .display()
+                    .to_string();
+                let live = proc
+                    .permissions
+                    .capabilities
+                    .iter()
+                    .map(|&cap| (cap, "green"))
+                    .chain(proc.permissions.blocked.iter().map(|&cap| (cap, "red")));
+                for (cap, state) in live {
+                    let key = format!("{}::{}::{}", proc.type_id, workspace, cap.as_str());
+                    if !stored_keys.insert(key) {
+                        continue; // already covered by a stored row
+                    }
+                    rows.push(serde_json::json!({
+                        "app_id": proc.type_id,
+                        "workspace": workspace,
+                        "capability": cap.as_str(),
+                        "state": state,
+                        "stored": false,
+                        "sensitive": cap.is_sensitive(),
+                        "description": cap.description(),
+                    }));
+                }
+            }
+        }
+
+        let body = serde_json::json!({
+            "permissions": rows,
+            "running": running.into_iter().collect::<Vec<_>>(),
+        })
+        .to_string();
+        if let Err(e) = std::fs::write(response_file, &body) {
+            log::error!(
+                "pane_ipc: list_permissions: could not write response file {response_file:?}: {e}"
+            );
+        }
+    }
+
+    /// `SetPermission` host handler (stint 0017). Persists the new state to
+    /// `permissions.toml` and live-updates every running app instance with a
+    /// matching (app_id, workspace) so a revocation takes effect on the app's
+    /// next request. Unknown capability/state strings fail closed with an
+    /// error reply; a missing workspace fails unless the app is running.
+    fn handle_set_permission(
+        &mut self,
+        app_id: &str,
+        workspace: Option<&str>,
+        capability: &str,
+        state: &str,
+        response_file: &str,
+    ) {
+        use crate::app::permissions::{Capability, PermissionState, PermissionStore};
+        use crate::host::pane::{AppRuntime, Pane};
+
+        let outcome: Result<(), String> = (|| {
+            let cap = Capability::try_from(capability).map_err(|e| e.to_string())?;
+            let new_state = PermissionState::try_from(state)?;
+
+            let ws: std::path::PathBuf = match workspace {
+                Some(w) => std::path::PathBuf::from(w),
+                None => self
+                    .windows
+                    .iter()
+                    .find_map(|win| {
+                        win.panes.values().find_map(|pane| {
+                            let Pane::App(app_pane) = pane else {
+                                return None;
+                            };
+                            let AppRuntime::Process(proc) = &app_pane.runtime else {
+                                return None;
+                            };
+                            (proc.type_id == app_id).then(|| proc.workspace_root.clone())
+                        })
+                    })
+                    .ok_or_else(|| {
+                        format!(
+                            "workspace required: app '{app_id}' is not running; \
+                             pass workspace explicitly"
+                        )
+                    })?,
+            };
+
+            let mut store = PermissionStore::load_or_default(&self.permission_store_dir);
+            store.set(app_id, &ws, cap, new_state);
+            store.save();
+
+            // Live-update every running instance of this app in this workspace.
+            let ws_canonical = ws.canonicalize().unwrap_or_else(|_| ws.clone());
+            for win in &mut self.windows {
+                for pane in win.panes.values_mut() {
+                    let Pane::App(app_pane) = pane else { continue };
+                    let AppRuntime::Process(proc) = &mut app_pane.runtime else {
+                        continue;
+                    };
+                    if proc.type_id != app_id {
+                        continue;
+                    }
+                    let proc_ws = proc
+                        .workspace_root
+                        .canonicalize()
+                        .unwrap_or_else(|_| proc.workspace_root.clone());
+                    if proc_ws != ws_canonical {
+                        continue;
+                    }
+                    match new_state {
+                        PermissionState::Green => {
+                            proc.permissions.capabilities.insert(cap);
+                            proc.permissions.blocked.remove(&cap);
+                        }
+                        PermissionState::Yellow => {
+                            proc.permissions.capabilities.remove(&cap);
+                            proc.permissions.blocked.remove(&cap);
+                        }
+                        PermissionState::Red => {
+                            proc.permissions.blocked.insert(cap);
+                            proc.permissions.capabilities.remove(&cap);
+                        }
+                    }
+                    // Keep the app's in-memory store copy in sync so a later
+                    // save from its own consent flow doesn't resurrect stale
+                    // state, and mirror onto the AppPane copy.
+                    proc.permission_store.set(app_id, &ws, cap, new_state);
+                    app_pane.permissions = proc.permissions.clone();
+                    log::info!(
+                        "pane_ipc: set_permission: live-updated '{app_id}' pane {} — {} → {}",
+                        app_pane.id,
+                        cap.as_str(),
+                        new_state.as_str()
+                    );
+                }
+            }
+            Ok(())
+        })();
+
+        let body = match &outcome {
+            Ok(()) => "{\"ok\":true}".to_string(),
+            Err(e) => serde_json::json!({ "error": e }).to_string(),
+        };
+        if let Err(e) = std::fs::write(response_file, &body) {
+            log::error!(
+                "pane_ipc: set_permission: could not write response file {response_file:?}: {e}"
+            );
+        }
+        if let Err(e) = outcome {
+            log::warn!("pane_ipc: set_permission failed: {e}");
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@ mod focus;
 mod lifecycle;
 pub(crate) mod notification_image;
 mod notifications;
+pub mod package;
 pub mod packs;
 pub mod permissions;
 pub mod plexi_descriptor;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -155,6 +155,11 @@ pub struct PlexiApp {
     /// Repaint-cause diagnostics sample window (#2019): start instant and
     /// frame count. `None` until the first frame opens a window.
     pub(crate) frame_diag_window: Option<(std::time::Instant, u32)>,
+    /// Directory holding `permissions.toml` for the host-level permission
+    /// management handlers (`ListPermissions` / `SetPermission`, stint 0017).
+    /// `config_dir()` in production; an isolated temp dir in tests so harness
+    /// runs never read or write the developer's real permission store.
+    pub(crate) permission_store_dir: std::path::PathBuf,
     /// Cached config so confirmation settings are read through the config
     /// tunnel rather than duplicated as individual bool fields.
     pub(crate) config: crate::config::PlexiConfig,
@@ -722,6 +727,7 @@ impl PlexiApp {
                     pending_context_close: None,
                     frame_tick: frame_tick.clone(),
                     frame_diag_window: None,
+                    permission_store_dir: crate::config::config_dir(),
                     renaming_window: None,
                     rename_buffer: String::new(),
                     editing_description: None,
@@ -905,6 +911,7 @@ impl PlexiApp {
             pending_context_close: None,
             frame_tick,
             frame_diag_window: None,
+            permission_store_dir: crate::config::config_dir(),
             renaming_window: None,
             rename_buffer: String::new(),
             editing_description: None,
@@ -1098,6 +1105,12 @@ impl PlexiApp {
                 pending_context_close: None,
                 frame_tick,
                 frame_diag_window: None,
+                permission_store_dir: {
+                    let dir =
+                        std::env::temp_dir().join(format!("plexi-test-perms-{}", uuid::Uuid::new_v4()));
+                    std::fs::create_dir_all(&dir).expect("create test permission store dir");
+                    dir
+                },
                 renaming_window: None,
                 rename_buffer: String::new(),
                 editing_description: None,

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -1,0 +1,981 @@
+//! Single-app package artifact — `.plexipkg` (stint 0015).
+//!
+//! A package is a gzipped tar with the app's files at the archive root plus a
+//! generated `PACKAGE.toml` describing the contents:
+//!
+//! ```toml
+//! schema_version = 1
+//!
+//! [package]
+//! id      = "my-app"
+//! version = "0.1.0"
+//! runtime = "python"   # "python" if entry ends in .py, else "native"
+//!
+//! capabilities = ["ai.query"]
+//!
+//! [[files]]
+//! path   = "manifest.toml"
+//! sha256 = "…"
+//! size   = 123
+//! ```
+//!
+//! NOT a "pack" (`src/app/packs.rs`) — a pack is a *collection* manifest that
+//! lists multiple apps to install; a package is one app's distributable
+//! artifact.
+//!
+//! The validator is fail-closed: every check is a hard [`PackageError`], never
+//! a warning. Archive extraction is streaming and path-checked — absolute
+//! paths, `..` components, and symlinks (in a source dir or as archive
+//! entries) are all rejected before any byte is written.
+
+use crate::app::permissions::Capability;
+use crate::app::registry::{AppManifest, MANIFEST_SCHEMA_VERSION};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::convert::TryFrom;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+/// Current `PACKAGE.toml` schema version.
+pub const PACKAGE_SCHEMA_VERSION: u32 = 1;
+
+/// File extension for single-app package artifacts.
+pub const PACKAGE_EXTENSION: &str = "plexipkg";
+
+/// Name of the generated package descriptor inside the archive.
+pub const PACKAGE_TOML: &str = "PACKAGE.toml";
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// Fail-closed package validation/build errors. Every variant names what
+/// failed, what was expected, and the offending path or value.
+#[derive(Debug, thiserror::Error)]
+pub enum PackageError {
+    #[error("io error during {action} at {path}: {source}")]
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("not a directory: {0} — expected an app directory containing manifest.toml")]
+    NotADirectory(PathBuf),
+    #[error("manifest.toml not found in {0} — every package requires one at the app root")]
+    ManifestMissing(PathBuf),
+    #[error("manifest.toml at {path} failed to parse: {source}")]
+    ManifestParse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("manifest schema_version {found} is newer than supported (max {max}) in {path}")]
+    UnsupportedSchemaVersion {
+        found: u32,
+        max: u32,
+        path: PathBuf,
+    },
+    #[error("manifest field [app].{field} is missing or empty in {path}")]
+    MissingField { field: &'static str, path: PathBuf },
+    #[error("entry file '{entry}' declared in manifest.toml not found at {path}")]
+    EntryMissing { entry: String, path: PathBuf },
+    #[error("symlink not allowed in a package: {0} — packages must contain only regular files")]
+    SymlinkInDir(PathBuf),
+    #[error("archive entry '{0}' is a {1} — only regular files and directories are allowed")]
+    ForbiddenEntryType(String, &'static str),
+    #[error("unsafe archive path '{0}' — absolute paths and '..' components are rejected")]
+    UnsafePath(String),
+    #[error(
+        "unknown capability '{value}' in {path} — valid capabilities: {valid}",
+        valid = Capability::all_str_values().join(", ")
+    )]
+    UnknownCapability { value: String, path: PathBuf },
+    #[error("sha256 mismatch for '{path}': PACKAGE.toml says {expected}, actual content is {actual}")]
+    ChecksumMismatch {
+        path: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("size mismatch for '{path}': PACKAGE.toml says {expected} bytes, actual is {actual}")]
+    SizeMismatch {
+        path: String,
+        expected: u64,
+        actual: u64,
+    },
+    #[error("PACKAGE.toml missing from archive {0} — not a valid .plexipkg")]
+    PackageTomlMissing(PathBuf),
+    #[error("PACKAGE.toml in {path} failed to parse: {source}")]
+    PackageTomlParse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("PACKAGE.toml schema_version {found} is newer than supported (max {max})")]
+    UnsupportedPackageSchema { found: u32, max: u32 },
+    #[error("PACKAGE.toml id '{package}' disagrees with manifest.toml id '{manifest}'")]
+    IdMismatch { package: String, manifest: String },
+    #[error("PACKAGE.toml version '{package}' disagrees with manifest.toml version '{manifest}'")]
+    VersionMismatch { package: String, manifest: String },
+    #[error("unsupported runtime '{0}' in PACKAGE.toml — expected \"python\" or \"native\"")]
+    UnsupportedRuntime(String),
+    #[error("file '{0}' listed in PACKAGE.toml is missing from the archive")]
+    ListedFileMissing(String),
+    #[error("file '{0}' present in the archive but not listed in PACKAGE.toml")]
+    UnlistedFile(String),
+    #[error("package file {0} does not have the .{PACKAGE_EXTENSION} extension")]
+    WrongExtension(PathBuf),
+}
+
+fn io_err(action: &'static str, path: &Path, source: std::io::Error) -> PackageError {
+    PackageError::Io {
+        action,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+// ── Runtime ───────────────────────────────────────────────────────────────────
+
+/// Package runtime — derived from the manifest entry point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageRuntime {
+    /// Entry ends in `.py` — launched via python3.
+    Python,
+    /// Anything else — a native executable.
+    Native,
+}
+
+impl PackageRuntime {
+    pub fn from_entry(entry: &str) -> Self {
+        if entry.ends_with(".py") {
+            Self::Python
+        } else {
+            Self::Native
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Python => "python",
+            Self::Native => "native",
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self, PackageError> {
+        match s {
+            "python" => Ok(Self::Python),
+            "native" => Ok(Self::Native),
+            other => Err(PackageError::UnsupportedRuntime(other.to_string())),
+        }
+    }
+}
+
+// ── PACKAGE.toml schema ───────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackageToml {
+    schema_version: u32,
+    package: PackageSection,
+    capabilities: Vec<String>,
+    files: Vec<PackageFile>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackageSection {
+    id: String,
+    version: String,
+    runtime: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackageFile {
+    path: String,
+    sha256: String,
+    size: u64,
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+/// Result of a successful validation — the parsed identity of the package.
+/// Reused by `plexi app install <file.plexipkg>` and the future inspect path
+/// (stint 0016).
+#[derive(Debug, Clone)]
+pub struct PackageReport {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub runtime: PackageRuntime,
+    pub entry: String,
+    pub capabilities: Vec<Capability>,
+    pub file_count: usize,
+    pub total_size: u64,
+}
+
+// ── Directory validation ──────────────────────────────────────────────────────
+
+/// Validate an app directory as packageable. Fail-closed: any structural
+/// problem is a hard error. A root-level `PACKAGE.toml` (left over from a
+/// previous extraction) is ignored by the file walk — it is regenerated at
+/// build time and verified at package-validate time.
+pub fn validate_dir(app_dir: &Path) -> Result<PackageReport, PackageError> {
+    let report = validate_dir_inner(app_dir)?;
+    log::info!(
+        "package: validate_dir ok id={} version={} runtime={} files={} bytes={} dir={}",
+        report.id,
+        report.version,
+        report.runtime.as_str(),
+        report.file_count,
+        report.total_size,
+        app_dir.display()
+    );
+    Ok(report)
+}
+
+fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
+    if !app_dir.is_dir() {
+        return Err(PackageError::NotADirectory(app_dir.to_path_buf()));
+    }
+
+    let manifest = read_manifest(app_dir)?;
+    let entry = manifest.app.entry.clone();
+
+    // Entry must exist and must not be a symlink.
+    let entry_path = app_dir.join(&entry);
+    let entry_meta = fs::symlink_metadata(&entry_path).map_err(|_| PackageError::EntryMissing {
+        entry: entry.clone(),
+        path: entry_path.clone(),
+    })?;
+    if entry_meta.file_type().is_symlink() {
+        return Err(PackageError::SymlinkInDir(entry_path));
+    }
+
+    let capabilities = parse_capabilities(
+        &manifest.app.capabilities.capabilities,
+        &app_dir.join("manifest.toml"),
+    )?;
+
+    let files = collect_files(app_dir)?;
+    let total_size = files.iter().map(|(_, size)| size).sum();
+
+    Ok(PackageReport {
+        id: manifest.app.id,
+        name: manifest.app.name,
+        version: manifest.app.version,
+        runtime: PackageRuntime::from_entry(&entry),
+        entry,
+        capabilities,
+        file_count: files.len(),
+        total_size,
+    })
+}
+
+/// Read + structurally validate `manifest.toml` from an app dir.
+fn read_manifest(app_dir: &Path) -> Result<AppManifest, PackageError> {
+    let manifest_path = app_dir.join("manifest.toml");
+    if !manifest_path.exists() {
+        return Err(PackageError::ManifestMissing(app_dir.to_path_buf()));
+    }
+    let raw =
+        fs::read_to_string(&manifest_path).map_err(|e| io_err("read", &manifest_path, e))?;
+    let manifest: AppManifest =
+        toml::from_str(&raw).map_err(|e| PackageError::ManifestParse {
+            path: manifest_path.clone(),
+            source: e,
+        })?;
+
+    if manifest.schema_version > MANIFEST_SCHEMA_VERSION {
+        return Err(PackageError::UnsupportedSchemaVersion {
+            found: manifest.schema_version,
+            max: MANIFEST_SCHEMA_VERSION,
+            path: manifest_path,
+        });
+    }
+    // serde enforces id/name/entry presence; version is serde(default) so an
+    // empty version must be rejected here — the artifact name needs it.
+    for (field, value) in [
+        ("id", &manifest.app.id),
+        ("name", &manifest.app.name),
+        ("entry", &manifest.app.entry),
+        ("version", &manifest.app.version),
+    ] {
+        if value.is_empty() {
+            return Err(PackageError::MissingField {
+                field,
+                path: manifest_path,
+            });
+        }
+    }
+    Ok(manifest)
+}
+
+/// Parse capability strings against the real enum. Unknown → hard error.
+fn parse_capabilities(
+    strings: &[String],
+    source_path: &Path,
+) -> Result<Vec<Capability>, PackageError> {
+    strings
+        .iter()
+        .map(|s| {
+            Capability::try_from(s.as_str()).map_err(|_| PackageError::UnknownCapability {
+                value: s.clone(),
+                path: source_path.to_path_buf(),
+            })
+        })
+        .collect()
+}
+
+/// Recursively collect every regular file under `root` as
+/// `(relative path, size)`, sorted by path for deterministic archives.
+/// Rejects any symlink anywhere in the tree. Skips a root-level PACKAGE.toml.
+fn collect_files(root: &Path) -> Result<Vec<(PathBuf, u64)>, PackageError> {
+    let mut files = Vec::new();
+    collect_files_rec(root, Path::new(""), &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_files_rec(
+    root: &Path,
+    rel: &Path,
+    out: &mut Vec<(PathBuf, u64)>,
+) -> Result<(), PackageError> {
+    let dir = root.join(rel);
+    let entries = fs::read_dir(&dir).map_err(|e| io_err("read_dir", &dir, e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| io_err("read_dir", &dir, e))?;
+        let path = entry.path();
+        let rel_path = rel.join(entry.file_name());
+        let meta = fs::symlink_metadata(&path).map_err(|e| io_err("stat", &path, e))?;
+        if meta.file_type().is_symlink() {
+            return Err(PackageError::SymlinkInDir(path));
+        }
+        if meta.is_dir() {
+            collect_files_rec(root, &rel_path, out)?;
+        } else {
+            // Root-level PACKAGE.toml is the descriptor, never package content:
+            // regenerated at build, verified separately at validate.
+            if rel_path == Path::new(PACKAGE_TOML) {
+                continue;
+            }
+            out.push((rel_path, meta.len()));
+        }
+    }
+    Ok(())
+}
+
+// ── Build ─────────────────────────────────────────────────────────────────────
+
+/// Build a `.plexipkg` artifact from an app directory.
+///
+/// Validates the directory first (fail-closed), then writes
+/// `<id>-<version>.plexipkg` into the current directory, or to `out` when
+/// given (used verbatim as the output file path).
+pub fn build_package(app_dir: &Path, out: Option<&Path>) -> Result<PathBuf, PackageError> {
+    let report = validate_dir(app_dir)?;
+    if app_dir.join(PACKAGE_TOML).exists() {
+        log::warn!(
+            "package: ignoring stale root-level {PACKAGE_TOML} in {} — it is regenerated at build",
+            app_dir.display()
+        );
+    }
+    let files = collect_files(app_dir)?;
+
+    // Hash every file.
+    let mut package_files = Vec::with_capacity(files.len());
+    for (rel, size) in &files {
+        let abs = app_dir.join(rel);
+        let sha256 = sha256_file(&abs)?;
+        package_files.push(PackageFile {
+            path: rel.to_string_lossy().into_owned(),
+            sha256,
+            size: *size,
+        });
+    }
+
+    let descriptor = PackageToml {
+        schema_version: PACKAGE_SCHEMA_VERSION,
+        package: PackageSection {
+            id: report.id.clone(),
+            version: report.version.clone(),
+            runtime: report.runtime.as_str().to_string(),
+        },
+        capabilities: report.capabilities.iter().map(|c| c.as_str().to_string()).collect(),
+        files: package_files,
+    };
+    let descriptor_toml = toml::to_string_pretty(&descriptor).map_err(|e| {
+        // Serialization of an in-memory struct failing is unexpected; surface
+        // it as an io-class error on the output path.
+        io_err(
+            "serialize PACKAGE.toml",
+            app_dir,
+            std::io::Error::other(e),
+        )
+    })?;
+
+    let out_path = match out {
+        Some(p) => p.to_path_buf(),
+        None => PathBuf::from(format!(
+            "{}-{}.{PACKAGE_EXTENSION}",
+            report.id, report.version
+        )),
+    };
+
+    let out_file = fs::File::create(&out_path).map_err(|e| io_err("create", &out_path, e))?;
+    let gz = flate2::write::GzEncoder::new(out_file, flate2::Compression::default());
+    let mut builder = tar::Builder::new(gz);
+
+    // PACKAGE.toml first, then app files at the archive root.
+    let descriptor_bytes = descriptor_toml.as_bytes();
+    let mut header = tar::Header::new_gnu();
+    header.set_size(descriptor_bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, PACKAGE_TOML, descriptor_bytes)
+        .map_err(|e| io_err("append PACKAGE.toml", &out_path, e))?;
+
+    for (rel, _) in &files {
+        let abs = app_dir.join(rel);
+        builder
+            .append_path_with_name(&abs, rel)
+            .map_err(|e| io_err("append file", &abs, e))?;
+    }
+
+    let gz = builder
+        .into_inner()
+        .map_err(|e| io_err("finish tar", &out_path, e))?;
+    gz.finish().map_err(|e| io_err("finish gzip", &out_path, e))?;
+
+    log::info!(
+        "package: built id={} version={} files={} → {}",
+        report.id,
+        report.version,
+        files.len(),
+        out_path.display()
+    );
+    Ok(out_path)
+}
+
+fn sha256_file(path: &Path) -> Result<String, PackageError> {
+    let mut file = fs::File::open(path).map_err(|e| io_err("open", path, e))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).map_err(|e| io_err("hash", path, e))?;
+    Ok(hex_string(&hasher.finalize()))
+}
+
+fn hex_string(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+// ── Archive extraction (safe, streaming) ──────────────────────────────────────
+
+/// Returns the path-safe relative form of an archive entry path, or an error
+/// if the path is absolute or contains `..` / non-normal components.
+fn safe_entry_path(raw: &Path) -> Result<PathBuf, PackageError> {
+    let display = raw.display().to_string();
+    if raw.is_absolute() {
+        return Err(PackageError::UnsafePath(display));
+    }
+    let mut safe = PathBuf::new();
+    for component in raw.components() {
+        match component {
+            Component::Normal(c) => safe.push(c),
+            Component::CurDir => {}
+            _ => return Err(PackageError::UnsafePath(display)),
+        }
+    }
+    if safe.as_os_str().is_empty() {
+        return Err(PackageError::UnsafePath(display));
+    }
+    Ok(safe)
+}
+
+/// Safely extract a `.plexipkg` archive into `dest` (created if absent).
+/// Streams entries; each path is checked before any write; only regular files
+/// and directories are accepted — symlinks, hardlinks, and devices are
+/// rejected. Does NOT validate content hashes — callers wanting the full
+/// fail-closed gate use [`validate_package`].
+pub fn extract_package(file: &Path, dest: &Path) -> Result<(), PackageError> {
+    let f = fs::File::open(file).map_err(|e| io_err("open", file, e))?;
+    let gz = flate2::read::GzDecoder::new(f);
+    let mut archive = tar::Archive::new(gz);
+
+    fs::create_dir_all(dest).map_err(|e| io_err("create_dir_all", dest, e))?;
+
+    let entries = archive.entries().map_err(|e| io_err("read archive", file, e))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| io_err("read archive entry", file, e))?;
+        let raw_path = entry
+            .path()
+            .map_err(|e| io_err("read entry path", file, e))?
+            .into_owned();
+        let rel = safe_entry_path(&raw_path)?;
+        let entry_type = entry.header().entry_type();
+        match entry_type {
+            tar::EntryType::Directory => {
+                let dir = dest.join(&rel);
+                fs::create_dir_all(&dir).map_err(|e| io_err("create_dir_all", &dir, e))?;
+            }
+            tar::EntryType::Regular => {
+                let target = dest.join(&rel);
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent).map_err(|e| io_err("create_dir_all", parent, e))?;
+                }
+                let mut out =
+                    fs::File::create(&target).map_err(|e| io_err("create", &target, e))?;
+                std::io::copy(&mut entry, &mut out).map_err(|e| io_err("write", &target, e))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(mode) = entry.header().mode() {
+                        // Preserve the executable bit; never honor setuid/sticky bits.
+                        let mode = mode & 0o777;
+                        let _ = fs::set_permissions(&target, fs::Permissions::from_mode(mode));
+                    }
+                }
+            }
+            other => {
+                let kind: &'static str = match other {
+                    tar::EntryType::Symlink => "symlink",
+                    tar::EntryType::Link => "hardlink",
+                    _ => "non-regular entry",
+                };
+                return Err(PackageError::ForbiddenEntryType(
+                    rel.to_string_lossy().into_owned(),
+                    kind,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Removes a temp extraction dir on drop — cleanup happens on both the success
+/// and every error path.
+struct TempDirGuard(PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_dir_all(&self.0) {
+            if self.0.exists() {
+                log::warn!(
+                    "package: could not clean up temp dir {}: {e}",
+                    self.0.display()
+                );
+            }
+        }
+    }
+}
+
+/// Create a unique temp dir for package extraction.
+fn unique_temp_dir() -> Result<TempDirGuard, PackageError> {
+    let dir = std::env::temp_dir().join(format!("plexipkg-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&dir).map_err(|e| io_err("create_dir_all", &dir, e))?;
+    Ok(TempDirGuard(dir))
+}
+
+// ── Package validation ────────────────────────────────────────────────────────
+
+/// Validate a `.plexipkg` file end-to-end (fail-closed):
+///
+/// 1. safe streaming extraction into a unique temp dir (path + entry-type checks)
+/// 2. `PACKAGE.toml` present, parseable, supported schema, supported runtime
+/// 3. every listed file present with matching sha256 + size; no unlisted files
+/// 4. the extracted tree passes [`validate_dir`] (manifest, entry, symlinks,
+///    capability strings)
+/// 5. `PACKAGE.toml` id/version/runtime agree with `manifest.toml`
+pub fn validate_package(file: &Path) -> Result<PackageReport, PackageError> {
+    let result = validate_package_inner(file);
+    match &result {
+        Ok(report) => log::info!(
+            "package: validate_package ok id={} version={} files={} file={}",
+            report.id,
+            report.version,
+            report.file_count,
+            file.display()
+        ),
+        Err(e) => log::warn!("package: validate_package failed for {}: {e}", file.display()),
+    }
+    result
+}
+
+fn validate_package_inner(file: &Path) -> Result<PackageReport, PackageError> {
+    if file.extension().and_then(|e| e.to_str()) != Some(PACKAGE_EXTENSION) {
+        return Err(PackageError::WrongExtension(file.to_path_buf()));
+    }
+
+    let tmp = unique_temp_dir()?;
+    let root = tmp.0.clone();
+    extract_package(file, &root)?;
+
+    // PACKAGE.toml
+    let descriptor_path = root.join(PACKAGE_TOML);
+    if !descriptor_path.exists() {
+        return Err(PackageError::PackageTomlMissing(file.to_path_buf()));
+    }
+    let raw = fs::read_to_string(&descriptor_path)
+        .map_err(|e| io_err("read", &descriptor_path, e))?;
+    let descriptor: PackageToml =
+        toml::from_str(&raw).map_err(|e| PackageError::PackageTomlParse {
+            path: file.to_path_buf(),
+            source: e,
+        })?;
+    if descriptor.schema_version > PACKAGE_SCHEMA_VERSION {
+        return Err(PackageError::UnsupportedPackageSchema {
+            found: descriptor.schema_version,
+            max: PACKAGE_SCHEMA_VERSION,
+        });
+    }
+    let declared_runtime = PackageRuntime::parse(&descriptor.package.runtime)?;
+    // Capability strings in PACKAGE.toml must also resolve against the enum.
+    parse_capabilities(&descriptor.capabilities, file)?;
+
+    // Verify every listed file's checksum + size, and that nothing extra is present.
+    let on_disk = collect_files(&root)?; // also rejects symlinks defensively
+    let mut listed: std::collections::BTreeMap<&str, &PackageFile> = std::collections::BTreeMap::new();
+    for pf in &descriptor.files {
+        // Listed paths must themselves be safe before we join them anywhere.
+        safe_entry_path(Path::new(&pf.path))?;
+        listed.insert(pf.path.as_str(), pf);
+    }
+    for (rel, size) in &on_disk {
+        let rel_str = rel.to_string_lossy();
+        let Some(pf) = listed.remove(rel_str.as_ref()) else {
+            return Err(PackageError::UnlistedFile(rel_str.into_owned()));
+        };
+        if *size != pf.size {
+            return Err(PackageError::SizeMismatch {
+                path: pf.path.clone(),
+                expected: pf.size,
+                actual: *size,
+            });
+        }
+        let actual = sha256_file(&root.join(rel))?;
+        if actual != pf.sha256 {
+            return Err(PackageError::ChecksumMismatch {
+                path: pf.path.clone(),
+                expected: pf.sha256.clone(),
+                actual,
+            });
+        }
+    }
+    if let Some((path, _)) = listed.into_iter().next() {
+        return Err(PackageError::ListedFileMissing(path.to_string()));
+    }
+
+    // The extracted tree must itself be a valid app dir.
+    let report = validate_dir_inner(&root)?;
+
+    // PACKAGE.toml identity must agree with manifest.toml.
+    if descriptor.package.id != report.id {
+        return Err(PackageError::IdMismatch {
+            package: descriptor.package.id,
+            manifest: report.id,
+        });
+    }
+    if descriptor.package.version != report.version {
+        return Err(PackageError::VersionMismatch {
+            package: descriptor.package.version,
+            manifest: report.version,
+        });
+    }
+    if declared_runtime != report.runtime {
+        return Err(PackageError::UnsupportedRuntime(format!(
+            "{} (manifest entry '{}' implies {})",
+            descriptor.package.runtime,
+            report.entry,
+            report.runtime.as_str()
+        )));
+    }
+
+    Ok(report)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::io::{Read, Write};
+    use tempfile::TempDir;
+
+    /// Minimal valid python app dir: manifest + entry.
+    fn write_app(dir: &Path, id: &str, capabilities: &str) {
+        fs::write(
+            dir.join("manifest.toml"),
+            format!(
+                "schema_version = 1\n\n\
+                 [app]\n\
+                 id = \"{id}\"\n\
+                 type = \"app\"\n\
+                 name = \"Test App\"\n\
+                 entry = \"main.py\"\n\
+                 version = \"0.1.0\"\n\
+                 description = \"A test app\"\n\n\
+                 [app.capabilities]\n\
+                 capabilities = [{capabilities}]\n\n\
+                 [launch]\n"
+            ),
+        )
+        .unwrap();
+        fs::write(dir.join("main.py"), "# entry\nprint('hi')\n").unwrap();
+    }
+
+    /// Read every entry of a built package into (path → bytes).
+    fn read_entries(pkg: &Path) -> BTreeMap<String, Vec<u8>> {
+        let f = fs::File::open(pkg).unwrap();
+        let gz = flate2::read::GzDecoder::new(f);
+        let mut archive = tar::Archive::new(gz);
+        let mut map = BTreeMap::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().display().to_string();
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).unwrap();
+            map.insert(path, bytes);
+        }
+        map
+    }
+
+    /// Write a tar.gz package from (path → bytes) entries. Writes the entry
+    /// name into the raw GNU header bytes so tests can forge paths (e.g.
+    /// `../evil`) that `tar::Header::set_path` would refuse to create.
+    fn write_entries(out: &Path, entries: &BTreeMap<String, Vec<u8>>) {
+        let f = fs::File::create(out).unwrap();
+        let gz = flate2::write::GzEncoder::new(f, flate2::Compression::default());
+        let mut builder = tar::Builder::new(gz);
+        for (path, bytes) in entries {
+            let mut header = tar::Header::new_gnu();
+            {
+                let gnu = header.as_gnu_mut().unwrap();
+                let name = path.as_bytes();
+                assert!(name.len() < gnu.name.len(), "test path too long: {path}");
+                gnu.name[..name.len()].copy_from_slice(name);
+            }
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, bytes.as_slice()).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap();
+    }
+
+    /// Build a valid package for a fresh app dir; returns (workdir, pkg path).
+    fn build_valid_package(id: &str) -> (TempDir, PathBuf) {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, id, "\"ai.query\"");
+        let out = work.path().join(format!("{id}-0.1.0.plexipkg"));
+        let pkg = build_package(&app_dir, Some(&out)).unwrap();
+        (work, pkg)
+    }
+
+    #[test]
+    fn round_trip_build_and_validate() {
+        let (_work, pkg) = build_valid_package("pkg-roundtrip");
+        let report = validate_package(&pkg).expect("freshly built package must validate");
+        assert_eq!(report.id, "pkg-roundtrip");
+        assert_eq!(report.name, "Test App");
+        assert_eq!(report.version, "0.1.0");
+        assert_eq!(report.runtime, PackageRuntime::Python);
+        assert_eq!(report.entry, "main.py");
+        assert_eq!(report.capabilities, vec![Capability::AiQuery]);
+        assert_eq!(report.file_count, 2, "manifest.toml + main.py");
+        assert!(report.total_size > 0);
+    }
+
+    #[test]
+    fn tampered_content_fails_checksum() {
+        let (work, pkg) = build_valid_package("pkg-tamper");
+        let mut entries = read_entries(&pkg);
+        // Flip a byte in main.py without changing its length.
+        let body = entries.get_mut("main.py").unwrap();
+        body[0] ^= 0xFF;
+        let tampered = work.path().join("tampered.plexipkg");
+        write_entries(&tampered, &entries);
+
+        let err = validate_package(&tampered).unwrap_err();
+        assert!(
+            matches!(err, PackageError::ChecksumMismatch { ref path, .. } if path == "main.py"),
+            "expected ChecksumMismatch for main.py, got: {err}"
+        );
+    }
+
+    #[test]
+    fn path_traversal_entry_rejected() {
+        let (work, pkg) = build_valid_package("pkg-traversal");
+        let mut entries = read_entries(&pkg);
+        entries.insert("../evil".to_string(), b"owned".to_vec());
+        let evil = work.path().join("evil.plexipkg");
+        write_entries(&evil, &entries);
+
+        let err = validate_package(&evil).unwrap_err();
+        assert!(
+            matches!(err, PackageError::UnsafePath(ref p) if p.contains("..")),
+            "expected UnsafePath, got: {err}"
+        );
+        // The traversal target must not have been written.
+        assert!(!work.path().join("evil").exists());
+    }
+
+    #[test]
+    fn symlink_in_dir_rejected_at_build() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, "pkg-symlink", "");
+        std::os::unix::fs::symlink("/etc/hosts", app_dir.join("link")).unwrap();
+
+        let err = build_package(&app_dir, Some(&work.path().join("x.plexipkg"))).unwrap_err();
+        assert!(
+            matches!(err, PackageError::SymlinkInDir(_)),
+            "expected SymlinkInDir, got: {err}"
+        );
+    }
+
+    #[test]
+    fn symlink_entry_in_archive_rejected() {
+        let (work, pkg) = build_valid_package("pkg-symlink-tar");
+        let entries = read_entries(&pkg);
+
+        // Re-write the archive and append a symlink entry by hand.
+        let evil = work.path().join("symlink.plexipkg");
+        let f = fs::File::create(&evil).unwrap();
+        let gz = flate2::write::GzEncoder::new(f, flate2::Compression::default());
+        let mut builder = tar::Builder::new(gz);
+        for (path, bytes) in &entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path.as_str(), bytes.as_slice())
+                .unwrap();
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        builder
+            .append_link(&mut header, "sneaky-link", "/etc/hosts")
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let err = validate_package(&evil).unwrap_err();
+        assert!(
+            matches!(err, PackageError::ForbiddenEntryType(ref p, "symlink") if p == "sneaky-link"),
+            "expected ForbiddenEntryType symlink, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_capability_is_hard_error() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        // "net.dns" is NOT a Capability variant.
+        write_app(&app_dir, "pkg-badcap", "\"net.dns\"");
+
+        let err = validate_dir(&app_dir).unwrap_err();
+        match err {
+            PackageError::UnknownCapability { ref value, .. } => assert_eq!(value, "net.dns"),
+            other => panic!("expected UnknownCapability, got: {other}"),
+        }
+        // Build must refuse too.
+        assert!(build_package(&app_dir, Some(&work.path().join("x.plexipkg"))).is_err());
+    }
+
+    #[test]
+    fn missing_manifest_is_hard_error() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        fs::write(app_dir.join("main.py"), "# no manifest\n").unwrap();
+
+        let err = validate_dir(&app_dir).unwrap_err();
+        assert!(
+            matches!(err, PackageError::ManifestMissing(_)),
+            "expected ManifestMissing, got: {err}"
+        );
+    }
+
+    #[test]
+    fn package_toml_id_mismatch_rejected() {
+        let (work, pkg) = build_valid_package("pkg-idmismatch");
+        let mut entries = read_entries(&pkg);
+        let descriptor = String::from_utf8(entries.get(PACKAGE_TOML).unwrap().clone()).unwrap();
+        let edited = descriptor.replace("pkg-idmismatch", "some-other-id");
+        assert_ne!(descriptor, edited, "fixture must actually change the id");
+        entries.insert(PACKAGE_TOML.to_string(), edited.into_bytes());
+        let forged = work.path().join("forged.plexipkg");
+        write_entries(&forged, &entries);
+
+        let err = validate_package(&forged).unwrap_err();
+        assert!(
+            matches!(err, PackageError::IdMismatch { .. }),
+            "expected IdMismatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_package_toml_rejected() {
+        let (work, pkg) = build_valid_package("pkg-nodescriptor");
+        let mut entries = read_entries(&pkg);
+        entries.remove(PACKAGE_TOML).unwrap();
+        let stripped = work.path().join("stripped.plexipkg");
+        write_entries(&stripped, &entries);
+
+        let err = validate_package(&stripped).unwrap_err();
+        assert!(
+            matches!(err, PackageError::PackageTomlMissing(_)),
+            "expected PackageTomlMissing, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unlisted_extra_file_rejected() {
+        let (work, pkg) = build_valid_package("pkg-extrafile");
+        let mut entries = read_entries(&pkg);
+        entries.insert("smuggled.py".to_string(), b"import os\n".to_vec());
+        let smuggled = work.path().join("smuggled.plexipkg");
+        write_entries(&smuggled, &entries);
+
+        let err = validate_package(&smuggled).unwrap_err();
+        assert!(
+            matches!(err, PackageError::UnlistedFile(ref p) if p == "smuggled.py"),
+            "expected UnlistedFile, got: {err}"
+        );
+    }
+
+    #[test]
+    fn wrong_extension_rejected() {
+        let work = TempDir::new().unwrap();
+        let bogus = work.path().join("app.tar.gz");
+        fs::File::create(&bogus).unwrap().write_all(b"x").unwrap();
+        let err = validate_package(&bogus).unwrap_err();
+        assert!(
+            matches!(err, PackageError::WrongExtension(_)),
+            "expected WrongExtension, got: {err}"
+        );
+    }
+
+    #[test]
+    fn default_output_name_is_id_version() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, "pkg-name", "");
+        // Build with out inside the temp dir to avoid touching CWD.
+        let out = work.path().join("pkg-name-0.1.0.plexipkg");
+        let path = build_package(&app_dir, Some(&out)).unwrap();
+        assert_eq!(path, out);
+        assert!(path.exists());
+        let report = validate_package(&path).unwrap();
+        assert_eq!(report.runtime, PackageRuntime::Python);
+    }
+}

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -210,6 +210,51 @@ pub struct PackageReport {
     pub total_size: u64,
 }
 
+// ── Trust label ───────────────────────────────────────────────────────────────
+
+/// Blunt trust classification shown before any install proceeds (stint 0016).
+///
+/// v1 security stance: there is NO sandbox. Anything not bundled with Plexi
+/// runs with the user's full permissions, and the label says so verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLabel {
+    /// The app id is in the bundled core pack — ships with Plexi itself.
+    FirstPartyCore,
+    /// A native executable from outside the core pack.
+    NativeUnreviewed,
+    /// A Python app from outside the core pack.
+    PythonUnreviewed,
+}
+
+impl TrustLabel {
+    /// Honest display string. Never claims sandboxing — none exists in v1.
+    pub fn display_str(self) -> &'static str {
+        match self {
+            Self::FirstPartyCore => "First-party core — ships with Plexi",
+            Self::PythonUnreviewed => {
+                "Unreviewed Python process — runs with your full user permissions"
+            }
+            Self::NativeUnreviewed => {
+                "Unreviewed native process — runs with your full user permissions"
+            }
+        }
+    }
+}
+
+/// Classify a validated package/dir for the trust sheet. `core_ids` is the
+/// bundled first-party core pack id set
+/// (see `crate::cli::install_host::core_pack_ids`).
+pub fn trust_label(report: &PackageReport, core_ids: &[&str]) -> TrustLabel {
+    if core_ids.contains(&report.id.as_str()) {
+        TrustLabel::FirstPartyCore
+    } else {
+        match report.runtime {
+            PackageRuntime::Python => TrustLabel::PythonUnreviewed,
+            PackageRuntime::Native => TrustLabel::NativeUnreviewed,
+        }
+    }
+}
+
 // ── Directory validation ──────────────────────────────────────────────────────
 
 /// Validate an app directory as packageable. Fail-closed: any structural
@@ -961,6 +1006,55 @@ mod tests {
         assert!(
             matches!(err, PackageError::WrongExtension(_)),
             "expected WrongExtension, got: {err}"
+        );
+    }
+
+    fn report(id: &str, runtime: PackageRuntime) -> PackageReport {
+        PackageReport {
+            id: id.to_string(),
+            name: "Test App".to_string(),
+            version: "0.1.0".to_string(),
+            runtime,
+            entry: match runtime {
+                PackageRuntime::Python => "main.py".to_string(),
+                PackageRuntime::Native => "bin/app".to_string(),
+            },
+            capabilities: Vec::new(),
+            file_count: 2,
+            total_size: 100,
+        }
+    }
+
+    #[test]
+    fn trust_label_core_id_is_first_party() {
+        let r = report("welcome", PackageRuntime::Python);
+        assert_eq!(
+            trust_label(&r, &["welcome", "snake"]),
+            TrustLabel::FirstPartyCore
+        );
+        assert_eq!(
+            TrustLabel::FirstPartyCore.display_str(),
+            "First-party core — ships with Plexi"
+        );
+    }
+
+    #[test]
+    fn trust_label_python_entry_is_python_unreviewed() {
+        let r = report("third-party", PackageRuntime::Python);
+        assert_eq!(trust_label(&r, &["welcome"]), TrustLabel::PythonUnreviewed);
+        assert_eq!(
+            TrustLabel::PythonUnreviewed.display_str(),
+            "Unreviewed Python process — runs with your full user permissions"
+        );
+    }
+
+    #[test]
+    fn trust_label_native_entry_is_native_unreviewed() {
+        let r = report("third-party-bin", PackageRuntime::Native);
+        assert_eq!(trust_label(&r, &[]), TrustLabel::NativeUnreviewed);
+        assert_eq!(
+            TrustLabel::NativeUnreviewed.display_str(),
+            "Unreviewed native process — runs with your full user permissions"
         );
     }
 

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -74,6 +74,11 @@ pub enum Capability {
     /// and `SendAppAction` — the same host handlers the `plexi pane` CLI
     /// commands use over PLEXI_SOCKET.
     PanesControl,
+    /// Inspect and mutate other apps' permission state (stint 0017). Gates
+    /// the PGAP path for `ListPermissions` and `SetPermission`, the host-
+    /// mediated surface a permission-manager app uses to list, grant, and
+    /// revoke capabilities.
+    PermissionsManage,
 }
 
 impl fmt::Display for Capability {
@@ -106,6 +111,7 @@ impl Capability {
             Self::PanesSpawn => "Open new panes in your workspace",
             Self::PanesRead => "See your open panes and read app or terminal pane state",
             Self::PanesControl => "Control your panes: focus, close, send input, and drive apps",
+            Self::PermissionsManage => "See and change what other apps are allowed to do",
         }
     }
 
@@ -130,6 +136,7 @@ impl Capability {
             Self::PanesSpawn => "panes.spawn",
             Self::PanesRead => "panes.read",
             Self::PanesControl => "panes.control",
+            Self::PermissionsManage => "permissions.manage",
         }
     }
 
@@ -157,6 +164,7 @@ impl Capability {
         Self::PanesSpawn,
         Self::PanesRead,
         Self::PanesControl,
+        Self::PermissionsManage,
     ];
 
     /// All capability wire strings, derived from [`Capability::ALL`].
@@ -191,6 +199,7 @@ impl Capability {
             Self::PanesSpawn
                 | Self::PanesRead
                 | Self::PanesControl
+                | Self::PermissionsManage
                 | Self::SpawnApp
                 | Self::AiQuery
                 | Self::Llm
@@ -229,6 +238,32 @@ pub enum PermissionState {
     Red,
 }
 
+impl PermissionState {
+    /// Wire string for this state — matches the serde `lowercase` rename.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Green => "green",
+            Self::Yellow => "yellow",
+            Self::Red => "red",
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for PermissionState {
+    type Error = String;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        match s {
+            "green" => Ok(Self::Green),
+            "yellow" => Ok(Self::Yellow),
+            "red" => Ok(Self::Red),
+            other => Err(format!(
+                "unknown permission state: '{other}' (expected green | yellow | red)"
+            )),
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a str> for Capability {
     type Error = UnknownCapability;
 
@@ -253,6 +288,7 @@ impl<'a> TryFrom<&'a str> for Capability {
             "panes.spawn" => Ok(Self::PanesSpawn),
             "panes.read" => Ok(Self::PanesRead),
             "panes.control" => Ok(Self::PanesControl),
+            "permissions.manage" => Ok(Self::PermissionsManage),
             other => Err(UnknownCapability(other.to_string())),
         }
     }
@@ -393,30 +429,46 @@ impl PermissionStore {
         format!("{}::{}::{}", app_id, canonical.display(), cap.as_str())
     }
 
+    /// Split a store key (`app_id::workspace_path::capability_str`) into its
+    /// parts. Uses rsplitn so workspace paths containing `::` parse correctly.
+    /// Returns `None` for malformed keys.
+    fn parse_entry_key(key: &str) -> Option<(&str, &str, &str)> {
+        let mut right = key.rsplitn(2, "::");
+        let cap_str = right.next()?;
+        let left = right.next()?;
+        let mut left_parts = left.splitn(2, "::");
+        let app_id = left_parts.next()?;
+        let workspace = left_parts.next()?;
+        Some((app_id, workspace, cap_str))
+    }
+
+    /// Iterate all stored entries as `(app_id, workspace_path, capability, state)`.
+    /// Entries with malformed keys or unknown capability strings are skipped
+    /// (logged at warn). Used by the `ListPermissions` host handler.
+    pub fn iter_entries(
+        &self,
+    ) -> impl Iterator<Item = (&str, &str, Capability, PermissionState)> + '_ {
+        self.data.entries.iter().filter_map(|(key, &state)| {
+            let Some((app_id, workspace, cap_str)) = Self::parse_entry_key(key) else {
+                log::warn!("permission_store: skipping malformed entry key '{key}'");
+                return None;
+            };
+            let Ok(cap) = Capability::try_from(cap_str) else {
+                log::warn!("permission_store: skipping entry with unknown capability '{cap_str}'");
+                return None;
+            };
+            Some((app_id, workspace, cap, state))
+        })
+    }
+
     /// Re-key any entries whose workspace path component resolves to a different canonical path.
     /// Returns the number of entries migrated.
     fn migrate_raw_path_keys(data: &mut PermissionStoreData) -> usize {
         let mut to_rekey: Vec<(String, String, PermissionState)> = Vec::new();
         for (key, &state) in &data.entries {
             // key format: "app_id::workspace_path::cap_str"
-            // Use rsplitn to correctly handle workspace paths that contain "::".
-            let mut right = key.rsplitn(2, "::");
-            let cap_str = match right.next() {
-                Some(s) => s,
-                None => continue,
-            };
-            let left = match right.next() {
-                Some(s) => s,
-                None => continue,
-            };
-            let mut left_parts = left.splitn(2, "::");
-            let app_id = match left_parts.next() {
-                Some(s) => s,
-                None => continue,
-            };
-            let workspace_raw = match left_parts.next() {
-                Some(s) => s,
-                None => continue,
+            let Some((app_id, workspace_raw, cap_str)) = Self::parse_entry_key(key) else {
+                continue;
             };
 
             let raw_path = Path::new(workspace_raw);
@@ -640,7 +692,7 @@ mod tests {
         }
         assert_eq!(
             Capability::ALL.len(),
-            19,
+            20,
             "update Capability::ALL (and this count) when adding a variant"
         );
         assert_eq!(Capability::all_str_values().len(), Capability::ALL.len());
@@ -782,6 +834,72 @@ mod tests {
             }
             PermissionCheck::Allowed => panic!("must be denied without declaration"),
         }
+    }
+
+    #[test]
+    fn permissions_manage_capability_recognized() {
+        let parsed =
+            Capability::try_from("permissions.manage").expect("permissions.manage must parse");
+        assert_eq!(parsed, Capability::PermissionsManage);
+        assert_eq!(parsed.as_str(), "permissions.manage");
+        assert!(parsed.is_sensitive(), "permissions.manage must be sensitive");
+        let perms = AppPermissions::from_capability_strings(&["permissions.manage".to_string()]);
+        assert!(perms.capabilities.contains(&Capability::PermissionsManage));
+        assert!(matches!(
+            check(&perms, Capability::PermissionsManage),
+            PermissionCheck::Allowed
+        ));
+        match check(
+            &AppPermissions::from_capability_strings(&[]),
+            Capability::PermissionsManage,
+        ) {
+            PermissionCheck::Denied(reason) => {
+                assert!(
+                    reason.contains("permissions.manage"),
+                    "denial must name capability: {reason}"
+                );
+            }
+            PermissionCheck::Allowed => panic!("must be denied without declaration"),
+        }
+    }
+
+    #[test]
+    fn permission_state_string_round_trips() {
+        for state in [
+            PermissionState::Green,
+            PermissionState::Yellow,
+            PermissionState::Red,
+        ] {
+            assert_eq!(
+                PermissionState::try_from(state.as_str()).expect("must round-trip"),
+                state
+            );
+        }
+        assert!(
+            PermissionState::try_from("purple").is_err(),
+            "unknown state strings must fail closed"
+        );
+    }
+
+    #[test]
+    fn iter_entries_parses_stored_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = std::path::Path::new("/test/project");
+        let mut store = PermissionStore::load_or_default(tmp.path());
+        store.set(
+            "my-app",
+            workspace,
+            Capability::NetHttp,
+            PermissionState::Red,
+        );
+
+        let entries: Vec<_> = store.iter_entries().collect();
+        assert_eq!(entries.len(), 1);
+        let (app_id, ws, cap, state) = entries[0];
+        assert_eq!(app_id, "my-app");
+        assert_eq!(ws, "/test/project");
+        assert_eq!(cap, Capability::NetHttp);
+        assert_eq!(state, PermissionState::Red);
     }
 
     #[test]

--- a/src/app/permissions.rs
+++ b/src/app/permissions.rs
@@ -133,28 +133,35 @@ impl Capability {
         }
     }
 
-    pub fn all_str_values() -> &'static [&'static str] {
-        &[
-            "fs.read",
-            "fs.write",
-            "net.http",
-            "secrets.get",
-            "pipe.open",
-            "spawn.app",
-            "audio.record",
-            "audio.playback",
-            "video.playback",
-            "llm",
-            "timer",
-            "ai.query",
-            "midi.in",
-            "midi.out",
-            "terminal.bindings",
-            "fs.pick",
-            "panes.spawn",
-            "panes.read",
-            "panes.control",
-        ]
+    /// Every capability variant. The single source of truth for "all known
+    /// capabilities" — validators iterate this instead of hand-rolling string
+    /// lists. When adding a variant, `as_str`/`try_from` won't compile without
+    /// it, and `capability_all_round_trips` fails if it is missing here.
+    pub const ALL: &'static [Capability] = &[
+        Self::FsRead,
+        Self::FsWrite,
+        Self::NetHttp,
+        Self::SecretsGet,
+        Self::PipeOpen,
+        Self::SpawnApp,
+        Self::AudioRecord,
+        Self::AudioPlayback,
+        Self::VideoPlayback,
+        Self::Llm,
+        Self::Timer,
+        Self::AiQuery,
+        Self::MidiIn,
+        Self::MidiOut,
+        Self::TerminalBindings,
+        Self::FsPick,
+        Self::PanesSpawn,
+        Self::PanesRead,
+        Self::PanesControl,
+    ];
+
+    /// All capability wire strings, derived from [`Capability::ALL`].
+    pub fn all_str_values() -> Vec<&'static str> {
+        Self::ALL.iter().map(|c| c.as_str()).collect()
     }
 
     /// Returns a human-readable description of why this capability cannot be
@@ -617,6 +624,27 @@ impl PermissionStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capability_all_round_trips() {
+        // ALL must contain every variant exactly once, and each variant must
+        // round-trip through as_str / try_from. A variant added to the enum
+        // but not to ALL would silently weaken every ALL-derived validator.
+        let mut seen = HashSet::new();
+        for &cap in Capability::ALL {
+            assert!(seen.insert(cap), "duplicate in Capability::ALL: {cap}");
+            assert_eq!(
+                Capability::try_from(cap.as_str()).expect("must round-trip"),
+                cap
+            );
+        }
+        assert_eq!(
+            Capability::ALL.len(),
+            19,
+            "update Capability::ALL (and this count) when adding a variant"
+        );
+        assert_eq!(Capability::all_str_values().len(), Capability::ALL.len());
+    }
 
     #[test]
     fn ai_query_capability_recognized() {

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -383,11 +383,183 @@ pub(super) fn write_pinned_version(app_dir: &std::path::Path, version: &str) {
     }
 }
 
-/// `plexi app install <path> [--version X.Y.Z]`
+/// Who approved this install. Threaded explicitly through every install call
+/// chain — no default, every caller chooses (stint 0016).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallConfirm {
+    /// A user typed the command — show the trust sheet and prompt.
+    Interactive,
+    /// An internal caller (bundled pack seeding, an outer install path that
+    /// already prompted) — never prompt.
+    PreApproved,
+}
+
+/// Format a byte count for the trust sheet (B / KB / MB / GB, one decimal).
+fn human_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    let b = bytes as f64;
+    if b < KB {
+        format!("{bytes} B")
+    } else if b < KB * KB {
+        format!("{:.1} KB", b / KB)
+    } else if b < KB * KB * KB {
+        format!("{:.1} MB", b / (KB * KB))
+    } else {
+        format!("{:.1} GB", b / (KB * KB * KB))
+    }
+}
+
+/// Print the trust sheet for a validated app dir or package: identity,
+/// runtime + trust label, size, and every declared capability with its
+/// description (sensitive ones marked). Plain text — no color, so NO_COLOR
+/// holds trivially.
+pub fn print_trust_sheet(
+    report: &crate::app::package::PackageReport,
+    label: crate::app::package::TrustLabel,
+) {
+    println!("id:           {}", report.id);
+    println!("name:         {}", report.name);
+    println!("version:      {}", report.version);
+    println!("entry:        {}", report.entry);
+    println!(
+        "runtime:      {} — {}",
+        report.runtime.as_str(),
+        label.display_str()
+    );
+    println!(
+        "files:        {} ({})",
+        report.file_count,
+        human_size(report.total_size)
+    );
+    if report.capabilities.is_empty() {
+        println!("capabilities: (none)");
+    } else {
+        println!("capabilities:");
+        for cap in &report.capabilities {
+            let sensitive = if cap.is_sensitive() { " [sensitive]" } else { "" };
+            println!("  {:<18}{}{sensitive}", cap.as_str(), cap.description());
+        }
+    }
+}
+
+/// Resolve the trust label for a report against the bundled core pack ids.
+fn trust_label_for(
+    report: &crate::app::package::PackageReport,
+) -> crate::app::package::TrustLabel {
+    let core_ids = crate::cli::install_host::core_pack_ids();
+    let core_refs: Vec<&str> = core_ids.iter().map(String::as_str).collect();
+    crate::app::package::trust_label(report, &core_refs)
+}
+
+/// The install confirmation gate. Returns `Ok(true)` to proceed,
+/// `Ok(false)` when the user declined, `Err` when confirmation is impossible
+/// (non-interactive stdin without `--yes`) or unreadable.
+///
+/// Pure decision logic over an injected reader so tests can feed answers.
+pub fn confirm_install(
+    report: &crate::app::package::PackageReport,
+    label: crate::app::package::TrustLabel,
+    mode: InstallConfirm,
+    assume_yes: bool,
+    is_tty: bool,
+    reader: &mut impl io::BufRead,
+) -> Result<bool, String> {
+    match mode {
+        InstallConfirm::PreApproved => Ok(true),
+        InstallConfirm::Interactive => {
+            if assume_yes {
+                log::info!(
+                    "confirm_install: --yes given, skipping prompt for '{}' ({:?})",
+                    report.id,
+                    label
+                );
+                return Ok(true);
+            }
+            if !is_tty {
+                return Err(format!(
+                    "stdin is not a terminal — cannot confirm install of '{}'. \
+                     Re-run with --yes to approve non-interactively.",
+                    report.id
+                ));
+            }
+            eprint!("Install? [y/N] ");
+            let _ = io::stderr().flush();
+            let mut answer = String::new();
+            reader
+                .read_line(&mut answer)
+                .map_err(|e| format!("failed to read install confirmation: {e}"))?;
+            Ok(matches!(answer.trim().to_lowercase().as_str(), "y" | "yes"))
+        }
+    }
+}
+
+/// Run the full trust gate for an interactive install: print the trust sheet,
+/// then prompt. Returns an exit code on refusal/abort, `None` to proceed.
+fn run_install_gate(
+    report: &crate::app::package::PackageReport,
+    assume_yes: bool,
+) -> Option<i32> {
+    use std::io::IsTerminal;
+    let label = trust_label_for(report);
+    print_trust_sheet(report, label);
+    let is_tty = io::stdin().is_terminal();
+    let mut stdin = io::stdin().lock();
+    match confirm_install(
+        report,
+        label,
+        InstallConfirm::Interactive,
+        assume_yes,
+        is_tty,
+        &mut stdin,
+    ) {
+        Ok(true) => None,
+        Ok(false) => {
+            eprintln!("install aborted — '{}' was not installed", report.id);
+            Some(1)
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            Some(1)
+        }
+    }
+}
+
+/// `plexi app inspect <path>` — validate a local app dir or `.plexipkg` file
+/// and print the trust sheet without installing anything (stint 0016).
+pub fn app_inspect_cli(path: &str) -> i32 {
+    log::info!("app_inspect:cli: path={path}");
+    let target = std::path::Path::new(path);
+    let report = if target.is_file() {
+        crate::app::package::validate_package(target)
+    } else {
+        crate::app::package::validate_dir(target)
+    };
+    match report {
+        Ok(report) => {
+            print_trust_sheet(&report, trust_label_for(&report));
+            0
+        }
+        Err(e) => {
+            eprintln!("error: validation failed for {path}: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi app install <path> [--version X.Y.Z] [--yes]`
 ///
 /// When `pin` is `None` (the common case) this is a plain install.
 /// When `pin` is `Some(ver)` the version is stored in `pinned_version.txt`.
-pub fn app_install_with_pin(path: &str, pin: Option<&str>) -> i32 {
+///
+/// `confirm` decides whether the trust sheet + prompt gate runs:
+/// `Interactive` for user-typed installs, `PreApproved` for internal callers
+/// that already gated (or are first-party bundled content).
+pub fn app_install_with_pin(
+    path: &str,
+    pin: Option<&str>,
+    confirm: InstallConfirm,
+    assume_yes: bool,
+) -> i32 {
     let src = match std::path::Path::new(path).canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -395,6 +567,35 @@ pub fn app_install_with_pin(path: &str, pin: Option<&str>) -> i32 {
             return 1;
         }
     };
+
+    // The 0015 validator is the install gate (stint 0016). User-initiated
+    // installs must pass it; PreApproved installs (bundled first-party
+    // content, or an outer path that already validated and prompted) proceed
+    // with a warning so startup seeding can never break on legacy layouts.
+    match crate::app::package::validate_dir(&src) {
+        Ok(report) => {
+            if confirm == InstallConfirm::Interactive {
+                if let Some(code) = run_install_gate(&report, assume_yes) {
+                    return code;
+                }
+            }
+        }
+        Err(e) => match confirm {
+            InstallConfirm::Interactive => {
+                eprintln!(
+                    "error: validation failed — refusing install of {}: {e}",
+                    src.display()
+                );
+                return 1;
+            }
+            InstallConfirm::PreApproved => {
+                log::warn!(
+                    "app::install: pre-approved install of {} proceeding despite validation failure: {e}",
+                    src.display()
+                );
+            }
+        },
+    }
 
     let manifest_path = src.join("manifest.toml");
     if !manifest_path.exists() {
@@ -529,8 +730,16 @@ pub fn app_package_cli(path: &str, out: Option<&str>) -> i32 {
 
 /// `plexi app install <file.plexipkg>` — validate the package (fail-closed),
 /// then extract to a temp dir and run the standard dir install on it.
-pub fn app_install_package(file: &str, pin: Option<&str>) -> i32 {
-    log::info!("app_install:cli: package file={file} pin={pin:?}");
+///
+/// The trust gate runs here (against the validated package report); the inner
+/// dir install is then `PreApproved` so the user is prompted exactly once.
+pub fn app_install_package(
+    file: &str,
+    pin: Option<&str>,
+    confirm: InstallConfirm,
+    assume_yes: bool,
+) -> i32 {
+    log::info!("app_install:cli: package file={file} pin={pin:?} confirm={confirm:?}");
     let pkg_path = match std::path::Path::new(file).canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -547,6 +756,12 @@ pub fn app_install_package(file: &str, pin: Option<&str>) -> i32 {
         }
     };
 
+    if confirm == InstallConfirm::Interactive {
+        if let Some(code) = run_install_gate(&report, assume_yes) {
+            return code;
+        }
+    }
+
     // Extract into a unique temp dir and reuse the existing dir-install path.
     let staging = std::env::temp_dir().join(format!("plexipkg-install-{}", uuid::Uuid::new_v4()));
     if let Err(e) = crate::app::package::extract_package(&pkg_path, &staging) {
@@ -561,7 +776,14 @@ pub fn app_install_package(file: &str, pin: Option<&str>) -> i32 {
         report.file_count,
         staging.display()
     );
-    let code = app_install_with_pin(&staging.to_string_lossy(), pin);
+    // Already validated and (when interactive) confirmed above — the inner
+    // dir install must not prompt a second time.
+    let code = app_install_with_pin(
+        &staging.to_string_lossy(),
+        pin,
+        InstallConfirm::PreApproved,
+        assume_yes,
+    );
     if let Err(e) = std::fs::remove_dir_all(&staging) {
         log::warn!(
             "app_install:cli: could not clean up staging dir {}: {e}",
@@ -1137,7 +1359,9 @@ mod app_install_workspace_tests {
         let path = src.path().to_string_lossy().to_string();
 
         // No workspace present in src or any ancestor (temp dir) — must return 0.
-        let code = super::app_install_with_pin(&path, None);
+        // Interactive + --yes: gate prints the trust sheet but never prompts.
+        let code =
+            super::app_install_with_pin(&path, None, super::InstallConfirm::Interactive, true);
 
         // Clean up installed app to avoid polluting the apps dir between runs.
         let dest = crate::app::registry::apps_dir().join(app_id);
@@ -1153,9 +1377,147 @@ mod app_install_workspace_tests {
     fn install_fails_on_missing_manifest_not_workspace_error() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().to_string_lossy().to_string();
-        let code = super::app_install_with_pin(&path, None);
+        let code =
+            super::app_install_with_pin(&path, None, super::InstallConfirm::Interactive, true);
         // Must fail with exit code 1 (manifest missing), not a workspace error.
         assert_eq!(code, 1, "missing manifest must return 1");
+    }
+}
+
+#[cfg(test)]
+mod install_confirm_tests {
+    use super::{confirm_install, human_size, InstallConfirm};
+    use crate::app::package::{PackageReport, PackageRuntime, TrustLabel};
+    use std::io::Cursor;
+
+    fn report() -> PackageReport {
+        PackageReport {
+            id: "gate-test".to_string(),
+            name: "Gate Test".to_string(),
+            version: "0.1.0".to_string(),
+            runtime: PackageRuntime::Python,
+            entry: "main.py".to_string(),
+            capabilities: Vec::new(),
+            file_count: 2,
+            total_size: 64,
+        }
+    }
+
+    #[test]
+    fn non_tty_without_yes_fails_closed() {
+        let r = report();
+        let err = confirm_install(
+            &r,
+            TrustLabel::PythonUnreviewed,
+            InstallConfirm::Interactive,
+            false, // no --yes
+            false, // stdin not a tty
+            &mut Cursor::new(b"y\n"),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("--yes"),
+            "fail-closed error must tell the user to pass --yes, got: {err}"
+        );
+    }
+
+    #[test]
+    fn assume_yes_skips_prompt() {
+        let r = report();
+        // Reader is empty: --yes must never read stdin, even non-tty.
+        let ok = confirm_install(
+            &r,
+            TrustLabel::PythonUnreviewed,
+            InstallConfirm::Interactive,
+            true,
+            false,
+            &mut Cursor::new(b""),
+        )
+        .unwrap();
+        assert!(ok, "--yes must approve without reading stdin");
+    }
+
+    #[test]
+    fn pre_approved_never_prompts() {
+        let r = report();
+        let ok = confirm_install(
+            &r,
+            TrustLabel::FirstPartyCore,
+            InstallConfirm::PreApproved,
+            false,
+            false,
+            &mut Cursor::new(b""),
+        )
+        .unwrap();
+        assert!(ok, "PreApproved must approve unconditionally");
+    }
+
+    #[test]
+    fn interactive_y_approves_and_n_refuses() {
+        let r = report();
+        for (input, expected) in [
+            (&b"y\n"[..], true),
+            (b"Y\n", true),
+            (b"yes\n", true),
+            (b"n\n", false),
+            (b"no\n", false),
+            (b"\n", false),
+            (b"", false), // EOF = refuse
+        ] {
+            let got = confirm_install(
+                &r,
+                TrustLabel::PythonUnreviewed,
+                InstallConfirm::Interactive,
+                false,
+                true,
+                &mut Cursor::new(input),
+            )
+            .unwrap();
+            assert_eq!(got, expected, "input {input:?}");
+        }
+    }
+
+    #[test]
+    fn human_size_formats() {
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.0 KB");
+        assert_eq!(human_size(3 * 1024 * 1024), "3.0 MB");
+    }
+}
+
+#[cfg(test)]
+mod app_inspect_tests {
+    use tempfile::TempDir;
+
+    #[test]
+    fn inspect_valid_dir_returns_0() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.toml"),
+            "schema_version = 1\n\n\
+             [app]\n\
+             id = \"inspect-test\"\n\
+             type = \"app\"\n\
+             name = \"Inspect Test\"\n\
+             entry = \"main.py\"\n\
+             version = \"0.1.0\"\n\
+             description = \"Test\"\n\n\
+             [app.capabilities]\n\
+             capabilities = [\"ai.query\"]\n\n\
+             [launch]\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("main.py"), "# stub\n").unwrap();
+        let code = super::app_inspect_cli(&dir.path().to_string_lossy());
+        assert_eq!(code, 0, "valid app dir must inspect cleanly");
+    }
+
+    #[test]
+    fn inspect_invalid_dir_returns_1() {
+        let dir = TempDir::new().unwrap();
+        // No manifest — must fail validation, exit non-zero.
+        let code = super::app_inspect_cli(&dir.path().to_string_lossy());
+        assert_eq!(code, 1, "dir without manifest must fail inspect");
     }
 }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -504,6 +504,73 @@ pub fn app_install_with_pin(path: &str, pin: Option<&str>) -> i32 {
     0
 }
 
+/// `plexi app package <path> [--out <file>]` — build a `.plexipkg` artifact.
+pub fn app_package_cli(path: &str, out: Option<&str>) -> i32 {
+    log::info!("app_package:cli: path={path} out={out:?}");
+    let app_dir = match std::path::Path::new(path).canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {path}: {e}");
+            return 1;
+        }
+    };
+    match crate::app::package::build_package(&app_dir, out.map(std::path::Path::new)) {
+        Ok(pkg) => {
+            println!("Built package {}", pkg.display());
+            println!("  Validate with: plexi app validate {}", pkg.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: package build failed: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi app install <file.plexipkg>` — validate the package (fail-closed),
+/// then extract to a temp dir and run the standard dir install on it.
+pub fn app_install_package(file: &str, pin: Option<&str>) -> i32 {
+    log::info!("app_install:cli: package file={file} pin={pin:?}");
+    let pkg_path = match std::path::Path::new(file).canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {file}: {e}");
+            return 1;
+        }
+    };
+
+    let report = match crate::app::package::validate_package(&pkg_path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: package validation failed — refusing install: {e}");
+            return 1;
+        }
+    };
+
+    // Extract into a unique temp dir and reuse the existing dir-install path.
+    let staging = std::env::temp_dir().join(format!("plexipkg-install-{}", uuid::Uuid::new_v4()));
+    if let Err(e) = crate::app::package::extract_package(&pkg_path, &staging) {
+        eprintln!("error: could not extract {}: {e}", pkg_path.display());
+        let _ = std::fs::remove_dir_all(&staging);
+        return 1;
+    }
+    log::info!(
+        "app_install:cli: validated package id={} v{} ({} files) — installing from {}",
+        report.id,
+        report.version,
+        report.file_count,
+        staging.display()
+    );
+    let code = app_install_with_pin(&staging.to_string_lossy(), pin);
+    if let Err(e) = std::fs::remove_dir_all(&staging) {
+        log::warn!(
+            "app_install:cli: could not clean up staging dir {}: {e}",
+            staging.display()
+        );
+    }
+    code
+}
+
 fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -481,11 +481,28 @@ pub enum AppCmd {
         #[arg(long)]
         from_pane_id: Option<u64>,
     },
-    /// Check a Plexi app directory for errors before publishing or installing.
+    /// Check a Plexi app directory or .plexipkg package for errors before publishing or installing.
+    ///
+    /// A directory is validated in place. A `.plexipkg` file is extracted to a
+    /// temp dir with path-safety checks and verified end-to-end: descriptor,
+    /// content hashes, manifest, entry point, and capability strings.
     Validate {
-        /// Path to check (default: current directory)
-        #[arg(default_value = ".", value_hint = ValueHint::DirPath)]
+        /// App directory or .plexipkg file to check (default: current directory)
+        #[arg(default_value = ".", value_hint = ValueHint::AnyPath)]
         path: String,
+    },
+    /// Build a distributable .plexipkg package from an app directory.
+    ///
+    /// Validates the directory first (fail-closed), then writes
+    /// `<id>-<version>.plexipkg` containing the app files plus a generated
+    /// PACKAGE.toml with per-file sha256 checksums.
+    Package {
+        /// App directory to package
+        #[arg(value_hint = ValueHint::DirPath)]
+        path: String,
+        /// Output file path (default: ./<id>-<version>.plexipkg)
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        out: Option<String>,
     },
     /// Export your currently installed apps as a single TOML snapshot for sharing or backup.
     ///

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -360,6 +360,11 @@ pub enum AppCmd {
         /// The pinned version is recorded and shown by `plexi app update`.
         #[arg(long, value_name = "SEMVER")]
         version: Option<String>,
+        /// Skip the trust-sheet confirmation prompt. Required for
+        /// non-interactive (scripted) installs — without a terminal the
+        /// install fails closed instead of proceeding silently.
+        #[arg(long = "yes", short = 'y')]
+        yes: bool,
     },
     /// Remove an installed app by id.
     ///
@@ -489,6 +494,16 @@ pub enum AppCmd {
     Validate {
         /// App directory or .plexipkg file to check (default: current directory)
         #[arg(default_value = ".", value_hint = ValueHint::AnyPath)]
+        path: String,
+    },
+    /// Show the trust sheet for a local app directory or .plexipkg package.
+    ///
+    /// Validates first (fail-closed), then prints what the app is, what
+    /// runtime it uses with a blunt trust label, and every capability it
+    /// declares — the same sheet shown before `plexi app install` proceeds.
+    Inspect {
+        /// App directory or .plexipkg file to inspect
+        #[arg(value_hint = ValueHint::AnyPath)]
         path: String,
     },
     /// Build a distributable .plexipkg package from an app directory.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -177,8 +177,9 @@ pub use agent::{
 };
 pub use ai::{ai_doctor_cli, ai_setup_cli};
 pub use app::{
-    app_action_cli, app_info, app_init, app_install_package, app_install_with_pin, app_list,
-    app_package_cli, app_publish, app_render, app_uninstall, app_update_cli,
+    app_action_cli, app_info, app_init, app_inspect_cli, app_install_package,
+    app_install_with_pin, app_list, app_package_cli, app_publish, app_render, app_uninstall,
+    app_update_cli, InstallConfirm,
 };
 pub use app_check::app_check_cli;
 pub use completions::{complete_open_cli, completions_cli};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -177,8 +177,8 @@ pub use agent::{
 };
 pub use ai::{ai_doctor_cli, ai_setup_cli};
 pub use app::{
-    app_action_cli, app_info, app_init, app_install_with_pin, app_list, app_publish, app_render,
-    app_uninstall, app_update_cli,
+    app_action_cli, app_info, app_init, app_install_package, app_install_with_pin, app_list,
+    app_package_cli, app_publish, app_render, app_uninstall, app_update_cli,
 };
 pub use app_check::app_check_cli;
 pub use completions::{complete_open_cli, completions_cli};

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -4,6 +4,19 @@ pub fn validate_cli(path: &str) -> i32 {
         eprintln!("validate: path does not exist: {path}");
         return 1;
     }
+    // A .plexipkg file gets the full fail-closed package validation.
+    if app_dir.is_file() {
+        if app_dir.extension().and_then(|e| e.to_str())
+            == Some(crate::app::package::PACKAGE_EXTENSION)
+        {
+            return validate_package_cli(app_dir);
+        }
+        eprintln!(
+            "validate: path is not a directory or .{} file: {path}",
+            crate::app::package::PACKAGE_EXTENSION
+        );
+        return 1;
+    }
     if !app_dir.is_dir() {
         eprintln!("validate: path is not a directory: {path}");
         return 1;
@@ -88,31 +101,21 @@ pub fn validate_cli(path: &str) -> i32 {
         }
     }
 
-    // capabilities validation
+    // capabilities validation — checked against the real Capability enum.
+    // Unknown capability strings are hard errors (fail closed): the host would
+    // refuse to install/launch the app, so validate must too.
     if let Some(caps) = app_section
         .and_then(|a| a.get("capabilities"))
+        .and_then(|c| c.get("capabilities"))
         .and_then(|v| v.as_array())
     {
-        let known: &[&str] = &[
-            "net.http",
-            "net.dns",
-            "fs.read",
-            "fs.write",
-            "audio.record",
-            "audio.play",
-            "midi.in",
-            "midi.out",
-            "ai.query",
-            "panes.spawn",
-            "panes.read",
-            "panes.control",
-            "video.decode",
-        ];
+        use std::convert::TryFrom;
         for cap in caps {
             if let Some(s) = cap.as_str() {
-                if !known.contains(&s) {
-                    warnings.push(format!(
-                        "  unknown capability: {s:?} — check the manifest reference"
+                if crate::app::permissions::Capability::try_from(s).is_err() {
+                    errors.push(format!(
+                        "  unknown capability: {s:?} — valid capabilities: {}",
+                        crate::app::permissions::Capability::all_str_values().join(", ")
                     ));
                 }
             }
@@ -154,6 +157,43 @@ pub fn validate_cli(path: &str) -> i32 {
         0
     } else {
         1
+    }
+}
+
+/// Validate a `.plexipkg` file and print the report (fail-closed; stint 0015).
+fn validate_package_cli(file: &std::path::Path) -> i32 {
+    log::info!("validate: package file {}", file.display());
+    match crate::app::package::validate_package(file) {
+        Ok(report) => {
+            println!("✓ {} — package valid", report.id);
+            println!("  name:         {}", report.name);
+            println!("  version:      {}", report.version);
+            println!("  runtime:      {}", report.runtime.as_str());
+            println!("  entry:        {}", report.entry);
+            println!(
+                "  capabilities: {}",
+                if report.capabilities.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    report
+                        .capabilities
+                        .iter()
+                        .map(|c| c.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                }
+            );
+            println!(
+                "  files:        {} ({} bytes)",
+                report.file_count, report.total_size
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!("✗ {} — package validation failed:", file.display());
+            eprintln!("  {e}");
+            1
+        }
     }
 }
 
@@ -206,6 +246,60 @@ mod validate_tests {
         let path = dir.path().to_string_lossy().to_string();
         let code = super::validate_cli(&path);
         assert_eq!(code, 1, "missing manifest.toml must return 1");
+    }
+
+    #[test]
+    fn validate_fails_on_unknown_capability() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.toml"),
+            "schema_version = 1\n\n\
+             [app]\n\
+             id = \"test-app\"\n\
+             type = \"app\"\n\
+             name = \"Test App\"\n\
+             entry = \"main.py\"\n\
+             version = \"0.1.0\"\n\
+             description = \"A test app\"\n\n\
+             [app.capabilities]\n\
+             capabilities = [\"net.dns\"]\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("main.py"), "# stub\n").unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+        let code = super::validate_cli(&path);
+        assert_eq!(code, 1, "unknown capability must be a hard error");
+    }
+
+    #[test]
+    fn validate_routes_plexipkg_file_to_package_validation() {
+        let dir = TempDir::new().unwrap();
+        let app_dir = dir.path().join("app");
+        std::fs::create_dir(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("manifest.toml"),
+            "schema_version = 1\n\n\
+             [app]\n\
+             id = \"pkg-cli-test\"\n\
+             type = \"app\"\n\
+             name = \"Pkg CLI Test\"\n\
+             entry = \"main.py\"\n\
+             version = \"0.1.0\"\n\
+             description = \"A test app\"\n",
+        )
+        .unwrap();
+        std::fs::write(app_dir.join("main.py"), "# stub\n").unwrap();
+        let pkg = dir.path().join("pkg-cli-test-0.1.0.plexipkg");
+        crate::app::package::build_package(&app_dir, Some(&pkg)).unwrap();
+
+        let code = super::validate_cli(&pkg.to_string_lossy());
+        assert_eq!(code, 0, "a valid .plexipkg must pass validate_cli");
+
+        // A non-package file must be rejected, not treated as a directory.
+        let bogus = dir.path().join("not-a-package.txt");
+        std::fs::write(&bogus, "x").unwrap();
+        let code = super::validate_cli(&bogus.to_string_lossy());
+        assert_eq!(code, 1, "non-.plexipkg file must fail validate_cli");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,14 @@ fn main() -> eframe::Result {
                                         std::process::exit(cli::install_workspace_pack_cli());
                                     }
                                     Some(s) => {
+                                        // .plexipkg artifact: validate fail-closed, then install (stint 0015).
+                                        if s.ends_with(".plexipkg") {
+                                            log::info!("app_install:cli: package={s} version={version:?}");
+                                            std::process::exit(cli::app_install_package(
+                                                &s,
+                                                version.as_deref(),
+                                            ));
+                                        }
                                         // Local path: contains a path separator, starts with . or /, or is an existing directory.
                                         // Using is_dir() (not exists()) avoids misrouting bare app IDs that happen
                                         // to match a file in the current directory.
@@ -493,6 +501,10 @@ fn main() -> eframe::Result {
                             AppCmd::Validate { path } => {
                                 log::info!("app_validate:cli: path={path}");
                                 std::process::exit(cli::validate_cli(&path));
+                            }
+                            AppCmd::Package { path, out } => {
+                                log::info!("app_package:cli: path={path} out={out:?}");
+                                std::process::exit(cli::app_package_cli(&path, out.as_deref()));
                             }
                             AppCmd::Freeze { path } => {
                                 log::info!("app_freeze:cli: path={path}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,6 +417,7 @@ fn main() -> eframe::Result {
                                 spec_or_path,
                                 pack,
                                 version,
+                                yes,
                             } => {
                                 if let Some(p) = pack {
                                     log::info!("app_install:cli: pack={p}");
@@ -434,6 +435,8 @@ fn main() -> eframe::Result {
                                             std::process::exit(cli::app_install_package(
                                                 &s,
                                                 version.as_deref(),
+                                                cli::InstallConfirm::Interactive,
+                                                yes,
                                             ));
                                         }
                                         // Local path: contains a path separator, starts with . or /, or is an existing directory.
@@ -447,6 +450,8 @@ fn main() -> eframe::Result {
                                             std::process::exit(cli::app_install_with_pin(
                                                 &s,
                                                 version.as_deref(),
+                                                cli::InstallConfirm::Interactive,
+                                                yes,
                                             ));
                                         } else {
                                             log::info!("app_install:cli: remote spec={s} version={version:?}");
@@ -501,6 +506,10 @@ fn main() -> eframe::Result {
                             AppCmd::Validate { path } => {
                                 log::info!("app_validate:cli: path={path}");
                                 std::process::exit(cli::validate_cli(&path));
+                            }
+                            AppCmd::Inspect { path } => {
+                                log::info!("app_inspect:cli: path={path}");
+                                std::process::exit(cli::app_inspect_cli(&path));
                             }
                             AppCmd::Package { path, out } => {
                                 log::info!("app_package:cli: path={path} out={out:?}");

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -173,6 +173,8 @@ impl PlexiApp {
             mut secret_input_buf,
             mut permission_store,
             mut deferred_ai_queries,
+            mut deferred_gated_requests,
+            mut pending_commands,
             type_id,
             workspace_root,
             ai_broker,
@@ -196,6 +198,8 @@ impl PlexiApp {
                 std::mem::take(&mut proc.secret_input_buf),
                 std::mem::take(&mut proc.permission_store),
                 std::mem::take(&mut proc.deferred_ai_queries),
+                std::mem::take(&mut proc.deferred_gated_requests),
+                std::mem::take(&mut proc.pending_commands),
                 proc.type_id.clone(),
                 proc.workspace_root.clone(),
                 std::sync::Arc::clone(&proc.ai_broker),
@@ -217,6 +221,8 @@ impl PlexiApp {
             &mut permission_store,
             &colors,
             &mut deferred_ai_queries,
+            &mut deferred_gated_requests,
+            &mut pending_commands,
             ai_broker,
             http_tx,
             proc_pane_id,
@@ -236,6 +242,13 @@ impl PlexiApp {
         proc.secret_input_buf = secret_input_buf;
         proc.permission_store = permission_store;
         proc.deferred_ai_queries = deferred_ai_queries;
+        proc.deferred_gated_requests = deferred_gated_requests;
+        // The modal may have appended ForwardPaneRequest commands for
+        // deferred gated requests; anything routed onto proc.pending_commands
+        // between take and restore would be lost, so append rather than
+        // overwrite.
+        pending_commands.append(&mut proc.pending_commands);
+        proc.pending_commands = pending_commands;
     }
 
     /// Context-close confirmation dialog. Shows pane inventory with three choices:

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -36,7 +36,8 @@ pub(crate) use transport::StdinItem;
 use crate::app::app_trait::{App, AppCommand, AppRenderContext};
 use crate::app::permissions::{AppPermissions, Capability};
 use crate::app_protocol::{
-    AiMessage, AiTool, ControlCommand, DrawCommand, ModelTier, Modifiers, PlexiEvent, RenderCommand,
+    AiMessage, AiTool, AppRequest, ControlCommand, DrawCommand, ModelTier, Modifiers, PlexiEvent,
+    RenderCommand,
 };
 use crate::host::event_log::{self, HostEvent};
 use crate::host::runs::RunRegistry;
@@ -167,6 +168,12 @@ pub struct ProcessApp {
     /// AiQuery requests withheld pending first-run `ai.query` consent.
     /// Drained on consent resolution — dispatched if granted, errored if denied.
     pub(crate) deferred_ai_queries: VecDeque<DeferredAiQuery>,
+    /// Capability-gated pane/permission requests withheld pending consent
+    /// (yellow-state routing, stint 0017). Each entry pairs the gating
+    /// capability with the original request. Drained on consent resolution —
+    /// forwarded via `AppCommand::ForwardPaneRequest` if granted, answered
+    /// with the standard denial JSON on the request's response_file if denied.
+    pub(crate) deferred_gated_requests: Vec<(Capability, AppRequest)>,
     pub(crate) status_summary: Option<String>,
     /// Navigation stack maintained by `DrawCommand::PushNav` / `PopNav`.
     /// Each entry carries a stable `view_id` and a display `title`. When the
@@ -634,6 +641,7 @@ impl ProcessApp {
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
             deferred_ai_queries: VecDeque::new(),
+            deferred_gated_requests: Vec::new(),
             status_summary: None,
             nav_stack: Vec::new(),
             outbound_events: VecDeque::new(),
@@ -792,6 +800,7 @@ impl ProcessApp {
             run_registry: RunRegistry::new(),
             pending_prompts: VecDeque::new(),
             deferred_ai_queries: VecDeque::new(),
+            deferred_gated_requests: Vec::new(),
             status_summary: None,
             nav_stack: Vec::new(),
             outbound_events: VecDeque::new(),

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -1,7 +1,8 @@
 //! Capability and secret prompt modals — shown when an app requests access.
 
-use crate::app::permissions::AppPermissions;
-use crate::app_protocol::PlexiEvent;
+use crate::app::app_trait::AppCommand;
+use crate::app::permissions::{AppPermissions, Capability};
+use crate::app_protocol::{AppRequest, PlexiEvent};
 use crate::host::event_log::{self, HostEvent};
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
 use crate::workspace::secrets::SecretStore;
@@ -92,6 +93,8 @@ pub(crate) fn show_prompt_modal(
     permission_store: &mut crate::app::permissions::PermissionStore,
     colors: &crate::ui::theme::Colors,
     deferred_ai_queries: &mut VecDeque<DeferredAiQuery>,
+    deferred_gated_requests: &mut Vec<(Capability, AppRequest)>,
+    pending_commands: &mut Vec<AppCommand>,
     ai_broker: Arc<dyn AiBroker>,
     http_tx: Sender<PlexiEvent>,
     pane_id: u64,
@@ -314,7 +317,6 @@ pub(crate) fn show_prompt_modal(
     }
 
     if grant_once || grant_forever || deny_once || deny_forever {
-        use crate::app::permissions::Capability;
         let actually_granted = grant_once || grant_forever;
         match pending_prompts.pop_front() {
             Some(PendingPrompt::Capability {
@@ -469,6 +471,46 @@ pub(crate) fn show_prompt_modal(
                                 tokens_out: 0,
                                 error: Some("capability denied by user".to_string()),
                             });
+                        }
+                    }
+                }
+                // Drain capability-gated pane/permission requests that were
+                // withheld pending this consent (yellow-state routing, stint
+                // 0017). Granted → forward into the host pane-IPC handler;
+                // denied → answer each response_file with the standard
+                // denial JSON so blocking callers unblock immediately.
+                if let Ok(cap) = Capability::try_from(capability.as_str()) {
+                    let mut drained: Vec<AppRequest> = Vec::new();
+                    deferred_gated_requests.retain_mut(|(c, request)| {
+                        if *c == cap {
+                            drained.push(request.clone());
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    if !drained.is_empty() {
+                        log::info!(
+                            "prompts: '{}' {} for {} — {} {} deferred gated request(s)",
+                            cap,
+                            if actually_granted { "granted" } else { "denied" },
+                            type_id,
+                            if actually_granted {
+                                "forwarding"
+                            } else {
+                                "denying"
+                            },
+                            drained.len()
+                        );
+                        for request in drained {
+                            if actually_granted {
+                                pending_commands
+                                    .push(AppCommand::ForwardPaneRequest { request });
+                            } else {
+                                super::routing::write_pane_request_denial(
+                                    type_id, &request, cap,
+                                );
+                            }
                         }
                     }
                 }

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1703,6 +1703,14 @@ impl ProcessApp {
                 self.gate_and_forward_pane_request(request, Capability::PanesControl);
             }
 
+            // ── Permission management over PGAP (stint 0017) ───────────────
+            // A manager app may inspect and mutate other apps' permission
+            // state through the same host pane-IPC path, gated on the
+            // `permissions.manage` capability.
+            request @ (AppRequest::ListPermissions { .. } | AppRequest::SetPermission { .. }) => {
+                self.gate_and_forward_pane_request(request, Capability::PermissionsManage);
+            }
+
             // Context commands are only valid over PLEXI_SOCKET; log and drop
             // when sent via PGAP.
             AppRequest::CreateContext { .. } => {
@@ -1860,42 +1868,72 @@ impl ProcessApp {
         }
     }
 
-    /// Capability gate for pane read/control requests arriving over PGAP
-    /// (stint 0013/0014). On grant the original request is forwarded into the
-    /// host's pane-IPC handler — the same path `plexi pane ...` CLI commands
-    /// take over PLEXI_SOCKET. On denial, callers waiting on a response_file
-    /// get a JSON error object so they don't hang until their poll timeout;
-    /// fire-and-forget requests just log.
+    /// Capability gate for pane read/control and permission-management
+    /// requests arriving over PGAP (stint 0013/0014/0017). On grant the
+    /// original request is forwarded into the host's pane-IPC handler — the
+    /// same path `plexi pane ...` CLI commands take over PLEXI_SOCKET.
+    ///
+    /// Yellow-state routing (stint 0017): a capability that is neither
+    /// granted nor blocked (stored Yellow, or sensitive-and-unset) defers the
+    /// request and queues the runtime consent prompt instead of flat-denying.
+    /// Only a stored Red (blocked) decision denies without a prompt — callers
+    /// waiting on a response_file get a JSON error object so they don't hang
+    /// until their poll timeout; fire-and-forget requests just log.
     fn gate_and_forward_pane_request(&mut self, request: AppRequest, cap: Capability) {
         let kind = pane_request_kind(&request);
-        if let PermissionCheck::Denied(reason) = check(&self.permissions, cap) {
-            log::warn!(
-                "ProcessApp[{}]: {kind} denied — missing capability '{}': {reason}",
+        if let PermissionCheck::Allowed = check(&self.permissions, cap) {
+            log::info!(
+                "ProcessApp[{}]: forwarding {kind} to host pane-IPC handler (capability '{}')",
                 self.type_id,
                 cap.as_str()
             );
-            if let Some(response_file) = pane_request_response_file(&request) {
-                let body = serde_json::json!({
-                    "error": format!("capability denied: {}", cap.as_str()),
-                    "capability": cap.as_str(),
-                })
-                .to_string();
-                if let Err(e) = std::fs::write(response_file, body) {
-                    log::warn!(
-                        "ProcessApp[{}]: {kind} denial — could not write response file {response_file:?}: {e}",
-                        self.type_id
-                    );
-                }
-            }
+            self.pending_commands
+                .push(AppCommand::ForwardPaneRequest { request });
+            return;
+        }
+
+        if is_blocked(&self.permissions, cap) {
+            log::warn!(
+                "ProcessApp[{}]: {kind} denied — capability '{}' permanently blocked",
+                self.type_id,
+                cap.as_str()
+            );
+            write_pane_request_denial(&self.type_id, &request, cap);
+            return;
+        }
+
+        // Yellow / unset: defer the request and queue the consent prompt.
+        // Cap the deferred queue (mirrors deferred_ai_queries) so an app
+        // firing many requests before the modal resolves can't grow it
+        // unboundedly.
+        const MAX_DEFERRED_GATED: usize = 16;
+        if self.deferred_gated_requests.len() >= MAX_DEFERRED_GATED {
+            log::warn!(
+                "ProcessApp[{}]: {kind} dropped — deferred gated queue full (>={MAX_DEFERRED_GATED} pending consent)",
+                self.type_id
+            );
+            write_pane_request_denial(&self.type_id, &request, cap);
             return;
         }
         log::info!(
-            "ProcessApp[{}]: forwarding {kind} to host pane-IPC handler (capability '{}')",
+            "ProcessApp[{}]: {kind} withheld — queuing for '{}' consent",
             self.type_id,
             cap.as_str()
         );
-        self.pending_commands
-            .push(AppCommand::ForwardPaneRequest { request });
+        self.deferred_gated_requests.push((cap, request));
+        // Deduplicate: only push a prompt if one isn't already pending for
+        // this capability.
+        let already_pending = self.pending_prompts.iter().any(|p| {
+            matches!(p, super::PendingPrompt::Capability { capability, .. }
+                if capability == cap.as_str())
+        });
+        if !already_pending {
+            self.pending_prompts
+                .push_back(super::PendingPrompt::Capability {
+                    request_id: uuid::Uuid::new_v4().to_string(),
+                    capability: cap.as_str().to_string(),
+                });
+        }
     }
 
     /// Allocate a binary pipe for `pipe_id`, spin up the audio capture
@@ -2310,8 +2348,8 @@ impl ProcessApp {
     }
 }
 
-/// Wire name of a pane read/control request, for capability-gate log lines.
-fn pane_request_kind(request: &AppRequest) -> &'static str {
+/// Wire name of a capability-gated pane/permission request, for gate log lines.
+pub(crate) fn pane_request_kind(request: &AppRequest) -> &'static str {
     match request {
         AppRequest::ListPanes { .. } => "ListPanes",
         AppRequest::ListContexts { .. } => "ListContexts",
@@ -2325,24 +2363,49 @@ fn pane_request_kind(request: &AppRequest) -> &'static str {
         AppRequest::SendToPane { .. } => "SendToPane",
         AppRequest::KeyPane { .. } => "KeyPane",
         AppRequest::SendAppAction { .. } => "SendAppAction",
+        AppRequest::ListPermissions { .. } => "ListPermissions",
+        AppRequest::SetPermission { .. } => "SetPermission",
         _ => "unknown pane request",
     }
 }
 
-/// The response_file path a pane read/control request carries, if any.
+/// The response_file path a capability-gated request carries, if any.
 /// Used to write a capability-denied error object so callers don't hang.
-fn pane_request_response_file(request: &AppRequest) -> Option<&str> {
+pub(crate) fn pane_request_response_file(request: &AppRequest) -> Option<&str> {
     match request {
         AppRequest::ListPanes { response_file, .. }
         | AppRequest::ListContexts { response_file }
         | AppRequest::GetPaneInfo { response_file, .. }
         | AppRequest::GetPreviousPaneInfo { response_file }
         | AppRequest::GetPaneState { response_file, .. }
-        | AppRequest::CapturePane { response_file, .. } => Some(response_file),
+        | AppRequest::CapturePane { response_file, .. }
+        | AppRequest::ListPermissions { response_file }
+        | AppRequest::SetPermission { response_file, .. } => Some(response_file),
         AppRequest::SendToPane { response_file, .. }
         | AppRequest::KeyPane { response_file, .. }
         | AppRequest::SendAppAction { response_file, .. } => response_file.as_deref(),
         _ => None,
+    }
+}
+
+/// Write the standard capability-denial JSON object to a gated request's
+/// response_file (when it carries one) so blocking SDK callers unblock
+/// immediately instead of hitting their poll timeout. Shared by the routing
+/// gate (blocked / queue-full paths) and the consent-deny drain in prompts.rs.
+pub(crate) fn write_pane_request_denial(type_id: &str, request: &AppRequest, cap: Capability) {
+    let kind = pane_request_kind(request);
+    let Some(response_file) = pane_request_response_file(request) else {
+        return;
+    };
+    let body = serde_json::json!({
+        "error": format!("capability denied: {}", cap.as_str()),
+        "capability": cap.as_str(),
+    })
+    .to_string();
+    if let Err(e) = std::fs::write(response_file, body) {
+        log::warn!(
+            "ProcessApp[{type_id}]: {kind} denial — could not write response file {response_file:?}: {e}"
+        );
     }
 }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -686,6 +686,53 @@ pub enum AppRequest {
     /// Sent by `plexi pane info --previous`.
     GetPreviousPaneInfo { response_file: String },
 
+    /// List permission state across apps (stint 0017). Gated on
+    /// `permissions.manage` when arriving over PGAP. Host writes a JSON object
+    /// to `response_file`:
+    ///
+    /// ```json
+    /// {
+    ///   "permissions": [
+    ///     {
+    ///       "app_id": "...",
+    ///       "workspace": "/abs/path",
+    ///       "capability": "panes.read",
+    ///       "state": "green" | "yellow" | "red",
+    ///       "stored": true | false,
+    ///       "sensitive": true | false,
+    ///       "description": "..."
+    ///     }
+    ///   ],
+    ///   "running": ["app_id", ...]
+    /// }
+    /// ```
+    ///
+    /// One row per entry persisted in `permissions.toml` (`stored: true`),
+    /// plus one row per live capability of a currently-running app that has
+    /// no stored entry (`stored: false` — granted → "green", blocked →
+    /// "red"). Live capabilities in the effective yellow state (declared but
+    /// neither granted nor blocked) are not retained by the host after
+    /// launch and only appear once a decision is stored.
+    ListPermissions { response_file: String },
+
+    /// Set the stored permission state for an (app, workspace, capability)
+    /// triple (stint 0017). Gated on `permissions.manage` when arriving over
+    /// PGAP. `state` is one of "green" | "yellow" | "red". When `workspace`
+    /// is omitted, the workspace root of a running app with `app_id` is used;
+    /// if no such app is running the request fails. Persists to
+    /// `permissions.toml` AND live-updates any running app's permission set,
+    /// so a revocation takes effect on the app's next request. Host writes
+    /// `{"ok":true}` or `{"error":"..."}` to `response_file`. Unknown
+    /// capability or state strings fail closed with an error reply.
+    SetPermission {
+        app_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace: Option<String>,
+        capability: String,
+        state: String,
+        response_file: String,
+    },
+
     /// Write bytes to a named host-managed pane file slot.
     SlotWrite {
         pane_id: u64,

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1356,11 +1356,15 @@ fn capability_secret_overlay_focus_wins_after_central_panel_steal() {
 
 // -- Pane read/control over PGAP (stint 0013/0014) --------------------------
 
-/// App WITHOUT `panes.read` sends ListPanes via PGAP: the request must not be
-/// forwarded — instead the capability gate writes a JSON error object to the
-/// response_file so the caller doesn't hang until its poll timeout.
+/// App WITHOUT `panes.read` (yellow/unset, NOT blocked) sends ListPanes via
+/// PGAP: with yellow-state routing (stint 0017) the request is deferred and a
+/// consent prompt is queued — no denial JSON is written and no forward happens
+/// until the user decides.
 #[test]
-fn pgap_list_panes_denied_without_panes_read() {
+fn pgap_list_panes_yellow_queues_prompt_without_panes_read() {
+    use crate::host::pane::AppRuntime;
+    use crate::process_app::PendingPrompt;
+
     let mut h = HostHarness::new();
     let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
 
@@ -1375,18 +1379,27 @@ fn pgap_list_panes_denied_without_panes_read() {
     );
     h.run_frames(2);
 
-    let content =
-        std::fs::read_to_string(&response_file).expect("denial must write the response file");
-    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
-    assert_eq!(
-        v["capability"], "panes.read",
-        "denial object must name the missing capability: {content}"
-    );
     assert!(
-        v["error"]
-            .as_str()
-            .is_some_and(|e| e.contains("capability denied")),
-        "denial object must carry an error message: {content}"
+        !response_file.exists(),
+        "yellow-state request must not write a denial or a forward result — it waits on consent"
+    );
+    let win = &h.app.windows[0];
+    let Some(Pane::App(app_pane)) = win.panes.get(&pane) else {
+        panic!("expected App pane");
+    };
+    let AppRuntime::Process(ref proc) = app_pane.runtime else {
+        panic!("expected Process runtime");
+    };
+    assert!(
+        proc.pending_prompts.iter().any(|p| {
+            matches!(p, PendingPrompt::Capability { capability, .. } if capability == "panes.read")
+        }),
+        "a consent prompt for panes.read must be queued"
+    );
+    assert_eq!(
+        proc.deferred_gated_requests.len(),
+        1,
+        "the request must be deferred pending consent"
     );
 }
 
@@ -1422,14 +1435,20 @@ fn pgap_list_panes_forwarded_with_panes_read() {
     );
 }
 
-/// App WITHOUT `panes.control` sends SendToPane via PGAP: the gate must write
-/// the capability-denied error object instead of forwarding.
+/// App with `panes.control` BLOCKED (stored Red) sends SendToPane via PGAP:
+/// the gate must write the capability-denied error object instead of
+/// forwarding — and must not queue a consent prompt (only the yellow/unset
+/// middle state prompts; Red stays flat-denied).
 #[test]
 fn pgap_send_to_pane_denied_without_panes_control() {
     let mut h = HostHarness::new();
-    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+    let mut perms = AppPermissions::from_capability_strings(&[
         "panes.read".to_string(), // read alone must NOT grant control
-    ]));
+    ]);
+    perms
+        .blocked
+        .insert(crate::app::permissions::Capability::PanesControl);
+    let pane = h.add_test_pane_with_permissions(perms);
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let response_file = tmp.path().join("send-to-pane.json");
@@ -1487,5 +1506,357 @@ fn pgap_send_to_pane_forwarded_with_panes_control() {
             .as_str()
             .is_some_and(|e| e.contains("not a terminal pane")),
         "host handler must answer with its own pane-type error: {content}"
+    );
+}
+
+// -- Permission management + yellow-state routing (stint 0017) ---------------
+
+/// App WITHOUT `permissions.manage` (yellow/unset) sends ListPermissions via
+/// PGAP: yellow-state routing queues a consent prompt and defers the request —
+/// no denial JSON, no forward.
+#[test]
+fn list_permissions_denied_without_manage() {
+    use crate::host::pane::AppRuntime;
+    use crate::process_app::PendingPrompt;
+
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-permissions.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPermissions {
+            response_file: response_file.to_string_lossy().into_owned(),
+        }),
+    );
+    h.run_frames(2);
+
+    assert!(
+        !response_file.exists(),
+        "ungranted+unblocked permissions.manage must defer, not deny or forward"
+    );
+    let win = &h.app.windows[0];
+    let Some(Pane::App(app_pane)) = win.panes.get(&pane) else {
+        panic!("expected App pane");
+    };
+    let AppRuntime::Process(ref proc) = app_pane.runtime else {
+        panic!("expected Process runtime");
+    };
+    assert!(
+        proc.pending_prompts.iter().any(|p| {
+            matches!(p, PendingPrompt::Capability { capability, .. }
+                if capability == "permissions.manage")
+        }),
+        "a consent prompt for permissions.manage must be queued"
+    );
+    assert_eq!(proc.deferred_gated_requests.len(), 1);
+}
+
+/// App WITH `permissions.manage` sends ListPermissions via PGAP: the request
+/// is forwarded into the host handler, which writes the permission inventory —
+/// stored rows from permissions.toml plus live rows for running apps.
+#[test]
+fn list_permissions_granted() {
+    use crate::app::permissions::{Capability, PermissionState, PermissionStore};
+
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "permissions.manage".to_string(),
+    ]));
+
+    // Seed a stored decision for an (unrelated) app.
+    let store_dir = h.app.permission_store_dir.clone();
+    {
+        let mut store = PermissionStore::load_or_default(&store_dir);
+        store.set(
+            "other-app",
+            std::path::Path::new("/test/project"),
+            Capability::NetHttp,
+            PermissionState::Red,
+        );
+        store.save();
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-permissions.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPermissions {
+            response_file: response_file.to_string_lossy().into_owned(),
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("grant must write the response file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    let rows = v["permissions"]
+        .as_array()
+        .expect("permissions must be an array");
+    let stored_row = rows
+        .iter()
+        .find(|r| r["app_id"] == "other-app")
+        .unwrap_or_else(|| panic!("stored entry must appear: {content}"));
+    assert_eq!(stored_row["capability"], "net.http");
+    assert_eq!(stored_row["state"], "red");
+    assert_eq!(stored_row["stored"], true);
+    assert_eq!(stored_row["sensitive"], true);
+
+    // The requesting app itself is running with a live (unstored) grant.
+    let live_row = rows
+        .iter()
+        .find(|r| r["app_id"] == "test" && r["capability"] == "permissions.manage")
+        .unwrap_or_else(|| panic!("live capability of running app must appear: {content}"));
+    assert_eq!(live_row["state"], "green");
+    assert_eq!(live_row["stored"], false);
+
+    let running = v["running"].as_array().expect("running must be an array");
+    assert!(
+        running.iter().any(|a| a == "test"),
+        "running list must contain the requesting app: {content}"
+    );
+}
+
+/// SetPermission to red must persist to the store AND live-update the running
+/// app's AppPermissions so the revocation takes effect on its next request.
+#[test]
+fn set_permission_revokes_running_app() {
+    use crate::app::permissions::{Capability, PermissionState, PermissionStore};
+    use crate::host::pane::AppRuntime;
+
+    let mut h = HostHarness::new();
+    let manager = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "permissions.manage".to_string(),
+    ]));
+    let target = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "panes.read".to_string(),
+    ]));
+
+    let workspace = std::env::temp_dir();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("set-permission.json");
+    h.inject(
+        manager,
+        DrawCommand::Host(AppRequest::SetPermission {
+            app_id: "test".to_string(),
+            workspace: Some(workspace.to_string_lossy().into_owned()),
+            capability: "panes.read".to_string(),
+            state: "red".to_string(),
+            response_file: response_file.to_string_lossy().into_owned(),
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("SetPermission must write a reply");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("reply must be JSON");
+    assert_eq!(v["ok"], true, "reply must be ok: {content}");
+
+    // Live AppPermissions of the running target must reflect the revocation.
+    let win = &h.app.windows[0];
+    let Some(Pane::App(app_pane)) = win.panes.get(&target) else {
+        panic!("expected App pane");
+    };
+    let AppRuntime::Process(ref proc) = app_pane.runtime else {
+        panic!("expected Process runtime");
+    };
+    assert!(
+        proc.permissions.blocked.contains(&Capability::PanesRead),
+        "live permissions must have panes.read blocked"
+    );
+    assert!(
+        !proc.permissions.capabilities.contains(&Capability::PanesRead),
+        "live permissions must no longer grant panes.read"
+    );
+
+    // The store must have persisted the Red decision.
+    let store = PermissionStore::load_or_default(&h.app.permission_store_dir);
+    assert_eq!(
+        store.get("test", &workspace, Capability::PanesRead),
+        Some(PermissionState::Red),
+        "permissions.toml must persist the red decision"
+    );
+}
+
+/// SetPermission with an unknown capability or state must fail closed with an
+/// error reply and persist nothing.
+#[test]
+fn set_permission_unknown_capability_fails_closed() {
+    let mut h = HostHarness::new();
+    let manager = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[
+        "permissions.manage".to_string(),
+    ]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("set-permission.json");
+    h.inject(
+        manager,
+        DrawCommand::Host(AppRequest::SetPermission {
+            app_id: "test".to_string(),
+            workspace: Some(std::env::temp_dir().to_string_lossy().into_owned()),
+            capability: "not.a.capability".to_string(),
+            state: "red".to_string(),
+            response_file: response_file.to_string_lossy().into_owned(),
+        }),
+    );
+    h.run_frames(2);
+
+    let content = std::fs::read_to_string(&response_file).expect("error reply must be written");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("reply must be JSON");
+    assert!(
+        v["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("not.a.capability")),
+        "error must name the unknown capability: {content}"
+    );
+}
+
+/// Yellow-state routing end-to-end: a gated request with no stored decision
+/// queues the consent prompt; granting via the modal forwards the deferred
+/// request into the host handler, which writes the real response.
+#[test]
+fn yellow_capability_queues_prompt_then_grant_forwards() {
+    use crate::app::FocusLayer;
+    use crate::host::pane::AppRuntime;
+    use crate::process_app::PendingPrompt;
+
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-panes.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPanes {
+            response_file: response_file.to_string_lossy().into_owned(),
+            context_id: None,
+        }),
+    );
+    h.focus_pane(pane);
+    h.run_frames(2);
+
+    // Prompt queued, request deferred, nothing written yet.
+    {
+        let win = &h.app.windows[0];
+        let Some(Pane::App(app_pane)) = win.panes.get(&pane) else {
+            panic!("expected App pane");
+        };
+        let AppRuntime::Process(ref proc) = app_pane.runtime else {
+            panic!("expected Process runtime");
+        };
+        assert!(
+            proc.pending_prompts.iter().any(|p| {
+                matches!(p, PendingPrompt::Capability { capability, .. }
+                    if capability == "panes.read")
+            }),
+            "consent prompt for panes.read must be queued"
+        );
+        assert!(!response_file.exists());
+    }
+    assert!(
+        h.app
+            .focus_stack
+            .iter()
+            .any(|l| *l == FocusLayer::CapabilityModal),
+        "CapabilityModal must be on the focus stack while the prompt is pending"
+    );
+
+    // Grant once via the modal (plain Enter).
+    h.key(egui::Key::Enter, egui::Modifiers::NONE);
+    h.run_frames(2);
+
+    let content = std::fs::read_to_string(&response_file)
+        .expect("granted deferred request must be forwarded and answered");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    let panes = v
+        .as_array()
+        .expect("ListPanes response must be a JSON array");
+    assert!(
+        panes.iter().any(|p| p["id"].as_u64() == Some(pane)),
+        "pane list must contain the requesting pane: {content}"
+    );
+}
+
+/// Yellow-state routing deny path: denying the consent prompt must answer each
+/// deferred request's response_file with the standard denial JSON.
+#[test]
+fn yellow_capability_deny_writes_denial() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane_with_permissions(AppPermissions::from_capability_strings(&[]));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-panes.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPanes {
+            response_file: response_file.to_string_lossy().into_owned(),
+            context_id: None,
+        }),
+    );
+    h.focus_pane(pane);
+    h.run_frames(2);
+
+    // Deny once via the modal (Escape).
+    h.key(egui::Key::Escape, egui::Modifiers::NONE);
+    h.run_frames(1);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("deny must write the denial JSON");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    assert_eq!(
+        v["capability"], "panes.read",
+        "denial must name the capability: {content}"
+    );
+    assert!(
+        v["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("capability denied")),
+        "denial must carry the standard error message: {content}"
+    );
+}
+
+/// A blocked (Red) capability stays flat-denied with no consent prompt — only
+/// the yellow/unset middle state routes through the modal.
+#[test]
+fn red_capability_flat_denies_without_prompt() {
+    use crate::app::permissions::Capability;
+    use crate::host::pane::AppRuntime;
+
+    let mut h = HostHarness::new();
+    let mut perms = AppPermissions::from_capability_strings(&[]);
+    perms.blocked.insert(Capability::PanesRead);
+    let pane = h.add_test_pane_with_permissions(perms);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let response_file = tmp.path().join("list-panes.json");
+    h.inject(
+        pane,
+        DrawCommand::Host(AppRequest::ListPanes {
+            response_file: response_file.to_string_lossy().into_owned(),
+            context_id: None,
+        }),
+    );
+    h.run_frames(2);
+
+    let content =
+        std::fs::read_to_string(&response_file).expect("blocked cap must write denial JSON");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+    assert_eq!(v["capability"], "panes.read");
+
+    let win = &h.app.windows[0];
+    let Some(Pane::App(app_pane)) = win.panes.get(&pane) else {
+        panic!("expected App pane");
+    };
+    let AppRuntime::Process(ref proc) = app_pane.runtime else {
+        panic!("expected Process runtime");
+    };
+    assert!(
+        proc.pending_prompts.is_empty(),
+        "a blocked capability must not queue a consent prompt"
+    );
+    assert!(
+        proc.deferred_gated_requests.is_empty(),
+        "a blocked capability must not defer the request"
     );
 }


### PR DESCRIPTION
Stint tasks 0015, 0016, 0017 (S3 — packages install locally with explicit capability and trust handling). No linked GitHub issue; stint-tracked.

## Summary

**0015 — package artifact + validator contract**
- `.plexipkg`: gzipped tar with generated `PACKAGE.toml` (per-file sha256+size, runtime, capability snapshot)
- `plexi app package <dir>`; `plexi app validate` accepts dirs and `.plexipkg`; `plexi app install <file.plexipkg>`
- Fail-closed validator: missing manifest, unknown capabilities (now enum-derived — stale hand-rolled list in validate.rs removed), path traversal, absolute paths, symlinks, checksum/size mismatch, unlisted/missing files, metadata mismatch

**0016 — install inspection + trust sheet**
- `plexi app inspect <pack|dir>`: validator-gated trust sheet with per-capability descriptions and `[sensitive]` markers
- Install gate on both install paths: trust sheet + y/N confirm, `--yes` to skip, non-tty without `--yes` fails closed
- Blunt trust labels: "First-party core" / "Unreviewed Python|native process — runs with your full user permissions" (no WASM claims)

**0017 — permission manager + yellow-state routing**
- New sensitive capability `permissions.manage`; `ListPermissions`/`SetPermission` AppRequests via the 0013 gate-then-forward path; revoke live-updates running apps
- Yellow routing: gated requests on an undecided capability raise the consent modal (deferred + forwarded on grant) instead of flat-deny; Red stays silent-deny
- First-party `apps/permissions` core app: state badges, g/y/b allow/ask/block, grant-and-retry on denial

## Test Evidence
- `cargo test --bin plexi`: 873 passed, 0 failed (32 new)
- SDK pytest: 176 passed (7 new)
- Live smokes: package round-trip on assistant app; tampered archive rejected (exit 1); inspect sheet renders; non-tty install fails closed; headless render of permissions app

🤖 Generated with [Claude Code](https://claude.com/claude-code)