### PR TITLE
feat(command-palette): add trailing row metadata

### DIFF
--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -4,7 +4,7 @@ use crate::app::PlexiApp;
 use crate::ui::{
     hints::{HintBar, HintGroup},
     labels::description_label,
-    list::ListRow,
+    list::{ListRow, ListRowPips},
     overlay::ModalShell,
     style,
     text_field::TextField,
@@ -16,6 +16,8 @@ enum PaletteEntry {
         context_id: u64,
         name: String,
         workspace_name: String,
+        metadata_chip: &'static str,
+        pane_pips: Option<ListRowPips>,
         /// If set, focus this specific pane after navigating to the window.
         pane_id: Option<u64>,
     },
@@ -26,6 +28,91 @@ enum PaletteEntry {
         running_in_background: bool,
         is_workspace_local: bool,
     },
+}
+
+pub(crate) fn app_metadata_chips(
+    running_in_background: bool,
+    is_workspace_local: bool,
+) -> &'static [&'static str] {
+    match (running_in_background, is_workspace_local) {
+        (false, false) => &["app"],
+        (true, false) => &["app", "bg"],
+        (false, true) => &["app", "ws"],
+        (true, true) => &["app", "bg", "ws"],
+    }
+}
+
+fn palette_pips_for_context(
+    windows: &[crate::host::context::Window],
+    context_active_window: &std::collections::HashMap<u64, u64>,
+    ctx_id: u64,
+    fallback_active_window_id: Option<u64>,
+) -> Option<ListRowPips> {
+    let mut ctx_windows: Vec<usize> = windows
+        .iter()
+        .enumerate()
+        .filter(|(_, w)| w.context_id == ctx_id)
+        .map(|(idx, _)| idx)
+        .collect();
+    ctx_windows.sort_by_key(|&idx| {
+        let w = &windows[idx];
+        (w.grid_y, w.grid_x)
+    });
+
+    let mut pane_ids = Vec::new();
+    for &win_idx in &ctx_windows {
+        let win = &windows[win_idx];
+        if let Some(root) = win.tree.root() {
+            pane_ids.extend(crate::spatial::tiling::collect_pane_ids_spatial(
+                &win.tree.tiles,
+                root,
+            ));
+        }
+    }
+    if pane_ids.is_empty() {
+        return None;
+    }
+
+    let active_window_id = context_active_window
+        .get(&ctx_id)
+        .copied()
+        .or_else(|| {
+            fallback_active_window_id.filter(|win_id| {
+                windows
+                    .iter()
+                    .any(|w| w.window_id == *win_id && w.context_id == ctx_id)
+            })
+        })
+        .or_else(|| ctx_windows.first().map(|idx| windows[*idx].window_id));
+
+    let focused_pane_id = active_window_id
+        .and_then(|active_win_id| windows.iter().find(|w| w.window_id == active_win_id))
+        .and_then(|win| {
+            win.focused_pane
+                .and_then(|tile_id| match win.tree.tiles.get(tile_id) {
+                    Some(egui_tiles::Tile::Pane(pid)) => Some(*pid),
+                    _ => None,
+                })
+        });
+    let focused_idx = focused_pane_id.and_then(|pid| pane_ids.iter().position(|&p| p == pid));
+    let hidden_indices = pane_ids
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, pane_id)| {
+            windows
+                .iter()
+                .filter(|w| w.context_id == ctx_id)
+                .find_map(|w| w.panes.get(pane_id))
+                .is_some_and(|pane| pane.is_hidden())
+                .then_some(idx)
+        })
+        .collect();
+
+    Some(ListRowPips {
+        count: pane_ids.len(),
+        focused_idx,
+        hidden_indices,
+    })
 }
 
 impl PlexiApp {
@@ -95,12 +182,14 @@ impl PlexiApp {
             };
 
             for (ci, w) in self.windows.iter().enumerate() {
-                let ctx_name = self
-                    .router
-                    .iter()
-                    .find(|c| c.context_id == w.context_id)
-                    .map(|c| c.name.clone())
-                    .unwrap_or_default();
+                let Some(ctx_meta) = self.router.iter().find(|c| c.context_id == w.context_id)
+                else {
+                    continue;
+                };
+                if ctx_meta.parked {
+                    continue;
+                }
+                let ctx_name = ctx_meta.name.clone();
 
                 // Primary entry — one per context.
                 if !seen_contexts.contains(&w.context_id) {
@@ -133,6 +222,13 @@ impl PlexiApp {
                                 context_id: win_id,
                                 name: pane_name,
                                 workspace_name: ctx_name.clone(),
+                                metadata_chip: "term",
+                                pane_pips: palette_pips_for_context(
+                                    &self.windows,
+                                    &self.context_active_window,
+                                    w.context_id,
+                                    Some(active_win_id),
+                                ),
                                 pane_id: Some(pane_id),
                             });
                         }
@@ -144,6 +240,13 @@ impl PlexiApp {
                                 context_id: fallback_win_id.1,
                                 name: ctx_name.clone(),
                                 workspace_name: String::new(),
+                                metadata_chip: "ctx",
+                                pane_pips: palette_pips_for_context(
+                                    &self.windows,
+                                    &self.context_active_window,
+                                    w.context_id,
+                                    Some(active_win_id),
+                                ),
                                 pane_id: None,
                             });
                         }
@@ -183,6 +286,13 @@ impl PlexiApp {
                                     context_id: w.window_id,
                                     name: pane_name.clone(),
                                     workspace_name: ctx_name.clone(),
+                                    metadata_chip: "term",
+                                    pane_pips: palette_pips_for_context(
+                                        &self.windows,
+                                        &self.context_active_window,
+                                        w.context_id,
+                                        Some(active_win_id),
+                                    ),
                                     pane_id: Some(pane_id),
                                 });
                             }
@@ -391,12 +501,17 @@ impl PlexiApp {
                                     context_id,
                                     name,
                                     workspace_name,
+                                    metadata_chip,
+                                    pane_pips,
                                     pane_id,
                                 } => {
-                                    let row = ListRow::new(name.as_str())
-                                        .chip("ctx")
+                                    let mut row = ListRow::new(name.as_str())
+                                        .metadata_chips(std::slice::from_ref(metadata_chip))
                                         .secondary(workspace_name.as_str())
                                         .selected(is_selected);
+                                    if let Some(pips) = pane_pips.clone() {
+                                        row = row.pane_pips(pips);
+                                    }
                                     let row_response = row.show(ui, &colors);
 
                                     if is_selected && should_scroll {
@@ -431,23 +546,12 @@ impl PlexiApp {
                                         ui.add_space(style::SPACE_XS);
                                     }
 
-                                    let mut secondary = description.clone();
-                                    if *running_in_background {
-                                        if !secondary.is_empty() {
-                                            secondary.push_str(" · ");
-                                        }
-                                        secondary.push_str("bg");
-                                    }
-                                    if *is_workspace_local {
-                                        if !secondary.is_empty() {
-                                            secondary.push_str(" · ");
-                                        }
-                                        secondary.push_str("ws");
-                                    }
-
                                     let row = ListRow::new(name.as_str())
-                                        .chip("app")
-                                        .secondary(&secondary)
+                                        .metadata_chips(app_metadata_chips(
+                                            *running_in_background,
+                                            *is_workspace_local,
+                                        ))
+                                        .secondary(description)
                                         .selected(is_selected);
 
                                     let row_response = row.show(ui, &colors);
@@ -534,5 +638,98 @@ impl PlexiApp {
                 win.focused_pane = Some(tile_id);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::pane::{Pane, PortalPane};
+    use crate::ui::list::ListRowPips;
+
+    #[test]
+    fn app_metadata_chips_add_workspace_scope_without_secondary_text() {
+        assert_eq!(app_metadata_chips(false, false), &["app"]);
+        assert_eq!(app_metadata_chips(false, true), &["app", "ws"]);
+        assert_eq!(app_metadata_chips(true, true), &["app", "bg", "ws"]);
+    }
+
+    #[test]
+    fn palette_pips_include_hidden_and_focused_panes() {
+        let win = test_window(1, 1, 0, 0, &[(10, false), (20, false), (30, true)], 1);
+        let context_active_window = std::collections::HashMap::from([(1, 1)]);
+        let windows = vec![win];
+        let pips = palette_pips_for_context(&windows, &context_active_window, 1, None);
+
+        assert_eq!(
+            pips,
+            Some(ListRowPips {
+                count: 3,
+                focused_idx: Some(1),
+                hidden_indices: vec![2],
+            })
+        );
+    }
+
+    #[test]
+    fn palette_pips_cover_every_window_in_the_context() {
+        let first = test_window(1, 1, 0, 0, &[(10, false), (20, true), (30, false)], 0);
+        let second = test_window(1, 2, 1, 0, &[(40, false), (50, true), (60, false)], 2);
+        let context_active_window = std::collections::HashMap::from([(1, 2)]);
+        let windows = vec![first, second];
+        let pips = palette_pips_for_context(&windows, &context_active_window, 1, None);
+
+        assert_eq!(
+            pips,
+            Some(ListRowPips {
+                count: 6,
+                focused_idx: Some(5),
+                hidden_indices: vec![1, 4],
+            })
+        );
+    }
+
+    fn test_window(
+        context_id: u64,
+        window_id: u64,
+        grid_x: u32,
+        grid_y: u32,
+        panes_spec: &[(u64, bool)],
+        focused_idx: usize,
+    ) -> crate::host::context::Window {
+        let mut panes = std::collections::HashMap::new();
+        let mut tiles = egui_tiles::Tiles::default();
+        let mut tile_ids = Vec::new();
+        for &(pane_id, hidden) in panes_spec {
+            panes.insert(pane_id, test_pane(pane_id, hidden));
+            tile_ids.push(tiles.insert_pane(pane_id));
+        }
+        let focused_pane = tile_ids.get(focused_idx).copied();
+        let root = match tile_ids.as_slice() {
+            [only] => *only,
+            _ => tiles.insert_horizontal_tile(tile_ids),
+        };
+        let tree = egui_tiles::Tree::new("test", root, tiles);
+        crate::host::context::Window {
+            name: "test".to_string(),
+            path: std::path::PathBuf::from("/tmp"),
+            tree,
+            panes,
+            focused_pane,
+            zoomed_pane: None,
+            grid_x,
+            grid_y,
+            window_id,
+            context_id,
+        }
+    }
+
+    fn test_pane(id: u64, hidden: bool) -> Pane {
+        Pane::Portal(Box::new(PortalPane {
+            pane_id: id,
+            target_context_id: id + 1000,
+            context_state: None,
+            hidden,
+        }))
     }
 }

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -3,10 +3,19 @@ use egui::{Align2, Color32, CornerRadius, Pos2, Response, Stroke, StrokeKind, Ve
 use crate::ui::style;
 use crate::ui::theme::Colors;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ListRowPips {
+    pub count: usize,
+    pub focused_idx: Option<usize>,
+    pub hidden_indices: Vec<usize>,
+}
+
 pub struct ListRow<'a> {
     body: &'a str,
     secondary: Option<&'a str>,
     chip: Option<&'a str>,
+    metadata_chips: &'a [&'a str],
+    pane_pips: Option<ListRowPips>,
     trailing: Option<&'a str>,
     selected: bool,
     danger_trailing: bool,
@@ -18,6 +27,8 @@ impl<'a> ListRow<'a> {
             body,
             secondary: None,
             chip: None,
+            metadata_chips: &[],
+            pane_pips: None,
             trailing: None,
             selected: false,
             danger_trailing: false,
@@ -31,6 +42,16 @@ impl<'a> ListRow<'a> {
 
     pub fn chip(mut self, label: &'a str) -> Self {
         self.chip = Some(label);
+        self
+    }
+
+    pub fn metadata_chips(mut self, labels: &'a [&'a str]) -> Self {
+        self.metadata_chips = labels;
+        self
+    }
+
+    pub fn pane_pips(mut self, pips: ListRowPips) -> Self {
+        self.pane_pips = Some(pips);
         self
     }
 
@@ -119,12 +140,7 @@ impl<'a> ListRow<'a> {
                 trailing_response
             });
 
-        let text_right = self
-            .trailing
-            .map(|label| {
-                rect.right() - TRAILING_PAD_H - trailing_size(ui, label).x - style::LIST_ROW_GAP
-            })
-            .unwrap_or_else(|| rect.right() - style::LIST_ROW_PAD_H);
+        let text_right = self.text_right(ui, rect);
         // The chip trails the title so every row's title starts at the same
         // x — variable-width leading chips made list starts ragged. Reserve
         // its width out of the primary line's budget only; secondary metadata
@@ -135,21 +151,89 @@ impl<'a> ListRow<'a> {
             .unwrap_or(0.0);
         let primary_max = (text_right - x - chip_reserved).max(0.0);
         let secondary_max = (text_right - x).max(0.0);
-        let (primary_end_x, primary_center_y) =
+        let text_metrics =
             draw_text_block(ui, &self, colors, x, center_y, primary_max, secondary_max);
         if let Some(label) = self.chip {
             draw_chip(
                 ui,
                 label,
                 colors,
-                primary_end_x + style::LIST_ROW_GAP,
-                primary_center_y,
+                text_metrics.primary_end_x + style::LIST_ROW_GAP,
+                text_metrics.primary_center_y,
             );
         }
+        self.draw_metadata(ui, colors, rect, trailing_rect, text_metrics);
 
         ListRowResponse {
             row: response,
             trailing: trailing_response,
+        }
+    }
+
+    fn action_left(&self, ui: &egui::Ui, rect: egui::Rect) -> f32 {
+        self.trailing
+            .map(|label| rect.right() - TRAILING_PAD_H - trailing_size(ui, label).x)
+            .unwrap_or_else(|| rect.right() - style::LIST_ROW_PAD_H)
+    }
+
+    fn text_right(&self, ui: &egui::Ui, rect: egui::Rect) -> f32 {
+        let action_left = self.action_left(ui, rect);
+        let has_trailing = self.trailing.is_some();
+        let metadata_width = self.metadata_lane_width(ui);
+        if metadata_width > 0.0 {
+            action_left - style::LIST_ROW_GAP - metadata_width - style::LIST_ROW_GAP
+        } else if has_trailing {
+            action_left - style::LIST_ROW_GAP
+        } else {
+            action_left
+        }
+    }
+
+    fn metadata_lane_width(&self, ui: &egui::Ui) -> f32 {
+        let chip_width = metadata_chip_row_width(ui, self.metadata_chips);
+        let pip_width = self
+            .pane_pips
+            .as_ref()
+            .map(|pips| pane_pips_width(pips.count))
+            .unwrap_or(0.0);
+        chip_width.max(pip_width)
+    }
+
+    fn draw_metadata(
+        &self,
+        ui: &egui::Ui,
+        colors: &Colors,
+        rect: egui::Rect,
+        trailing_rect: Option<egui::Rect>,
+        text_metrics: TextBlockMetrics,
+    ) {
+        let lane_width = self.metadata_lane_width(ui);
+        if lane_width <= 0.0 {
+            return;
+        }
+        let action_left = trailing_rect
+            .map(|r| r.left())
+            .unwrap_or_else(|| rect.right() - style::LIST_ROW_PAD_H);
+        let lane_right = action_left - style::LIST_ROW_GAP;
+        let lane_left = lane_right - lane_width;
+
+        let has_compact_pips =
+            self.pane_pips.is_some() && text_metrics.secondary_center_y.is_none();
+        let chip_center_y = if has_compact_pips {
+            text_metrics.primary_center_y - COMPACT_METADATA_CHIP_OFFSET_Y
+        } else {
+            text_metrics.primary_center_y
+        };
+
+        if !self.metadata_chips.is_empty() {
+            draw_chip_row(ui, self.metadata_chips, colors, lane_right, chip_center_y);
+        }
+
+        if let Some(pips) = &self.pane_pips {
+            let center_y = text_metrics
+                .secondary_center_y
+                .unwrap_or(text_metrics.primary_center_y + COMPACT_METADATA_PIP_OFFSET_Y);
+            draw_pips(ui, pips, colors, lane_left, lane_right, center_y);
         }
     }
 }
@@ -192,7 +276,7 @@ fn draw_text_block(
     center_y: f32,
     primary_max: f32,
     secondary_max: f32,
-) -> (f32, f32) {
+) -> TextBlockMetrics {
     // Primary is always full-strength — selection is conveyed by the accent
     // rail and tint, not by dimming unselected titles into the metadata.
     let primary_color = colors.text_primary;
@@ -211,21 +295,34 @@ fn draw_text_block(
             colors.text_dim,
             secondary_max,
         );
-        let total_h = primary_size.y + 2.0 + secondary_galley.size().y;
+        let secondary_h = secondary_galley.size().y;
+        let total_h = primary_size.y + 2.0 + secondary_h;
         let primary_pos = Pos2::new(x, center_y - total_h / 2.0);
         let secondary_pos = Pos2::new(x, primary_pos.y + primary_size.y + 2.0);
         ui.painter().galley(primary_pos, primary, primary_color);
         ui.painter()
             .galley(secondary_pos, secondary_galley, colors.text_dim);
-        (
-            primary_pos.x + primary_size.x,
-            primary_pos.y + primary_size.y / 2.0,
-        )
+        TextBlockMetrics {
+            primary_end_x: primary_pos.x + primary_size.x,
+            primary_center_y: primary_pos.y + primary_size.y / 2.0,
+            secondary_center_y: Some(secondary_pos.y + secondary_h / 2.0),
+        }
     } else {
         let pos = Pos2::new(x, center_y - primary_size.y / 2.0);
         ui.painter().galley(pos, primary, primary_color);
-        (pos.x + primary_size.x, center_y)
+        TextBlockMetrics {
+            primary_end_x: pos.x + primary_size.x,
+            primary_center_y: center_y,
+            secondary_center_y: None,
+        }
     }
+}
+
+#[derive(Clone, Copy)]
+struct TextBlockMetrics {
+    primary_end_x: f32,
+    primary_center_y: f32,
+    secondary_center_y: Option<f32>,
 }
 
 fn elided_galley(
@@ -368,6 +465,94 @@ fn draw_chip(ui: &egui::Ui, label: &str, colors: &Colors, x: f32, center_y: f32)
     );
 }
 
+fn metadata_chip_row_width(ui: &egui::Ui, labels: &[&str]) -> f32 {
+    if labels.is_empty() {
+        return 0.0;
+    }
+    labels
+        .iter()
+        .map(|label| chip_size(ui, label).x)
+        .sum::<f32>()
+        + style::SPACE_XS * labels.len().saturating_sub(1) as f32
+}
+
+fn draw_chip_row(ui: &egui::Ui, labels: &[&str], colors: &Colors, right: f32, center_y: f32) {
+    let total_w = metadata_chip_row_width(ui, labels);
+    let mut x = right - total_w;
+    for label in labels {
+        draw_chip(ui, label, colors, x, center_y);
+        x += chip_size(ui, label).x + style::SPACE_XS;
+    }
+}
+
+const PANE_PIP_RADIUS: f32 = 3.0;
+const PANE_PIP_SPACING: f32 = 9.0;
+const PANE_PIP_MAX: usize = 8;
+const COMPACT_METADATA_CHIP_OFFSET_Y: f32 = 10.0;
+const COMPACT_METADATA_PIP_OFFSET_Y: f32 = 10.0;
+
+fn pane_pips_width(count: usize) -> f32 {
+    if count == 0 {
+        return 0.0;
+    }
+    let capped = count.min(PANE_PIP_MAX);
+    let base = (capped.saturating_sub(1) as f32) * PANE_PIP_SPACING + PANE_PIP_RADIUS * 2.0;
+    if count > PANE_PIP_MAX {
+        base + style::SPACE_XS + 16.0
+    } else {
+        base
+    }
+}
+
+fn draw_pips(
+    ui: &egui::Ui,
+    pips: &ListRowPips,
+    colors: &Colors,
+    lane_left: f32,
+    lane_right: f32,
+    center_y: f32,
+) {
+    if pips.count == 0 {
+        return;
+    }
+    let width = pane_pips_width(pips.count);
+    let start_x = (lane_right - width).max(lane_left);
+    let capped = pips.count.min(PANE_PIP_MAX);
+    for dot_i in 0..capped {
+        let center = Pos2::new(
+            start_x + PANE_PIP_RADIUS + dot_i as f32 * PANE_PIP_SPACING,
+            center_y,
+        );
+        let hidden = pips.hidden_indices.contains(&dot_i);
+        let color = if pips.focused_idx == Some(dot_i) {
+            colors.accent
+        } else {
+            colors.text_dim.gamma_multiply(0.45)
+        };
+        if hidden {
+            ui.painter()
+                .circle_stroke(center, PANE_PIP_RADIUS, Stroke::new(1.0, color));
+        } else {
+            ui.painter().circle_filled(center, PANE_PIP_RADIUS, color);
+        }
+    }
+    if pips.count > PANE_PIP_MAX {
+        let overflow_x = start_x + PANE_PIP_RADIUS + capped as f32 * PANE_PIP_SPACING;
+        let overflow_color = if pips.focused_idx.is_some_and(|idx| idx >= PANE_PIP_MAX) {
+            colors.accent
+        } else {
+            colors.text_dim.gamma_multiply(0.55)
+        };
+        ui.painter().text(
+            Pos2::new(overflow_x, center_y),
+            Align2::LEFT_CENTER,
+            format!("+{}", pips.count - PANE_PIP_MAX),
+            egui::FontId::proportional(style::TEXT_HINT),
+            overflow_color,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,7 +563,65 @@ mod tests {
         assert_eq!(row.body, "note");
         assert!(row.secondary.is_none());
         assert_eq!(row.chip, Some("app"));
+        assert!(row.metadata_chips.is_empty());
         assert!(!row.selected);
+    }
+
+    #[test]
+    fn trailing_metadata_reserves_text_width() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let row_rect =
+                egui::Rect::from_min_size(Pos2::ZERO, Vec2::new(240.0, style::LIST_ROW_H));
+            let plain = ListRow::new("Assistant").secondary("Long app description");
+            let metadata = ListRow::new("Assistant")
+                .secondary("Long app description")
+                .metadata_chips(&["app", "ws"]);
+
+            assert!(
+                metadata.text_right(ui, row_rect) < plain.text_right(ui, row_rect),
+                "metadata lane must reduce the text area so secondary text truncates before chips"
+            );
+        });
+        let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn pane_pips_reserve_the_metadata_lane() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let row_rect =
+                egui::Rect::from_min_size(Pos2::ZERO, Vec2::new(240.0, style::LIST_ROW_H));
+            let row = ListRow::new("Workspace").pane_pips(ListRowPips {
+                count: 3,
+                focused_idx: Some(1),
+                hidden_indices: vec![2],
+            });
+
+            assert!(row.metadata_lane_width(ui) > 0.0);
+            assert!(row.text_right(ui, row_rect) < row_rect.right() - style::LIST_ROW_PAD_H);
+        });
+        let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn compact_metadata_keeps_pips_padded_below_chip() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let primary_center_y = style::LIST_ROW_H / 2.0;
+            let chip_bottom =
+                primary_center_y - COMPACT_METADATA_CHIP_OFFSET_Y + chip_size(ui, "ctx").y / 2.0;
+            let pip_top = primary_center_y + COMPACT_METADATA_PIP_OFFSET_Y - PANE_PIP_RADIUS;
+
+            assert!(
+                pip_top - chip_bottom >= style::SPACE_SM,
+                "compact metadata pips need visible padding below the chip"
+            );
+        });
+        let _ = ctx.end_pass();
     }
 
     #[test]

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -275,7 +275,8 @@ mod tests {
     use super::*;
     use crate::app::permissions::AppPermissions;
     use crate::app::FocusLayer;
-    use crate::host::pane::{AppPane, AppRuntime, Pane};
+    use crate::host::context::Window;
+    use crate::host::pane::{AppPane, AppRuntime, Pane, PortalPane};
     use crate::process_app::ProcessApp;
 
     fn add_focused_pane(h: &mut PlexiUiHarness) -> crate::spatial::tiling::PaneId {
@@ -381,6 +382,98 @@ mod tests {
             "capability modal should own focus for screenshot"
         );
         println!("Screenshot saved to /tmp/plexi_permission_prompt_chrome.png");
+    }
+
+    #[test]
+    fn screenshot_command_palette_metadata_lane() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
+        let first_pane_id = add_focused_pane(&mut h);
+        h.with_app_mut(|app| {
+            let second_pane_id = app.host.alloc_pane_id();
+            let (process_app, _draw_tx) =
+                ProcessApp::new_for_test(second_pane_id, AppPermissions::builtin());
+            let app_pane = AppPane {
+                id: second_pane_id,
+                runtime: AppRuntime::Process(Box::new(process_app)),
+                workspace_root: std::env::temp_dir(),
+                permissions: AppPermissions::builtin(),
+                manifest_id: "hidden-test".to_string(),
+                name: "Hidden Test App".to_string(),
+                pane_group: None,
+                linked_pane_id: None,
+                overlay_replaced: None,
+                hidden: true,
+                agent: None,
+                slots: std::collections::HashMap::new(),
+            };
+            let win = &mut app.windows[app.active_window];
+            win.panes
+                .insert(second_pane_id, Pane::App(Box::new(app_pane)));
+            let second_tile = win.tree.tiles.insert_pane(second_pane_id);
+            if let Some(first_tile) = win.tree.root {
+                let root = win
+                    .tree
+                    .tiles
+                    .insert_horizontal_tile(vec![first_tile, second_tile]);
+                win.tree.root = Some(root);
+                win.focused_pane = Some(first_tile);
+            }
+            let ctx_idx = app.router.active_idx();
+            app.router.get_mut(ctx_idx).name = "Command Palette Metadata".to_string();
+            let ctx_id = app.router.get(ctx_idx).context_id;
+            let extra_a = app.host.alloc_pane_id();
+            let extra_b = app.host.alloc_pane_id();
+            let mut extra_panes = std::collections::HashMap::new();
+            extra_panes.insert(
+                extra_a,
+                Pane::Portal(Box::new(PortalPane {
+                    pane_id: extra_a,
+                    target_context_id: extra_a + 10_000,
+                    context_state: None,
+                    hidden: false,
+                })),
+            );
+            extra_panes.insert(
+                extra_b,
+                Pane::Portal(Box::new(PortalPane {
+                    pane_id: extra_b,
+                    target_context_id: extra_b + 10_000,
+                    context_state: None,
+                    hidden: true,
+                })),
+            );
+            let mut extra_tiles = egui_tiles::Tiles::default();
+            let extra_tile_a = extra_tiles.insert_pane(extra_a);
+            let extra_tile_b = extra_tiles.insert_pane(extra_b);
+            let extra_root = extra_tiles.insert_horizontal_tile(vec![extra_tile_a, extra_tile_b]);
+            let extra_window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(Window {
+                name: "palette metadata extra".to_string(),
+                path: std::env::temp_dir(),
+                tree: egui_tiles::Tree::new("palette metadata extra", extra_root, extra_tiles),
+                panes: extra_panes,
+                focused_pane: Some(extra_tile_a),
+                zoomed_pane: None,
+                grid_x: 1,
+                grid_y: 0,
+                window_id: extra_window_id,
+                context_id: ctx_id,
+            });
+            app.show_command_palette = true;
+            app.sync_command_palette_focus();
+        });
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_command_palette_metadata_lane.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app.show_command_palette
+                && app.windows[app.active_window]
+                    .panes
+                    .contains_key(&first_pane_id)),
+            "command palette should remain open over the populated context"
+        );
+        println!("Screenshot saved to /tmp/plexi_command_palette_metadata_lane.png");
     }
 
     // ── Regression: layout flows ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Moves command palette row type chips into a fixed right-side metadata lane.
- Adds context-wide pane pips for context rows: all panes across every window in the context, ordered like the sidebar by window grid then spatial pane order.
- Renders hollow pips for hidden panes and an accent pip for the active/focused pane in that context.
- Shows workspace/background app scope as metadata chips (`app`, `bg`, `ws`) instead of appending `bg`/`ws` into descriptions.
- Skips parked contexts from command palette context entries.

Closes #2190

**Test evidence:**
- `cargo build` — passed.
- `cargo test --bin plexi` — passed: 898 passed, 0 failed, 1 ignored. One prior full-suite run hit `process_app::mcp_server::tests::test_wrong_token_returns_401`; reran that test in isolation and it passed, then reran the full suite and it passed.
- Focused tests: `palette_pips_include_hidden_and_focused_panes`, `palette_pips_cover_every_window_in_the_context`, `trailing_metadata_reserves_text_width`, `pane_pips_reserve_the_metadata_lane`, `app_metadata_chips_add_workspace_scope_without_secondary_text` — passed.
- PlexiUiHarness render: `/tmp/plexi_command_palette_metadata_lane.png` — inspected; shows the `ctx` chip in the right lane with aggregate context pips from multiple same-context windows, including accented focused pip and hollow hidden pips.
- Conclusion: install skippable — host UI harness and full binary test coverage passed.