### PR TITLE
fix: render zoomed app panes through shared app_pane::render path

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -650,104 +650,143 @@ impl PlexiApp {
                         } else {
                             inner_rect
                         };
-                        let mut frame_ui = ui.new_child(egui::UiBuilder::new().max_rect(frame_rect));
-                        frame_ui.set_opacity(0.88);
-                        egui::Frame::new()
-                            .fill(self.colors.terminal_bg)
-                            .inner_margin(egui::Margin::same(8))
-                            .show(&mut frame_ui, |ui| {
-                                if let Some(pane) = ctx.panes.get_mut(&pane_id) {
-                                    if let Some(t) = pane.as_terminal_mut() {
-                                        if dropped_to_zoom {
-                                            crate::spatial::tiling::write_dropped_paths_to_terminal(ui, t);
-                                        }
-                                        if t.exited {
-                                            let rect = ui.max_rect();
-                                            ui.painter().rect_filled(
-                                                rect,
-                                                0.0,
-                                                self.colors.terminal_bg,
-                                            );
-                                            ui.allocate_new_ui(
-                                                egui::UiBuilder::new().max_rect(rect),
-                                                |ui| {
-                                                    ui.centered_and_justified(|ui| {
-                                                        ui.colored_label(
-                                                            self.colors.text_dim,
-                                                            "[process exited]",
-                                                        );
-                                                    });
-                                                },
-                                            );
-                                        } else if hovered_files {
-                                            // Skip TerminalView render while a file is being
-                                            // dragged over the zoomed pane. TerminalView::show()
-                                            // calls backend.sync() which clones the full grid
-                                            // under FairMutex contention — on a large terminal
-                                            // (e.g. a full-window Claude Code session) this
-                                            // blocked the main thread for several seconds.
-                                            // The drop itself is handled above (dropped_to_zoom
-                                            // guard), so we skip only the hover-frame renders.
-                                            log::debug!("[DRAG] zoom overlay: skipping TerminalView render during file hover");
-                                            let rect = ui.max_rect();
-                                            ui.allocate_new_ui(
-                                                egui::UiBuilder::new().max_rect(rect),
-                                                |ui| {
-                                                    ui.centered_and_justified(|ui| {
-                                                        ui.colored_label(
-                                                            self.colors.text_dim,
-                                                            "Drop to paste path",
-                                                        );
-                                                    });
-                                                },
-                                            );
-                                        } else {
-                                            // Reserve space for tab dots when no name bar
-                                            if !has_name && zoomed_tab_info.is_some() {
-                                                ui.add_space(
-                                                    crate::spatial::tiling::TAB_DOT_RESERVED_HEIGHT,
-                                                );
+                        // Branch on pane type BEFORE the Frame. PGAP app runtimes
+                        // paint via `ui.painter()` WITHOUT allocating UI space, so
+                        // wrapping them in an `egui::Frame` collapses it to ~16x16
+                        // at the top-left (see src/process_app/mod.rs docs). Mirror
+                        // the tiling path (tiling.rs pane_ui) for app panes instead:
+                        // full-rect background fill + child Ui + app_pane::render,
+                        // which also restores the overtake bar and nav-back chrome.
+                        let is_app_pane = ctx
+                            .panes
+                            .get(&pane_id)
+                            .is_some_and(|p| p.as_app().is_some());
+                        if is_app_pane {
+                            ui.painter()
+                                .rect_filled(frame_rect, 0.0, self.colors.bg_darkest);
+                            let mut app_ui =
+                                ui.new_child(egui::UiBuilder::new().max_rect(frame_rect));
+                            app_ui.set_opacity(0.88);
+                            if let Some(app_pane) =
+                                ctx.panes.get_mut(&pane_id).and_then(|p| p.as_app_mut())
+                            {
+                                crate::render::app_pane::render(
+                                    &mut app_ui,
+                                    app_pane,
+                                    &self.colors,
+                                    !modal_open,
+                                );
+                            }
+                            // Tab indicator dots for unnamed panes in a tab group —
+                            // painter-only, painted after the app render so they
+                            // sit on top of the app content.
+                            if !has_name {
+                                if let Some((active_idx, count)) = zoomed_tab_info {
+                                    crate::spatial::tiling::paint_tab_dots(
+                                        app_ui.painter(),
+                                        frame_rect.left(),
+                                        frame_rect.top() + 2.0 + 4.0, // 4.0 = dot radius
+                                        active_idx,
+                                        count,
+                                        self.colors.accent,
+                                        self.colors.bg_active,
+                                    );
+                                }
+                            }
+                        } else {
+                            let mut frame_ui = ui.new_child(egui::UiBuilder::new().max_rect(frame_rect));
+                            frame_ui.set_opacity(0.88);
+                            egui::Frame::new()
+                                .fill(self.colors.terminal_bg)
+                                .inner_margin(egui::Margin::same(8))
+                                .show(&mut frame_ui, |ui| {
+                                    if let Some(pane) = ctx.panes.get_mut(&pane_id) {
+                                        if let Some(t) = pane.as_terminal_mut() {
+                                            if dropped_to_zoom {
+                                                crate::spatial::tiling::write_dropped_paths_to_terminal(ui, t);
                                             }
-                                            let font_size = t.font_size;
-                                            log::debug!("[DRAG] zoom overlay: TerminalView render start");
-                                            use egui_term::TerminalView;
-                                            use crate::ui::theme;
-                                            let terminal = TerminalView::new(ui, &mut t.backend)
-                                                .set_focus(!modal_open)
-                                                .set_theme(self.theme.clone())
-                                                .set_font(theme::terminal_font(font_size))
-                                                .set_size(Vec2::new(
-                                                    ui.available_width(),
-                                                    ui.available_height(),
-                                                ));
-                                            ui.add(terminal);
-                                            log::debug!("[DRAG] zoom overlay: TerminalView render done");
+                                            if t.exited {
+                                                let rect = ui.max_rect();
+                                                ui.painter().rect_filled(
+                                                    rect,
+                                                    0.0,
+                                                    self.colors.terminal_bg,
+                                                );
+                                                ui.allocate_new_ui(
+                                                    egui::UiBuilder::new().max_rect(rect),
+                                                    |ui| {
+                                                        ui.centered_and_justified(|ui| {
+                                                            ui.colored_label(
+                                                                self.colors.text_dim,
+                                                                "[process exited]",
+                                                            );
+                                                        });
+                                                    },
+                                                );
+                                            } else if hovered_files {
+                                                // Skip TerminalView render while a file is being
+                                                // dragged over the zoomed pane. TerminalView::show()
+                                                // calls backend.sync() which clones the full grid
+                                                // under FairMutex contention — on a large terminal
+                                                // (e.g. a full-window Claude Code session) this
+                                                // blocked the main thread for several seconds.
+                                                // The drop itself is handled above (dropped_to_zoom
+                                                // guard), so we skip only the hover-frame renders.
+                                                log::debug!("[DRAG] zoom overlay: skipping TerminalView render during file hover");
+                                                let rect = ui.max_rect();
+                                                ui.allocate_new_ui(
+                                                    egui::UiBuilder::new().max_rect(rect),
+                                                    |ui| {
+                                                        ui.centered_and_justified(|ui| {
+                                                            ui.colored_label(
+                                                                self.colors.text_dim,
+                                                                "Drop to paste path",
+                                                            );
+                                                        });
+                                                    },
+                                                );
+                                            } else {
+                                                // Reserve space for tab dots when no name bar
+                                                if !has_name && zoomed_tab_info.is_some() {
+                                                    ui.add_space(
+                                                        crate::spatial::tiling::TAB_DOT_RESERVED_HEIGHT,
+                                                    );
+                                                }
+                                                let font_size = t.font_size;
+                                                log::debug!("[DRAG] zoom overlay: TerminalView render start");
+                                                use egui_term::TerminalView;
+                                                use crate::ui::theme;
+                                                let terminal = TerminalView::new(ui, &mut t.backend)
+                                                    .set_focus(!modal_open)
+                                                    .set_theme(self.theme.clone())
+                                                    .set_font(theme::terminal_font(font_size))
+                                                    .set_size(Vec2::new(
+                                                        ui.available_width(),
+                                                        ui.available_height(),
+                                                    ));
+                                                ui.add(terminal);
+                                                log::debug!("[DRAG] zoom overlay: TerminalView render done");
+                                            }
                                         }
-                                    } else if let Some(a) = pane.as_app_mut() {
-                                        let app_ctx = crate::app::app_trait::AppRenderContext {
-                                            colors: &self.colors,
-                                            is_focused: !modal_open,
-                                        };
-                                        a.runtime.ui(ui, &app_ctx);
                                     }
-                                }
 
-                                // Draw tab indicator dots for unnamed panes in a tab group
-                                if !has_name {
-                                    if let Some((active_idx, count)) = zoomed_tab_info {
-                                        let rect = ui.max_rect();
-                                        crate::spatial::tiling::paint_tab_dots(
-                                            ui.painter(),
-                                            rect.left(),
-                                            rect.top() + 2.0 + 4.0, // 4.0 = dot radius
-                                            active_idx,
-                                            count,
-                                            self.colors.accent,
-                                            self.colors.bg_active,
-                                        );
+                                    // Draw tab indicator dots for unnamed panes in a tab group
+                                    if !has_name {
+                                        if let Some((active_idx, count)) = zoomed_tab_info {
+                                            let rect = ui.max_rect();
+                                            crate::spatial::tiling::paint_tab_dots(
+                                                ui.painter(),
+                                                rect.left(),
+                                                rect.top() + 2.0 + 4.0, // 4.0 = dot radius
+                                                active_idx,
+                                                count,
+                                                self.colors.accent,
+                                                self.colors.bg_active,
+                                            );
+                                        }
                                     }
-                                }
-                            });
+                                });
+                        }
                     } else {
                         drop(behavior);
                     }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -335,6 +335,47 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_with_pane.png");
     }
 
+    /// Regression: zoomed app panes must render through the shared
+    /// `render::app_pane::render` path (full-rect fill, no collapsing
+    /// `egui::Frame`) and exercise the overtake-bar chrome. Guards against
+    /// the black-square / missing-chrome zoom bugs (zoom overlay previously
+    /// duplicated pane rendering inline and called `runtime.ui()` directly).
+    #[test]
+    fn zoomed_app_pane_renders_via_shared_path() {
+        let mut h = PlexiUiHarness::new();
+        let pane_id = add_focused_pane(&mut h);
+        h.step();
+        h.with_app_mut(|app| {
+            let win = &mut app.windows[app.active_window];
+            // Set overlay_replaced so the zoom path renders the overtake bar
+            // ("← <replaced> / Esc return") via render::app_pane::render.
+            if let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane_id) {
+                app_pane.overlay_replaced =
+                    Some(Box::new(Pane::Portal(Box::new(PortalPane {
+                        pane_id: pane_id + 1_000,
+                        target_context_id: 42,
+                        context_state: None,
+                        hidden: false,
+                    }))));
+            }
+            let tile_id = win
+                .tree
+                .tiles
+                .find_pane(&pane_id)
+                .expect("test pane tile missing");
+            win.zoom_to(tile_id);
+        });
+        h.run_steps(3);
+        h.render()
+            .expect("zoomed app pane frame should render without panic");
+        assert!(
+            h.with_app(|app| app.windows[app.active_window].zoomed_pane.is_some()),
+            "pane should remain zoomed after stepping frames"
+        );
+        h.save_screenshot("/tmp/plexi_zoomed_app_pane.png")
+            .expect("render failed");
+    }
+
     #[test]
     fn screenshot_host_ui_gallery_trust_states() {
         let mut h = PlexiUiHarness::new_sized(1280.0, 900.0);


### PR DESCRIPTION
## Problem

Three user-visible bugs in zoomed (in-app fullscreen) app panes, one root cause — the zoom overlay in `src/app/render.rs` duplicated pane rendering inline instead of reusing the shared per-pane render functions:

1. **Black square top-left**: apps were wrapped in `egui::Frame::new().inner_margin(8)`, but PGAP runtimes paint via `ui.painter()` without allocating UI space, so the Frame collapsed to ~16×16 at the top-left and the 8px margin band showed the black scrim. This exact failure mode is documented in `src/process_app/mod.rs` and was already fixed in the tiling path — the zoom path never got the fix.
2. **Missing layered chrome**: the inline `runtime.ui()` call bypassed `render::app_pane::render`, so the overtake bar ("← Terminal / Esc return") and nav-back bar disappeared in fullscreen.
3. **Toggle flicker**: the 8px geometry delta between the two paths caused resize/repaint artifacts on every zoom toggle.

## Fix

The zoom overlay branches on pane type before the Frame. App panes mirror the tiling path exactly: full-rect `bg_darkest` fill → child Ui → `render::app_pane::render` (0.88 zoom opacity preserved, tab dots painted on top). Terminal panes keep the existing Frame path unchanged (TerminalView allocates, so the Frame works there).

## Test

`ui_tests::tests::zoomed_app_pane_renders_via_shared_path` — zooms a ProcessApp pane with `overlay_replaced` set, steps frames, asserts render + zoom persistence. `cargo test --bin plexi`: 913 passed, 0 failed.

## Deferred

The terminal branch of the zoom overlay is still an inline copy of `terminal_pane::render` (zoomed exited terminals have no close-exited affordance). Unifying it needs `tile_id`/`close_exited` plumbing — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)