### PR TITLE
fix(sdk): migrate TextCommand to canonical 9-value align vocabulary (#2198 follow-up)

### DIFF
--- a/sdk/python/plexi_sdk/_render_context.py
+++ b/sdk/python/plexi_sdk/_render_context.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from ._constants import BODY
 from ._theme import theme as _sdk_theme
 from ._emitter import _emit, _LOCK
+from ._types import VALID_TEXT_ALIGN as _VALID_ALIGN
 
 if TYPE_CHECKING:
     from ._app import App
@@ -16,12 +17,6 @@ if TYPE_CHECKING:
 
 COMPACT_DEFAULT: float = 280.0
 REGULAR_DEFAULT: float = 480.0
-
-_VALID_ALIGN = frozenset({
-    "left_top", "center_top", "right_top",
-    "left_center", "center_center", "right_center",
-    "left_bottom", "center_bottom", "right_bottom",
-})
 
 # ── RenderContext ──────────────────────────────────────────────────────────────
 

--- a/sdk/python/plexi_sdk/_types.py
+++ b/sdk/python/plexi_sdk/_types.py
@@ -28,7 +28,13 @@ class VideoHandle:
 
 # ── Typed draw command dataclasses (#627) ─────────────────────────────────────
 
-_VALID_TEXT_ALIGN = {"top_left", "center", "top_center", "right"}
+# Canonical text-align vocabulary (#2198). Single source of truth — the host
+# deserializes these as a closed serde enum, so any other value fails the frame.
+VALID_TEXT_ALIGN = frozenset({
+    "left_top", "center_top", "right_top",
+    "left_center", "center_center", "right_center",
+    "left_bottom", "center_bottom", "right_bottom",
+})
 
 
 @dataclass
@@ -58,15 +64,15 @@ class TextCommand:
     color: str
     monospace: bool = False
     bold: bool = False
-    align: str = "top_left"
+    align: str = "left_top"
     max_width: Optional[float] = None
     elide: bool = True
     selectable: bool = False
 
     def __post_init__(self) -> None:
-        if self.align not in _VALID_TEXT_ALIGN:
+        if self.align not in VALID_TEXT_ALIGN:
             raise ValueError(
-                f"TextCommand: align must be one of {sorted(_VALID_TEXT_ALIGN)}, got {self.align!r}"
+                f"TextCommand: align must be one of {sorted(VALID_TEXT_ALIGN)}, got {self.align!r}"
             )
         if self.size <= 0:
             raise ValueError(f"TextCommand: size must be positive, got {self.size}")

--- a/sdk/python/tests/test_error_messages.py
+++ b/sdk/python/tests/test_error_messages.py
@@ -16,6 +16,7 @@ from plexi_sdk.ui import (
     RowChip, Tabs, Grid, render_tree,
 )
 from plexi_sdk._render_context import RenderContext
+from plexi_sdk._types import TextCommand, VALID_TEXT_ALIGN
 from plexi_sdk.widgets.list_view import ListView
 from plexi_sdk.ui import ListItem
 
@@ -107,6 +108,37 @@ def test_ctx_text_rejects_non_number_size():
     ctx = _make_ctx()
     with pytest.raises(TypeError, match="size must be a number"):
         ctx.text(0, 0, "hello", size="big", color="#cdd6f4")
+
+
+# ── Text align vocabulary (#2198) ─────────────────────────────────────────────
+
+
+def test_ctx_text_rejects_legacy_align():
+    ctx = _make_ctx()
+    with pytest.raises(ValueError, match="left_top"):
+        ctx.text(0, 0, "hello", size=14.0, color="#cdd6f4", align="top_left")
+
+
+def test_ctx_text_accepts_all_nine_aligns():
+    ctx = _make_ctx()
+    for align in VALID_TEXT_ALIGN:
+        ctx.text(0, 0, "hello", size=14.0, color="#cdd6f4", align=align)
+
+
+def test_text_command_default_align_is_canonical():
+    cmd = TextCommand(x=0, y=0, text="hi", size=14.0, color="#cdd6f4")
+    assert cmd.align in VALID_TEXT_ALIGN
+
+
+def test_text_command_rejects_legacy_align():
+    with pytest.raises(ValueError, match="align must be one of"):
+        TextCommand(x=0, y=0, text="hi", size=14.0, color="#cdd6f4", align="top_left")
+
+
+def test_text_command_accepts_center_center():
+    cmd = TextCommand(x=0, y=0, text="hi", size=14.0, color="#cdd6f4",
+                      align="center_center")
+    assert cmd.align == "center_center"
 
 
 # ── ctx.render_tree() validation ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Completes the app/SDK migration to the new align vocabulary from #2198 (merged as #2200). Audit of every `align=` site across `apps/`, `sdk/`, and templates found exactly one leftover: the public `TextCommand` dataclass in `_types.py` still validated against the dead 4-value set and defaulted to `"top_left"` — it rejected now-valid values like `center_center` and let through values the host now refuses to deserialize.

## Changes
- `sdk/python/plexi_sdk/_types.py` — `VALID_TEXT_ALIGN` becomes the canonical 9-value frozenset and the single source of truth; `TextCommand` default is `left_top`.
- `sdk/python/plexi_sdk/_render_context.py` — imports the set from `_types` instead of carrying a duplicate copy.
- `sdk/python/tests/test_error_messages.py` — first Python-side align tests: `ctx.text` rejects legacy values and accepts all nine; `TextCommand` default is canonical, rejects `top_left`, accepts `center_center`.

## Audit evidence (no other work needed)
- `grep -rE 'align\s*=\s*"' apps sdk` → every value is in the 9-value set (the one other hit is `Scrollable(align="bottom")`, a separate scroll-anchor param).
- No remaining `top_left`/`top_center` tokens in Python or Rust fixtures.
- `uv run pytest tests/` → 181 passed.
- Python-only diff; no Rust changes, no bump needed until merge.

Closes nothing — follow-up to #2198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)