### PR TITLE
feat(infra/merge): explicit no-issue flag for standalone PRs in merge-pr

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -48,6 +48,7 @@ Handles: rebase, squash-merge, alpha sync, artifact cleanup, version bump, issue
 | PR already merged | `just merge-sync && just merge-cleanup $PR $BRANCH && just merge-bump && just merge-close $ISSUE $PR` |
 | Dirty root worktree | Commit or restore changed files, re-run `just merge-pr $PR` |
 | `>1 unexpected commits` on local alpha | Investigate before proceeding; do not force-reset blindly |
+| `could not resolve GitHub issue or stint tasks` | Only if the PR genuinely has nothing to close (standalone follow-up): `just merge-pr $PR no-issue`. Otherwise fix the PR body's closing keyword first. |
 
 **Available sub-steps:**
 ```bash

--- a/justfile
+++ b/justfile
@@ -206,8 +206,9 @@ uninstall channel="all":
 # Squash-merge a validated PR to alpha: rebase, merge, sync, cleanup, bump, close issue.
 # Intended for the merge-pr skill — run from repo root.
 #   just merge-pr 2155
-merge-pr PR:
-    bash scripts/merge-pr.sh {{PR}}
+#   just merge-pr 2202 no-issue   — standalone follow-up PR, skips issue/stint close
+merge-pr PR *FLAGS:
+    bash scripts/merge-pr.sh {{PR}} {{FLAGS}}
 
 # Sub-steps for conflict recovery. Call individually to resume a failed merge-pr.
 #   just merge-rebase feature/2155-foo   — rebase + force-push feature branch

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -3,6 +3,7 @@
 #
 # Usage:
 #   scripts/merge-pr.sh <PR>                   full flow (rebase→squash→sync→cleanup→bump→close)
+#   scripts/merge-pr.sh <PR> no-issue          full flow for a standalone PR — skips issue/stint close
 #   scripts/merge-pr.sh rebase <BRANCH>        rebase feature branch on origin/alpha + force-push
 #   scripts/merge-pr.sh squash <PR>            squash-merge only
 #   scripts/merge-pr.sh sync                   reset local alpha to origin/alpha (safe — fails if unexpected commits)
@@ -254,27 +255,42 @@ case "$CMD" in
         ;;
     *)
         PR="${1:?PR number required}"
+        NO_ISSUE=0
+        case "${2:-}" in
+            "") ;;
+            no-issue|--no-issue) NO_ISSUE=1 ;;
+            *)
+                echo "ERROR: unknown argument '${2}' (did you mean 'no-issue'?)" >&2
+                exit 1
+                ;;
+        esac
 
         INFO=$(gh pr view "$PR" --json headRefName,state,body --jq '{branch: .headRefName, state: .state, body: .body}')
         BRANCH=$(echo "$INFO" | jq -r .branch)
         STATE=$(echo "$INFO" | jq -r .state)
         PR_BODY=$(echo "$INFO" | jq -r '.body // ""')
-        ISSUE=$(resolve_issue "$PR" "$BRANCH" "$PR_BODY" || true)
+        ISSUE=""
         STINTS=""
         STINT_ARGS=()
-        if [ -z "$ISSUE" ]; then
-            STINTS=$(resolve_stints "$BRANCH" "$PR_BODY")
-            if [ -z "$STINTS" ]; then
-                echo "ERROR: could not resolve GitHub issue or stint tasks for PR #$PR ($BRANCH)" >&2
-                echo "Add a closing keyword like 'Closes #1234', use a numeric feature/fix branch, or include stint ids in the branch/body." >&2
-                exit 1
+        if [ "$NO_ISSUE" -eq 0 ]; then
+            ISSUE=$(resolve_issue "$PR" "$BRANCH" "$PR_BODY" || true)
+            if [ -z "$ISSUE" ]; then
+                STINTS=$(resolve_stints "$BRANCH" "$PR_BODY")
+                if [ -z "$STINTS" ]; then
+                    echo "ERROR: could not resolve GitHub issue or stint tasks for PR #$PR ($BRANCH)" >&2
+                    echo "Add a closing keyword like 'Closes #1234', use a numeric feature/fix branch, or include stint ids in the branch/body." >&2
+                    echo "For a standalone follow-up PR with nothing to close, re-run: just merge-pr $PR no-issue" >&2
+                    exit 1
+                fi
+                while IFS= read -r STINT; do
+                    [ -n "$STINT" ] && STINT_ARGS+=("$STINT")
+                done <<< "$STINTS"
             fi
-            while IFS= read -r STINT; do
-                [ -n "$STINT" ] && STINT_ARGS+=("$STINT")
-            done <<< "$STINTS"
         fi
 
-        if [ -n "$ISSUE" ]; then
+        if [ "$NO_ISSUE" -eq 1 ]; then
+            echo "==> PR #$PR: $BRANCH (standalone — no issue/stint to close, state: $STATE)"
+        elif [ -n "$ISSUE" ]; then
             echo "==> PR #$PR: $BRANCH (issue #$ISSUE, state: $STATE)"
         else
             echo "==> PR #$PR: $BRANCH (stint tasks: $(join_by ", " "${STINT_ARGS[@]}"), state: $STATE)"
@@ -298,7 +314,9 @@ case "$CMD" in
         do_sync
         do_cleanup "$PR" "$BRANCH"
         do_bump
-        if [ -n "$ISSUE" ]; then
+        if [ "$NO_ISSUE" -eq 1 ]; then
+            echo "==> Skipping issue/stint close (no-issue)"
+        elif [ -n "$ISSUE" ]; then
             do_close "$ISSUE" "$PR"
         else
             do_close_stints "$PR" "${STINT_ARGS[@]}"
@@ -306,7 +324,9 @@ case "$CMD" in
 
         VERSION=$(grep '^version' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
         echo ""
-        if [ -n "$ISSUE" ]; then
+        if [ "$NO_ISSUE" -eq 1 ]; then
+            echo "==> Done: PR #$PR merged → alpha v$VERSION (standalone — nothing closed)"
+        elif [ -n "$ISSUE" ]; then
             echo "==> Done: PR #$PR merged → alpha v$VERSION, issue #$ISSUE closed"
         else
             echo "==> Done: PR #$PR merged → alpha v$VERSION, stint task(s) $(join_by ", " "${STINT_ARGS[@]}") closed"


### PR DESCRIPTION
## Summary
`just merge-pr <PR> no-issue` runs the full merge flow for a PR with nothing to close, instead of forcing manual sub-steps.

## What
- `scripts/merge-pr.sh`: optional `no-issue` second arg skips issue/stint resolution and the close step; summary line says `(standalone — nothing closed)`. Without the flag, unresolvable PRs still fail loud — error now includes the re-run hint. Unknown second args are rejected.
- `justfile`: `merge-pr PR *FLAGS` passes the flag through.
- merge-pr skill: recovery-table row for the `could not resolve` error.

## Why
PR #2202 (standalone follow-up, no linked issue) failed the resolution gate and required three manual sub-steps. The gate stays as a guard against typo'd closing keywords; intentional standalone merges become one explicit command.

## Verified
- `bash -n` clean; `test-resolve-issue` / `test-resolve-stints` pass
- Stubbed-gh dry runs: no-issue path skips resolution and proceeds; no-flag unresolvable path errors with hint; bogus flag rejected
- `just -n merge-pr 9999 no-issue` → `bash scripts/merge-pr.sh 9999 no-issue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)