### PR TITLE
Sidebar row: unify selection treatment + layout refactor (#2206)

### DIFF
--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -7,6 +7,9 @@ pub const ACTION_ZONE_WIDTH: f32 = 30.0;
 /// Fixed-width left gutter that holds the context index number.
 const GUTTER_W: f32 = 24.0;
 
+/// Top and bottom padding added inside each row for vertical breathing room.
+const ROW_PAD_V: f32 = 7.0;
+
 const PANE_DOT_RADIUS: f32 = 4.0;
 const PANE_DOT_SPACING: f32 = 11.0;
 const PANE_DOT_MAX: usize = 8;
@@ -166,6 +169,8 @@ impl ContextItem {
         let scope_out = ui.scope(|ui| {
             ui.set_width(ui.available_width());
 
+            ui.add_space(ROW_PAD_V);
+
             // --- Outer row: left gutter (index number) + content column ---
             let y_before = ui.cursor().min.y;
             // name_row_h is captured from inside the horizontal closure and
@@ -180,21 +185,39 @@ impl ContextItem {
                 // centered across the full row height.
                 ui.add_space(GUTTER_W);
 
-                // Content column: name row + optional path+pips row.
-                // Capture name_row_h so the action zone is limited to the
-                // header line regardless of how many metadata rows follow.
+                // Content column: name row + optional path row.
+                // Pips live on the name row, right-aligned before the action zone.
                 let name_row_h = ui.vertical(|ui| {
-                    // --- Name row ---
+                    // --- Name row (includes pips right-aligned) ---
                     let name_y_before = ui.cursor().min.y;
                     ui.horizontal(|ui| {
+                        // Compute pip strip width so we can budget the name text.
+                        let pip_strip_w = if let Some(ref dots) = pane_dots {
+                            if dots.count > 0 {
+                                let capped = dots.count.min(PANE_DOT_MAX);
+                                let mut w = (capped as f32) * PANE_DOT_SPACING;
+                                if dots.count > PANE_DOT_MAX {
+                                    w += 20.0;
+                                }
+                                w + 6.0 // gap between name text and dots
+                            } else {
+                                0.0
+                            }
+                        } else {
+                            0.0
+                        };
+
                         let right_reserve = if action_enabled {
                             ACTION_ZONE_WIDTH + 4.0
                         } else {
                             8.0
                         };
                         let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
-                        let text_max =
-                            (ui.available_width() - right_reserve - badge_w).max(0.0);
+                        let text_max = (ui.available_width()
+                            - right_reserve
+                            - badge_w
+                            - pip_strip_w)
+                            .max(0.0);
 
                         ui.scope(|ui| {
                             ui.set_max_width(text_max);
@@ -208,6 +231,16 @@ impl ContextItem {
                                 .truncate(),
                             );
                         });
+
+                        // Pips: rendered inline right of the name, before badge/action.
+                        draw_pips(
+                            ui,
+                            &pane_dots,
+                            accent_color,
+                            text_dim,
+                            row_alpha,
+                            is_dragging,
+                        );
 
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                             ui.add_space(if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 });
@@ -225,32 +258,13 @@ impl ContextItem {
                             }
                         });
                     });
-                    // Capture name-row height before any metadata rows are added.
+                    // Capture name-row height before the subtitle row is added.
                     let name_h = ui.cursor().min.y - name_y_before;
 
-                    // --- Path row with inline pips on the right ---
-                    // When subtitle is present, pips go inline to its right.
-                    // When subtitle is absent but pips exist, render pips alone.
+                    // --- Path row (subtitle only, no pips) ---
                     if let Some(ref path) = subtitle {
                         ui.horizontal(|ui| {
-                            // × is on the name row only — full width minus pip strip and margin.
-                            let pip_strip_w = if let Some(ref dots) = pane_dots {
-                                if dots.count > 0 {
-                                    let capped = dots.count.min(PANE_DOT_MAX);
-                                    let mut w = (capped as f32) * PANE_DOT_SPACING;
-                                    if dots.count > PANE_DOT_MAX {
-                                        w += 20.0;
-                                    }
-                                    w + 6.0 // gap between path text and dots
-                                } else {
-                                    0.0
-                                }
-                            } else {
-                                0.0
-                            };
-
-                            let path_max = (ui.available_width() - pip_strip_w - 8.0).max(0.0);
-
+                            let path_max = (ui.available_width() - 8.0).max(0.0);
                             ui.scope(|ui| {
                                 ui.set_max_width(path_max);
                                 ui.add(
@@ -263,39 +277,15 @@ impl ContextItem {
                                     .truncate(),
                                 );
                             });
-
-                            draw_pips(
-                                ui,
-                                &pane_dots,
-                                accent_color,
-                                text_dim,
-                                row_alpha,
-                                is_dragging,
-                            );
-                        });
-                    } else if pane_dots
-                        .as_ref()
-                        .map_or(false, |d| d.count > 0)
-                    {
-                        // No subtitle — render pips on their own metadata row so
-                        // contexts without a root path still show pane indicators.
-                        ui.horizontal(|ui| {
-                            draw_pips(
-                                ui,
-                                &pane_dots,
-                                accent_color,
-                                text_dim,
-                                row_alpha,
-                                is_dragging,
-                            );
                         });
                     }
 
                     name_h
                 }).inner;
                 name_row_h_capture = name_row_h;
-
             });
+
+            ui.add_space(ROW_PAD_V);
 
             (ui.cursor().min.y - y_before, name_row_h_capture)
         });

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -1,7 +1,11 @@
+use crate::ui::list::paint_selection;
 use crate::ui::theme::Colors;
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
 
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
+
+/// Fixed-width left gutter that holds the context index number.
+const GUTTER_W: f32 = 24.0;
 
 const PANE_DOT_RADIUS: f32 = 4.0;
 const PANE_DOT_SPACING: f32 = 11.0;
@@ -103,139 +107,173 @@ impl ContextItem {
         let scope_out = ui.scope(|ui| {
             ui.set_width(ui.available_width());
 
-            // --- Name row — single fixed-height row regardless of path or pane count ---
+            // --- Outer row: left gutter (index number) + content column ---
             let y_before = ui.cursor().min.y;
             ui.horizontal(|ui| {
                 ui.add_space(indent);
-                if let Some(idx) = ctx_index {
-                    if idx < 9 {
-                        ui.label(
-                            egui::RichText::new(format!("{}", idx + 1))
-                                .size(11.0)
-                                .color(with_alpha(text_dim, row_alpha)),
-                        );
-                    }
-                }
 
-                // Reserve space on the right for: action zone, badge.
-                let right_reserve = if action_enabled {
-                    ACTION_ZONE_WIDTH + 4.0
-                } else {
-                    8.0
-                };
-                let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
-                let text_max = (ui.available_width() - right_reserve - badge_w).max(0.0);
+                // Gutter: fixed-width column for the 1-9 index number.
+                // Width is reserved here; the number is painted post-scope
+                // centered across the full row height.
+                ui.add_space(GUTTER_W);
 
-                ui.scope(|ui| {
-                    ui.set_max_width(text_max);
-                    ui.add(
-                        egui::Label::new(
-                            egui::RichText::new(&ctx_name).size(13.0).color(text_color),
-                        )
-                        .selectable(false)
-                        .truncate(),
-                    );
-                });
-
-                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                    ui.add_space(if action_enabled {
-                        ACTION_ZONE_WIDTH
-                    } else {
-                        0.0
-                    });
-                    if badge_count > 0 {
-                        let badge_text = if badge_count > 9 {
-                            "9+".to_string()
-                        } else {
-                            badge_count.to_string()
-                        };
-                        ui.label(
-                            egui::RichText::new(badge_text)
-                                .size(10.0)
-                                .color(with_alpha(accent_color, row_alpha)),
-                        );
-                    }
-                });
-            });
-            let name_row_h = ui.cursor().min.y - y_before;
-
-            // --- Path row — subtitle on its own line below the name ---
-            if let Some(ref path) = subtitle {
-                ui.horizontal(|ui| {
-                    ui.add_space(indent);
-                    ui.scope(|ui| {
-                        let path_max = (ui.available_width() - 8.0).max(0.0);
-                        ui.set_max_width(path_max);
-                        ui.add(
-                            egui::Label::new(
-                                egui::RichText::new(shorten_path(path))
-                                    .size(11.0)
-                                    .color(with_alpha(text_dim, row_alpha * 0.7)),
-                            )
-                            .selectable(false)
-                            .truncate(),
-                        );
-                    });
-                });
-            }
-
-            // --- Dot row — one dot per pane, rendered below the path ---
-            if let Some(ref dots) = pane_dots {
-                if dots.count > 0 {
+                // Content column: name row + optional path+pips row.
+                ui.vertical(|ui| {
+                    // --- Name row ---
                     ui.horizontal(|ui| {
-                        ui.add_space(indent);
-                        let capped = dots.count.min(PANE_DOT_MAX);
-                        let mut dot_area_width = (capped as f32) * PANE_DOT_SPACING;
-                        if dots.count > PANE_DOT_MAX {
-                            dot_area_width += 20.0;
-                        }
-                        let dot_size = Vec2::new(dot_area_width, PANE_DOT_RADIUS * 2.0 + 4.0);
-                        let (rect, _) = ui.allocate_exact_size(dot_size, Sense::hover());
-                        let painter = ui.painter();
-                        let cy = rect.center().y;
-                        for dot_i in 0..capped {
-                            let cx =
-                                rect.min.x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
-                            let is_hidden = dots.hidden_set.contains(&dot_i);
-                            let color = if dots.focused_idx == Some(dot_i) {
-                                with_alpha(accent_color, row_alpha)
-                            } else {
-                                with_alpha(text_dim, if is_dragging { 0.15 } else { 0.35 })
-                            };
-                            let center = egui::pos2(cx, cy);
-                            if is_hidden {
-                                painter.circle_stroke(
-                                    center,
-                                    PANE_DOT_RADIUS,
-                                    egui::Stroke::new(1.0, color),
-                                );
-                            } else {
-                                painter.circle_filled(center, PANE_DOT_RADIUS, color);
-                            }
-                        }
-                        if dots.count > PANE_DOT_MAX {
-                            let overflow_x = rect.min.x
-                                + (capped as f32) * PANE_DOT_SPACING
-                                + PANE_DOT_RADIUS * 0.5;
-                            let overflow_color =
-                                if dots.focused_idx.map_or(false, |idx| idx >= PANE_DOT_MAX) {
-                                    with_alpha(accent_color, row_alpha)
-                                } else {
-                                    with_alpha(text_dim, 0.5)
-                                };
-                            painter.text(
-                                egui::pos2(overflow_x, cy),
-                                egui::Align2::LEFT_CENTER,
-                                format!("+{}", dots.count - PANE_DOT_MAX),
-                                egui::FontId::proportional(8.0),
-                                overflow_color,
-                            );
-                        }
-                    });
-                }
-            }
+                        let right_reserve = if action_enabled {
+                            ACTION_ZONE_WIDTH + 4.0
+                        } else {
+                            8.0
+                        };
+                        let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
+                        let text_max =
+                            (ui.available_width() - right_reserve - badge_w).max(0.0);
 
-            name_row_h
+                        ui.scope(|ui| {
+                            ui.set_max_width(text_max);
+                            ui.add(
+                                egui::Label::new(
+                                    egui::RichText::new(&ctx_name)
+                                        .size(13.0)
+                                        .color(text_color),
+                                )
+                                .selectable(false)
+                                .truncate(),
+                            );
+                        });
+
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            ui.add_space(if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 });
+                            if badge_count > 0 {
+                                let badge_text = if badge_count > 9 {
+                                    "9+".to_string()
+                                } else {
+                                    badge_count.to_string()
+                                };
+                                ui.label(
+                                    egui::RichText::new(badge_text)
+                                        .size(10.0)
+                                        .color(with_alpha(accent_color, row_alpha)),
+                                );
+                            }
+                        });
+                    });
+
+                    // --- Path row with inline pips on the right ---
+                    if let Some(ref path) = subtitle {
+                        ui.horizontal(|ui| {
+                            // Build the pip strip on the right first (RTL), then
+                            // fill remaining width with the truncated path label.
+                            let right_reserve = if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 };
+
+                            // Compute pip strip width so we can reserve it.
+                            let pip_strip_w = if let Some(ref dots) = pane_dots {
+                                if dots.count > 0 {
+                                    let capped = dots.count.min(PANE_DOT_MAX);
+                                    let mut w = (capped as f32) * PANE_DOT_SPACING;
+                                    if dots.count > PANE_DOT_MAX {
+                                        w += 20.0;
+                                    }
+                                    w + 6.0 // gap between path text and dots
+                                } else {
+                                    0.0
+                                }
+                            } else {
+                                0.0
+                            };
+
+                            let path_max = (ui.available_width()
+                                - right_reserve
+                                - pip_strip_w
+                                - 8.0)
+                                .max(0.0);
+
+                            ui.scope(|ui| {
+                                ui.set_max_width(path_max);
+                                ui.add(
+                                    egui::Label::new(
+                                        egui::RichText::new(shorten_path(path))
+                                            .size(10.0)
+                                            .color(with_alpha(text_dim, row_alpha * 0.7)),
+                                    )
+                                    .selectable(false)
+                                    .truncate(),
+                                );
+                            });
+
+                            // Pip dots inline to the right of the path.
+                            if let Some(ref dots) = pane_dots {
+                                if dots.count > 0 {
+                                    let capped = dots.count.min(PANE_DOT_MAX);
+                                    let mut dot_area_width =
+                                        (capped as f32) * PANE_DOT_SPACING;
+                                    if dots.count > PANE_DOT_MAX {
+                                        dot_area_width += 20.0;
+                                    }
+                                    let dot_size = Vec2::new(
+                                        dot_area_width,
+                                        PANE_DOT_RADIUS * 2.0 + 4.0,
+                                    );
+                                    let (rect, _) =
+                                        ui.allocate_exact_size(dot_size, Sense::hover());
+                                    let painter = ui.painter();
+                                    let cy = rect.center().y;
+                                    for dot_i in 0..capped {
+                                        let cx = rect.min.x
+                                            + (dot_i as f32) * PANE_DOT_SPACING
+                                            + PANE_DOT_RADIUS;
+                                        let is_hidden = dots.hidden_set.contains(&dot_i);
+                                        let color = if dots.focused_idx == Some(dot_i) {
+                                            with_alpha(accent_color, row_alpha)
+                                        } else {
+                                            with_alpha(
+                                                text_dim,
+                                                if is_dragging { 0.15 } else { 0.35 },
+                                            )
+                                        };
+                                        let center = egui::pos2(cx, cy);
+                                        if is_hidden {
+                                            painter.circle_stroke(
+                                                center,
+                                                PANE_DOT_RADIUS,
+                                                egui::Stroke::new(1.0, color),
+                                            );
+                                        } else {
+                                            painter.circle_filled(
+                                                center, PANE_DOT_RADIUS, color,
+                                            );
+                                        }
+                                    }
+                                    if dots.count > PANE_DOT_MAX {
+                                        let overflow_x = rect.min.x
+                                            + (capped as f32) * PANE_DOT_SPACING
+                                            + PANE_DOT_RADIUS * 0.5;
+                                        let overflow_color = if dots
+                                            .focused_idx
+                                            .map_or(false, |idx| idx >= PANE_DOT_MAX)
+                                        {
+                                            with_alpha(accent_color, row_alpha)
+                                        } else {
+                                            with_alpha(text_dim, 0.5)
+                                        };
+                                        painter.text(
+                                            egui::pos2(overflow_x, cy),
+                                            egui::Align2::LEFT_CENTER,
+                                            format!("+{}", dots.count - PANE_DOT_MAX),
+                                            egui::FontId::proportional(8.0),
+                                            overflow_color,
+                                        );
+                                    }
+                                }
+                            }
+                        });
+                    }
+                });
+
+            });
+
+            ui.cursor().min.y - y_before
         });
 
         let row_rect = scope_out.response.rect;
@@ -244,25 +282,48 @@ impl ContextItem {
         let response = ui.interact(row_rect, id, Sense::click_and_drag());
         let hovered = response.hovered();
 
-        let fill = if is_active {
-            with_alpha(bg_active, row_alpha)
-        } else if hovered && !is_dragging {
-            with_alpha(bg_sidebar_hover, row_alpha)
-        } else {
-            Color32::TRANSPARENT
-        };
-
-        ui.painter().set(
-            bg_idx,
-            egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
-        );
-
+        // Selection: use paint_selection (inset tinted pill + soft outline) to
+        // match palette/picker rows. Hover keeps the flat sidebar fill.
         if is_active {
-            ui.painter().rect_filled(
-                Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
-                CornerRadius::ZERO,
-                with_alpha(accent_color, row_alpha),
+            // Clear the bg placeholder — paint_selection draws its own rect.
+            ui.painter().set(bg_idx, egui::Shape::Noop);
+            if row_alpha < 1.0 {
+                // Dragging: just a dim solid fill, no outline.
+                ui.painter().rect_filled(
+                    row_rect,
+                    CornerRadius::ZERO,
+                    with_alpha(bg_active, row_alpha),
+                );
+            } else {
+                paint_selection(ui.painter(), row_rect, colors);
+            }
+        } else {
+            let fill = if hovered && !is_dragging {
+                with_alpha(bg_sidebar_hover, row_alpha)
+            } else {
+                Color32::TRANSPARENT
+            };
+            ui.painter().set(
+                bg_idx,
+                egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
             );
+        }
+
+        // Paint the index number centered vertically in the gutter.
+        if let Some(idx) = ctx_index {
+            if idx < 9 {
+                let gutter_rect = Rect::from_min_size(
+                    egui::pos2(row_rect.min.x + indent, row_rect.min.y),
+                    Vec2::new(GUTTER_W, row_rect.height()),
+                );
+                ui.painter().text(
+                    gutter_rect.center(),
+                    egui::Align2::CENTER_CENTER,
+                    format!("{}", idx + 1),
+                    egui::FontId::proportional(11.0),
+                    with_alpha(text_dim, row_alpha),
+                );
+            }
         }
 
         let action_zone = if action_enabled {

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -142,7 +142,9 @@ impl ContextItem {
         // Reserve background shape slot before rendering content.
         let bg_idx = ui.painter().add(egui::Shape::Noop);
 
-        let indent = 20.0 + 16.0 * self.indent as f32;
+        // 6px base + 16px per nesting level — keeps the gutter number close to
+        // the sidebar edge for top-level contexts.
+        let indent = 6.0 + 16.0 * self.indent as f32;
 
         let is_active = self.is_active;
         let is_dragging = self.is_dragging;
@@ -231,9 +233,7 @@ impl ContextItem {
                     // When subtitle is absent but pips exist, render pips alone.
                     if let Some(ref path) = subtitle {
                         ui.horizontal(|ui| {
-                            let right_reserve = if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 };
-
-                            // Compute pip strip width so we can reserve it.
+                            // × is on the name row only — full width minus pip strip and margin.
                             let pip_strip_w = if let Some(ref dots) = pane_dots {
                                 if dots.count > 0 {
                                     let capped = dots.count.min(PANE_DOT_MAX);
@@ -249,11 +249,7 @@ impl ContextItem {
                                 0.0
                             };
 
-                            let path_max = (ui.available_width()
-                                - right_reserve
-                                - pip_strip_w
-                                - 8.0)
-                                .max(0.0);
+                            let path_max = (ui.available_width() - pip_strip_w - 8.0).max(0.0);
 
                             ui.scope(|ui| {
                                 ui.set_max_width(path_max);
@@ -323,7 +319,13 @@ impl ContextItem {
                     with_alpha(bg_active, row_alpha),
                 );
             } else {
-                paint_selection(ui.painter(), row_rect, colors);
+                // 4px horizontal inset gives the pill breathing room from the
+                // sidebar edges, matching the visual weight of palette rows.
+                let pill_rect = Rect::from_min_max(
+                    egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
+                    egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
+                );
+                paint_selection(ui.painter(), pill_rect, colors);
             }
         } else {
             let fill = if hovered && !is_dragging {

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -73,6 +73,63 @@ pub struct ContextItem {
     pub indent: u32,
 }
 
+/// Render pane-indicator dots into the current horizontal layout position.
+/// Shared by both the subtitle+pips path and the pips-only fallback path.
+fn draw_pips(
+    ui: &mut egui::Ui,
+    pane_dots: &Option<PaneDots>,
+    accent_color: Color32,
+    text_dim: Color32,
+    row_alpha: f32,
+    is_dragging: bool,
+) {
+    let Some(dots) = pane_dots else { return };
+    if dots.count == 0 {
+        return;
+    }
+    let capped = dots.count.min(PANE_DOT_MAX);
+    let mut dot_area_width = (capped as f32) * PANE_DOT_SPACING;
+    if dots.count > PANE_DOT_MAX {
+        dot_area_width += 20.0;
+    }
+    let dot_size = Vec2::new(dot_area_width, PANE_DOT_RADIUS * 2.0 + 4.0);
+    let (rect, _) = ui.allocate_exact_size(dot_size, Sense::hover());
+    let painter = ui.painter();
+    let cy = rect.center().y;
+    for dot_i in 0..capped {
+        let cx = rect.min.x + (dot_i as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS;
+        let is_hidden = dots.hidden_set.contains(&dot_i);
+        let color = if dots.focused_idx == Some(dot_i) {
+            with_alpha(accent_color, row_alpha)
+        } else {
+            with_alpha(text_dim, if is_dragging { 0.15 } else { 0.35 })
+        };
+        let center = egui::pos2(cx, cy);
+        if is_hidden {
+            painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0, color));
+        } else {
+            painter.circle_filled(center, PANE_DOT_RADIUS, color);
+        }
+    }
+    if dots.count > PANE_DOT_MAX {
+        let overflow_x =
+            rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
+        let overflow_color =
+            if dots.focused_idx.map_or(false, |idx| idx >= PANE_DOT_MAX) {
+                with_alpha(accent_color, row_alpha)
+            } else {
+                with_alpha(text_dim, 0.5)
+            };
+        painter.text(
+            egui::pos2(overflow_x, cy),
+            egui::Align2::LEFT_CENTER,
+            format!("+{}", dots.count - PANE_DOT_MAX),
+            egui::FontId::proportional(8.0),
+            overflow_color,
+        );
+    }
+}
+
 impl ContextItem {
     pub fn draw(
         self,
@@ -109,6 +166,10 @@ impl ContextItem {
 
             // --- Outer row: left gutter (index number) + content column ---
             let y_before = ui.cursor().min.y;
+            // name_row_h is captured from inside the horizontal closure and
+            // returned as part of the scope inner so the action zone can be
+            // limited to the header line height.
+            let mut name_row_h_capture = 0.0_f32;
             ui.horizontal(|ui| {
                 ui.add_space(indent);
 
@@ -118,8 +179,11 @@ impl ContextItem {
                 ui.add_space(GUTTER_W);
 
                 // Content column: name row + optional path+pips row.
-                ui.vertical(|ui| {
+                // Capture name_row_h so the action zone is limited to the
+                // header line regardless of how many metadata rows follow.
+                let name_row_h = ui.vertical(|ui| {
                     // --- Name row ---
+                    let name_y_before = ui.cursor().min.y;
                     ui.horizontal(|ui| {
                         let right_reserve = if action_enabled {
                             ACTION_ZONE_WIDTH + 4.0
@@ -159,12 +223,14 @@ impl ContextItem {
                             }
                         });
                     });
+                    // Capture name-row height before any metadata rows are added.
+                    let name_h = ui.cursor().min.y - name_y_before;
 
                     // --- Path row with inline pips on the right ---
+                    // When subtitle is present, pips go inline to its right.
+                    // When subtitle is absent but pips exist, render pips alone.
                     if let Some(ref path) = subtitle {
                         ui.horizontal(|ui| {
-                            // Build the pip strip on the right first (RTL), then
-                            // fill remaining width with the truncated path label.
                             let right_reserve = if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 };
 
                             // Compute pip strip width so we can reserve it.
@@ -202,82 +268,44 @@ impl ContextItem {
                                 );
                             });
 
-                            // Pip dots inline to the right of the path.
-                            if let Some(ref dots) = pane_dots {
-                                if dots.count > 0 {
-                                    let capped = dots.count.min(PANE_DOT_MAX);
-                                    let mut dot_area_width =
-                                        (capped as f32) * PANE_DOT_SPACING;
-                                    if dots.count > PANE_DOT_MAX {
-                                        dot_area_width += 20.0;
-                                    }
-                                    let dot_size = Vec2::new(
-                                        dot_area_width,
-                                        PANE_DOT_RADIUS * 2.0 + 4.0,
-                                    );
-                                    let (rect, _) =
-                                        ui.allocate_exact_size(dot_size, Sense::hover());
-                                    let painter = ui.painter();
-                                    let cy = rect.center().y;
-                                    for dot_i in 0..capped {
-                                        let cx = rect.min.x
-                                            + (dot_i as f32) * PANE_DOT_SPACING
-                                            + PANE_DOT_RADIUS;
-                                        let is_hidden = dots.hidden_set.contains(&dot_i);
-                                        let color = if dots.focused_idx == Some(dot_i) {
-                                            with_alpha(accent_color, row_alpha)
-                                        } else {
-                                            with_alpha(
-                                                text_dim,
-                                                if is_dragging { 0.15 } else { 0.35 },
-                                            )
-                                        };
-                                        let center = egui::pos2(cx, cy);
-                                        if is_hidden {
-                                            painter.circle_stroke(
-                                                center,
-                                                PANE_DOT_RADIUS,
-                                                egui::Stroke::new(1.0, color),
-                                            );
-                                        } else {
-                                            painter.circle_filled(
-                                                center, PANE_DOT_RADIUS, color,
-                                            );
-                                        }
-                                    }
-                                    if dots.count > PANE_DOT_MAX {
-                                        let overflow_x = rect.min.x
-                                            + (capped as f32) * PANE_DOT_SPACING
-                                            + PANE_DOT_RADIUS * 0.5;
-                                        let overflow_color = if dots
-                                            .focused_idx
-                                            .map_or(false, |idx| idx >= PANE_DOT_MAX)
-                                        {
-                                            with_alpha(accent_color, row_alpha)
-                                        } else {
-                                            with_alpha(text_dim, 0.5)
-                                        };
-                                        painter.text(
-                                            egui::pos2(overflow_x, cy),
-                                            egui::Align2::LEFT_CENTER,
-                                            format!("+{}", dots.count - PANE_DOT_MAX),
-                                            egui::FontId::proportional(8.0),
-                                            overflow_color,
-                                        );
-                                    }
-                                }
-                            }
+                            draw_pips(
+                                ui,
+                                &pane_dots,
+                                accent_color,
+                                text_dim,
+                                row_alpha,
+                                is_dragging,
+                            );
+                        });
+                    } else if pane_dots
+                        .as_ref()
+                        .map_or(false, |d| d.count > 0)
+                    {
+                        // No subtitle — render pips on their own metadata row so
+                        // contexts without a root path still show pane indicators.
+                        ui.horizontal(|ui| {
+                            draw_pips(
+                                ui,
+                                &pane_dots,
+                                accent_color,
+                                text_dim,
+                                row_alpha,
+                                is_dragging,
+                            );
                         });
                     }
-                });
+
+                    name_h
+                }).inner;
+                name_row_h_capture = name_row_h;
 
             });
 
-            ui.cursor().min.y - y_before
+            (ui.cursor().min.y - y_before, name_row_h_capture)
         });
 
         let row_rect = scope_out.response.rect;
-        let name_row_h = scope_out.inner;
+        let (_total_h, name_row_h) = scope_out.inner;
 
         let response = ui.interact(row_rect, id, Sense::click_and_drag());
         let hovered = response.hovered();


### PR DESCRIPTION
Closes #2206

## Summary

- Replace flat `bg_active` fill + 3px left accent bar with `paint_selection` (inset tinted pill + soft accent outline), unifying sidebar selection with palette/picker row visual language
- Add fixed-width 24px left gutter for the 1–9 index number, painted post-layout so it is vertically centered across the full row height
- Collapse the separate dot row into inline-right of the path row — name, path, and pips all share the same left content edge

## Done When

- Selected sidebar row visually matches palette row selection (tinted inset pill, soft outline)
- No 3px left bar on selected rows
- Index number is vertically centered across the full row height in a left gutter
- Name, path, and pips are all left-aligned to the same x
- Pips appear inline right of the path — not a separate row below
- `cargo build` passes