### PR TITLE
feat(context): default first context root to home directory

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -856,7 +856,7 @@ impl PlexiApp {
                 );
                 (name, desc, Some(a.root.clone()))
             }
-            None => ("Default".to_string(), None, None),
+            None => ("Default".to_string(), None, dirs::home_dir()),
         };
 
         let default_cwd = std::env::current_dir().unwrap_or_default();


### PR DESCRIPTION
## Summary

- When the app loads fresh (no anchor detected), the first context's `root` was `None`
- This caused quirky UI states when certain features expect a context root to be present
- One-line fix: set `default_root` to `dirs::home_dir()` in the no-anchor branch

## Test plan

- [ ] Fresh launch (no workspace) — context root should be `~`
- [ ] Launch from a workspace with an anchor — context root should still come from the anchor (unchanged)
- [ ] New panes open at `~` instead of inheriting no root

🤖 Generated with [Claude Code](https://claude.com/claude-code)