### PR TITLE
Sprint s13 perf batch: background wake gating, render allocation cuts, hung-render timeout, perf lint gate, frame_diag ground truth

### DIFF
--- a/deps/egui_term/src/lib.rs
+++ b/deps/egui_term/src/lib.rs
@@ -1,3 +1,12 @@
+// Vendored crate: excluded from the first-party perf lint gate (`just perf-clippy`).
+// Do not refactor vendored code to satisfy these lints — see issue #2026.
+#![allow(
+    clippy::perf,
+    clippy::redundant_clone,
+    clippy::needless_collect,
+    clippy::large_enum_variant
+)]
+
 mod backend;
 mod bindings;
 mod diag;

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -703,6 +703,10 @@ impl<'a> TerminalView<'a> {
                     if elapsed >= blink_interval {
                         state.cursor_visible = !state.cursor_visible;
                         state.last_cursor_toggle = Instant::now();
+                        // Note only when the toggle actually fires — noting
+                        // every rendered frame falsely flagged the blink as
+                        // the repaint driver in idle-CPU audits (#2209).
+                        crate::diag::diag_note("terminal_cursor_blink");
                     }
                     if state.cursor_visible {
                         match content.cursor_shape {
@@ -738,7 +742,6 @@ impl<'a> TerminalView<'a> {
                     }
                     let remaining = blink_interval
                         .saturating_sub(state.last_cursor_toggle.elapsed());
-                    crate::diag::diag_note("terminal_cursor_blink");
                     painter.ctx().request_repaint_after(remaining);
                 } else {
                     // Unfocused: hollow outline, no blink

--- a/justfile
+++ b/justfile
@@ -31,6 +31,12 @@ coverage:
 coverage-summary:
     cargo llvm-cov --bin plexi --summary-only -- --skip "welcome_tab_falls_back_to_home_dir_when_no_root"
 
+# Perf lint gate — run before and after any perf work; must exit clean.
+# Scoped to the perf lint set only (`-A clippy::all` silences unrelated lints);
+# vendored deps/egui_term opts out via crate-level allows in its lib.rs.
+perf-clippy:
+    RUSTC_WRAPPER= RUSTFLAGS= cargo clippy --all-targets --all-features --locked -- -A clippy::all -D clippy::perf -D clippy::redundant_clone -D clippy::needless_collect -D clippy::large_enum_variant -D clippy::clone_on_copy
+
 build:
     cargo build --release
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -312,7 +312,7 @@ impl PlexiApp {
                             options: options.clone(),
                             input_prompt: input_prompt.clone(),
                             required: *required,
-                            priority: priority.clone(),
+                            priority: *priority,
                             scope: resolved_scope,
                             image_inline: image_inline.clone(),
                             image_pipe_id: image_pipe_id.clone(),

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1,7 +1,6 @@
 //! App command dispatch — keyboard routing + command drain from app panes.
 
 use crate::app::app_trait::{App, AppCommand};
-use crate::host::pane::AppRuntime;
 
 use super::PlexiApp;
 
@@ -85,6 +84,157 @@ mod tests {
         assert!(
             h.app.background_processes_need_wake(),
             "parked process apps with pending timers/async work must keep the host wake loop alive"
+        );
+    }
+
+    /// Issue #2021: an idle parked app (no pending timers, no async work, no
+    /// queued draw commands) must NOT be background-ticked on every frame.
+    #[test]
+    fn idle_parked_app_is_not_background_ticked() {
+        let mut h = HostHarness::new();
+        let (process_app, _draw_tx) = ProcessApp::new_for_test(999, AppPermissions::builtin());
+        assert!(
+            !process_app.needs_background_tick(),
+            "a fresh idle test app must report no pending background work"
+        );
+        h.app
+            .background_apps
+            .insert("idle-app".to_string(), (1, Box::new(process_app)));
+
+        let _ = h.app.drain_all_app_commands();
+
+        let (_, app) = &h.app.background_apps["idle-app"];
+        assert_eq!(
+            app.background_tick_count, 0,
+            "idle parked app must not be ticked by the foreground frame loop (#2021)"
+        );
+        assert!(
+            !h.app.background_processes_need_wake(),
+            "an idle parked app must not keep the host wake loop alive"
+        );
+    }
+
+    /// Issue #2021 done-condition: a parked app's timer can surface its event
+    /// in a single wake frame, without relying on continuous foreground
+    /// repaint — and after draining, the app quiesces again.
+    #[test]
+    fn parked_app_timer_event_is_consumed_by_a_single_gated_tick() {
+        let mut h = HostHarness::new();
+        let (mut process_app, _draw_tx) = ProcessApp::new_for_test(999, AppPermissions::builtin());
+        // Simulate SetTimer: routing inserts the pending flag, the timer
+        // thread later delivers the Timer event on http_tx.
+        process_app.pending_timers.insert(
+            "t1".to_string(),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        );
+        process_app
+            .http_tx
+            .clone()
+            .send(PlexiEvent::Timer {
+                timer_id: "t1".to_string(),
+            })
+            .expect("test http channel send");
+        assert!(
+            process_app.needs_background_tick(),
+            "a pending timer must mark the parked app as needing a tick"
+        );
+        h.app
+            .background_apps
+            .insert("timer-app".to_string(), (1, Box::new(process_app)));
+        assert!(
+            h.app.background_processes_need_wake(),
+            "pending timer must keep the host wake loop alive"
+        );
+
+        let _ = h.app.drain_all_app_commands();
+
+        let (_, app) = &h.app.background_apps["timer-app"];
+        assert_eq!(
+            app.background_tick_count, 1,
+            "parked app with a fired timer must be ticked exactly once"
+        );
+        assert!(
+            app.pending_timers.is_empty(),
+            "the gated tick must consume the timer event"
+        );
+        assert!(
+            !h.app.background_processes_need_wake(),
+            "after the timer drains, the host wake loop must quiesce"
+        );
+    }
+
+    /// Issue #2021: a parked app emitting a notification from its own process
+    /// (draw command arriving on the stdout channel) surfaces in one wake
+    /// frame. The stdout reader thread marks `draw_pending` and wakes the
+    /// host; the next drain must tick the app and return the notification.
+    #[test]
+    fn parked_app_draw_command_notification_surfaces_via_draw_pending() {
+        let mut h = HostHarness::new();
+        let (process_app, draw_tx) = ProcessApp::new_for_test(999, AppPermissions::builtin());
+        let draw_pending = std::sync::Arc::clone(&process_app.draw_pending);
+        h.app
+            .background_apps
+            .insert("notify-app".to_string(), (7, Box::new(process_app)));
+
+        // Idle frame first: no tick.
+        let _ = h.app.drain_all_app_commands();
+        assert_eq!(h.app.background_apps["notify-app"].1.background_tick_count, 0);
+
+        // App emits a notification: the stdout reader sends the command, then
+        // sets draw_pending (and wakes the host via repaint_ctx in prod).
+        let cmd: crate::app_protocol::DrawCommand = serde_json::from_str(
+            r#"{"type":"notify","level":"info","title":"ping","body":"","priority":50}"#,
+        )
+        .expect("notify draw command parses");
+        draw_tx.send(cmd).expect("draw channel send");
+        draw_pending.store(true, std::sync::atomic::Ordering::Release);
+
+        let cmds = h.app.drain_all_app_commands();
+        assert!(
+            cmds.iter().any(|c| matches!(
+                c,
+                AppCommand::ShowNotification { title, .. } if title == "ping"
+            )),
+            "parked app's notification must surface on the wake frame"
+        );
+        assert!(
+            !h.app.background_processes_need_wake(),
+            "after draining the draw command, the host wake loop must quiesce"
+        );
+    }
+
+    /// Issue #2021: an app exposing an MCP server must not keep the host in
+    /// a permanent 100ms wake loop — only a queued (undelivered) tool call
+    /// counts as pending background work.
+    #[test]
+    fn mcp_server_only_needs_tick_when_calls_are_queued() {
+        use std::sync::{Arc, Mutex};
+
+        let (mut process_app, _draw_tx) = ProcessApp::new_for_test(999, AppPermissions::builtin());
+        let handle =
+            crate::process_app::mcp_server::start_mcp_server(vec![], Arc::new(Mutex::new(None)))
+                .expect("mcp server starts");
+        let queue = Arc::clone(&handle.call_queue);
+        process_app.mcp_server = Some(handle);
+
+        assert!(
+            !process_app.needs_background_tick(),
+            "an MCP server with an empty call queue must not keep the host awake"
+        );
+
+        let (response_tx, _response_rx) = std::sync::mpsc::sync_channel(1);
+        queue
+            .lock()
+            .unwrap()
+            .push_back(crate::process_app::mcp_server::McpCallRequest {
+                call_id: "c1".to_string(),
+                tool_name: "noop".to_string(),
+                arguments: serde_json::Value::Null,
+                response_tx,
+            });
+        assert!(
+            process_app.needs_background_tick(),
+            "a queued MCP tool call must mark the app as needing a background tick"
         );
     }
 
@@ -199,6 +349,11 @@ impl PlexiApp {
         }
     }
 
+    /// True when any non-active-context pane or parked background app has
+    /// pending background work. Drives the bounded 100ms wake loop in
+    /// `update()` — this MUST use the same predicate as the tick gate in
+    /// [`Self::drain_all_app_commands`], otherwise work could be marked
+    /// pending without a frame ever being scheduled to drain it (#2021).
     pub(crate) fn background_processes_need_wake(&self) -> bool {
         let active = self.active_window;
         let inactive_context_needs_wake =
@@ -206,11 +361,7 @@ impl PlexiApp {
                 ctx_idx != active
                     && context.panes.values().any(|pane| {
                         pane.as_app()
-                            .and_then(|app_pane| match &app_pane.runtime {
-                                AppRuntime::Process(app) => Some(app.needs_headless_wake_poll()),
-                                AppRuntime::Builtin(_) => None,
-                            })
-                            .unwrap_or(false)
+                            .is_some_and(|app_pane| app_pane.runtime.needs_background_tick())
                     })
             });
 
@@ -218,7 +369,7 @@ impl PlexiApp {
             || self
                 .background_apps
                 .values()
-                .any(|(_, app)| app.needs_headless_wake_poll())
+                .any(|(_, app)| app.needs_background_tick())
     }
 
     /// Drain `pending_commands` from **every** app pane in **every** context,
@@ -246,8 +397,11 @@ impl PlexiApp {
                     // Active-context panes are already fully updated by ui()
                     // this frame. Non-active panes need a headless tick so
                     // timer/async events reach the subprocess and control
-                    // commands flow out.
-                    if ctx_idx != active {
+                    // commands flow out — but only when they actually have
+                    // pending background work; idle apps are skipped so a
+                    // busy foreground doesn't tick every background app on
+                    // every frame (#2021).
+                    if ctx_idx != active && app_pane.runtime.needs_background_tick() {
                         app_pane.runtime.background_tick();
                     }
                     let type_id = app_pane.runtime.type_id().to_string();
@@ -269,7 +423,13 @@ impl PlexiApp {
             .background_apps
             .iter_mut()
             .map(|(type_id, (park_context_id, app))| {
-                app.background_tick();
+                // Same gate as visible non-active panes: tick only when the
+                // app has pending background work (#2021). Already-queued
+                // pending_commands are still taken unconditionally.
+                if app.needs_background_tick() {
+                    log::debug!("parked background app '{type_id}': pending work — ticking");
+                    app.background_tick();
+                }
                 let cmds = app.take_pending_commands();
                 (type_id.to_owned(), *park_context_id, cmds)
             })

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -566,7 +566,7 @@ impl PlexiApp {
         let theme_cfg = Self::resolve_theme_config(&fresh);
         let new_colors = crate::ui::theme::Colors::from_config(&theme_cfg);
         if self.colors != new_colors {
-            self.colors = new_colors.clone();
+            self.colors = new_colors;
             let dark_mode =
                 !crate::ui::theme::is_light_preset(
                     fresh.theme.as_ref().and_then(|t| t.preset.as_deref()).unwrap_or(""),
@@ -657,7 +657,7 @@ impl PlexiApp {
             let theme_cfg = crate::ui::theme::apply_preset(&preset, &user_theme);
             let new_colors = crate::ui::theme::Colors::from_config(&theme_cfg);
             if self.colors != new_colors {
-                self.colors = new_colors.clone();
+                self.colors = new_colors;
                 let dark_mode = !crate::ui::theme::is_light_preset(new_preset);
                 crate::ui::theme::setup_style(&self.ctx, &new_colors, dark_mode);
                 let window_theme = if dark_mode {
@@ -701,10 +701,7 @@ impl PlexiApp {
     /// deterministically each frame.
     pub(crate) fn sync_confirm_close_focus(&mut self) {
         let should_own = self.pending_close;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::ConfirmClose);
+        let has_layer = self.focus_stack.contains(&FocusLayer::ConfirmClose);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ConfirmClose);
         } else if !should_own && has_layer {
@@ -715,10 +712,7 @@ impl PlexiApp {
 
     pub(crate) fn sync_context_close_focus(&mut self) {
         let should_own = self.pending_context_close.is_some();
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::ContextCloseConfirm);
+        let has_layer = self.focus_stack.contains(&FocusLayer::ContextCloseConfirm);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ContextCloseConfirm);
         } else if !should_own && has_layer {
@@ -799,10 +793,7 @@ impl PlexiApp {
 
     pub(crate) fn sync_notification_modal_focus(&mut self) {
         let should_own = self.show_notification_modal;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::NotificationModal);
+        let has_layer = self.focus_stack.contains(&FocusLayer::NotificationModal);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::NotificationModal);
         } else if !should_own && has_layer {
@@ -814,10 +805,7 @@ impl PlexiApp {
 
     pub(crate) fn sync_cli_setup_prompt_focus(&mut self) {
         let should_own = self.show_cli_setup_prompt;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CliSetupPrompt);
+        let has_layer = self.focus_stack.contains(&FocusLayer::CliSetupPrompt);
         if should_own && !has_layer {
             log::info!("cli_setup: focus captured by CliSetupPrompt layer");
             self.push_focus_layer(FocusLayer::CliSetupPrompt);
@@ -835,10 +823,7 @@ impl PlexiApp {
     /// source of truth, focus stack follows it deterministically each frame.
     pub(crate) fn sync_command_palette_focus(&mut self) {
         let should_own = self.show_command_palette;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CommandPalette);
+        let has_layer = self.focus_stack.contains(&FocusLayer::CommandPalette);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::CommandPalette);
         } else if !should_own && has_layer {
@@ -909,10 +894,7 @@ impl PlexiApp {
     /// Reconcile the rename-pane focus layer with `renaming_pane`.
     pub(crate) fn sync_rename_pane_focus(&mut self) {
         let should_own = self.renaming_pane.is_some();
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::RenamePane);
+        let has_layer = self.focus_stack.contains(&FocusLayer::RenamePane);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::RenamePane);
         } else if !should_own && has_layer {
@@ -926,10 +908,7 @@ impl PlexiApp {
     /// never renders, so we promote the rename to a modal overlay instead.
     pub(crate) fn sync_context_rename_focus(&mut self) {
         let should_own = self.renaming_window.is_some() && !self.sidebar_visible;
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::ContextRename);
+        let has_layer = self.focus_stack.contains(&FocusLayer::ContextRename);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::ContextRename);
         } else if !should_own && has_layer {
@@ -941,7 +920,7 @@ impl PlexiApp {
     /// Reconcile the text-input overlay focus layer with `text_overlay`.
     pub(crate) fn sync_text_input_focus(&mut self) {
         let should_own = self.text_overlay.is_some();
-        let has_layer = self.focus_stack.iter().any(|l| *l == FocusLayer::TextInput);
+        let has_layer = self.focus_stack.contains(&FocusLayer::TextInput);
         if should_own && !has_layer {
             self.push_focus_layer(FocusLayer::TextInput);
         } else if !should_own && has_layer {
@@ -956,10 +935,7 @@ impl PlexiApp {
     /// without polling lag.
     pub(crate) fn sync_capability_modal_focus(&mut self) {
         let should_own = self.focused_pane_has_pending_prompts();
-        let has_layer = self
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CapabilityModal);
+        let has_layer = self.focus_stack.contains(&FocusLayer::CapabilityModal);
         let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::CapabilityModal));
         if should_own && !is_top {
             // Push to top (re-promoting from buried position if already in stack).

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1628,6 +1628,12 @@ impl PlexiApp {
                     response_file,
                 );
             }
+            crate::app_protocol::AppRequest::Wake => {
+                // No-op: the wake effect is the socket listener's repaint
+                // request — by the time this arm runs, a frame is already
+                // in flight and queued work (spawn-queue, channels) drains.
+                log::debug!("pane_ipc: kind=wake (no-op)");
+            }
             _ => {
                 log::warn!("pane_ipc: unsupported command kind, dropping");
             }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -484,9 +484,9 @@ impl PlexiApp {
                 let tracked_path = slots.get(slot_name).cloned();
                 let existing_path = tracked_path.clone().unwrap_or(slot_path.clone());
                 let write_path = if *append {
-                    tracked_path.clone().unwrap_or(slot_path.clone())
+                    tracked_path.clone().unwrap_or(slot_path)
                 } else {
-                    slot_path.clone()
+                    slot_path
                 };
                 let exists = tracked_path.as_ref().is_some_and(|path| path.exists());
                 if exists && !*append && !*replace {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -370,7 +370,35 @@ fn configure_egui_ctx(ctx: &egui::Context, colors: &Colors) {
     theme::setup_style(ctx, colors, true);
 }
 
-fn spawn_socket_listener(tx: std::sync::mpsc::Sender<crate::app_protocol::AppRequest>) {
+/// Handle one newline-delimited JSON line from the notify socket: parse the
+/// `AppRequest`, queue it on the pane-IPC channel, and wake the UI thread.
+///
+/// The repaint request is load-bearing: a fully idle Plexi produces zero
+/// frames, and the pane-IPC channel is only drained during a frame. Without
+/// the wake, a CLI request against an idle instance sits queued until the
+/// user touches the window (#s13 perf batch regression).
+fn handle_socket_line(
+    line: &str,
+    tx: &std::sync::mpsc::Sender<crate::app_protocol::AppRequest>,
+    egui_ctx: &egui::Context,
+) {
+    match serde_json::from_str::<crate::app_protocol::AppRequest>(line) {
+        Ok(cmd) => {
+            if tx.send(cmd).is_ok() {
+                log::debug!("pane_ipc: request queued — requesting repaint to wake idle UI thread");
+                egui_ctx.request_repaint();
+            }
+        }
+        Err(e) => {
+            log::warn!("pane_ipc: parse error: {e}  line={line:?}");
+        }
+    }
+}
+
+fn spawn_socket_listener(
+    tx: std::sync::mpsc::Sender<crate::app_protocol::AppRequest>,
+    egui_ctx: egui::Context,
+) {
     use std::io::{BufRead, BufReader};
     use std::os::unix::net::UnixListener;
 
@@ -388,6 +416,7 @@ fn spawn_socket_listener(tx: std::sync::mpsc::Sender<crate::app_protocol::AppReq
         for stream in listener.incoming() {
             let Ok(stream) = stream else { break };
             let tx = tx.clone();
+            let egui_ctx = egui_ctx.clone();
             std::thread::spawn(move || {
                 let reader = BufReader::new(stream);
                 for line in reader.lines() {
@@ -396,14 +425,7 @@ fn spawn_socket_listener(tx: std::sync::mpsc::Sender<crate::app_protocol::AppReq
                     if line.is_empty() {
                         continue;
                     }
-                    match serde_json::from_str::<crate::app_protocol::AppRequest>(&line) {
-                        Ok(cmd) => {
-                            let _ = tx.send(cmd);
-                        }
-                        Err(e) => {
-                            log::warn!("pane_ipc: parse error: {e}  line={line:?}");
-                        }
-                    }
+                    handle_socket_line(&line, &tx, &egui_ctx);
                 }
             });
         }
@@ -414,11 +436,18 @@ impl PlexiApp {
     pub fn new(
         cc: &eframe::CreationContext<'_>,
         frame_tick: crate::platform::logging::FrameTick,
+        heartbeat_ctx: crate::platform::logging::HeartbeatCtxSlot,
     ) -> Self {
+        // Hand the egui context to the heartbeat watchdog so it can tell
+        // healthy zero-frame idle apart from a genuine UI freeze.
+        if let Ok(mut slot) = heartbeat_ctx.lock() {
+            *slot = Some(cc.egui_ctx.clone());
+        }
+
         #[cfg(target_os = "macos")]
         crate::platform::macos_menu::customize_app_menu();
         #[cfg(target_os = "macos")]
-        crate::platform::finder_service::register();
+        crate::platform::finder_service::register(cc.egui_ctx.clone());
 
         // Repaint-cause diagnostics (#2019): route egui_term's repaint labels
         // into the host counters; `update()` flushes a summary every 10s.
@@ -524,7 +553,7 @@ impl PlexiApp {
 
         let (pane_ipc_tx, pane_ipc_rx) =
             std::sync::mpsc::channel::<crate::app_protocol::AppRequest>();
-        spawn_socket_listener(pane_ipc_tx);
+        spawn_socket_listener(pane_ipc_tx, cc.egui_ctx.clone());
 
         // One-time migration: remove the legacy file-queue directory if it
         // still exists from a previous install. Notify commands now travel

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -184,6 +184,15 @@ pub struct PlexiApp {
     /// was opened. Resolved once on open, not per-frame, to avoid repeated
     /// filesystem traversal in the egui draw loop.
     pub(crate) palette_workspace_root: Option<std::path::PathBuf>,
+    /// TTL cache for the cwd-derived fallback workspace root passed to
+    /// `PlexiBehavior` each frame (#2023). The fallback
+    /// (`config::active_workspace_root()`) stat-walks the filesystem from the
+    /// process cwd, so it must not run per frame. The underlying state is
+    /// external filesystem layout — no enumerable mutation sites — so a 1s
+    /// TTL is the invalidation, matching the downstream
+    /// `OUTSIDE_WORKSPACE_CHECK_INTERVAL` of the only consumer (the terminal
+    /// "outside workspace" badge).
+    pub(crate) workspace_root_fallback_cache: Option<(std::time::Instant, Option<std::path::PathBuf>)>,
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
     /// One-shot guard: true after `request_focus()` fires on the rename modal's
@@ -750,6 +759,7 @@ impl PlexiApp {
                     palette_query: String::new(),
                     palette_selected: 0,
                     palette_workspace_root: None,
+                    workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
                     rename_pane_focus_requested: false,
@@ -939,6 +949,7 @@ impl PlexiApp {
             palette_query: String::new(),
             palette_selected: 0,
             palette_workspace_root: None,
+            workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
             rename_pane_focus_requested: false,
@@ -1142,6 +1153,7 @@ impl PlexiApp {
                 palette_query: String::new(),
                 palette_selected: 0,
                 palette_workspace_root: None,
+                workspace_root_fallback_cache: None,
                 context_visit_history: Vec::new(),
                 renaming_pane: None,
                 rename_pane_focus_requested: false,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1459,6 +1459,10 @@ impl eframe::App for PlexiApp {
                     crate::platform::frame_diag::RepaintCause::UserInput,
                 );
             }
+            // Ground truth (#2209): egui records the file:line of every
+            // request_repaint() from the previous pass — including sites the
+            // self-reported counters above never instrumented.
+            crate::platform::frame_diag::note_egui_causes(&ctx.repaint_causes());
             if elapsed >= std::time::Duration::from_secs(10) {
                 let counts = crate::platform::frame_diag::snapshot_and_reset();
                 log::info!(
@@ -1469,6 +1473,12 @@ impl eframe::App for PlexiApp {
                         elapsed.as_secs_f32(),
                         &counts
                     )
+                );
+                let egui_counts = crate::platform::frame_diag::egui_snapshot_and_reset();
+                log::info!(
+                    target: "plexi::frame_diag",
+                    "{}",
+                    crate::platform::frame_diag::egui_summary_line(&egui_counts, 8)
                 );
                 self.frame_diag_window = Some((std::time::Instant::now(), 0));
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -735,7 +735,7 @@ impl PlexiApp {
                     binding_table: crate::host::keys::build_binding_table(&key_bindings),
                     pending_close: false,
                     pending_context_close: None,
-                    frame_tick: frame_tick.clone(),
+                    frame_tick,
                     frame_diag_window: None,
                     last_sent_window_title: None,
                     permission_store_dir: crate::config::config_dir(),
@@ -756,7 +756,7 @@ impl PlexiApp {
                     text_overlay: None,
                     text_overlay_browse_rx: None,
                     registry,
-                    features: features.clone(),
+                    features,
                     pending_notifications: load_pending_notifications_from(
                         &crate::config::config_dir().join("notifications.json"),
                     ),
@@ -813,7 +813,7 @@ impl PlexiApp {
                     focus_started_at: None,
                     last_system_theme: None,
                     overlay_held_cmds: Vec::new(),
-                    agent_host: crate::agent::AgentHost::production(config.ai.clone()),
+                    agent_host: crate::agent::AgentHost::production(config.ai),
                 };
                 app.apply_context_transition_effects();
                 return app;
@@ -831,7 +831,7 @@ impl PlexiApp {
                 .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
             // macOS GUI apps launch with CWD = /. Use home_dir instead so
             // the initial context and all derived CWDs start at ~.
-            if cwd == PathBuf::from("/") {
+            if cwd == std::path::Path::new("/") {
                 dirs::home_dir().unwrap_or(cwd)
             } else {
                 cwd
@@ -1077,7 +1077,7 @@ impl PlexiApp {
                 theme: theme::terminal_theme(&theme_cfg),
                 colors,
                 default_font_size: theme::FONT_SIZE,
-                ctx: ctx.clone(),
+                ctx,
                 router: crate::workspace::router::WorkspaceRouter::new(
                     vec![crate::host::context::Context {
                         name: "Test".into(),

--- a/src/app/notification_image.rs
+++ b/src/app/notification_image.rs
@@ -276,7 +276,7 @@ mod tests {
     /// placeholder ("image frame malformed").
     #[test]
     fn notify_with_short_pipe_frame_is_malformed() {
-        let frame = vec![1u8, 2, 3]; // 3 bytes — too short for the header
+        let frame = [1u8, 2, 3]; // 3 bytes — too short for the header
         assert!(frame.len() < PIPE_HEADER_LEN);
     }
 }

--- a/src/app/plexi_descriptor.rs
+++ b/src/app/plexi_descriptor.rs
@@ -199,7 +199,7 @@ pub fn parse(json: &str) -> Result<PlexiDescriptor, DescriptorError> {
     let (major, _minor) = parse_semver_major_minor(&descriptor.plexi_version)?;
     if major > PLEXI_DESCRIPTOR_MAJOR {
         return Err(DescriptorError::UnsupportedMajorVersion {
-            found: descriptor.plexi_version.clone(),
+            found: descriptor.plexi_version,
             supported: PLEXI_DESCRIPTOR_MAJOR,
         });
     }

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -351,7 +351,7 @@ impl AppRegistry {
                 registry.scan_dir(
                     &local_agents,
                     RegistrySource::LocalAgent,
-                    Some(root.clone()),
+                    Some(root),
                 );
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -10,6 +10,22 @@ const FLASH_DUR: f32 = 0.4;
 const FLASH_TAU: f32 = 0.10;
 
 impl PlexiApp {
+    /// Cwd-derived fallback workspace root, used when the active context has no
+    /// explicit `root`. `config::active_workspace_root()` stat-walks the
+    /// filesystem from the process cwd, so it must not run every frame; the
+    /// result is cached with a 1s TTL (see `workspace_root_fallback_cache`).
+    fn fallback_workspace_root(&mut self) -> Option<std::path::PathBuf> {
+        const TTL: std::time::Duration = std::time::Duration::from_secs(1);
+        if let Some((resolved_at, ref root)) = self.workspace_root_fallback_cache {
+            if resolved_at.elapsed() < TTL {
+                return root.clone();
+            }
+        }
+        let root = crate::config::active_workspace_root();
+        self.workspace_root_fallback_cache = Some((std::time::Instant::now(), root.clone()));
+        root
+    }
+
     /// Early per-frame work that runs before overlay dispatch and panel rendering.
     /// Handles adopted context paths, finder service drains, notification polling,
     /// pane command draining, update channel checks, PTY event draining, and
@@ -231,16 +247,21 @@ impl PlexiApp {
                 let canvas_old_focus = self.windows[self.active_window].focused_pane;
                 let canvas_old_window_id = self.windows[self.active_window].window_id;
 
+                // Portal panes in the active window — computed once and shared by
+                // the preview map and the ContextState refresh below. Most contexts
+                // have zero portal panes; when the list is empty ALL portal work
+                // below is skipped (#2023).
+                let active_win = self.active_window;
+                let portal_panes: Vec<(crate::spatial::tiling::PaneId, u64)> = self.windows[active_win]
+                    .panes
+                    .iter()
+                    .filter_map(|(pid, p)| p.portal_target().map(|cid| (*pid, cid)))
+                    .collect();
+
                 // Build portal preview data before taking the mutable ctx borrow.
                 let portal_info: std::collections::HashMap<crate::spatial::tiling::PaneId, crate::spatial::tiling::PortalPreview> = {
-                    let active_win = self.active_window;
                     let mut map = std::collections::HashMap::new();
-                    let portal_panes: Vec<(crate::spatial::tiling::PaneId, u64)> = self.windows[active_win]
-                        .panes
-                        .iter()
-                        .filter_map(|(pid, p)| p.portal_target().map(|cid| (*pid, cid)))
-                        .collect();
-                    for (pane_id, child_ctx_id) in portal_panes {
+                    for &(pane_id, child_ctx_id) in &portal_panes {
                         let ctx_entry = self.router.iter().find(|c| c.context_id == child_ctx_id);
                         let ctx_name = ctx_entry
                             .map(|c| c.name.clone())
@@ -316,20 +337,17 @@ impl PlexiApp {
                     map
                 };
 
-                // Update cached ContextState on portal panes (recomputed each frame for now;
-                // future: throttle to change events only).
+                // Update cached ContextState on portal panes. Recomputed each frame
+                // while portal panes exist — child-context state mutates from too
+                // many sites to track a generation safely, and a stale preview is a
+                // correctness regression while an extra recompute is not (#2023).
+                // The whole block (including any Context access) is skipped when
+                // the active window has no portal panes.
                 {
-                    let contexts: Vec<crate::host::context::Context> = self.router.iter().cloned().collect();
-                    let active_win = self.active_window;
-                    let portal_pane_ids: Vec<(crate::spatial::tiling::PaneId, u64)> = self.windows[active_win]
-                        .panes
-                        .iter()
-                        .filter_map(|(pid, p)| p.portal_target().map(|cid| (*pid, cid)))
-                        .collect();
-                    for (pid, child_ctx_id) in portal_pane_ids {
+                    for &(pid, child_ctx_id) in &portal_panes {
                         let state = crate::host::context_state::ContextState::compute(
                             child_ctx_id,
-                            &contexts,
+                            self.router.as_slice(),
                             &self.windows,
                         );
                         if let Some(portal) = self.windows[active_win].panes.get_mut(&pid)
@@ -351,6 +369,16 @@ impl PlexiApp {
                 // Computed before the mutable borrow of `ctx` — needed by PlexiBehavior
                 // to prevent terminal panes from stealing egui focus while a modal is open.
                 let modal_open = self.input_captured_by_overlay();
+
+                // Resolved before the mutable borrow of the active window. The
+                // explicit context root is a cheap field clone; the cwd-derived
+                // fallback stat-walks the filesystem and is TTL-cached (#2023).
+                let workspace_root = self
+                    .router
+                    .active()
+                    .root
+                    .clone()
+                    .or_else(|| self.fallback_workspace_root());
 
                 let ctx = &mut self.windows[self.active_window];
 
@@ -495,7 +523,7 @@ impl PlexiApp {
                     pane_names,
                     drag_cursor_pos,
                     hovered_files,
-                    workspace_root: self.router.active().root.clone().or_else(crate::config::active_workspace_root),
+                    workspace_root,
                     unfocused_opacity,
                     portal_info,
                     modal_open,

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -37,3 +37,48 @@ fn test_spawn_pane_targets_correct_window_with_from_pane_id() {
     assert_eq!(found_win_idx, 0, "pane should be in window 0");
     assert_eq!(found_tile, tile_in_w0);
 }
+
+/// A valid socket line must queue the request AND leave a repaint pending —
+/// with zero-frame idle, the repaint is what gets the queued request drained.
+#[test]
+fn socket_line_queues_request_and_requests_repaint() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let ctx = egui::Context::default();
+    handle_socket_line(r#"{"type":"wake"}"#, &tx, &ctx);
+    assert!(
+        matches!(rx.try_recv(), Ok(crate::app_protocol::AppRequest::Wake)),
+        "request must be queued on the pane-IPC channel"
+    );
+    assert!(
+        ctx.has_requested_repaint(),
+        "socket line must request a repaint so the idle UI thread wakes"
+    );
+}
+
+/// A malformed socket line must queue nothing (and therefore wake nothing).
+#[test]
+fn socket_line_parse_error_queues_nothing() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let ctx = egui::Context::default();
+    handle_socket_line("definitely not json", &tx, &ctx);
+    assert!(
+        rx.try_recv().is_err(),
+        "parse failures must not queue anything"
+    );
+}
+
+/// `AppRequest::Wake` through the host handler is a pure no-op: no panic,
+/// no window/pane state change.
+#[test]
+fn wake_request_is_noop_on_host() {
+    let mut h = crate::testing::HostHarness::new();
+    let windows_before = h.app.windows.len();
+    let panes_before: usize = h.app.windows.iter().map(|w| w.panes.len()).sum();
+
+    h.inject_ipc(crate::app_protocol::AppRequest::Wake);
+    h.app.drain_pane_cmd_channel();
+
+    assert_eq!(h.app.windows.len(), windows_before, "wake must not touch windows");
+    let panes_after: usize = h.app.windows.iter().map(|w| w.panes.len()).sum();
+    assert_eq!(panes_after, panes_before, "wake must not touch panes");
+}

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -132,7 +132,7 @@ pub fn app_init(
     } else {
         let home = dirs::home_dir();
         let workspace_root = {
-            let mut current = cwd.clone();
+            let mut current = cwd;
             let mut found: Option<std::path::PathBuf> = None;
             loop {
                 if let Some(ref h) = home {

--- a/src/cli/crawl.rs
+++ b/src/cli/crawl.rs
@@ -206,7 +206,7 @@ fn is_command_section_header(line: &str) -> bool {
     let upper = line.trim().to_uppercase();
     // Strip a trailing colon before matching.
     let upper = upper.trim_end_matches(':').trim();
-    COMMAND_SECTION_KEYWORDS.iter().any(|kw| upper == *kw)
+    COMMAND_SECTION_KEYWORDS.contains(&upper)
 }
 
 fn is_any_section_header(line: &str) -> bool {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -148,7 +148,7 @@ pub fn install_workspace_pack_cli() -> i32 {
     // Walk up from CWD looking for the channel dir (workspace marker).
     let workspace_root = {
         let home = dirs::home_dir();
-        let mut current = cwd.clone();
+        let mut current = cwd;
         let mut found: Option<std::path::PathBuf> = None;
         loop {
             if let Some(ref h) = home {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -164,6 +164,31 @@ pub(super) fn send_to_socket(payload: serde_json::Value) -> i32 {
     0
 }
 
+/// Best-effort wake of a running instance after a spawn-queue file write.
+///
+/// A fully idle Plexi produces zero frames and only drains the spawn-queue
+/// during a frame, so without this nudge an outside-shell `plexi terminal`
+/// hangs until the user touches the window. Connects to the channel
+/// profile's `notify.sock` and sends a no-op `AppRequest::Wake`; the socket
+/// listener requests a repaint, the resulting frame drains the queue.
+///
+/// All errors are ignored silently and intentionally: no instance running
+/// means the queue is drained at next startup — the designed fallback.
+pub(super) fn nudge_running_instance() {
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    let path = crate::config::config_dir().join("notify.sock");
+    let Ok(mut stream) = UnixStream::connect(&path) else {
+        return;
+    };
+    let Ok(payload) = serde_json::to_string(&crate::app_protocol::AppRequest::Wake) else {
+        return;
+    };
+    if stream.write_all(format!("{payload}\n").as_bytes()).is_ok() {
+        log::debug!("cli: sent wake nudge to running instance at {path:?}");
+    }
+}
+
 pub(super) fn binary_in_path(name: &str) -> bool {
     std::env::var_os("PATH")
         .map(|path| std::env::split_paths(&path).any(|dir| dir.join(name).is_file()))

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -186,6 +186,7 @@ pub fn pane_new_cli(
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
+    crate::cli::nudge_running_instance();
     log::info!("pane_new:cli: queued type_id={type_id} name={name:?} ephemeral={ephemeral} no_focus={no_focus} cwd={cwd:?}");
     println!("queued: open {type_id}");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");
@@ -496,6 +497,7 @@ fn open_app_by_path(abs_path: &str, layout: Option<&str>, from_pane_id: Option<u
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
+    crate::cli::nudge_running_instance();
     log::info!("open_app_by_path: queued path={abs_path}");
     println!("queued: open {abs_path}");
     println!("(running outside a Plexi pane; Plexi will pick this up within a second)");

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -523,7 +523,7 @@ pub fn pane_info_cli(previous: bool) -> i32 {
                             return 1;
                         }
                         let mut obj = v;
-                        obj["socket"] = serde_json::Value::String(socket_path.clone());
+                        obj["socket"] = serde_json::Value::String(socket_path);
                         let channel =
                             crate::config::build_channel().unwrap_or_else(|| "main".to_string());
                         obj["channel"] = serde_json::Value::String(channel);

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1004,6 +1004,7 @@ pub(super) fn open_github_ephemeral(
         eprintln!("error: could not write spawn request: {e}");
         return 1;
     }
+    crate::cli::nudge_running_instance();
     log::info!("open_github_ephemeral: queued path={abs_path}");
     println!("queued: open github:{owner}/{repo}");
     println!("(running outside a Plexi pane — Plexi will pick this up within a second)");

--- a/src/cli/registry_watch.rs
+++ b/src/cli/registry_watch.rs
@@ -103,7 +103,7 @@ pub fn watch_one<I: CliInspector>(inspector: &I, cli: &str) -> WatchReport {
             cli: cli.to_string(),
             status: WatchStatus::Stale {
                 installed: installed_version,
-                registered: descriptor.version.clone(),
+                registered: descriptor.version,
             },
         };
     }
@@ -134,7 +134,7 @@ pub fn watch_one<I: CliInspector>(inspector: &I, cli: &str) -> WatchReport {
     WatchReport {
         cli: cli.to_string(),
         status: WatchStatus::UpToDate {
-            version: descriptor.version.clone(),
+            version: descriptor.version,
         },
     }
 }

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -37,7 +37,7 @@ pub fn start(config_path: PathBuf) -> Option<(ConfigWatcher, Receiver<()>)> {
     let (reload_tx, reload_rx) = mpsc::channel::<()>();
     let (raw_tx, raw_rx) = mpsc::channel::<()>();
 
-    let filter_name = target_name.clone();
+    let filter_name = target_name;
     let mut watcher = match notify::recommended_watcher(move |res: notify::Result<Event>| match res
     {
         Ok(ev) => {

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -425,7 +425,7 @@ impl FileBrowserApp {
             self.directory_selection_memory
                 .insert(self.cwd.clone(), entry.name.clone());
         }
-        self.cwd = path.clone();
+        self.cwd = path;
         self.selected = 0;
         self.refresh();
         self.pending_scroll = true;
@@ -520,7 +520,7 @@ impl FileBrowserApp {
                 .cwd
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string());
-            self.cwd = parent.clone();
+            self.cwd = parent;
             self.selected = 0;
             self.refresh();
             let restore_name = self

--- a/src/host/app_timeline.rs
+++ b/src/host/app_timeline.rs
@@ -206,7 +206,7 @@ impl SubscriptionRecord {
         if self.app_id != app_id {
             return false;
         }
-        if !self.event_names.is_empty() && !self.event_names.iter().any(|n| *n == record.event) {
+        if !self.event_names.is_empty() && !self.event_names.contains(&record.event) {
             return false;
         }
         match &self.resource_id {

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -345,6 +345,16 @@ impl AppRuntime {
         }
     }
 
+    /// Does this pane have pending background work that `background_tick`
+    /// would make progress on? Always false for builtins — they have no
+    /// subprocess, timers, or async workers (#2021).
+    pub fn needs_background_tick(&self) -> bool {
+        match self {
+            AppRuntime::Process(app) => app.needs_background_tick(),
+            AppRuntime::Builtin(_) => false,
+        }
+    }
+
     /// Current nav stack depth as reported by the app via `PushNav`/`PopNav`.
     /// Always 0 for builtin apps — they manage their own internal navigation.
     pub fn nav_stack_depth(&self) -> usize {

--- a/src/host/runs.rs
+++ b/src/host/runs.rs
@@ -67,7 +67,7 @@ impl RunRegistry {
     pub fn complete(&mut self, run_id: &str) {
         if let Some(run) = self.runs.remove(run_id) {
             crate::host::event_log::emit(crate::host::event_log::HostEvent::RunCompleted {
-                run_id: run.run_id.clone(),
+                run_id: run.run_id,
                 status: RunStatus::Completed.as_str().to_string(),
                 timestamp: crate::host::event_log::now_timestamp(),
             });

--- a/src/host/typed_pipes.rs
+++ b/src/host/typed_pipes.rs
@@ -220,7 +220,7 @@ impl TypedPipeRegistry {
             error_flag,
         };
 
-        self.pipes.insert(pipe_id.clone(), PipeEntry::Binary(entry));
+        self.pipes.insert(pipe_id, PipeEntry::Binary(entry));
 
         Ok(BinaryPipeAllocation { socket_path })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -995,7 +995,8 @@ fn main() -> eframe::Result {
 
     // Shell probes are done. Start the heartbeat now so it only monitors
     // eframe operation — not pre-startup shell work (#588).
-    crate::platform::logging::spawn_heartbeat(frame_tick.clone());
+    let heartbeat_ctx = crate::platform::logging::new_heartbeat_ctx_slot();
+    crate::platform::logging::spawn_heartbeat(frame_tick.clone(), heartbeat_ctx.clone());
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -1011,7 +1012,7 @@ fn main() -> eframe::Result {
     eframe::run_native(
         env!("CARGO_PKG_NAME"),
         native_options,
-        Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc, frame_tick)))),
+        Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc, frame_tick, heartbeat_ctx)))),
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -605,7 +605,7 @@ fn main() -> eframe::Result {
                             }
                         }
                         // Any --host-action keys not matched to a --choice are an error.
-                        for (key, _) in &host_action_map {
+                        if let Some(key) = host_action_map.keys().next() {
                             let msg = format!(
                                 "error: --host-action key {:?} does not match any --choice key",
                                 key
@@ -723,7 +723,7 @@ fn main() -> eframe::Result {
                                 let payload = if enter {
                                     format!("{text}\n")
                                 } else {
-                                    text.clone()
+                                    text
                                 };
                                 log::info!(
                                     "pane_command:cli: pane_id={pane_id} len={} enter={enter}",

--- a/src/media/audio.rs
+++ b/src/media/audio.rs
@@ -667,8 +667,8 @@ mod tests {
         let dev = MockAudioDevice::new();
         let inputs = dev.list_input_devices();
         assert!(!inputs.is_empty(), "mock must report at least one input");
-        let defaults: Vec<_> = inputs.iter().filter(|d| d.default).collect();
-        assert_eq!(defaults.len(), 1, "exactly one input must be the default");
+        let defaults = inputs.iter().filter(|d| d.default).count();
+        assert_eq!(defaults, 1, "exactly one input must be the default");
     }
 
     #[test]

--- a/src/media/midi.rs
+++ b/src/media/midi.rs
@@ -655,8 +655,8 @@ mod tests {
         let dev = MockMidiDevice::new();
         let inputs = dev.list_input_ports();
         assert!(!inputs.is_empty(), "mock must report at least one input");
-        let defaults: Vec<_> = inputs.iter().filter(|p| p.default).collect();
-        assert_eq!(defaults.len(), 1, "exactly one input must be the default");
+        let defaults = inputs.iter().filter(|p| p.default).count();
+        assert_eq!(defaults, 1, "exactly one input must be the default");
     }
 
     #[test]

--- a/src/media/video.rs
+++ b/src/media/video.rs
@@ -282,7 +282,7 @@ mod avf_impl {
         let state = Arc::new(std::sync::Mutex::new(VideoState::Play));
         let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let path_thread = path.clone();
+        let path_thread = path;
         let state_thread = Arc::clone(&state);
         let stop_thread = Arc::clone(&stop);
         let width = metadata.width;

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -130,7 +130,6 @@ impl NotePickerEntry {
             .to_string();
         let title = fm
             .title
-            .clone()
             .filter(|t| !t.is_empty())
             .or_else(|| (!first_line.is_empty()).then(|| first_line.clone()))
             .unwrap_or_else(|| file_name.clone());

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -164,6 +164,7 @@ impl PlexiApp {
             ai_broker,
             http_tx,
             proc_pane_id,
+            mut pending_async_completions,
         ) = {
             let pane = match self.windows[active].panes.get_mut(&pane_id) {
                 Some(crate::host::pane::Pane::App(a)) => a,
@@ -188,8 +189,9 @@ impl PlexiApp {
                 proc.type_id.clone(),
                 proc.workspace_root.clone(),
                 std::sync::Arc::clone(&proc.ai_broker),
-                proc.http_tx.clone(),
+                proc.waking_http_tx("ai_query_deferred"),
                 proc.pane_id,
+                proc.pending_async_completions,
             )
         };
 
@@ -212,6 +214,7 @@ impl PlexiApp {
             ai_broker,
             http_tx,
             proc_pane_id,
+            &mut pending_async_completions,
         );
 
         // Put the data back.
@@ -230,6 +233,10 @@ impl PlexiApp {
         proc.grant_store = grant_store;
         proc.deferred_ai_queries = deferred_ai_queries;
         proc.deferred_gated_requests = deferred_gated_requests;
+        // Restore the async-wake count, including arms added for deferred
+        // ai.query dispatches. Nothing else mutates the counter while the
+        // modal renders (single-threaded UI pass), so copy-back is safe.
+        proc.pending_async_completions = pending_async_completions;
         // The modal may have appended ForwardPaneRequest commands for
         // deferred gated requests; anything routed onto proc.pending_commands
         // between take and restore would be lost, so append rather than

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -494,7 +494,7 @@ impl PlexiApp {
                                                     value: Some(
                                                         "tombstone_dismiss".to_string(),
                                                     ),
-                                                    response_file: n.response_file.clone(),
+                                                    response_file: n.response_file,
                                                     host_action: None,
                                                 });
                                         }

--- a/src/overlays/ui_gallery.rs
+++ b/src/overlays/ui_gallery.rs
@@ -17,7 +17,7 @@ impl PlexiApp {
             return;
         }
 
-        let colors = self.colors.clone();
+        let colors = self.colors;
         // Escape is gated off while the nested text-entry demo is open so the
         // nested modal consumes it first — otherwise one press closes both.
         let response = ModalShell::centered("host_ui_gallery")

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -917,7 +917,7 @@ impl PlexiApp {
         let missing = self.registry.check_config_capabilities(id, &self.config);
         if !missing.is_empty() {
             log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
-            let fail_hint = layout.clone().or_else(|| Some("overlay".to_string()));
+            let fail_hint = layout.or_else(|| Some("overlay".to_string()));
             self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
             return Ok(());
         }
@@ -1064,7 +1064,7 @@ impl PlexiApp {
         let perms = crate::app::permissions::AppPermissions::from_capability_strings(
             &descriptor.capabilities,
         );
-        let caps = perms.capabilities.clone();
+        let caps = perms.capabilities;
 
         // Step 4: Spawn the ProcessApp.
         let app_id = format!("cli:{cli_name}");

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -156,7 +156,7 @@ fn clone_tile_subtree(
                 .map(|(_, new_child)| *new_child)
                 .collect();
             let mut new_grid = egui_tiles::Grid::new(new_children);
-            new_grid.layout = grid.layout.clone();
+            new_grid.layout = grid.layout;
             new_grid.col_shares = grid.col_shares.clone();
             new_grid.row_shares = grid.row_shares.clone();
             dest_tiles.insert_container(new_grid)
@@ -302,7 +302,7 @@ impl PlexiApp {
         });
         self.windows.push(crate::host::context::Window {
             name: String::new(),
-            path: path.clone(),
+            path,
             tree: child_tree,
             panes: child_panes,
             focused_pane: Some(child_root_tile),

--- a/src/platform/finder_service.rs
+++ b/src/platform/finder_service.rs
@@ -15,6 +15,12 @@ use std::sync::{Mutex, OnceLock};
 
 static PATH_QUEUE: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
+/// egui context used to wake the UI thread after queueing paths. A fully
+/// idle Plexi produces zero frames and `PATH_QUEUE` is only drained during
+/// a frame, so without a repaint request a Finder "Open in Plexi" against
+/// an idle instance sits queued until the user touches the window.
+static EGUI_CTX: OnceLock<egui::Context> = OnceLock::new();
+
 fn register_provider_class() -> &'static objc2::runtime::AnyClass {
     static CLASS: OnceLock<&'static objc2::runtime::AnyClass> = OnceLock::new();
     CLASS.get_or_init(|| {
@@ -59,6 +65,12 @@ fn register_provider_class() -> &'static objc2::runtime::AnyClass {
             if let Ok(mut queue) = PATH_QUEUE.lock() {
                 queue.extend(paths);
             }
+            if let Some(ctx) = EGUI_CTX.get() {
+                log::debug!(
+                    "finder_service: paths queued — requesting repaint to wake idle UI thread"
+                );
+                ctx.request_repaint();
+            }
         }
 
         unsafe {
@@ -73,8 +85,10 @@ fn register_provider_class() -> &'static objc2::runtime::AnyClass {
 }
 
 /// Register the Finder services provider with NSApp. Call once from
-/// `PlexiApp::new()` on the main thread.
-pub fn register() {
+/// `PlexiApp::new()` on the main thread. `egui_ctx` is used to wake the
+/// (possibly zero-frame idle) UI thread whenever the service queues paths.
+pub fn register(egui_ctx: egui::Context) {
+    let _ = EGUI_CTX.set(egui_ctx);
     let Some(mtm) = MainThreadMarker::new() else {
         log::warn!("finder_service: not on main thread, cannot register");
         return;

--- a/src/platform/frame_diag.rs
+++ b/src/platform/frame_diag.rs
@@ -8,7 +8,9 @@
 //! by [`RepaintCause::UserInput`], noted once per frame that carries raw input
 //! events.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{LazyLock, Mutex};
 
 /// Why a repaint was requested. Every variant maps to a stable snake_case
 /// label via [`RepaintCause::label`] for grep-able log output.
@@ -99,6 +101,59 @@ impl RepaintCause {
 /// (image cache and PTY readers note from background threads).
 pub fn note(cause: RepaintCause) {
     COUNTERS[cause as usize].fetch_add(1, Ordering::Relaxed);
+}
+
+/// Ground-truth repaint causes from egui (#2209): per sample window, count of
+/// frames each `file:line` repaint-request site appeared in. Cross-checks the
+/// self-reported [`note`] counters above — egui sees every
+/// `request_repaint()` caller, including sites Plexi never instrumented.
+static EGUI_CAUSES: LazyLock<Mutex<HashMap<String, u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Accumulate one frame's `ctx.repaint_causes()` (the PREVIOUS pass's
+/// requests). Causes are dedup'd by `file:line` within the pass — the same
+/// site can request a repaint several times per pass, but "how many frames
+/// did this site wake" is the useful idle-CPU signal, so we count per-frame
+/// presence, not raw request volume.
+pub fn note_egui_causes(causes: &[egui::RepaintCause]) {
+    if causes.is_empty() {
+        return;
+    }
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut map = EGUI_CAUSES.lock().unwrap();
+    for cause in causes {
+        let key = format!("{}:{}", cause.file, cause.line);
+        if seen.insert(key.clone()) {
+            *map.entry(key).or_insert(0) += 1;
+        }
+    }
+}
+
+/// Returns all egui cause counts sorted descending (ties alphabetical by
+/// `file:line` for stable output) and clears the accumulator.
+pub fn egui_snapshot_and_reset() -> Vec<(String, u32)> {
+    let mut map = EGUI_CAUSES.lock().unwrap();
+    let mut counts: Vec<(String, u32)> = map.drain().collect();
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    counts
+}
+
+/// Formats the egui ground-truth line logged under the same window as
+/// [`summary_line`], truncated to the top `top_n` sites, e.g.
+/// `egui_causes: crates/egui/src/context.rs:1234=601 src/app/mod.rs:99=12 (+3 more)`.
+pub fn egui_summary_line(counts: &[(String, u32)], top_n: usize) -> String {
+    let mut line = String::from("egui_causes:");
+    if counts.is_empty() {
+        line.push_str(" none");
+        return line;
+    }
+    for (site, n) in counts.iter().take(top_n) {
+        line.push_str(&format!(" {site}={n}"));
+    }
+    if counts.len() > top_n {
+        line.push_str(&format!(" (+{} more)", counts.len() - top_n));
+    }
+    line
 }
 
 /// Returns all nonzero counts sorted descending and zeroes every counter.
@@ -209,6 +264,101 @@ mod tests {
             summary_line(5, 0.0, &[]),
             "frames=5 window=0.0s fps=0.0 causes: none"
         );
+    }
+
+    fn egui_cause(file: &'static str, line: u32) -> egui::RepaintCause {
+        egui::RepaintCause {
+            file,
+            line,
+            reason: std::borrow::Cow::Borrowed("test"),
+        }
+    }
+
+    /// Harness tests run real frames in parallel and feed real sites into the
+    /// global egui accumulator; assertions only look at synthetic
+    /// `tests/fake_*.rs` keys no real frame can produce.
+    fn fake_only(counts: &[(String, u32)]) -> Vec<(String, u32)> {
+        counts
+            .iter()
+            .filter(|(k, _)| k.starts_with("tests/fake_"))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn egui_causes_dedup_within_pass_and_accumulate_across_passes() {
+        let _guard = SERIAL.lock().unwrap();
+        egui_snapshot_and_reset();
+
+        // Pass 1: the same site requests twice — counts once for the frame.
+        note_egui_causes(&[
+            egui_cause("tests/fake_a.rs", 10),
+            egui_cause("tests/fake_a.rs", 10),
+            egui_cause("tests/fake_b.rs", 20),
+        ]);
+        // Pass 2: only fake_a.rs wakes again.
+        note_egui_causes(&[egui_cause("tests/fake_a.rs", 10)]);
+        // Empty pass is a no-op.
+        note_egui_causes(&[]);
+
+        let counts = fake_only(&egui_snapshot_and_reset());
+        assert_eq!(
+            counts,
+            vec![
+                ("tests/fake_a.rs:10".to_string(), 2),
+                ("tests/fake_b.rs:20".to_string(), 1),
+            ]
+        );
+
+        // Snapshot cleared the accumulator.
+        assert!(fake_only(&egui_snapshot_and_reset()).is_empty());
+    }
+
+    #[test]
+    fn egui_snapshot_sorted_descending_then_alphabetical() {
+        let _guard = SERIAL.lock().unwrap();
+        egui_snapshot_and_reset();
+
+        for _ in 0..3 {
+            note_egui_causes(&[egui_cause("tests/fake_z.rs", 1)]);
+        }
+        note_egui_causes(&[
+            egui_cause("tests/fake_m.rs", 5),
+            egui_cause("tests/fake_a.rs", 9),
+        ]);
+
+        let counts = fake_only(&egui_snapshot_and_reset());
+        assert_eq!(
+            counts,
+            vec![
+                ("tests/fake_z.rs:1".to_string(), 3),
+                ("tests/fake_a.rs:9".to_string(), 1),
+                ("tests/fake_m.rs:5".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn egui_summary_line_format() {
+        assert_eq!(egui_summary_line(&[], 8), "egui_causes: none");
+
+        let counts = vec![
+            ("src/a.rs:10".to_string(), 95),
+            ("src/b.rs:20".to_string(), 12),
+        ];
+        assert_eq!(
+            egui_summary_line(&counts, 8),
+            "egui_causes: src/a.rs:10=95 src/b.rs:20=12"
+        );
+
+        // Truncation appends the overflow count.
+        let many: Vec<(String, u32)> = (0..10)
+            .map(|i| (format!("src/f.rs:{i}"), 10 - i))
+            .collect();
+        let line = egui_summary_line(&many, 8);
+        assert!(line.ends_with(" (+2 more)"), "got: {line}");
+        assert!(line.contains("src/f.rs:0=10"));
+        assert!(!line.contains("src/f.rs:8="));
     }
 
     #[test]

--- a/src/platform/logging.rs
+++ b/src/platform/logging.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// How often the watchdog samples the frame counter. Short enough to catch brief freezes.
@@ -201,13 +201,37 @@ pub fn new_frame_tick() -> FrameTick {
     Arc::new(AtomicU64::new(0))
 }
 
-/// Spawn a background thread that:
-/// - Writes a heartbeat line every 30s (grep `[HEARTBEAT]` for last-alive timestamp)
-/// - Detects UI-thread freezes via `frame_tick` and logs `[FREEZE]` / `[THAW]` lines
+/// Shared slot the heartbeat reads the egui context from. Filled by
+/// `PlexiApp::new` once eframe hands out the context; `None` until then.
+/// The heartbeat needs it to distinguish a genuine UI freeze (repaint
+/// requested but no frame produced) from healthy zero-frame idle.
+pub type HeartbeatCtxSlot = Arc<Mutex<Option<egui::Context>>>;
+
+/// Create an empty heartbeat context slot. Pass one clone to
+/// `spawn_heartbeat` and another into `PlexiApp::new` to fill.
+pub fn new_heartbeat_ctx_slot() -> HeartbeatCtxSlot {
+    Arc::new(Mutex::new(None))
+}
+
+/// Pure freeze decision. A stalled frame counter alone is the *normal* idle
+/// state (a fully idle Plexi produces zero frames); a freeze additionally
+/// requires egui to have a pending repaint request that the UI thread is
+/// failing to service. `repaint_pending` is `None` when the egui context is
+/// not yet available — never report a freeze in that window.
+pub(crate) fn freeze_verdict(counter_stalled: bool, repaint_pending: Option<bool>) -> bool {
+    counter_stalled && repaint_pending == Some(true)
+}
+
+/// Spawn a background thread that detects UI-thread freezes via `frame_tick`
+/// and logs `[FREEZE]` / `[THAW]` lines.
 ///
-/// Both writes go directly to the file, bypassing the logger, so they survive
+/// `egui_ctx` gates the verdict: with zero-frame idle, a stalled counter only
+/// counts as frozen while egui has a repaint request pending (see
+/// `freeze_verdict`). Healthy idle produces neither FREEZE nor THAW lines.
+///
+/// Writes go directly to the file, bypassing the logger, so they survive
 /// even if the logger thread is itself blocked by a freeze.
-pub fn spawn_heartbeat(frame_tick: FrameTick) {
+pub fn spawn_heartbeat(frame_tick: FrameTick, egui_ctx: HeartbeatCtxSlot) {
     let log_path = log_path();
     std::thread::Builder::new()
         .name("plexi-heartbeat".into())
@@ -226,13 +250,26 @@ pub fn spawn_heartbeat(frame_tick: FrameTick) {
                 let mut lines = String::new();
 
                 if now_tick == last_tick {
-                    // Frame counter stalled — UI thread may be frozen.
-                    let frozen_secs = last_tick_seen_at.elapsed().as_secs();
-                    if frozen_secs >= FREEZE_THRESHOLD_SECS && !freeze_reported {
-                        freeze_reported = true;
-                        lines.push_str(&format!(
-                            "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s\n"
-                        ));
+                    // Frame counter stalled — frozen only if egui has a
+                    // repaint pending that the UI thread isn't servicing.
+                    // Zero frames with nothing pending is healthy idle.
+                    let repaint_pending = egui_ctx
+                        .lock()
+                        .ok()
+                        .and_then(|slot| slot.as_ref().map(|c| c.has_requested_repaint()));
+                    if freeze_verdict(true, repaint_pending) {
+                        let frozen_secs = last_tick_seen_at.elapsed().as_secs();
+                        if frozen_secs >= FREEZE_THRESHOLD_SECS && !freeze_reported {
+                            freeze_reported = true;
+                            lines.push_str(&format!(
+                                "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s\n"
+                            ));
+                        }
+                    } else if !freeze_reported {
+                        // Healthy idle: keep the freeze clock pinned to now so
+                        // a later pending repaint measures only its own stall,
+                        // not the whole idle period before it.
+                        last_tick_seen_at = Instant::now();
                     }
                 } else {
                     // Frame counter advanced — UI thread is alive.
@@ -267,6 +304,34 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use std::fs;
+
+    /// Zero frames with no pending repaint is healthy idle — never a freeze.
+    #[test]
+    fn freeze_verdict_idle_without_pending_repaint_is_not_frozen() {
+        assert!(!freeze_verdict(true, Some(false)));
+    }
+
+    /// Stalled counter with a pending repaint the UI thread isn't servicing
+    /// is the genuine freeze condition.
+    #[test]
+    fn freeze_verdict_stalled_with_pending_repaint_is_frozen() {
+        assert!(freeze_verdict(true, Some(true)));
+    }
+
+    /// Before `PlexiApp::new` fills the context slot there is no signal —
+    /// never report a freeze in that window.
+    #[test]
+    fn freeze_verdict_without_ctx_is_not_frozen() {
+        assert!(!freeze_verdict(true, None));
+    }
+
+    /// An advancing frame counter is never frozen, whatever egui says.
+    #[test]
+    fn freeze_verdict_advancing_counter_is_not_frozen() {
+        assert!(!freeze_verdict(false, Some(true)));
+        assert!(!freeze_verdict(false, Some(false)));
+        assert!(!freeze_verdict(false, None));
+    }
 
     fn today_plus(days: i64) -> NaiveDate {
         chrono::Local::now().date_naive() + chrono::Duration::days(days)

--- a/src/plexi_ai/backend/ollama.rs
+++ b/src/plexi_ai/backend/ollama.rs
@@ -263,7 +263,7 @@ mod tests {
         let raw = RawToolCall {
             id: String::new(),
             name,
-            arguments: arguments.clone(),
+            arguments,
         };
 
         assert_eq!(raw.name, "add");

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn system_prompt_goes_in_messages_array_not_top_level() {
         let system = "You are a helpful assistant.".to_string();
-        let msgs = vec![serde_json::json!({"role": "user", "content": "hello"})];
+        let msgs = [serde_json::json!({"role": "user", "content": "hello"})];
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if !system.is_empty() {
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn empty_system_omits_system_message() {
         let system = String::new();
-        let msgs = vec![serde_json::json!({"role": "user", "content": "hi"})];
+        let msgs = [serde_json::json!({"role": "user", "content": "hi"})];
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if !system.is_empty() {

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -596,7 +596,7 @@ fn run_turn_and_respond(
                     let row = LedgerRow::with_attribution(
                         &backend_name,
                         billing,
-                        Some(app_id.clone()),
+                        Some(app_id),
                         Some(model_id_bg),
                         Some(tokens_in),
                         Some(tokens_out),
@@ -635,7 +635,7 @@ fn run_turn_and_respond(
     let row = LedgerRow::with_attribution(
         backend.name(),
         billing,
-        Some(request.app_id.clone()),
+        Some(request.app_id),
         Some(model_id),
         Some(total_tokens_in),
         Some(total_tokens_out),

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -548,7 +548,7 @@ mod tests {
         reg.register(
             1,
             vec![make_tool("search")],
-            AppEventSender { tx: tx.clone() },
+            AppEventSender { tx },
             ws.clone(),
         );
 
@@ -573,7 +573,7 @@ mod tests {
         reg.register(
             20,
             vec![make_tool("safe_tool")],
-            AppEventSender { tx: tx.clone() },
+            AppEventSender { tx },
             PathBuf::from("/workspace/victim"),
         );
 

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -118,7 +118,7 @@ impl ProcessApp {
                 );
                 self.outbound_events.push_back(
                     crate::app_protocol::PlexiEvent::TextWrappedMeasured {
-                        request_id: request_id.clone(),
+                        request_id,
                         height,
                     },
                 );

--- a/src/process_app/lifecycle.rs
+++ b/src/process_app/lifecycle.rs
@@ -160,6 +160,16 @@ impl LifecycleTracker {
             .store(self.elapsed_ms().max(1), Ordering::Release);
     }
 
+    /// Called by the UI thread when a Render transaction exceeded the
+    /// render-in-flight timeout with no FrameDone (issue #2208). The process
+    /// may still be alive, but it has stopped answering the render protocol —
+    /// the same user-facing condition the frame-gap detector reports, so it
+    /// reuses the non-sticky `Hung` state: a late FrameDone flips the app
+    /// back to `Running` via `on_frame_done`.
+    pub fn on_render_timeout(&self) {
+        self.set_state(LifecycleState::Hung);
+    }
+
     /// Called when `process.try_wait()` returns `Some(_)` — i.e. the
     /// subprocess has exited. Sticky: Crashed.
     pub fn on_process_exited(&self) {

--- a/src/process_app/mcp_server.rs
+++ b/src/process_app/mcp_server.rs
@@ -61,7 +61,14 @@ pub struct McpServerHandle {
 
 /// Start the HTTP/SSE MCP server for `tools`. Returns the handle with the
 /// bound port, per-app auth token, and the shared call queue.
-pub fn start_mcp_server(tools: Vec<McpTool>) -> std::io::Result<McpServerHandle> {
+///
+/// `repaint_ctx` is the pane's shared egui-context slot: when an external
+/// client enqueues a tool call, the connection thread wakes the host so the
+/// queue is drained promptly even while the host is fully idle (#2021).
+pub fn start_mcp_server(
+    tools: Vec<McpTool>,
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+) -> std::io::Result<McpServerHandle> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     let token = uuid::Uuid::new_v4().to_string();
@@ -79,10 +86,13 @@ pub fn start_mcp_server(tools: Vec<McpTool>) -> std::io::Result<McpServerHandle>
                         let tools = Arc::clone(&tools);
                         let queue = Arc::clone(&queue_clone);
                         let token = Arc::clone(&token_arc);
+                        let repaint_ctx = Arc::clone(&repaint_ctx);
                         std::thread::Builder::new()
                             .name("mcp-conn".to_string())
                             .spawn(move || {
-                                if let Err(e) = handle_connection(stream, &tools, &queue, &token) {
+                                if let Err(e) =
+                                    handle_connection(stream, &tools, &queue, &token, &repaint_ctx)
+                                {
                                     log::warn!("mcp_server: connection error: {e}");
                                 }
                             })
@@ -114,6 +124,7 @@ fn handle_connection(
     tools: &[McpTool],
     queue: &Arc<Mutex<VecDeque<McpCallRequest>>>,
     token: &str,
+    repaint_ctx: &Arc<Mutex<Option<egui::Context>>>,
 ) -> std::io::Result<()> {
     let peer = stream
         .peer_addr()
@@ -259,6 +270,9 @@ fn handle_connection(
                     response_tx,
                 });
             }
+            // Wake the host so poll_mcp_calls drains the queue promptly even
+            // while the host is fully idle (#2021).
+            super::transport::wake_host_for_background_work(repaint_ctx, "mcp_tool_call");
 
             log::info!("mcp_server: tool_call call_id={call_id} tool={tool_name} peer={peer}");
 
@@ -386,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_no_auth_returns_401() {
-        let handle = start_mcp_server(vec![]).unwrap();
+        let handle = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
         let (status, _) = post_mcp(handle.port, None, body);
         assert_eq!(status, 401);
@@ -394,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_wrong_token_returns_401() {
-        let handle = start_mcp_server(vec![]).unwrap();
+        let handle = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
         let (status, _) = post_mcp(handle.port, Some("wrong-token"), body);
         assert_eq!(status, 401);
@@ -402,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_correct_token_tools_list_returns_200() {
-        let handle = start_mcp_server(vec![]).unwrap();
+        let handle = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         let token = handle.token.clone();
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
         let (status, resp_body) = post_mcp(handle.port, Some(&token), body);
@@ -413,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_correct_token_initialize_returns_200() {
-        let handle = start_mcp_server(vec![]).unwrap();
+        let handle = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         let token = handle.token.clone();
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}"#;
         let (status, resp_body) = post_mcp(handle.port, Some(&token), body);
@@ -424,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_oversized_body_returns_413() {
-        let handle = start_mcp_server(vec![]).unwrap();
+        let handle = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         let token = handle.token.clone();
         // Send a legitimate-looking request but with a content-length exceeding MAX_BODY.
         // We only send the headers — the server checks content_length before reading.
@@ -450,8 +464,8 @@ mod tests {
 
     #[test]
     fn test_each_server_has_unique_token() {
-        let h1 = start_mcp_server(vec![]).unwrap();
-        let h2 = start_mcp_server(vec![]).unwrap();
+        let h1 = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
+        let h2 = start_mcp_server(vec![], Arc::new(Mutex::new(None))).unwrap();
         assert_ne!(h1.token, h2.token);
     }
 }

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -25,7 +25,7 @@ mod render_session;
 mod routing;
 mod runtime_state;
 mod scheduler;
-mod transport;
+pub(crate) mod transport;
 
 pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 use render_diag::RenderDiagnostics;
@@ -146,6 +146,13 @@ pub struct ProcessApp {
     pub(crate) render_in_queue: Arc<AtomicBool>,
     /// Receives draw commands from the subprocess on a background thread.
     draw_rx: Option<Receiver<DrawCommand>>,
+    /// True when the stdout reader has queued at least one draw command since
+    /// the last `drain_draw_commands` (issue #2021). Set by the reader thread
+    /// AFTER each send; cleared by the host BEFORE each drain, so a queued
+    /// command can never be left behind with the flag unset. This is what
+    /// lets `needs_background_tick` skip idle apps without ever stranding a
+    /// spontaneous command (e.g. `emit.notify` outside a frame).
+    pub(crate) draw_pending: Arc<AtomicBool>,
     /// The last fully committed frame (commands between two FrameDones).
     pub(crate) frame: Vec<RenderCommand>,
     /// Accumulates draw commands for the frame currently being received.
@@ -159,7 +166,7 @@ pub struct ProcessApp {
     /// Absolute frame clock — `Some` iff `scheduler_mode` is `Continuous`.
     animation_clock: Option<scheduler::AnimationClock>,
     render_diag: RenderDiagnostics,
-    pending_async_completions: usize,
+    pub(crate) pending_async_completions: usize,
     idle_render_poll_logged: bool,
     sdk: Option<String>,
     features_used: Vec<String>,
@@ -333,7 +340,7 @@ pub struct ProcessApp {
     /// `MAX_STREAM_THREADS` to bound peak stack memory.
     pub(crate) active_stream_threads: Arc<AtomicUsize>,
     /// MCP server handle — `Some` when the app has `[app.mcp]` in its manifest.
-    mcp_server: Option<mcp_server::McpServerHandle>,
+    pub(crate) mcp_server: Option<mcp_server::McpServerHandle>,
     /// Pending MCP tool call responses awaiting `AppRequest::McpToolResult`.
     /// Key = call_id, value = channel to the blocked HTTP handler thread.
     pub(crate) mcp_pending:
@@ -353,6 +360,10 @@ pub struct ProcessApp {
     /// Launch arguments passed via CLI or SpawnPane. Forwarded in PlexiEvent::Init
     /// so the SDK can expose them as ctx.args.
     pub(crate) launch_args: Vec<String>,
+    /// Number of `background_tick()` calls — observable proof for the #2021
+    /// gating tests that idle apps are skipped and pending apps are ticked.
+    #[cfg(test)]
+    pub(crate) background_tick_count: usize,
 }
 
 impl ProcessApp {
@@ -502,10 +513,16 @@ impl ProcessApp {
             active_channel.as_deref().unwrap_or("main")
         );
 
+        // Shared egui-context slot, populated on the first `ui()` frame.
+        // Background threads (stdout/stderr readers, reaper, MCP connections,
+        // async workers) use it to wake the host when work arrives.
+        let repaint_ctx: Arc<Mutex<Option<egui::Context>>> = Arc::new(Mutex::new(None));
+
         // Start the MCP server when the manifest declares [app.mcp].
         let mcp_server_handle = mcp
-            .map(
-                |section| match mcp_server::start_mcp_server(section.tools.clone()) {
+            .map(|section| {
+                match mcp_server::start_mcp_server(section.tools.clone(), Arc::clone(&repaint_ctx))
+                {
                     Ok(handle) => {
                         cmd.env("PLEXI_MCP_PORT", handle.port.to_string());
                         cmd.env("PLEXI_MCP_TOKEN", &handle.token);
@@ -515,8 +532,8 @@ impl ProcessApp {
                         log::error!("ProcessApp[{type_id}]: failed to start MCP server: {e}");
                         None
                     }
-                },
-            )
+                }
+            })
             .flatten();
         // Prepend the bundled Python interpreter's bin/ dir to PATH so that
         // dev-mode .py entries without the bundle still resolve python3 correctly.
@@ -592,7 +609,6 @@ impl ProcessApp {
         // waiting for `try_wait` to observe the eventual exit.
         let recent_stderr_capture = Arc::new(Mutex::new(VecDeque::<String>::new()));
         let lifecycle_tracker = Arc::new(LifecycleTracker::new());
-        let repaint_ctx = Arc::new(Mutex::new(None));
         transport::spawn_stderr_reader(
             type_id.clone(),
             stderr,
@@ -606,10 +622,12 @@ impl ProcessApp {
         //   - Malformed JSON → on_parse_error() (counts toward ProtocolError).
         //   - Stdout EOF / read error → on_stdout_closed() (sticky Crashed).
         let (draw_tx, draw_rx) = mpsc::channel::<DrawCommand>();
+        let draw_pending: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         transport::spawn_stdout_reader(
             type_id.clone(),
             stdout,
             draw_tx,
+            Arc::clone(&draw_pending),
             Arc::clone(&lifecycle_tracker),
             Arc::clone(&repaint_ctx),
         );
@@ -670,6 +688,7 @@ impl ProcessApp {
             render_slot,
             render_in_queue,
             draw_rx: Some(draw_rx),
+            draw_pending,
             frame: Vec::new(),
             pending_frame: Vec::new(),
             pending_commands: Vec::new(),
@@ -747,6 +766,8 @@ impl ProcessApp {
             wants_close_self: false,
             click_awaiting_frame: false,
             launch_args: args.to_vec(),
+            #[cfg(test)]
+            background_tick_count: 0,
         })
     }
 
@@ -839,6 +860,7 @@ impl ProcessApp {
             render_slot: Arc::new(Mutex::new(None)),
             render_in_queue: Arc::new(AtomicBool::new(false)),
             draw_rx: Some(draw_rx),
+            draw_pending: Arc::new(AtomicBool::new(false)),
             frame: Vec::new(),
             pending_frame: Vec::new(),
             pending_commands: Vec::new(),
@@ -915,6 +937,7 @@ impl ProcessApp {
             wants_close_self: false,
             click_awaiting_frame: false,
             launch_args: Vec::new(),
+            background_tick_count: 0,
         };
         (app, draw_tx)
     }
@@ -1298,6 +1321,26 @@ impl ProcessApp {
         self.pending_async_completions = self.pending_async_completions.saturating_sub(1);
     }
 
+    /// An `http_tx` clone that wakes the host after every send, so worker
+    /// thread completions surface on the next frame instead of waiting for
+    /// the bounded async-wake poll (#2021).
+    pub(crate) fn waking_http_tx(&self, reason: &'static str) -> transport::WakingEventSender {
+        transport::WakingEventSender::new(
+            self.http_tx.clone(),
+            Arc::clone(&self.repaint_ctx),
+            reason,
+        )
+    }
+
+    /// `file_picker_tx` counterpart of [`Self::waking_http_tx`].
+    fn waking_file_picker_tx(&self, reason: &'static str) -> transport::WakingEventSender {
+        transport::WakingEventSender::new(
+            self.file_picker_tx.clone(),
+            Arc::clone(&self.repaint_ctx),
+            reason,
+        )
+    }
+
     fn drain_async_events(&mut self) {
         while let Ok(event) = self.http_rx.try_recv() {
             match &event {
@@ -1322,12 +1365,44 @@ impl ProcessApp {
         self.pending_async_completions > 0
             || !self.pending_timers.is_empty()
             || self.active_stream_threads.load(Ordering::Relaxed) > 0
-            || self.mcp_server.is_some()
+            || self.has_pending_mcp_work()
             || self.image_cache.has_pending()
     }
 
-    pub(crate) fn needs_headless_wake_poll(&self) -> bool {
+    /// An MCP server only counts as pending work while a tool call is queued
+    /// (awaiting delivery to the app) or delivered-but-unanswered. A merely
+    /// *present* MCP server must not pin the host in a permanent wake loop
+    /// (#2021) — the MCP connection thread wakes the host when a call arrives.
+    fn has_pending_mcp_work(&self) -> bool {
+        if !self.mcp_pending.is_empty() {
+            return true;
+        }
+        self.mcp_server
+            .as_ref()
+            .is_some_and(|mcp| mcp.call_queue.lock().map_or(true, |q| !q.is_empty()))
+    }
+
+    fn needs_headless_wake_poll(&self) -> bool {
         self.runtime.is_rendering() || self.needs_async_wake_poll()
+    }
+
+    /// Does this app have any background work that `background_tick()` would
+    /// make progress on? Used by the host to skip idle background/parked apps
+    /// on every frame (#2021). Every source of background work must be
+    /// represented here:
+    /// - queued draw commands from the app process → `draw_pending`
+    ///   (set by the stdout reader, which also wakes the host)
+    /// - host-queued events awaiting flush to the app → `outbound_events`
+    /// - timer/HTTP/file-picker/AI/audio/MIDI worker completions →
+    ///   `pending_async_completions` / `pending_timers` / stream threads
+    /// - MCP tool calls → `has_pending_mcp_work`
+    /// - async image loads → `image_cache.has_pending`
+    /// - an in-flight render that may need the hung-timeout check →
+    ///   `is_rendering` (via `needs_headless_wake_poll`)
+    pub(crate) fn needs_background_tick(&self) -> bool {
+        self.draw_pending.load(Ordering::Acquire)
+            || !self.outbound_events.is_empty()
+            || self.needs_headless_wake_poll()
     }
 
     /// Drain the MCP call queue and forward each request to the app as a
@@ -1375,6 +1450,10 @@ impl ProcessApp {
     }
 
     fn drain_draw_commands(&mut self) -> Vec<DrawCommand> {
+        // Clear BEFORE draining (paired with the stdout reader's send-then-set)
+        // so a command sent after this drain always leaves the flag set for
+        // the next frame (#2021).
+        self.draw_pending.store(false, Ordering::Release);
         let Some(rx) = self.draw_rx.as_ref() else {
             return vec![];
         };
@@ -1599,6 +1678,10 @@ impl ProcessApp {
     ///
     /// Visual draw commands are discarded — there is no pane to render into.
     pub(crate) fn background_tick(&mut self) {
+        #[cfg(test)]
+        {
+            self.background_tick_count += 1;
+        }
         self.drain_async_events();
         self.poll_mcp_calls();
         self.flush_outbound_events();

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -31,6 +31,8 @@ pub(crate) use lifecycle::{LifecycleState, LifecycleTracker};
 use render_diag::RenderDiagnostics;
 use render_session::RenderSession;
 use runtime_state::{FrameDoneOutcome, PgapRuntime, RenderPoll};
+#[cfg(test)]
+pub(crate) use scheduler::RENDER_IN_FLIGHT_TIMEOUT;
 pub(crate) use transport::StdinItem;
 
 fn channel_from_config_dir(config_dir: &Path) -> Option<String> {
@@ -1263,6 +1265,26 @@ impl ProcessApp {
         }
     }
 
+    /// Abandon a Render that has been in flight longer than
+    /// `RENDER_IN_FLIGHT_TIMEOUT` with no FrameDone (issue #2208). Clears the
+    /// in-flight state so the repaint scheduler stops polling, and surfaces
+    /// the app through the existing hung lifecycle path. Called once per
+    /// frame from both `ui()` and `background_tick()`.
+    fn check_render_timeout(&mut self) {
+        if let Some(frame_id) = self.runtime.abandon_render_if_stalled(
+            std::time::Instant::now(),
+            scheduler::RENDER_IN_FLIGHT_TIMEOUT,
+        ) {
+            log::warn!(
+                "ProcessApp[{}]: no FrameDone for render frame {frame_id} within {:?}; \
+                 marking app hung and stopping render polling",
+                self.type_id,
+                scheduler::RENDER_IN_FLIGHT_TIMEOUT,
+            );
+            self.lifecycle.on_render_timeout();
+        }
+    }
+
     fn arm_async_completion_wake(&mut self, reason: &'static str) {
         self.pending_async_completions = self.pending_async_completions.saturating_add(1);
         log::info!(
@@ -1550,6 +1572,19 @@ impl ProcessApp {
         self.outbound_events.push_back(ev);
     }
 
+    /// Test hook: shift the in-flight render's start time into the past so
+    /// the render-in-flight timeout can be exercised without sleeping.
+    #[cfg(test)]
+    pub(crate) fn backdate_in_flight_render(&mut self, by: std::time::Duration) {
+        self.runtime.backdate_in_flight_render(by);
+    }
+
+    /// Test hook: is a Render transaction currently in flight?
+    #[cfg(test)]
+    pub(crate) fn render_in_flight_for_test(&self) -> bool {
+        self.runtime.is_rendering()
+    }
+
     /// Pump event I/O for a pane that is not currently rendered.
     ///
     /// Active-context panes are fully updated by `ui()` each frame. Non-active
@@ -1567,6 +1602,9 @@ impl ProcessApp {
         self.drain_async_events();
         self.poll_mcp_calls();
         self.flush_outbound_events();
+        // A hung in-flight render must not keep the headless wake poll alive
+        // forever either (`needs_headless_wake_poll` checks `is_rendering`).
+        self.check_render_timeout();
         for cmd in self.drain_draw_commands() {
             match cmd {
                 DrawCommand::Host(h) => self.route_command(h),
@@ -1659,6 +1697,10 @@ impl App for ProcessApp {
 
         // Lifecycle: drive the time-based Hung check once per frame.
         self.lifecycle.tick_check_hung();
+
+        // Render-in-flight timeout: an app that never sends FrameDone must
+        // not keep the host repaint-polling forever (issue #2208).
+        self.check_render_timeout();
 
         if !self.initialized {
             self.initialized = true;

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2142,7 +2142,7 @@ impl App for ProcessApp {
                             x: pos.x - origin.x,
                             y: pos.y - origin.y,
                             buttons,
-                            modifiers: frame_mods.clone(),
+                            modifiers: frame_mods,
                         });
                         self.mark_render_needed("mouse_move");
                         needs_tracking_repaint = true;

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -1240,7 +1240,15 @@ impl ProcessApp {
 
     fn mark_render_needed(&mut self, reason: &'static str) {
         if self.runtime.request_render_now() {
-            log::info!("ProcessApp[{}]: render requested ({reason})", self.type_id);
+            // mouse_move fires once per pointer event while an app has mouse
+            // tracking enabled (opt-in via SetMouseTracking) — at info level
+            // it floods the log at cursor speed. Volume stays visible in the
+            // 10s render_diag summary.
+            if reason == "mouse_move" {
+                log::debug!("ProcessApp[{}]: render requested ({reason})", self.type_id);
+            } else {
+                log::info!("ProcessApp[{}]: render requested ({reason})", self.type_id);
+            }
         }
     }
 

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -12,7 +12,7 @@ use crate::ui::text_field::TextField;
 use crate::workspace::secrets::SecretStore;
 use std::collections::VecDeque;
 use std::path::Path;
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 
 use super::{DeferredAiQuery, PendingPrompt};
 
@@ -101,8 +101,9 @@ pub(crate) fn show_prompt_modal(
     deferred_gated_requests: &mut Vec<(Capability, AppRequest)>,
     pending_commands: &mut Vec<AppCommand>,
     ai_broker: Arc<dyn AiBroker>,
-    http_tx: Sender<PlexiEvent>,
+    http_tx: super::transport::WakingEventSender,
     pane_id: u64,
+    pending_async_completions: &mut usize,
 ) {
     let Some(prompt) = pending_prompts.front() else {
         return;
@@ -370,6 +371,16 @@ pub(crate) fn show_prompt_modal(
                             ),
                         );
                         while let Some(q) = deferred_ai_queries.pop_front() {
+                            // Keep the async-wake accounting balanced: the
+                            // AiResponse drain decrements this counter, so
+                            // every deferred dispatch must increment it
+                            // (mirrors `arm_async_completion_wake`, #2021).
+                            *pending_async_completions =
+                                pending_async_completions.saturating_add(1);
+                            log::info!(
+                                "prompts: async wake armed (ai_query_deferred); pending={}",
+                                *pending_async_completions
+                            );
                             let broker = Arc::clone(&ai_broker);
                             let app_id = type_id.to_string();
                             let tx = http_tx.clone();

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -124,7 +124,10 @@ pub(crate) fn render_draw_commands(
                         .unwrap_or((pane_rect.max.x - (origin.x + x)).max(1.0));
                     let galley =
                         ui.fonts(|f| f.layout(text.clone(), font_id.clone(), color, wrap_w));
-                    let final_text: std::borrow::Cow<str> = if galley.rows.len() > *n as usize {
+                    // Reuse the measured galley directly when the text fits —
+                    // re-laying-out identical text would clone the string again
+                    // for the same result. Only the overflow path allocates.
+                    let final_galley = if galley.rows.len() > *n as usize {
                         let mut lo = 0usize;
                         let mut hi = text.chars().count();
                         while lo + 1 < hi {
@@ -139,13 +142,11 @@ pub(crate) fn render_draw_commands(
                                 hi = mid;
                             }
                         }
-                        std::borrow::Cow::Owned(text.chars().take(lo).collect::<String>() + "…")
+                        let truncated = text.chars().take(lo).collect::<String>() + "…";
+                        ui.fonts(|f| f.layout(truncated, font_id.clone(), color, wrap_w))
                     } else {
-                        std::borrow::Cow::Borrowed(text.as_str())
+                        galley
                     };
-                    let final_galley = ui.fonts(|f| {
-                        f.layout(final_text.to_string(), font_id.clone(), color, wrap_w)
-                    });
                     let pos = egui::pos2(origin.x + x, origin.y + y);
                     ui.painter()
                         .with_clip_rect(clip)
@@ -723,7 +724,10 @@ pub(crate) fn render_draw_commands(
                                     list_rect.max.x - PAD_X
                                 };
                                 let avail_w = (text_right - text_start_x).max(0.0);
-                                let display_primary: std::borrow::Cow<'_, str> = {
+                                // Reuse the measured galley when the title fits —
+                                // `painter.text` would clone + re-lay-out the same
+                                // string. Only the overflow path allocates.
+                                let primary_galley = {
                                     let galley = ui.fonts(|f| {
                                         f.layout_no_wrap(
                                             row.primary.clone(),
@@ -752,18 +756,23 @@ pub(crate) fn render_draw_commands(
                                                 hi = mid;
                                             }
                                         }
-                                        std::borrow::Cow::Owned(
-                                            row.primary.chars().take(lo).collect::<String>() + "…",
-                                        )
+                                        let truncated =
+                                            row.primary.chars().take(lo).collect::<String>() + "…";
+                                        ui.fonts(|f| {
+                                            f.layout_no_wrap(
+                                                truncated,
+                                                primary_font.clone(),
+                                                colors.text_primary,
+                                            )
+                                        })
                                     } else {
-                                        std::borrow::Cow::Borrowed(row.primary.as_str())
+                                        galley
                                     }
                                 };
-                                painter.text(
+                                // LEFT_TOP anchor: galley min == anchor pos.
+                                painter.galley(
                                     egui::pos2(text_start_x, primary_y),
-                                    egui::Align2::LEFT_TOP,
-                                    display_primary.as_ref(),
-                                    primary_font,
+                                    primary_galley,
                                     colors.text_primary,
                                 );
 
@@ -1156,12 +1165,24 @@ pub(crate) fn render_draw_commands(
                     "render: ComponentTree received; rendering via render_component_tree; pane_origin={:?}",
                     pane_rect.min
                 );
+                // Thread the pane's persistent caches so `UiNode::Raw` nodes
+                // reuse them instead of building throwaway caches per node.
+                let mut raw_caches = crate::render::components::RawNodeCaches {
+                    commonmark_cache: &mut *commonmark_cache,
+                    image_cache: &mut *image_cache,
+                    audio_peaks,
+                    workspace_root,
+                    net_http_granted,
+                    list_view_scroll_offsets: &mut *list_view_scroll_offsets,
+                    list_view_last_aligned_sel: &mut *list_view_last_aligned_sel,
+                };
                 let component_events = crate::render::components::render_component_tree(
                     ui,
                     root,
                     colors,
                     text_edit_buffers,
                     text_edit_focus_ctx,
+                    &mut raw_caches,
                 );
                 for evt in component_events {
                     log::info!(

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -17,6 +17,10 @@ pub(crate) struct RenderSession {
     /// IDs of `TextInput` widgets visible in the most recently rendered frame.
     /// Used to detect newly-visible inputs for auto-focus.
     text_input_visible_prev: HashSet<String>,
+    /// Scratch set for the current frame's visible `TextInput` ids. Swapped
+    /// into `text_input_visible_prev` at the end of each render pass so the
+    /// allocation is reused instead of rebuilt every frame.
+    text_input_visible_current: HashSet<String>,
     /// True when any `TextInput` or `TextEdit` widget had egui focus during the
     /// last render pass. Read by `handle_key` in mod.rs to suppress key
     /// forwarding while the user types.
@@ -50,6 +54,7 @@ impl RenderSession {
             text_input_buffers: HashMap::new(),
             text_edit_buffers: HashMap::new(),
             text_input_visible_prev: HashSet::new(),
+            text_input_visible_current: HashSet::new(),
             text_input_has_focus: false,
             scroll_offsets: HashMap::new(),
             list_view_scroll_offsets: HashMap::new(),
@@ -146,7 +151,7 @@ impl RenderSession {
     ) {
         let origin = pane_rect.min;
         let mut submitted: Vec<String> = Vec::new();
-        let mut visible_this_frame: HashSet<String> = HashSet::new();
+        self.text_input_visible_current.clear();
         let mut focus_granted = false;
         let mut any_has_focus = false;
 
@@ -165,7 +170,7 @@ impl RenderSession {
                 continue;
             };
 
-            visible_this_frame.insert(id.clone());
+            self.text_input_visible_current.insert(id.clone());
             let newly_visible = !self.text_input_visible_prev.contains(id.as_str());
 
             let desired_h = h.max(24.0);
@@ -359,7 +364,12 @@ impl RenderSession {
             }
         }
 
-        self.text_input_visible_prev = visible_this_frame;
+        // Rotate visibility sets, reusing both allocations across frames.
+        std::mem::swap(
+            &mut self.text_input_visible_prev,
+            &mut self.text_input_visible_current,
+        );
+        self.text_input_visible_current.clear();
         self.pane_just_focused = false;
         self.text_input_has_focus = any_has_focus;
 
@@ -511,21 +521,16 @@ impl RenderSession {
         // Reset intercept flag — recalculate from current frame
         self.list_view_intercepts_nav = false;
 
-        // Prune scroll state for lists no longer in the frame
-        let live_ids: std::collections::HashSet<String> = frame
-            .iter()
-            .filter_map(|cmd| {
-                if let RenderCommand::ListView { id, .. } = cmd {
-                    Some(id.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        self.list_view_scroll_offsets
-            .retain(|id, _| live_ids.contains(id));
-        self.list_view_last_aligned_sel
-            .retain(|id, _| live_ids.contains(id));
+        // Prune scroll state for lists no longer in the frame. A frame holds
+        // at most a handful of ListView commands, so a linear scan per stale
+        // key beats rebuilding a HashSet of cloned ids every frame.
+        let is_live = |id: &String| {
+            frame
+                .iter()
+                .any(|cmd| matches!(cmd, RenderCommand::ListView { id: live, .. } if live == id))
+        };
+        self.list_view_scroll_offsets.retain(|id, _| is_live(id));
+        self.list_view_last_aligned_sel.retain(|id, _| is_live(id));
 
         let mut handled_nav = false;
         for cmd in frame {

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -639,25 +639,29 @@ impl ProcessApp {
                     }
                     StreamChannel::Stderr => Box::new(child.stderr.take().expect("stderr piped")),
                 };
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("stream_process");
                 let type_id = self.type_id.clone();
                 let corr_id = correlation_id.clone();
                 const MAX_STREAM_THREADS: usize = 32;
                 let active = Arc::clone(&self.active_stream_threads);
                 let prior = active.fetch_add(1, Ordering::Relaxed);
+                // Arm before the limit check: the reject path below sends a
+                // StreamEnd, whose drain decrements the pending-completion
+                // count — an unmatched decrement would steal another pending
+                // operation's wake.
+                self.arm_async_completion_wake("stream_process");
                 if prior >= MAX_STREAM_THREADS {
                     active.fetch_sub(1, Ordering::Relaxed);
                     log::warn!(
                         "ProcessApp[{}]: StreamProcess {correlation_id} rejected — stream thread limit ({MAX_STREAM_THREADS}) reached",
                         self.type_id
                     );
-                    let _ = self.http_tx.send(PlexiEvent::StreamEnd {
+                    let _ = tx.send(PlexiEvent::StreamEnd {
                         correlation_id,
                         exit_code: -1,
                     });
                     return;
                 }
-                self.arm_async_completion_wake("stream_process");
                 let thread_name = format!("stream-reader-{}-{}", type_id, corr_id);
                 std::thread::Builder::new()
                     .name(thread_name)
@@ -748,7 +752,7 @@ impl ProcessApp {
                     self.type_id
                 );
                 self.arm_async_completion_wake("file_picker");
-                let tx = self.file_picker_tx.clone();
+                let tx = self.waking_file_picker_tx("file_picker");
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
                     .name(format!("file-picker-{type_id}"))
@@ -925,7 +929,7 @@ impl ProcessApp {
                 self.arm_async_completion_wake("http_request");
                 let allowed_hosts = normalized_allowed_hosts;
                 let net = std::sync::Arc::clone(&self.net);
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("http_request");
                 let type_id = self.type_id.clone();
 
                 std::thread::Builder::new()
@@ -1125,7 +1129,7 @@ impl ProcessApp {
                 let broker = self.ai_broker.clone();
                 let app_id = self.type_id.clone();
                 self.arm_async_completion_wake("ai_query");
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("ai_query");
                 let workspace_root = self.workspace_root.clone();
                 let open_panes = crate::plexi_ai::broker::get_pane_snapshot();
                 let tool_dispatcher = std::sync::Arc::new(
@@ -1333,7 +1337,7 @@ impl ProcessApp {
                 // block for hundreds of milliseconds on macOS (Bluetooth scan).
                 let audio = std::sync::Arc::clone(&self.audio_device);
                 self.arm_async_completion_wake("list_audio_devices");
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("list_audio_devices");
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
                     .name(format!("audio-devices-{type_id}"))
@@ -1364,7 +1368,7 @@ impl ProcessApp {
                 // Offload to a background thread for the same reason as audio.
                 let midi = std::sync::Arc::clone(&self.midi_device);
                 self.arm_async_completion_wake("list_midi_devices");
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("list_midi_devices");
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
                     .name(format!("midi-devices-{type_id}"))
@@ -1532,7 +1536,7 @@ impl ProcessApp {
                 let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 self.pending_timers
                     .insert(timer_id.clone(), std::sync::Arc::clone(&cancelled));
-                let tx = self.http_tx.clone();
+                let tx = self.waking_http_tx("timer_fired");
                 let type_id = self.type_id.clone();
                 std::thread::Builder::new()
                     .name(format!("timer-{type_id}-{timer_id}"))

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -23,6 +23,12 @@ impl ProcessApp {
     /// Exhaustive match — no wildcard arm. The compiler enforces coverage.
     pub(super) fn route_command(&mut self, cmd: AppRequest) {
         match cmd {
+            // ── Wake (no-op) ───────────────────────────────────────────────
+            // CLI-originated nudge for the idle host; carries no payload and
+            // has no effect when routed from an app.
+            AppRequest::Wake => {
+                log::debug!("ProcessApp[{}]: wake request (no-op)", self.type_id);
+            }
             // ── Capability request ─────────────────────────────────────────
             AppRequest::CapabilityRequest {
                 request_id,

--- a/src/process_app/runtime_state.rs
+++ b/src/process_app/runtime_state.rs
@@ -26,6 +26,7 @@ pub(crate) enum RuntimeState {
     Idle,
     Rendering {
         frame_id: u64,
+        started_at: Instant,
         followup_deadline: Option<Instant>,
     },
     Closing,
@@ -57,6 +58,10 @@ pub(crate) enum RenderPoll {
 pub(crate) struct PgapRuntime {
     state: RuntimeState,
     frame_counter: u64,
+    /// Frame id of a Render transaction abandoned by the in-flight timeout
+    /// (issue #2208). A late FrameDone for this id is tolerated — the app
+    /// recovered, slowly — instead of being treated as a protocol error.
+    abandoned_frame_id: Option<u64>,
 }
 
 impl PgapRuntime {
@@ -66,6 +71,7 @@ impl PgapRuntime {
                 pending_deadline: Some(Instant::now()),
             },
             frame_counter: 0,
+            abandoned_frame_id: None,
         }
     }
 
@@ -76,6 +82,7 @@ impl PgapRuntime {
                 next_deadline: Instant::now(),
             },
             frame_counter: 0,
+            abandoned_frame_id: None,
         }
     }
 
@@ -148,6 +155,7 @@ impl PgapRuntime {
                 let frame_id = self.frame_counter;
                 self.state = RuntimeState::Rendering {
                     frame_id,
+                    started_at: now,
                     followup_deadline: None,
                 };
                 RenderPoll::Send { frame_id }
@@ -164,10 +172,49 @@ impl PgapRuntime {
         }
     }
 
+    /// If the in-flight render has been outstanding longer than `timeout`,
+    /// abandon the transaction so the host stops repaint-polling for a
+    /// FrameDone that may never come (issue #2208). Returns the abandoned
+    /// frame id when the timeout fires, `None` otherwise.
+    ///
+    /// Any followup deadline is dropped — re-arming a render against an app
+    /// that has stopped answering would just restart the poll loop. A late
+    /// FrameDone for the abandoned frame is still committed (see
+    /// `complete_frame`), and fresh input re-arms rendering normally.
+    pub(crate) fn abandon_render_if_stalled(
+        &mut self,
+        now: Instant,
+        timeout: Duration,
+    ) -> Option<u64> {
+        let RuntimeState::Rendering {
+            frame_id,
+            started_at,
+            ..
+        } = self.state
+        else {
+            return None;
+        };
+        if now.saturating_duration_since(started_at) < timeout {
+            return None;
+        }
+        self.abandoned_frame_id = Some(frame_id);
+        self.state = RuntimeState::Idle;
+        Some(frame_id)
+    }
+
     pub(crate) fn complete_frame(&mut self, frame_id: u64) -> FrameDoneOutcome {
+        if self.abandoned_frame_id == Some(frame_id) {
+            // The app finally answered a render the timeout already gave up
+            // on. The state machine has moved on (Idle, or a newer request);
+            // commit the late frame without disturbing it.
+            self.abandoned_frame_id = None;
+            return FrameDoneOutcome::Matched;
+        }
+
         let RuntimeState::Rendering {
             frame_id: expected,
             followup_deadline,
+            ..
         } = &self.state
         else {
             let expected = self.in_flight_frame_id();
@@ -200,6 +247,17 @@ impl PgapRuntime {
             None => RuntimeState::Idle,
         };
         FrameDoneOutcome::Matched
+    }
+
+    /// Test hook: shift the in-flight render's start time into the past so a
+    /// wall-clock timeout can be exercised without sleeping.
+    #[cfg(test)]
+    pub(crate) fn backdate_in_flight_render(&mut self, by: Duration) {
+        if let RuntimeState::Rendering { started_at, .. } = &mut self.state {
+            *started_at = started_at
+                .checked_sub(by)
+                .expect("backdate underflowed the Instant epoch");
+        }
     }
 
     pub(crate) fn in_flight_frame_id(&self) -> Option<u64> {
@@ -345,6 +403,56 @@ mod tests {
             runtime.poll_render(commit),
             RenderPoll::Send { frame_id: 2 }
         );
+    }
+
+    #[test]
+    fn stalled_render_is_abandoned_after_timeout() {
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        let t0 = Instant::now();
+        assert_eq!(runtime.poll_render(t0), RenderPoll::Send { frame_id: 1 });
+
+        let timeout = Duration::from_secs(5);
+        // Before the timeout: still a live transaction.
+        assert_eq!(
+            runtime.abandon_render_if_stalled(t0 + Duration::from_secs(4), timeout),
+            None
+        );
+        assert!(runtime.is_rendering());
+
+        // Past the timeout: abandoned, in-flight cleared, polling stops.
+        assert_eq!(
+            runtime.abandon_render_if_stalled(t0 + Duration::from_secs(6), timeout),
+            Some(1)
+        );
+        assert!(!runtime.is_rendering());
+        assert_eq!(
+            runtime.poll_render(t0 + Duration::from_secs(6)),
+            RenderPoll::Idle
+        );
+        // Idempotent — no second abandon for the same stall.
+        assert_eq!(
+            runtime.abandon_render_if_stalled(t0 + Duration::from_secs(7), timeout),
+            None
+        );
+    }
+
+    #[test]
+    fn late_frame_done_after_abandonment_is_tolerated() {
+        let mut runtime = PgapRuntime::ready_for_test_with_initial_render();
+        let t0 = Instant::now();
+        assert_eq!(runtime.poll_render(t0), RenderPoll::Send { frame_id: 1 });
+        runtime.abandon_render_if_stalled(t0 + Duration::from_secs(6), Duration::from_secs(5));
+
+        // The app finally answers — commit, don't flag a protocol error.
+        assert_eq!(runtime.complete_frame(1), FrameDoneOutcome::Matched);
+
+        // The runtime is healthy again: a fresh render round-trips normally.
+        assert!(runtime.request_render_now());
+        assert_eq!(
+            runtime.poll_render(Instant::now()),
+            RenderPoll::Send { frame_id: 2 }
+        );
+        assert_eq!(runtime.complete_frame(2), FrameDoneOutcome::Matched);
     }
 
     #[test]

--- a/src/process_app/scheduler.rs
+++ b/src/process_app/scheduler.rs
@@ -3,8 +3,24 @@
 use crate::platform::frame_diag::{self, RepaintCause};
 use std::time::{Duration, Instant};
 
-const RENDER_IN_FLIGHT_POLL: Duration = Duration::from_millis(16);
+/// Poll cadence while a Render is in flight, waiting for FrameDone.
+///
+/// Must stay comfortably above one host frame time: egui's
+/// `request_repaint_after` subtracts the predicted frame time (~16.7ms at
+/// 60Hz) from the requested delay, so a 16ms poll saturated to zero and
+/// repainted the host at full frame rate (issue #2208). 50ms survives the
+/// subtraction with margin (even at 24Hz, predicted ~41.7ms) and a 20Hz
+/// FrameDone pickup adds at most one host frame of latency to a commit.
+const RENDER_IN_FLIGHT_POLL: Duration = Duration::from_millis(50);
 const ASYNC_WAKE_POLL: Duration = Duration::from_millis(100);
+
+/// How long a Render may stay in flight with no FrameDone before the host
+/// abandons the transaction, marks the app hung, and stops repaint polling.
+///
+/// 5s matches `lifecycle::HUNG_FRAME_GAP` — there is exactly one notion of
+/// "this app has stopped answering" so the repaint scheduler and the status
+/// pill flip at the same moment.
+pub(crate) const RENDER_IN_FLIGHT_TIMEOUT: Duration = super::lifecycle::HUNG_FRAME_GAP;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AppSchedulerMode {
@@ -157,12 +173,28 @@ mod tests {
     }
 
     #[test]
-    fn in_flight_render_polls_at_frame_cadence() {
+    fn in_flight_render_polls_at_bounded_cadence() {
         let mut input = idle_inputs();
         input.render_in_flight = true;
         assert_eq!(
             decide_repaint(input),
             RepaintDecision::After(RENDER_IN_FLIGHT_POLL)
+        );
+    }
+
+    /// Issue #2208: egui's `request_repaint_after` subtracts the predicted
+    /// frame time (~16.7ms at 60Hz) from the requested delay. A poll at or
+    /// below one frame time saturates to zero = immediate repaint = the host
+    /// pinned at full frame rate while any render is in flight.
+    #[test]
+    fn in_flight_poll_survives_predicted_frame_time_subtraction() {
+        let predicted_60hz_frame = Duration::from_secs_f32(1.0 / 60.0);
+        assert!(
+            !RENDER_IN_FLIGHT_POLL
+                .saturating_sub(predicted_60hz_frame)
+                .is_zero(),
+            "RENDER_IN_FLIGHT_POLL ({RENDER_IN_FLIGHT_POLL:?}) must exceed one \
+             60Hz frame time or egui turns it into an immediate repaint"
         );
     }
 

--- a/src/process_app/tests/render_session_tests.rs
+++ b/src/process_app/tests/render_session_tests.rs
@@ -42,6 +42,218 @@ fn render_session_submit_produces_event() {
     }
 }
 
+/// Recursively collect painted galley texts from an egui shape tree.
+fn collect_shape_texts(shape: &egui::Shape, out: &mut Vec<String>) {
+    match shape {
+        egui::Shape::Text(ts) => out.push(ts.galley.text().to_string()),
+        egui::Shape::Vec(v) => {
+            for s in v {
+                collect_shape_texts(s, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Allocation-reduction regression test (#2024): a PGAP frame with many list
+/// rows, elided/wrapped text, a TextInput, and a ComponentTree containing a
+/// TextEdit and a Raw text node must render identically across frames and
+/// emit no spurious events. Exercises:
+/// - ListView primary-text galley reuse + elision
+/// - Text `max_width`/`elide` and `max_lines` truncation paths
+/// - TextInput visibility scratch-set rotation
+/// - Raw-node persistent cache threading (`RawNodeCaches`)
+/// - TextEdit buffer seeding without per-frame key clones
+#[test]
+fn render_session_pgap_frame_stable_output_no_spurious_events() {
+    use crate::app_protocol::{
+        ListViewItem, ListViewRowDescriptor, PlexiEvent, RenderCommand, UiNode,
+    };
+    use crate::protocol::commands::TextAlign;
+
+    let ctx = egui::Context::default();
+    ctx.set_fonts(egui::FontDefinitions::default());
+    let rect = egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(800.0, 600.0));
+
+    let long: String = "very long row text segment ".repeat(20);
+    let items: Vec<ListViewItem> = (0..50)
+        .map(|i| {
+            ListViewItem::Row(ListViewRowDescriptor {
+                id: format!("row-{i}"),
+                leading: None,
+                primary: format!("Row title {i} {long}"),
+                secondary: Some(format!("secondary {i}")),
+                chips: vec![],
+                trailing: None,
+            })
+        })
+        .collect();
+
+    let text_cmd = |y: f32, text: String, max_width: Option<f32>, max_lines: Option<u32>| {
+        RenderCommand::Text {
+            x: 0.0,
+            y,
+            text,
+            size: 13.0,
+            color: "#ffffff".to_string(),
+            monospace: false,
+            bold: false,
+            align: TextAlign::LeftTop,
+            max_width,
+            elide: true,
+            selectable: false,
+            max_lines,
+        }
+    };
+
+    let frame = vec![
+        RenderCommand::ListView {
+            id: "lv".to_string(),
+            x: 0.0,
+            y: 0.0,
+            w: 0.0,
+            h: 400.0,
+            items,
+            selected: 3,
+            loading: false,
+            error: None,
+        },
+        // Overflowing single-line text → max_width elision path.
+        text_cmd(420.0, long.clone(), Some(200.0), None),
+        // Overflowing wrapped text → max_lines truncation path.
+        text_cmd(440.0, long.clone(), None, Some(2)),
+        // Fitting text → galley-reuse fast path.
+        text_cmd(560.0, "short fits".to_string(), Some(400.0), None),
+        RenderCommand::TextInput {
+            id: "ti-1".to_string(),
+            x: 0.0,
+            y: 580.0,
+            w: 200.0,
+            h: 24.0,
+            placeholder: "type here".to_string(),
+            multiline: false,
+            value: None,
+        },
+        RenderCommand::ComponentTree {
+            root: UiNode::Column {
+                children: vec![
+                    UiNode::TextEdit {
+                        node_id: "te-1".to_string(),
+                        placeholder: "edit".to_string(),
+                        value: "seeded value".to_string(),
+                        multiline: false,
+                        max_length: 0,
+                    },
+                    UiNode::Raw {
+                        command: Box::new(text_cmd(
+                            0.0,
+                            "raw node text".to_string(),
+                            None,
+                            None,
+                        )),
+                    },
+                ],
+                gap: 4.0,
+                padding_top: 0.0,
+                padding: 0.0,
+            },
+        },
+    ];
+
+    let mut session = render_session::RenderSession::new();
+    let colors = crate::ui::theme::Colors::from_config(&Default::default());
+    let mut cm_cache = egui_commonmark::CommonMarkCache::default();
+    let peaks: std::collections::HashMap<String, f32> = std::collections::HashMap::new();
+    let mut img_cache = image_cache::ImageCache::new();
+    let app_dir = std::env::temp_dir();
+
+    let mut texts_per_pass: Vec<Vec<String>> = Vec::new();
+    for pass in 0..2 {
+        let raw_input = egui::RawInput {
+            screen_rect: Some(rect),
+            ..Default::default()
+        };
+        let full_output = ctx.run(raw_input, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    session.render(
+                        ui,
+                        rect,
+                        &frame,
+                        &colors,
+                        &mut cm_cache,
+                        &peaks,
+                        1,
+                        &mut img_cache,
+                        &app_dir,
+                        false,
+                        false,
+                    );
+                });
+        });
+
+        // A static frame with no user input must emit no events.
+        let events: Vec<PlexiEvent> = session.drain_events().collect();
+        assert!(
+            events.is_empty(),
+            "pass {pass}: expected no events from a static frame, got {events:?}"
+        );
+
+        let mut texts = Vec::new();
+        for cs in &full_output.shapes {
+            collect_shape_texts(&cs.shape, &mut texts);
+        }
+        texts_per_pass.push(texts);
+    }
+
+    let texts = &texts_per_pass[0];
+    // Selected list row title is painted and elided (never the full string).
+    assert!(
+        texts
+            .iter()
+            .any(|t| t.starts_with("Row title 3") && t.ends_with('…')),
+        "expected elided 'Row title 3 …' in painted texts"
+    );
+    assert!(
+        !texts.iter().any(|t| t == &format!("Row title 3 {long}")),
+        "overflowing row title must not paint at full length"
+    );
+    // Fitting text paints verbatim via the reused galley.
+    assert!(
+        texts.iter().any(|t| t == "short fits"),
+        "fitting text must paint unmodified"
+    );
+    // max_lines text is truncated with an ellipsis.
+    assert!(
+        texts
+            .iter()
+            .any(|t| t.starts_with("very long row text segment")
+                && t.ends_with('…')
+                && t.len() < long.len()),
+        "max_lines text must be truncated with an ellipsis"
+    );
+    // Raw node rendered through the threaded persistent caches.
+    assert!(
+        texts.iter().any(|t| t == "raw node text"),
+        "Raw node text must render via threaded caches"
+    );
+
+    // TextEdit buffer seeded once from the app value (no per-frame reseed).
+    assert_eq!(
+        session.text_edit_buffers.get("te-1").map(String::as_str),
+        Some("seeded value"),
+        "TextEdit buffer must be seeded from the app value"
+    );
+
+    // Painted output must be identical across frames — cache/scratch reuse
+    // must not change what is rendered.
+    assert_eq!(
+        texts_per_pass[0], texts_per_pass[1],
+        "painted text output must be stable across frames"
+    );
+}
+
 #[test]
 fn render_session_process_app_has_no_text_input_fields() {
     // Compile-time proof: ProcessApp::render_session owns the state.

--- a/src/process_app/transport.rs
+++ b/src/process_app/transport.rs
@@ -29,6 +29,57 @@ pub(crate) fn request_repaint_from_thread(repaint_ctx: &Arc<Mutex<Option<egui::C
     }
 }
 
+/// Wake the host because background work arrived (issue #2021). Same as
+/// [`request_repaint_from_thread`] but with a trace, so every async wake
+/// path is observable in the log.
+pub(crate) fn wake_host_for_background_work(
+    repaint_ctx: &Arc<Mutex<Option<egui::Context>>>,
+    reason: &str,
+) {
+    log::debug!("host wake requested from background thread ({reason})");
+    request_repaint_from_thread(repaint_ctx);
+}
+
+/// An `http_tx` / `file_picker_tx` sender that wakes the host after every
+/// send, so async completions (timer fires, HTTP responses, AI chunks,
+/// picker results) surface on the next frame instead of waiting for the
+/// bounded 100ms async-wake poll (issue #2021).
+#[derive(Clone)]
+pub(crate) struct WakingEventSender {
+    tx: Sender<crate::app_protocol::PlexiEvent>,
+    repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+    reason: &'static str,
+}
+
+impl WakingEventSender {
+    pub(crate) fn new(
+        tx: Sender<crate::app_protocol::PlexiEvent>,
+        repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            tx,
+            repaint_ctx,
+            reason,
+        }
+    }
+
+    /// Send and wake. The error drops the payload (`SendError<()>`) — a
+    /// 232-byte `PlexiEvent` in the `Err` variant trips
+    /// `clippy::result_large_err`, and no caller recovers the event anyway.
+    pub(crate) fn send(
+        &self,
+        event: crate::app_protocol::PlexiEvent,
+    ) -> Result<(), std::sync::mpsc::SendError<()>> {
+        let result = self
+            .tx
+            .send(event)
+            .map_err(|_| std::sync::mpsc::SendError(()));
+        wake_host_for_background_work(&self.repaint_ctx, self.reason);
+        result
+    }
+}
+
 fn stdout_command_wakes_host(cmd: &DrawCommand) -> bool {
     !matches!(cmd, DrawCommand::Render(_))
 }
@@ -110,6 +161,7 @@ pub(crate) fn spawn_stdout_reader(
     type_id: String,
     stdout: ChildStdout,
     draw_tx: Sender<DrawCommand>,
+    draw_pending: Arc<AtomicBool>,
     lifecycle: Arc<LifecycleTracker>,
     repaint_ctx: Arc<Mutex<Option<egui::Context>>>,
 ) {
@@ -125,6 +177,11 @@ pub(crate) fn spawn_stdout_reader(
                             if draw_tx.send(cmd).is_err() {
                                 break;
                             }
+                            // Mark AFTER the send (paired with the host's
+                            // clear-then-drain in drain_draw_commands) so a
+                            // command can never sit in the channel with the
+                            // flag unset (#2021).
+                            draw_pending.store(true, Ordering::Release);
                             if wakes_host {
                                 request_repaint_from_thread(&repaint_ctx);
                             }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1479,6 +1479,10 @@ pub enum ControlCommand {
 /// The JSON `{"type":"rect",...}` still works; `{"type":"ai_query",...}` still works.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(untagged)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "DrawCommand is a transient per-message wire decode (parsed, routed, dropped within a frame), never stored in bulk; boxing AppRequest would add a heap allocation per host request and force deref rewrites at 80+ match sites"
+)]
 pub enum DrawCommand {
     Render(RenderCommand),
     Host(AppRequest),

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1326,6 +1326,13 @@ pub enum AppRequest {
     /// (`PlexiEvent::RollbackVerify` → `AppRequest::RollbackVerifyResult` →
     /// `PlexiEvent::RollbackApply`). Denials and conflicts are logged.
     RequestRollback { checkpoint_id: String },
+
+    /// No-op wake. Nudges the (zero-frame-idle) UI thread to run a frame so
+    /// queued work — spawn-queue files, pane-IPC channel messages — is
+    /// drained promptly. Sent by the CLI after writing a spawn-queue file
+    /// when no `PLEXI_SOCKET` is set. Fire-and-forget; the handler does
+    /// nothing — the wake effect is the socket listener's repaint request.
+    Wake,
 }
 
 /// Who caused an app state change (`AppRequest::EmitEvent`).
@@ -3927,6 +3934,19 @@ mod ai_stream_chunk_tests {
         assert!(
             serialised.contains(r#""response_file":"/tmp/prev.json""#),
             "response_file missing: {serialised}"
+        );
+    }
+
+    /// Wire-format round-trip for the no-op Wake nudge sent by the CLI
+    /// after a spawn-queue write.
+    #[test]
+    fn wake_round_trips_serde() {
+        let req: AppRequest = serde_json::from_str(r#"{"type":"wake"}"#).expect("deserialise");
+        assert!(matches!(req, AppRequest::Wake), "expected Wake, got {req:?}");
+        let serialised = serde_json::to_string(&req).expect("serialise");
+        assert!(
+            serialised.contains(r#""type":"wake""#),
+            "wire tag missing: {serialised}"
         );
     }
 

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -11,6 +11,24 @@ use crate::app_protocol::{PinnedEdge, StackDirection, UiNode};
 use crate::ui::style;
 use crate::ui::theme::Colors;
 
+/// Persistent per-pane render resources threaded into `UiNode::Raw` nodes.
+///
+/// Raw escape-hatch nodes delegate to `render_draw_commands`, which needs the
+/// pane's long-lived caches (markdown, images) and per-widget state maps.
+/// Threading these from the parent render pass instead of creating throwaway
+/// instances per node per frame avoids re-allocating caches every frame and
+/// lets Raw-embedded markdown/images/list views keep state across frames,
+/// matching top-level draw-command behavior.
+pub(crate) struct RawNodeCaches<'a> {
+    pub(crate) commonmark_cache: &'a mut egui_commonmark::CommonMarkCache,
+    pub(crate) image_cache: &'a mut crate::process_app::image_cache::ImageCache,
+    pub(crate) audio_peaks: &'a std::collections::HashMap<String, f32>,
+    pub(crate) workspace_root: &'a std::path::Path,
+    pub(crate) net_http_granted: bool,
+    pub(crate) list_view_scroll_offsets: &'a mut std::collections::HashMap<String, f32>,
+    pub(crate) list_view_last_aligned_sel: &'a mut std::collections::HashMap<String, usize>,
+}
+
 /// Carries the data needed to emit a `PlexiEvent::ComponentEvent`.
 ///
 /// Returned from `render_component_tree` and converted to `PlexiEvent` by
@@ -83,6 +101,7 @@ pub(crate) fn render_component_tree(
     colors: &Colors,
     text_edit_buffers: &mut std::collections::HashMap<String, String>,
     focus_ctx: &mut TextEditFocusCtx,
+    raw_caches: &mut RawNodeCaches<'_>,
 ) -> Vec<ComponentEventPayload> {
     let mut events: Vec<ComponentEventPayload> = Vec::new();
 
@@ -110,6 +129,7 @@ pub(crate) fn render_component_tree(
                         colors,
                         text_edit_buffers,
                         focus_ctx,
+                        raw_caches,
                     ));
                 });
         }
@@ -127,6 +147,7 @@ pub(crate) fn render_component_tree(
                     colors,
                     text_edit_buffers,
                     focus_ctx,
+                    raw_caches,
                 ));
             });
         }
@@ -140,6 +161,7 @@ pub(crate) fn render_component_tree(
                     colors,
                     text_edit_buffers,
                     focus_ctx,
+                    raw_caches,
                 ));
             }
         }
@@ -178,8 +200,14 @@ pub(crate) fn render_component_tree(
             // Render the child inside an interact-sense scope so we get a
             // Response covering the child's bounding rect.
             let child_response = ui.scope(|ui| {
-                let child_evts =
-                    render_component_tree(ui, child, colors, text_edit_buffers, focus_ctx);
+                let child_evts = render_component_tree(
+                    ui,
+                    child,
+                    colors,
+                    text_edit_buffers,
+                    focus_ctx,
+                    raw_caches,
+                );
                 // Bubble child events up.
                 (child_evts, ui.min_rect())
             });
@@ -223,36 +251,40 @@ pub(crate) fn render_component_tree(
                 colors,
                 text_edit_buffers,
                 focus_ctx,
+                raw_caches,
             ));
         }
 
         UiNode::Raw { command } => {
-            // Delegate to the existing flat renderer for a single draw command.
+            // Delegate to the existing flat renderer for a single draw command,
+            // threading the pane's persistent caches so markdown/image/list
+            // state survives across frames instead of being rebuilt per node.
             let pane_rect = ui.clip_rect();
-            // V1: fresh cache per Raw node — loses cache state across frames.
-            // A future pass will thread parent caches through. See epic #1897 A2.
             let mut raw_events: Vec<crate::app_protocol::PlexiEvent> = Vec::new();
             // Raw escape-hatch uses a throwaway focus ctx — focus tracking doesn't
             // apply to legacy draw commands embedded inside a component tree.
+            // (Fresh HashSets are allocation-free until first insert.)
             let mut raw_focus_ctx = TextEditFocusCtx::new();
             crate::process_app::render::render_draw_commands(
                 ui,
                 pane_rect,
                 std::slice::from_ref(command.as_ref()),
                 colors,
-                &mut egui_commonmark::CommonMarkCache::default(),
-                &std::collections::HashMap::new(),
-                &mut crate::process_app::image_cache::ImageCache::new(),
-                std::path::Path::new("."),
-                false,
-                &mut std::collections::HashMap::new(),
-                &mut std::collections::HashMap::new(),
+                &mut *raw_caches.commonmark_cache,
+                raw_caches.audio_peaks,
+                &mut *raw_caches.image_cache,
+                raw_caches.workspace_root,
+                raw_caches.net_http_granted,
+                &mut *raw_caches.list_view_scroll_offsets,
+                &mut *raw_caches.list_view_last_aligned_sel,
                 &mut raw_events,
                 text_edit_buffers,
                 &mut raw_focus_ctx,
             );
             // Convert any ComponentEvent payloads back from PlexiEvent (unlikely
             // from a Raw draw command, but keep the pipeline consistent).
+            // Non-ComponentEvent PlexiEvents are intentionally dropped here,
+            // preserving pre-existing Raw-node behavior.
             for evt in raw_events {
                 if let crate::app_protocol::PlexiEvent::ComponentEvent {
                     node_id,
@@ -387,9 +419,14 @@ pub(crate) fn render_component_tree(
             ..
         } => {
             // Seed the buffer from the app's value when this node_id first appears.
+            // contains_key-then-insert avoids cloning node_id on the steady-state
+            // (already-seeded) path, unlike `entry(node_id.clone())`.
+            if !text_edit_buffers.contains_key(node_id.as_str()) {
+                text_edit_buffers.insert(node_id.clone(), value.clone());
+            }
             let buffer = text_edit_buffers
-                .entry(node_id.clone())
-                .or_insert_with(|| value.clone());
+                .get_mut(node_id.as_str())
+                .expect("text_edit_buffers: buffer seeded above");
 
             // Enforce max_length by truncating the buffer if it exceeds the limit.
             if *max_length > 0 && buffer.len() > *max_length {
@@ -583,6 +620,7 @@ pub(crate) fn render_component_tree(
                         colors,
                         text_edit_buffers,
                         focus_ctx,
+                        raw_caches,
                     ));
                 });
         }
@@ -905,6 +943,7 @@ pub(crate) fn render_component_tree(
                             colors,
                             text_edit_buffers,
                             focus_ctx,
+                            raw_caches,
                         ));
                     }
                 });
@@ -1054,6 +1093,7 @@ fn render_stack(
     colors: &Colors,
     text_edit_buffers: &mut std::collections::HashMap<String, String>,
     focus_ctx: &mut TextEditFocusCtx,
+    raw_caches: &mut RawNodeCaches<'_>,
 ) -> Vec<ComponentEventPayload> {
     let mut events = Vec::new();
     match direction {
@@ -1069,6 +1109,7 @@ fn render_stack(
                         colors,
                         text_edit_buffers,
                         focus_ctx,
+                        raw_caches,
                     ));
                 }
             });
@@ -1133,6 +1174,7 @@ fn render_stack(
                             colors,
                             text_edit_buffers,
                             focus_ctx,
+                            raw_caches,
                         ));
                     }
                 });
@@ -1143,6 +1185,7 @@ fn render_stack(
                         colors,
                         text_edit_buffers,
                         focus_ctx,
+                        raw_caches,
                     ));
                 }
                 log::info!(
@@ -1160,6 +1203,7 @@ fn render_stack(
                             colors,
                             text_edit_buffers,
                             focus_ctx,
+                            raw_caches,
                         ));
                     }
                 });

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -216,7 +216,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             let padding = style::SPACE_MD;
             let inner = pane_rect.shrink(padding);
             let mut portal_ui = ui.new_child(egui::UiBuilder::new().max_rect(inner));
-            let colors_for_portal = self.colors.clone();
+            let colors_for_portal = self.colors;
             portal_ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
                 ui.label(
                     egui::RichText::new(&preview.context_name)

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1104,10 +1104,7 @@ fn capability_modal_escape_fires_deny_once() {
     // One idle frame: sync_capability_modal_focus should push the layer.
     h.run_frames(1);
     assert!(
-        h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CapabilityModal),
+        h.app.focus_stack.contains(&FocusLayer::CapabilityModal),
         "CapabilityModal must be on the focus stack when the focused pane has pending prompts"
     );
 
@@ -1135,10 +1132,7 @@ fn capability_modal_escape_fires_deny_once() {
     // CapabilityModal must have been popped from the focus stack since
     // sync_capability_modal_focus removes it when pending_prompts drains.
     assert!(
-        !h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CapabilityModal),
+        !h.app.focus_stack.contains(&FocusLayer::CapabilityModal),
         "CapabilityModal must be removed from the focus stack after deny_once drains the queue"
     );
 }
@@ -1158,10 +1152,7 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
     h.app.pending_close = true;
     h.app.sync_confirm_close_focus();
     assert!(
-        h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::ConfirmClose),
+        h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
         "ConfirmClose must be pushed when pending_close is true"
     );
 
@@ -1174,10 +1165,7 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
         "CommandPalette must be at the top after its source state becomes true"
     );
     assert!(
-        h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::ConfirmClose),
+        h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
         "ConfirmClose must still be in the stack (buried beneath CommandPalette)"
     );
 
@@ -1186,17 +1174,14 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
     h.app.sync_confirm_close_focus();
 
     assert!(
-        !h.app.focus_stack.iter().any(|l| *l == FocusLayer::ConfirmClose),
+        !h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
         "ConfirmClose must be removed from the stack even though CommandPalette was on top. \
          If this fails, sync_confirm_close_focus used pop_focus_layer (top-only) instead of retain."
     );
 
     // The layer that was on top must still be present — we only removed ConfirmClose.
     assert!(
-        h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CommandPalette),
+        h.app.focus_stack.contains(&FocusLayer::CommandPalette),
         "CommandPalette must remain in the stack after removing the buried ConfirmClose layer"
     );
 }
@@ -1440,7 +1425,7 @@ fn capability_secret_overlay_focus_wins_after_central_panel_steal() {
     // requests focus on capability_secret_input.
     h.run_frames(1);
     assert!(
-        h.app.focus_stack.iter().any(|l| *l == FocusLayer::CapabilityModal),
+        h.app.focus_stack.contains(&FocusLayer::CapabilityModal),
         "CapabilityModal must be on the focus stack when the focused pane has a pending Secret prompt"
     );
 
@@ -1860,10 +1845,7 @@ fn yellow_capability_queues_prompt_then_grant_forwards() {
         assert!(!response_file.exists());
     }
     assert!(
-        h.app
-            .focus_stack
-            .iter()
-            .any(|l| *l == FocusLayer::CapabilityModal),
+        h.app.focus_stack.contains(&FocusLayer::CapabilityModal),
         "CapabilityModal must be on the focus stack while the prompt is pending"
     );
 
@@ -2449,7 +2431,7 @@ fn rollback_blocked_on_revision_mismatch() {
     h.inject(
         pane,
         DrawCommand::Host(AppRequest::RollbackVerifyResult {
-            checkpoint_id: ckpt_id.clone(),
+            checkpoint_id: ckpt_id,
             current_revision: "rev-99".to_string(),
         }),
     );

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3207,3 +3207,177 @@ default = "ask"
         tool_dispatch::unregister(PANE);
     }
 }
+
+// -- Central-panel per-frame metadata (#2023) -------------------------------
+//
+// Issue #2023 short-circuits all portal preview / ContextState work when the
+// active window has no portal panes. These tests guard the invalidation side:
+// the data must still refresh on the very next frame after a change.
+
+/// Insert a test App pane directly into the window with the given window_id.
+/// Mirrors `PlexiApp::add_test_pane` but targets an arbitrary window.
+fn add_app_pane_to_window(h: &mut HostHarness, window_id: u64, pane_id: u64) {
+    use crate::process_app::ProcessApp;
+    let (process_app, _draw_tx) = ProcessApp::new_for_test(pane_id, AppPermissions::builtin());
+    let app_pane = crate::host::pane::AppPane {
+        id: pane_id,
+        runtime: AppRuntime::Process(Box::new(process_app)),
+        workspace_root: std::env::temp_dir(),
+        permissions: AppPermissions::builtin(),
+        manifest_id: "test".to_string(),
+        name: "Test App".to_string(),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden: false,
+        agent: None,
+        slots: HashMap::new(),
+    };
+    let win = h
+        .app
+        .windows
+        .iter_mut()
+        .find(|w| w.window_id == window_id)
+        .expect("target window must exist");
+    win.panes
+        .insert(pane_id, Pane::App(Box::new(app_pane)));
+    let tile_id = win.tree.tiles.insert_pane(pane_id);
+    if win.tree.root.is_none() {
+        win.tree.root = Some(tile_id);
+    }
+}
+
+/// Portal preview (cached `ContextState` on the portal pane) must reflect a
+/// pane added to the child context on the next rendered frame.
+#[test]
+fn portal_context_state_refreshes_when_child_context_changes() {
+    let mut h = HostHarness::new();
+    let _root_pane = h.add_test_pane();
+    let root_ctx_id = h.app.router.active().context_id;
+
+    // Child context with its own window and one pane.
+    let child_ctx_id = 77001u64;
+    let child_win_id = 77002u64;
+    h.app.router.push(crate::host::context::Context {
+        name: "child".to_string(),
+        path: std::path::PathBuf::from("/tmp/harness_2023_child"),
+        root: None,
+        description: None,
+        context_id: child_ctx_id,
+        parent_id: Some(root_ctx_id),
+        depth: 1,
+        parked: false,
+    });
+    h.app.context_active_window.insert(child_ctx_id, child_win_id);
+    h.app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp/harness_2023_child"),
+        tree: egui_tiles::Tree::empty("harness_2023_child"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: child_win_id,
+        context_id: child_ctx_id,
+    });
+    add_app_pane_to_window(&mut h, child_win_id, 77100);
+
+    // Portal pane in the active (root) window pointing at the child context.
+    let portal_pane_id = 77200u64;
+    {
+        let win = &mut h.app.windows[0];
+        let _ = win.tree.tiles.insert_pane(portal_pane_id);
+        win.panes.insert(
+            portal_pane_id,
+            Pane::Portal(Box::new(crate::host::pane::PortalPane {
+                pane_id: portal_pane_id,
+                target_context_id: child_ctx_id,
+                context_state: None,
+                hidden: false,
+            })),
+        );
+    }
+
+    let portal_state = |h: &HostHarness| {
+        let win = &h.app.windows[0];
+        match win.panes.get(&portal_pane_id) {
+            Some(Pane::Portal(p)) => p.context_state.clone(),
+            other => panic!("expected Portal pane, got {:?}", other.map(|p| p.id())),
+        }
+    };
+
+    h.run_frames(1);
+    let state = portal_state(&h).expect("context_state must be computed on first frame");
+    assert_eq!(state.pane_count, 1, "child context starts with one pane");
+
+    // Mutate the child context — add a second pane — and verify the portal
+    // preview reflects it on the very next frame (no stale cache).
+    add_app_pane_to_window(&mut h, child_win_id, 77101);
+    h.run_frames(1);
+    let state = portal_state(&h).expect("context_state must persist");
+    assert_eq!(
+        state.pane_count, 2,
+        "portal preview must reflect a pane added to the child context on the next frame"
+    );
+}
+
+/// The per-pane notification badge count must update on the next frame after
+/// a notification arrives, and clear after it is removed.
+#[test]
+fn notification_badge_count_propagates_to_sender_pane() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    h.run_frames(1);
+    assert_eq!(
+        h.process_app_mut(pane).pending_notification_count,
+        0,
+        "no notifications queued — badge count must be 0"
+    );
+
+    let source_context_id = h.app.router.active().context_id;
+    let source_window_id = h.app.windows[h.app.active_window].window_id;
+    h.app
+        .pending_notifications
+        .push(crate::app::PendingNotification {
+            notify_id: "harness-2023-badge".to_string(),
+            sender_pane_id: pane,
+            source_context_id,
+            source_window_id,
+            level: "info".to_string(),
+            title: "badge test".to_string(),
+            body: String::new(),
+            kind: crate::app_protocol::NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            priority: 0,
+            scope: crate::app_protocol::NotifyScope::Global,
+            image_inline: None,
+            image_pipe_id: None,
+            response_file: None,
+            timeout_secs: None,
+            on_dismiss: None,
+            enqueued_at: std::time::Instant::now(),
+            tombstoned: false,
+            deliver_after: None,
+        });
+
+    h.run_frames(1);
+    assert_eq!(
+        h.process_app_mut(pane).pending_notification_count,
+        1,
+        "badge count must reflect the queued notification on the next frame"
+    );
+
+    h.app
+        .pending_notifications
+        .retain(|n| n.notify_id != "harness-2023-badge");
+    h.run_frames(1);
+    assert_eq!(
+        h.process_app_mut(pane).pending_notification_count,
+        0,
+        "badge count must clear on the next frame after the notification is removed"
+    );
+}

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -106,6 +106,64 @@ fn idle_frame_requests_no_immediate_repaint() {
     );
 }
 
+/// Issue #2208: a PGAP app that never sends FrameDone must not pin the host
+/// at full frame rate. Two guarantees:
+///
+/// 1. While a render is legitimately in flight, the poll is a *bounded
+///    delay* — never an immediate repaint. The old 16ms poll saturated to
+///    zero inside egui's `request_repaint_after` (it subtracts the predicted
+///    frame time, ~16.7ms at 60Hz), which meant 60fps polling.
+/// 2. After `RENDER_IN_FLIGHT_TIMEOUT` with no FrameDone, the host abandons
+///    the render transaction, marks the app hung (existing lifecycle path),
+///    and stops requesting repaints entirely.
+#[test]
+fn hung_render_stops_repaint_polling_after_timeout() {
+    use crate::process_app::{LifecycleState, RENDER_IN_FLIGHT_TIMEOUT};
+
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+
+    // Frame 1 sends Render(1); the app never answers with FrameDone.
+    h.run_frames(1);
+    h.render_payload_take(pane)
+        .expect("first visible frame must request an app Render");
+    h.run_frames(3);
+
+    // Pre-timeout: the in-flight poll must survive egui's predicted-frame-
+    // time subtraction — a bounded delayed repaint, not an immediate one.
+    assert!(
+        !h.app.ctx.requested_repaint_last_pass(),
+        "render-in-flight polling must be a bounded delay, not an immediate \
+         repaint; a poll interval at or below one frame time saturates to \
+         zero and pins the host at full frame rate"
+    );
+    assert!(
+        h.process_app_mut(pane).render_in_flight_for_test(),
+        "render must still be in flight before the timeout"
+    );
+
+    // Simulate the render having been stuck for longer than the timeout.
+    h.process_app_mut(pane)
+        .backdate_in_flight_render(RENDER_IN_FLIGHT_TIMEOUT + std::time::Duration::from_secs(1));
+    h.run_frames(2);
+
+    let app = h.process_app_mut(pane);
+    assert!(
+        !app.render_in_flight_for_test(),
+        "render-in-flight state must be cleared once the timeout expires"
+    );
+    assert_eq!(
+        app.lifecycle.state(),
+        LifecycleState::Hung,
+        "a render timeout must surface through the existing hung status path"
+    );
+    assert!(
+        !h.app.ctx.requested_repaint_last_pass(),
+        "after the render timeout the host must stop requesting repaints \
+         for the hung app instead of polling forever"
+    );
+}
+
 #[test]
 fn visible_idle_process_app_does_not_emit_recurring_render_events() {
     let mut h = HostHarness::new();

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -52,7 +52,7 @@ impl PlexiUiHarness {
     pub fn new() -> Self {
         let frame_tick = Arc::new(AtomicU64::new(0));
         let harness = egui_kittest::Harness::new_eframe(move |cc| {
-            let (app, _ipc_tx) = PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick.clone());
+            let (app, _ipc_tx) = PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
             app
         });
         Self { inner: harness }
@@ -67,7 +67,7 @@ impl PlexiUiHarness {
             .with_size(egui::Vec2::new(width, height))
             .build_eframe(move |cc| {
                 let (app, _ipc_tx) =
-                    PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick.clone());
+                    PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
                 app
             });
         Self { inner: harness }


### PR DESCRIPTION
## Summary
Completes all remaining sprint s13 (v1 PGAP performance hardening) tasks in one sequential batch: #2026, #2208, #2209, #2021, #2024, #2023.

One commit per issue, each independently revertible:

- **#2026 — perf clippy gate.** `just perf-clippy` (`-D clippy::perf/redundant_clone/needless_collect/large_enum_variant/clone_on_copy`, vendored `egui_term` excluded via crate-level allow). Fixed the `never_loop` blocker and ~50 first-party perf lints. The gate already caught its first real regression during this PR's rebase (a `Colors` clone from #2210).
- **#2208 — render-in-flight poll/timeout.** `RENDER_IN_FLIGHT_POLL` 16ms → 50ms (16ms saturated to an immediate repaint after egui subtracts predicted frame time = full-frame-rate loop). New 5s timeout (`= lifecycle::HUNG_FRAME_GAP`) abandons a stalled render, marks the app Hung via the existing lifecycle path, and stops polling; a late FrameDone is tolerated and restores Running.
- **#2209 — frame_diag ground truth.** 10s summaries now include an `egui_causes:` line aggregating `ctx.repaint_causes()` (file:line of every repaint requester, per-pass dedup'd) — uninstrumented repaint loops are now diagnosable from the log alone. Cursor-blink note moved inside the toggle branch (was falsely attributing every frame).
- **#2021 — background wake scheduling.** `background_tick()` is now gated on `needs_background_tick()` — idle parked/non-active apps are no longer ticked every frame. The same predicate drives the bounded wake loop, so pending work always gets a frame. Worker threads (timer/HTTP/file-picker/AI/audio/MIDI/MCP) wake the host directly on completion via `WakingEventSender`; spontaneous app draw commands via a `draw_pending` flag (set-after-send / clear-before-drain). MCP servers no longer pin a permanent 100ms wake loop — only queued/unanswered calls count. Fixed two pre-existing async-wake accounting bugs found in the audit.
- **#2024 — render allocation reduction.** `UiNode::Raw` nodes now reuse the pane's persistent markdown/image/list caches (also fixes images inside Raw nodes never loading); per-frame `HashSet` rebuilds replaced with scratch-set rotation/retain scans; measured galleys reused instead of re-laying-out fitting text.
- **#2023 — portal/context metadata.** Deleted the unconditional per-frame clone of every `Context`; all portal preview/state work is skipped when the active window has no portal panes; cwd-derived fallback workspace root (per-frame filesystem stat-walk) is TTL-cached at 1s.

## Testing
- `cargo test --bin plexi`: 1045 passed, 0 failed (baseline 1029; 16 new tests across the batch, each written red-first where the seam allowed)
- `just perf-clippy`: clean
- `cargo build`: clean
- Rebased on alpha after #2207/#2210 landed; full suite re-run post-rebase.

Stint tasks 0057, 0169, 0170, 0051, 0052, 0059 marked done with actuals; sprint s13 is fully complete on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)