### PR TITLE
feat(keys): Cmd+Arrow pane navigation (alias for Cmd+hjkl)

### DIFF
--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -24,7 +24,8 @@ use crate::config::KeybindingsConfig;
 // Cmd+Shift+R                 — rename context
 // Cmd+[                       — nav back / focus history back
 // Cmd+]                       — focus history forward
-// Cmd+Up / Cmd+Down           — scroll
+// Cmd+Arrow                   — navigate panes (alias for Cmd+H/J/K/L)
+// Cmd+Shift+Up / Cmd+Shift+Down — scroll
 // Cmd+= / Cmd+-               — font size
 // Cmd+F                       — terminal search (handled inside egui_term, not host)
 // Cmd+U                       — toggle pane hidden state
@@ -278,8 +279,8 @@ impl Default for KeyBindings {
             new_context: (cmd_shift(), egui::Key::N),
             new_page_right: (cmd(), egui::Key::N),
             toggle_minimap: (cmd_shift(), egui::Key::M),
-            scroll_up: (cmd(), egui::Key::ArrowUp),
-            scroll_down: (cmd(), egui::Key::ArrowDown),
+            scroll_up: (cmd_shift(), egui::Key::ArrowUp),
+            scroll_down: (cmd_shift(), egui::Key::ArrowDown),
             increase_font_size: (cmd(), egui::Key::Equals),
             decrease_font_size: (cmd(), egui::Key::Minus),
             open_file_browser: (cmd(), egui::Key::E),
@@ -775,6 +776,35 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
         BindingEntry {
             modifiers: b.navigate_right.0,
             key: b.navigate_right.1,
+            exact: true,
+            context: BindingContext::Normal,
+            action: Action::Navigate(Direction::Right),
+        },
+        // Cmd+Arrow aliases for Cmd+H/J/K/L pane navigation.
+        BindingEntry {
+            modifiers: cmd(),
+            key: egui::Key::ArrowLeft,
+            exact: true,
+            context: BindingContext::Normal,
+            action: Action::Navigate(Direction::Left),
+        },
+        BindingEntry {
+            modifiers: cmd(),
+            key: egui::Key::ArrowDown,
+            exact: true,
+            context: BindingContext::Normal,
+            action: Action::Navigate(Direction::Down),
+        },
+        BindingEntry {
+            modifiers: cmd(),
+            key: egui::Key::ArrowUp,
+            exact: true,
+            context: BindingContext::Normal,
+            action: Action::Navigate(Direction::Up),
+        },
+        BindingEntry {
+            modifiers: cmd(),
+            key: egui::Key::ArrowRight,
             exact: true,
             context: BindingContext::Normal,
             action: Action::Navigate(Direction::Right),


### PR DESCRIPTION
## Summary

- `Cmd+ArrowLeft/Down/Up/Right` now navigate panes, matching `Cmd+H/J/K/L`
- Scroll (was `Cmd+ArrowUp/Down`) moved to `Cmd+Shift+ArrowUp/Down` to free the chord
- Arrow nav entries are hardcoded aliases in `build_binding_table` — they are not new configurable fields, so no `KeybindingsConfig` churn

## Test plan

- [ ] `cargo test --bin plexi` green
- [ ] Install alpha build, verify `Cmd+ArrowLeft/Right/Up/Down` moves focus between panes
- [ ] Verify `Cmd+Shift+ArrowUp/Down` still scrolls terminal output
- [ ] Verify `Cmd+H/J/K/L` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)