### PR TITLE
Themeable status pips + SessionStart idle fix (#2219, #2220)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -61,6 +61,10 @@ Apply a named preset and optionally override individual color tokens.
 | `bright_cyan` | hex color | preset | ANSI color 14. |
 | `bright_white` | hex color | preset | ANSI color 15. |
 | `bright_foreground` | hex color | preset | Bright terminal foreground. |
+| `pip_working` | hex color | `green` | Status pip color for Working state. Defaults to the `green` ANSI color. |
+| `pip_idle` | hex color | `yellow` | Status pip color for Idle state. Defaults to the `yellow` ANSI color. |
+| `pip_blocked` | hex color | `red` | Status pip color for Blocked state. Defaults to the `red` ANSI color. |
+| `pip_dim` | float | 0.45 | Opacity multiplier applied to status pips on unfocused panes. Range: 0.0–1.0. |
 
 **Available presets:** `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `gruvbox-dark`, `nord`, `solarized-dark`, `solarized-light`
 

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -455,7 +455,8 @@ tool_detail() {{
 DETAIL=""
 case "$EVENT" in
     PreToolUse)                    STATE="working"; DETAIL=$(tool_detail) ;;
-    SessionStart|UserPromptSubmit) STATE="working" ;;
+    SessionStart)                  STATE="idle" ;;
+    UserPromptSubmit)              STATE="working" ;;
     PermissionRequest)             STATE="blocked" ;;
     PostToolUse|PostToolBatch)       STATE="working" ;;
     Stop|StopFailure|SessionEnd)     STATE="idle" ;;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -707,6 +707,12 @@ pub struct ThemeConfig {
     pub bright_cyan: Option<String>,
     pub bright_white: Option<String>,
     pub bright_foreground: Option<String>,
+    // Activity pip color overrides — optional; fall back to success/warning/danger.
+    pub pip_working: Option<String>,
+    pub pip_idle: Option<String>,
+    pub pip_blocked: Option<String>,
+    // Opacity multiplier for unfocused pips. Default 0.45.
+    pub pip_dim: Option<f32>,
 }
 
 use std::sync::{Mutex, OnceLock};
@@ -1265,6 +1271,10 @@ impl ThemeConfig {
         overlay_field!(bright_cyan);
         overlay_field!(bright_white);
         overlay_field!(bright_foreground);
+        overlay_field!(pip_working);
+        overlay_field!(pip_idle);
+        overlay_field!(pip_blocked);
+        overlay_field!(pip_dim);
     }
 }
 

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -3,15 +3,10 @@
 use crate::app_protocol::AgentState;
 use crate::ui::theme::Colors;
 
-/// Opacity multiplier for activity pips on panes that are not the focused
-/// pane in their context — keeps the focused pip locatable when several
-/// pips carry activity colors.
-pub const UNFOCUSED_DIM: f32 = 0.45;
-
 /// Single source of truth for pip coloring across every pip surface
 /// (sidebar rows, palette rows, portal rows). Handles both the activity
 /// color and the focused/unfocused dim uniformly: focused pips render at
-/// full strength, unfocused pips at `UNFOCUSED_DIM` — regardless of
+/// full strength, unfocused pips at `colors.pip_dim` — regardless of
 /// whether the pip carries an activity color or the neutral/accent pair.
 pub fn pip_color(
     state: Option<&AgentState>,
@@ -27,7 +22,7 @@ pub fn pip_color(
     if focused {
         base
     } else {
-        base.gamma_multiply(UNFOCUSED_DIM)
+        base.gamma_multiply(colors.pip_dim)
     }
 }
 
@@ -39,7 +34,7 @@ pub fn dot_color_from_time(state: &AgentState, colors: &Colors, time: f64) -> eg
         AgentState::Working => {
             // Sine oscillates –1..1; remap to 0.45..1.0.
             let alpha = 0.45 + 0.55 * (0.5 + 0.5 * (time * std::f64::consts::PI).sin()) as f32;
-            let c = colors.success;
+            let c = colors.pip_working;
             egui::Color32::from_rgba_unmultiplied(
                 c.r(),
                 c.g(),
@@ -47,7 +42,7 @@ pub fn dot_color_from_time(state: &AgentState, colors: &Colors, time: f64) -> eg
                 (c.a() as f32 * alpha) as u8,
             )
         }
-        AgentState::Idle => colors.warning,
-        AgentState::Blocked => colors.danger,
+        AgentState::Idle => colors.pip_idle,
+        AgentState::Blocked => colors.pip_blocked,
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -47,6 +47,12 @@ pub struct Colors {
     pub danger: Color32,
     pub success: Color32,
     pub warning: Color32,
+    // Activity pip colors — override success/warning/danger when set in [theme]
+    pub pip_working: Color32,
+    pub pip_idle: Color32,
+    pub pip_blocked: Color32,
+    // Opacity multiplier for unfocused pips (default 0.45)
+    pub pip_dim: f32,
     // Terminal fg/bg as bytes for dynamic colors
     pub terminal_fg_bytes: [u8; 3],
     pub terminal_bg_bytes: [u8; 3],
@@ -120,6 +126,19 @@ impl Colors {
             danger: parse_hex_or(&cfg.red, Color32::from_rgb(0xff, 0x55, 0x55)),
             success: parse_hex_or(&cfg.green, Color32::from_rgb(0xa6, 0xe3, 0xa1)),
             warning: parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
+            pip_working: parse_hex_or(
+                &cfg.pip_working,
+                parse_hex_or(&cfg.green, Color32::from_rgb(0xa6, 0xe3, 0xa1)),
+            ),
+            pip_idle: parse_hex_or(
+                &cfg.pip_idle,
+                parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
+            ),
+            pip_blocked: parse_hex_or(
+                &cfg.pip_blocked,
+                parse_hex_or(&cfg.red, Color32::from_rgb(0xff, 0x55, 0x55)),
+            ),
+            pip_dim: cfg.pip_dim.unwrap_or(0.45),
             terminal_fg_bytes: hex_to_bytes(cfg.foreground.as_deref(), [0xe8, 0xe6, 0xed]),
             terminal_bg_bytes: hex_to_bytes(cfg.background.as_deref(), [0x29, 0x2a, 0x44]),
         }
@@ -298,6 +317,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#8bfde1"),
             bright_white: s("#f4f2f9"),
             bright_foreground: s("#f4f2f9"),
+            ..ThemeConfig::default()
         }),
         "dracula" => Some(ThemeConfig {
             preset: None,
@@ -332,6 +352,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#a4ffff"),
             bright_white: s("#ffffff"),
             bright_foreground: s("#ffffff"),
+            ..ThemeConfig::default()
         }),
         "tokyo-night" => Some(ThemeConfig {
             preset: None,
@@ -366,6 +387,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#90d8ff"),
             bright_white: s("#c0caf5"),
             bright_foreground: s("#c0caf5"),
+            ..ThemeConfig::default()
         }),
         "tokyo-day" => Some(ThemeConfig {
             preset: None,
@@ -400,6 +422,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#007197"),
             bright_white: s("#3760bf"),
             bright_foreground: s("#3760bf"),
+            ..ThemeConfig::default()
         }),
         "gruvbox-dark" => Some(ThemeConfig {
             preset: None,
@@ -434,6 +457,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#8ec07c"),
             bright_white: s("#fbf1c7"),
             bright_foreground: s("#fbf1c7"),
+            ..ThemeConfig::default()
         }),
         "gruvbox-light" => Some(ThemeConfig {
             preset: None,
@@ -468,6 +492,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#427b58"),
             bright_white: s("#3c3836"),
             bright_foreground: s("#3c3836"),
+            ..ThemeConfig::default()
         }),
         "nord" => Some(ThemeConfig {
             preset: None,
@@ -502,6 +527,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#8fbcbb"),
             bright_white: s("#e5e9f0"),
             bright_foreground: s("#e5e9f0"),
+            ..ThemeConfig::default()
         }),
         "solarized-dark" => Some(ThemeConfig {
             preset: None,
@@ -536,6 +562,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#2aa198"),
             bright_white: s("#fdf6e3"),
             bright_foreground: s("#fdf6e3"),
+            ..ThemeConfig::default()
         }),
         "catppuccin-latte" => Some(ThemeConfig {
             preset: None,
@@ -570,6 +597,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#04a5e5"),
             bright_white: s("#bcc0cc"),
             bright_foreground: s("#4c4f69"),
+            ..ThemeConfig::default()
         }),
         "solarized-light" => Some(ThemeConfig {
             preset: None,
@@ -604,6 +632,7 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bright_cyan: s("#2aa198"),
             bright_white: s("#fdf6e3"),
             bright_foreground: s("#fdf6e3"),
+            ..ThemeConfig::default()
         }),
         _ => None,
     }
@@ -645,6 +674,10 @@ pub fn apply_preset(preset: &ThemeConfig, user: &ThemeConfig) -> ThemeConfig {
         bright_cyan: m(&user.bright_cyan, &preset.bright_cyan),
         bright_white: m(&user.bright_white, &preset.bright_white),
         bright_foreground: m(&user.bright_foreground, &preset.bright_foreground),
+        pip_working: m(&user.pip_working, &preset.pip_working),
+        pip_idle: m(&user.pip_idle, &preset.pip_idle),
+        pip_blocked: m(&user.pip_blocked, &preset.pip_blocked),
+        pip_dim: user.pip_dim.or(preset.pip_dim),
     }
 }
 
@@ -903,6 +936,32 @@ pub fn setup_fonts(ctx: &egui::Context) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ThemeConfig;
+
+    /// pip_working/idle/blocked fall back to success/warning/danger when not set,
+    /// and use the override color when set. pip_dim defaults to 0.45.
+    #[test]
+    fn pip_colors_fall_back_to_semantic_and_accept_overrides() {
+        let default_cfg = ThemeConfig::default();
+        let colors = Colors::from_config(&default_cfg);
+        assert_eq!(colors.pip_working, colors.success);
+        assert_eq!(colors.pip_idle, colors.warning);
+        assert_eq!(colors.pip_blocked, colors.danger);
+        assert!((colors.pip_dim - 0.45).abs() < f32::EPSILON);
+
+        let override_cfg = ThemeConfig {
+            pip_working: Some("#ff0000".to_string()),
+            pip_idle: Some("#00ff00".to_string()),
+            pip_blocked: Some("#0000ff".to_string()),
+            pip_dim: Some(0.7),
+            ..ThemeConfig::default()
+        };
+        let oc = Colors::from_config(&override_cfg);
+        assert_eq!(oc.pip_working, Color32::from_rgb(0xff, 0x00, 0x00));
+        assert_eq!(oc.pip_idle, Color32::from_rgb(0x00, 0xff, 0x00));
+        assert_eq!(oc.pip_blocked, Color32::from_rgb(0x00, 0x00, 0xff));
+        assert!((oc.pip_dim - 0.7).abs() < f32::EPSILON);
+    }
 
     /// Every preset's accent button must render legible text: text_on must
     /// return a color with at least 3:1 WCAG contrast against the accent and


### PR DESCRIPTION
Closes #2219, Closes #2220

## Summary

**#2219 — feat(ui/theme): themeable status pips**
- Adds optional `[theme]` fields `pip_working`, `pip_idle`, `pip_blocked` (hex color overrides for agent state pips) and `pip_dim` (unfocused opacity multiplier, default 0.45)
- Removes hardcoded `UNFOCUSED_DIM = 0.45` const; threads `pip_dim` through `Colors` struct instead
- Falls back to `success`/`warning`/`danger` semantic colors when overrides are unset — no behavior change without config

**#2220 — fix(agents): SessionStart hook reports idle**
- Splits `SessionStart|UserPromptSubmit` case into two: `SessionStart → idle`, `UserPromptSubmit → working`
- New Claude Code sessions now show a yellow pip on launch instead of green-pulsing before any prompt is sent
- Hooks must be reinstalled after this change: `plexi agent install-hooks`

## Done When — #2219
- Setting `pip_working`/`pip_idle`/`pip_blocked`/`pip_dim` in `[theme]` visibly changes pips after config hot-reload; omitting them preserves current behavior exactly (unit test on color resolution)

## Done When — #2220
- Fresh Claude Code session with reinstalled hooks shows a yellow pip on start; turns green on first prompt submit