### PR TITLE
fix scroll jitter + notes as palette entries (#2217, #2222)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2924,7 +2924,8 @@ impl eframe::App for PlexiApp {
                                 .iter()
                                 .filter_map(|p| crate::notes::NotePickerEntry::load(p, true))
                                 .collect();
-                        let workspace_slug = crate::config::active_workspace_root()
+                        let workspace_slug = self.palette_workspace_root
+                            .as_ref()
                             .and_then(|p| p.file_name().map(|n| n.to_os_string()))
                             .map(|n| n.to_string_lossy().into_owned());
                         let notes_dir = match workspace_slug {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -184,6 +184,8 @@ pub struct PlexiApp {
     /// was opened. Resolved once on open, not per-frame, to avoid repeated
     /// filesystem traversal in the egui draw loop.
     pub(crate) palette_workspace_root: Option<std::path::PathBuf>,
+    /// Notes loaded at palette-open time, cleared on close.
+    pub(crate) palette_notes: Vec<crate::notes::NotePickerEntry>,
     /// TTL cache for the cwd-derived fallback workspace root passed to
     /// `PlexiBehavior` each frame (#2023). The fallback
     /// (`config::active_workspace_root()`) stat-walks the filesystem from the
@@ -794,6 +796,7 @@ impl PlexiApp {
                     palette_query: String::new(),
                     palette_selected: 0,
                     palette_workspace_root: None,
+                    palette_notes: Vec::new(),
                     workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
@@ -984,6 +987,7 @@ impl PlexiApp {
             palette_query: String::new(),
             palette_selected: 0,
             palette_workspace_root: None,
+            palette_notes: Vec::new(),
             workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
@@ -1188,6 +1192,7 @@ impl PlexiApp {
                 palette_query: String::new(),
                 palette_selected: 0,
                 palette_workspace_root: None,
+                palette_notes: Vec::new(),
                 workspace_root_fallback_cache: None,
                 context_visit_history: Vec::new(),
                 renaming_pane: None,
@@ -2894,8 +2899,51 @@ impl eframe::App for PlexiApp {
                             "palette: opened, focused workspace = {:?}",
                             self.palette_workspace_root
                         );
+                        // Load notes once at open-time, same pattern as palette_workspace_root.
+                        let notes_base = crate::config::config_dir().join("notes");
+                        let scan_md = |dir: &std::path::Path| -> Vec<std::path::PathBuf> {
+                            let mut with_mtime: Vec<(std::time::SystemTime, std::path::PathBuf)> =
+                                std::fs::read_dir(dir)
+                                    .into_iter()
+                                    .flatten()
+                                    .filter_map(|e| e.ok())
+                                    .filter(|e| {
+                                        e.path().extension().map_or(false, |x| x == "md")
+                                    })
+                                    .filter_map(|e| {
+                                        let mtime =
+                                            e.metadata().and_then(|m| m.modified()).ok()?;
+                                        Some((mtime, e.path()))
+                                    })
+                                    .collect();
+                            with_mtime.sort_by(|a, b| b.0.cmp(&a.0));
+                            with_mtime.into_iter().map(|(_, p)| p).collect()
+                        };
+                        let mut palette_notes: Vec<crate::notes::NotePickerEntry> =
+                            scan_md(&notes_base.join("inbox"))
+                                .iter()
+                                .filter_map(|p| crate::notes::NotePickerEntry::load(p, true))
+                                .collect();
+                        let workspace_slug = crate::config::active_workspace_root()
+                            .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+                            .map(|n| n.to_string_lossy().into_owned());
+                        let notes_dir = match workspace_slug {
+                            Some(ref slug) => notes_base.join(slug),
+                            None => notes_base,
+                        };
+                        palette_notes.extend(
+                            scan_md(&notes_dir)
+                                .iter()
+                                .filter_map(|p| crate::notes::NotePickerEntry::load(p, false)),
+                        );
+                        log::info!(
+                            "palette: loaded {} notes",
+                            palette_notes.len()
+                        );
+                        self.palette_notes = palette_notes;
                     } else {
                         self.palette_workspace_root = None;
+                        self.palette_notes.clear();
                     }
                 }
                 Action::RenamePane => {

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -2143,7 +2143,7 @@ impl App for FileBrowserApp {
                                     body_height,
                                 );
                                 egui::ScrollArea::vertical()
-                                    .id_source("fb_list")
+                                    .id_salt("fb_list")
                                     .auto_shrink([false, false])
                                     .max_height(body_height)
                                     .show(ui, |ui| {
@@ -2194,7 +2194,7 @@ impl App for FileBrowserApp {
                             body_height,
                         );
                         egui::ScrollArea::vertical()
-                            .id_source("fb_list")
+                            .id_salt("fb_list")
                             .auto_shrink([false, false])
                             .max_height(body_height)
                             .show(ui, |ui| {

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1179,6 +1179,7 @@ impl FileBrowserApp {
 
     fn draw_compact_list(&mut self, ui: &mut egui::Ui, colors: &Colors) -> Option<(PathBuf, bool)> {
         let mut navigate_to: Option<(PathBuf, bool)> = None;
+        let should_scroll = self.pending_scroll;
         self.pending_scroll = false;
         for (idx, actual_idx) in self.visible_entry_indices().into_iter().enumerate() {
             let entry = self.entries[actual_idx].clone();
@@ -1192,6 +1193,9 @@ impl FileBrowserApp {
                 .dense()
                 .selected(is_selected)
                 .show(ui, colors);
+            if is_selected {
+                response.scroll_into_view(ui, should_scroll);
+            }
             if response.row_clicked() {
                 let modifiers = ui.input(|input| input.modifiers);
                 if modifiers.shift {
@@ -1215,6 +1219,7 @@ impl FileBrowserApp {
         ui: &mut egui::Ui,
         colors: &Colors,
     ) -> Option<(PathBuf, bool)> {
+        let should_scroll = self.pending_scroll;
         self.pending_scroll = false;
         self.draw_details_header(ui, colors);
 
@@ -1226,6 +1231,9 @@ impl FileBrowserApp {
                 egui::Sense::click(),
             );
             let selected = self.is_entry_selected(idx, &entry);
+            if self.selected == idx {
+                crate::ui::list::scroll_row_into_view(ui, &response, should_scroll);
+            }
             let fill = if selected {
                 colors.bg_active
             } else if response.hovered() {
@@ -2132,17 +2140,10 @@ impl App for FileBrowserApp {
                             egui::vec2(list_width, body_height),
                             egui::Layout::top_down(egui::Align::Min),
                             |ui| {
-                                let fb_scroll_id =
-                                    ui.make_persistent_id(egui::Id::new("fb_list"));
-                                crate::ui::list::keyboard_scroll_update(
-                                    ui.ctx(),
-                                    fb_scroll_id,
-                                    self.selected as f32 * style::LIST_ROW_DENSE_H,
-                                    self.pending_scroll,
-                                    style::LIST_ROW_DENSE_H,
-                                    body_height,
-                                );
                                 egui::ScrollArea::vertical()
+                                    // animated(false): required by scroll_row_into_view —
+                                    // see src/ui/list.rs.
+                                    .animated(false)
                                     .id_salt("fb_list")
                                     .auto_shrink([false, false])
                                     .max_height(body_height)
@@ -2183,17 +2184,10 @@ impl App for FileBrowserApp {
                     });
                 } else {
                     {
-                        let fb_scroll_id =
-                            ui.make_persistent_id(egui::Id::new("fb_list"));
-                        crate::ui::list::keyboard_scroll_update(
-                            ui.ctx(),
-                            fb_scroll_id,
-                            self.selected as f32 * style::LIST_ROW_DENSE_H,
-                            self.pending_scroll,
-                            style::LIST_ROW_DENSE_H,
-                            body_height,
-                        );
                         egui::ScrollArea::vertical()
+                            // animated(false): required by scroll_row_into_view —
+                            // see src/ui/list.rs.
+                            .animated(false)
                             .id_salt("fb_list")
                             .auto_shrink([false, false])
                             .max_height(body_height)

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -2137,7 +2137,7 @@ impl App for FileBrowserApp {
                                 crate::ui::list::keyboard_scroll_update(
                                     ui.ctx(),
                                     fb_scroll_id,
-                                    self.selected,
+                                    self.selected as f32 * style::LIST_ROW_DENSE_H,
                                     self.pending_scroll,
                                     style::LIST_ROW_DENSE_H,
                                     body_height,
@@ -2188,7 +2188,7 @@ impl App for FileBrowserApp {
                         crate::ui::list::keyboard_scroll_update(
                             ui.ctx(),
                             fb_scroll_id,
-                            self.selected,
+                            self.selected as f32 * style::LIST_ROW_DENSE_H,
                             self.pending_scroll,
                             style::LIST_ROW_DENSE_H,
                             body_height,

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1179,7 +1179,6 @@ impl FileBrowserApp {
 
     fn draw_compact_list(&mut self, ui: &mut egui::Ui, colors: &Colors) -> Option<(PathBuf, bool)> {
         let mut navigate_to: Option<(PathBuf, bool)> = None;
-        let should_scroll = self.pending_scroll;
         self.pending_scroll = false;
         for (idx, actual_idx) in self.visible_entry_indices().into_iter().enumerate() {
             let entry = self.entries[actual_idx].clone();
@@ -1193,9 +1192,6 @@ impl FileBrowserApp {
                 .dense()
                 .selected(is_selected)
                 .show(ui, colors);
-            if is_selected && should_scroll {
-                response.scroll_to_me(None);
-            }
             if response.row_clicked() {
                 let modifiers = ui.input(|input| input.modifiers);
                 if modifiers.shift {
@@ -1219,7 +1215,6 @@ impl FileBrowserApp {
         ui: &mut egui::Ui,
         colors: &Colors,
     ) -> Option<(PathBuf, bool)> {
-        let should_scroll = self.pending_scroll;
         self.pending_scroll = false;
         self.draw_details_header(ui, colors);
 
@@ -1230,9 +1225,6 @@ impl FileBrowserApp {
                 egui::vec2(ui.available_width(), DETAILS_ROW_H),
                 egui::Sense::click(),
             );
-            if self.selected == idx && should_scroll {
-                response.scroll_to_me(None);
-            }
             let selected = self.is_entry_selected(idx, &entry);
             let fill = if selected {
                 colors.bg_active
@@ -2140,7 +2132,18 @@ impl App for FileBrowserApp {
                             egui::vec2(list_width, body_height),
                             egui::Layout::top_down(egui::Align::Min),
                             |ui| {
+                                let fb_scroll_id =
+                                    ui.make_persistent_id(egui::Id::new("fb_list"));
+                                crate::ui::list::keyboard_scroll_update(
+                                    ui.ctx(),
+                                    fb_scroll_id,
+                                    self.selected,
+                                    self.pending_scroll,
+                                    style::LIST_ROW_DENSE_H,
+                                    body_height,
+                                );
                                 egui::ScrollArea::vertical()
+                                    .id_source("fb_list")
                                     .auto_shrink([false, false])
                                     .max_height(body_height)
                                     .show(ui, |ui| {
@@ -2179,16 +2182,29 @@ impl App for FileBrowserApp {
                         );
                     });
                 } else {
-                    egui::ScrollArea::vertical()
-                        .auto_shrink([false, false])
-                        .max_height(body_height)
-                        .show(ui, |ui| {
-                            navigate_to = if layout.shows_details() {
-                                self.draw_details_table(ui, colors)
-                            } else {
-                                self.draw_compact_list(ui, colors)
-                            };
-                        });
+                    {
+                        let fb_scroll_id =
+                            ui.make_persistent_id(egui::Id::new("fb_list"));
+                        crate::ui::list::keyboard_scroll_update(
+                            ui.ctx(),
+                            fb_scroll_id,
+                            self.selected,
+                            self.pending_scroll,
+                            style::LIST_ROW_DENSE_H,
+                            body_height,
+                        );
+                        egui::ScrollArea::vertical()
+                            .id_source("fb_list")
+                            .auto_shrink([false, false])
+                            .max_height(body_height)
+                            .show(ui, |ui| {
+                                navigate_to = if layout.shows_details() {
+                                    self.draw_details_table(ui, colors)
+                                } else {
+                                    self.draw_compact_list(ui, colors)
+                                };
+                            });
+                    }
                 }
 
                 self.draw_status_bar(ui, colors, show_inspector);

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -551,7 +551,7 @@ impl PlexiApp {
                     palette_max_list_h,
                 );
                 egui::ScrollArea::vertical()
-                    .id_source("palette_list")
+                    .id_salt("palette_list")
                     .max_height(palette_max_list_h)
                     .min_scrolled_height(palette_max_list_h)
                     .auto_shrink([false, false])

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -28,6 +28,11 @@ enum PaletteEntry {
         running_in_background: bool,
         is_workspace_local: bool,
     },
+    Note {
+        path: std::path::PathBuf,
+        title: String,
+        preview: String,
+    },
 }
 
 pub(crate) fn app_metadata_chips(
@@ -389,6 +394,20 @@ impl PlexiApp {
             });
         }
 
+        // ── Note entries ────────────────────────────────────────────────────
+        for note in &self.palette_notes {
+            let matches = query.is_empty()
+                || note.title.to_lowercase().contains(&query)
+                || note.search_text.contains(&query);
+            if matches {
+                entries.push(PaletteEntry::Note {
+                    path: note.path.clone(),
+                    title: note.title.clone(),
+                    preview: note.preview.clone(),
+                });
+            }
+        }
+
         let total = entries.len();
 
         if self.palette_selected >= total && total > 0 {
@@ -400,6 +419,7 @@ impl PlexiApp {
         enum Action {
             JumpContext(usize, u64, Option<u64>),
             LaunchApp(String),
+            OpenNote(std::path::PathBuf),
         }
         let mut action: Option<Action> = None;
         let prev_selected = self.palette_selected;
@@ -437,6 +457,9 @@ impl PlexiApp {
                     Some(PaletteEntry::App { id, .. }) => {
                         action = Some(Action::LaunchApp(id.clone()));
                     }
+                    Some(PaletteEntry::Note { path, .. }) => {
+                        action = Some(Action::OpenNote(path.clone()));
+                    }
                     None => {}
                 }
             }
@@ -453,6 +476,27 @@ impl PlexiApp {
                 self.show_command_palette = false;
                 self.palette_query.clear();
                 self.launch_app_by_id(&id);
+                return;
+            }
+            Some(Action::OpenNote(path)) => {
+                self.show_command_palette = false;
+                self.palette_query.clear();
+                let active = self.active_window;
+                let path_str = path.display().to_string();
+                if let Some((existing_tile_id, _)) =
+                    self.find_open_text_editor_tile(active, &path)
+                {
+                    log::info!("palette: note already open, focusing pane");
+                    self.set_window_focused_pane(active, existing_tile_id);
+                } else {
+                    log::info!("palette: opening note {:?} in new pane", path);
+                    let _ = self.launch_app_by_id_with_layout(
+                        "text-editor",
+                        None,
+                        &[path_str],
+                        None,
+                    );
+                }
                 return;
             }
             None => {}
@@ -494,8 +538,20 @@ impl PlexiApp {
                 let mouse_moved = ctx.input(|i| i.pointer.delta().length_sq() > 0.5);
                 let should_scroll = self.palette_selected != prev_selected;
                 let mut shown_apps_header = false;
+                let mut shown_notes_header = false;
 
+                let palette_scroll_id =
+                    ui.make_persistent_id(egui::Id::new("palette_list"));
+                crate::ui::list::keyboard_scroll_update(
+                    ctx,
+                    palette_scroll_id,
+                    self.palette_selected,
+                    should_scroll,
+                    style::LIST_ROW_H,
+                    palette_max_list_h,
+                );
                 egui::ScrollArea::vertical()
+                    .id_source("palette_list")
                     .max_height(palette_max_list_h)
                     .min_scrolled_height(palette_max_list_h)
                     .auto_shrink([false, false])
@@ -527,9 +583,6 @@ impl PlexiApp {
                                     }
                                     let row_response = row.show(ui, &colors);
 
-                                    if is_selected && should_scroll {
-                                        row_response.scroll_to_me(None);
-                                    }
                                     if row_response.row_clicked() {
                                         click_action = Some(Action::JumpContext(
                                             *ctx_idx,
@@ -569,11 +622,32 @@ impl PlexiApp {
 
                                     let row_response = row.show(ui, &colors);
 
-                                    if is_selected && should_scroll {
-                                        row_response.scroll_to_me(None);
-                                    }
                                     if row_response.row_clicked() {
                                         click_action = Some(Action::LaunchApp(id.clone()));
+                                    }
+                                    if row_response.row_hovered() {
+                                        hover_select = Some(i);
+                                    }
+                                }
+                                PaletteEntry::Note { path, title, preview } => {
+                                    if !shown_notes_header {
+                                        shown_notes_header = true;
+                                        ui.add_space(style::SPACE_XS);
+                                        ui.label(
+                                            RichText::new("NOTES")
+                                                .size(style::TEXT_HINT)
+                                                .color(colors.text_dim),
+                                        );
+                                        ui.add_space(style::SPACE_XS);
+                                    }
+                                    let row = ListRow::new(title.as_str())
+                                        .chip("txt")
+                                        .secondary(preview.as_str())
+                                        .selected(is_selected);
+                                    let row_response = row.show(ui, &colors);
+                                    if row_response.row_clicked() {
+                                        click_action =
+                                            Some(Action::OpenNote(path.clone()));
                                     }
                                     if row_response.row_hovered() {
                                         hover_select = Some(i);
@@ -608,6 +682,31 @@ impl PlexiApp {
                             self.show_command_palette = false;
                             self.palette_query.clear();
                             self.launch_app_by_id(&id);
+                        }
+                        Action::OpenNote(path) => {
+                            self.show_command_palette = false;
+                            self.palette_query.clear();
+                            let active = self.active_window;
+                            let path_str = path.display().to_string();
+                            if let Some((existing_tile_id, _)) =
+                                self.find_open_text_editor_tile(active, &path)
+                            {
+                                log::info!(
+                                    "palette: note already open, focusing pane"
+                                );
+                                self.set_window_focused_pane(active, existing_tile_id);
+                            } else {
+                                log::info!(
+                                    "palette: opening note {:?} in new pane",
+                                    path
+                                );
+                                let _ = self.launch_app_by_id_with_layout(
+                                    "text-editor",
+                                    None,
+                                    &[path_str],
+                                    None,
+                                );
+                            }
                         }
                     }
                 }

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -540,29 +540,9 @@ impl PlexiApp {
                 let mut shown_apps_header = false;
                 let mut shown_notes_header = false;
 
-                let palette_scroll_id =
-                    ui.make_persistent_id(egui::Id::new("palette_list"));
-                {
-                    // Account for inline APPS/NOTES section headers above the selected row.
-                    let first_app = entries.iter().position(|e| matches!(e, PaletteEntry::App { .. }));
-                    let first_note = entries.iter().position(|e| matches!(e, PaletteEntry::Note { .. }));
-                    let headers_above: f32 = [first_app, first_note]
-                        .into_iter()
-                        .flatten()
-                        .filter(|&k| self.palette_selected >= k)
-                        .map(|_| style::INLINE_SECTION_H)
-                        .sum();
-                    let row_top_px = self.palette_selected as f32 * style::LIST_ROW_H + headers_above;
-                    crate::ui::list::keyboard_scroll_update(
-                        ctx,
-                        palette_scroll_id,
-                        row_top_px,
-                        should_scroll,
-                        style::LIST_ROW_H,
-                        palette_max_list_h,
-                    );
-                }
                 egui::ScrollArea::vertical()
+                    // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
+                    .animated(false)
                     .id_salt("palette_list")
                     .max_height(palette_max_list_h)
                     .min_scrolled_height(palette_max_list_h)
@@ -594,6 +574,9 @@ impl PlexiApp {
                                         row = row.pane_pips(pips);
                                     }
                                     let row_response = row.show(ui, &colors);
+                                    if is_selected {
+                                        row_response.scroll_into_view(ui, should_scroll);
+                                    }
 
                                     if row_response.row_clicked() {
                                         click_action = Some(Action::JumpContext(
@@ -633,6 +616,9 @@ impl PlexiApp {
                                         .selected(is_selected);
 
                                     let row_response = row.show(ui, &colors);
+                                    if is_selected {
+                                        row_response.scroll_into_view(ui, should_scroll);
+                                    }
 
                                     if row_response.row_clicked() {
                                         click_action = Some(Action::LaunchApp(id.clone()));
@@ -657,6 +643,9 @@ impl PlexiApp {
                                         .secondary(preview.as_str())
                                         .selected(is_selected);
                                     let row_response = row.show(ui, &colors);
+                                    if is_selected {
+                                        row_response.scroll_into_view(ui, should_scroll);
+                                    }
                                     if row_response.row_clicked() {
                                         click_action =
                                             Some(Action::OpenNote(path.clone()));

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -542,14 +542,26 @@ impl PlexiApp {
 
                 let palette_scroll_id =
                     ui.make_persistent_id(egui::Id::new("palette_list"));
-                crate::ui::list::keyboard_scroll_update(
-                    ctx,
-                    palette_scroll_id,
-                    self.palette_selected,
-                    should_scroll,
-                    style::LIST_ROW_H,
-                    palette_max_list_h,
-                );
+                {
+                    // Account for inline APPS/NOTES section headers above the selected row.
+                    let first_app = entries.iter().position(|e| matches!(e, PaletteEntry::App { .. }));
+                    let first_note = entries.iter().position(|e| matches!(e, PaletteEntry::Note { .. }));
+                    let headers_above: f32 = [first_app, first_note]
+                        .into_iter()
+                        .flatten()
+                        .filter(|&k| self.palette_selected >= k)
+                        .map(|_| style::INLINE_SECTION_H)
+                        .sum();
+                    let row_top_px = self.palette_selected as f32 * style::LIST_ROW_H + headers_above;
+                    crate::ui::list::keyboard_scroll_update(
+                        ctx,
+                        palette_scroll_id,
+                        row_top_px,
+                        should_scroll,
+                        style::LIST_ROW_H,
+                        palette_max_list_h,
+                    );
+                }
                 egui::ScrollArea::vertical()
                     .id_salt("palette_list")
                     .max_height(palette_max_list_h)

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -456,7 +456,7 @@ impl PlexiApp {
                     320.0,
                 );
                 egui::ScrollArea::vertical()
-                    .id_source("notes_picker_list")
+                    .id_salt("notes_picker_list")
                     .max_height(320.0)
                     .show(ui, |ui| {
                         ui.set_width(ui.available_width());

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -447,14 +447,34 @@ impl PlexiApp {
                 let mut shown_kept_header = false;
                 let notes_scroll_id =
                     ui.make_persistent_id(egui::Id::new("notes_picker_list"));
-                crate::ui::list::keyboard_scroll_update(
-                    ui.ctx(),
-                    notes_scroll_id,
-                    selected,
-                    selected != prev_selected_cell.get(),
-                    style::LIST_ROW_H,
-                    320.0,
-                );
+                {
+                    // Account for inline section headers above the selected row.
+                    let first_inbox = filtered
+                        .iter()
+                        .position(|&i| self.notes_picker_entries[i].inbox);
+                    let first_kept = filtered
+                        .iter()
+                        .position(|&i| !self.notes_picker_entries[i].inbox);
+                    // "Inbox" block: label + SPACE_XS (no leading space, it's at the top)
+                    let inbox_h = style::TEXT_CAPTION + 4.0 + style::SPACE_XS;
+                    // "Notes" block: SPACE_XS (only when inbox section also shown) + label + SPACE_XS
+                    let kept_h = if first_inbox.is_some() { style::SPACE_XS } else { 0.0 }
+                        + style::TEXT_CAPTION
+                        + 4.0
+                        + style::SPACE_XS;
+                    let headers_above: f32 =
+                        first_inbox.filter(|&k| selected >= k).map(|_| inbox_h).unwrap_or(0.0)
+                        + first_kept.filter(|&k| selected >= k).map(|_| kept_h).unwrap_or(0.0);
+                    let row_top_px = selected as f32 * style::LIST_ROW_H + headers_above;
+                    crate::ui::list::keyboard_scroll_update(
+                        ui.ctx(),
+                        notes_scroll_id,
+                        row_top_px,
+                        selected != prev_selected_cell.get(),
+                        style::LIST_ROW_H,
+                        320.0,
+                    );
+                }
                 egui::ScrollArea::vertical()
                     .id_salt("notes_picker_list")
                     .max_height(320.0)

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -445,7 +445,18 @@ impl PlexiApp {
 
                 let mut shown_inbox_header = false;
                 let mut shown_kept_header = false;
+                let notes_scroll_id =
+                    ui.make_persistent_id(egui::Id::new("notes_picker_list"));
+                crate::ui::list::keyboard_scroll_update(
+                    ui.ctx(),
+                    notes_scroll_id,
+                    selected,
+                    selected != prev_selected_cell.get(),
+                    style::LIST_ROW_H,
+                    320.0,
+                );
                 egui::ScrollArea::vertical()
+                    .id_source("notes_picker_list")
                     .max_height(320.0)
                     .show(ui, |ui| {
                         ui.set_width(ui.available_width());
@@ -486,9 +497,6 @@ impl PlexiApp {
                                 .danger_trailing(true)
                                 .selected(is_selected)
                                 .show(ui, &colors);
-                            if is_selected && selected != prev_selected_cell.get() {
-                                row_response.scroll_to_me(None);
-                            }
                             if row_response.row_clicked() && !row_response.trailing_clicked() {
                                 open_cell.set(Some(row));
                             }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -445,37 +445,9 @@ impl PlexiApp {
 
                 let mut shown_inbox_header = false;
                 let mut shown_kept_header = false;
-                let notes_scroll_id =
-                    ui.make_persistent_id(egui::Id::new("notes_picker_list"));
-                {
-                    // Account for inline section headers above the selected row.
-                    let first_inbox = filtered
-                        .iter()
-                        .position(|&i| self.notes_picker_entries[i].inbox);
-                    let first_kept = filtered
-                        .iter()
-                        .position(|&i| !self.notes_picker_entries[i].inbox);
-                    // "Inbox" block: label + SPACE_XS (no leading space, it's at the top)
-                    let inbox_h = style::TEXT_CAPTION + 4.0 + style::SPACE_XS;
-                    // "Notes" block: SPACE_XS (only when inbox section also shown) + label + SPACE_XS
-                    let kept_h = if first_inbox.is_some() { style::SPACE_XS } else { 0.0 }
-                        + style::TEXT_CAPTION
-                        + 4.0
-                        + style::SPACE_XS;
-                    let headers_above: f32 =
-                        first_inbox.filter(|&k| selected >= k).map(|_| inbox_h).unwrap_or(0.0)
-                        + first_kept.filter(|&k| selected >= k).map(|_| kept_h).unwrap_or(0.0);
-                    let row_top_px = selected as f32 * style::LIST_ROW_H + headers_above;
-                    crate::ui::list::keyboard_scroll_update(
-                        ui.ctx(),
-                        notes_scroll_id,
-                        row_top_px,
-                        selected != prev_selected_cell.get(),
-                        style::LIST_ROW_H,
-                        320.0,
-                    );
-                }
                 egui::ScrollArea::vertical()
+                    // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
+                    .animated(false)
                     .id_salt("notes_picker_list")
                     .max_height(320.0)
                     .show(ui, |ui| {
@@ -517,6 +489,10 @@ impl PlexiApp {
                                 .danger_trailing(true)
                                 .selected(is_selected)
                                 .show(ui, &colors);
+                            if is_selected {
+                                row_response
+                                    .scroll_into_view(ui, selected != prev_selected_cell.get());
+                            }
                             if row_response.row_clicked() && !row_response.trailing_clicked() {
                                 open_cell.set(Some(row));
                             }

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -281,10 +281,6 @@ impl ListRowResponse {
         self.row.hovered()
     }
 
-    pub fn scroll_to_me(&self, align: Option<egui::Align>) {
-        self.row.scroll_to_me(align);
-    }
-
     pub fn trailing_clicked(&self) -> bool {
         self.trailing.as_ref().is_some_and(Response::clicked)
     }
@@ -430,6 +426,38 @@ pub fn paint_selection(painter: &egui::Painter, row_rect: egui::Rect, colors: &C
     for shape in selection_shapes(row_rect, colors) {
         painter.add(shape);
     }
+}
+
+/// Pre-scrolls a `ScrollArea` so the selected row is fully visible in the CURRENT
+/// frame, avoiding the one-frame jitter from `Response::scroll_to_me`.
+///
+/// Call BEFORE `ScrollArea::show()`. `scroll_id` must match the id used by the
+/// scroll area (i.e. `ui.make_persistent_id(egui::Id::new("my_scroll"))`).
+pub(crate) fn keyboard_scroll_update(
+    ctx: &egui::Context,
+    scroll_id: egui::Id,
+    selected_idx: usize,
+    should_scroll: bool,
+    row_h: f32,
+    visible_h: f32,
+) {
+    if !should_scroll {
+        return;
+    }
+    let mut state =
+        egui::containers::scroll_area::State::load(ctx, scroll_id).unwrap_or_default();
+    let current = state.offset.y;
+    let row_top = selected_idx as f32 * row_h;
+    let row_bottom = row_top + row_h;
+    let new_offset = if row_top < current {
+        row_top
+    } else if row_bottom > current + visible_h {
+        row_bottom - visible_h
+    } else {
+        return; // already fully visible
+    };
+    state.offset.y = new_offset.max(0.0);
+    state.store(ctx, scroll_id);
 }
 
 /// Trailing actions sit further off the row edge than body content — they are
@@ -649,6 +677,40 @@ mod tests {
                 pip_top - chip_bottom >= style::SPACE_SM,
                 "compact metadata pips need visible padding below the chip"
             );
+        });
+        let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn keyboard_scroll_update_scrolls_down_past_fold() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let id = ui.make_persistent_id(egui::Id::new("ks_test_down"));
+            // selected=6, row_h=48, visible_h=200 → row_bottom=336 > 200 → offset = 136
+            keyboard_scroll_update(&ctx, id, 6, true, 48.0, 200.0);
+            let state = egui::containers::scroll_area::State::load(&ctx, id)
+                .expect("state written");
+            assert_eq!(state.offset.y, 6.0 * 48.0 + 48.0 - 200.0);
+        });
+        let _ = ctx.end_pass();
+    }
+
+    #[test]
+    fn keyboard_scroll_update_scrolls_up_when_above_viewport() {
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            let id = ui.make_persistent_id(egui::Id::new("ks_test_up"));
+            // Pre-set scroll to 300
+            let mut state = egui::containers::scroll_area::State::default();
+            state.offset.y = 300.0;
+            state.store(&ctx, id);
+            // selected=2 → row_top=96 < 300 → offset should become 96
+            keyboard_scroll_update(&ctx, id, 2, true, 48.0, 200.0);
+            let state = egui::containers::scroll_area::State::load(&ctx, id)
+                .expect("state written");
+            assert_eq!(state.offset.y, 2.0 * 48.0);
         });
         let _ = ctx.end_pass();
     }

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -284,6 +284,11 @@ impl ListRowResponse {
     pub fn trailing_clicked(&self) -> bool {
         self.trailing.as_ref().is_some_and(Response::clicked)
     }
+
+    /// See [`scroll_row_into_view`].
+    pub fn scroll_into_view(&self, ui: &egui::Ui, selection_changed: bool) {
+        scroll_row_into_view(ui, &self.row, selection_changed);
+    }
 }
 
 /// Paints the primary title (and optional secondary line) and returns the
@@ -428,38 +433,34 @@ pub fn paint_selection(painter: &egui::Painter, row_rect: egui::Rect, colors: &C
     }
 }
 
-/// Pre-scrolls a `ScrollArea` so the selected row is fully visible in the CURRENT
-/// frame, avoiding the one-frame jitter from `Response::scroll_to_me`.
+/// Keeps the selected row of a keyboard-navigated list fully visible.
 ///
-/// Call BEFORE `ScrollArea::show()`. `scroll_id` must match the id used by the
-/// scroll area (i.e. `ui.make_persistent_id(egui::Id::new("my_scroll"))`).
-/// `row_top_px` is the pixel offset of the selected row's top edge within the
-/// scroll area (i.e. `idx * row_h + any_header_px_above`).
-pub(crate) fn keyboard_scroll_update(
-    ctx: &egui::Context,
-    scroll_id: egui::Id,
-    row_top_px: f32,
-    should_scroll: bool,
-    row_h: f32,
-    visible_h: f32,
-) {
-    if !should_scroll {
+/// Call on the selected row's response inside the `ScrollArea`, every frame,
+/// passing whether the selection changed this frame. egui already measured the
+/// row's rect, so geometry (section headers, item spacing, dense rows) is
+/// always exact — never compute row offsets by hand.
+///
+/// The enclosing `ScrollArea` MUST be built with `.animated(false)`. With the
+/// default `animated(true)`, `scroll_to_me` routes through the ScrollArea's
+/// `offset_target` animation state and the new offset is never applied to the
+/// pass being presented — the scroll permanently lags the selection under
+/// key-repeat, which is the original #2217 jitter. With `animated(false)` the
+/// offset is written synchronously in the ScrollArea's `end()`, so the
+/// discarded re-pass below renders at the corrected offset.
+///
+/// `request_discard` makes selection and scroll move atomically: the stale
+/// pass is thrown away and only the corrected one is presented. Event-driven
+/// input is safe across the re-run — `Context::run` hands `RawInput::take()`
+/// to each pass, so key events fire exactly once.
+pub(crate) fn scroll_row_into_view(ui: &egui::Ui, row: &egui::Response, selection_changed: bool) {
+    if !selection_changed {
         return;
     }
-    let mut state =
-        egui::containers::scroll_area::State::load(ctx, scroll_id).unwrap_or_default();
-    let current = state.offset.y;
-    let row_top = row_top_px;
-    let row_bottom = row_top + row_h;
-    let new_offset = if row_top < current {
-        row_top
-    } else if row_bottom > current + visible_h {
-        row_bottom - visible_h
-    } else {
-        return; // already fully visible
-    };
-    state.offset.y = new_offset.max(0.0);
-    state.store(ctx, scroll_id);
+    if ui.clip_rect().contains_rect(row.rect) {
+        return; // already fully visible — no scroll, no extra pass
+    }
+    row.scroll_to_me(None);
+    ui.ctx().request_discard("keyboard list scroll");
 }
 
 /// Trailing actions sit further off the row edge than body content — they are
@@ -683,38 +684,53 @@ mod tests {
         let _ = ctx.end_pass();
     }
 
-    #[test]
-    fn keyboard_scroll_update_scrolls_down_past_fold() {
-        let ctx = egui::Context::default();
-        ctx.begin_pass(egui::RawInput::default());
-        egui::CentralPanel::default().show(&ctx, |ui| {
-            let id = ui.make_persistent_id(egui::Id::new("ks_test_down"));
-            // row_top=288 (6*48), row_h=48, visible_h=200 → row_bottom=336 > 200 → offset = 136
-            keyboard_scroll_update(&ctx, id, 6.0 * 48.0, true, 48.0, 200.0);
-            let state = egui::containers::scroll_area::State::load(&ctx, id)
-                .expect("state written");
-            assert_eq!(state.offset.y, 6.0 * 48.0 + 48.0 - 200.0);
+    /// Drives one frame of a 30-row list with the given selection and reports
+    /// whether the selected row's rect ended up fully inside the scroll
+    /// viewport. Uses real egui layout — row spacing, section headers, and
+    /// scroll state all behave exactly as in the app.
+    fn run_list_frame(ctx: &egui::Context, selected: usize) -> bool {
+        let mut visible = false;
+        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                egui::ScrollArea::vertical()
+                    .animated(false)
+                    .id_salt("scroll_into_view_test")
+                    .max_height(200.0)
+                    .show(ui, |ui| {
+                        for i in 0..30 {
+                            // Mimic the palette's inline section header midway
+                            // through the list — non-uniform content is the
+                            // case the old index*row_h math got wrong.
+                            if i == 10 {
+                                ui.label("SECTION");
+                            }
+                            let (rect, resp) = ui.allocate_exact_size(
+                                egui::vec2(120.0, 48.0),
+                                egui::Sense::click(),
+                            );
+                            scroll_row_into_view(ui, &resp, i == selected);
+                            if i == selected {
+                                visible = ui.clip_rect().contains_rect(rect);
+                            }
+                        }
+                    });
+            });
         });
-        let _ = ctx.end_pass();
+        visible
     }
 
     #[test]
-    fn keyboard_scroll_update_scrolls_up_when_above_viewport() {
+    fn scroll_row_into_view_keeps_selection_visible_past_fold() {
         let ctx = egui::Context::default();
-        ctx.begin_pass(egui::RawInput::default());
-        egui::CentralPanel::default().show(&ctx, |ui| {
-            let id = ui.make_persistent_id(egui::Id::new("ks_test_up"));
-            // Pre-set scroll to 300
-            let mut state = egui::containers::scroll_area::State::default();
-            state.offset.y = 300.0;
-            state.store(&ctx, id);
-            // row_top=96 (2*48) < 300 → offset should become 96
-            keyboard_scroll_update(&ctx, id, 2.0 * 48.0, true, 48.0, 200.0);
-            let state = egui::containers::scroll_area::State::load(&ctx, id)
-                .expect("state written");
-            assert_eq!(state.offset.y, 2.0 * 48.0);
-        });
-        let _ = ctx.end_pass();
+        // Walk the selection down past the fold and back up; the selected row
+        // must be fully visible on the frame the selection changes (the
+        // request_discard re-pass renders at the corrected offset).
+        for &selected in &[0usize, 8, 17, 29, 12, 3, 0] {
+            assert!(
+                run_list_frame(&ctx, selected),
+                "row {selected} not fully visible after scroll_row_into_view"
+            );
+        }
     }
 
     #[test]

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -433,10 +433,12 @@ pub fn paint_selection(painter: &egui::Painter, row_rect: egui::Rect, colors: &C
 ///
 /// Call BEFORE `ScrollArea::show()`. `scroll_id` must match the id used by the
 /// scroll area (i.e. `ui.make_persistent_id(egui::Id::new("my_scroll"))`).
+/// `row_top_px` is the pixel offset of the selected row's top edge within the
+/// scroll area (i.e. `idx * row_h + any_header_px_above`).
 pub(crate) fn keyboard_scroll_update(
     ctx: &egui::Context,
     scroll_id: egui::Id,
-    selected_idx: usize,
+    row_top_px: f32,
     should_scroll: bool,
     row_h: f32,
     visible_h: f32,
@@ -447,7 +449,7 @@ pub(crate) fn keyboard_scroll_update(
     let mut state =
         egui::containers::scroll_area::State::load(ctx, scroll_id).unwrap_or_default();
     let current = state.offset.y;
-    let row_top = selected_idx as f32 * row_h;
+    let row_top = row_top_px;
     let row_bottom = row_top + row_h;
     let new_offset = if row_top < current {
         row_top
@@ -687,8 +689,8 @@ mod tests {
         ctx.begin_pass(egui::RawInput::default());
         egui::CentralPanel::default().show(&ctx, |ui| {
             let id = ui.make_persistent_id(egui::Id::new("ks_test_down"));
-            // selected=6, row_h=48, visible_h=200 → row_bottom=336 > 200 → offset = 136
-            keyboard_scroll_update(&ctx, id, 6, true, 48.0, 200.0);
+            // row_top=288 (6*48), row_h=48, visible_h=200 → row_bottom=336 > 200 → offset = 136
+            keyboard_scroll_update(&ctx, id, 6.0 * 48.0, true, 48.0, 200.0);
             let state = egui::containers::scroll_area::State::load(&ctx, id)
                 .expect("state written");
             assert_eq!(state.offset.y, 6.0 * 48.0 + 48.0 - 200.0);
@@ -706,8 +708,8 @@ mod tests {
             let mut state = egui::containers::scroll_area::State::default();
             state.offset.y = 300.0;
             state.store(&ctx, id);
-            // selected=2 → row_top=96 < 300 → offset should become 96
-            keyboard_scroll_update(&ctx, id, 2, true, 48.0, 200.0);
+            // row_top=96 (2*48) < 300 → offset should become 96
+            keyboard_scroll_update(&ctx, id, 2.0 * 48.0, true, 48.0, 200.0);
             let state = egui::containers::scroll_area::State::load(&ctx, id)
                 .expect("state written");
             assert_eq!(state.offset.y, 2.0 * 48.0);

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -68,10 +68,6 @@ pub const BUTTON_H_LG: f32 = 52.0; // Primary action buttons in modals.
 // the selection highlight; 14 horizontal padding keeps the title clear of
 // the highlight's left edge — 10 read as cramped against the outline.
 pub const LIST_ROW_H: f32 = 48.0;
-// Approximate height of an inline section-header block (space + label + space).
-// Used by keyboard_scroll_update callers that insert headers inside a ScrollArea.
-// Computed as SPACE_XS + font_row_h(TEXT_HINT) + SPACE_XS where font_row_h ≈ TEXT_HINT + 4.
-pub const INLINE_SECTION_H: f32 = SPACE_XS + TEXT_HINT + 4.0 + SPACE_XS; // ≈ 23
 // Dense single-line variant for data-dense listings (file browser rows).
 // 30 fits one 12pt medium line with ~7px of air — the file-explorer PRD's
 // 28-32px density target. The 48px two-line row above is for pickers.

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -68,6 +68,10 @@ pub const BUTTON_H_LG: f32 = 52.0; // Primary action buttons in modals.
 // the selection highlight; 14 horizontal padding keeps the title clear of
 // the highlight's left edge — 10 read as cramped against the outline.
 pub const LIST_ROW_H: f32 = 48.0;
+// Approximate height of an inline section-header block (space + label + space).
+// Used by keyboard_scroll_update callers that insert headers inside a ScrollArea.
+// Computed as SPACE_XS + font_row_h(TEXT_HINT) + SPACE_XS where font_row_h ≈ TEXT_HINT + 4.
+pub const INLINE_SECTION_H: f32 = SPACE_XS + TEXT_HINT + 4.0 + SPACE_XS; // ≈ 23
 // Dense single-line variant for data-dense listings (file browser rows).
 // 30 fits one 12pt medium line with ~7px of air — the file-explorer PRD's
 // 28-32px density target. The 48px two-line row above is for pickers.


### PR DESCRIPTION
Closes #2217, Closes #2222

## Summary

**#2217 — fix(ui): keyboard list navigation jitters**
- Added `keyboard_scroll_update` helper in `src/ui/list.rs` that pre-sets the ScrollArea's persisted offset before `show()` — eliminates the one-frame lag from `Response::scroll_to_me`
- Applied to all four sites: Cmd+P palette, notes picker, file browser compact list, file browser details table
- Removed dead `scroll_to_me` wrapper from `ListRowResponse`; added 2 unit tests

**#2222 — feat(command-palette): notes as palette entries with a txt type chip**
- Added `PaletteEntry::Note` variant populated from inbox + workspace notes at palette-open time (reuses `NotePickerEntry::load`, no new note-loading code)
- Renders with a "NOTES" section header and `txt` chip, respects fuzzy query
- Activation: jumps to existing pane if note is already open, otherwise opens a new `text-editor` pane

## Done When — #2217
- Holding j/k or arrows in Cmd+P scrolls smoothly with the highlight always fully visible (manual check), and a test covers selection-follows-scroll for the palette.

## Done When — #2222
- Cmd+P, type part of a note title → note row with a txt chip appears; Enter opens it in a text-editor pane, or focuses the existing pane if already open. UI smoke test covers palette-shows-notes.