### PR TITLE
fix: cursor height + scratchpad dedup (#2218, #2221)

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -30,6 +30,7 @@ pub struct TextEditorApp {
     wants_close: bool,
     load_error: Option<String>,
     font_size: f32,
+    cursor_blink_start: f64,
 }
 
 impl TextEditorApp {
@@ -53,6 +54,7 @@ impl TextEditorApp {
             wants_close: false,
             load_error,
             font_size: FONT_SIZE_DEFAULT,
+            cursor_blink_start: 0.0,
         }
     }
 
@@ -484,14 +486,69 @@ impl App for TextEditorApp {
         egui::ScrollArea::vertical()
             .auto_shrink([false, false])
             .show(ui, |ui| {
-                let output = egui::TextEdit::multiline(&mut self.content)
-                    .id(te_id)
-                    .font(font_id)
-                    .desired_width(f32::INFINITY)
-                    .desired_rows(min_rows)
-                    .margin(egui::vec2(4.0, 0.0))
-                    .frame(false)
-                    .show(ui);
+                let output = ui.scope(|ui| {
+                    ui.visuals_mut().text_cursor.blink = false;
+                    ui.visuals_mut().text_cursor.stroke =
+                        egui::Stroke::new(2.0, colors.accent);
+                    egui::TextEdit::multiline(&mut self.content)
+                        .id(te_id)
+                        .font(font_id)
+                        .desired_width(f32::INFINITY)
+                        .desired_rows(min_rows)
+                        .margin(egui::vec2(4.0, 0.0))
+                        .frame(false)
+                        .show(ui)
+                }).inner;
+
+                // Erase egui's full-height cursor and draw a shorter one matching font_size.
+                if output.response.has_focus() {
+                    let now = ui.ctx().input(|i| i.time);
+                    if output.response.changed() || output.response.gained_focus() {
+                        self.cursor_blink_start = now;
+                    }
+                    if let Some(cursor_range) = &output.cursor_range {
+                        let primary = cursor_range.primary;
+                        let cursor_pos = output.galley.pos_from_cursor(&primary);
+                        let row_h = if cursor_pos.height() > 0.01 {
+                            cursor_pos.height()
+                        } else {
+                            row_height
+                        };
+                        let erase_rect = egui::Rect::from_min_max(
+                            egui::pos2(
+                                output.galley_pos.x + cursor_pos.center().x - 2.0,
+                                output.galley_pos.y + cursor_pos.min.y - 2.0,
+                            ),
+                            egui::pos2(
+                                output.galley_pos.x + cursor_pos.center().x + 2.0,
+                                output.galley_pos.y + cursor_pos.min.y + row_h + 2.0,
+                            ),
+                        );
+                        ui.painter().rect_filled(erase_rect, 0.0, colors.terminal_bg);
+                        let on = 0.5_f64;
+                        let off = 0.5_f64;
+                        let t = (now - self.cursor_blink_start) % (on + off);
+                        if t < on {
+                            let target_h = self.font_size;
+                            let row_top = output.galley_pos.y + cursor_pos.min.y;
+                            let start_y = row_top + (row_h - target_h) * 0.5;
+                            let cx = output.galley_pos.x + cursor_pos.center().x;
+                            ui.painter().line_segment(
+                                [
+                                    egui::pos2(cx, start_y),
+                                    egui::pos2(cx, start_y + target_h),
+                                ],
+                                egui::Stroke::new(2.0, colors.accent),
+                            );
+                        }
+                        let wake = if t < on {
+                            (on - t) as f32
+                        } else {
+                            (on + off - t) as f32
+                        };
+                        ui.ctx().request_repaint_after_secs(wake);
+                    }
+                }
 
                 if output.response.changed() {
                     self.last_edit = Some(Instant::now());

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -111,22 +111,109 @@ impl PlexiApp {
                             .max_height(max_text_h)
                             .show(ui, |ui| {
                                 ui.scope(|ui| {
-                                    ui.visuals_mut().text_cursor.stroke.width = 1.5;
-                                    ui.visuals_mut().text_cursor.stroke.color = self.colors.accent;
-                                    ui.add(
-                                        egui::TextEdit::multiline(&mut self.quick_note_text)
-                                            .id(egui::Id::new("quick_note_text"))
-                                            .font(egui::FontId::monospace(style::TEXT_BODY))
-                                            .text_color(self.colors.text_primary)
-                                            .desired_width(f32::INFINITY)
-                                            .desired_rows(initial_rows)
-                                            .frame(false)
-                                            .hint_text(
-                                                RichText::new("What's on your mind?")
-                                                    .color(self.colors.text_dim.linear_multiply(0.3))
-                                                    .size(style::TEXT_BODY),
-                                            ),
-                                    );
+                                    ui.visuals_mut().text_cursor.blink = false;
+                                    ui.visuals_mut().text_cursor.stroke =
+                                        egui::Stroke::new(1.5, self.colors.accent);
+
+                                    let te_id = egui::Id::new("quick_note_text");
+                                    let qn_font_id = egui::FontId::monospace(style::TEXT_BODY);
+                                    let qn_row_height =
+                                        ui.fonts(|f| f.row_height(&qn_font_id));
+                                    let output = egui::TextEdit::multiline(
+                                        &mut self.quick_note_text,
+                                    )
+                                    .id(te_id)
+                                    .font(qn_font_id)
+                                    .text_color(self.colors.text_primary)
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(initial_rows)
+                                    .frame(false)
+                                    .hint_text(
+                                        RichText::new("What's on your mind?")
+                                            .color(
+                                                self.colors.text_dim.linear_multiply(0.3),
+                                            )
+                                            .size(style::TEXT_BODY),
+                                    )
+                                    .show(ui);
+
+                                    if output.response.has_focus() {
+                                        let blink_key =
+                                            egui::Id::new("quick_note_cursor_blink");
+                                        let now = ui.ctx().input(|i| i.time);
+                                        if output.response.changed()
+                                            || output.response.gained_focus()
+                                        {
+                                            ui.ctx().data_mut(|d| {
+                                                d.insert_temp(blink_key, now)
+                                            });
+                                        }
+                                        let blink_start: f64 = ui.ctx().data(|d| {
+                                            d.get_temp(blink_key).unwrap_or(0.0_f64)
+                                        });
+                                        if let Some(cursor_range) = &output.cursor_range {
+                                            let primary = cursor_range.primary;
+                                            let cursor_pos =
+                                                output.galley.pos_from_cursor(&primary);
+                                            let row_h = if cursor_pos.height() > 0.01 {
+                                                cursor_pos.height()
+                                            } else {
+                                                qn_row_height
+                                            };
+                                            let erase_rect = egui::Rect::from_min_max(
+                                                egui::pos2(
+                                                    output.galley_pos.x
+                                                        + cursor_pos.center().x
+                                                        - 2.0,
+                                                    output.galley_pos.y
+                                                        + cursor_pos.min.y
+                                                        - 2.0,
+                                                ),
+                                                egui::pos2(
+                                                    output.galley_pos.x
+                                                        + cursor_pos.center().x
+                                                        + 2.0,
+                                                    output.galley_pos.y
+                                                        + cursor_pos.min.y
+                                                        + row_h
+                                                        + 2.0,
+                                                ),
+                                            );
+                                            ui.painter().rect_filled(
+                                                erase_rect,
+                                                0.0,
+                                                self.colors.bg_sidebar,
+                                            );
+                                            let on = 0.5_f64;
+                                            let off = 0.5_f64;
+                                            let t = (now - blink_start) % (on + off);
+                                            if t < on {
+                                                let target_h = style::TEXT_BODY;
+                                                let row_top = output.galley_pos.y
+                                                    + cursor_pos.min.y;
+                                                let start_y =
+                                                    row_top + (row_h - target_h) * 0.5;
+                                                let cx = output.galley_pos.x
+                                                    + cursor_pos.center().x;
+                                                ui.painter().line_segment(
+                                                    [
+                                                        egui::pos2(cx, start_y),
+                                                        egui::pos2(cx, start_y + target_h),
+                                                    ],
+                                                    egui::Stroke::new(
+                                                        1.5,
+                                                        self.colors.accent,
+                                                    ),
+                                                );
+                                            }
+                                            let wake = if t < on {
+                                                (on - t) as f32
+                                            } else {
+                                                (on + off - t) as f32
+                                            };
+                                            ui.ctx().request_repaint_after_secs(wake);
+                                        }
+                                    }
                                 });
                             });
                     }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1179,15 +1179,8 @@ impl PlexiApp {
     ///
     /// Works from any focused pane type (terminal, app, file browser).
     pub(crate) fn open_scratchpad(&mut self) {
+        log::info!("scratchpad: opening new scratch note");
         let active = self.active_window;
-
-        // If an open editor still holds an untouched scratch note (body empty
-        // on disk), focus it instead of stacking another empty note.
-        if let Some((tile_id, pane_id)) = self.find_open_empty_inbox_editor(active) {
-            log::info!("scratchpad: empty scratch note already open in pane {pane_id}, focusing");
-            self.set_window_focused_pane(active, tile_id);
-            return;
-        }
 
         // Capture context like a quick note so triage shows where it came from.
         let cwd = self.windows[active]
@@ -1210,39 +1203,6 @@ impl PlexiApp {
         if let Err(e) = self.launch_app_by_id_with_layout("text-editor", None, &[path_str], None) {
             log::warn!("scratchpad: failed to launch text-editor pane: {e}");
         }
-    }
-
-    /// Find an open text-editor pane holding an inbox note whose on-disk body
-    /// is still empty (frontmatter only, or file not yet written).
-    fn find_open_empty_inbox_editor(
-        &self,
-        window_idx: usize,
-    ) -> Option<(TileId, PaneId)> {
-        let inbox_dir = crate::config::config_dir().join("notes").join("inbox");
-        let window = self.windows.get(window_idx)?;
-        window.tree.tiles.iter().find_map(|(tile_id, tile)| {
-            let Tile::Pane(pane_id) = tile else {
-                return None;
-            };
-            let app_pane = window.panes.get(pane_id)?.as_app()?;
-            if app_pane.runtime.type_id() != "text-editor" {
-                return None;
-            }
-            let path = app_pane
-                .runtime
-                .serialize_state()?
-                .get("path")
-                .and_then(|v| v.as_str())
-                .map(PathBuf::from)?;
-            if !path.starts_with(&inbox_dir) {
-                return None;
-            }
-            let body_empty = match std::fs::read_to_string(&path) {
-                Ok(content) => crate::notes::parse_note(&content).1.trim().is_empty(),
-                Err(_) => true, // not yet written → still empty
-            };
-            body_empty.then_some((*tile_id, *pane_id))
-        })
     }
 
     /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
@@ -1885,6 +1845,56 @@ mod tests {
             result.is_none(),
             "overlay with no focused pane must return None"
         );
+    }
+
+    /// Regression guard for issue #2221: `open_scratchpad` must always create a
+    /// fresh pane — even when an empty inbox note is already open.
+    #[test]
+    fn open_scratchpad_always_opens_new_pane() {
+        // open_scratchpad uses overlay mode, which replaces the focused tile
+        // in-place rather than inserting a new pane map entry.  Supply a
+        // focused pane so the overlay has somewhere to land; pane_count stays
+        // at 1 throughout.
+        let mut h = HostHarness::new();
+        let base_pane = h.add_test_pane();
+        h.focus_pane(base_pane);
+
+        h.app.open_scratchpad();
+        h.app.open_scratchpad();
+
+        // Overlay replaces in-place: still 1 pane in the map.
+        assert_eq!(h.pane_count(), 1, "overlay replaces in-place; count must stay 1");
+
+        // Top of the overlay chain — second scratchpad call.
+        let win = &h.app.windows[0];
+        let Pane::App(top) = &win.panes[&base_pane] else {
+            panic!("expected App pane at overlay top");
+        };
+        assert_eq!(top.manifest_id, "text-editor", "top pane must be text-editor");
+        let path2 = top
+            .runtime
+            .serialize_state()
+            .and_then(|v| v.get("path").and_then(|p| p.as_str()).map(|s| s.to_owned()))
+            .expect("second scratchpad pane must have a path");
+
+        // One level down — first scratchpad call.
+        let Pane::App(inner) = top
+            .overlay_replaced
+            .as_deref()
+            .expect("must have overlay_replaced after two scratchpad calls")
+        else {
+            panic!("overlay_replaced must be an App pane");
+        };
+        assert_eq!(inner.manifest_id, "text-editor", "inner pane must be text-editor");
+        let path1 = inner
+            .runtime
+            .serialize_state()
+            .and_then(|v| v.get("path").and_then(|p| p.as_str()).map(|s| s.to_owned()))
+            .expect("first scratchpad pane must have a path");
+
+        assert_ne!(path1, path2, "each scratchpad call must create a unique note file");
+        assert!(path1.contains("inbox"), "path1 must be an inbox note");
+        assert!(path2.contains("inbox"), "path2 must be an inbox note");
     }
 }
 


### PR DESCRIPTION
Closes #2218, Closes #2221

## Summary

**#2218 — Cursor renders taller than line in scratch pad and quick note**
- egui 0.31 expands cursor rect to row_height (~18px at 14px font); worked around by erasing the default cursor with a background rect and drawing a custom font_size-height cursor with independent blink tracking
- Applied to both `TextEditorApp` (scratch pad) and `quick_note.rs` overlay

**#2221 — Cmd+Shift+Space redirects to existing empty scratch pad instead of opening fresh**
- Deleted `find_open_empty_inbox_editor()` and the redirect block in `open_scratchpad()`; every invocation now unconditionally calls `write_inbox_note()` and opens a new editor
- HostHarness test asserts two consecutive calls produce an overlay chain with two distinct text-editor panes at distinct inbox note paths

## Done When — #2218
- Side-by-side before/after screenshot shows the caret no taller than the text line in both scratch pad and quick note; no change to line metrics/alignment.

## Done When — #2221
- Pressing Cmd+Shift+Space twice in a row (with or without typing) produces two separate scratch pads; HostHarness test asserts it; closing an untouched one still deletes its file.