### PR TITLE
test(infra): per-test tempdir isolation for cargo test (#2229)

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -9,6 +9,21 @@ Run this after implementation compiles, before pushing. Output is a `**Test evid
 
 All commands run from the feature worktree.
 
+## Flaky Test Policy
+
+**A failing test is never dismissed as "flaky" without proof.** The word "flaky" is a hypothesis, not a finding; treating it as a finding stops investigation prematurely.
+
+Before a test can be called flaky:
+1. It must pass twice in isolation: `cargo test --bin plexi <test_name> -- --exact`
+2. If it passes in isolation but fails in the full suite → **it has a concurrency bug**. Find and fix the shared state.
+3. Even after confirming flakiness, file a GitHub issue — don't shrug it off in the Ship Log.
+
+**Ship Log rule:** never write "test passed in isolation, likely flaky" as a conclusion. Write either:
+- `cargo test: N passed` (all green) — if the suite is clean
+- `binary install required — <test name> fails under parallelism, issue #N filed` — if there is a genuine intermittent
+
+**Concurrency interference was the root cause of issue #2229.** Tests shared `config_dir()` (a real $HOME subdir) across threads. The fix: HostHarness now auto-isolates every test into a per-test tempdir. Any new shared-state interference must be fixed the same way — not dismissed.
+
 ## Step 1 — Classify the Diff
 
 ```bash
@@ -60,9 +75,7 @@ assert = { pane_count = 1, lifecycle = "running", tree_contains = "balls" }
 shot = "balls.png"
 ```
 
-Verbs: `open_app` (+`args`), `open_file_browser`, `key`, `sidebar`, `switch_context`, `push_to_subcontext`, `wait_app_frame`, `run_steps`, `assert` (structured keys: `pane_count`, `window_count`, `context_count`, `portal_count`, `sidebar`, `lifecycle`, `tree_contains`), `shot`.
-
-The `SceneReport` JSON (`schema_version` field) contains per-step results, a host state snapshot, and the app's committed L1 render tree — assert on state, not pixels, whenever possible. If an app crashes before its first frame, the report carries its stderr — fix the app, don't screenshot a fallback state.
+For scene DSL reference (verbs, assertions, SceneReport format), see `docs/TESTING.md`.
 
 ## Step 4 — Inspect the Screenshots
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -88,3 +88,13 @@ The `/testing` skill (`.agents/skills/testing/SKILL.md`) is the agent workflow: 
 - Test-first for host logic: a new `AppRequest`/`HostEffect` gets a failing `HostHarness` test before implementation.
 - New host UI component or overlay → a scene in `tests/scenes/` (open → act → assert → shot).
 - Coverage: `cargo llvm-cov --bin plexi` (cargo-llvm-cov installed at `~/.cargo/bin/`).
+
+## Per-Test Profile Isolation
+
+Every `HostHarness::new()` call creates a fresh `tempfile::TempDir` and installs a thread-local override so `config_dir()` and `config_path()` resolve inside that tempdir for the lifetime of the harness. The tempdir is deleted when the harness drops.
+
+**What this means for test authors:**
+- Tests that go through `HostHarness` never touch `$HOME` — no stray `~/.plexi-<hash>/` dirs.
+- The override is thread-local, so worker threads spawned by the host (e.g. IPC handlers) won't see it. This is acceptable for dispatch tests; note it when writing tests that assert on paths written by background threads.
+- For unit tests that call `config_dir()` directly (without HostHarness), use `set_test_profile_dir(tempdir.path().to_path_buf())` and hold the returned `TestProfileDirGuard` for the test duration.
+- `set_test_channel()` remains for tests that specifically exercise channel-name derivation logic. Prefer `set_test_profile_dir` for everything else.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -848,6 +848,34 @@ pub fn set_test_channel(channel: &str) -> TestChannelGuard {
     TestChannelGuard
 }
 
+#[cfg(test)]
+thread_local! {
+    static TEST_PROFILE_DIR_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII guard that clears the per-thread test profile dir override on drop.
+#[cfg(test)]
+pub struct TestProfileDirGuard;
+
+#[cfg(test)]
+impl Drop for TestProfileDirGuard {
+    fn drop(&mut self) {
+        TEST_PROFILE_DIR_OVERRIDE.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// Override the full profile directory for the current test thread. The returned
+/// guard must be held for the duration of the test; dropping it clears the override.
+///
+/// Prefer this over `set_test_channel` for new tests — it redirects `config_dir()`
+/// and `config_path()` to a fully isolated tempdir rather than a subdir of $HOME.
+#[cfg(test)]
+pub fn set_test_profile_dir(path: std::path::PathBuf) -> TestProfileDirGuard {
+    TEST_PROFILE_DIR_OVERRIDE.with(|c| *c.borrow_mut() = Some(path));
+    TestProfileDirGuard
+}
+
 /// Returns the workspace channel directory name for the current binary.
 /// This is the dot-prefixed dir used inside workspace roots to scope
 /// workspace state per channel: `.plexi` (main), `.plexi-alpha`, `.plexi-beta`,
@@ -904,6 +932,13 @@ fn config_dir_name() -> String {
 }
 
 pub fn config_path() -> PathBuf {
+    #[cfg(test)]
+    {
+        let override_dir = TEST_PROFILE_DIR_OVERRIDE.with(|c| c.borrow().clone());
+        if let Some(dir) = override_dir {
+            return dir.join("config.toml");
+        }
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(config_dir_name())
@@ -911,6 +946,13 @@ pub fn config_path() -> PathBuf {
 }
 
 pub fn config_dir() -> PathBuf {
+    #[cfg(test)]
+    {
+        let override_dir = TEST_PROFILE_DIR_OVERRIDE.with(|c| c.borrow().clone());
+        if let Some(dir) = override_dir {
+            return dir;
+        }
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(config_dir_name())

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -10,6 +10,7 @@
 
 use crate::app::permissions::AppPermissions;
 use crate::app::PlexiApp;
+use crate::config::set_test_profile_dir;
 use crate::app_protocol::{AiMessage, AppRequest, DrawCommand, ModelTier};
 use crate::host::pane::{AppPane, AppRuntime, Pane};
 use crate::process_app::ProcessApp;
@@ -77,11 +78,17 @@ pub struct HostHarness {
     /// Platform output from the most recently completed frame.
     /// Contains clipboard writes, open URLs, etc.
     pub last_platform_output: egui::PlatformOutput,
+    /// Keeps the per-test tempdir alive for the harness lifetime; auto-deletes on drop.
+    _profile_dir: tempfile::TempDir,
+    /// Keeps the thread-local profile dir override active for the harness lifetime.
+    _profile_guard: crate::config::TestProfileDirGuard,
 }
 
 impl HostHarness {
     /// Create a harness with an empty `PlexiApp` and a 1280×800 viewport.
     pub fn new() -> Self {
+        let profile_dir = tempfile::TempDir::new().expect("failed to create test profile tempdir");
+        let profile_guard = set_test_profile_dir(profile_dir.path().to_path_buf());
         let ctx = egui::Context::default();
         let frame_tick = Arc::new(AtomicU64::new(0));
         let (app, ipc_tx) = PlexiApp::new_for_test(ctx.clone(), frame_tick);
@@ -92,6 +99,8 @@ impl HostHarness {
             next_pane_id: 100,
             ipc_tx,
             last_platform_output: egui::PlatformOutput::default(),
+            _profile_dir: profile_dir,
+            _profile_guard: profile_guard,
         }
     }
 
@@ -302,3 +311,20 @@ pub fn ai_query(request_id: &str) -> DrawCommand {
 mod flow_tests;
 #[cfg(test)]
 mod harness_tests;
+
+#[cfg(test)]
+mod profile_isolation_tests {
+    use super::HostHarness;
+
+    #[test]
+    fn host_harness_profile_dir_is_not_in_home() {
+        let _h = HostHarness::new();
+        let dir = crate::config::config_dir();
+        let home = dirs::home_dir().expect("no home dir");
+        assert!(
+            !dir.starts_with(&home),
+            "config_dir() must not point into $HOME inside HostHarness, got: {}",
+            dir.display()
+        );
+    }
+}


### PR DESCRIPTION
Closes #2229

## Summary

- Adds `set_test_profile_dir(path)` + `TestProfileDirGuard` RAII to `src/config/mod.rs` — thread-local full-path override so `config_dir()`/`config_path()` never touch `$HOME` under `#[cfg(test)]`
- `HostHarness::new()` now creates a `tempfile::TempDir` and installs the override before `PlexiApp::new_for_test`, eliminating all stray `~/.plexi-<hash>/` dirs
- Regression test asserts `config_dir()` resolves outside `$HOME` inside a harness; testing skill gets the flaky-dismissal rule and deduplicates scene DSL docs into `docs/TESTING.md`

## Done When

- `cargo test --bin plexi` run twice in a row creates zero new entries under `$HOME` (`ls -d ~/.plexi-*` unchanged before/after).
- A regression test asserts `config_dir()` inside a HostHarness test resolves under the tempdir, not `$HOME`.
- Full suite green under default parallelism for 3 consecutive runs.
- Testing skill contains the flaky-dismissal rule.