### PR TITLE
fix: closing the last pane in a subcontext collapses it and zooms out

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1586,20 +1586,7 @@ impl PlexiApp {
                     "pane_ipc: kind=zoom_out_of_context depth={}",
                     self.router.current_depth()
                 );
-                if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth()
-                {
-                    if let Some(ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
-                        self.switch_workspace(ctx_idx);
-                        if let Some(win_idx) = self
-                            .windows
-                            .iter()
-                            .position(|w| w.window_id == parent_win_id)
-                        {
-                            self.active_window = win_idx;
-                            self.windows[win_idx].focused_pane = focused_tile;
-                        }
-                    }
-                }
+                self.zoom_out_of_context();
             }
             crate::app_protocol::AppRequest::PushPaneToSubcontext { name } => {
                 log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3136,23 +3136,7 @@ impl eframe::App for PlexiApp {
                         "ContextZoomOut: popping depth stack (depth={})",
                         self.router.current_depth()
                     );
-                    if let Some((parent_ctx_id, parent_win_id, focused_tile)) =
-                        self.router.pop_depth()
-                    {
-                        if let Some(ctx_idx) =
-                            self.router.position(|c| c.context_id == parent_ctx_id)
-                        {
-                            self.switch_workspace(ctx_idx);
-                            if let Some(win_idx) = self
-                                .windows
-                                .iter()
-                                .position(|w| w.window_id == parent_win_id)
-                            {
-                                self.active_window = win_idx;
-                                self.windows[win_idx].focused_pane = focused_tile;
-                            }
-                        }
-                    }
+                    self.zoom_out_of_context();
                 }
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -917,7 +917,11 @@ impl PlexiApp {
                 }
 
                 if should_close_exited {
+                    let ctx_id = self.windows[self.active_window].context_id;
                     self.close_focused();
+                    // An emptied subcontext collapses entirely — delete it and
+                    // zoom back out to the parent, like Cmd+Escape.
+                    self.collapse_subcontext_if_empty(ctx_id);
                 }
 
                 // Portal double-click zoom — same logic as ToggleZoom on a Portal pane.

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1494,3 +1494,161 @@ fn rename_on_focused_pane_opens_pane_rename() {
     assert_eq!(app.renaming_pane, Some(pane_id));
     assert_eq!(app.renaming_window, None);
 }
+
+/// Closing the last pane in a subcontext must delete the subcontext and zoom
+/// back out to the parent — the exact landing Cmd+Escape (ContextZoomOut)
+/// would produce: parent context, parent window, previously focused tile.
+#[test]
+fn closing_last_pane_in_subcontext_collapses_and_zooms_out() {
+    use std::collections::HashMap;
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    let root_win_id = app.windows[0].window_id;
+    let (root_tile, _root_pane) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(root_tile);
+
+    // Child subcontext with a single pane.
+    let child_id = 9101u64;
+    let child_win_id = 9102u64;
+    let child_pane = 88991u64;
+    app.router
+        .push(test_context(child_id, root_id, "collapse_child"));
+    app.context_active_window.insert(child_id, child_win_id);
+
+    let mut child_tiles = egui_tiles::Tiles::default();
+    let child_tile = child_tiles.insert_pane(child_pane);
+    let mut child_panes = HashMap::new();
+    child_panes.insert(child_pane, test_app_pane(child_pane));
+    app.windows.push(Window {
+        name: "collapse_child".to_string(),
+        path: std::path::PathBuf::from("/tmp/collapse_child"),
+        tree: egui_tiles::Tree::new("collapse_child", child_tile, child_tiles),
+        panes: child_panes,
+        focused_pane: Some(child_tile),
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: child_win_id,
+        context_id: child_id,
+    });
+
+    // Zoom Root → child, as sidebar/portal zoom does.
+    app.router
+        .push_depth(root_id, root_win_id, Some(root_tile));
+    let child_idx = app.router.position(|c| c.context_id == child_id).unwrap();
+    app.switch_workspace(child_idx);
+    assert_eq!(app.router.active().context_id, child_id);
+
+    // Close the only pane in the subcontext (Cmd+W path).
+    app.execute_close_pane();
+
+    assert!(
+        app.router.iter().all(|c| c.context_id != child_id),
+        "emptied subcontext must be removed from the router"
+    );
+    assert!(
+        app.windows.iter().all(|w| w.context_id != child_id),
+        "emptied subcontext must have no remaining windows"
+    );
+    assert_eq!(
+        app.router.active().context_id,
+        root_id,
+        "closing the last subcontext pane must land on the parent context"
+    );
+    assert_eq!(
+        app.windows[app.active_window].window_id, root_win_id,
+        "must land on the same parent window Cmd+Escape would restore"
+    );
+    assert_eq!(
+        app.windows[app.active_window].focused_pane,
+        Some(root_tile),
+        "must restore the parent's previously focused tile"
+    );
+    assert_eq!(
+        app.router.current_depth(),
+        0,
+        "the depth-stack entry for the zoom-in must be consumed"
+    );
+}
+
+/// Closing the last pane in a ROOT context must NOT delete the context —
+/// the sole window stays alive so the welcome screen renders.
+#[test]
+fn closing_last_pane_in_root_context_keeps_context() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    let (root_tile, _pane) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(root_tile);
+
+    app.execute_close_pane();
+
+    assert_eq!(
+        app.router.active().context_id,
+        root_id,
+        "root context must survive closing its last pane"
+    );
+    assert!(
+        app.windows.iter().any(|w| w.context_id == root_id),
+        "root context must keep its welcome-screen window"
+    );
+}
+
+/// Closing the last pane of a NON-active subcontext (e.g. via CLI
+/// `plexi pane close`) removes the subcontext without switching the
+/// user's active context.
+#[test]
+fn closing_last_pane_in_background_subcontext_removes_it_without_switching() {
+    use std::collections::HashMap;
+
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    let (root_tile, _root_pane) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(root_tile);
+
+    let child_id = 9201u64;
+    let child_win_id = 9202u64;
+    let child_pane = 88992u64;
+    app.router
+        .push(test_context(child_id, root_id, "bg_collapse_child"));
+    app.context_active_window.insert(child_id, child_win_id);
+
+    let mut child_tiles = egui_tiles::Tiles::default();
+    let child_tile = child_tiles.insert_pane(child_pane);
+    let mut child_panes = HashMap::new();
+    child_panes.insert(child_pane, test_app_pane(child_pane));
+    app.windows.push(Window {
+        name: "bg_collapse_child".to_string(),
+        path: std::path::PathBuf::from("/tmp/bg_collapse_child"),
+        tree: egui_tiles::Tree::new("bg_collapse_child", child_tile, child_tiles),
+        panes: child_panes,
+        focused_pane: Some(child_tile),
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: child_win_id,
+        context_id: child_id,
+    });
+
+    // Root stays active; close the subcontext's only pane by id.
+    app.close_pane_by_id(child_pane);
+
+    assert!(
+        app.router.iter().all(|c| c.context_id != child_id),
+        "emptied background subcontext must be removed from the router"
+    );
+    assert_eq!(
+        app.router.active().context_id,
+        root_id,
+        "active context must not change when a background subcontext collapses"
+    );
+}

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -646,12 +646,12 @@ impl PlexiApp {
         // Find which context and tile owns this pane_id.
         for ctx_idx in 0..self.windows.len() {
             if let Some(tile_id) = self.windows[ctx_idx].tree.tiles.find_pane(&pane_id) {
+                let ctx_id = self.windows[ctx_idx].context_id;
                 self.close_tile(ctx_idx, tile_id);
                 // Mirror the guard in execute_close_pane: if the window is now empty
                 // and there are other pages in the same context, delete the zombie window.
                 // Without this, the window stays in self.windows[] as a phantom grid cell.
                 if self.windows[ctx_idx].panes.is_empty() {
-                    let ctx_id = self.windows[ctx_idx].context_id;
                     let pages_in_context = self
                         .windows
                         .iter()
@@ -664,6 +664,9 @@ impl PlexiApp {
                         self.delete_window(ctx_idx);
                     }
                 }
+                // An emptied subcontext collapses entirely — delete it and,
+                // when it was active, zoom back out like Cmd+Escape.
+                self.collapse_subcontext_if_empty(ctx_id);
                 return;
             }
         }
@@ -1465,14 +1468,19 @@ impl PlexiApp {
             .and_then(|p| p.as_app())
             .is_some();
         if is_app {
+            let ctx_id = self.windows[active].context_id;
             self.close_tile(active, focused_tile);
             self.windows[active].clear_zoom();
+            // An emptied subcontext collapses entirely — delete it and zoom
+            // back out to the parent, as if Cmd+Escape had been pressed.
+            self.collapse_subcontext_if_empty(ctx_id);
         }
     }
 
     /// Execute the close-pane action (called directly when confirm_close is false,
     /// or from the confirm-close dialog when the user confirms).
     pub(crate) fn execute_close_pane(&mut self) -> bool {
+        let ctx_id = self.windows[self.active_window].context_id;
         self.windows[self.active_window].clear_zoom();
         if !self.windows[self.active_window].panes.is_empty() {
             self.close_focused();
@@ -1481,7 +1489,6 @@ impl PlexiApp {
         // in the same context (i.e. it's one of several pages). When it's the
         // sole page, keep it alive so the welcome screen renders.
         if self.windows[self.active_window].panes.is_empty() {
-            let ctx_id = self.windows[self.active_window].context_id;
             let pages_in_context = self
                 .windows
                 .iter()
@@ -1491,6 +1498,9 @@ impl PlexiApp {
                 self.delete_window(self.active_window);
             }
         }
+        // An emptied subcontext collapses entirely — delete it and zoom back
+        // out to the parent, as if Cmd+Escape had been pressed.
+        self.collapse_subcontext_if_empty(ctx_id);
         false
     }
 }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -842,6 +842,69 @@ impl PlexiApp {
             .unwrap_or(page_count > 1);
     }
 
+    /// Pop the depth stack and return to the parent context/window/focus.
+    /// Shared body of Cmd+Escape (`Action::ContextZoomOut`) and the
+    /// `ZoomOutOfContext` IPC request. Returns true when a switch happened.
+    pub(crate) fn zoom_out_of_context(&mut self) -> bool {
+        if let Some((parent_ctx_id, parent_win_id, focused_tile)) = self.router.pop_depth() {
+            if let Some(ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
+                self.switch_workspace(ctx_idx);
+                if let Some(win_idx) = self
+                    .windows
+                    .iter()
+                    .position(|w| w.window_id == parent_win_id)
+                {
+                    self.active_window = win_idx;
+                    self.windows[win_idx].focused_pane = focused_tile;
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    /// If `ctx_id` names a subcontext whose windows are now all empty, delete
+    /// it. When it was the active context, first zoom back out to the parent
+    /// exactly as if Cmd+Escape had been pressed. Root contexts are never
+    /// collapsed — their sole window stays alive as the welcome screen.
+    pub(crate) fn collapse_subcontext_if_empty(&mut self, ctx_id: u64) {
+        if self.router.len() <= 1 {
+            return;
+        }
+        let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) else {
+            return;
+        };
+        let Some(parent_ctx_id) = self.router.get(ctx_idx).parent_id else {
+            return;
+        };
+        if self
+            .windows
+            .iter()
+            .any(|w| w.context_id == ctx_id && !w.panes.is_empty())
+        {
+            return;
+        }
+        let was_active = self.router.active().context_id == ctx_id;
+        log::info!(
+            "collapse_subcontext_if_empty: subcontext {ctx_id} emptied — deleting \
+             (was_active={was_active}, parent={parent_ctx_id})"
+        );
+        if was_active {
+            let zoomed_out = self.zoom_out_of_context();
+            if !zoomed_out || self.router.active().context_id == ctx_id {
+                // No usable depth-stack entry — land on the parent directly.
+                if let Some(parent_idx) =
+                    self.router.position(|c| c.context_id == parent_ctx_id)
+                {
+                    self.switch_workspace(parent_idx);
+                }
+            }
+        }
+        if let Some(idx) = self.router.position(|c| c.context_id == ctx_id) {
+            self.delete_context(idx);
+        }
+    }
+
     pub(crate) fn delete_window(&mut self, index: usize) {
         if self.windows.len() <= 1 {
             return;


### PR DESCRIPTION
Closing the last pane in a subcontext previously left the subcontext alive as an empty welcome screen. Now the subcontext is deleted and, when it was the active one, the host zooms back out to the parent context/window/focus exactly as Cmd+Escape (`ContextZoomOut`) would.

## Changes
- New `PlexiApp::collapse_subcontext_if_empty`, hooked into all four close paths: `execute_close_pane` (Cmd+W), `close_focused_app` (Escape on app), `close_pane_by_id` (CLI/IPC `ClosePane` + exited-pane sweep), and the exited-terminal auto-close in `render.rs`.
- Root contexts are unaffected: their sole window still survives as the welcome screen.
- Extracted shared `PlexiApp::zoom_out_of_context` from the duplicated `ContextZoomOut` action and `ZoomOutOfContext` IPC handler bodies.

## Tests
- `closing_last_pane_in_subcontext_collapses_and_zooms_out` — Cmd+W path lands on the parent window with the previously focused tile restored and the depth-stack entry consumed (written first, failed on alpha).
- `closing_last_pane_in_background_subcontext_removes_it_without_switching` — CLI close of a non-active subcontext deletes it without yanking the user's active context.
- `closing_last_pane_in_root_context_keeps_context` — welcome-screen guard.

`cargo test --bin plexi`: 1066 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)