### PR TITLE
feat(cli): caller-targeted CLI — portal anchor, context push/set-root/describe, unified --from flag

### DIFF
--- a/.agents/skills/dispatch/scripts/add-to-dispatch.sh
+++ b/.agents/skills/dispatch/scripts/add-to-dispatch.sh
@@ -15,11 +15,10 @@ fi
 EXISTING_PANE_ID=$1
 ISSUE=$2
 
-PANE_ID=$($PLEXI terminal \
-  --layout split_v \
-  --from-pane-id "$EXISTING_PANE_ID" \
+PANE_ID=$($PLEXI pane new "c '/implement-issue $ISSUE'" \
+  --down \
+  --from "$EXISTING_PANE_ID" \
   --cwd "$REPO_DIR" \
-  --no-focus \
-  "c '/implement-issue $ISSUE'")
+  --no-focus)
 $PLEXI pane name "$PANE_ID" "#${ISSUE}"
 echo "Added: pane $PANE_ID → #$ISSUE (below pane $EXISTING_PANE_ID)"

--- a/.agents/skills/hand-off/SKILL.md
+++ b/.agents/skills/hand-off/SKILL.md
@@ -65,12 +65,11 @@ Skip this step for any other command.
 ## Step 3 — Split and launch
 
 ```bash
-NEW_ID=$($PLEXI terminal \
-  --layout split_h \
-  --from-pane-id $MY_ID \
+NEW_ID=$($PLEXI pane new "c \"$CMD\"" \
+  --right \
+  --from $MY_ID \
   --cwd "$REPO_DIR" \
-  --no-focus \
-  "c \"$CMD\"")
+  --no-focus)
 $PLEXI pane name $NEW_ID "$LABEL"
 ```
 

--- a/.agents/skills/project-manager/SKILL.md
+++ b/.agents/skills/project-manager/SKILL.md
@@ -209,7 +209,7 @@ Filter this list to the current PRM milestone before bundle batching. Newest iss
 Group all `bundle: true` issues by their primary area (first `area:*` label). For each group that has 2+ issues and none of whose areas conflict with `IN_PROGRESS_AREAS`:
 - Treat the entire group as ONE candidate consuming ONE lane slot.
 - The single lane will implement all issues in the group in one PR.
-- Dispatch as ONE pane: `$PLEXI terminal "c '/implement-issue <N1> <N2> <N3>'"`. Name the pane `#N1+N2+N3`.
+- Dispatch as ONE pane: `$PLEXI pane new "c '/implement-issue <N1> <N2> <N3>'"`. Name the pane `#N1+N2+N3`.
 
 After bundle groups consume their slots, fill remaining slots with individual non-bundle issues.
 
@@ -269,24 +269,24 @@ UNPUSHED=$(git log origin/alpha..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
 [ "$UNPUSHED" -gt 0 ] && git push origin alpha
 ```
 
-Then open panes — one per lane. Use `split_h` for the first, `split_v` for each subsequent:
+Then open panes — one per lane. Use `--right` for the first, `--down` for each subsequent:
 
 ```bash
 PLEXI=plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL}
 PREV_ID=$PLEXI_PANE_ID
-LAYOUT=split_h
+LAYOUT=--right
 
 # Individual issue:
-PANE_ID=$($PLEXI terminal "c '/implement-issue <N>'" \
-  --layout $LAYOUT --from-pane-id $PREV_ID --cwd "$REPO_DIR" --no-focus)
+PANE_ID=$($PLEXI pane new "c '/implement-issue <N>'" \
+  $LAYOUT --from $PREV_ID --cwd "$REPO_DIR" --no-focus)
 $PLEXI pane name $PANE_ID "#<N>"
-PREV_ID=$PANE_ID; LAYOUT=split_v
+PREV_ID=$PANE_ID; LAYOUT=--down
 
 # Bundle (all issues → one pane, one PR):
-PANE_ID=$($PLEXI terminal "c '/implement-issue <N1> <N2> <N3>'" \
-  --layout $LAYOUT --from-pane-id $PREV_ID --cwd "$REPO_DIR" --no-focus)
+PANE_ID=$($PLEXI pane new "c '/implement-issue <N1> <N2> <N3>'" \
+  $LAYOUT --from $PREV_ID --cwd "$REPO_DIR" --no-focus)
 $PLEXI pane name $PANE_ID "#<N1>+<N2>+<N3>"
-PREV_ID=$PANE_ID; LAYOUT=split_v
+PREV_ID=$PANE_ID; LAYOUT=--down
 ```
 
 ---
@@ -323,7 +323,7 @@ On each re-entry after initial dispatch, lead with:
 - **Bare-shell pane recovery.** If a dispatch pane shows a prompt with no agent running ("← for agents"), re-send the command: `$PLEXI pane send <ID> 'c "/ship-issue <N>"\n'` — use `\n` for Enter, never a trailing `Enter` argument.
 - **Bundle issues should be batched.** Issues labeled `bundle` are micro-changes. Group by primary area and send all same-area bundles to one lane in one PR. Never open one PR per bundle issue.
 - **Post-merge cleanup runs every cycle.** Check merged PRs for still-open linked issues and close them automatically.
-- **Auto-push alpha before dispatch.** `$PLEXI terminal` will clone a dirty tree — push first.
+- **Auto-push alpha before dispatch.** `$PLEXI pane new` will clone a dirty tree — push first.
 - **Channel binary** auto-detected via `$PLEXI_CHANNEL` — never hardcode.
 - **PRM alignment is the default.** Higher issue numbers are only a tie-breaker inside the current PRM milestone.
 - **Conflict detection is live, not scored.** Two issues conflict only if they share an `area:*` label with something currently in-progress.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ Before adding any new CLI command, verify it belongs in the right namespace — 
 
 ## CLI Pane Naming
 
-Always name panes after spawning them. Every `plexi terminal`, `plexi app open`, split, or new window should be followed by `plexi pane name <id> "descriptive name"`. Named panes make the UI scannable, help the project-manager read state from `plexi pane list`, and make dispatch lanes identifiable at a glance.
+Always name panes after spawning them. Every `plexi pane new`, `plexi app open`, split, or new window should be followed by `plexi pane name <id> "descriptive name"`. Named panes make the UI scannable, help the project-manager read state from `plexi pane list`, and make dispatch lanes identifiable at a glance.
 
 ## CLI Tips
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ All `plexi` subcommands work identically on alpha, beta, stable, and PR builds. 
 | `plexi pack` | Pack management (apply, list packs) |
 | `plexi app init <name>` | Scaffold a new app in the current directory |
 | `plexi app open <app-id>` | Open an app pane |
-| `plexi terminal [cmd]` | Open a terminal pane, optionally running a command |
+| `plexi pane new [cmd]` | Open a terminal pane, optionally running a command |
 | `plexi pane <subcommand>` | Pane management (name, close, list, focus) |
 | `plexi notify` | Emit a notification (see Notifications section) |
 | `plexi context` | Query or set the active workspace context |

--- a/justfile
+++ b/justfile
@@ -263,7 +263,7 @@ merge-close-stints PR +STINTS:
 ship +issues:
     for issue in {{issues}}; do \
         gh issue edit "$issue" --add-label "in progress" --remove-label "ready" && \
-        plexi terminal "c '/ship-issue $issue'" --layout new_window; \
+        plexi pane new "c '/ship-issue $issue'" --window; \
     done
 
 # Run one UI scene file headlessly. Writes screenshots + a SceneReport JSON to

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -17,7 +17,7 @@ You are running inside a Plexi pane. `PLEXI_SOCKET` is set automatically -- ever
 | Var | Purpose |
 |-----|---------|
 | `PLEXI_SOCKET` | IPC socket path; routes all commands to the running instance |
-| `PLEXI_PANE_ID` | Numeric ID of the current pane; pass to `--from` / `--from-pane-id` |
+| `PLEXI_PANE_ID` | Numeric ID of the current pane; pass to `--from` |
 | `PLEXI_CONTEXT_ID` | Context ID the pane belongs to |
 | `PLEXI_CONTEXT_NAME` | Context name the pane belongs to |
 
@@ -48,11 +48,11 @@ pane state ID            App panes: L1 UiNode tree JSON. Terminal panes: simple 
 
 ```
 app open [TYPE_ID]       Open an installed app. Flags: -d, -l, -u, -r, --tab, --window,
-                         --from-pane-id ID. Extra args forwarded to the app.
+                         --from PANE_ID. Extra args forwarded to the app.
 app open --mcp CMD...    Wrap a stdio MCP server in a Plexi pane.
 app open --cli BINARY    Wrap a CLI tool with a Plexi UI.
 app init NAME            Scaffold a new app. --lang python (default), --global, --no-open,
-                         --from-pane-id ID.
+                         --from PANE_ID.
 app install [SPEC]       Install from path, github:owner/repo, or --pack core.
                          No args = install from .plexi/apps.toml. --version SEMVER to pin.
 app uninstall ID         Remove an installed app.
@@ -69,14 +69,14 @@ app action ID ACTION [ARGS]  Send a semantic action to a running app (not raw te
 ### context -- manage project scopes
 
 ```
-context new [NAME]       New context. --path DIR, --parent NAME, --window CMD (repeatable; creates extra windows atomically).
+context new [NAME]       New context. --path DIR, --parent[=NAME] (bare = current context), --from PANE_ID (portal anchor; defaults to caller), -d/-l/-u/-r portal direction, --focus, --window CMD (repeatable; creates extra windows atomically).
 context open [PATH]      Switch current pane to a context at PATH.
-context set-root [PATH]  Change root folder for active context.
+context set-root [PATH]  Change root folder for the caller's context (PLEXI_CONTEXT_ID).
 context current          Print context id/name as JSON.
-context describe TEXT    Set description for active context.
+context describe TEXT    Set description for the caller's context (PLEXI_CONTEXT_ID).
 context zoom ID          Zoom into a sub-context.
 context zoom-out         Zoom out to parent context.
-context push [NAME]      Push focused pane into a new sub-context.
+context push [NAME]      Push a pane into a new sub-context. --pane-id ID (defaults to the calling pane).
 ```
 
 ### notify -- surface information to the user
@@ -100,7 +100,7 @@ secret delete NAME       Remove a secret.
 ### agent -- workspace agent definitions
 
 ```
-agent init NAME          Scaffold agent app (ai.query + chat UI). --from-pane-id ID.
+agent init NAME          Scaffold agent app (ai.query + chat UI). --from PANE_ID.
 agent add NAME           Install from global registry into workspace.
 agent update NAME        Re-install from registry, preserving memory/logs.
 agent list               List workspace agents.
@@ -209,9 +209,9 @@ esac
 ### 2x2 grid layout (apps in three quadrants)
 
 ```bash
-BALLS=$(plexi app open balls -r --from-pane-id $PLEXI_PANE_ID)
-plexi app open tetris -d --from-pane-id $PLEXI_PANE_ID
-plexi app open snake -d --from-pane-id $BALLS
+BALLS=$(plexi app open balls -r --from $PLEXI_PANE_ID)
+plexi app open tetris -d --from $PLEXI_PANE_ID
+plexi app open snake -d --from $BALLS
 ```
 
 ### Named agent dispatch lane

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1452,15 +1452,13 @@ impl PlexiApp {
                     let current_ctx_id = self.router.active().context_id;
                     let current_win_id = self.windows[self.active_window].window_id;
                     let current_focused = self.windows[self.active_window].focused_pane;
-                    if let Err(e) =
-                        self.new_child_context(
-                            pname.as_str(),
-                            path,
-                            portal_vertical,
-                            portal_first,
-                            *anchor_pane,
-                        )
-                    {
+                    if let Err(e) = self.new_child_context(
+                        pname.as_str(),
+                        path,
+                        portal_vertical,
+                        portal_first,
+                        *anchor_pane,
+                    ) {
                         log::warn!("pane_ipc: create_context with parent failed: {e}");
                         ctx_ok = false;
                     } else {
@@ -1562,14 +1560,20 @@ impl PlexiApp {
                     root.display()
                 );
             }
-            crate::app_protocol::AppRequest::SetContextRoot { root } => {
-                log::info!("pane_ipc: kind=set_context_root root={}", root.display());
-                self.set_active_context_root(root.clone());
+            crate::app_protocol::AppRequest::SetContextRoot { root, context_id } => {
+                log::info!(
+                    "pane_ipc: kind=set_context_root root={} context_id={context_id:?}",
+                    root.display()
+                );
+                self.set_context_root(root.clone(), *context_id);
                 self.save_workspace();
             }
-            crate::app_protocol::AppRequest::SetContextDescription { description } => {
-                log::info!("pane_ipc: kind=set_context_description");
-                let idx = self.router.active_idx();
+            crate::app_protocol::AppRequest::SetContextDescription {
+                description,
+                context_id,
+            } => {
+                log::info!("pane_ipc: kind=set_context_description context_id={context_id:?}");
+                let idx = self.resolve_context_idx(*context_id, "set_context_description");
                 let trimmed = description.trim().to_string();
                 self.router.get_mut(idx).description = if trimmed.is_empty() {
                     None
@@ -1596,9 +1600,11 @@ impl PlexiApp {
                 );
                 self.zoom_out_of_context();
             }
-            crate::app_protocol::AppRequest::PushPaneToSubcontext { name } => {
-                log::info!("pane_ipc: kind=push_pane_to_subcontext name={:?}", name);
-                self.push_pane_to_subcontext(name.clone());
+            crate::app_protocol::AppRequest::PushPaneToSubcontext { name, pane_id } => {
+                log::info!(
+                    "pane_ipc: kind=push_pane_to_subcontext name={name:?} pane_id={pane_id:?}"
+                );
+                self.push_pane_to_subcontext(name.clone(), *pane_id);
             }
             crate::app_protocol::AppRequest::ListPermissions { response_file } => {
                 log::info!("pane_ipc: kind=list_permissions response_file={response_file:?}");
@@ -1761,8 +1767,7 @@ impl PlexiApp {
             // Dual-write the unified broker store so grants.toml stays in
             // lockstep with the legacy permissions.toml until all call sites
             // read through the broker (permissions-broker spec, Phase A).
-            let mut grants =
-                crate::broker::GrantStore::load_or_default(&self.permission_store_dir);
+            let mut grants = crate::broker::GrantStore::load_or_default(&self.permission_store_dir);
             grants.record_app_capability(
                 app_id,
                 &ws,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1411,6 +1411,7 @@ impl PlexiApp {
                 windows,
                 focus,
                 portal_direction,
+                anchor_pane,
                 response_file,
             } => {
                 // Map direction string to insert_split_tile params.
@@ -1426,12 +1427,13 @@ impl PlexiApp {
                     };
                 log::info!(
                     "pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?} \
-                     windows={} focus={focus} direction={:?}",
+                     windows={} focus={focus} direction={:?} anchor_pane={:?}",
                     root,
                     name,
                     parent_name,
                     windows.len(),
-                    portal_direction
+                    portal_direction,
+                    anchor_pane
                 );
                 let mut ctx_ok = true;
                 // Track which context was active before and which context was just created.
@@ -1451,7 +1453,13 @@ impl PlexiApp {
                     let current_win_id = self.windows[self.active_window].window_id;
                     let current_focused = self.windows[self.active_window].focused_pane;
                     if let Err(e) =
-                        self.new_child_context(pname.as_str(), path, portal_vertical, portal_first)
+                        self.new_child_context(
+                            pname.as_str(),
+                            path,
+                            portal_vertical,
+                            portal_first,
+                            *anchor_pane,
+                        )
                     {
                         log::warn!("pane_ipc: create_context with parent failed: {e}");
                         ctx_ok = false;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -194,7 +194,8 @@ pub struct PlexiApp {
     /// TTL is the invalidation, matching the downstream
     /// `OUTSIDE_WORKSPACE_CHECK_INTERVAL` of the only consumer (the terminal
     /// "outside workspace" badge).
-    pub(crate) workspace_root_fallback_cache: Option<(std::time::Instant, Option<std::path::PathBuf>)>,
+    pub(crate) workspace_root_fallback_cache:
+        Option<(std::time::Instant, Option<std::path::PathBuf>)>,
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
     /// One-shot guard: true after `request_focus()` fires on the rename modal's
@@ -523,7 +524,11 @@ impl PlexiApp {
         let theme_cfg = Self::resolve_theme_config(&config);
         let colors = Colors::from_config(&theme_cfg);
         let dark_mode = !theme::is_light_preset(
-            config.theme.as_ref().and_then(|t| t.preset.as_deref()).unwrap_or(""),
+            config
+                .theme
+                .as_ref()
+                .and_then(|t| t.preset.as_deref())
+                .unwrap_or(""),
         );
         theme::setup_style(&cc.egui_ctx, &colors, dark_mode);
         let window_theme = if dark_mode {
@@ -1305,7 +1310,10 @@ impl PlexiApp {
         let user_theme = config.theme.clone().unwrap_or_default();
         // Prefer [theme] preset; fall back to legacy top-level theme_preset so
         // existing configs survive the migration without silently losing their theme.
-        let preset_name = user_theme.preset.as_deref().or(config.theme_preset.as_deref());
+        let preset_name = user_theme
+            .preset
+            .as_deref()
+            .or(config.theme_preset.as_deref());
         if let Some(preset_name) = preset_name {
             if let Some(preset) = theme::preset_colors(preset_name) {
                 log::info!("Applying theme preset: {}", preset_name.trim());
@@ -2516,9 +2524,8 @@ impl eframe::App for PlexiApp {
                 // terminal renders later this same frame and would forward it
                 // to its PTY — swallow all key/text events before closing.
                 ctx.input_mut(|i| {
-                    i.events.retain(|e| {
-                        !matches!(e, egui::Event::Key { .. } | egui::Event::Text(_))
-                    });
+                    i.events
+                        .retain(|e| !matches!(e, egui::Event::Key { .. } | egui::Event::Text(_)));
                 });
                 self.close_focused_app();
             }
@@ -2907,12 +2914,9 @@ impl eframe::App for PlexiApp {
                                     .into_iter()
                                     .flatten()
                                     .filter_map(|e| e.ok())
-                                    .filter(|e| {
-                                        e.path().extension().map_or(false, |x| x == "md")
-                                    })
+                                    .filter(|e| e.path().extension().map_or(false, |x| x == "md"))
                                     .filter_map(|e| {
-                                        let mtime =
-                                            e.metadata().and_then(|m| m.modified()).ok()?;
+                                        let mtime = e.metadata().and_then(|m| m.modified()).ok()?;
                                         Some((mtime, e.path()))
                                     })
                                     .collect();
@@ -2924,7 +2928,8 @@ impl eframe::App for PlexiApp {
                                 .iter()
                                 .filter_map(|p| crate::notes::NotePickerEntry::load(p, true))
                                 .collect();
-                        let workspace_slug = self.palette_workspace_root
+                        let workspace_slug = self
+                            .palette_workspace_root
                             .as_ref()
                             .and_then(|p| p.file_name().map(|n| n.to_os_string()))
                             .map(|n| n.to_string_lossy().into_owned());
@@ -2937,10 +2942,7 @@ impl eframe::App for PlexiApp {
                                 .iter()
                                 .filter_map(|p| crate::notes::NotePickerEntry::load(p, false)),
                         );
-                        log::info!(
-                            "palette: loaded {} notes",
-                            palette_notes.len()
-                        );
+                        log::info!("palette: loaded {} notes", palette_notes.len());
                         self.palette_notes = palette_notes;
                     } else {
                         self.palette_workspace_root = None;
@@ -3104,14 +3106,14 @@ impl eframe::App for PlexiApp {
                     self.new_child_context_from_keyboard();
                 }
                 Action::PushPaneToSubcontext => {
-                    self.push_pane_to_subcontext(None);
+                    self.push_pane_to_subcontext(None, None);
                 }
                 Action::SetContextRootFromCwd => {
                     let active = self.active_window;
                     if let Some(tile_id) = self.windows[active].focused_pane {
                         if let Some(cwd) = self.windows[active].get_focused_pane_cwd(tile_id) {
                             log::info!("SetContextRootFromCwd: setting root to {}", cwd.display());
-                            self.set_active_context_root(cwd);
+                            self.set_context_root(cwd, None);
                         } else {
                             log::warn!("SetContextRootFromCwd: no CWD available for focused pane");
                         }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -166,6 +166,64 @@ fn new_child_context_anchor_pane_overrides_focused() {
     );
 }
 
+/// End-to-end over the real IPC path: the exact JSON `plexi context new --parent`
+/// sends (including `anchor_pane`) deserializes into `AppRequest::CreateContext`
+/// and the handler anchors the portal at that pane, not the focused one.
+#[test]
+fn create_context_ipc_anchor_pane_places_portal() {
+    let mut h = crate::testing::HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let pane_b = h.add_test_pane();
+    let tile_a = h.app.windows[0].tree.tiles.find_pane(&pane_a).unwrap();
+    let tile_b = h.app.windows[0].tree.tiles.find_pane(&pane_b).unwrap();
+    h.app.windows[0].focused_pane = Some(tile_a);
+    let parent_id = h.app.router.active().context_id;
+    let parent_name = h.app.router.active().name.clone();
+
+    let payload = serde_json::json!({
+        "type": "create_context",
+        "name": "anchored",
+        "parent_name": parent_name,
+        "anchor_pane": pane_b,
+        "portal_direction": "down",
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let parent_win = h
+        .app
+        .windows
+        .iter()
+        .find(|w| w.context_id == parent_id)
+        .expect("parent window must still exist");
+    let portal_pane_id = parent_win
+        .panes
+        .iter()
+        .find(|(_, p)| p.portal_target().is_some())
+        .map(|(id, _)| *id)
+        .expect("handler must insert a Portal tile");
+    let portal_tile = parent_win.tree.tiles.find_pane(&portal_pane_id).unwrap();
+    let container = parent_win
+        .tree
+        .tiles
+        .parent_of(portal_tile)
+        .expect("portal tile has a parent container");
+    let children: Vec<_> = match parent_win.tree.tiles.get(container) {
+        Some(egui_tiles::Tile::Container(c)) => c.children().copied().collect(),
+        other => panic!("portal parent is not a container: {other:?}"),
+    };
+    assert!(
+        children.contains(&tile_b),
+        "portal must split against the anchor pane sent over IPC"
+    );
+    assert!(
+        !children.contains(&tile_a),
+        "portal must NOT split against the focused pane"
+    );
+}
+
 /// An anchor pane id that doesn't exist in the parent context falls back to the
 /// focused pane — creation must still succeed.
 #[test]

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -19,6 +19,7 @@ fn new_child_context_does_not_adopt_focused_pane() {
         std::path::PathBuf::from("/tmp/no_adopt"),
         true,
         false,
+        None,
     )
     .expect("child create should succeed");
 
@@ -65,7 +66,13 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     let parent_id = app.router.active().context_id;
 
     let result =
-        app.new_child_context("Test", std::path::PathBuf::from("/tmp/child2"), true, false);
+        app.new_child_context(
+            "Test",
+            std::path::PathBuf::from("/tmp/child2"),
+            true,
+            false,
+            None,
+        );
 
     // Whether success or failure, the parent's focused_pane must remain None.
     assert_eq!(
@@ -100,6 +107,118 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     }
 }
 
+/// `plexi context new --pane <id>`: the portal split must anchor at the given
+/// pane, not the parent context's focused pane. Two panes exist; A is focused;
+/// the anchor names B — the portal must land as B's sibling.
+#[test]
+fn new_child_context_anchor_pane_overrides_focused() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, _pane_a) = app.add_test_pane();
+    let (tile_b, pane_b) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+    let parent_id = app.router.active().context_id;
+    let parent_name = app.router.active().name.clone();
+
+    app.new_child_context(
+        &parent_name,
+        std::path::PathBuf::from("/tmp/anchor_pane"),
+        true,
+        false,
+        Some(pane_b),
+    )
+    .expect("child create should succeed");
+
+    let parent_win = app
+        .windows
+        .iter()
+        .find(|w| w.context_id == parent_id)
+        .expect("parent window must still exist");
+    let portal_pane_id = parent_win
+        .panes
+        .iter()
+        .find(|(_, p)| p.portal_target().is_some())
+        .map(|(id, _)| *id)
+        .expect("parent must contain a Portal tile");
+    let portal_tile = parent_win
+        .tree
+        .tiles
+        .find_pane(&portal_pane_id)
+        .expect("portal tile in tree");
+    let container = parent_win
+        .tree
+        .tiles
+        .parent_of(portal_tile)
+        .expect("portal tile has a parent container");
+    let children: Vec<_> = match parent_win.tree.tiles.get(container) {
+        Some(egui_tiles::Tile::Container(c)) => c.children().copied().collect(),
+        other => panic!("portal parent is not a container: {other:?}"),
+    };
+    assert!(
+        children.contains(&tile_b),
+        "portal must split against the anchor pane's tile"
+    );
+    assert!(
+        !children.contains(&tile_a),
+        "portal must NOT split against the focused pane when an anchor is given"
+    );
+}
+
+/// An anchor pane id that doesn't exist in the parent context falls back to the
+/// focused pane — creation must still succeed.
+#[test]
+fn new_child_context_unknown_anchor_falls_back_to_focused() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (tile_a, _pane_a) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_a);
+    let parent_id = app.router.active().context_id;
+    let parent_name = app.router.active().name.clone();
+
+    app.new_child_context(
+        &parent_name,
+        std::path::PathBuf::from("/tmp/anchor_missing"),
+        true,
+        false,
+        Some(999_999),
+    )
+    .expect("child create should succeed despite unknown anchor");
+
+    let parent_win = app
+        .windows
+        .iter()
+        .find(|w| w.context_id == parent_id)
+        .expect("parent window must still exist");
+    let portal_pane_id = parent_win
+        .panes
+        .iter()
+        .find(|(_, p)| p.portal_target().is_some())
+        .map(|(id, _)| *id)
+        .expect("parent must contain a Portal tile");
+    let portal_tile = parent_win
+        .tree
+        .tiles
+        .find_pane(&portal_pane_id)
+        .expect("portal tile in tree");
+    let container = parent_win
+        .tree
+        .tiles
+        .parent_of(portal_tile)
+        .expect("portal tile has a parent container");
+    let children: Vec<_> = match parent_win.tree.tiles.get(container) {
+        Some(egui_tiles::Tile::Container(c)) => c.children().copied().collect(),
+        other => panic!("portal parent is not a container: {other:?}"),
+    };
+    assert!(
+        children.contains(&tile_a),
+        "unknown anchor must fall back to the focused pane"
+    );
+}
+
 /// Issue #1409: parent name lookup must be case-insensitive.
 #[test]
 fn new_child_context_case_insensitive_parent() {
@@ -115,6 +234,7 @@ fn new_child_context_case_insensitive_parent() {
         std::path::PathBuf::from("/tmp/child_ci"),
         true,
         false,
+        None,
     );
     match result {
         Ok(_) => {}
@@ -148,6 +268,7 @@ fn create_child_context_auto_zooms() {
         std::path::PathBuf::from("/tmp/child_zoom"),
         true,
         false,
+        None,
     );
 
     if result.is_err() {
@@ -254,7 +375,7 @@ fn depth_four_chain_has_portal_tiles() {
 
     for &child in &names {
         let path = std::path::PathBuf::from(format!("/tmp/depth_test_{child}"));
-        let result = app.new_child_context(&parent_name, path, true, false);
+        let result = app.new_child_context(&parent_name, path, true, false, None);
         if result.is_err() {
             // PTY unavailable — can't build the full chain in test env. Stop here.
             break;

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -65,14 +65,13 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     let parent_pane_count_before = app.windows[0].panes.len();
     let parent_id = app.router.active().context_id;
 
-    let result =
-        app.new_child_context(
-            "Test",
-            std::path::PathBuf::from("/tmp/child2"),
-            true,
-            false,
-            None,
-        );
+    let result = app.new_child_context(
+        "Test",
+        std::path::PathBuf::from("/tmp/child2"),
+        true,
+        false,
+        None,
+    );
 
     // Whether success or failure, the parent's focused_pane must remain None.
     assert_eq!(
@@ -107,7 +106,7 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     }
 }
 
-/// `plexi context new --pane <id>`: the portal split must anchor at the given
+/// `plexi context new --from <id>`: the portal split must anchor at the given
 /// pane, not the parent context's focused pane. Two panes exist; A is focused;
 /// the anchor names B — the portal must land as B's sibling.
 #[test]
@@ -1829,5 +1828,169 @@ fn closing_last_pane_in_background_subcontext_removes_it_without_switching() {
         app.router.active().context_id,
         root_id,
         "active context must not change when a background subcontext collapses"
+    );
+}
+
+/// End-to-end over the real IPC path: `plexi context push` sends `pane_id`
+/// (the caller's PLEXI_PANE_ID) and the host pushes THAT pane into the new
+/// sub-context — not the focused one.
+#[test]
+fn push_pane_ipc_targets_caller_pane_not_focused() {
+    let mut h = crate::testing::HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let pane_b = h.add_test_pane();
+    let tile_a = h.app.windows[0].tree.tiles.find_pane(&pane_a).unwrap();
+    h.app.windows[0].focused_pane = Some(tile_a);
+    let parent_id = h.app.router.active().context_id;
+    let ctx_count_before = h.app.router.len();
+
+    let payload = serde_json::json!({
+        "type": "push_pane_to_subcontext",
+        "name": "pushed",
+        "pane_id": pane_b,
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    assert_eq!(
+        h.app.router.len(),
+        ctx_count_before + 1,
+        "push must create one child context"
+    );
+    let parent_win = h
+        .app
+        .windows
+        .iter()
+        .find(|w| w.context_id == parent_id)
+        .expect("parent window must still exist");
+    assert!(
+        parent_win.panes.contains_key(&pane_a),
+        "focused pane A must stay in the parent window"
+    );
+    assert!(
+        !parent_win.panes.contains_key(&pane_b),
+        "caller pane B must have moved into the child context"
+    );
+    let child_win = h
+        .app
+        .windows
+        .iter()
+        .find(|w| w.context_id != parent_id)
+        .expect("child window must exist");
+    assert!(
+        child_win.panes.contains_key(&pane_b),
+        "caller pane B must live in the child window"
+    );
+}
+
+/// `plexi context push` with an unknown pane id falls back to the focused pane.
+#[test]
+fn push_pane_ipc_unknown_pane_falls_back_to_focused() {
+    let mut h = crate::testing::HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let tile_a = h.app.windows[0].tree.tiles.find_pane(&pane_a).unwrap();
+    h.app.windows[0].focused_pane = Some(tile_a);
+    let parent_id = h.app.router.active().context_id;
+
+    let payload = serde_json::json!({
+        "type": "push_pane_to_subcontext",
+        "pane_id": 999_999u64,
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let parent_win = h
+        .app
+        .windows
+        .iter()
+        .find(|w| w.context_id == parent_id)
+        .expect("parent window must still exist");
+    assert!(
+        !parent_win.panes.contains_key(&pane_a),
+        "fallback must push the focused pane"
+    );
+}
+
+/// `plexi context describe` sends the caller's PLEXI_CONTEXT_ID — the host
+/// must set the description on THAT context, not the active one.
+#[test]
+fn set_context_description_ipc_targets_caller_context() {
+    let mut h = crate::testing::HostHarness::new();
+    let active_id = h.app.router.active().context_id;
+    let other_id = active_id + 100;
+    h.app
+        .router
+        .push(test_context(other_id, active_id, "background"));
+
+    let payload = serde_json::json!({
+        "type": "set_context_description",
+        "description": "set from a background pane",
+        "context_id": other_id,
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let other_idx = h.app.router.position(|c| c.context_id == other_id).unwrap();
+    assert_eq!(
+        h.app.router.get(other_idx).description.as_deref(),
+        Some("set from a background pane"),
+        "description must land on the caller's context"
+    );
+    let active_idx = h
+        .app
+        .router
+        .position(|c| c.context_id == active_id)
+        .unwrap();
+    assert_eq!(
+        h.app.router.get(active_idx).description,
+        None,
+        "active context must be untouched"
+    );
+}
+
+/// `plexi context set-root` sends the caller's PLEXI_CONTEXT_ID — the host
+/// must re-root THAT context, not the active one.
+#[test]
+fn set_context_root_ipc_targets_caller_context() {
+    let mut h = crate::testing::HostHarness::new();
+    let active_id = h.app.router.active().context_id;
+    let active_root_before = h.app.router.active().root.clone();
+    let other_id = active_id + 100;
+    h.app
+        .router
+        .push(test_context(other_id, active_id, "background"));
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let payload = serde_json::json!({
+        "type": "set_context_root",
+        "root": tmp.path(),
+        "context_id": other_id,
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let other_idx = h.app.router.position(|c| c.context_id == other_id).unwrap();
+    assert_eq!(
+        h.app.router.get(other_idx).root.as_deref(),
+        Some(tmp.path()),
+        "root must land on the caller's context"
+    );
+    let active_idx = h
+        .app
+        .router
+        .position(|c| c.context_id == active_id)
+        .unwrap();
+    assert_eq!(
+        h.app.router.get(active_idx).root,
+        active_root_before,
+        "active context root must be untouched"
     );
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -858,6 +858,11 @@ pub enum ContextCmd {
         /// Focus (zoom into) the new sub-context after creation. Default: stay in current pane.
         #[arg(long)]
         focus: bool,
+        /// Pane to anchor the portal split at (requires --parent).
+        /// Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the
+        /// parent context's focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        pane: Option<u64>,
         /// Split portal below instead of right (requires --parent).
         #[arg(long, short = 'd', conflicts_with_all = ["left", "up", "right"])]
         down: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -347,9 +347,10 @@ pub enum AppCmd {
         /// New window
         #[arg(long, conflicts_with_all = ["down", "left", "up", "right", "tab"])]
         window: bool,
-        /// Open the new pane relative to this pane ID instead of the focused pane
-        #[arg(long)]
-        from_pane_id: Option<u64>,
+        /// Open the new pane relative to this pane ID. Defaults to the calling
+        /// pane (PLEXI_PANE_ID env), falling back to the focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        from: Option<u64>,
         /// Extra arguments passed through to the app (only valid with an app id)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, conflicts_with_all = ["mcp", "cli"])]
         extra_args: Vec<String>,
@@ -494,10 +495,10 @@ pub enum AppCmd {
         #[arg(long)]
         #[arg(hide = true)]
         no_open: bool,
-        /// Open the new pane relative to this pane ID instead of the focused pane.
-        /// Defaults to PLEXI_PANE_ID if set in the environment.
-        #[arg(long)]
-        from_pane_id: Option<u64>,
+        /// Open the new pane relative to this pane ID. Defaults to the calling
+        /// pane (PLEXI_PANE_ID env), falling back to the focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        from: Option<u64>,
     },
     /// Check a Plexi app directory or .plexipkg package for errors before publishing or installing.
     ///
@@ -621,8 +622,9 @@ pub enum PaneCmd {
         /// Overlay pane
         #[arg(long, conflicts_with_all = ["down", "left", "up", "tab", "window"])]
         overlay: bool,
-        /// Pane ID to split relative to (default: focused pane)
-        #[arg(long)]
+        /// Pane ID to split relative to. Defaults to the calling pane
+        /// (PLEXI_PANE_ID env), falling back to the focused pane.
+        #[arg(long, value_name = "PANE_ID")]
         from: Option<u64>,
         /// Close the pane when the command finishes
         #[arg(long, short = 'e')]
@@ -840,7 +842,7 @@ pub enum ContextCmd {
     /// Examples:
     ///   plexi context new "sprint"                          # top-level context
     ///   plexi context new "sprint" --parent                 # child of current context (no-focus)
-    ///   plexi context new "sprint" --parent "main" -d       # child, portal splits below
+    ///   plexi context new "sprint" --parent=main -d         # child of "main", portal splits below
     ///   plexi context new "sprint" --parent --window "echo a" --window "echo b"
     New {
         /// Name for the new context. Defaults to the directory basename.
@@ -848,9 +850,10 @@ pub enum ContextCmd {
         /// Root path for the new context. Defaults to current working directory.
         #[arg(long)]
         path: Option<String>,
-        /// Create as a child of the named context.
-        /// With no value, uses the current context (reads PLEXI_CONTEXT_NAME from env).
-        #[arg(long, num_args = 0..=1, default_missing_value = "__current__")]
+        /// Create as a child of a context (the new context is its sub-context).
+        /// Bare `--parent` uses the current context (reads PLEXI_CONTEXT_NAME from
+        /// env); use `--parent=<name>` to target another context by name.
+        #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "__current__", value_name = "NAME")]
         parent: Option<String>,
         /// Command to run in each pre-populated window. Repeatable.
         #[arg(long, action = clap::ArgAction::Append)]
@@ -862,7 +865,7 @@ pub enum ContextCmd {
         /// Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the
         /// parent context's focused pane.
         #[arg(long, value_name = "PANE_ID")]
-        pane: Option<u64>,
+        from: Option<u64>,
         /// Split portal below instead of right (requires --parent).
         #[arg(long, short = 'd', conflicts_with_all = ["left", "up", "right"])]
         down: bool,
@@ -891,10 +894,17 @@ pub enum ContextCmd {
     Zoom { context_id: u64 },
     /// Zoom out of the current sub-context to the parent.
     ZoomOut,
-    /// Push the focused pane into a new sub-context.
+    /// Push a pane into a new sub-context.
+    ///
+    /// Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the
+    /// focused pane.
     Push {
         /// Name for the new sub-context. Defaults to the pane name.
         name: Option<String>,
+        /// Pane to push. Defaults to the calling pane (PLEXI_PANE_ID env),
+        /// falling back to the focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        pane_id: Option<u64>,
     },
     /// List all open contexts as a JSON array.
     List,
@@ -958,10 +968,10 @@ pub enum AgentCmd {
     Init {
         /// App name (used as the directory name and app ID)
         name: String,
-        /// Open the new pane relative to this pane ID instead of the focused pane.
-        /// Defaults to PLEXI_PANE_ID if set in the environment.
-        #[arg(long)]
-        from_pane_id: Option<u64>,
+        /// Open the new pane relative to this pane ID. Defaults to the calling
+        /// pane (PLEXI_PANE_ID env), falling back to the focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        from: Option<u64>,
     },
     /// Install an agent definition from the global registry into the current workspace.
     ///

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -8,7 +8,7 @@ pub fn context_new_cli(
     windows: &[String],
     focus: bool,
     direction: &str,
-    pane: Option<u64>,
+    from: Option<u64>,
 ) -> i32 {
     let explicit_root = match path {
         Some(_) => match resolve_path(path) {
@@ -58,9 +58,9 @@ pub fn context_new_cli(
     } else {
         None
     };
-    // Portal split anchor: explicit --pane wins; otherwise the caller's own pane
+    // Portal split anchor: explicit --from wins; otherwise the caller's own pane
     // (PLEXI_PANE_ID, set in every Plexi terminal). Only meaningful with --parent.
-    let anchor_pane = pane.or_else(|| {
+    let anchor_pane = from.or_else(|| {
         std::env::var("PLEXI_PANE_ID")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -173,7 +173,8 @@ pub fn context_open_cli(path: Option<&str>) -> i32 {
 
 /// `plexi context set-root [path]`
 ///
-/// Sets the root of the active context. Uses CWD if path omitted.
+/// Sets the root of the caller's context (PLEXI_CONTEXT_ID), falling back to
+/// the active context. Uses CWD if path omitted.
 pub fn context_set_root_cli(path: Option<&str>) -> i32 {
     let root = match resolve_path(path) {
         Ok(p) => p,
@@ -182,10 +183,19 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
             return 1;
         }
     };
-    let rc = send_to_socket(serde_json::json!({
+    let context_id = caller_context_id();
+    log::info!(
+        "context_set_root_cli: root={} context_id={context_id:?}",
+        root.display()
+    );
+    let mut payload = serde_json::json!({
         "type": "set_context_root",
         "root": root,
-    }));
+    });
+    if let Some(cid) = context_id {
+        payload["context_id"] = serde_json::Value::from(cid);
+    }
+    let rc = send_to_socket(payload);
     if rc == 0 {
         print_tip(
             "you can also press \u{21E7}\u{2318}I to set the context root from the focused pane",
@@ -196,24 +206,48 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
 
 /// `plexi context describe "text"`
 ///
-/// Sets the description of the active context.
+/// Sets the description of the caller's context (PLEXI_CONTEXT_ID), falling
+/// back to the active context.
 pub fn context_describe_cli(text: &str) -> i32 {
-    send_to_socket(serde_json::json!({
+    let context_id = caller_context_id();
+    log::info!("context_describe_cli: context_id={context_id:?}");
+    let mut payload = serde_json::json!({
         "type": "set_context_description",
         "description": text,
-    }))
+    });
+    if let Some(cid) = context_id {
+        payload["context_id"] = serde_json::Value::from(cid);
+    }
+    send_to_socket(payload)
 }
 
-/// `plexi context push [name]`
+/// `plexi context push [name] [--pane-id <id>]`
 ///
-/// Push the focused pane into a new sub-context. The pane becomes a portal
-/// and its content moves into the child context.
-pub fn context_push_cli(name: Option<&str>) -> i32 {
+/// Push a pane into a new sub-context. The pane becomes a portal and its
+/// content moves into the child context. Defaults to the calling pane
+/// (PLEXI_PANE_ID), falling back to the focused pane.
+pub fn context_push_cli(name: Option<&str>, pane_id: Option<u64>) -> i32 {
+    let pane_id = pane_id.or_else(|| {
+        std::env::var("PLEXI_PANE_ID")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+    });
+    log::info!("context_push_cli: name={name:?} pane_id={pane_id:?}");
     let mut payload = serde_json::json!({ "type": "push_pane_to_subcontext" });
     if let Some(n) = name {
         payload["name"] = serde_json::Value::String(n.to_string());
     }
+    if let Some(pid) = pane_id {
+        payload["pane_id"] = serde_json::Value::from(pid);
+    }
     send_to_socket(payload)
+}
+
+/// The caller's context id from PLEXI_CONTEXT_ID (set in every Plexi pane).
+fn caller_context_id() -> Option<u64> {
+    std::env::var("PLEXI_CONTEXT_ID")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
 }
 
 /// `plexi context current`

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -8,6 +8,7 @@ pub fn context_new_cli(
     windows: &[String],
     focus: bool,
     direction: &str,
+    pane: Option<u64>,
 ) -> i32 {
     let explicit_root = match path {
         Some(_) => match resolve_path(path) {
@@ -57,8 +58,15 @@ pub fn context_new_cli(
     } else {
         None
     };
+    // Portal split anchor: explicit --pane wins; otherwise the caller's own pane
+    // (PLEXI_PANE_ID, set in every Plexi terminal). Only meaningful with --parent.
+    let anchor_pane = pane.or_else(|| {
+        std::env::var("PLEXI_PANE_ID")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+    });
     log::info!(
-        "context_new_cli: name={:?} root={:?} parent={:?} windows={} focus={focus} direction={direction}",
+        "context_new_cli: name={:?} root={:?} parent={:?} windows={} focus={focus} direction={direction} anchor_pane={anchor_pane:?}",
         name,
         explicit_root
             .as_ref()
@@ -84,6 +92,11 @@ pub fn context_new_cli(
     }
     if direction != "right" {
         payload["portal_direction"] = serde_json::Value::String(direction.to_string());
+    }
+    if explicit_parent.is_some() {
+        if let Some(ap) = anchor_pane {
+            payload["anchor_pane"] = serde_json::Value::from(ap);
+        }
     }
     if let Some(ref rf) = response_file {
         payload["response_file"] = serde_json::Value::String(rf.clone());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -172,7 +172,7 @@ pub(super) fn send_to_socket(payload: serde_json::Value) -> i32 {
 /// Best-effort wake of a running instance after a spawn-queue file write.
 ///
 /// A fully idle Plexi produces zero frames and only drains the spawn-queue
-/// during a frame, so without this nudge an outside-shell `plexi terminal`
+/// during a frame, so without this nudge an outside-shell `plexi pane new`
 /// hangs until the user touches the window. Connects to the channel
 /// profile's `notify.sock` and sends a no-op `AppRequest::Wake`; the socket
 /// listener requests a repaint, the resulting frame drains the queue.

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -152,8 +152,10 @@ pub fn pane_new_cli(
 
     // Fallback: spawn-queue (outside a Plexi pane)
     if from_pane_id.is_some() {
-        log::warn!("pane_new:cli: --from-pane-id requires PLEXI_SOCKET (run inside a Plexi pane); ignoring");
-        eprintln!("warning: --from-pane-id is ignored outside a Plexi pane");
+        log::warn!(
+            "pane_new:cli: --from requires PLEXI_SOCKET (run inside a Plexi pane); ignoring"
+        );
+        eprintln!("warning: --from is ignored outside a Plexi pane");
     }
     let queue_dir = crate::config::config_dir().join("spawn-queue");
     if let Err(e) = std::fs::create_dir_all(&queue_dir) {

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -182,7 +182,7 @@ pub struct TerminalPane {
     pub name_locked: bool,
     pub font_size: f32,
     /// When true, the pane closes automatically when its process exits (no "[process exited]" prompt).
-    /// Set by `plexi terminal --ephemeral`.
+    /// Set by `plexi pane new --ephemeral`.
     pub ephemeral: bool,
     /// Last OSC 2 title string the process wrote, tracked independently of `name` and `name_locked`.
     /// Used by FocusChanged events to record what was running in the pane.
@@ -298,7 +298,6 @@ impl AppRuntime {
             AppRuntime::Builtin(app) => app.sync_cwd(new_cwd),
         }
     }
-
 
     pub fn type_id(&self) -> &'static str {
         match self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -872,6 +872,7 @@ fn main() -> eframe::Result {
                             parent,
                             window,
                             focus,
+                            pane,
                             down,
                             left,
                             up,
@@ -893,6 +894,7 @@ fn main() -> eframe::Result {
                                 &window,
                                 focus,
                                 dir,
+                                pane,
                             ))
                         }
                         ContextCmd::Open { path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,10 @@ mod cli;
 
 mod config;
 mod features;
-mod notes;
 mod file_browser;
 mod host;
 mod media;
+mod notes;
 mod overlays;
 mod pane_ops;
 mod platform;
@@ -221,8 +221,8 @@ fn main() -> eframe::Result {
                         RoutineCmd::Run { name } => std::process::exit(cli::routine_run(&name)),
                     },
                     Commands::Agent { cmd } => match cmd {
-                        AgentCmd::Init { name, from_pane_id } => {
-                            std::process::exit(cli::agent_init(&name, from_pane_id))
+                        AgentCmd::Init { name, from } => {
+                            std::process::exit(cli::agent_init(&name, from))
                         }
                         AgentCmd::Add { name } => std::process::exit(cli::agent_add(&name)),
                         AgentCmd::Update { name } => std::process::exit(cli::agent_update(&name)),
@@ -290,7 +290,7 @@ fn main() -> eframe::Result {
                                 right,
                                 tab,
                                 window,
-                                from_pane_id,
+                                from: from_pane_id,
                                 extra_args,
                             } => {
                                 let layout: Option<String> = if down {
@@ -472,7 +472,7 @@ fn main() -> eframe::Result {
                                 global,
                                 open,
                                 no_open,
-                                from_pane_id,
+                                from: from_pane_id,
                             } => std::process::exit(cli::app_init(
                                 &name,
                                 &lang,
@@ -720,11 +720,7 @@ fn main() -> eframe::Result {
                                 text,
                                 enter,
                             } => {
-                                let payload = if enter {
-                                    format!("{text}\n")
-                                } else {
-                                    text
-                                };
+                                let payload = if enter { format!("{text}\n") } else { text };
                                 log::info!(
                                     "pane_command:cli: pane_id={pane_id} len={} enter={enter}",
                                     payload.len()
@@ -872,7 +868,7 @@ fn main() -> eframe::Result {
                             parent,
                             window,
                             focus,
-                            pane,
+                            from,
                             down,
                             left,
                             up,
@@ -894,7 +890,7 @@ fn main() -> eframe::Result {
                                 &window,
                                 focus,
                                 dir,
-                                pane,
+                                from,
                             ))
                         }
                         ContextCmd::Open { path } => {
@@ -911,8 +907,8 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::context_zoom_cli(context_id))
                         }
                         ContextCmd::ZoomOut => std::process::exit(cli::context_zoom_out_cli()),
-                        ContextCmd::Push { name } => {
-                            std::process::exit(cli::context_push_cli(name.as_deref()))
+                        ContextCmd::Push { name, pane_id } => {
+                            std::process::exit(cli::context_push_cli(name.as_deref(), pane_id))
                         }
                         ContextCmd::List => std::process::exit(cli::context_list_cli()),
                     },
@@ -944,9 +940,7 @@ fn main() -> eframe::Result {
                     Commands::Notes { cmd } => match cmd {
                         Some(NotesCmd::List) | None => std::process::exit(cli::notes_list_cli()),
                         Some(NotesCmd::Open) => std::process::exit(cli::notes_open_cli()),
-                        Some(NotesCmd::Inbox) => {
-                            std::process::exit(cli::notes::notes_inbox_cli())
-                        }
+                        Some(NotesCmd::Inbox) => std::process::exit(cli::notes::notes_inbox_cli()),
                         Some(NotesCmd::Process) => {
                             std::process::exit(cli::notes::notes_process_cli())
                         }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -202,6 +202,7 @@ impl PlexiApp {
         path: PathBuf,
         vertical: bool,
         new_pane_first: bool,
+        anchor_pane: Option<u64>,
     ) -> Result<(), String> {
         let parent_idx = self
             .router
@@ -252,7 +253,22 @@ impl PlexiApp {
         };
 
         // 2. Insert Portal tile into the parent window via the standard split path.
-        let parent_win_idx = {
+        // An explicit anchor pane (the CLI caller's pane, from --pane or
+        // PLEXI_PANE_ID) selects both the parent window and the split target;
+        // otherwise fall back to the parent's active window and its focused pane.
+        let portal_anchor = anchor_pane.and_then(|pid| {
+            self.windows
+                .iter()
+                .position(|w| w.context_id == parent_id && w.tree.tiles.find_pane(&pid).is_some())
+                .map(|idx| (idx, pid))
+        });
+        if anchor_pane.is_some() && portal_anchor.is_none() {
+            log::warn!(
+                "new_child_context: anchor pane {anchor_pane:?} not found in parent \
+                 ctx_id={parent_id} — falling back to focused pane"
+            );
+        }
+        let parent_win_idx = portal_anchor.map(|(idx, _)| idx).or_else(|| {
             let preferred = self.context_active_window.get(&parent_id).copied();
             preferred
                 .and_then(|wid| {
@@ -261,10 +277,12 @@ impl PlexiApp {
                         .position(|w| w.window_id == wid && w.context_id == parent_id)
                 })
                 .or_else(|| self.windows.iter().position(|w| w.context_id == parent_id))
-        };
+        });
         let sub_ctx_pane_id = self.host.alloc_pane_id();
         if let Some(parent_win_idx) = parent_win_idx {
-            let split_target = self.windows[parent_win_idx].focused_pane;
+            let split_target = portal_anchor
+                .and_then(|(_, pid)| self.windows[parent_win_idx].tree.tiles.find_pane(&pid))
+                .or(self.windows[parent_win_idx].focused_pane);
             crate::pane_ops::layout::insert_split_tile(
                 &mut self.windows[parent_win_idx].tree,
                 split_target,
@@ -333,7 +351,7 @@ impl PlexiApp {
             parent_path.display()
         );
 
-        match self.new_child_context(&parent_name, parent_path, true, false) {
+        match self.new_child_context(&parent_name, parent_path, true, false, None) {
             Ok(()) => {
                 let new_ctx_idx = self.router.len() - 1;
                 self.router

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -368,8 +368,35 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn push_pane_to_subcontext(&mut self, name: Option<String>) {
-        let parent_win_idx = self.active_window;
+    pub(crate) fn push_pane_to_subcontext(
+        &mut self,
+        name: Option<String>,
+        target_pane: Option<u64>,
+    ) {
+        // An explicit pane (the caller's PLEXI_PANE_ID over IPC) selects both
+        // the window and the tile; otherwise the focused pane is pushed.
+        let target = target_pane.and_then(|pid| {
+            self.windows
+                .iter()
+                .enumerate()
+                .find_map(|(idx, w)| w.tree.tiles.find_pane(&pid).map(|tile| (idx, tile)))
+        });
+        if target_pane.is_some() && target.is_none() {
+            log::warn!(
+                "push_pane_to_subcontext: pane {target_pane:?} not found — falling back to focused pane"
+            );
+        }
+        let (parent_win_idx, target_tile) = match target {
+            Some(t) => t,
+            None => {
+                let win_idx = self.active_window;
+                let Some(focused_tile) = self.windows[win_idx].focused_pane else {
+                    log::warn!("push_pane_to_subcontext: no focused pane");
+                    return;
+                };
+                (win_idx, focused_tile)
+            }
+        };
         let parent_ctx_id = self.windows[parent_win_idx].context_id;
         let parent_depth = self
             .router
@@ -378,15 +405,10 @@ impl PlexiApp {
             .map(|c| c.depth)
             .unwrap_or(0);
 
-        let Some(focused_tile) = self.windows[parent_win_idx].focused_pane else {
-            log::warn!("push_pane_to_subcontext: no focused pane");
-            return;
-        };
-
-        let pane_id = match self.windows[parent_win_idx].tree.tiles.get(focused_tile) {
+        let pane_id = match self.windows[parent_win_idx].tree.tiles.get(target_tile) {
             Some(egui_tiles::Tile::Pane(pid)) => *pid,
             _ => {
-                log::warn!("push_pane_to_subcontext: focused tile is not a pane");
+                log::warn!("push_pane_to_subcontext: target tile is not a pane");
                 return;
             }
         };
@@ -443,10 +465,8 @@ impl PlexiApp {
         };
 
         let portal_pane_id = self.host.alloc_pane_id();
-        if let Some(egui_tiles::Tile::Pane(slot)) = self.windows[parent_win_idx]
-            .tree
-            .tiles
-            .get_mut(focused_tile)
+        if let Some(egui_tiles::Tile::Pane(slot)) =
+            self.windows[parent_win_idx].tree.tiles.get_mut(target_tile)
         {
             *slot = portal_pane_id;
         }
@@ -493,7 +513,7 @@ impl PlexiApp {
 
         let current_win_id = self.windows[parent_win_idx].window_id;
         self.router
-            .push_depth(parent_ctx_id, current_win_id, Some(focused_tile));
+            .push_depth(parent_ctx_id, current_win_id, Some(target_tile));
         let new_ctx_idx = self.router.len() - 1;
         self.switch_workspace(new_ctx_idx);
 
@@ -1162,17 +1182,37 @@ impl PlexiApp {
         self.save_workspace();
     }
 
-    /// Set the `root` of the active context.
-    pub(crate) fn set_active_context_root(&mut self, root: PathBuf) {
-        let idx = self.router.active_idx();
+    /// Resolve an optional context id to a router index. Falls back to the
+    /// active context (with a warning) when the id is absent or unknown.
+    pub(crate) fn resolve_context_idx(&self, context_id: Option<u64>, op: &str) -> usize {
+        match context_id {
+            Some(cid) => match self.router.position(|c| c.context_id == cid) {
+                Some(idx) => idx,
+                None => {
+                    log::warn!("{op}: context_id={cid} not found — falling back to active context");
+                    self.router.active_idx()
+                }
+            },
+            None => self.router.active_idx(),
+        }
+    }
+
+    /// Set the `root` of a context. `context_id` targets a specific context
+    /// (the caller's PLEXI_CONTEXT_ID over IPC); `None` means the active one.
+    pub(crate) fn set_context_root(&mut self, root: PathBuf, context_id: Option<u64>) {
+        let idx = self.resolve_context_idx(context_id, "set_context_root");
         log::info!(
-            "set_active_context_root: ctx_id={} root={}",
-            self.router.active().context_id,
+            "set_context_root: ctx_id={} root={}",
+            self.router.get(idx).context_id,
             root.display()
         );
         auto_init_workspace(&root);
         self.router.get_mut(idx).root = Some(root);
-        self.apply_context_transition_effects();
+        // Transition effects (registry rescan, watcher restart, agent reload)
+        // only apply when the *active* context's root changed.
+        if idx == self.router.active_idx() {
+            self.apply_context_transition_effects();
+        }
     }
 
     /// Single choke point for all context-transition side effects.

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -869,6 +869,11 @@ pub enum AppRequest {
         /// Direction the portal tile splits in the parent window: "right" | "down" | "left" | "up".
         #[serde(default, skip_serializing_if = "Option::is_none")]
         portal_direction: Option<String>,
+        /// Pane in the parent context to anchor the portal split at. The CLI sends
+        /// the caller's pane (--pane or PLEXI_PANE_ID); absent or unknown ids fall
+        /// back to the parent's focused pane.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        anchor_pane: Option<u64>,
         /// If set, the host writes a JSON response (context_id, windows) to this path.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         response_file: Option<String>,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -38,7 +38,9 @@ impl schemars::JsonSchema for LayoutChild {
 
 /// Closed vocabulary for text anchor alignment.
 /// Values match egui's `Align2` naming convention: `{h}_{v}`.
-#[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TextAlign {
     LeftTop,
@@ -880,18 +882,34 @@ pub enum AppRequest {
     },
     /// Focus existing context by root, or create one. Sent by `plexi context open`.
     FocusContext { root: std::path::PathBuf },
-    /// Set/update the root of the active context. Sent by `plexi context set-root`.
-    SetContextRoot { root: std::path::PathBuf },
-    /// Set/update the description of the active context. Sent by `plexi context describe`.
-    SetContextDescription { description: String },
+    /// Set/update the root of a context. Sent by `plexi context set-root`.
+    /// `context_id` targets the caller's context (PLEXI_CONTEXT_ID); when
+    /// absent, the active context is used.
+    SetContextRoot {
+        root: std::path::PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_id: Option<u64>,
+    },
+    /// Set/update the description of a context. Sent by `plexi context describe`.
+    /// `context_id` targets the caller's context (PLEXI_CONTEXT_ID); when
+    /// absent, the active context is used.
+    SetContextDescription {
+        description: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_id: Option<u64>,
+    },
     /// Zoom into a sub-context. Pushes depth stack. Sent by `plexi context zoom`.
     ZoomIntoContext { context_id: u64 },
     /// Zoom out of a sub-context. Pops depth stack. Sent by `plexi context zoom-out`.
     ZoomOutOfContext,
-    /// Push the focused pane into a new sub-context. Sent by `plexi context push`.
+    /// Push a pane into a new sub-context. Sent by `plexi context push`.
+    /// `pane_id` targets the caller's pane (PLEXI_PANE_ID); when absent, the
+    /// focused pane is pushed.
     PushPaneToSubcontext {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pane_id: Option<u64>,
     },
 
     /// Query the rolled-up `ContextState` for a context (#1518).
@@ -3302,8 +3320,19 @@ mod tests {
         let json = r#"{"type":"set_context_description","description":"Main project workspace"}"#;
         let cmd: DrawCommand = serde_json::from_str(json).expect("deserialise");
         match &cmd {
-            DrawCommand::Host(AppRequest::SetContextDescription { description }) => {
+            DrawCommand::Host(AppRequest::SetContextDescription {
+                description,
+                context_id,
+            }) => {
                 assert_eq!(description, "Main project workspace");
+                assert_eq!(*context_id, None, "context_id defaults to None");
+            }
+            other => panic!("expected SetContextDescription, got {other:?}"),
+        }
+        let targeted = r#"{"type":"set_context_description","description":"d","context_id":7}"#;
+        match serde_json::from_str::<DrawCommand>(targeted).expect("deserialise targeted") {
+            DrawCommand::Host(AppRequest::SetContextDescription { context_id, .. }) => {
+                assert_eq!(context_id, Some(7));
             }
             other => panic!("expected SetContextDescription, got {other:?}"),
         }
@@ -3947,7 +3976,10 @@ mod ai_stream_chunk_tests {
     #[test]
     fn wake_round_trips_serde() {
         let req: AppRequest = serde_json::from_str(r#"{"type":"wake"}"#).expect("deserialise");
-        assert!(matches!(req, AppRequest::Wake), "expected Wake, got {req:?}");
+        assert!(
+            matches!(req, AppRequest::Wake),
+            "expected Wake, got {req:?}"
+        );
         let serialised = serde_json::to_string(&req).expect("serialise");
         assert!(
             serialised.contains(r#""type":"wake""#),

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -373,7 +373,7 @@ fn read_json_response(path: &str) -> serde_json::Value {
 fn pane_slots_write_read_list_delete() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let write_file = temp_response(tmp.path(), "slot-write");
@@ -441,7 +441,7 @@ fn pane_slots_write_read_list_delete() {
 fn pane_slot_read_preserves_error_like_json_content() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
     let raw_json = br#"{"ok":false,"error":"stored artifact"}"#;
 
@@ -475,7 +475,7 @@ fn pane_slot_read_preserves_error_like_json_content() {
 fn pane_slot_read_errors_use_sidecar_file() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let read_file = temp_response(tmp.path(), "slot-missing-read");
@@ -503,7 +503,7 @@ fn pane_slot_read_errors_use_sidecar_file() {
 fn pane_slot_write_requires_replace_or_append_for_existing_slot() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let first_file = temp_response(tmp.path(), "slot-first");
@@ -552,7 +552,7 @@ fn pane_slot_write_requires_replace_or_append_for_existing_slot() {
 fn pane_slot_write_rejects_content_over_10_mib() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let response_file = temp_response(tmp.path(), "slot-too-large");
@@ -577,7 +577,7 @@ fn pane_slot_write_rejects_content_over_10_mib() {
 fn pane_slot_append_rejects_final_file_over_10_mib() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let first_file = temp_response(tmp.path(), "slot-first");
@@ -618,7 +618,7 @@ fn pane_slot_append_uses_tracked_path_after_context_root_changes() {
     let second_root = tempfile::tempdir().expect("second root");
     let mut h = HostHarness::new();
     h.app
-        .set_active_context_root(first_root.path().to_path_buf());
+        .set_context_root(first_root.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let write_file = temp_response(first_root.path(), "slot-root-write");
@@ -637,7 +637,7 @@ fn pane_slot_append_uses_tracked_path_after_context_root_changes() {
         .to_string();
 
     h.app
-        .set_active_context_root(second_root.path().to_path_buf());
+        .set_context_root(second_root.path().to_path_buf(), None);
     let append_file = temp_response(second_root.path(), "slot-root-append");
     h.inject_ipc(AppRequest::SlotWrite {
         pane_id: pane,
@@ -661,7 +661,7 @@ fn pane_slot_append_uses_tracked_path_after_context_root_changes() {
 fn pane_info_and_list_include_slots_object() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let write_file = temp_response(tmp.path(), "slot-info-write");
@@ -711,7 +711,7 @@ fn pane_info_and_list_include_slots_object() {
 fn workspace_clean_slots_lists_and_removes_dead_pane_slot_dirs() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let write_file = temp_response(tmp.path(), "slot-clean-write");
@@ -764,7 +764,7 @@ fn workspace_clean_slots_lists_and_removes_dead_pane_slot_dirs() {
 fn workspace_clean_slots_removes_unregistered_files_for_reused_pane_ids() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(tmp.path().to_path_buf());
+    h.app.set_context_root(tmp.path().to_path_buf(), None);
     let pane = h.add_test_pane();
 
     let slot_dir = tmp
@@ -1086,7 +1086,7 @@ fn notification_modal_handle_key_returns_consumed() {
 fn cwd_for_welcome_tab_returns_context_root_when_set() {
     let root = std::path::PathBuf::from("/tmp");
     let mut h = HostHarness::new();
-    h.app.set_active_context_root(root.clone());
+    h.app.set_context_root(root.clone(), None);
     assert_eq!(
         h.app.cwd_for_welcome_tab(),
         root,
@@ -2291,14 +2291,21 @@ fn emit_event_enters_host_timeline() {
     proc.background_tick();
 
     let timeline = proc.app_timeline.lock().unwrap();
-    assert_eq!(timeline.events().len(), 1, "accepted event must be recorded");
+    assert_eq!(
+        timeline.events().len(),
+        1,
+        "accepted event must be recorded"
+    );
     let rec = &timeline.events()[0];
     assert_eq!(rec.app_id, "test");
     assert_eq!(rec.event, "move.played");
     assert_eq!(rec.summary, "White played e4");
     assert_eq!(rec.resource_id, "game-abc");
     assert_eq!(rec.revision_after, "rev-13");
-    assert!(timeline.checkpoints().is_empty(), "no rollback metadata = no checkpoint");
+    assert!(
+        timeline.checkpoints().is_empty(),
+        "no rollback metadata = no checkpoint"
+    );
 }
 
 /// EmitEvent with a rollback token also creates an undo checkpoint carrying
@@ -2568,9 +2575,10 @@ fn list_undo_checkpoints_responds_with_serialized_records() {
     proc.background_tick();
     let events = h.effects_drain(pane);
     let listed = events.iter().find_map(|e| match e {
-        PlexiEvent::UndoCheckpoints { request_id, checkpoints } if request_id == "lc-1" => {
-            Some(checkpoints.clone())
-        }
+        PlexiEvent::UndoCheckpoints {
+            request_id,
+            checkpoints,
+        } if request_id == "lc-1" => Some(checkpoints.clone()),
         _ => None,
     });
     let listed = listed.expect("ListUndoCheckpoints must answer with UndoCheckpoints");
@@ -2632,21 +2640,23 @@ fn subscribe_app_events_gated_and_delivers() {
     );
 
     // Allow grant for this subscriber on the publisher's stream.
-    h.process_app_mut(subscriber).grant_store.record(GrantRecord {
-        actor_type: ActorType::App,
-        actor_id: "agent-app".to_string(),
-        actor_scope: ActorScope::User,
-        workspace_root: None,
-        target_type: TargetType::AppEventStream,
-        target_id: "test::move.played".to_string(),
-        resource_scope: ResourceScope::Game,
-        resource_id: None,
-        decision: Decision::Allow,
-        duration: GrantDuration::Session,
-        source: GrantSource::User,
-        created_at: 0,
-        expires_at: None,
-    });
+    h.process_app_mut(subscriber)
+        .grant_store
+        .record(GrantRecord {
+            actor_type: ActorType::App,
+            actor_id: "agent-app".to_string(),
+            actor_scope: ActorScope::User,
+            workspace_root: None,
+            target_type: TargetType::AppEventStream,
+            target_id: "test::move.played".to_string(),
+            resource_scope: ResourceScope::Game,
+            resource_id: None,
+            decision: Decision::Allow,
+            duration: GrantDuration::Session,
+            source: GrantSource::User,
+            created_at: 0,
+            expires_at: None,
+        });
     h.inject(subscriber, subscribe_cmd("sub-req-2"));
     h.process_app_mut(subscriber).background_tick();
     let events = h.effects_drain(subscriber);
@@ -2690,8 +2700,14 @@ fn subscribe_app_events_gated_and_delivers() {
     assert_eq!(event, "move.played");
     assert_eq!(trigger, TriggerMode::Conversation);
     assert_eq!(summary.as_deref(), Some("White played e4"));
-    assert!(payload.is_none(), "summary mode must not deliver the payload");
-    assert!(state_ref.is_none(), "summary mode must not deliver the state ref");
+    assert!(
+        payload.is_none(),
+        "summary mode must not deliver the payload"
+    );
+    assert!(
+        state_ref.is_none(),
+        "summary mode must not deliver the state ref"
+    );
 }
 
 /// Subscribing to an undeclared stream name is refused before the broker is
@@ -2839,15 +2855,19 @@ default = "ask"
     }
 
     fn chess_tools() -> Vec<AiTool> {
-        ["chess.current_state", "chess.legal_moves", "chess.make_move"]
-            .into_iter()
-            .map(|name| AiTool {
-                name: name.to_string(),
-                description: format!("test {name}"),
-                input_schema: serde_json::json!({"type": "object", "properties": {}}),
-                timeout_ms: Some(2_000),
-            })
-            .collect()
+        [
+            "chess.current_state",
+            "chess.legal_moves",
+            "chess.make_move",
+        ]
+        .into_iter()
+        .map(|name| AiTool {
+            name: name.to_string(),
+            description: format!("test {name}"),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            timeout_ms: Some(2_000),
+        })
+        .collect()
     }
 
     /// Register the chess tools and spawn a thread acting as the chess app:
@@ -2922,8 +2942,7 @@ default = "ask"
                 .tool_dispatcher
                 .as_ref()
                 .expect("agent turns must carry a tool dispatcher");
-            let visible: Vec<String> =
-                dispatcher.all_tools().into_iter().map(|t| t.name).collect();
+            let visible: Vec<String> = dispatcher.all_tools().into_iter().map(|t| t.name).collect();
             if visible.iter().any(|n| n == "chess.make_move") {
                 let result = dispatcher.dispatch_call(
                     "call-1".to_string(),
@@ -2953,8 +2972,7 @@ default = "ask"
                     "denied tool must be uninvocable: {result:?}"
                 );
                 AiBrokerResponse::ok(
-                    "A fine position. I would play Nf6, but I am not allowed to move."
-                        .to_string(),
+                    "A fine position. I would play Nf6, but I am not allowed to move.".to_string(),
                     1,
                     1,
                 )
@@ -2967,7 +2985,11 @@ default = "ask"
         loop {
             host.tick();
             let agent = &host.agents[0];
-            if agent.transcript.iter().any(|e| e.role == "agent" || e.role == "error") {
+            if agent
+                .transcript
+                .iter()
+                .any(|e| e.role == "agent" || e.role == "error")
+            {
                 return agent.transcript.clone();
             }
             assert!(
@@ -3110,7 +3132,10 @@ default = "ask"
             .unwrap()
             .record_event("chess", CHESS_PANE, turn_ready())
             .unwrap();
-        assert_eq!(outcome.deliveries_queued, 0, "no subscription = no delivery");
+        assert_eq!(
+            outcome.deliveries_queued, 0,
+            "no subscription = no delivery"
+        );
 
         host.tick();
         assert!(
@@ -3164,21 +3189,23 @@ default = "ask"
             .unwrap();
 
         // Allow the requesting app to roll back chess checkpoints.
-        h.process_app_mut(requester).grant_store.record(GrantRecord {
-            actor_type: ActorType::App,
-            actor_id: "test".to_string(),
-            actor_scope: ActorScope::User,
-            workspace_root: None,
-            target_type: TargetType::UndoCheckpoint,
-            target_id: "chess".to_string(),
-            resource_scope: ResourceScope::Game,
-            resource_id: None,
-            decision: Decision::Allow,
-            duration: GrantDuration::Session,
-            source: GrantSource::User,
-            created_at: 0,
-            expires_at: None,
-        });
+        h.process_app_mut(requester)
+            .grant_store
+            .record(GrantRecord {
+                actor_type: ActorType::App,
+                actor_id: "test".to_string(),
+                actor_scope: ActorScope::User,
+                workspace_root: None,
+                target_type: TargetType::UndoCheckpoint,
+                target_id: "chess".to_string(),
+                resource_scope: ResourceScope::Game,
+                resource_id: None,
+                decision: Decision::Allow,
+                duration: GrantDuration::Session,
+                source: GrantSource::User,
+                created_at: 0,
+                expires_at: None,
+            });
 
         h.process_app_mut(requester)
             .request_rollback(ActorType::App, "test", &ckpt_id)
@@ -3239,8 +3266,7 @@ fn add_app_pane_to_window(h: &mut HostHarness, window_id: u64, pane_id: u64) {
         .iter_mut()
         .find(|w| w.window_id == window_id)
         .expect("target window must exist");
-    win.panes
-        .insert(pane_id, Pane::App(Box::new(app_pane)));
+    win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
     let tile_id = win.tree.tiles.insert_pane(pane_id);
     if win.tree.root.is_none() {
         win.tree.root = Some(tile_id);
@@ -3268,7 +3294,9 @@ fn portal_context_state_refreshes_when_child_context_changes() {
         depth: 1,
         parked: false,
     });
-    h.app.context_active_window.insert(child_ctx_id, child_win_id);
+    h.app
+        .context_active_window
+        .insert(child_ctx_id, child_win_id);
     h.app.windows.push(crate::host::context::Window {
         name: String::new(),
         path: std::path::PathBuf::from("/tmp/harness_2023_child"),

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -66,8 +66,7 @@ impl PlexiUiHarness {
         let harness = egui_kittest::Harness::builder()
             .with_size(egui::Vec2::new(width, height))
             .build_eframe(move |cc| {
-                let (app, _ipc_tx) =
-                    PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
+                let (app, _ipc_tx) = PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
                 app
             });
         Self { inner: harness }
@@ -264,7 +263,7 @@ impl PlexiUiHarness {
     /// Convert the focused pane into a subcontext portal — same path as the
     /// push-pane-to-subcontext host shortcut and CLI command.
     pub fn push_focused_pane_to_subcontext(&mut self, name: Option<String>) {
-        self.with_app_mut(|app| app.push_pane_to_subcontext(name));
+        self.with_app_mut(|app| app.push_pane_to_subcontext(name, None));
     }
 
     /// Open the host Assistant pane rooted at `workspace_root` — same builtin
@@ -366,10 +365,8 @@ mod tests {
         let mut h = PlexiUiHarness::new();
         h.step();
 
-        let path = std::env::temp_dir().join(format!(
-            "plexi-ui-note-title-{}.md",
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("plexi-ui-note-title-{}.md", std::process::id()));
         std::fs::write(
             &path,
             "---\ntitle: \"Groceries\"\nsource: \"scratchpad\"\n---\nmilk and eggs\n",
@@ -524,13 +521,12 @@ mod tests {
             // Set overlay_replaced so the zoom path renders the overtake bar
             // ("← <replaced> / Esc return") via render::app_pane::render.
             if let Some(Pane::App(app_pane)) = win.panes.get_mut(&pane_id) {
-                app_pane.overlay_replaced =
-                    Some(Box::new(Pane::Portal(Box::new(PortalPane {
-                        pane_id: pane_id + 1_000,
-                        target_context_id: 42,
-                        context_state: None,
-                        hidden: false,
-                    }))));
+                app_pane.overlay_replaced = Some(Box::new(Pane::Portal(Box::new(PortalPane {
+                    pane_id: pane_id + 1_000,
+                    target_context_id: 42,
+                    context_state: None,
+                    hidden: false,
+                }))));
             }
             let tile_id = win
                 .tree
@@ -603,11 +599,8 @@ mod tests {
 
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
-        let mut assistant = crate::assistant::AssistantApp::new(
-            ws.path().to_path_buf(),
-            broker,
-            ws.path(),
-        );
+        let mut assistant =
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
         assistant
             .model
             .permission_requested("csv.write_range", r#"{"range": "A1:B2"}"#);

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description: Complete reference for all plexi subcommands and flags.
-verified_version: "0.0.749"
+verified_version: "0.0.752"
 order: 7
 ---
 
@@ -181,7 +181,7 @@ Example: plexi agent init my-agent
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<name>` | string | yes | App name (used as the directory name and app ID) |
-| `--from-pane-id` | string | no | Open the new pane relative to this pane ID instead of the focused pane. Defaults to PLEXI_PANE_ID if set in the environment |
+| `--from` | string | no | Open the new pane relative to this pane ID. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 
 ### `plexi agent add`
 
@@ -284,22 +284,23 @@ Manage the active context (the folder and project scope tied to the current pane
 | `describe` | Set the description for the active context |
 | `zoom` | Zoom into a sub-context by its numeric context_id |
 | `zoom-out` | Zoom out of the current sub-context to the parent |
-| `push` | Push the focused pane into a new sub-context |
+| `push` | Push a pane into a new sub-context |
 | `list` | List all open contexts as a JSON array |
 
 ### `plexi context new`
 
 Open a new context with an optional name.
 
-Examples: plexi context new "sprint"                          # top-level context plexi context new "sprint" --parent                 # child of current context (no-focus) plexi context new "sprint" --parent "main" -d       # child, portal splits below plexi context new "sprint" --parent --window "echo a" --window "echo b"
+Examples: plexi context new "sprint"                          # top-level context plexi context new "sprint" --parent                 # child of current context (no-focus) plexi context new "sprint" --parent=main -d         # child of "main", portal splits below plexi context new "sprint" --parent --window "echo a" --window "echo b"
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<name>` | string | no | Name for the new context. Defaults to the directory basename |
 | `--path` | string | no | Root path for the new context. Defaults to current working directory |
-| `--parent` | string | no | Create as a child of the named context. With no value, uses the current context (reads PLEXI_CONTEXT_NAME from env) |
+| `--parent` | string | no | Create as a child of a context (the new context is its sub-context). Bare `--parent` uses the current context (reads PLEXI_CONTEXT_NAME from env); use `--parent=<name>` to target another context by name |
 | `--window` | string (repeatable) | no | Command to run in each pre-populated window. Repeatable |
 | `--focus` | flag | no | Focus (zoom into) the new sub-context after creation. Default: stay in current pane |
+| `--from` | string | no | Pane to anchor the portal split at (requires --parent). Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the parent context's focused pane |
 | `--down` / `-d` | flag | no | Split portal below instead of right (requires --parent) |
 | `--left` / `-l` | flag | no | Split portal left (requires --parent) |
 | `--up` / `-u` | flag | no | Split portal above (requires --parent) |
@@ -347,11 +348,14 @@ Zoom out of the current sub-context to the parent
 
 ### `plexi context push`
 
-Push the focused pane into a new sub-context
+Push a pane into a new sub-context.
+
+Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane.
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<name>` | string | no | Name for the new sub-context. Defaults to the pane name |
+| `--pane-id` | string | no | Pane to push. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 
 ### `plexi context list`
 
@@ -396,7 +400,7 @@ Pass an app id (e.g. `plexi app open snake`) or a path to an app directory conta
 | `--right` / `-r` | flag | no | Split right |
 | `--tab` | flag | no | New tab |
 | `--window` | flag | no | New window |
-| `--from-pane-id` | string | no | Open the new pane relative to this pane ID instead of the focused pane |
+| `--from` | string | no | Open the new pane relative to this pane ID. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 | `<extra_args>` | string (repeatable) | no | Extra arguments passed through to the app (only valid with an app id) |
 
 ### `plexi app install`
@@ -475,7 +479,7 @@ Use --open to launch it in a split-right pane after scaffolding.
 | `--global` | flag | no | Scaffold into the global app registry instead of the workspace |
 | `--open` | flag | no | Open the app in a split-right pane after scaffolding |
 | `--no-open` | flag | no | Deprecated compatibility flag. App init no longer opens by default |
-| `--from-pane-id` | string | no | Open the new pane relative to this pane ID instead of the focused pane. Defaults to PLEXI_PANE_ID if set in the environment |
+| `--from` | string | no | Open the new pane relative to this pane ID. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 
 ### `plexi app validate`
 
@@ -603,7 +607,7 @@ For apps use `plexi app open`. For MCP servers use `plexi app open --mcp`.
 | `--tab` | flag | no | New tab |
 | `--window` | flag | no | New window |
 | `--overlay` | flag | no | Overlay pane |
-| `--from` | string | no | Pane ID to split relative to (default: focused pane) |
+| `--from` | string | no | Pane ID to split relative to. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 | `--ephemeral` / `-e` | flag | no | Close the pane when the command finishes |
 | `--no-focus` | flag | no | Keep focus on the current pane |
 | `--cwd` | string | no | Working directory |

--- a/website/src/content/docs/config.md
+++ b/website/src/content/docs/config.md
@@ -276,7 +276,7 @@ path  = "~/.plexi/backlog"
 [[quick_note.destinations]]
 key     = 2
 label   = "Ask Claude"
-command = "plexi terminal --layout context-end -- claude -p {note}"
+command = "plexi pane new 'claude -p {note}' --window"
 
 [[quick_note.destinations]]
 key   = 3
@@ -300,7 +300,7 @@ hidden  = true
 # label        = "Recent projects"
 # children_cmd = "~/.plexi/scripts/top-projects.sh"
 # # Script stdout format: one entry per line as  key|label|command
-# # Example line: 1|PLEXI|cd ~/Documents/GitHub/PLEXI && plexi terminal --layout context-end -- claude -p {note}
+# # Example line: 1|PLEXI|cd ~/Documents/GitHub/PLEXI && plexi pane new 'claude -p {note}' --window
 
 # ── Coding Agent Commands ──────────────────────────────────────
 # Command templates used when Plexi skills dispatch coding agent panes.


### PR DESCRIPTION
## Summary
CLI commands run from an agent's PTY now act on the calling pane/context by default instead of whatever the user has focused, and the anchor-pane flag is spelled the same everywhere.

## What

**Portal anchor (original scope)**
- `plexi context new --parent` portal split anchors at the calling pane (`PLEXI_PANE_ID`), or an explicit `--from <PANE_ID>`, falling back to the parent context's focused pane. Fixes dispatch sub-contexts splitting against the user's focused pane.

**Caller-targeting fixes (same bug family)**
- `context push` — new `--pane-id`, defaults to `PLEXI_PANE_ID`; previously always pushed the focused pane.
- `context set-root` / `context describe` — now send `PLEXI_CONTEXT_ID` so the host edits the caller's context, not the active one.

**Language unification**
- One spelling for "anchor relative to pane X": `--from` on `pane new`, `app open`, `app init`, `agent init`, `context new` (was `--from-pane-id` / `--pane`). Clean break, no aliases.
- `--parent` now uses `require_equals`: bare `--parent` = current context, `--parent=NAME` = explicit. Fixes greedy parse where `context new --parent sprint` bound "sprint" as the parent instead of the name.

**Docs**
- Regenerated `website/src/content/docs/cli.md` (gen_cli_docs).
- Purged dead `plexi terminal` (removed in #2117) from README, justfile, CLAUDE.md, config.md, and the dispatch / hand-off / project-manager / plexi-cli skills — all now use `pane new --from`.

## Tests
- `HostHarness` IPC tests (exact CLI JSON via `inject_ipc`): portal anchor placement, pane-targeted push + unknown-pane fallback, context-targeted set-root/describe (active context untouched).
- Serde round-trip extended for `context_id`.
- Full suite: 1070 passed, 0 failed.

## Breaking
`--from-pane-id` no longer exists (use `--from`); `--parent NAME` (space form) now parses NAME as the context name (use `--parent=NAME`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)