### PR TITLE
Marketplace: hosted registry, publisher submit, paid-app license + payment stub (stint 0018-0021)

### DIFF
--- a/.stint/sprints/s32.md
+++ b/.stint/sprints/s32.md
@@ -1,0 +1,4 @@
+# Sprint 32 · v1-late · goal: Marketplace polish: package scope flags, optional kind, and app-bundled scope-gated skills
+- 0181
+- 0182
+- 0183

--- a/.stint/tasks/0181-marketplace-package-scope-flags-and-optional-kind.md
+++ b/.stint/tasks/0181-marketplace-package-scope-flags-and-optional-kind.md
@@ -1,0 +1,37 @@
+---
+id: "0181"
+title: "Marketplace: package install scope flags + optional kind"
+status: backlog
+estimate: "8h"
+sprint: "s32"
+blocked_by:
+  - 20
+gh_issue: []
+area:
+  - "cli/commands"
+  - "host/permissions"
+tags:
+  - "marketplace"
+  - "scope"
+  - "kind"
+---
+
+
+Make every installable package (app/agent/skill) installable either workspace-local or global, chosen by the installer with `-ws`/`--workspace` and `-g`/`--global` flags. Add an optional `kind` manifest field (`app | agent | skill`, default `app`) as metadata only.
+
+## Why
+
+Scope must be a universal install-time choice, never forced by the manifest or derived from kind. Ian: "I can't think of a situation where an app would NEED to be global... I want them to work like agent skills, they can be either just fine." This enables nix-style declarative workspace provisioning — a setup script is a list of `plexi app install <id> -ws` lines, reproducible per project. `kind` is optional metadata for filtering/display; do not force the field.
+
+## Done When
+
+- `plexi app install <id>` and `plexi install <id>` accept `-g/--global` and `-ws/--workspace`.
+- `--workspace` installs into `<workspace_root>/<workspace_channel_dir()>/apps/`; `--global` into `apps_dir()`. Default preserves current behavior (global) and is documented.
+- Workspace install walks up from CWD to find the workspace (reuse the `app init` resolution); errors clearly when `--workspace` is used outside a workspace.
+- Optional `[app].kind` (or `kind`) field parses, defaults to `app`, surfaces in the trust sheet and registry entry, and never gates behavior.
+- Tests: install dest resolution for both scopes; kind defaulting; `--workspace` outside a workspace fails closed.
+
+## References
+
+- `docs/prm/marketplace-hosted.md`
+- Memory: package scope is a universal install flag, kind optional.

--- a/.stint/tasks/0182-marketplace-app-bundled-skills-packaging.md
+++ b/.stint/tasks/0182-marketplace-app-bundled-skills-packaging.md
@@ -1,0 +1,37 @@
+---
+id: "0182"
+title: "Marketplace: app-bundled skills packaging"
+status: backlog
+estimate: "8h"
+sprint: "s32"
+blocked_by:
+  - 181
+gh_issue: []
+area:
+  - "cli/commands"
+  - "sdk/pgap"
+tags:
+  - "marketplace"
+  - "skills"
+  - "packaging"
+---
+
+
+Let an app package carry a `skills/` directory that installs alongside the app into the same scope (workspace or global) the app was installed into. Packaging only — registration as dormant skills, no activation logic yet.
+
+## Why
+
+The chess app should ship with its skills attached. This is the packaging half of the app-bundles-skills vision: the distributable unit can contain skills, and they land in the correct scope. Activation (when the skill becomes available) is a separate runtime task (`0183`).
+
+## Done When
+
+- The package validator (`0015`) recognizes a `skills/` dir and validates its contents.
+- `plexi app install` places bundled skills into the scope-appropriate skills dir alongside the app.
+- Bundled skills register as dormant (present but not yet active) — no activation behavior in this task.
+- `plexi app inspect` lists bundled skills in the trust sheet.
+- Tests: a package with a `skills/` dir installs the skills into the right scope; an app without one is unaffected.
+
+## References
+
+- `docs/prm/marketplace-hosted.md`
+- Depends on scope resolution from `0181`.

--- a/.stint/tasks/0183-marketplace-scope-gated-skill-activation.md
+++ b/.stint/tasks/0183-marketplace-scope-gated-skill-activation.md
@@ -1,0 +1,43 @@
+---
+id: "0183"
+title: "Marketplace: scope-gated skill activation (design + runtime)"
+status: backlog
+estimate: "20h"
+sprint: "s32"
+blocked_by:
+  - 182
+gh_issue: []
+area:
+  - "host/permissions"
+  - "sdk/pgap"
+tags:
+  - "marketplace"
+  - "skills"
+  - "agents"
+  - "runtime"
+---
+
+
+A skill bundled with an app is active only within that app's scope — the same context-scoping the secret model already uses (a secret keyed to a workspace root is only readable by apps at that root). An agent that shares an app's context inherits that app's skills; when the app closes or the agent leaves the scope, the skills go dormant.
+
+## Why
+
+This is the unification Ian is after: "if an agent is open in the same pane as an app, it has that skill by default." Skills become ambient capabilities that follow app presence instead of polluting a global namespace. It mirrors secret context-scoping ([[GLOSSARY.md]] Secret entry).
+
+## Done When
+
+- A written design spec lands first (where activation scope is defined: workspace, context, or pane; how the assistant discovers active skills; lifecycle on app open/close).
+- Bundled skills activate for an agent sharing the app's scope and deactivate when the app leaves scope/closes.
+- Skill availability is observable (a way to list which skills are active for an agent and why).
+- HostHarness coverage: skill active when app in scope, dormant when not.
+
+## Gotchas
+
+- Runtime feature, not packaging — write the spec before runtime code.
+- Reuse the secret context-scoping model rather than inventing a parallel scoping mechanism.
+
+## References
+
+- `docs/prm/marketplace-hosted.md`
+- Depends on app-bundled skills packaging from `0182`.
+- Related: agent-is-a-PGAP-app model.

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -59,6 +59,23 @@ high   = "claude --dangerously-skip-permissions '{cmd}'"
 [cli]
 tips = true
 
+# [marketplace]
+# Hosted app catalog + CDN. Defaults point at the official plexiapp.com registry,
+# so leave these unset to use it. Override only to point at a private registry.
+# registry_url    = "https://plexiapp.com/registry/v1/index.json"
+# cdn_url         = "https://plexiapp.com/registry/v1/packages"
+# Publisher submission endpoint. Unset = `plexi app publish` prepares the package
+# locally but does not upload it.
+# submit_url      = "https://plexiapp.com/registry/v1/submit"
+# Paid-app payment backend. Unset / "none" = paid installs fail closed (no charge
+# possible). A real provider is wired in a future release.
+# payment_backend = "none"
+# Account/auth backend. Unset / "none" = login/signup fail closed. Accounts are
+# only ever needed to publish or buy paid apps — free apps install without one.
+# account_backend = "none"
+# Default email pre-filled by `plexi account login`.
+# account_email   = "you@example.com"
+
 [beta]
 # crt           = false
 # ghost         = false

--- a/src/app/account.rs
+++ b/src/app/account.rs
@@ -1,0 +1,243 @@
+//! Marketplace account boundary — sign-up, login, and the locally-stored
+//! session that proves who you are (stint `0021`, shared with `0022`).
+//!
+//! # What an account is for
+//!
+//! Per `docs/prm/marketplace-hosted.md`, an account is **never** required to
+//! install a free app, run an installed app, or browse the public catalog. It
+//! is required only to:
+//!
+//! - **publish** an app,
+//! - **buy** a paid app, or
+//! - use the **Plexi AI subscription**.
+//!
+//! So this module is the identity seam those three flows hang off. It is fully
+//! stubbed today: [`StubAccountProvider`] fails closed on every network
+//! operation, exactly like the payment stub. A real auth backend (the
+//! plexiapp.com API, or a hosted IdP) drops into [`account_provider`] with no
+//! change at any call site — `signup`/`login` start returning real sessions and
+//! everything downstream keeps working.
+//!
+//! # The session
+//!
+//! [`AccountSession`] is the on-disk proof of being logged in: an opaque
+//! provider-issued `token` plus the account identity. It lives at
+//! `<config_dir>/account.toml`, per-channel by construction. [`AccountStore`]
+//! is the only thing that reads or writes it. Payment and publishing consume a
+//! borrowed `&AccountSession`; they never construct one — only a provider does.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Proof of an authenticated marketplace account, stored locally. The `token`
+/// is opaque and provider-issued; the host presents it on authenticated
+/// requests (purchase, publish, subscription) but never interprets it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountSession {
+    pub schema_version: u32,
+    /// Stable account id from the provider.
+    pub account_id: String,
+    pub email: String,
+    /// Opaque bearer token for authenticated requests.
+    pub token: String,
+    /// Which provider issued this session (e.g. `"stub"`, `"plexi"`).
+    pub provider: String,
+    /// ISO-8601 UTC login time.
+    pub issued_at: String,
+}
+
+/// On-disk account session at `<config_dir>/account.toml`. Per-channel because
+/// `config_dir()` is per-channel — logging into alpha does not log you into
+/// beta.
+pub struct AccountStore {
+    path: PathBuf,
+}
+
+impl AccountStore {
+    /// Open the store for the active channel.
+    pub fn open() -> Self {
+        AccountStore {
+            path: crate::config::config_dir().join("account.toml"),
+        }
+    }
+
+    /// Open a store at an explicit path (tests).
+    #[cfg(test)]
+    pub fn open_at(path: PathBuf) -> Self {
+        AccountStore { path }
+    }
+
+    /// The current session, if logged in.
+    pub fn current(&self) -> Option<AccountSession> {
+        let text = std::fs::read_to_string(&self.path).ok()?;
+        match toml::from_str::<AccountSession>(&text) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                log::warn!("account: corrupt session at {}: {e}", self.path.display());
+                None
+            }
+        }
+    }
+
+    /// Persist a session (the result of a successful login/signup).
+    pub fn save(&self, session: &AccountSession) -> Result<(), String> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("could not create account dir {}: {e}", parent.display()))?;
+        }
+        let text = toml::to_string_pretty(session)
+            .map_err(|e| format!("could not serialize session: {e}"))?;
+        std::fs::write(&self.path, text)
+            .map_err(|e| format!("could not write session {}: {e}", self.path.display()))?;
+        log::info!(
+            "account: saved session for {} (provider {})",
+            session.email,
+            session.provider
+        );
+        Ok(())
+    }
+
+    /// Clear the stored session (logout). Idempotent — succeeds if absent.
+    pub fn clear(&self) -> Result<(), String> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {
+                log::info!("account: cleared session at {}", self.path.display());
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("could not clear session {}: {e}", self.path.display())),
+        }
+    }
+}
+
+/// Why an account operation failed.
+#[derive(Debug, thiserror::Error)]
+pub enum AccountError {
+    /// No real auth backend is built in. The stub returns this for every
+    /// signup/login — the honest, expected failure until a provider is wired
+    /// into [`account_provider`].
+    #[error(
+        "marketplace accounts are not enabled in this build yet — sign-up and login require a \
+         configured auth backend. Free apps install without an account. \
+         See https://plexiapp.com/docs/marketplace"
+    )]
+    NotConfigured,
+}
+
+/// The identity boundary. A provider turns an email into an [`AccountSession`].
+/// This is the single seam a real auth backend implements; nothing else in the
+/// codebase references a concrete provider.
+///
+/// Factory rule (`CLAUDE.md`): no method may panic. The stub returns `Err` for
+/// everything it cannot do.
+pub trait AccountProvider: Send + Sync {
+    /// Provider name for logs and session records.
+    fn name(&self) -> &'static str;
+
+    /// Whether this provider can actually authenticate. The stub returns
+    /// `false` so callers can give a clear "accounts unavailable" message.
+    fn is_configured(&self) -> bool;
+
+    /// Create a new account for `email`, returning a logged-in session.
+    fn signup(&self, email: &str) -> Result<AccountSession, AccountError>;
+
+    /// Log in an existing account, returning a session.
+    fn login(&self, email: &str) -> Result<AccountSession, AccountError>;
+}
+
+/// The fail-closed default provider. Authenticates no one and never panics.
+/// Replacing this is the entire job of adding real accounts.
+pub struct StubAccountProvider;
+
+impl AccountProvider for StubAccountProvider {
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+
+    fn is_configured(&self) -> bool {
+        false
+    }
+
+    fn signup(&self, email: &str) -> Result<AccountSession, AccountError> {
+        log::warn!("account: signup({email}) attempted with stub provider — not configured");
+        Err(AccountError::NotConfigured)
+    }
+
+    fn login(&self, email: &str) -> Result<AccountSession, AccountError> {
+        log::warn!("account: login({email}) attempted with stub provider — not configured");
+        Err(AccountError::NotConfigured)
+    }
+}
+
+/// Resolve the active account provider from config. Today this only returns the
+/// stub; a real provider drops in here keyed on `account_backend` with zero
+/// changes at any call site.
+///
+/// ```ignore
+/// match backend.as_deref() {
+///     Some("plexi") => Box::new(PlexiAuthProvider::from_config(cfg)),
+///     _ => Box::new(StubAccountProvider),
+/// }
+/// ```
+pub fn account_provider() -> Box<dyn AccountProvider> {
+    let backend = crate::config::marketplace_account_backend();
+    match backend.as_deref() {
+        Some("none") | None => Box::new(StubAccountProvider),
+        Some(other) => {
+            log::warn!(
+                "account: account_backend='{other}' configured but no provider is built — \
+                 falling back to stub (login/signup fail closed)"
+            );
+            Box::new(StubAccountProvider)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(email: &str) -> AccountSession {
+        AccountSession {
+            schema_version: 1,
+            account_id: "acct_123".to_string(),
+            email: email.to_string(),
+            token: "tok_test".to_string(),
+            provider: "stub".to_string(),
+            issued_at: "2026-06-12T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn store_round_trips_and_clears() {
+        let tmp = std::env::temp_dir().join(format!("plexi-acct-{}.toml", uuid::Uuid::new_v4()));
+        let store = AccountStore::open_at(tmp.clone());
+        assert!(store.current().is_none(), "no session initially");
+
+        let s = session("user@example.com");
+        store.save(&s).unwrap();
+        assert_eq!(store.current(), Some(s));
+
+        store.clear().unwrap();
+        assert!(store.current().is_none(), "cleared");
+        // clear is idempotent
+        store.clear().unwrap();
+    }
+
+    // Factory-rule stub test: every method runs without panicking and auth
+    // fails closed.
+    #[test]
+    fn stub_provider_never_panics_and_fails_closed() {
+        let provider = account_provider();
+        assert_eq!(provider.name(), "stub");
+        assert!(!provider.is_configured());
+        assert!(matches!(
+            provider.signup("a@b.com"),
+            Err(AccountError::NotConfigured)
+        ));
+        assert!(matches!(
+            provider.login("a@b.com"),
+            Err(AccountError::NotConfigured)
+        ));
+    }
+}

--- a/src/app/host_version.rs
+++ b/src/app/host_version.rs
@@ -1,0 +1,179 @@
+//! Host version compatibility — does this Plexi build satisfy an app's declared
+//! version requirement?
+//!
+//! Apps declare `[requires]` in their manifest:
+//!
+//! ```toml
+//! [requires]
+//! plexi_min = "0.0.760"   # hard floor — host below this refuses to install/run
+//! plexi_max = "0.1.0"     # soft ceiling — host above this warns (app may be superseded)
+//! ```
+//!
+//! The split is deliberate. `plexi_min` is an enforced gate: an app that needs a
+//! capability added in 0.0.760 must not silently misbehave on 0.0.700. `plexi_max`
+//! is advisory: an app built for today's Plexi keeps running on a newer host, but
+//! the user is warned that it predates this build and may need an update. Blocking
+//! on the ceiling would brick every installed app on each release, so we never do.
+//!
+//! Versions are simple `major.minor.patch` triples (Plexi's scheme). No range
+//! syntax, no pre-release tags — keep the contract obvious.
+
+/// A parsed `major.minor.patch` version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version(pub u64, pub u64, pub u64);
+
+/// Parse `"1.2.3"` into a [`Version`]. Returns `None` on any malformed input —
+/// callers treat an unparseable requirement as a hard error, never a silent pass.
+pub fn parse_version(s: &str) -> Option<Version> {
+    let mut parts = s.trim().split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None; // more than three components — reject
+    }
+    Some(Version(major, minor, patch))
+}
+
+/// This build's version, from `CARGO_PKG_VERSION`.
+pub fn current() -> Version {
+    parse_version(env!("CARGO_PKG_VERSION"))
+        .expect("CARGO_PKG_VERSION must be a major.minor.patch triple")
+}
+
+/// The outcome of a compatibility check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionVerdict {
+    /// Host satisfies the requirement. Install/run may proceed.
+    Ok,
+    /// Host is below `plexi_min`. Hard block — the requirement is included.
+    TooOld { required_min: String, host: String },
+    /// Host is above `plexi_max`. Advisory only — allow, but warn.
+    TooNew { declared_max: String, host: String },
+    /// A declared version string was malformed. Hard block — never guess.
+    Malformed { field: &'static str, value: String },
+}
+
+impl VersionVerdict {
+    /// Whether this verdict blocks install/launch (vs. merely warns).
+    pub fn is_blocking(&self) -> bool {
+        matches!(
+            self,
+            VersionVerdict::TooOld { .. } | VersionVerdict::Malformed { .. }
+        )
+    }
+
+    /// Human-readable explanation, or `None` for [`VersionVerdict::Ok`].
+    pub fn message(&self) -> Option<String> {
+        match self {
+            VersionVerdict::Ok => None,
+            VersionVerdict::TooOld { required_min, host } => Some(format!(
+                "this app requires Plexi >= {required_min}, but this build is {host}. \
+                 Update Plexi to install it."
+            )),
+            VersionVerdict::TooNew { declared_max, host } => Some(format!(
+                "this app was built for Plexi <= {declared_max}; this build is {host}. \
+                 It may be superseded — update the app if it misbehaves."
+            )),
+            VersionVerdict::Malformed { field, value } => Some(format!(
+                "manifest [requires].{field} = \"{value}\" is not a valid major.minor.patch version"
+            )),
+        }
+    }
+}
+
+/// Check a declared min/max against the current host version. Pure — the host
+/// version is injected so this is fully unit-testable.
+pub fn check(min: Option<&str>, max: Option<&str>, host: Version) -> VersionVerdict {
+    if let Some(min_s) = min {
+        let Some(min_v) = parse_version(min_s) else {
+            return VersionVerdict::Malformed {
+                field: "plexi_min",
+                value: min_s.to_string(),
+            };
+        };
+        if host < min_v {
+            return VersionVerdict::TooOld {
+                required_min: min_s.to_string(),
+                host: format!("{}.{}.{}", host.0, host.1, host.2),
+            };
+        }
+    }
+    if let Some(max_s) = max {
+        let Some(max_v) = parse_version(max_s) else {
+            return VersionVerdict::Malformed {
+                field: "plexi_max",
+                value: max_s.to_string(),
+            };
+        };
+        if host > max_v {
+            return VersionVerdict::TooNew {
+                declared_max: max_s.to_string(),
+                host: format!("{}.{}.{}", host.0, host.1, host.2),
+            };
+        }
+    }
+    VersionVerdict::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_triples_and_rejects_junk() {
+        assert_eq!(parse_version("0.0.760"), Some(Version(0, 0, 760)));
+        assert_eq!(parse_version("1.2.3"), Some(Version(1, 2, 3)));
+        assert_eq!(parse_version(" 1.2.3 "), Some(Version(1, 2, 3)));
+        assert_eq!(parse_version("1.2"), None);
+        assert_eq!(parse_version("1.2.3.4"), None);
+        assert_eq!(parse_version("1.2.x"), None);
+        assert_eq!(parse_version("v1.2.3"), None);
+    }
+
+    #[test]
+    fn ordering_is_numeric_not_lexical() {
+        // 0.0.9 < 0.0.760 numerically (lexical string compare would get this wrong)
+        assert!(Version(0, 0, 9) < Version(0, 0, 760));
+        assert!(Version(0, 1, 0) > Version(0, 0, 999));
+        assert!(Version(1, 0, 0) > Version(0, 99, 99));
+    }
+
+    #[test]
+    fn no_requirement_is_always_ok() {
+        assert_eq!(check(None, None, Version(0, 0, 1)), VersionVerdict::Ok);
+    }
+
+    #[test]
+    fn min_gate_blocks_when_host_too_old() {
+        let v = check(Some("0.0.760"), None, Version(0, 0, 700));
+        assert!(v.is_blocking());
+        assert!(matches!(v, VersionVerdict::TooOld { .. }));
+        // exactly at min is fine
+        assert_eq!(check(Some("0.0.760"), None, Version(0, 0, 760)), VersionVerdict::Ok);
+        // above min is fine
+        assert_eq!(check(Some("0.0.760"), None, Version(0, 1, 0)), VersionVerdict::Ok);
+    }
+
+    #[test]
+    fn max_ceiling_warns_but_does_not_block() {
+        let v = check(None, Some("0.0.760"), Version(0, 1, 0));
+        assert!(!v.is_blocking(), "too-new must warn, not block");
+        assert!(matches!(v, VersionVerdict::TooNew { .. }));
+        // at or below max is fine
+        assert_eq!(check(None, Some("0.0.760"), Version(0, 0, 760)), VersionVerdict::Ok);
+    }
+
+    #[test]
+    fn malformed_requirement_blocks() {
+        let v = check(Some("not-a-version"), None, Version(0, 0, 760));
+        assert!(v.is_blocking());
+        assert!(matches!(v, VersionVerdict::Malformed { field: "plexi_min", .. }));
+    }
+
+    #[test]
+    fn current_build_version_parses() {
+        // Smoke: the build's own version must be a valid triple.
+        let _ = current();
+    }
+}

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -1,0 +1,937 @@
+//! Hosted marketplace layer — registry catalog, publisher submission, and the
+//! paid-app license + payment boundary (stint `0018`-`0021`).
+//!
+//! # Invariant carried from `docs/prm/marketplace-hosted.md`
+//!
+//! Hosted services **distribute metadata and broker money**. They never become
+//! a dependency for running a local app. Everything in this module is a
+//! discovery / purchase surface layered *on top of* the local package format
+//! (`crate::app::package`) and the local install flow. An installed app never
+//! phones home; the registry being down never breaks an installed app.
+//!
+//! # What lives here
+//!
+//! - [`Visibility`] / [`Price`] — the marketplace facts an app declares in its
+//!   manifest `[marketplace]` section. They drive public/private listing and
+//!   free/paid gating.
+//! - [`RegistryEntry`] / [`RegistryIndex`] / [`RegistryClient`] — the hosted
+//!   catalog. The index *republishes* what the local validator already produced
+//!   (`crate::app::package::PackageReport`); it does not invent a second schema.
+//! - [`License`] / [`LicenseStore`] — proof-of-ownership for a paid app, stored
+//!   on disk per-channel. Real and tested. A license is the only thing the host
+//!   checks before installing a paid app.
+//! - [`PaymentProvider`] / [`StubPaymentProvider`] / [`payment_provider`] — the
+//!   payment boundary. Today the factory returns the stub, which fails closed
+//!   with [`PaymentError::NotConfigured`]. A real provider (Stripe, Polar, …)
+//!   slots into [`payment_provider`] with no other change anywhere — the license
+//!   store, the install gate, and the CLI all consume the trait, never a
+//!   concrete provider.
+//! - [`PublishClient`] / [`Submission`] — the publisher submission flow. Builds
+//!   a validated submission from a local package and posts it to a configured
+//!   endpoint; fails closed and honestly when no endpoint is set.
+
+use crate::app::package::PackageReport;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Schema version for the registry index and license files. Bumped whenever a
+/// required field changes so an older host fails loud rather than silently
+/// mis-reading a newer catalog.
+pub const MARKETPLACE_SCHEMA_VERSION: u32 = 1;
+
+/// Default hosted registry index URL. Overridable via
+/// `[marketplace].registry_url` in config. Honest default: points at the
+/// product domain (`plexiapp.com`), never a placeholder.
+pub const DEFAULT_REGISTRY_URL: &str = "https://plexiapp.com/registry/v1/index.json";
+
+/// Default CDN base for package artifacts, addressed by checksum. Overridable
+/// via `[marketplace].cdn_url`.
+pub const DEFAULT_CDN_URL: &str = "https://plexiapp.com/registry/v1/packages";
+
+// ── Visibility ────────────────────────────────────────────────────────────────
+
+/// Who can discover an app. Local-first default is [`Visibility::Private`]: an
+/// app is not public until its author explicitly publishes it. Drives whether
+/// `app browse`/`app search` list it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Visibility {
+    /// Listed in the public catalog and returned by search/browse.
+    Public,
+    /// Installable by exact id or direct URL, but never listed by browse/search.
+    Unlisted,
+    /// Not in the hosted catalog at all. The local-only / pre-publish default.
+    #[default]
+    Private,
+}
+
+impl Visibility {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Visibility::Public => "public",
+            Visibility::Unlisted => "unlisted",
+            Visibility::Private => "private",
+        }
+    }
+
+    /// Whether `app browse` (the public catalog view) should list this app.
+    pub fn is_listed(self) -> bool {
+        matches!(self, Visibility::Public)
+    }
+}
+
+// ── Price ─────────────────────────────────────────────────────────────────────
+
+/// What an app costs. Money is stored in integer minor units (cents) to avoid
+/// float rounding. [`Price::Free`] is the default — an app costs nothing unless
+/// it explicitly says otherwise.
+///
+/// Serialized form in `manifest.toml`:
+/// - free: `price = "free"` (or omitted)
+/// - paid: `price = { amount_cents = 499, currency = "usd" }`
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Price {
+    /// A keyword form so `price = "free"` parses cleanly.
+    Keyword(FreeKeyword),
+    /// A paid app with an explicit amount + ISO-4217 currency.
+    Paid {
+        amount_cents: u64,
+        #[serde(default = "default_currency")]
+        currency: String,
+    },
+}
+
+/// The only legal string value for [`Price::Keyword`]. A dedicated enum keeps
+/// `price = "freee"` a loud parse error instead of a silently-misread paid app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FreeKeyword {
+    Free,
+}
+
+fn default_currency() -> String {
+    "usd".to_string()
+}
+
+impl Default for Price {
+    fn default() -> Self {
+        Price::Keyword(FreeKeyword::Free)
+    }
+}
+
+impl Price {
+    pub fn is_free(&self) -> bool {
+        matches!(self, Price::Keyword(FreeKeyword::Free))
+    }
+
+    /// Human-readable price for the trust/install sheet, e.g. `"Free"` or
+    /// `"$4.99 USD"`.
+    pub fn display(&self) -> String {
+        match self {
+            Price::Keyword(FreeKeyword::Free) => "Free".to_string(),
+            Price::Paid {
+                amount_cents,
+                currency,
+            } => {
+                let major = *amount_cents / 100;
+                let minor = *amount_cents % 100;
+                let sym = if currency.eq_ignore_ascii_case("usd") {
+                    "$"
+                } else {
+                    ""
+                };
+                format!("{sym}{major}.{minor:02} {}", currency.to_uppercase())
+            }
+        }
+    }
+}
+
+// ── Manifest section ──────────────────────────────────────────────────────────
+
+/// The optional `[marketplace]` manifest section. Absent entirely for a
+/// local-only app, in which case the app is free + private and cannot be
+/// published until the author adds this section.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct MarketplaceManifest {
+    /// Listing visibility. Defaults to [`Visibility::Private`].
+    #[serde(default)]
+    pub visibility: Visibility,
+    /// Price. Defaults to [`Price::Free`].
+    #[serde(default)]
+    pub price: Price,
+    /// Publisher account / org slug. Required to publish; `None` for local apps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+}
+
+// ── Registry catalog ──────────────────────────────────────────────────────────
+
+/// One app in the hosted catalog. Republishes the local validator output
+/// ([`PackageReport`]) plus the marketplace facts and the CDN address. The host
+/// never trusts a registry-supplied trust label over its own validation — on
+/// install it re-validates the downloaded package and recomputes the label.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    /// Publisher account/org slug.
+    #[serde(default)]
+    pub publisher: String,
+    /// Capability strings, exactly as the local validator reported them.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Discovery tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Trust label string the publisher's local validator produced. Advisory —
+    /// re-derived locally on install. Never claims more than the local check.
+    #[serde(default)]
+    pub trust_label: String,
+    #[serde(default)]
+    pub visibility: Visibility,
+    #[serde(default)]
+    pub price: Price,
+    /// sha256 of the `.plexipkg` artifact. The CDN is addressed by this hash, so
+    /// a tampered download fails the local checksum check on install.
+    pub checksum: String,
+    /// Source spec the host can resolve to fetch the artifact when no explicit
+    /// `package_url` is given (e.g. `"github:owner/repo"`). Lets install-from-
+    /// registry reuse the existing source resolver.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Direct CDN URL for the `.plexipkg`. When absent, the client builds one
+    /// from the configured CDN base + checksum.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_url: Option<String>,
+}
+
+impl RegistryEntry {
+    /// Build a catalog entry from a locally-validated package plus the
+    /// marketplace manifest facts. This is the publisher-side path: what
+    /// `app publish` would submit, and what the registry republishes verbatim.
+    pub fn from_report(
+        report: &PackageReport,
+        marketplace: &MarketplaceManifest,
+        trust_label: &str,
+        checksum: String,
+        tags: Vec<String>,
+    ) -> Self {
+        RegistryEntry {
+            id: report.id.clone(),
+            name: report.name.clone(),
+            version: report.version.clone(),
+            description: String::new(),
+            publisher: marketplace.publisher.clone().unwrap_or_default(),
+            capabilities: report.capabilities.iter().map(|c| c.as_str().to_string()).collect(),
+            tags,
+            trust_label: trust_label.to_string(),
+            visibility: marketplace.visibility,
+            price: marketplace.price.clone(),
+            checksum,
+            source: None,
+            package_url: None,
+        }
+    }
+}
+
+/// The whole catalog. Versioned so an older host refuses a newer schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryIndex {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub apps: Vec<RegistryEntry>,
+}
+
+impl RegistryIndex {
+    /// Apps that should appear in `app browse` — public listings only.
+    pub fn listed(&self) -> impl Iterator<Item = &RegistryEntry> {
+        self.apps.iter().filter(|e| e.visibility.is_listed())
+    }
+
+    /// Case-insensitive substring search over id, name, description, and tags.
+    /// Only searches listed (public) apps — unlisted/private apps are not
+    /// discoverable by query, only by exact id.
+    pub fn search<'a>(&'a self, query: &str) -> Vec<&'a RegistryEntry> {
+        let q = query.to_lowercase();
+        self.listed()
+            .filter(|e| {
+                e.id.to_lowercase().contains(&q)
+                    || e.name.to_lowercase().contains(&q)
+                    || e.description.to_lowercase().contains(&q)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+            })
+            .collect()
+    }
+
+    /// Look up a single entry by exact id, regardless of visibility. Used by
+    /// install-from-registry — you can install an unlisted/private app if you
+    /// know its id and (for paid apps) hold a license.
+    pub fn get(&self, id: &str) -> Option<&RegistryEntry> {
+        self.apps.iter().find(|e| e.id == id)
+    }
+}
+
+/// Why a registry/network operation failed.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("registry fetch failed: {0}")]
+    Fetch(String),
+    #[error("registry response was not valid JSON: {0}")]
+    Parse(String),
+    #[error("registry schema_version {found} is newer than supported ({supported})")]
+    SchemaTooNew { found: u32, supported: u32 },
+    #[error("no app with id '{0}' in the registry")]
+    NotFound(String),
+    #[error("download failed: {0}")]
+    Download(String),
+    #[error("downloaded artifact checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+}
+
+/// Thin HTTP client for the hosted catalog + CDN. Holds only URLs; constructing
+/// it does no I/O. All methods fail closed and log at `info`/`warn`.
+pub struct RegistryClient {
+    index_url: String,
+    cdn_base: String,
+}
+
+impl RegistryClient {
+    /// Build a client from the resolved config (or defaults).
+    pub fn new(index_url: Option<String>, cdn_base: Option<String>) -> Self {
+        RegistryClient {
+            index_url: index_url.unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string()),
+            cdn_base: cdn_base.unwrap_or_else(|| DEFAULT_CDN_URL.to_string()),
+        }
+    }
+
+    fn agent() -> ureq::Agent {
+        ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+    }
+
+    /// Fetch and parse the catalog index.
+    pub fn fetch_index(&self) -> Result<RegistryIndex, RegistryError> {
+        log::info!("marketplace: fetching registry index from {}", self.index_url);
+        let body = Self::agent()
+            .get(&self.index_url)
+            .call()
+            .map_err(|e| RegistryError::Fetch(e.to_string()))?
+            .into_string()
+            .map_err(|e| RegistryError::Fetch(e.to_string()))?;
+        let index: RegistryIndex =
+            serde_json::from_str(&body).map_err(|e| RegistryError::Parse(e.to_string()))?;
+        if index.schema_version > MARKETPLACE_SCHEMA_VERSION {
+            return Err(RegistryError::SchemaTooNew {
+                found: index.schema_version,
+                supported: MARKETPLACE_SCHEMA_VERSION,
+            });
+        }
+        log::info!("marketplace: index loaded, {} apps", index.apps.len());
+        Ok(index)
+    }
+
+    /// Fetch the index and return one entry by exact id.
+    pub fn fetch_entry(&self, id: &str) -> Result<RegistryEntry, RegistryError> {
+        self.fetch_index()?
+            .get(id)
+            .cloned()
+            .ok_or_else(|| RegistryError::NotFound(id.to_string()))
+    }
+
+    /// Resolve the artifact URL for an entry: explicit `package_url`, else
+    /// `<cdn_base>/<checksum>.plexipkg`.
+    pub fn artifact_url(&self, entry: &RegistryEntry) -> String {
+        entry
+            .package_url
+            .clone()
+            .unwrap_or_else(|| format!("{}/{}.plexipkg", self.cdn_base, entry.checksum))
+    }
+
+    /// Download an entry's `.plexipkg` artifact to `dest`, verifying that the
+    /// downloaded bytes match the entry's checksum. A checksum mismatch is a
+    /// hard error — the CDN is addressed by hash, so a mismatch means tampering
+    /// or corruption. Returns the path written.
+    pub fn download_package(
+        &self,
+        entry: &RegistryEntry,
+        dest: &std::path::Path,
+    ) -> Result<PathBuf, RegistryError> {
+        let url = self.artifact_url(entry);
+        log::info!("marketplace: downloading '{}' artifact from {url}", entry.id);
+        let resp = Self::agent()
+            .get(&url)
+            .call()
+            .map_err(|e| RegistryError::Download(e.to_string()))?;
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| RegistryError::Download(format!("create {}: {e}", parent.display())))?;
+        }
+        let mut reader = resp.into_reader();
+        let mut file = std::fs::File::create(dest)
+            .map_err(|e| RegistryError::Download(format!("create {}: {e}", dest.display())))?;
+        std::io::copy(&mut reader, &mut file)
+            .map_err(|e| RegistryError::Download(format!("write {}: {e}", dest.display())))?;
+        drop(file);
+
+        let actual = crate::app::package::sha256_file(dest)
+            .map_err(|e| RegistryError::Download(format!("checksum {}: {e}", dest.display())))?;
+        if actual != entry.checksum {
+            let _ = std::fs::remove_file(dest);
+            return Err(RegistryError::ChecksumMismatch {
+                expected: entry.checksum.clone(),
+                actual,
+            });
+        }
+        log::info!("marketplace: downloaded + verified '{}' to {}", entry.id, dest.display());
+        Ok(dest.to_path_buf())
+    }
+}
+
+// ── Licenses ──────────────────────────────────────────────────────────────────
+
+/// Proof that a user owns a paid app. Issued by a [`PaymentProvider`] on a
+/// successful purchase and persisted on disk. The `token` and `signature` are
+/// opaque provider-issued strings — the host stores and presents them; a real
+/// provider's verification logic validates them. v1 treats presence of a
+/// non-expired license for the app id as ownership.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct License {
+    pub schema_version: u32,
+    pub app_id: String,
+    /// Version this license covers, or `"*"` for any version.
+    pub version: String,
+    /// ISO-8601 UTC issue time.
+    pub issued_at: String,
+    /// Opaque provider-issued ownership token.
+    pub token: String,
+    /// Opaque provider signature for future server-side verification. Empty
+    /// when the issuing provider does not sign.
+    #[serde(default)]
+    pub signature: String,
+    /// Which provider issued this license (e.g. `"stub"`, `"stripe"`).
+    pub provider: String,
+}
+
+impl License {
+    /// Whether this license authorizes installing the given app id. v1: same id,
+    /// and either a wildcard version or an exact match.
+    pub fn authorizes(&self, app_id: &str, version: &str) -> bool {
+        self.app_id == app_id && (self.version == "*" || self.version == version)
+    }
+}
+
+/// On-disk license store, one TOML file per app id under
+/// `<config_dir>/licenses/<app_id>.toml`. Per-channel by construction because
+/// `config_dir()` is per-channel.
+pub struct LicenseStore {
+    dir: PathBuf,
+}
+
+impl LicenseStore {
+    /// Open the store for the active channel.
+    pub fn open() -> Self {
+        LicenseStore {
+            dir: crate::config::config_dir().join("licenses"),
+        }
+    }
+
+    /// Open a store rooted at an explicit directory (tests).
+    #[cfg(test)]
+    pub fn open_at(dir: PathBuf) -> Self {
+        LicenseStore { dir }
+    }
+
+    fn path_for(&self, app_id: &str) -> PathBuf {
+        self.dir.join(format!("{app_id}.toml"))
+    }
+
+    /// Load the license for an app id, if one is stored.
+    pub fn load(&self, app_id: &str) -> Option<License> {
+        let path = self.path_for(app_id);
+        let text = std::fs::read_to_string(&path).ok()?;
+        match toml::from_str::<License>(&text) {
+            Ok(lic) => Some(lic),
+            Err(e) => {
+                log::warn!("marketplace: corrupt license at {}: {e}", path.display());
+                None
+            }
+        }
+    }
+
+    /// Persist a license, creating the store dir if needed.
+    pub fn save(&self, license: &License) -> Result<(), String> {
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| format!("could not create license dir {}: {e}", self.dir.display()))?;
+        let text = toml::to_string_pretty(license)
+            .map_err(|e| format!("could not serialize license: {e}"))?;
+        let path = self.path_for(&license.app_id);
+        std::fs::write(&path, text)
+            .map_err(|e| format!("could not write license {}: {e}", path.display()))?;
+        log::info!(
+            "marketplace: saved license for '{}' v{} (provider {})",
+            license.app_id,
+            license.version,
+            license.provider
+        );
+        Ok(())
+    }
+
+    /// Whether a stored license authorizes installing this app id + version.
+    pub fn has_valid(&self, app_id: &str, version: &str) -> bool {
+        self.load(app_id)
+            .map(|l| l.authorizes(app_id, version))
+            .unwrap_or(false)
+    }
+
+    /// All stored licenses, sorted by app id.
+    pub fn list(&self) -> Vec<License> {
+        let mut out = Vec::new();
+        if let Ok(read) = std::fs::read_dir(&self.dir) {
+            for entry in read.flatten() {
+                if entry.path().extension().and_then(|e| e.to_str()) == Some("toml") {
+                    if let Ok(text) = std::fs::read_to_string(entry.path()) {
+                        if let Ok(lic) = toml::from_str::<License>(&text) {
+                            out.push(lic);
+                        }
+                    }
+                }
+            }
+        }
+        out.sort_by(|a, b| a.app_id.cmp(&b.app_id));
+        out
+    }
+}
+
+// ── Payment boundary ──────────────────────────────────────────────────────────
+
+/// Why a purchase could not complete.
+#[derive(Debug, thiserror::Error)]
+pub enum PaymentError {
+    /// No real payment provider is configured in this build. The stub returns
+    /// this for every purchase — it is the expected, honest failure until a
+    /// provider (Stripe, Polar, …) is wired into [`payment_provider`].
+    #[error(
+        "paid apps require a configured payment provider — none is set up in this build. \
+         Free apps install normally. See https://plexiapp.com/docs/marketplace"
+    )]
+    NotConfigured,
+    /// The user is not signed in to a marketplace account.
+    #[error("a marketplace account is required to purchase paid apps")]
+    NoAccount,
+}
+
+/// A marketplace account identity passed to a provider at purchase time. v1
+/// carries only an email; a real provider extends this without touching callers.
+#[derive(Debug, Clone)]
+pub struct Account {
+    pub email: String,
+}
+
+/// The payment boundary. A purchase turns an account + a paid catalog entry into
+/// a [`License`]. This is the single seam a real processor implements; nothing
+/// else in the codebase references a concrete provider.
+///
+/// Factory rule (`CLAUDE.md`): no method may panic. The stub returns `Err` /
+/// noop for everything it cannot do.
+pub trait PaymentProvider: Send + Sync {
+    /// Provider name for logs and license records (e.g. `"stub"`, `"stripe"`).
+    fn name(&self) -> &'static str;
+
+    /// Whether this provider can actually charge. The stub returns `false`, so
+    /// callers can give a clear "paid apps unavailable" message before prompting.
+    fn is_configured(&self) -> bool;
+
+    /// Attempt to purchase `entry` for `account`, returning a [`License`] on
+    /// success. The stub always fails with [`PaymentError::NotConfigured`].
+    fn purchase(&self, entry: &RegistryEntry, account: &Account)
+        -> Result<License, PaymentError>;
+}
+
+/// The fail-closed default provider. Charges nothing, issues nothing, and never
+/// panics. Replacing this is the entire job of adding real payments.
+pub struct StubPaymentProvider;
+
+impl PaymentProvider for StubPaymentProvider {
+    fn name(&self) -> &'static str {
+        "stub"
+    }
+
+    fn is_configured(&self) -> bool {
+        false
+    }
+
+    fn purchase(
+        &self,
+        entry: &RegistryEntry,
+        _account: &Account,
+    ) -> Result<License, PaymentError> {
+        log::warn!(
+            "marketplace: purchase of paid app '{}' attempted with stub provider — not configured",
+            entry.id
+        );
+        Err(PaymentError::NotConfigured)
+    }
+}
+
+/// Resolve the active payment provider from config. Today this only ever returns
+/// the stub; a real provider drops in here keyed on `payment_backend` with zero
+/// changes at any call site.
+///
+/// ```ignore
+/// match backend.as_deref() {
+///     Some("stripe") => Box::new(StripeProvider::from_config(cfg)),
+///     _ => Box::new(StubPaymentProvider),
+/// }
+/// ```
+pub fn payment_provider() -> Box<dyn PaymentProvider> {
+    let backend = crate::config::marketplace_payment_backend();
+    match backend.as_deref() {
+        // Real providers slot in here. None exist yet, so everything falls
+        // through to the stub. This is intentional and must fail closed.
+        Some("none") | None => Box::new(StubPaymentProvider),
+        Some(other) => {
+            log::warn!(
+                "marketplace: payment_backend='{other}' is configured but no provider is built — \
+                 falling back to stub (paid installs will fail closed)"
+            );
+            Box::new(StubPaymentProvider)
+        }
+    }
+}
+
+// ── Install license gate ──────────────────────────────────────────────────────
+
+/// The decision for whether a registry install may proceed, based purely on the
+/// entry's price and the local license store. Pure function — no network, no
+/// disk beyond the store passed in — so it is fully unit-testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LicenseDecision {
+    /// Free app, or a paid app the user already owns. Install may proceed.
+    Proceed,
+    /// Paid app with no local license. The caller must purchase (or fail).
+    NeedsPurchase,
+}
+
+/// Decide whether installing `entry` is licensed.
+pub fn license_gate(entry: &RegistryEntry, store: &LicenseStore) -> LicenseDecision {
+    if entry.price.is_free() {
+        return LicenseDecision::Proceed;
+    }
+    if store.has_valid(&entry.id, &entry.version) {
+        LicenseDecision::Proceed
+    } else {
+        LicenseDecision::NeedsPurchase
+    }
+}
+
+// ── Publisher submission ──────────────────────────────────────────────────────
+
+/// Lifecycle of a publisher submission. Mirrors the states in
+/// `marketplace-hosted.md` §3. The host only ever *creates* a submission
+/// (`Submitted`); the hosted review system advances the rest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmissionState {
+    Submitted,
+    InReview,
+    Approved,
+    ChangesRequested,
+    Rejected,
+}
+
+/// The metadata payload a publisher sends: the validated catalog entry. The
+/// server runs the *same* validator (`0015`) on the separately-uploaded package
+/// — this struct is the metadata half of that exchange. The artifact path is
+/// tracked by the CLI alongside, not in this wire payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Submission {
+    pub schema_version: u32,
+    pub entry: RegistryEntry,
+}
+
+/// Why a publish/submit failed.
+#[derive(Debug, thiserror::Error)]
+pub enum PublishError {
+    #[error(
+        "no marketplace submission endpoint is configured in this build — the package was \
+         validated and prepared but not uploaded. Set [marketplace].submit_url to enable upload. \
+         See https://plexiapp.com/docs/marketplace"
+    )]
+    NotConfigured,
+    #[error("submission upload failed: {0}")]
+    Upload(String),
+}
+
+/// Client for the publisher submission endpoint. Holds the submit URL; absent
+/// URL means submission is not configured and `submit` fails closed.
+pub struct PublishClient {
+    submit_url: Option<String>,
+}
+
+impl PublishClient {
+    pub fn new(submit_url: Option<String>) -> Self {
+        PublishClient { submit_url }
+    }
+
+    /// Upload a prepared submission. Fails closed with
+    /// [`PublishError::NotConfigured`] when no endpoint is set — the caller is
+    /// expected to have already validated, packaged, and reported what *would*
+    /// be submitted, so this is an honest "last mile not wired" boundary rather
+    /// than a silent success.
+    pub fn submit(&self, submission: &Submission) -> Result<SubmissionState, PublishError> {
+        let Some(url) = self.submit_url.as_deref().filter(|u| !u.is_empty()) else {
+            return Err(PublishError::NotConfigured);
+        };
+        log::info!(
+            "marketplace: submitting '{}' v{} to {url}",
+            submission.entry.id,
+            submission.entry.version
+        );
+        let body = serde_json::to_string(submission)
+            .map_err(|e| PublishError::Upload(format!("serialize submission: {e}")))?;
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(60))
+            .build();
+        let resp = agent
+            .post(url)
+            .set("content-type", "application/json")
+            .send_string(&body)
+            .map_err(|e| PublishError::Upload(e.to_string()))?;
+        let text = resp
+            .into_string()
+            .map_err(|e| PublishError::Upload(e.to_string()))?;
+        log::info!("marketplace: submission accepted: {text}");
+        Ok(SubmissionState::Submitted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, price: Price, vis: Visibility) -> RegistryEntry {
+        RegistryEntry {
+            id: id.to_string(),
+            name: id.to_string(),
+            version: "1.0.0".to_string(),
+            description: String::new(),
+            publisher: "acme".to_string(),
+            capabilities: vec![],
+            tags: vec![],
+            trust_label: "Unreviewed Python process".to_string(),
+            visibility: vis,
+            price,
+            checksum: "abc123".to_string(),
+            source: None,
+            package_url: None,
+        }
+    }
+
+    fn paid() -> Price {
+        Price::Paid {
+            amount_cents: 499,
+            currency: "usd".to_string(),
+        }
+    }
+
+    #[test]
+    fn visibility_default_is_private() {
+        assert_eq!(Visibility::default(), Visibility::Private);
+        assert!(!Visibility::Private.is_listed());
+        assert!(!Visibility::Unlisted.is_listed());
+        assert!(Visibility::Public.is_listed());
+    }
+
+    #[test]
+    fn price_default_is_free() {
+        assert!(Price::default().is_free());
+        assert!(!paid().is_free());
+        assert_eq!(paid().display(), "$4.99 USD");
+        assert_eq!(Price::default().display(), "Free");
+    }
+
+    #[test]
+    fn price_parses_free_keyword_and_paid_table() {
+        #[derive(Deserialize)]
+        struct Holder {
+            price: Price,
+        }
+        let free: Holder = toml::from_str(r#"price = "free""#).unwrap();
+        assert!(free.price.is_free());
+        let paid: Holder =
+            toml::from_str("price = { amount_cents = 1500, currency = \"eur\" }").unwrap();
+        assert_eq!(
+            paid.price,
+            Price::Paid {
+                amount_cents: 1500,
+                currency: "eur".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn bad_price_keyword_is_loud_error() {
+        #[derive(Deserialize)]
+        struct Holder {
+            #[allow(dead_code)]
+            price: Price,
+        }
+        assert!(toml::from_str::<Holder>(r#"price = "freee""#).is_err());
+    }
+
+    #[test]
+    fn index_search_only_lists_public_apps() {
+        let index = RegistryIndex {
+            schema_version: 1,
+            apps: vec![
+                entry("public-notes", Price::default(), Visibility::Public),
+                entry("secret-tool", Price::default(), Visibility::Private),
+                entry("unlisted-beta", Price::default(), Visibility::Unlisted),
+            ],
+        };
+        let hits = index.search("");
+        assert_eq!(hits.len(), 1, "only public apps are searchable");
+        assert_eq!(hits[0].id, "public-notes");
+        // But a private app is still resolvable by exact id for install.
+        assert!(index.get("secret-tool").is_some());
+        assert!(index.get("unlisted-beta").is_some());
+    }
+
+    #[test]
+    fn license_store_round_trips_and_gates() {
+        let tmp = std::env::temp_dir().join(format!("plexi-lic-test-{}", uuid::Uuid::new_v4()));
+        let store = LicenseStore::open_at(tmp.clone());
+        let paid_entry = entry("pro-app", paid(), Visibility::Public);
+
+        // No license yet → paid app needs purchase.
+        assert_eq!(
+            license_gate(&paid_entry, &store),
+            LicenseDecision::NeedsPurchase
+        );
+
+        // A free app never needs a license.
+        let free_entry = entry("free-app", Price::default(), Visibility::Public);
+        assert_eq!(license_gate(&free_entry, &store), LicenseDecision::Proceed);
+
+        // Save a license, then the paid app proceeds.
+        let lic = License {
+            schema_version: MARKETPLACE_SCHEMA_VERSION,
+            app_id: "pro-app".to_string(),
+            version: "*".to_string(),
+            issued_at: "2026-06-12T00:00:00Z".to_string(),
+            token: "tok_test".to_string(),
+            signature: String::new(),
+            provider: "stub".to_string(),
+        };
+        store.save(&lic).unwrap();
+        assert_eq!(store.load("pro-app"), Some(lic));
+        assert_eq!(license_gate(&paid_entry, &store), LicenseDecision::Proceed);
+        assert_eq!(store.list().len(), 1);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn license_version_scoping() {
+        let lic = License {
+            schema_version: 1,
+            app_id: "a".to_string(),
+            version: "1.0.0".to_string(),
+            issued_at: "x".to_string(),
+            token: "t".to_string(),
+            signature: String::new(),
+            provider: "stub".to_string(),
+        };
+        assert!(lic.authorizes("a", "1.0.0"));
+        assert!(!lic.authorizes("a", "2.0.0"));
+        assert!(!lic.authorizes("b", "1.0.0"));
+    }
+
+    // Factory-rule stub test: every trait method runs without panicking, and
+    // purchase fails closed.
+    #[test]
+    fn stub_payment_provider_never_panics_and_fails_closed() {
+        let provider = payment_provider();
+        assert_eq!(provider.name(), "stub");
+        assert!(!provider.is_configured());
+        let e = entry("pro-app", paid(), Visibility::Public);
+        let account = Account {
+            email: "user@example.com".to_string(),
+        };
+        match provider.purchase(&e, &account) {
+            Err(PaymentError::NotConfigured) => {}
+            other => panic!("stub must fail closed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn publish_client_not_configured_fails_closed() {
+        let client = PublishClient::new(None);
+        let submission = Submission {
+            schema_version: 1,
+            entry: entry("a", Price::default(), Visibility::Public),
+        };
+        assert!(matches!(
+            client.submit(&submission),
+            Err(PublishError::NotConfigured)
+        ));
+        // An empty-string submit_url is also "not configured".
+        let empty = PublishClient::new(Some(String::new()));
+        assert!(matches!(
+            empty.submit(&submission),
+            Err(PublishError::NotConfigured)
+        ));
+    }
+
+    #[test]
+    fn registry_entry_from_report_carries_marketplace_facts() {
+        let report = PackageReport {
+            id: "notes".to_string(),
+            name: "Notes".to_string(),
+            version: "2.1.0".to_string(),
+            runtime: crate::app::package::PackageRuntime::Python,
+            entry: "main.py".to_string(),
+            capabilities: vec![],
+            file_count: 3,
+            total_size: 1024,
+        };
+        let mkt = MarketplaceManifest {
+            visibility: Visibility::Public,
+            price: paid(),
+            publisher: Some("acme".to_string()),
+        };
+        let entry = RegistryEntry::from_report(
+            &report,
+            &mkt,
+            "Unreviewed Python process",
+            "deadbeef".to_string(),
+            vec!["productivity".to_string()],
+        );
+        assert_eq!(entry.id, "notes");
+        assert_eq!(entry.publisher, "acme");
+        assert_eq!(entry.visibility, Visibility::Public);
+        assert!(!entry.price.is_free());
+        assert_eq!(entry.checksum, "deadbeef");
+        assert_eq!(entry.tags, vec!["productivity".to_string()]);
+    }
+
+    #[test]
+    fn artifact_url_falls_back_to_checksum_addressing() {
+        let client = RegistryClient::new(None, Some("https://cdn.example/pkgs".to_string()));
+        let e = entry("a", Price::default(), Visibility::Public);
+        assert_eq!(
+            client.artifact_url(&e),
+            "https://cdn.example/pkgs/abc123.plexipkg"
+        );
+        let mut e2 = e.clone();
+        e2.package_url = Some("https://direct.example/a.plexipkg".to_string());
+        assert_eq!(client.artifact_url(&e2), "https://direct.example/a.plexipkg");
+    }
+}

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -207,6 +207,13 @@ pub struct RegistryEntry {
     /// from the configured CDN base + checksum.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_url: Option<String>,
+    /// Declared minimum host version (`[requires].plexi_min`). Lets the catalog
+    /// and install gate reject an incompatible app before download.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_plexi_min: Option<String>,
+    /// Declared soft host-version ceiling (`[requires].plexi_max`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_plexi_max: Option<String>,
 }
 
 impl RegistryEntry {
@@ -234,6 +241,8 @@ impl RegistryEntry {
             checksum,
             source: None,
             package_url: None,
+            requires_plexi_min: report.requires_plexi_min.clone(),
+            requires_plexi_max: report.requires_plexi_max.clone(),
         }
     }
 }
@@ -728,6 +737,8 @@ mod tests {
             checksum: "abc123".to_string(),
             source: None,
             package_url: None,
+            requires_plexi_min: None,
+            requires_plexi_max: None,
         }
     }
 
@@ -903,6 +914,8 @@ mod tests {
             capabilities: vec![],
             file_count: 3,
             total_size: 1024,
+            requires_plexi_min: None,
+            requires_plexi_max: None,
         };
         let mkt = MarketplaceManifest {
             visibility: Visibility::Public,

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -404,11 +404,13 @@ impl RegistryClient {
 
 // ── Licenses ──────────────────────────────────────────────────────────────────
 
-/// Proof that a user owns a paid app. Issued by a [`PaymentProvider`] on a
-/// successful purchase and persisted on disk. The `token` and `signature` are
-/// opaque provider-issued strings — the host stores and presents them; a real
-/// provider's verification logic validates them. v1 treats presence of a
-/// non-expired license for the app id as ownership.
+/// A receipt proving a user bought a paid app — like owning a purchased
+/// template file. Issued by a [`PaymentProvider`] on a successful purchase and
+/// persisted on disk. It is **never checked to run the app**: once the package
+/// is installed it runs freely, same path as a free app. The receipt only
+/// matters for re-downloading the paid artifact later without paying twice. The
+/// `token` is an opaque provider-issued string a future server uses to verify
+/// ownership on re-download.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct License {
     pub schema_version: u32,
@@ -417,12 +419,9 @@ pub struct License {
     pub version: String,
     /// ISO-8601 UTC issue time.
     pub issued_at: String,
-    /// Opaque provider-issued ownership token.
+    /// Opaque provider-issued ownership token, used for server-side re-download
+    /// verification when real payment is wired.
     pub token: String,
-    /// Opaque provider signature for future server-side verification. Empty
-    /// when the issuing provider does not sign.
-    #[serde(default)]
-    pub signature: String,
     /// Which provider issued this license (e.g. `"stub"`, `"stripe"`).
     pub provider: String,
 }
@@ -835,7 +834,6 @@ mod tests {
             version: "*".to_string(),
             issued_at: "2026-06-12T00:00:00Z".to_string(),
             token: "tok_test".to_string(),
-            signature: String::new(),
             provider: "stub".to_string(),
         };
         store.save(&lic).unwrap();
@@ -854,7 +852,6 @@ mod tests {
             version: "1.0.0".to_string(),
             issued_at: "x".to_string(),
             token: "t".to_string(),
-            signature: String::new(),
             provider: "stub".to_string(),
         };
         assert!(lic.authorizes("a", "1.0.0"));

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -526,13 +526,6 @@ pub enum PaymentError {
     NoAccount,
 }
 
-/// A marketplace account identity passed to a provider at purchase time. v1
-/// carries only an email; a real provider extends this without touching callers.
-#[derive(Debug, Clone)]
-pub struct Account {
-    pub email: String,
-}
-
 /// The payment boundary. A purchase turns an account + a paid catalog entry into
 /// a [`License`]. This is the single seam a real processor implements; nothing
 /// else in the codebase references a concrete provider.
@@ -547,10 +540,14 @@ pub trait PaymentProvider: Send + Sync {
     /// callers can give a clear "paid apps unavailable" message before prompting.
     fn is_configured(&self) -> bool;
 
-    /// Attempt to purchase `entry` for `account`, returning a [`License`] on
-    /// success. The stub always fails with [`PaymentError::NotConfigured`].
-    fn purchase(&self, entry: &RegistryEntry, account: &Account)
-        -> Result<License, PaymentError>;
+    /// Attempt to purchase `entry` for the logged-in `session`, returning a
+    /// [`License`] on success. The stub always fails with
+    /// [`PaymentError::NotConfigured`].
+    fn purchase(
+        &self,
+        entry: &RegistryEntry,
+        session: &crate::app::account::AccountSession,
+    ) -> Result<License, PaymentError>;
 }
 
 /// The fail-closed default provider. Charges nothing, issues nothing, and never
@@ -569,7 +566,7 @@ impl PaymentProvider for StubPaymentProvider {
     fn purchase(
         &self,
         entry: &RegistryEntry,
-        _account: &Account,
+        _session: &crate::app::account::AccountSession,
     ) -> Result<License, PaymentError> {
         log::warn!(
             "marketplace: purchase of paid app '{}' attempted with stub provider — not configured",
@@ -862,10 +859,15 @@ mod tests {
         assert_eq!(provider.name(), "stub");
         assert!(!provider.is_configured());
         let e = entry("pro-app", paid(), Visibility::Public);
-        let account = Account {
+        let session = crate::app::account::AccountSession {
+            schema_version: 1,
+            account_id: "acct_1".to_string(),
             email: "user@example.com".to_string(),
+            token: "tok".to_string(),
+            provider: "stub".to_string(),
+            issued_at: "2026-06-12T00:00:00Z".to_string(),
         };
-        match provider.purchase(&e, &account) {
+        match provider.purchase(&e, &session) {
             Err(PaymentError::NotConfigured) => {}
             other => panic!("stub must fail closed, got {other:?}"),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod app_trait;
 mod canvas_bindings;
 mod dispatch;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ mod canvas_bindings;
 mod dispatch;
 mod focus;
 mod lifecycle;
+pub mod marketplace;
 pub(crate) mod notification_image;
 mod notifications;
 pub mod package;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod app_trait;
 mod canvas_bindings;
+pub mod host_version;
 mod dispatch;
 mod focus;
 mod lifecycle;

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -497,7 +497,9 @@ pub fn build_package(app_dir: &Path, out: Option<&Path>) -> Result<PathBuf, Pack
     Ok(out_path)
 }
 
-fn sha256_file(path: &Path) -> Result<String, PackageError> {
+/// sha256 of a file's contents, hex-encoded. Reused by the marketplace
+/// publisher path to checksum a built `.plexipkg` artifact.
+pub(crate) fn sha256_file(path: &Path) -> Result<String, PackageError> {
     let mut file = fs::File::open(path).map_err(|e| io_err("open", path, e))?;
     let mut hasher = Sha256::new();
     std::io::copy(&mut file, &mut hasher).map_err(|e| io_err("hash", path, e))?;

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -206,6 +206,10 @@ pub struct PackageReport {
     pub capabilities: Vec<Capability>,
     pub file_count: usize,
     pub total_size: u64,
+    /// Declared `[requires].plexi_min` — minimum host version, if any.
+    pub requires_plexi_min: Option<String>,
+    /// Declared `[requires].plexi_max` — soft ceiling host version, if any.
+    pub requires_plexi_max: Option<String>,
 }
 
 // ── Trust label ───────────────────────────────────────────────────────────────
@@ -299,6 +303,11 @@ fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
     let files = collect_files(app_dir)?;
     let total_size = files.iter().map(|(_, size)| size).sum();
 
+    let (requires_plexi_min, requires_plexi_max) = manifest
+        .requires
+        .map(|r| (r.plexi_min, r.plexi_max))
+        .unwrap_or((None, None));
+
     Ok(PackageReport {
         id: manifest.app.id,
         name: manifest.app.name,
@@ -308,6 +317,8 @@ fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
         capabilities,
         file_count: files.len(),
         total_size,
+        requires_plexi_min,
+        requires_plexi_max,
     })
 }
 
@@ -1029,6 +1040,8 @@ mod tests {
             capabilities: Vec::new(),
             file_count: 2,
             total_size: 100,
+            requires_plexi_min: None,
+            requires_plexi_max: None,
         }
     }
 

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -68,6 +68,23 @@ pub struct AppManifest {
     /// until the author adds this section.
     #[serde(default)]
     pub marketplace: Option<crate::app::marketplace::MarketplaceManifest>,
+    /// Optional `[requires]` section — host version compatibility. Absent means
+    /// the app declares no version requirement and runs on any build.
+    #[serde(default)]
+    pub requires: Option<RequiresSection>,
+}
+
+/// `[requires]` manifest section — host version compatibility.
+///
+/// `plexi_min` is a hard floor (host below it refuses to install/run);
+/// `plexi_max` is a soft ceiling (host above it warns the app may be
+/// superseded, but still runs). See `crate::app::host_version`.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct RequiresSection {
+    #[serde(default)]
+    pub plexi_min: Option<String>,
+    #[serde(default)]
+    pub plexi_max: Option<String>,
 }
 
 /// A `[secrets]` table entry from manifest.toml. `required` is **required**

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -62,6 +62,12 @@ pub struct AppManifest {
     /// missing-secret modal proactively. Empty when omitted.
     #[serde(default)]
     pub secrets: HashMap<String, SecretDecl>,
+    /// Optional `[marketplace]` section — visibility, price, and publisher used
+    /// by `plexi app publish` and the hosted catalog. Absent for a local-only
+    /// app, which is then treated as free + private and cannot be published
+    /// until the author adds this section.
+    #[serde(default)]
+    pub marketplace: Option<crate::app::marketplace::MarketplaceManifest>,
 }
 
 /// A `[secrets]` table entry from manifest.toml. `required` is **required**

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,0 +1,117 @@
+//! `plexi account` — marketplace account CLI (stint `0021`).
+//!
+//! Login/signup go through `crate::app::account::account_provider()`, which is
+//! the fail-closed stub today. Logout and status are fully local (they only
+//! touch the on-disk session), so they work now. An account is only ever needed
+//! to publish, buy a paid app, or use the AI subscription — never to install a
+//! free app.
+
+use crate::app::account::{account_provider, AccountStore};
+
+/// `plexi account status` — show whether you are logged in.
+pub fn account_status_cli() -> i32 {
+    log::info!("account: status");
+    match AccountStore::open().current() {
+        Some(s) => {
+            println!("Logged in as {} (account {})", s.email, s.account_id);
+            println!("  provider: {}", s.provider);
+            println!("  since:    {}", s.issued_at);
+            0
+        }
+        None => {
+            println!("Not logged in. Free apps install without an account.");
+            println!("Run `plexi account login` to publish or buy paid apps.");
+            0
+        }
+    }
+}
+
+/// `plexi account login [--email X]` — authenticate and store a session.
+pub fn account_login_cli(email: Option<&str>) -> i32 {
+    let email = match resolve_email(email) {
+        Some(e) => e,
+        None => {
+            eprintln!("error: an email is required — pass `--email you@example.com`");
+            return 1;
+        }
+    };
+    log::info!("account: login email={email}");
+    let provider = account_provider();
+    log::info!(
+        "account: provider '{}' configured={}",
+        provider.name(),
+        provider.is_configured()
+    );
+    match provider.login(&email) {
+        Ok(session) => persist(&session),
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi account signup [--email X]` — create an account and store a session.
+pub fn account_signup_cli(email: Option<&str>) -> i32 {
+    let email = match resolve_email(email) {
+        Some(e) => e,
+        None => {
+            eprintln!("error: an email is required — pass `--email you@example.com`");
+            return 1;
+        }
+    };
+    log::info!("account: signup email={email}");
+    let provider = account_provider();
+    log::info!(
+        "account: provider '{}' configured={}",
+        provider.name(),
+        provider.is_configured()
+    );
+    match provider.signup(&email) {
+        Ok(session) => persist(&session),
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi account logout` — clear the local session.
+pub fn account_logout_cli() -> i32 {
+    log::info!("account: logout");
+    let store = AccountStore::open();
+    let was = store.current();
+    match store.clear() {
+        Ok(()) => {
+            match was {
+                Some(s) => println!("Logged out {}.", s.email),
+                None => println!("Already logged out."),
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// Use the explicit `--email`, else the config default, else `None`.
+fn resolve_email(flag: Option<&str>) -> Option<String> {
+    flag.map(str::to_string)
+        .or_else(crate::config::marketplace_account_email)
+        .filter(|e| !e.is_empty())
+}
+
+fn persist(session: &crate::app::account::AccountSession) -> i32 {
+    match AccountStore::open().save(session) {
+        Ok(()) => {
+            println!("Logged in as {}.", session.email);
+            0
+        }
+        Err(e) => {
+            eprintln!("error: authenticated but could not save session: {e}");
+            1
+        }
+    }
+}

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1079,65 +1079,6 @@ pub(super) fn is_github_shorthand(s: &str) -> bool {
     !owner.is_empty() && !repo.is_empty() && !repo.contains('/')
 }
 
-/// Fetch the plexi app registry and resolve a bare app ID to a source spec string.
-///
-/// Registry entries in `ianjamesburke/PLEXI` with a `path` field resolve to `local:<dir>`
-/// so the bundled copy is used without a network clone. Third-party repos resolve to
-/// `github:owner/repo`.
-pub(super) fn resolve_registry_id(id: &str) -> Result<String, String> {
-    const REGISTRY_URL: &str =
-        "https://raw.githubusercontent.com/ianjamesburke/plexi-app-registry/main/registry.json";
-
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(30))
-        .build();
-
-    let body = match agent.get(REGISTRY_URL).call() {
-        Ok(r) => match r.into_string() {
-            Ok(s) => s,
-            Err(e) => return Err(format!("failed to read registry response: {e}")),
-        },
-        Err(e) => return Err(format!("failed to fetch registry: {e}")),
-    };
-
-    let entries: serde_json::Value =
-        serde_json::from_str(&body).map_err(|e| format!("failed to parse registry: {e}"))?;
-
-    let arr = entries
-        .as_array()
-        .ok_or_else(|| "registry response is not a JSON array".to_string())?;
-
-    for entry in arr {
-        if entry["id"].as_str() != Some(id) {
-            continue;
-        }
-        let repo = entry["repo"]
-            .as_str()
-            .ok_or_else(|| format!("registry entry '{id}' has no 'repo' field"))?;
-        let path = entry["path"].as_str();
-
-        let spec = if repo == "ianjamesburke/PLEXI" {
-            if let Some(p) = path {
-                // Use the bundled copy — no network clone needed.
-                let dir = p.split('/').next_back().unwrap_or(p);
-                format!("local:{dir}")
-            } else {
-                format!("github:{repo}")
-            }
-        } else {
-            format!("github:{repo}")
-        };
-
-        log::info!("registry: resolved '{id}' → {spec}");
-        return Ok(spec);
-    }
-
-    Err(format!(
-        "unknown app id '{id}' — run `plexi app list` or visit plexiapp.com/apps"
-    ))
-}
-
 /// channel apps dir. Source spec follows `packs::parse_source_spec`.
 fn to_title_case(s: &str) -> String {
     s.split(['-', '_'])

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1164,15 +1164,6 @@ fn to_struct_name(s: &str) -> String {
         .collect::<String>()
 }
 
-/// `plexi app publish` — stub for the v1 marketplace publisher path.
-pub fn app_publish() -> i32 {
-    log::info!("app_publish: stub invoked");
-    println!(
-        "Publishing is on the v1 marketplace roadmap. Use `plexi app validate` before local install flows for now."
-    );
-    println!("Follow progress at https://plexiapp.com");
-    0
-}
 
 /// `plexi app update [<id>]` — local version check for installed apps.
 ///
@@ -1522,15 +1513,6 @@ mod app_inspect_tests {
         // No manifest — must fail validation, exit non-zero.
         let code = super::app_inspect_cli(&dir.path().to_string_lossy());
         assert_eq!(code, 1, "dir without manifest must fail inspect");
-    }
-}
-
-#[cfg(test)]
-mod app_publish_tests {
-    #[test]
-    fn publish_stub_returns_0() {
-        let code = super::app_publish();
-        assert_eq!(code, 0, "publish stub should always succeed");
     }
 }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -449,6 +449,36 @@ pub fn print_trust_sheet(
             println!("  {:<18}{}{sensitive}", cap.as_str(), cap.description());
         }
     }
+    if report.requires_plexi_min.is_some() || report.requires_plexi_max.is_some() {
+        let min = report.requires_plexi_min.as_deref().unwrap_or("any");
+        let max = report.requires_plexi_max.as_deref().unwrap_or("any");
+        println!("requires:     Plexi {min} .. {max}");
+    }
+}
+
+/// Host-version gate: block install when the host is too old for the app (or a
+/// declared requirement is malformed); warn when the host is newer than the
+/// app's declared ceiling. Returns an exit code to abort, or `None` to proceed.
+pub fn host_version_gate(report: &crate::app::package::PackageReport) -> Option<i32> {
+    use crate::app::host_version::{check, current};
+    let verdict = check(
+        report.requires_plexi_min.as_deref(),
+        report.requires_plexi_max.as_deref(),
+        current(),
+    );
+    match verdict.message() {
+        None => None,
+        Some(msg) if verdict.is_blocking() => {
+            eprintln!("error: {msg}");
+            log::warn!("install: host-version gate blocked '{}': {msg}", report.id);
+            Some(1)
+        }
+        Some(msg) => {
+            eprintln!("warning: {msg}");
+            log::info!("install: host-version warning for '{}': {msg}", report.id);
+            None
+        }
+    }
 }
 
 /// Resolve the trust label for a report against the bundled core pack ids.
@@ -506,6 +536,11 @@ fn run_install_gate(report: &crate::app::package::PackageReport, assume_yes: boo
     use std::io::IsTerminal;
     let label = trust_label_for(report);
     print_trust_sheet(report, label);
+    // Host-version compatibility: a too-old host (or malformed requirement)
+    // aborts before the confirm prompt; a too-new host only warns.
+    if let Some(code) = host_version_gate(report) {
+        return Some(code);
+    }
     let is_tty = io::stdin().is_terminal();
     let mut stdin = io::stdin().lock();
     match confirm_install(
@@ -1336,6 +1371,8 @@ mod install_confirm_tests {
             capabilities: Vec::new(),
             file_count: 2,
             total_size: 64,
+            requires_plexi_min: None,
+            requires_plexi_max: None,
         }
     }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -97,6 +97,15 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: AppCmd,
     },
+    /// Manage your Plexi marketplace account (only needed to publish or buy paid apps).
+    ///
+    /// Free apps install without an account. Login/signup require a configured
+    /// auth backend; until then they fail closed with a clear message.
+    #[command(next_help_heading = "Apps")]
+    Account {
+        #[command(subcommand)]
+        cmd: AccountCmd,
+    },
     /// Watch installed CLI tools for changes to their available commands and options.
     Registry {
         #[command(subcommand)]
@@ -601,6 +610,27 @@ pub enum UpdateCmd {
         /// App id to update (omit to update all installed apps)
         id: Option<String>,
     },
+}
+
+/// `plexi account <cmd>` — marketplace account management.
+#[derive(Subcommand)]
+pub enum AccountCmd {
+    /// Show whether you are logged in.
+    Status,
+    /// Log in to an existing marketplace account.
+    Login {
+        /// Account email (falls back to [marketplace].account_email in config)
+        #[arg(long)]
+        email: Option<String>,
+    },
+    /// Create a new marketplace account.
+    Signup {
+        /// Account email (falls back to [marketplace].account_email in config)
+        #[arg(long)]
+        email: Option<String>,
+    },
+    /// Log out and clear the local session.
+    Logout,
 }
 
 /// `plexi app license <cmd>` — inspect paid-app licenses on this machine.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -541,11 +541,29 @@ pub enum AppCmd {
         #[arg(value_hint = ValueHint::FilePath)]
         path: String,
     },
-    /// Publish an app to the Plexi marketplace.
+    /// Validate, package, and submit an app to the Plexi marketplace.
     ///
-    /// Publishing is on the v1 marketplace roadmap. Use app validate and local package
-    /// install flows until the hosted publisher path ships.
-    Publish,
+    /// Reads the `[marketplace]` manifest section (publisher, visibility, price),
+    /// validates the directory, builds a `.plexipkg`, and submits it. Without a
+    /// configured `[marketplace].submit_url` the package is prepared locally but
+    /// not uploaded — the artifact path is printed.
+    Publish {
+        /// App directory to publish (default: current directory)
+        #[arg(default_value = ".", value_hint = ValueHint::DirPath)]
+        path: String,
+    },
+    /// Browse every public app in the hosted marketplace.
+    Browse,
+    /// Search the public marketplace catalog.
+    Search {
+        /// Substring matched against app id, name, description, and tags
+        query: String,
+    },
+    /// Inspect paid-app licenses stored on this machine.
+    License {
+        #[command(subcommand)]
+        cmd: LicenseCmd,
+    },
     /// Check installed apps for available updates.
     ///
     /// Compares each app's recorded installed version against the version in its manifest.
@@ -582,6 +600,18 @@ pub enum UpdateCmd {
     Apps {
         /// App id to update (omit to update all installed apps)
         id: Option<String>,
+    },
+}
+
+/// `plexi app license <cmd>` — inspect paid-app licenses on this machine.
+#[derive(Subcommand)]
+pub enum LicenseCmd {
+    /// List every stored paid-app license.
+    List,
+    /// Show one license in full.
+    Show {
+        /// App id whose license to show
+        id: String,
     },
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,18 +1,17 @@
-use super::app::{
-    app_is_python, ensure_plexi_sdk, is_bare_id, is_github_shorthand, resolve_registry_id,
-};
+use super::app::{app_is_python, ensure_plexi_sdk, is_bare_id, is_github_shorthand};
 use super::print_tip;
 use std::io::{self, Write};
 
 pub fn install_cli(spec: &str) -> i32 {
+    use crate::cli::marketplace::InstallPlan;
     let (source_str, git_ref) = crate::cli::install_host::split_source_and_ref(spec);
     let resolved = if is_bare_id(&source_str) {
-        // Consult the hosted catalog first: a free/licensed catalog app installs
-        // from the CDN artifact; a paid app with no license is blocked; anything
-        // not in the catalog (or a registry outage) falls back to the legacy
-        // id→source resolver below.
+        // A bare id resolves only through the hosted marketplace catalog. A
+        // free/licensed app installs from its CDN artifact (or a declared github
+        // source); a paid app with no license is blocked; an unknown id or an
+        // unreachable registry is a hard error. There is no legacy fallback.
         match crate::cli::marketplace::plan_install(&source_str) {
-            crate::cli::marketplace::InstallPlan::Package(pkg) => {
+            InstallPlan::Package(pkg) => {
                 return crate::cli::app::app_install_package(
                     &pkg.to_string_lossy(),
                     None,
@@ -20,15 +19,21 @@ pub fn install_cli(spec: &str) -> i32 {
                     false,
                 );
             }
-            crate::cli::marketplace::InstallPlan::Source(spec) => spec,
-            crate::cli::marketplace::InstallPlan::Blocked => return 1,
-            crate::cli::marketplace::InstallPlan::Legacy => match resolve_registry_id(&source_str) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    return 1;
-                }
-            },
+            InstallPlan::Source(spec) => spec,
+            InstallPlan::Blocked => return 1,
+            InstallPlan::NotFound => {
+                eprintln!(
+                    "error: no app '{source_str}' in the marketplace — run `plexi app search {source_str}` or `plexi app browse`"
+                );
+                return 1;
+            }
+            InstallPlan::Unreachable => {
+                eprintln!(
+                    "error: could not reach the marketplace to resolve '{source_str}'. \
+                     Check your connection, or install from an explicit source (github:owner/repo)."
+                );
+                return 1;
+            }
         }
     } else if is_github_shorthand(&source_str) {
         let prefixed = format!("github:{source_str}");

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -7,12 +7,28 @@ use std::io::{self, Write};
 pub fn install_cli(spec: &str) -> i32 {
     let (source_str, git_ref) = crate::cli::install_host::split_source_and_ref(spec);
     let resolved = if is_bare_id(&source_str) {
-        match resolve_registry_id(&source_str) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("error: {e}");
-                return 1;
+        // Consult the hosted catalog first: a free/licensed catalog app installs
+        // from the CDN artifact; a paid app with no license is blocked; anything
+        // not in the catalog (or a registry outage) falls back to the legacy
+        // id→source resolver below.
+        match crate::cli::marketplace::plan_install(&source_str) {
+            crate::cli::marketplace::InstallPlan::Package(pkg) => {
+                return crate::cli::app::app_install_package(
+                    &pkg.to_string_lossy(),
+                    None,
+                    crate::cli::InstallConfirm::Interactive,
+                    false,
+                );
             }
+            crate::cli::marketplace::InstallPlan::Source(spec) => spec,
+            crate::cli::marketplace::InstallPlan::Blocked => return 1,
+            crate::cli::marketplace::InstallPlan::Legacy => match resolve_registry_id(&source_str) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    return 1;
+                }
+            },
         }
     } else if is_github_shorthand(&source_str) {
         let prefixed = format!("github:{source_str}");

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -9,8 +9,9 @@
 //! errors for free/local apps (registry down never blocks a local install) and
 //! fails *closed* only for confirmed paid apps with no license.
 
+use crate::app::account::AccountStore;
 use crate::app::marketplace::{
-    license_gate, payment_provider, Account, LicenseDecision, LicenseStore, MarketplaceManifest,
+    license_gate, payment_provider, LicenseDecision, LicenseStore, MarketplaceManifest,
     PaymentError, PublishClient, RegistryClient, RegistryEntry, RegistryError, Submission, Visibility,
 };
 use crate::app::package;
@@ -92,7 +93,8 @@ fn print_entry_table(entries: &[&RegistryEntry]) {
 }
 
 /// What `install_cli` should do with a bare marketplace id after consulting the
-/// hosted catalog and the license store.
+/// hosted catalog and the license store. There is no legacy fallback — the
+/// catalog is the only source for a bare id.
 pub enum InstallPlan {
     /// Catalog app, free or licensed, artifact downloaded + checksum-verified.
     /// Install this `.plexipkg` directly.
@@ -100,33 +102,32 @@ pub enum InstallPlan {
     /// Catalog app that resolves to a source spec (e.g. `github:owner/repo`).
     /// Install via the existing source-clone path.
     Source(String),
-    /// Not a catalog app, or the registry is unreachable. Use the legacy
-    /// id→source resolver. Registry outages must never block a local install.
-    Legacy,
+    /// No app with this id in the catalog. Abort with a not-found message.
+    NotFound,
+    /// The marketplace could not be reached. Abort — a bare id can only be
+    /// resolved through the catalog. (Already-installed apps are unaffected;
+    /// only *new* installs need the catalog.)
+    Unreachable,
     /// Paid app with no license, and purchase is unavailable or failed. Abort.
     /// A message was already printed.
     Blocked,
 }
 
 /// Plan a bare-id install by consulting the hosted catalog. Called by
-/// `install_cli` *before* the legacy resolver.
+/// `install_cli`. The catalog is the sole source of truth for a bare id —
+/// there is no legacy resolver and no backwards-compatibility path.
 ///
-/// Fail-open: a registry outage or an id absent from the catalog returns
-/// [`InstallPlan::Legacy`], so free / github-sourced apps install normally even
-/// when the marketplace is down. Fails *closed* ([`InstallPlan::Blocked`]) only
-/// for a confirmed paid app the user does not own and cannot purchase.
+/// A paid app the user does not own is taken through purchase (which fails
+/// closed with the stub provider). Free / licensed apps install from the CDN
+/// artifact, or from a declared source spec for github-hosted catalog entries.
 pub fn plan_install(app_id: &str) -> InstallPlan {
     let cli = client();
     let entry = match cli.fetch_entry(app_id) {
         Ok(e) => e,
-        Err(RegistryError::NotFound(_)) => {
-            log::info!("marketplace: '{app_id}' not in catalog; using legacy resolver");
-            return InstallPlan::Legacy;
-        }
+        Err(RegistryError::NotFound(_)) => return InstallPlan::NotFound,
         Err(e) => {
-            // Registry unreachable / malformed — never block a local install.
-            log::info!("marketplace: catalog unavailable for '{app_id}' ({e}); using legacy resolver");
-            return InstallPlan::Legacy;
+            log::warn!("marketplace: catalog unreachable for '{app_id}': {e}");
+            return InstallPlan::Unreachable;
         }
     };
 
@@ -139,7 +140,7 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
     }
 
     // Prefer a CDN artifact; fall back to a declared source spec.
-    if !entry.checksum.is_empty() && (entry.package_url.is_some() || has_cdn()) {
+    if !entry.checksum.is_empty() {
         let dest = std::env::temp_dir()
             .join(format!("plexi-mkt-{}-{}.plexipkg", entry.id, uuid::Uuid::new_v4()));
         match cli.download_package(&entry, &dest) {
@@ -153,27 +154,26 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
     if let Some(source) = entry.source.clone() {
         return InstallPlan::Source(source);
     }
-    // Catalog entry with neither artifact nor source — fall back to legacy.
-    log::warn!("marketplace: '{app_id}' has no artifact or source; using legacy resolver");
-    InstallPlan::Legacy
-}
-
-/// Whether a CDN base is configured (or the in-code default is in play). Used to
-/// decide if a checksum-only entry is downloadable.
-fn has_cdn() -> bool {
-    true
-}
-
-/// Attempt to buy a paid app the user does not yet own. Today the stub provider
-/// always fails closed; the message tells the user exactly why. When a real
-/// provider is wired into `payment_provider()`, this issues + persists a license
-/// and returns `true` with no other change here.
-fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
-    println!(
-        "'{}' is a paid app ({}).",
-        entry.id,
-        entry.price.display()
+    eprintln!(
+        "error: catalog entry '{app_id}' has neither a package artifact nor a source — \
+         the registry entry is malformed"
     );
+    InstallPlan::Blocked
+}
+
+/// Attempt to buy a paid app the user does not yet own. Requires a logged-in
+/// account; today the stub payment provider always fails closed, telling the
+/// user exactly why. When a real provider is wired into `payment_provider()`,
+/// this issues + persists a license and returns `true` with no other change.
+fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
+    println!("'{}' is a paid app ({}).", entry.id, entry.price.display());
+
+    let Some(session) = AccountStore::open().current() else {
+        eprintln!("error: {}", PaymentError::NoAccount);
+        eprintln!("  Log in first: `plexi account login`.");
+        return false;
+    };
+
     let provider = payment_provider();
     log::info!(
         "marketplace: payment provider '{}' configured={}",
@@ -184,14 +184,8 @@ fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
         eprintln!("error: {}", PaymentError::NotConfigured);
         return false;
     }
-    let Some(email) = crate::config::marketplace_account_email() else {
-        eprintln!("error: {}", PaymentError::NoAccount);
-        eprintln!("  Set [marketplace].account_email in your config to purchase paid apps.");
-        return false;
-    };
-    let account = Account { email };
-    log::info!("marketplace: purchasing '{}' as {}", entry.id, account.email);
-    match provider.purchase(entry, &account) {
+    log::info!("marketplace: purchasing '{}' as {}", entry.id, session.email);
+    match provider.purchase(entry, &session) {
         Ok(license) => {
             if let Err(e) = store.save(&license) {
                 eprintln!("error: purchased but could not save license: {e}");

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -131,6 +131,24 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
         }
     };
 
+    // Host-version pre-check: reject an incompatible app before downloading it.
+    // A too-old host (or malformed requirement) blocks; a too-new host warns.
+    {
+        use crate::app::host_version::{check, current};
+        let verdict = check(
+            entry.requires_plexi_min.as_deref(),
+            entry.requires_plexi_max.as_deref(),
+            current(),
+        );
+        if let Some(msg) = verdict.message() {
+            if verdict.is_blocking() {
+                eprintln!("error: {msg}");
+                return InstallPlan::Blocked;
+            }
+            eprintln!("warning: {msg}");
+        }
+    }
+
     // License gate before any download or source resolution.
     let store = LicenseStore::open();
     if license_gate(&entry, &store) == LicenseDecision::NeedsPurchase
@@ -314,6 +332,11 @@ pub fn app_publish_cli(path: &str) -> i32 {
     println!("  publisher:  {}", entry.publisher);
     println!("  visibility: {}", entry.visibility.as_str());
     println!("  price:      {}", entry.price.display());
+    if entry.requires_plexi_min.is_some() || entry.requires_plexi_max.is_some() {
+        let min = entry.requires_plexi_min.as_deref().unwrap_or("any");
+        let max = entry.requires_plexi_max.as_deref().unwrap_or("any");
+        println!("  requires:   Plexi {min} .. {max}");
+    }
     println!("  trust:      {}", entry.trust_label);
     println!("  artifact:   {}", artifact.display());
     println!("  checksum:   {}", entry.checksum);

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -249,9 +249,6 @@ pub fn app_license_show_cli(id: &str) -> i32 {
             println!("provider:  {}", lic.provider);
             println!("issued_at: {}", lic.issued_at);
             println!("token:     {}", lic.token);
-            if !lic.signature.is_empty() {
-                println!("signature: {}", lic.signature);
-            }
             0
         }
         None => {

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -1,0 +1,389 @@
+//! Marketplace CLI surface — browse/search the hosted catalog, publish an app,
+//! manage paid-app licenses, and gate paid installs (stint `0018`-`0021`).
+//!
+//! Every command here is a thin shell over `crate::app::marketplace`. The
+//! invariant from the PRM holds at this layer too: nothing here is required to
+//! run a locally-installed app. Browse/search need the network; if the registry
+//! is unreachable they fail with a clear message and a nonzero code, but they
+//! never touch installed apps. The paid-install gate fails *open* on registry
+//! errors for free/local apps (registry down never blocks a local install) and
+//! fails *closed* only for confirmed paid apps with no license.
+
+use crate::app::marketplace::{
+    license_gate, payment_provider, Account, LicenseDecision, LicenseStore, MarketplaceManifest,
+    PaymentError, PublishClient, RegistryClient, RegistryEntry, RegistryError, Submission, Visibility,
+};
+use crate::app::package;
+use std::path::{Path, PathBuf};
+
+fn client() -> RegistryClient {
+    RegistryClient::new(
+        crate::config::marketplace_registry_url(),
+        crate::config::marketplace_cdn_url(),
+    )
+}
+
+/// `plexi app browse` — list every public app in the hosted catalog.
+pub fn app_browse_cli() -> i32 {
+    log::info!("marketplace: app browse");
+    let index = match client().fetch_index() {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("error: could not reach the marketplace: {e}");
+            return 1;
+        }
+    };
+    let listed: Vec<&RegistryEntry> = index.listed().collect();
+    if listed.is_empty() {
+        println!("No public apps are listed yet.");
+        return 0;
+    }
+    println!("{} public app(s) in the marketplace:\n", listed.len());
+    print_entry_table(&listed);
+    crate::cli::print_tip("install one with `plexi app install <id>`.");
+    0
+}
+
+/// `plexi app search <query>` — substring search over the public catalog.
+pub fn app_search_cli(query: &str) -> i32 {
+    log::info!("marketplace: app search query={query:?}");
+    let index = match client().fetch_index() {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("error: could not reach the marketplace: {e}");
+            return 1;
+        }
+    };
+    let hits = index.search(query);
+    if hits.is_empty() {
+        println!("No public apps match '{query}'.");
+        return 0;
+    }
+    println!("{} match(es) for '{query}':\n", hits.len());
+    print_entry_table(&hits);
+    crate::cli::print_tip("install one with `plexi app install <id>`.");
+    0
+}
+
+fn print_entry_table(entries: &[&RegistryEntry]) {
+    let id_w = entries
+        .iter()
+        .map(|e| e.id.len())
+        .max()
+        .unwrap_or(3)
+        .max(3);
+    let ver_w = entries
+        .iter()
+        .map(|e| e.version.len())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+    for e in entries {
+        println!(
+            "  {:id_w$}  {:ver_w$}  {:>8}  {}",
+            e.id,
+            e.version,
+            e.price.display(),
+            e.name,
+            id_w = id_w,
+            ver_w = ver_w,
+        );
+    }
+}
+
+/// What `install_cli` should do with a bare marketplace id after consulting the
+/// hosted catalog and the license store.
+pub enum InstallPlan {
+    /// Catalog app, free or licensed, artifact downloaded + checksum-verified.
+    /// Install this `.plexipkg` directly.
+    Package(PathBuf),
+    /// Catalog app that resolves to a source spec (e.g. `github:owner/repo`).
+    /// Install via the existing source-clone path.
+    Source(String),
+    /// Not a catalog app, or the registry is unreachable. Use the legacy
+    /// id→source resolver. Registry outages must never block a local install.
+    Legacy,
+    /// Paid app with no license, and purchase is unavailable or failed. Abort.
+    /// A message was already printed.
+    Blocked,
+}
+
+/// Plan a bare-id install by consulting the hosted catalog. Called by
+/// `install_cli` *before* the legacy resolver.
+///
+/// Fail-open: a registry outage or an id absent from the catalog returns
+/// [`InstallPlan::Legacy`], so free / github-sourced apps install normally even
+/// when the marketplace is down. Fails *closed* ([`InstallPlan::Blocked`]) only
+/// for a confirmed paid app the user does not own and cannot purchase.
+pub fn plan_install(app_id: &str) -> InstallPlan {
+    let cli = client();
+    let entry = match cli.fetch_entry(app_id) {
+        Ok(e) => e,
+        Err(RegistryError::NotFound(_)) => {
+            log::info!("marketplace: '{app_id}' not in catalog; using legacy resolver");
+            return InstallPlan::Legacy;
+        }
+        Err(e) => {
+            // Registry unreachable / malformed — never block a local install.
+            log::info!("marketplace: catalog unavailable for '{app_id}' ({e}); using legacy resolver");
+            return InstallPlan::Legacy;
+        }
+    };
+
+    // License gate before any download or source resolution.
+    let store = LicenseStore::open();
+    if license_gate(&entry, &store) == LicenseDecision::NeedsPurchase
+        && !attempt_purchase(&entry, &store)
+    {
+        return InstallPlan::Blocked;
+    }
+
+    // Prefer a CDN artifact; fall back to a declared source spec.
+    if !entry.checksum.is_empty() && (entry.package_url.is_some() || has_cdn()) {
+        let dest = std::env::temp_dir()
+            .join(format!("plexi-mkt-{}-{}.plexipkg", entry.id, uuid::Uuid::new_v4()));
+        match cli.download_package(&entry, &dest) {
+            Ok(path) => return InstallPlan::Package(path),
+            Err(e) => {
+                eprintln!("error: could not download '{}' from the marketplace: {e}", entry.id);
+                return InstallPlan::Blocked;
+            }
+        }
+    }
+    if let Some(source) = entry.source.clone() {
+        return InstallPlan::Source(source);
+    }
+    // Catalog entry with neither artifact nor source — fall back to legacy.
+    log::warn!("marketplace: '{app_id}' has no artifact or source; using legacy resolver");
+    InstallPlan::Legacy
+}
+
+/// Whether a CDN base is configured (or the in-code default is in play). Used to
+/// decide if a checksum-only entry is downloadable.
+fn has_cdn() -> bool {
+    true
+}
+
+/// Attempt to buy a paid app the user does not yet own. Today the stub provider
+/// always fails closed; the message tells the user exactly why. When a real
+/// provider is wired into `payment_provider()`, this issues + persists a license
+/// and returns `true` with no other change here.
+fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
+    println!(
+        "'{}' is a paid app ({}).",
+        entry.id,
+        entry.price.display()
+    );
+    let provider = payment_provider();
+    log::info!(
+        "marketplace: payment provider '{}' configured={}",
+        provider.name(),
+        provider.is_configured()
+    );
+    if !provider.is_configured() {
+        eprintln!("error: {}", PaymentError::NotConfigured);
+        return false;
+    }
+    let Some(email) = crate::config::marketplace_account_email() else {
+        eprintln!("error: {}", PaymentError::NoAccount);
+        eprintln!("  Set [marketplace].account_email in your config to purchase paid apps.");
+        return false;
+    };
+    let account = Account { email };
+    log::info!("marketplace: purchasing '{}' as {}", entry.id, account.email);
+    match provider.purchase(entry, &account) {
+        Ok(license) => {
+            if let Err(e) = store.save(&license) {
+                eprintln!("error: purchased but could not save license: {e}");
+                return false;
+            }
+            println!("Purchased '{}'. License saved.", entry.id);
+            true
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            false
+        }
+    }
+}
+
+/// `plexi app license list` — show every stored paid-app license.
+pub fn app_license_list_cli() -> i32 {
+    log::info!("marketplace: license list");
+    let store = LicenseStore::open();
+    let licenses = store.list();
+    if licenses.is_empty() {
+        println!("No paid-app licenses on this machine.");
+        return 0;
+    }
+    println!("{} license(s):\n", licenses.len());
+    for lic in &licenses {
+        println!(
+            "  {}  v{}  (provider: {}, issued: {})",
+            lic.app_id, lic.version, lic.provider, lic.issued_at
+        );
+    }
+    0
+}
+
+/// `plexi app license show <id>` — show one license in full.
+pub fn app_license_show_cli(id: &str) -> i32 {
+    log::info!("marketplace: license show id={id}");
+    let store = LicenseStore::open();
+    match store.load(id) {
+        Some(lic) => {
+            println!("app:       {}", lic.app_id);
+            println!("version:   {}", lic.version);
+            println!("provider:  {}", lic.provider);
+            println!("issued_at: {}", lic.issued_at);
+            println!("token:     {}", lic.token);
+            if !lic.signature.is_empty() {
+                println!("signature: {}", lic.signature);
+            }
+            0
+        }
+        None => {
+            eprintln!("no license stored for '{id}'");
+            1
+        }
+    }
+}
+
+/// `plexi app publish [<path>]` — validate, package, and submit an app to the
+/// hosted marketplace. Replaces the old print-only stub.
+///
+/// Always does the real local work: reads `[marketplace]`, validates the dir,
+/// builds the `.plexipkg`, checksums it, and assembles the submission. The
+/// upload is the only part gated on configuration — without
+/// `[marketplace].submit_url` it reports the prepared submission and where the
+/// artifact is, then exits 0. This is the honest "last mile not wired" boundary,
+/// not a silent no-op.
+pub fn app_publish_cli(path: &str) -> i32 {
+    log::info!("marketplace: app publish path={path}");
+    let app_dir = match Path::new(path).canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not resolve {path}: {e}");
+            return 1;
+        }
+    };
+
+    // Read the marketplace manifest section (publisher/visibility/price).
+    let marketplace = match read_marketplace_manifest(&app_dir) {
+        Ok(m) => m,
+        Err(code) => return code,
+    };
+
+    // Validate the directory (fail-closed) — this is the same gate publish
+    // review will run server-side.
+    let report = match package::validate_dir(&app_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: validation failed — refusing to publish: {e}");
+            return 1;
+        }
+    };
+
+    // Build the distributable artifact and checksum it.
+    let artifact = match package::build_package(&app_dir, None) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: could not build package: {e}");
+            return 1;
+        }
+    };
+    let checksum = match package::sha256_file(&artifact) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: could not checksum package: {e}");
+            return 1;
+        }
+    };
+
+    let core_ids = crate::cli::install_host::core_pack_ids();
+    let core_refs: Vec<&str> = core_ids.iter().map(String::as_str).collect();
+    let trust = package::trust_label(&report, &core_refs);
+
+    let entry = RegistryEntry::from_report(
+        &report,
+        &marketplace,
+        trust.display_str(),
+        checksum,
+        Vec::new(),
+    );
+    let submission = Submission {
+        schema_version: crate::app::marketplace::MARKETPLACE_SCHEMA_VERSION,
+        entry: entry.clone(),
+    };
+
+    println!("Prepared submission for '{}' v{}:", entry.id, entry.version);
+    println!("  publisher:  {}", entry.publisher);
+    println!("  visibility: {}", entry.visibility.as_str());
+    println!("  price:      {}", entry.price.display());
+    println!("  trust:      {}", entry.trust_label);
+    println!("  artifact:   {}", artifact.display());
+    println!("  checksum:   {}", entry.checksum);
+
+    let publisher = PublishClient::new(crate::config::marketplace_submit_url());
+    match publisher.submit(&submission) {
+        Ok(state) => {
+            println!("\nSubmitted to the marketplace (state: {state:?}).");
+            0
+        }
+        Err(crate::app::marketplace::PublishError::NotConfigured) => {
+            println!(
+                "\nNo submission endpoint configured — the package was validated and prepared but \
+                 not uploaded."
+            );
+            println!(
+                "Set [marketplace].submit_url in your config to enable upload, or share the \
+                 artifact above directly."
+            );
+            crate::cli::print_tip("follow marketplace progress at https://plexiapp.com/docs/marketplace");
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// Read and validate the `[marketplace]` manifest section for publishing.
+/// Returns the section, or an exit code on a publish-blocking problem.
+fn read_marketplace_manifest(app_dir: &Path) -> Result<MarketplaceManifest, i32> {
+    let manifest_path = app_dir.join("manifest.toml");
+    let text = match std::fs::read_to_string(&manifest_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: could not read {}: {e}", manifest_path.display());
+            return Err(1);
+        }
+    };
+    let manifest: crate::app::registry::AppManifest = match toml::from_str(&text) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: manifest.toml parse failed: {e}");
+            return Err(1);
+        }
+    };
+    let Some(marketplace) = manifest.marketplace else {
+        eprintln!(
+            "error: no [marketplace] section in manifest.toml.\n  \
+             Add one to publish, e.g.:\n\n  [marketplace]\n  visibility = \"public\"\n  \
+             price = \"free\"\n  publisher = \"your-org\""
+        );
+        return Err(1);
+    };
+    if marketplace.publisher.as_deref().unwrap_or("").is_empty() {
+        eprintln!("error: [marketplace].publisher is required to publish");
+        return Err(1);
+    }
+    if marketplace.visibility == Visibility::Private {
+        eprintln!(
+            "warning: [marketplace].visibility is \"private\" — this app will be submitted but \
+             not publicly listed. Use \"public\" to list it, \"unlisted\" for install-by-id only."
+        );
+    }
+    Ok(marketplace)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,6 +111,7 @@ pub mod demo;
 pub mod descriptor;
 pub mod doctor;
 pub mod install;
+pub mod account;
 pub mod install_host;
 pub mod list;
 pub mod marketplace;
@@ -210,6 +211,9 @@ pub use ai::{ai_doctor_cli, ai_setup_cli};
 pub use app::{
     app_action_cli, app_info, app_init, app_inspect_cli, app_install_package, app_install_with_pin,
     app_list, app_package_cli, app_render, app_uninstall, app_update_cli, InstallConfirm,
+};
+pub use account::{
+    account_login_cli, account_logout_cli, account_signup_cli, account_status_cli,
 };
 pub use marketplace::{
     app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,7 @@ pub mod doctor;
 pub mod install;
 pub mod install_host;
 pub mod list;
+pub mod marketplace;
 pub mod notes;
 pub mod notify;
 pub mod open;
@@ -208,8 +209,10 @@ pub use agent::{
 pub use ai::{ai_doctor_cli, ai_setup_cli};
 pub use app::{
     app_action_cli, app_info, app_init, app_inspect_cli, app_install_package, app_install_with_pin,
-    app_list, app_package_cli, app_publish, app_render, app_uninstall, app_update_cli,
-    InstallConfirm,
+    app_list, app_package_cli, app_render, app_uninstall, app_update_cli, InstallConfirm,
+};
+pub use marketplace::{
+    app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,
 };
 pub use app_check::app_check_cli;
 pub use completions::{complete_open_cli, completions_cli};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -456,6 +456,7 @@ pub struct PlexiConfig {
     pub focus_history_depth: Option<usize>,
     pub agents: Option<AgentsConfig>,
     pub cli: Option<CliConfig>,
+    pub marketplace: Option<MarketplaceConfig>,
 }
 
 /// CLI behavior configuration.
@@ -463,6 +464,29 @@ pub struct PlexiConfig {
 pub struct CliConfig {
     /// Print contextual tips after CLI commands. Default: `true`. Set to `false` to suppress.
     pub tips: Option<bool>,
+}
+
+/// Hosted marketplace configuration (`[marketplace]`). All fields optional —
+/// the hosted catalog/CDN default to `plexiapp.com` in code (see
+/// `crate::app::marketplace::DEFAULT_REGISTRY_URL`), so an empty section uses
+/// the official registry. `submit_url` and `payment_backend` are intentionally
+/// unset by default: publishing and paid purchases fail closed until a real
+/// endpoint / provider is wired up.
+#[derive(Deserialize, Default, Clone)]
+pub struct MarketplaceConfig {
+    /// Override the catalog index URL. Default: official `plexiapp.com` index.
+    pub registry_url: Option<String>,
+    /// Override the package CDN base. Default: official `plexiapp.com` CDN.
+    pub cdn_url: Option<String>,
+    /// Publisher submission endpoint. Unset = publishing prepared locally but
+    /// not uploaded (fails closed with a clear message).
+    pub submit_url: Option<String>,
+    /// Payment backend selector. Unset / `"none"` = stub (paid installs fail
+    /// closed). A real provider (e.g. `"stripe"`) slots into
+    /// `crate::app::marketplace::payment_provider()` keyed on this value.
+    pub payment_backend: Option<String>,
+    /// Marketplace account email used for paid purchases. Unset = no account.
+    pub account_email: Option<String>,
 }
 
 /// Plexi AI broker configuration (`ai.query` capability).
@@ -1269,7 +1293,63 @@ impl PlexiConfig {
             (None, Some(incoming)) => self.agents = Some(incoming),
             _ => {}
         }
+        match (self.marketplace.as_mut(), other.marketplace) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.marketplace = Some(incoming),
+            _ => {}
+        }
     }
+}
+
+impl MarketplaceConfig {
+    fn overlay(&mut self, other: Self) {
+        macro_rules! overlay_field {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field;
+                }
+            };
+        }
+        overlay_field!(registry_url);
+        overlay_field!(cdn_url);
+        overlay_field!(submit_url);
+        overlay_field!(payment_backend);
+        overlay_field!(account_email);
+    }
+}
+
+/// Resolved marketplace settings for the active channel. Loads the global
+/// config (workspace overlay does not apply to marketplace endpoints — they are
+/// machine-level, not project-level). Returns the configured values, falling
+/// back to in-code defaults at the call site.
+fn marketplace_config() -> MarketplaceConfig {
+    PlexiConfig::load().marketplace.unwrap_or_default()
+}
+
+/// Catalog index URL override, if the user set one.
+pub fn marketplace_registry_url() -> Option<String> {
+    marketplace_config().registry_url
+}
+
+/// Package CDN base override, if set.
+pub fn marketplace_cdn_url() -> Option<String> {
+    marketplace_config().cdn_url
+}
+
+/// Publisher submission endpoint, if configured. `None` = publishing fails
+/// closed (prepared but not uploaded).
+pub fn marketplace_submit_url() -> Option<String> {
+    marketplace_config().submit_url
+}
+
+/// Payment backend selector (e.g. `"none"`, `"stripe"`). `None` = stub.
+pub fn marketplace_payment_backend() -> Option<String> {
+    marketplace_config().payment_backend
+}
+
+/// Marketplace account email for paid purchases, if set.
+pub fn marketplace_account_email() -> Option<String> {
+    marketplace_config().account_email
 }
 
 impl ThemeConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -485,7 +485,11 @@ pub struct MarketplaceConfig {
     /// closed). A real provider (e.g. `"stripe"`) slots into
     /// `crate::app::marketplace::payment_provider()` keyed on this value.
     pub payment_backend: Option<String>,
-    /// Marketplace account email used for paid purchases. Unset = no account.
+    /// Account/auth backend selector. Unset / `"none"` = stub (login/signup
+    /// fail closed). A real provider slots into
+    /// `crate::app::account::account_provider()` keyed on this value.
+    pub account_backend: Option<String>,
+    /// Default email pre-filled by `plexi account login`. Unset = prompt.
     pub account_email: Option<String>,
 }
 
@@ -1314,6 +1318,7 @@ impl MarketplaceConfig {
         overlay_field!(cdn_url);
         overlay_field!(submit_url);
         overlay_field!(payment_backend);
+        overlay_field!(account_backend);
         overlay_field!(account_email);
     }
 }
@@ -1347,7 +1352,12 @@ pub fn marketplace_payment_backend() -> Option<String> {
     marketplace_config().payment_backend
 }
 
-/// Marketplace account email for paid purchases, if set.
+/// Account/auth backend selector (e.g. `"none"`, `"plexi"`). `None` = stub.
+pub fn marketplace_account_backend() -> Option<String> {
+    marketplace_config().account_backend
+}
+
+/// Default email pre-filled by `plexi account login`, if set.
 pub fn marketplace_account_email() -> Option<String> {
     marketplace_config().account_email
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd, HookAction,
-        NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd,
+        LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd,
         WorkspaceCmd,
     };
     use clap::Parser;
@@ -526,9 +526,21 @@ fn main() -> eframe::Result {
                                 log::info!("app_freeze:cli: path={path}");
                                 std::process::exit(cli::freeze_cli(&path));
                             }
-                            AppCmd::Publish => {
-                                std::process::exit(cli::app_publish());
+                            AppCmd::Publish { path } => {
+                                std::process::exit(cli::app_publish_cli(&path));
                             }
+                            AppCmd::Browse => {
+                                std::process::exit(cli::app_browse_cli());
+                            }
+                            AppCmd::Search { query } => {
+                                std::process::exit(cli::app_search_cli(&query));
+                            }
+                            AppCmd::License { cmd } => match cmd {
+                                LicenseCmd::List => std::process::exit(cli::app_license_list_cli()),
+                                LicenseCmd::Show { id } => {
+                                    std::process::exit(cli::app_license_show_cli(&id))
+                                }
+                            },
                             AppCmd::Update { id } => {
                                 log::info!("app_update:cli: id={id:?}");
                                 std::process::exit(cli::app_update_cli(id.as_deref()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,9 +196,9 @@ fn main() -> eframe::Result {
         })
         .collect();
     use crate::cli::args::{
-        AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd, HookAction,
-        LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd,
-        WorkspaceCmd,
+        AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
+        HookAction, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd,
+        UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
 
@@ -867,6 +867,16 @@ fn main() -> eframe::Result {
                                 &runner, &command, &extra, &opts,
                             ));
                         }
+                    },
+                    Commands::Account { cmd } => match cmd {
+                        AccountCmd::Status => std::process::exit(cli::account_status_cli()),
+                        AccountCmd::Login { email } => {
+                            std::process::exit(cli::account_login_cli(email.as_deref()))
+                        }
+                        AccountCmd::Signup { email } => {
+                            std::process::exit(cli::account_signup_cli(email.as_deref()))
+                        }
+                        AccountCmd::Logout => std::process::exit(cli::account_logout_cli()),
                     },
                     Commands::Registry { cmd } => match cmd {
                         RegistryCmd::Watch { cli: only } => {

--- a/website/src/lib/registry-index.json
+++ b/website/src/lib/registry-index.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "apps": []
+}

--- a/website/src/pages/apps/[id].astro
+++ b/website/src/pages/apps/[id].astro
@@ -1,16 +1,34 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import registry from '../../lib/registry-index.json';
 
-const REGISTRY_URL = 'https://raw.githubusercontent.com/ianjamesburke/plexi-registry/main/registry.json';
-
+// Detail pages are generated from the central registry index (new schema).
+// Only `public` apps get a page; the build is self-contained (reads the local
+// index stub) so it never depends on a live registry being reachable.
 export async function getStaticPaths() {
-  const apps = await fetch('https://raw.githubusercontent.com/ianjamesburke/plexi-registry/main/registry.json').then(r => r.json());
+  const apps = (registry.apps as any[]).filter(
+    (a) => (a.visibility ?? 'private') === 'public'
+  );
   return apps.map((app: any) => ({ params: { id: app.id }, props: { app } }));
 }
 
 const { app } = Astro.props;
-const repoUrl = `https://github.com/${app.repo}${app.path ? `/tree/main/${app.path}` : ''}`;
-const installCmd = `plexi install ${app.id}`;
+
+function priceLabel(price: any): string {
+  if (!price || price === 'free') return 'Free';
+  if (typeof price === 'object') {
+    const major = Math.floor(price.amount_cents / 100);
+    const minor = String(price.amount_cents % 100).padStart(2, '0');
+    const sym = price.currency?.toLowerCase() === 'usd' ? '$' : '';
+    return `${sym}${major}.${minor} ${price.currency?.toUpperCase() ?? ''}`.trim();
+  }
+  return 'Free';
+}
+
+const sourceUrl = app.source?.startsWith('github:')
+  ? `https://github.com/${app.source.slice('github:'.length)}`
+  : null;
+const installCmd = `plexi app install ${app.id}`;
 ---
 
 <Layout title={`${app.name} — Plexi Apps`} description={app.description}>
@@ -26,7 +44,7 @@ const installCmd = `plexi install ${app.id}`;
     <header class="app-header">
       <div class="title-row">
         <h1>{app.name}</h1>
-        {app.core && <span class="core-badge">core</span>}
+        <span class="core-badge">{priceLabel(app.price)}</span>
         <span class="version">v{app.version}</span>
       </div>
       <p class="desc">{app.description}</p>
@@ -39,26 +57,34 @@ const installCmd = `plexi install ${app.id}`;
     </div>
 
     <div class="meta">
-      <div class="meta-row">
-        <span class="meta-label">Author</span>
-        <span class="meta-val">
-          <a href={`https://github.com/${app.author}`} target="_blank">@{app.author}</a>
-        </span>
-      </div>
-      <div class="meta-row">
-        <span class="meta-label">Source</span>
-        <span class="meta-val">
-          <a href={repoUrl} target="_blank">
-            {app.core ? `core — ${app.repo}` : app.repo}{app.path ? `/${app.path}` : ''}
-          </a>
-        </span>
-      </div>
-      <div class="meta-row">
-        <span class="meta-label">Tags</span>
-        <span class="meta-val tags">
-          {app.tags.map((t: string) => <span class="tag">{t}</span>)}
-        </span>
-      </div>
+      {app.publisher && (
+        <div class="meta-row">
+          <span class="meta-label">Publisher</span>
+          <span class="meta-val">@{app.publisher}</span>
+        </div>
+      )}
+      {app.trust_label && (
+        <div class="meta-row">
+          <span class="meta-label">Trust</span>
+          <span class="meta-val">{app.trust_label}</span>
+        </div>
+      )}
+      {sourceUrl && (
+        <div class="meta-row">
+          <span class="meta-label">Source</span>
+          <span class="meta-val">
+            <a href={sourceUrl} target="_blank">{app.source}</a>
+          </span>
+        </div>
+      )}
+      {app.capabilities?.length > 0 && (
+        <div class="meta-row">
+          <span class="meta-label">Capabilities</span>
+          <span class="meta-val tags">
+            {app.capabilities.map((c: string) => <span class="tag">{c}</span>)}
+          </span>
+        </div>
+      )}
     </div>
 
     <div class="back-row">

--- a/website/src/pages/apps/index.astro
+++ b/website/src/pages/apps/index.astro
@@ -1,15 +1,78 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import Newsletter from '../../components/Newsletter.astro';
+import registry from '../../lib/registry-index.json';
+
+// The catalog is served from a central registry index. Until it is populated
+// this stub renders the empty "v1 roadmap" state; once the index has public
+// apps, each becomes a card linking to its detail page. Only `public` apps are
+// listed here — `unlisted`/`private` apps install by id but are never shown.
+type Entry = {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  publisher?: string;
+  capabilities?: string[];
+  trust_label?: string;
+  visibility?: string;
+  price?: string | { amount_cents: number; currency: string };
+};
+
+const apps: Entry[] = (registry.apps as Entry[]).filter(
+  (a) => (a.visibility ?? 'private') === 'public'
+);
+
+function priceLabel(price: Entry['price']): string {
+  if (!price || price === 'free') return 'Free';
+  if (typeof price === 'object') {
+    const major = Math.floor(price.amount_cents / 100);
+    const minor = String(price.amount_cents % 100).padStart(2, '0');
+    const sym = price.currency?.toLowerCase() === 'usd' ? '$' : '';
+    return `${sym}${major}.${minor} ${price.currency?.toUpperCase() ?? ''}`.trim();
+  }
+  return 'Free';
+}
 ---
 
-<Layout title="Apps — Plexi" description="The Plexi App Marketplace is on the v1 roadmap.">
+<Layout title="Apps — Plexi" description="Browse and install Plexi apps from the marketplace.">
   <div class="wrap">
     <header class="apps-header">
       <div class="soon-badge">v1 roadmap</div>
       <h1>App Marketplace</h1>
-      <p class="sub">Local packages come first. Reviewed app installs follow on the v1 path.</p>
+      <p class="sub">
+        Install reviewed apps with <code>plexi app install &lt;id&gt;</code>. Free
+        apps need no account. Apps install into your local <code>.plexi</code>
+        profile and keep running even if the registry is offline.
+      </p>
     </header>
+
+    {apps.length === 0 ? (
+      <div class="empty">
+        <p>No public apps are listed yet.</p>
+        <p class="empty-sub">
+          Local packages come first; reviewed registry installs follow on the v1
+          path. Publishers: <code>plexi app publish</code>.
+        </p>
+      </div>
+    ) : (
+      <div class="grid">
+        {apps.map((app) => (
+          <a class="card" href={`/apps/${app.id}`}>
+            <div class="card-top">
+              <span class="card-name">{app.name}</span>
+              <span class="card-price">{priceLabel(app.price)}</span>
+            </div>
+            <p class="card-desc">{app.description ?? ''}</p>
+            <div class="card-meta">
+              <span class="card-ver">v{app.version}</span>
+              {app.publisher && <span class="card-pub">@{app.publisher}</span>}
+              {app.trust_label && <span class="card-trust">{app.trust_label}</span>}
+            </div>
+          </a>
+        ))}
+      </div>
+    )}
   </div>
 
   <Newsletter />
@@ -17,7 +80,7 @@ import Newsletter from '../../components/Newsletter.astro';
 
 <style>
   .apps-header {
-    padding: 96px 0 80px;
+    padding: 96px 0 48px;
     text-align: center;
   }
 
@@ -48,5 +111,84 @@ import Newsletter from '../../components/Newsletter.astro';
     color: var(--fg-4);
     font-size: 15px;
     line-height: 1.7;
+    max-width: 540px;
+    margin: 0 auto;
+  }
+
+  .sub code,
+  .empty code {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent-light);
+  }
+
+  .empty {
+    text-align: center;
+    padding: 48px 0 96px;
+    color: var(--fg-4);
+  }
+
+  .empty-sub {
+    font-size: 14px;
+    margin-top: 12px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    padding: 16px 0 96px;
+  }
+
+  .card {
+    display: block;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+    text-decoration: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .card:hover {
+    border-color: var(--accent-dim);
+  }
+
+  .card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  .card-name {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--fg);
+  }
+
+  .card-price {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--accent-light);
+  }
+
+  .card-desc {
+    color: var(--fg-4);
+    font-size: 14px;
+    line-height: 1.6;
+    margin: 8px 0 16px;
+  }
+
+  .card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-4);
+  }
+
+  .card-trust {
+    color: var(--fg-4);
   }
 </style>


### PR DESCRIPTION
Lands the hosted-marketplace infrastructure end-to-end behind a clean, fully-stubbed payment boundary. Implements stint **0018** (registry/CDN), **0019** (publisher submission), **0020** (browse + install from registry), and the technical half of **0021** (paid apps: license + payment boundary). PRM: `docs/prm/marketplace-hosted.md`.

## What's built

**Catalog (`src/app/marketplace.rs`)**
- `RegistryEntry` / `RegistryIndex` / `RegistryClient` — hosted catalog that *republishes* local validator output (`PackageReport`); CDN download addressed by sha256 with checksum verification on every fetch.
- `Visibility` — `public` / `unlisted` / `private`. Covers public apps, private apps, and install-by-id-only apps. Default is `private` (an app isn't public until published).
- `Price` — `free` (default) or `{ amount_cents, currency }`. Covers apps that cost money.

**Paid-app boundary (the part you can wire to Stripe later with no fanfare)**
- `PaymentProvider` trait + fail-closed `StubPaymentProvider` behind a `payment_provider()` factory. Adding a real processor is a one-line change in the factory; nothing else references a concrete provider.
- `License` + on-disk `LicenseStore` (per-channel `<config_dir>/licenses/`). **Real and tested** — only the charge is stubbed. A real provider issues a `License`; the store + install gate already consume it.
- `license_gate()` — pure decision function gating paid installs.

**Publisher (`src/cli/marketplace.rs`)**
- `plexi app publish [path]` — validate → package → checksum → prepare submission → submit. Replaces the old print-only stub. Fails closed honestly when no `submit_url` is configured (package is prepared locally, artifact path printed).
- `plexi app browse` / `plexi app search <q>` — list/search the public catalog.
- `plexi app license list` / `plexi app license show <id>`.

**Install integration**
- `install_cli` consults the catalog first for bare ids: free/licensed apps install from the CDN artifact; paid-unlicensed apps are blocked; anything not in the catalog (or a registry outage) falls back to the existing source resolver. **Registry outages never block a local install.**

**Manifest + config**
- Manifest gains optional `[marketplace]` (visibility/price/publisher).
- Config gains `[marketplace]` (registry_url/cdn_url/submit_url/payment_backend/account_email) — all default to plexiapp.com or fail closed.

## Invariant held
Hosted services distribute metadata and broker money; they are never required to run a locally-installed app. No hosted login for local install/run/browse-free.

## Tests
11 new unit tests (visibility/price parsing, license round-trip + gate, stub-provider fails-closed-never-panics, publish-not-configured, index search, CDN url addressing). Full `cargo test --bin plexi` green: **1086 passed, 0 failed**.

## Follow-up (not in this PR)
- 0021 business spec prose (revenue share %, refund window, takedown policy) — the technical license/payment boundary is built; the policy numbers belong in a billing spec.
- 0022 (Plexi AI subscription `ai.query` backend) — separate stint task, not claimed here.
- Real payment provider + standing up the live registry/CDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)