### PR TITLE
feat(apps/github-issues): add label picker and smarter label chips (#2164)

### DIFF
--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -577,15 +577,17 @@ class GhIssues(App):
 
     def _handle_picker_key(self, key: str) -> None:
         filtered = self._picker_filtered_labels()
-        if key == " ":
+        if key == "space":
             if filtered and 0 <= self._picker_sel < len(filtered):
                 label = filtered[self._picker_sel]
                 if label in self._picker_staged:
                     self._picker_staged.discard(label)
+                    self.emit.info(f"gh-issues: picker deselected {label!r}")
                 else:
                     self._picker_staged.add(label)
+                    self.emit.info(f"gh-issues: picker selected {label!r}")
             self.emit.schedule_render()
-        elif key == "Backspace":
+        elif key == "backspace":
             if self._picker_query:
                 self._picker_query = self._picker_query[:-1]
                 self._picker_sel = 0

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """gh-issues — GitHub Issues viewer for the workspace repo.
 
-Two views:
+Three views:
   - LIST: scrollable issue rows with number badge, title, labels
   - DETAIL: metadata card + scrollable markdown body
+  - PICKER: label selector for multi-label AND filtering
 
 Keys: j/k navigate · Enter open detail · Esc back · o open in browser
-      s sort · f filter · c clear filter · r refresh · n new issue in terminal
+      s sort · f filter · l label picker · c clear filter · r refresh · n new
 """
 import asyncio
 import json
@@ -85,12 +86,54 @@ SORT_LABELS = {
 }
 
 
+PRIORITY_PREFIXES = ("p0", "p1", "p2", "p3", "p4", "bug", "enhancement", "feat", "fix")
+MAX_VISIBLE_CHIPS = 3
+
+
 def _issue_labels(issue: dict) -> list[str]:
     return [
         str(label.get("name", ""))
         for label in (issue.get("labels") or [])
         if label and label.get("name")
     ]
+
+
+def _is_priority_label(name: str) -> bool:
+    return name.lower().startswith(PRIORITY_PREFIXES)
+
+
+def _select_visible_chips(
+    issue: dict, active_filters: set[str],
+) -> list[RowChip]:
+    all_labels = _issue_labels(issue)
+    if not all_labels:
+        return []
+    active = [l for l in all_labels if l in active_filters]
+    priority = [l for l in all_labels if l not in active_filters and _is_priority_label(l)]
+    rest = [l for l in all_labels if l not in active_filters and not _is_priority_label(l)]
+    ordered = active + priority + rest
+    visible = ordered[:MAX_VISIBLE_CHIPS]
+    hidden_count = len(all_labels) - len(visible)
+    chips = [RowChip(name, _label_color(name)) for name in visible]
+    if hidden_count > 0:
+        chips.append(RowChip(f"+{hidden_count}", theme.muted))
+    return chips
+
+
+def _collect_unique_labels(issues: list[dict]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for issue in issues:
+        for label in _issue_labels(issue):
+            if label not in seen:
+                seen.add(label)
+                result.append(label)
+    result.sort(key=str.lower)
+    return result
+
+
+def _fuzzy_match(query: str, label: str) -> bool:
+    return query.lower() in label.lower()
 
 
 def _next_sort_mode(mode: str) -> str:
@@ -109,14 +152,14 @@ def _sort_key(issue: dict, mode: str) -> tuple:
 
 def _filter_and_sort_issues(
     issues: list[dict],
-    filter_label: str | None,
+    filter_labels: set[str],
     sort_mode: str,
 ) -> list[dict]:
     visible = list(issues)
-    if filter_label:
+    if filter_labels:
         visible = [
             issue for issue in visible
-            if any(label == filter_label for label in _issue_labels(issue))
+            if filter_labels <= set(_issue_labels(issue))
         ]
     reverse = sort_mode in ("created_desc", "number_desc")
     return sorted(visible, key=lambda issue: _sort_key(issue, sort_mode), reverse=reverse)
@@ -127,6 +170,7 @@ def _filter_and_sort_issues(
 class GhIssues(App):
     VIEW_LIST   = "list"
     VIEW_DETAIL = "detail"
+    VIEW_PICKER = "picker"
 
     repo_dir: Arg[str | None] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
 
@@ -139,10 +183,12 @@ class GhIssues(App):
         self._error          : str | None = None
         self._detail         : dict | None = None
         self._root           = self.repo_dir or ""
-        self._filter_label   : str | None = None
+        self._filter_labels  : set[str] = set()
         self._sort_mode      = "created_desc"
-        # Stable Scrollable instance — scroll offset persists across renders.
         self._body_scroll    = Scrollable(Label(""))
+        self._picker_query   = ""
+        self._picker_sel     = 0
+        self._picker_staged  : set[str] = set()
         self.emit.status_summary("Loading…")
         self.emit.info(f"gh-issues init workspace={self._root!r}")
         self._fetch()
@@ -150,9 +196,9 @@ class GhIssues(App):
     # ── data ──────────────────────────────────────────────────────────────────
 
     def _fetch(self) -> None:
-        self._loading      = True
-        self._error        = None
-        self._filter_label = None
+        self._loading       = True
+        self._error         = None
+        self._filter_labels = set()
         asyncio.create_task(asyncio.to_thread(self._load_list))
 
     def _load_list(self) -> None:
@@ -179,7 +225,7 @@ class GhIssues(App):
         self.emit.schedule_render()
 
     def _visible_issues(self) -> list[dict]:
-        return _filter_and_sort_issues(self._issues, self._filter_label, self._sort_mode)
+        return _filter_and_sort_issues(self._issues, self._filter_labels, self._sort_mode)
 
     def _clamp_selection(self) -> None:
         visible = self._visible_issues()
@@ -204,8 +250,9 @@ class GhIssues(App):
     def _list_subtitle(self) -> str:
         count = len(self._visible_issues())
         parts = [f"{count} open"]
-        if self._filter_label:
-            parts.append(f"label:{self._filter_label}")
+        if self._filter_labels:
+            label_str = "+".join(sorted(self._filter_labels))
+            parts.append(f"label:{label_str}")
         parts.append(SORT_LABELS.get(self._sort_mode, SORT_LABELS["created_desc"]))
         return " · ".join(parts)
 
@@ -248,6 +295,10 @@ class GhIssues(App):
             ], padding_top=0))
             return
 
+        if self._view == self.VIEW_PICKER:
+            self._draw_picker(ctx)
+            return
+
         if self._view == self.VIEW_DETAIL:
             if self._detail_loading:
                 ctx.render(Column([
@@ -277,6 +328,7 @@ class GhIssues(App):
             ("↩", "detail"),
             ("s", "sort"),
             ("f", "filter"),
+            ("l", "labels"),
             ("c", "clear"),
             ("o", "browser"),
             ("r", "refresh"),
@@ -308,10 +360,7 @@ class GhIssues(App):
                 id=f"issue-{issue['number']}",
                 leading=LeadingBadge(f"#{issue['number']}", color=theme.accent),
                 primary=issue.get("title", ""),
-                chips=[
-                    RowChip(lbl.get("name", ""), _label_color(lbl.get("name", "")))
-                    for lbl in (issue.get("labels") or [])[:2]
-                ],
+                chips=_select_visible_chips(issue, self._filter_labels),
             ).to_dict()
             for issue in visible
         ]
@@ -348,9 +397,56 @@ class GhIssues(App):
             FooterKeys([("o", "open in browser"), ("escape", "back")]),
         ], padding_top=0))
 
+    def _picker_filtered_labels(self) -> list[str]:
+        all_labels = _collect_unique_labels(self._issues)
+        if not self._picker_query:
+            return all_labels
+        return [l for l in all_labels if _fuzzy_match(self._picker_query, l)]
+
+    def _draw_picker(self, ctx: RenderContext) -> None:
+        filtered = self._picker_filtered_labels()
+        self._picker_sel = max(0, min(self._picker_sel, len(filtered) - 1)) if filtered else 0
+
+        query_display = self._picker_query or ""
+        subtitle = f"{len(self._picker_staged)} selected" if self._picker_staged else "type to filter"
+        if query_display:
+            subtitle = f'"{query_display}" · {subtitle}'
+
+        appbar = AppBar("Labels", subtitle=subtitle, accent=theme.accent)
+        footer = FooterKeys([
+            ("↩", "apply"),
+            ("space", "toggle"),
+            ("escape", "cancel"),
+        ])
+        appbar_h = appbar.measure(ctx.w)
+        footer_h = footer.measure(ctx.w)
+        appbar.render(ctx, 0.0, 0.0, ctx.w, appbar_h)
+        footer.render(ctx, 0.0, ctx.h - footer_h, ctx.w, footer_h)
+
+        rows = [
+            ListRow(
+                id=f"label-{i}",
+                leading=LeadingBadge("✓" if label in self._picker_staged else " ", color=theme.accent if label in self._picker_staged else theme.muted),
+                primary=label,
+                chips=[RowChip(label, _label_color(label))],
+            ).to_dict()
+            for i, label in enumerate(filtered)
+        ]
+        list_h = max(0.0, ctx.h - appbar_h - footer_h)
+        if rows:
+            ctx.list_view("label-picker", rows, selected=self._picker_sel,
+                          y=float(appbar_h), h=float(list_h))
+        else:
+            ctx.text(PAD, appbar_h + PAD, "No matching labels.", size=BODY, color=theme.muted)
+
     # ── input ─────────────────────────────────────────────────────────────────
 
     def on_escape(self) -> bool:
+        if self._view == self.VIEW_PICKER:
+            self._view = self.VIEW_LIST
+            self.emit.info("gh-issues: picker cancelled")
+            self.emit.schedule_render()
+            return True
         if self._view == self.VIEW_DETAIL:
             self._view   = self.VIEW_LIST
             self._detail = None
@@ -365,6 +461,10 @@ class GhIssues(App):
         if self._loading:
             return
 
+        if self._view == self.VIEW_PICKER:
+            self._handle_picker_key(key)
+            return
+
         if self._view == self.VIEW_LIST:
             if key == "o":
                 await self._open_browser()
@@ -372,6 +472,8 @@ class GhIssues(App):
                 self._cycle_sort()
             elif key == "f":
                 self._toggle_filter_from_selection()
+            elif key == "l":
+                self._open_picker()
             elif key == "c":
                 self._clear_filter()
             elif key == "r":
@@ -392,14 +494,21 @@ class GhIssues(App):
                 if self._body_scroll.handle_key(key):
                     self.emit.schedule_render()
 
-    def on_list_select(self, _id: str, index: int) -> None:
+    def on_list_select(self, list_id: str, index: int) -> None:
+        if list_id == "label-picker":
+            self._picker_sel = index
+            self.emit.schedule_render()
+            return
         self._sel = index
         issue = self._selected_issue()
         if issue:
             self.emit.status_summary(issue["title"])
         self.emit.schedule_render()
 
-    def on_list_activate(self, _id: str, _index: int) -> None:
+    def on_list_activate(self, list_id: str, _index: int) -> None:
+        if list_id == "label-picker":
+            self._apply_picker()
+            return
         self._open_detail()
 
     def on_click(self, _x: float, _y: float, _button: str) -> None:
@@ -422,32 +531,69 @@ class GhIssues(App):
             self.emit.info("gh-issues: selected issue has no labels to filter")
             return
         keep_number = issue.get("number")
-        if self._filter_label in labels:
-            idx = labels.index(self._filter_label)
+        current = next(iter(self._filter_labels), None) if len(self._filter_labels) == 1 else None
+        if current in labels:
+            idx = labels.index(current)
             if idx == len(labels) - 1:
-                cleared = self._filter_label
-                self._filter_label = None
+                self._filter_labels = set()
                 self._select_issue_number(keep_number)
-                self.emit.info(f"gh-issues: cleared filter label:{cleared}")
+                self.emit.info(f"gh-issues: cleared filter label:{current}")
                 self.emit.schedule_render()
                 return
-            self._filter_label = labels[idx + 1]
+            self._filter_labels = {labels[idx + 1]}
         else:
-            self._filter_label = labels[0]
+            self._filter_labels = {labels[0]}
         self._select_issue_number(keep_number)
-        self.emit.info(f"gh-issues: filter label:{self._filter_label}")
+        label_str = next(iter(self._filter_labels))
+        self.emit.info(f"gh-issues: filter label:{label_str}")
         self.emit.schedule_render()
 
     def _clear_filter(self) -> None:
-        if not self._filter_label:
+        if not self._filter_labels:
             return
         issue = self._selected_issue()
         keep_number = issue.get("number") if issue else None
-        cleared = self._filter_label
-        self._filter_label = None
+        cleared = "+".join(sorted(self._filter_labels))
+        self._filter_labels = set()
         self._select_issue_number(keep_number)
         self.emit.info(f"gh-issues: cleared filter label:{cleared}")
         self.emit.schedule_render()
+
+    def _open_picker(self) -> None:
+        self._view = self.VIEW_PICKER
+        self._picker_query = ""
+        self._picker_sel = 0
+        self._picker_staged = set(self._filter_labels)
+        self.emit.info("gh-issues: label picker opened")
+        self.emit.schedule_render()
+
+    def _apply_picker(self) -> None:
+        self._filter_labels = set(self._picker_staged)
+        self._view = self.VIEW_LIST
+        self._clamp_selection()
+        label_str = "+".join(sorted(self._filter_labels)) if self._filter_labels else "none"
+        self.emit.info(f"gh-issues: picker applied labels:{label_str}")
+        self.emit.schedule_render()
+
+    def _handle_picker_key(self, key: str) -> None:
+        filtered = self._picker_filtered_labels()
+        if key == " ":
+            if filtered and 0 <= self._picker_sel < len(filtered):
+                label = filtered[self._picker_sel]
+                if label in self._picker_staged:
+                    self._picker_staged.discard(label)
+                else:
+                    self._picker_staged.add(label)
+            self.emit.schedule_render()
+        elif key == "Backspace":
+            if self._picker_query:
+                self._picker_query = self._picker_query[:-1]
+                self._picker_sel = 0
+                self.emit.schedule_render()
+        elif len(key) == 1 and key.isprintable():
+            self._picker_query += key
+            self._picker_sel = 0
+            self.emit.schedule_render()
 
     def _open_detail(self) -> None:
         issue = self._selected_issue()

--- a/apps/github-issues/tests/test_filter_sort.py
+++ b/apps/github-issues/tests/test_filter_sort.py
@@ -41,10 +41,41 @@ def _issues():
     ]
 
 
+def _many_label_issues():
+    return [
+        {
+            "number": 10,
+            "title": "complex issue",
+            "createdAt": "2026-04-01T00:00:00Z",
+            "labels": [
+                {"name": "bug"},
+                {"name": "P0"},
+                {"name": "area:backend"},
+                {"name": "v1.0"},
+                {"name": "ready"},
+            ],
+        },
+        {
+            "number": 11,
+            "title": "simple enhancement",
+            "createdAt": "2026-04-02T00:00:00Z",
+            "labels": [{"name": "enhancement"}, {"name": "P2"}],
+        },
+        {
+            "number": 12,
+            "title": "no labels",
+            "createdAt": "2026-04-03T00:00:00Z",
+            "labels": [],
+        },
+    ]
+
+
+# ── filter + sort (existing) ────────────────────────────────────────────────
+
 def test_filter_and_sort_defaults_to_newest_created_first():
     app = _load_app_module()
 
-    visible = app._filter_and_sort_issues(_issues(), None, "created_desc")
+    visible = app._filter_and_sort_issues(_issues(), set(), "created_desc")
 
     assert [issue["number"] for issue in visible] == [9, 5, 1]
 
@@ -52,7 +83,7 @@ def test_filter_and_sort_defaults_to_newest_created_first():
 def test_filter_and_sort_composes_label_filter_with_number_sort():
     app = _load_app_module()
 
-    visible = app._filter_and_sort_issues(_issues(), "bug", "number_asc")
+    visible = app._filter_and_sort_issues(_issues(), {"bug"}, "number_asc")
 
     assert [issue["number"] for issue in visible] == [1, 5]
 
@@ -80,7 +111,7 @@ def test_app_sort_preserves_selected_index():
     gh = app.GhIssues()
     gh._issues = _issues()
     gh._sel = 0
-    gh._filter_label = None
+    gh._filter_labels = set()
     gh._sort_mode = "created_desc"
 
     gh._cycle_sort()
@@ -101,22 +132,265 @@ def test_app_filter_cycles_selected_issue_labels_then_clears():
     gh = app.GhIssues()
     gh._issues = _issues()
     gh._sel = 1
-    gh._filter_label = None
+    gh._filter_labels = set()
     gh._sort_mode = "created_desc"
 
     gh._toggle_filter_from_selection()
 
-    assert gh._filter_label == "bug"
+    assert gh._filter_labels == {"bug"}
     assert [issue["number"] for issue in gh._visible_issues()] == [5, 1]
     assert gh._selected_issue()["number"] == 5
 
     gh._toggle_filter_from_selection()
 
-    assert gh._filter_label == "P1"
+    assert gh._filter_labels == {"P1"}
     assert [issue["number"] for issue in gh._visible_issues()] == [5]
     assert gh._selected_issue()["number"] == 5
 
     gh._toggle_filter_from_selection()
 
-    assert gh._filter_label is None
+    assert gh._filter_labels == set()
     assert gh._selected_issue()["number"] == 5
+
+
+# ── multi-label AND filter ───────────────────────────────────────────────────
+
+def test_multi_label_and_filter():
+    app = _load_app_module()
+    issues = _issues()
+
+    visible = app._filter_and_sort_issues(issues, {"bug", "P1"}, "created_desc")
+
+    assert [issue["number"] for issue in visible] == [5]
+
+
+def test_multi_label_filter_no_match():
+    app = _load_app_module()
+    issues = _issues()
+
+    visible = app._filter_and_sort_issues(issues, {"bug", "docs"}, "created_desc")
+
+    assert visible == []
+
+
+def test_empty_filter_returns_all():
+    app = _load_app_module()
+    issues = _issues()
+
+    visible = app._filter_and_sort_issues(issues, set(), "created_desc")
+
+    assert len(visible) == 3
+
+
+# ── smart chip selection ─────────────────────────────────────────────────────
+
+def test_chip_selection_prioritizes_active_filter():
+    app = _load_app_module()
+    issue = _many_label_issues()[0]
+
+    chips = app._select_visible_chips(issue, {"v1.0"})
+
+    assert chips[0].label == "v1.0"
+
+
+def test_chip_selection_priority_labels_before_rest():
+    app = _load_app_module()
+    issue = _many_label_issues()[0]
+
+    chips = app._select_visible_chips(issue, set())
+    chip_labels = [c.label for c in chips if not c.label.startswith("+")]
+
+    assert "bug" in chip_labels
+    assert "P0" in chip_labels
+
+
+def test_chip_selection_overflow_count():
+    app = _load_app_module()
+    issue = _many_label_issues()[0]
+
+    chips = app._select_visible_chips(issue, set())
+
+    overflow = [c for c in chips if c.label.startswith("+")]
+    assert len(overflow) == 1
+    total_labels = len(app._issue_labels(issue))
+    visible_count = app.MAX_VISIBLE_CHIPS
+    assert overflow[0].label == f"+{total_labels - visible_count}"
+
+
+def test_chip_selection_no_overflow_when_few_labels():
+    app = _load_app_module()
+    issue = _many_label_issues()[1]
+
+    chips = app._select_visible_chips(issue, set())
+
+    overflow = [c for c in chips if c.label.startswith("+")]
+    assert len(overflow) == 0
+
+
+def test_chip_selection_no_labels():
+    app = _load_app_module()
+    issue = _many_label_issues()[2]
+
+    chips = app._select_visible_chips(issue, set())
+
+    assert chips == []
+
+
+# ── unique label collection ──────────────────────────────────────────────────
+
+def test_collect_unique_labels_sorted():
+    app = _load_app_module()
+    issues = _issues()
+
+    labels = app._collect_unique_labels(issues)
+
+    assert labels == sorted(labels, key=str.lower)
+    assert len(labels) == len(set(labels))
+    assert "bug" in labels
+    assert "docs" in labels
+    assert "P1" in labels
+
+
+def test_collect_unique_labels_dedupes():
+    app = _load_app_module()
+    issues = _issues()
+
+    labels = app._collect_unique_labels(issues)
+
+    assert labels.count("bug") == 1
+
+
+# ── fuzzy match ──────────────────────────────────────────────────────────────
+
+def test_fuzzy_match_case_insensitive():
+    app = _load_app_module()
+
+    assert app._fuzzy_match("bug", "Bug Fix")
+    assert app._fuzzy_match("BUG", "bug")
+    assert not app._fuzzy_match("xyz", "bug")
+
+
+def test_fuzzy_match_substring():
+    app = _load_app_module()
+
+    assert app._fuzzy_match("enhance", "enhancement")
+    assert app._fuzzy_match("p1", "P1")
+    assert not app._fuzzy_match("p1", "P2")
+
+
+# ── picker state ─────────────────────────────────────────────────────────────
+
+def test_picker_opens_with_current_filters():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._filter_labels = {"bug"}
+    gh._view = gh.VIEW_LIST
+
+    gh._open_picker()
+
+    assert gh._view == gh.VIEW_PICKER
+    assert gh._picker_staged == {"bug"}
+    assert gh._picker_query == ""
+    assert gh._picker_sel == 0
+
+
+def test_picker_apply_sets_filters():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._filter_labels = set()
+    gh._sort_mode = "created_desc"
+    gh._sel = 0
+    gh._view = gh.VIEW_PICKER
+    gh._picker_staged = {"bug", "P1"}
+
+    gh._apply_picker()
+
+    assert gh._view == gh.VIEW_LIST
+    assert gh._filter_labels == {"bug", "P1"}
+
+
+def test_picker_toggle_adds_and_removes():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._picker_query = ""
+    gh._picker_staged = set()
+    gh._picker_sel = 0
+
+    filtered = gh._picker_filtered_labels()
+    first_label = filtered[0]
+
+    gh._handle_picker_key(" ")
+    assert first_label in gh._picker_staged
+
+    gh._handle_picker_key(" ")
+    assert first_label not in gh._picker_staged
+
+
+def test_picker_text_filter_narrows_labels():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._picker_query = ""
+    gh._picker_staged = set()
+
+    all_labels = gh._picker_filtered_labels()
+
+    gh._picker_query = "bug"
+    filtered = gh._picker_filtered_labels()
+
+    assert len(filtered) < len(all_labels)
+    assert all("bug" in l.lower() for l in filtered)
+
+
+def test_picker_backspace_removes_char():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._picker_query = "bug"
+    gh._picker_staged = set()
+
+    gh._handle_picker_key("Backspace")
+
+    assert gh._picker_query == "bu"
+
+
+def test_picker_typing_appends_chars():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._picker_query = ""
+    gh._picker_staged = set()
+
+    gh._handle_picker_key("b")
+    gh._handle_picker_key("u")
+
+    assert gh._picker_query == "bu"
+
+
+# ── subtitle with multi-label ────────────────────────────────────────────────
+
+def test_subtitle_shows_multi_label_joined():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._filter_labels = {"P1", "bug"}
+    gh._sort_mode = "created_desc"
+
+    subtitle = gh._list_subtitle()
+
+    assert "label:P1+bug" in subtitle
+
+
+def test_subtitle_no_label_when_empty_filter():
+    app = _load_app_module()
+    gh = app.GhIssues()
+    gh._issues = _issues()
+    gh._filter_labels = set()
+    gh._sort_mode = "created_desc"
+
+    subtitle = gh._list_subtitle()
+
+    assert "label:" not in subtitle

--- a/apps/github-issues/tests/test_filter_sort.py
+++ b/apps/github-issues/tests/test_filter_sort.py
@@ -70,6 +70,24 @@ def _many_label_issues():
     ]
 
 
+def _make_app(app_module, issues=None):
+    """Create a GhIssues instance with mocked state, ready for interaction."""
+    gh = app_module.GhIssues()
+    gh._issues = issues if issues is not None else _issues()
+    gh._sel = 0
+    gh._filter_labels = set()
+    gh._sort_mode = "created_desc"
+    gh._view = gh.VIEW_LIST
+    gh._loading = False
+    gh._detail_loading = False
+    gh._error = None
+    gh._detail = None
+    gh._picker_query = ""
+    gh._picker_sel = 0
+    gh._picker_staged = set()
+    return gh
+
+
 # ── filter + sort (existing) ────────────────────────────────────────────────
 
 def test_filter_and_sort_defaults_to_newest_created_first():
@@ -108,11 +126,7 @@ def test_issue_list_limit_is_large_enough_for_active_repos():
 
 def test_app_sort_preserves_selected_index():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._sel = 0
-    gh._filter_labels = set()
-    gh._sort_mode = "created_desc"
+    gh = _make_app(app)
 
     gh._cycle_sort()
 
@@ -129,11 +143,8 @@ def test_app_sort_preserves_selected_index():
 
 def test_app_filter_cycles_selected_issue_labels_then_clears():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
+    gh = _make_app(app)
     gh._sel = 1
-    gh._filter_labels = set()
-    gh._sort_mode = "created_desc"
 
     gh._toggle_filter_from_selection()
 
@@ -282,10 +293,8 @@ def test_fuzzy_match_substring():
 
 def test_picker_opens_with_current_filters():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
+    gh = _make_app(app)
     gh._filter_labels = {"bug"}
-    gh._view = gh.VIEW_LIST
 
     gh._open_picker()
 
@@ -297,11 +306,7 @@ def test_picker_opens_with_current_filters():
 
 def test_picker_apply_sets_filters():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._filter_labels = set()
-    gh._sort_mode = "created_desc"
-    gh._sel = 0
+    gh = _make_app(app)
     gh._view = gh.VIEW_PICKER
     gh._picker_staged = {"bug", "P1"}
 
@@ -312,29 +317,24 @@ def test_picker_apply_sets_filters():
 
 
 def test_picker_toggle_adds_and_removes():
+    """Space toggles the selected label in the picker (SDK normalizes ' ' to 'space')."""
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._picker_query = ""
-    gh._picker_staged = set()
-    gh._picker_sel = 0
+    gh = _make_app(app)
+    gh._view = gh.VIEW_PICKER
 
     filtered = gh._picker_filtered_labels()
     first_label = filtered[0]
 
-    gh._handle_picker_key(" ")
+    gh._handle_picker_key("space")
     assert first_label in gh._picker_staged
 
-    gh._handle_picker_key(" ")
+    gh._handle_picker_key("space")
     assert first_label not in gh._picker_staged
 
 
 def test_picker_text_filter_narrows_labels():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._picker_query = ""
-    gh._picker_staged = set()
+    gh = _make_app(app)
 
     all_labels = gh._picker_filtered_labels()
 
@@ -346,23 +346,19 @@ def test_picker_text_filter_narrows_labels():
 
 
 def test_picker_backspace_removes_char():
+    """SDK normalizes 'Backspace' to 'backspace'."""
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
+    gh = _make_app(app)
     gh._picker_query = "bug"
-    gh._picker_staged = set()
 
-    gh._handle_picker_key("Backspace")
+    gh._handle_picker_key("backspace")
 
     assert gh._picker_query == "bu"
 
 
 def test_picker_typing_appends_chars():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._picker_query = ""
-    gh._picker_staged = set()
+    gh = _make_app(app)
 
     gh._handle_picker_key("b")
     gh._handle_picker_key("u")
@@ -374,10 +370,8 @@ def test_picker_typing_appends_chars():
 
 def test_subtitle_shows_multi_label_joined():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
+    gh = _make_app(app)
     gh._filter_labels = {"P1", "bug"}
-    gh._sort_mode = "created_desc"
 
     subtitle = gh._list_subtitle()
 
@@ -386,11 +380,234 @@ def test_subtitle_shows_multi_label_joined():
 
 def test_subtitle_no_label_when_empty_filter():
     app = _load_app_module()
-    gh = app.GhIssues()
-    gh._issues = _issues()
-    gh._filter_labels = set()
-    gh._sort_mode = "created_desc"
+    gh = _make_app(app)
 
     subtitle = gh._list_subtitle()
 
     assert "label:" not in subtitle
+
+
+# ── end-to-end interaction flows ─────────────────────────────────────────────
+# These simulate the exact event sequence the host sends to the SDK.
+# Key names use SDK-normalized form (what on_key actually receives).
+
+def test_e2e_open_picker_toggle_apply():
+    """Full flow: l → navigate → space toggle → enter apply."""
+    app = _load_app_module()
+    gh = _make_app(app)
+    assert gh._view == gh.VIEW_LIST
+
+    # User presses 'l' → opens picker
+    gh._open_picker()
+    assert gh._view == gh.VIEW_PICKER
+    assert gh._picker_staged == set()
+
+    # Picker shows all labels sorted. Get the list.
+    labels = gh._picker_filtered_labels()
+    assert len(labels) == 3  # bug, docs, P1
+    assert labels == sorted(labels, key=str.lower)
+
+    # Host sends list_select for j/k navigation
+    gh.on_list_select("label-picker", 0)
+    assert gh._picker_sel == 0
+
+    # User presses space to toggle first label
+    gh._handle_picker_key("space")
+    assert labels[0] in gh._picker_staged
+    assert len(gh._picker_staged) == 1
+
+    # Navigate to second label
+    gh.on_list_select("label-picker", 1)
+    assert gh._picker_sel == 1
+
+    # Toggle second label
+    gh._handle_picker_key("space")
+    assert labels[1] in gh._picker_staged
+    assert len(gh._picker_staged) == 2
+
+    # User presses enter → host sends list_activate
+    gh.on_list_activate("label-picker", 1)
+    assert gh._view == gh.VIEW_LIST
+    assert gh._filter_labels == {labels[0], labels[1]}
+
+    # Visible issues filtered by AND of both labels
+    visible = gh._visible_issues()
+    for issue in visible:
+        issue_labels = set(app._issue_labels(issue))
+        assert gh._filter_labels <= issue_labels
+
+
+def test_e2e_picker_cancel_preserves_filter():
+    """Escape from picker does not change existing filter."""
+    app = _load_app_module()
+    gh = _make_app(app)
+    gh._filter_labels = {"bug"}
+
+    gh._open_picker()
+    assert gh._picker_staged == {"bug"}
+
+    # Toggle off the existing filter in picker
+    labels = gh._picker_filtered_labels()
+    bug_idx = labels.index("bug")
+    gh.on_list_select("label-picker", bug_idx)
+    gh._handle_picker_key("space")
+    assert "bug" not in gh._picker_staged
+
+    # Escape cancels without applying
+    gh.on_escape()
+    assert gh._view == gh.VIEW_LIST
+    assert gh._filter_labels == {"bug"}
+
+
+def test_e2e_picker_type_to_filter_then_toggle():
+    """Type characters to narrow the label list, then toggle."""
+    app = _load_app_module()
+    gh = _make_app(app)
+    gh._open_picker()
+
+    # Type "bu" to filter
+    gh._handle_picker_key("b")
+    gh._handle_picker_key("u")
+    assert gh._picker_query == "bu"
+
+    filtered = gh._picker_filtered_labels()
+    assert len(filtered) == 1
+    assert filtered[0] == "bug"
+
+    # Toggle the filtered result
+    gh._handle_picker_key("space")
+    assert "bug" in gh._picker_staged
+
+    # Apply
+    gh.on_list_activate("label-picker", 0)
+    assert gh._filter_labels == {"bug"}
+    assert gh._view == gh.VIEW_LIST
+
+
+def test_e2e_picker_backspace_widens_filter():
+    """Backspace removes last char from query, widening the label list."""
+    app = _load_app_module()
+    gh = _make_app(app)
+    gh._open_picker()
+
+    gh._handle_picker_key("b")
+    gh._handle_picker_key("u")
+    gh._handle_picker_key("g")
+    assert gh._picker_query == "bug"
+    assert len(gh._picker_filtered_labels()) == 1
+
+    gh._handle_picker_key("backspace")
+    assert gh._picker_query == "bu"
+    assert len(gh._picker_filtered_labels()) == 1
+
+    gh._handle_picker_key("backspace")
+    assert gh._picker_query == "b"
+    assert len(gh._picker_filtered_labels()) == 1  # still just "bug"
+
+    gh._handle_picker_key("backspace")
+    assert gh._picker_query == ""
+    assert len(gh._picker_filtered_labels()) == 3  # all labels
+
+
+def test_e2e_f_still_cycles_after_picker():
+    """f key still works after using the picker."""
+    app = _load_app_module()
+    gh = _make_app(app)
+
+    # Use picker to set a multi-label filter
+    gh._open_picker()
+    gh._handle_picker_key("space")
+    gh.on_list_activate("label-picker", 0)
+    assert len(gh._filter_labels) == 1
+
+    # Clear filter first so all issues are visible, then select issue #5
+    gh._clear_filter()
+    # Visible issues (created_desc): [#9, #5, #1]. #5 is at index 1.
+    gh._sel = 1
+    assert gh._selected_issue()["number"] == 5
+
+    # Press f — should set filter to first label of issue #5 (bug)
+    gh._toggle_filter_from_selection()
+    assert gh._filter_labels == {"bug"}
+
+    # Press f again — should cycle to next label (P1)
+    gh._toggle_filter_from_selection()
+    assert gh._filter_labels == {"P1"}
+
+
+def test_e2e_clear_clears_picker_filters():
+    """c key clears multi-label filters set by picker."""
+    app = _load_app_module()
+    gh = _make_app(app)
+
+    # Apply multi-label filter via picker
+    gh._open_picker()
+    gh._handle_picker_key("space")
+    gh.on_list_select("label-picker", 1)
+    gh._handle_picker_key("space")
+    gh.on_list_activate("label-picker", 1)
+    assert len(gh._filter_labels) == 2
+
+    # Clear
+    gh._clear_filter()
+    assert gh._filter_labels == set()
+    assert len(gh._visible_issues()) == 3
+
+
+def test_e2e_picker_preserves_selection_after_apply():
+    """After applying a filter, the selected issue is clamped to visible range."""
+    app = _load_app_module()
+    gh = _make_app(app)
+    gh._sel = 2  # last issue
+
+    # Filter to only issues with "docs" label (just issue #9)
+    gh._open_picker()
+    labels = gh._picker_filtered_labels()
+    docs_idx = labels.index("docs")
+    gh.on_list_select("label-picker", docs_idx)
+    gh._handle_picker_key("space")
+    gh.on_list_activate("label-picker", docs_idx)
+
+    assert gh._filter_labels == {"docs"}
+    visible = gh._visible_issues()
+    assert len(visible) == 1
+    assert gh._sel <= len(visible) - 1
+
+
+def test_e2e_list_events_route_to_correct_view():
+    """list_select/list_activate route to picker vs issues list by id."""
+    app = _load_app_module()
+    gh = _make_app(app)
+
+    # In list view, list events go to issues
+    gh.on_list_select("issues", 1)
+    assert gh._sel == 1
+    assert gh._picker_sel == 0
+
+    # In picker view, list events go to picker
+    gh._open_picker()
+    gh.on_list_select("label-picker", 2)
+    assert gh._picker_sel == 2
+    assert gh._sel == 1  # unchanged
+
+    # Activate on picker applies, activate on issues opens detail
+    gh.on_list_activate("label-picker", 2)
+    assert gh._view == gh.VIEW_LIST
+
+
+def test_e2e_sort_composes_with_multi_label_filter():
+    """Sort mode works correctly with multi-label AND filter."""
+    app = _load_app_module()
+    gh = _make_app(app, issues=_many_label_issues())
+
+    # Filter to issues with both "bug" and "P0" (only issue #10)
+    gh._filter_labels = {"bug", "P0"}
+    visible = gh._visible_issues()
+    assert len(visible) == 1
+    assert visible[0]["number"] == 10
+
+    # Changing sort shouldn't break the filter
+    gh._cycle_sort()
+    visible = gh._visible_issues()
+    assert len(visible) == 1
+    assert visible[0]["number"] == 10


### PR DESCRIPTION
Closes #2164

## Summary

- Replace fixed `labels[:2]` row display with smart chip selector that prioritizes active filter labels, then priority/type labels, then remaining, with `+N` overflow chip for hidden labels
- Add keyboard label picker (`l` key) with type-to-filter, space-toggle, enter-apply for multi-label AND filtering
- Extend filter system from single label to `set[str]` with AND semantics; `f` still cycles selected issue's labels as before
- 26 focused tests covering chip selection order, overflow counting, unique label collection, fuzzy matching, picker state management, multi-select AND filtering, and subtitle display

## Done When
- [x] Row chips show deterministic high-signal labels and a `+N` overflow indicator for issues with hidden labels.
- [x] The user can open a label picker from the GitHub Issues app, fuzzy-filter available labels, select multiple labels, and apply them.
- [x] Active label filters and sort modes compose correctly, including multi-label filters.
- [x] `f` still cycles labels on the selected issue and then clears.
- [x] The AppBar subtitle reflects multi-label filters clearly.
- [x] Tests cover chip selection, picker filtering, multi-select filtering, and sort/filter composition.