### PR TITLE
feat(sdk): add PGAP shortcut helper with scene harness parity (#2196)

### DIFF
--- a/.stint/tasks/0151-app-refresh-github-issues-label-picker.md
+++ b/.stint/tasks/0151-app-refresh-github-issues-label-picker.md
@@ -1,15 +1,23 @@
 ---
 id: "0151"
 title: "App refresh: GitHub Issues label picker"
-status: backlog
+status: in-progress
+estimate: "6h"
+started_at: "2026-06-13T02:23:03Z"
 sprint: "s7"
-estimate: 6h
 blocked_by:
   - 36
-gh_issue: ["2164"]
-area: ["apps/github-issues"]
-tags: ["apps", "app-refresh", "github", "labels"]
+gh_issue:
+  - "2164"
+area:
+  - "apps/github-issues"
+tags:
+  - "apps"
+  - "app-refresh"
+  - "github"
+  - "labels"
 ---
+
 
 Add a keyboard label picker and smarter row label chips to the GitHub Issues app.
 

--- a/.stint/tasks/0165-pgap-shortcut-helper-harness-parity.md
+++ b/.stint/tasks/0165-pgap-shortcut-helper-harness-parity.md
@@ -1,9 +1,10 @@
 ---
 id: "0165"
 title: "PGAP SDK shortcut helper and harness parity"
-status: backlog
+status: in-progress
+estimate: "6h"
+started_at: "2026-06-13T02:25:24Z"
 sprint: "s2"
-estimate: 6h
 blocked_by: []
 gh_issue:
   - "2196"
@@ -17,6 +18,7 @@ tags:
   - "shortcuts"
   - "testing"
 ---
+
 
 Add a first-class Python SDK shortcut helper so PGAP apps can bind command shortcuts without handwritten raw key/modifier branching, and make the scene harness mirror live printable-key delivery.
 

--- a/apps/dev/keymap-probe/keymap_probe.py
+++ b/apps/dev/keymap-probe/keymap_probe.py
@@ -1,0 +1,25 @@
+from plexi_sdk import App, RenderContext
+from plexi_sdk.widgets import KeyMap
+
+
+class KeyMapProbe(App):
+    def on_init(self) -> None:
+        self._last_action = "none"
+        self._km = KeyMap()
+        self._km.bind("z", "bare-z")
+        self._km.bind("z", "ctrl-z", mod="ctrl")
+        self._km.bind("return", "submit")
+
+    def on_render(self, ctx: RenderContext) -> None:
+        ctx.text(10, 10, f"last_action={self._last_action}", size=14, color="#ffffff",
+                 selectable=False)
+        ctx.status_summary(f"last_action={self._last_action}")
+
+    def on_key(self, key: str, mods: dict) -> None:
+        action = self._km.handle(key, mods)
+        if action is not None:
+            self._last_action = action
+            self.emit.schedule_render()
+
+
+KeyMapProbe().run()

--- a/apps/dev/keymap-probe/keymap_probe.py
+++ b/apps/dev/keymap-probe/keymap_probe.py
@@ -22,4 +22,5 @@ class KeyMapProbe(App):
             self.emit.schedule_render()
 
 
-KeyMapProbe().run()
+if __name__ == "__main__":
+    KeyMapProbe().run()

--- a/apps/dev/keymap-probe/manifest.toml
+++ b/apps/dev/keymap-probe/manifest.toml
@@ -1,0 +1,12 @@
+schema_version = 1
+
+[app]
+id = "keymap-probe"
+type = "app"
+name = "KeyMap Probe"
+version = "0.1.0"
+description = "POC proving KeyMap shortcut helper receives events via both Event::Text (printable) and Event::Key (chords) paths."
+entry = "keymap_probe.py"
+
+[app.capabilities]
+capabilities = []

--- a/sdk/python/tests/test_keymap.py
+++ b/sdk/python/tests/test_keymap.py
@@ -1,0 +1,62 @@
+"""Unit tests for KeyMap — verifies that handle() resolves correctly for the
+three event-delivery paths that live Plexi uses:
+
+  printable (Event::Text)  → on_key("z", {})           — key arrives lowercase
+  ctrl chord (Event::Key)  → on_key("Z", {ctrl: true}) — egui Debug fmt gives "Z"
+  named key  (Event::Key)  → on_key("return", {})      — _normalize_key applied
+"""
+
+from plexi_sdk.widgets import KeyMap
+
+
+def test_bare_printable_lowercase():
+    km = KeyMap()
+    km.bind("z", "undo")
+    assert km.handle("z", {}) == "undo"
+
+
+def test_bare_printable_uppercase_normalizes():
+    # ctrl+z arrives via Event::Key; egui formats Key::Z as "Z" in PlexiEvent.
+    # KeyMap.handle must normalize to lowercase so bind("z") catches it.
+    km = KeyMap()
+    km.bind("z", "undo", mod="ctrl")
+    assert km.handle("Z", {"ctrl": True}) == "undo"
+
+
+def test_named_key():
+    km = KeyMap()
+    km.bind("return", "submit")
+    assert km.handle("return", {}) == "submit"
+
+
+def test_modifier_chord_meta_alias():
+    # "meta" maps to "cmd" in handle()
+    km = KeyMap()
+    km.bind("s", "save", mod="cmd")
+    assert km.handle("s", {"meta": True}) == "save"
+
+
+def test_unbound_returns_none():
+    km = KeyMap()
+    km.bind("q", "quit")
+    assert km.handle("z", {}) is None
+
+
+def test_multiple_bindings_independent():
+    km = KeyMap()
+    km.bind("q", "quit")
+    km.bind("s", "save", mod="cmd")
+    km.bind("z", "undo", mod="ctrl")
+    assert km.handle("q", {}) == "quit"
+    assert km.handle("s", {"meta": True}) == "save"
+    # ctrl+z: egui sends "Z" uppercase
+    assert km.handle("Z", {"ctrl": True}) == "undo"
+    # bare "z" without modifier is not bound
+    assert km.handle("z", {}) is None
+
+
+def test_mod_order_normalized():
+    km = KeyMap()
+    km.bind("z", "redo", mod="ctrl|shift")
+    assert km.handle("z", {"ctrl": True, "shift": True}) == "redo"
+    assert km.handle("z", {"shift": True, "ctrl": True}) == "redo"

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -314,20 +314,26 @@ impl SceneRunner {
                 Ok(None)
             }
             Step::Key { key } => {
-                let trimmed = key.trim();
                 // Bare printable character — not a named key or modifier chord.
                 // Live Plexi delivers these via egui::Event::Text, not Event::Key
                 // (the host suppresses Event::Key for printable chars to avoid
                 // double-dispatch, relying on Event::Text for OS-resolved chars).
                 // Mirror that path here so scene injection reaches the app the
                 // same way a real keypress does.
-                let chars: Vec<char> = trimmed.chars().collect();
-                if !trimmed.contains('+') && chars.len() == 1 && !chars[0].is_control() {
+                //
+                // A single non-control character is unambiguously a bare key:
+                // named keys ("enter", "left") and chords ("ctrl+z") are always
+                // multi-character. No `+`-prefix check needed — a literal `+`
+                // key has len == 1 and must take the Event::Text path.
+                let mut key_chars = key.chars();
+                let is_bare_printable = key_chars.next().is_some_and(|c| !c.is_control())
+                    && key_chars.next().is_none();
+                if is_bare_printable {
                     self.h
                         .harness()
                         .input_mut()
                         .events
-                        .push(egui::Event::Text(trimmed.to_string()));
+                        .push(egui::Event::Text(key.to_string()));
                 } else {
                     let (modifiers, k) = parse_key(key)?;
                     self.h.harness().press_key_modifiers(modifiers, k);

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -314,8 +314,24 @@ impl SceneRunner {
                 Ok(None)
             }
             Step::Key { key } => {
-                let (modifiers, k) = parse_key(key)?;
-                self.h.harness().press_key_modifiers(modifiers, k);
+                let trimmed = key.trim();
+                // Bare printable character — not a named key or modifier chord.
+                // Live Plexi delivers these via egui::Event::Text, not Event::Key
+                // (the host suppresses Event::Key for printable chars to avoid
+                // double-dispatch, relying on Event::Text for OS-resolved chars).
+                // Mirror that path here so scene injection reaches the app the
+                // same way a real keypress does.
+                let chars: Vec<char> = trimmed.chars().collect();
+                if !trimmed.contains('+') && chars.len() == 1 && !chars[0].is_control() {
+                    self.h
+                        .harness()
+                        .input_mut()
+                        .events
+                        .push(egui::Event::Text(trimmed.to_string()));
+                } else {
+                    let (modifiers, k) = parse_key(key)?;
+                    self.h.harness().press_key_modifiers(modifiers, k);
+                }
                 self.h.step();
                 Ok(None)
             }

--- a/tests/scenes/keymap-probe.toml
+++ b/tests/scenes/keymap-probe.toml
@@ -1,0 +1,31 @@
+# Proves that key = "z" in a scene step reaches a PGAP app's KeyMap handler
+# the same way live Plexi does (via egui::Event::Text delivery, not Event::Key).
+# Without the Event::Text parity fix in src/scenes.rs, the bare-z binding would
+# never fire and the final assert would fail.
+# suite = false — spawns a real Python process.
+size = [640.0, 480.0]
+suite = false
+
+[[steps]]
+open_app = "apps/dev/keymap-probe"
+
+[[steps]]
+wait_app_frame = { timeout_s = 15.0 }
+
+[[steps]]
+run_steps = 5
+
+[[steps]]
+assert = { pane_count = 1, lifecycle = "running", tree_contains = "last_action=none" }
+
+[[steps]]
+key = "z"
+
+[[steps]]
+run_steps = 30
+
+[[steps]]
+assert = { tree_contains = "bare-z" }
+
+[[steps]]
+shot = "keymap-probe.png"


### PR DESCRIPTION
Closes #2196

## Summary

- Fix `src/scenes.rs` `Step::Key` to inject `egui::Event::Text` for bare printable characters, mirroring live Plexi's delivery path. Previously, `key = "z"` in a scene fired `Event::Key` which the host suppressed (printable-key guard), so bare-letter bindings never reached PGAP apps.
- Add 7 Python unit tests for `KeyMap.handle` covering all three delivery paths: printable (`"z"` lowercase), ctrl-chord (`"Z"` uppercase egui Debug fmt), named keys, meta alias, multi-binding independence, and mod-order normalization.
- Add `apps/dev/keymap-probe/` fixture app that binds `z`, `ctrl+z`, and `return` via `KeyMap` and renders `last_action=` into its draw tree.
- Add `tests/scenes/keymap-probe.toml` as the scene parity proof: opens the fixture, injects `key = "z"`, and asserts `tree_contains = "bare-z"` — fails before the Event::Text fix, passes after.

## Done When

- A PGAP app can register shortcuts through the SDK helper and handle `z`, `escape`/`return`, and a modifier chord without handwritten key/modifier branching. ✓
- A TOML scene test drives the real app process with `key = "z"` and passes because the shortcut helper receives the same normalized command path as live Plexi. ✓
- `cargo build` and the new Python unit tests pass. ✓