### PR TITLE
fix(ui): match sidebar hover rect to selected rect size

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,7 +1,7 @@
 use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
-use egui::{Align, Layout, Rect, RichText, Stroke};
+use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
@@ -219,22 +219,15 @@ impl PlexiApp {
                 });
                 let row_rect = scope.response.rect;
                 row_rects.push(row_rect);
-                let pill_rect = Rect::from_min_max(
-                    egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
-                    egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
+                ui.painter().set(
+                    bg_idx,
+                    egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
                 );
                 if is_active {
-                    ui.painter().set(bg_idx, egui::Shape::Noop);
-                    crate::ui::list::paint_selection(ui.painter(), pill_rect, &self.colors);
-                } else {
-                    let inset = crate::ui::list::selection_inset(pill_rect);
-                    ui.painter().set(
-                        bg_idx,
-                        egui::Shape::rect_filled(
-                            inset,
-                            crate::ui::style::RADIUS_SM,
-                            fill,
-                        ),
+                    ui.painter().rect_filled(
+                        Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
+                        CornerRadius::ZERO,
+                        self.colors.accent,
                     );
                 }
                 continue;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,7 +1,7 @@
 use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
-use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
+use egui::{Align, Layout, Rect, RichText, Stroke};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
@@ -219,15 +219,22 @@ impl PlexiApp {
                 });
                 let row_rect = scope.response.rect;
                 row_rects.push(row_rect);
-                ui.painter().set(
-                    bg_idx,
-                    egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
+                let pill_rect = Rect::from_min_max(
+                    egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
+                    egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
                 );
                 if is_active {
-                    ui.painter().rect_filled(
-                        Rect::from_min_size(row_rect.min, Vec2::new(3.0, row_rect.height())),
-                        CornerRadius::ZERO,
-                        self.colors.accent,
+                    ui.painter().set(bg_idx, egui::Shape::Noop);
+                    crate::ui::list::paint_selection(ui.painter(), pill_rect, &self.colors);
+                } else {
+                    let inset = crate::ui::list::selection_inset(pill_rect);
+                    ui.painter().set(
+                        bg_idx,
+                        egui::Shape::rect_filled(
+                            inset,
+                            crate::ui::style::RADIUS_SM,
+                            fill,
+                        ),
                     );
                 }
                 continue;

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -331,7 +331,10 @@ impl ContextItem {
             } else {
                 Color32::TRANSPARENT
             };
-            let hover_rect = crate::ui::list::selection_inset(row_rect);
+            let hover_rect = crate::ui::list::selection_inset(Rect::from_min_max(
+                egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
+                egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
+            ));
             ui.painter().set(
                 bg_idx,
                 egui::Shape::rect_filled(hover_rect, crate::ui::style::RADIUS_SM, fill),


### PR DESCRIPTION
## Summary
- Sidebar context hover state was rendering a wider background rect than the selected state
- The selected state applies a 4px horizontal inset (pill shape), but hover used the full row width
- Now both states use the same 4px inset so hover and selected rects are identical in size

## Test plan
- [ ] Hover over sidebar context items and confirm the hover rect matches the selected item's size
- [ ] Switch between contexts and verify selected state still looks correct