### PR TITLE
feat: Ghostty-style segmented tab bar + context navigation shortcuts

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -9,6 +9,7 @@ font_size = 14.0
 
 confirm_quit  = true
 confirm_close = false
+confirm_context_close = true
 
 # focus_history_depth = 100
 osc_pane_title = true
@@ -50,6 +51,7 @@ model_high   = "anthropic/claude-fable-5"
 # [keybindings]
 # toggle_command_palette = "cmd+p"
 # open_config            = "cmd+comma"
+# close_context          = "cmd+shift+w"
 
 [agents]
 low    = "claude --model claude-haiku-4-5 --dangerously-skip-permissions '{cmd}'"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3023,13 +3023,45 @@ impl eframe::App for PlexiApp {
                     self.cycle_tab(false);
                     log::info!("tab: prev — window={}", self.active_window);
                 }
-                Action::FirstTab => {
-                    self.jump_to_tab(0);
-                    log::info!("tab: first — window={}", self.active_window);
+                Action::NextContext => {
+                    let active = self.router.active_idx();
+                    let num = self.router.len();
+                    for offset in 1..num {
+                        let idx = (active + offset) % num;
+                        if !self.router.get(idx).parked {
+                            log::info!("context: next — idx={}", idx);
+                            self.switch_workspace(idx);
+                            break;
+                        }
+                    }
                 }
-                Action::LastTab => {
-                    self.jump_to_tab(usize::MAX);
-                    log::info!("tab: last — window={}", self.active_window);
+                Action::PrevContext => {
+                    let active = self.router.active_idx();
+                    let num = self.router.len();
+                    for offset in 1..num {
+                        let idx = (active + num - offset) % num;
+                        if !self.router.get(idx).parked {
+                            log::info!("context: prev — idx={}", idx);
+                            self.switch_workspace(idx);
+                            break;
+                        }
+                    }
+                }
+                Action::MoveContextUp => {
+                    let active = self.router.active_idx();
+                    if active > 0 {
+                        self.router.swap_tracking_active(active, active - 1);
+                        log::info!("context: moved up — {} to {}", active, active - 1);
+                        self.save_workspace();
+                    }
+                }
+                Action::MoveContextDown => {
+                    let active = self.router.active_idx();
+                    if active + 1 < self.router.len() {
+                        self.router.swap_tracking_active(active, active + 1);
+                        log::info!("context: moved down — {} to {}", active, active + 1);
+                        self.save_workspace();
+                    }
                 }
                 Action::IncreasePaneFontSize => {
                     self.adjust_focused_pane_font_size(1.0);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3165,6 +3165,24 @@ impl eframe::App for PlexiApp {
                     log::info!("notes_picker: Cmd+O — opening picker");
                     self.open_notes_picker();
                 }
+                Action::CloseContext => {
+                    let ctx_id = self.router.active().context_id;
+                    if self.router.len() <= 1 {
+                        log::info!("close_context: only one context remains, ignoring");
+                    } else {
+                        let state = self.build_context_close_state(ctx_id);
+                        let confirm = self.config.confirm_context_close.unwrap_or(true);
+                        if state.items.is_empty() || !confirm {
+                            let idx = self.router.active_idx();
+                            log::info!("close_context: closing ctx={ctx_id} idx={idx} (empty={}, confirm={confirm})", state.items.is_empty());
+                            self.delete_context(idx);
+                            self.save_workspace();
+                        } else {
+                            log::info!("close_context: ctx={ctx_id} has {} panes, showing confirm dialog", state.items.len());
+                            self.pending_context_close = Some(state);
+                        }
+                    }
+                }
                 Action::ContextZoomOut => {
                     log::info!(
                         "ContextZoomOut: popping depth stack (depth={})",

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3,7 +3,7 @@
 use super::{ClickFlash, FocusLayer, PlexiApp};
 use crate::spatial::tiling::{PaneId, PlexiBehavior};
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
-use egui_tiles::Tile;
+use egui_tiles::{Tile, TileId};
 use std::collections::HashMap;
 
 const FLASH_DUR: f32 = 0.4;
@@ -533,6 +533,7 @@ impl PlexiApp {
                     theme: self.theme.clone(),
                     new_focused: None,
                     close_exited: None,
+                    tab_click: None,
                     tab_info,
                     tab_labels,
                     zoomed_pane,
@@ -608,9 +609,11 @@ impl PlexiApp {
                 // needs &mut ctx but behavior holds &mut ctx.panes).
                 let new_focused = behavior.new_focused;
                 let should_close_exited = behavior.close_exited.is_some();
+                let tab_click = behavior.tab_click.take();
                 let portal_zoom = behavior.portal_zoom_request.take();
 
                 // Draw zoom overlay if a pane is zoomed
+                let mut zoomed_tab_click: Option<(TileId, usize)> = None;
                 if let Some(zoomed_tile) = zoomed_pane {
                     if let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.get(zoomed_tile) {
                         let pane_id = *pane_id;
@@ -665,46 +668,42 @@ impl PlexiApp {
                         // own child_ui scoped to the area below the name bar, so there
                         // is no cursor/spacing gap between them.
                         let has_name = zoomed_pane_name.is_some();
+                        let has_tabs = zoomed_tab_info.is_some();
+                        let has_top_bar = has_name || has_tabs;
                         const NAME_BAR_HEIGHT: f32 = 20.0;
-                        if has_name {
+                        if has_top_bar {
                             let bar_rect = egui::Rect::from_min_size(
                                 inner_rect.min,
                                 egui::vec2(inner_rect.width(), NAME_BAR_HEIGHT),
                             );
-                            // Paint via the parent `ui` painter at full opacity —
-                            // the explicit pane_header_bg() tone must match the
-                            // tiled name bar exactly, so it must not be dimmed by
-                            // the zoom overlay's 0.88-opacity child_ui.
                             ui.painter().rect_filled(
                                 bar_rect,
                                 0.0,
                                 self.colors.pane_header_bg(),
                             );
                             if let Some(ref group) = zoomed_tab_info {
-                                crate::spatial::tiling::paint_tab_bar(
+                                if let Some(idx) = crate::spatial::tiling::paint_tab_bar(
+                                    ui.ctx(),
                                     ui.painter(),
                                     bar_rect,
                                     group,
                                     &zoomed_tab_labels,
                                     &self.colors,
                                     self.config.pane_title_font_size.unwrap_or(11.0),
+                                ) {
+                                    zoomed_tab_click = Some((group.container_tile, idx));
+                                }
+                            } else if let Some(ref name) = zoomed_pane_name {
+                                ui.painter().text(
+                                    bar_rect.center(),
+                                    egui::Align2::CENTER_CENTER,
+                                    name,
+                                    egui::FontId::proportional(11.0),
+                                    self.colors.text_dim,
                                 );
                             }
-                            if zoomed_tab_info.is_none() {
-                                if let Some(ref name) = zoomed_pane_name {
-                                    ui.painter().text(
-                                        bar_rect.center(),
-                                        egui::Align2::CENTER_CENTER,
-                                        name,
-                                        egui::FontId::proportional(11.0),
-                                        self.colors.text_dim,
-                                    );
-                                }
-                            }
                         }
-                        // Frame rect starts exactly where the name bar ends (or at the
-                        // top of inner_rect when there is no name bar), so no gap appears.
-                        let frame_rect = if has_name {
+                        let frame_rect = if has_top_bar {
                             inner_rect.with_min_y(inner_rect.min.y + NAME_BAR_HEIGHT)
                         } else {
                             inner_rect
@@ -735,22 +734,6 @@ impl PlexiApp {
                                     &self.colors,
                                     !modal_open,
                                 );
-                            }
-                            if !has_name {
-                                if let Some(ref group) = zoomed_tab_info {
-                                    let tab_bar_rect = egui::Rect::from_min_size(
-                                        frame_rect.min,
-                                        egui::vec2(frame_rect.width(), crate::spatial::tiling::TAB_BAR_HEIGHT),
-                                    );
-                                    crate::spatial::tiling::paint_tab_bar(
-                                        app_ui.painter(),
-                                        tab_bar_rect,
-                                        group,
-                                        &zoomed_tab_labels,
-                                        &self.colors,
-                                        self.config.pane_title_font_size.unwrap_or(11.0),
-                                    );
-                                }
                             }
                         } else {
                             let mut frame_ui = ui.new_child(egui::UiBuilder::new().max_rect(frame_rect));
@@ -805,11 +788,6 @@ impl PlexiApp {
                                                     },
                                                 );
                                             } else {
-                                                if !has_name && zoomed_tab_info.is_some() {
-                                                    ui.add_space(
-                                                        crate::spatial::tiling::TAB_BAR_HEIGHT,
-                                                    );
-                                                }
                                                 let font_size = t.font_size;
                                                 log::debug!("[DRAG] zoom overlay: TerminalView render start");
                                                 use egui_term::TerminalView;
@@ -825,24 +803,6 @@ impl PlexiApp {
                                                 ui.add(terminal);
                                                 log::debug!("[DRAG] zoom overlay: TerminalView render done");
                                             }
-                                        }
-                                    }
-
-                                    if !has_name {
-                                        if let Some(ref group) = zoomed_tab_info {
-                                            let rect = ui.max_rect();
-                                            let tab_bar_rect = egui::Rect::from_min_size(
-                                                rect.min,
-                                                egui::vec2(rect.width(), crate::spatial::tiling::TAB_BAR_HEIGHT),
-                                            );
-                                            crate::spatial::tiling::paint_tab_bar(
-                                                ui.painter(),
-                                                tab_bar_rect,
-                                                group,
-                                                &zoomed_tab_labels,
-                                                &self.colors,
-                                                self.config.pane_title_font_size.unwrap_or(11.0),
-                                            );
                                         }
                                     }
                                 });
@@ -934,6 +894,11 @@ impl PlexiApp {
                             self.ctx.request_repaint();
                         }
                     }
+                }
+
+                let effective_tab_click = tab_click.or(zoomed_tab_click);
+                if let Some((container_tile, clicked_idx)) = effective_tab_click {
+                    self.switch_to_tab(container_tile, clicked_idx);
                 }
 
                 if should_close_exited {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -400,6 +400,22 @@ impl PlexiApp {
                     .iter()
                     .filter_map(|(&id, p)| p.as_terminal()?.name.as_ref().map(|n| (id, n.clone())))
                     .collect();
+                let tab_labels: HashMap<PaneId, String> = ctx
+                    .panes
+                    .iter()
+                    .map(|(&id, p)| {
+                        let label = if let Some(name) = p.as_terminal().and_then(|t| t.name.as_ref()) {
+                            name.clone()
+                        } else {
+                            match p {
+                                crate::host::pane::Pane::Terminal(_) => "Terminal".to_string(),
+                                crate::host::pane::Pane::App(a) => a.name.clone(),
+                                crate::host::pane::Pane::Portal(_) => "Portal".to_string(),
+                            }
+                        };
+                        (id, label)
+                    })
+                    .collect();
                 let suppress_focus = self.show_command_palette
                     || self.renaming_pane.is_some()
                     || self.renaming_window.is_some();
@@ -518,6 +534,7 @@ impl PlexiApp {
                     new_focused: None,
                     close_exited: None,
                     tab_info,
+                    tab_labels,
                     zoomed_pane,
                     colors: self.colors,
                     pane_names,
@@ -598,8 +615,9 @@ impl PlexiApp {
                     if let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.get(zoomed_tile) {
                         let pane_id = *pane_id;
                         let panel_rect = ui.max_rect();
-                        let zoomed_tab_info = behavior.tab_info.get(&zoomed_tile).copied();
+                        let zoomed_tab_info = behavior.tab_info.get(&zoomed_tile).cloned();
                         let zoomed_pane_name = behavior.pane_names.get(&pane_id).cloned();
+                        let zoomed_tab_labels = behavior.tab_labels.clone();
 
                         // Drop behavior to release the mutable borrow on ctx.panes
                         drop(behavior);
@@ -662,25 +680,26 @@ impl PlexiApp {
                                 0.0,
                                 self.colors.pane_header_bg(),
                             );
-                            if let Some((active_idx, count)) = zoomed_tab_info {
-                                crate::spatial::tiling::paint_tab_dots(
+                            if let Some(ref group) = zoomed_tab_info {
+                                crate::spatial::tiling::paint_tab_bar(
                                     ui.painter(),
-                                    bar_rect.left(),
-                                    bar_rect.center().y,
-                                    active_idx,
-                                    count,
-                                    self.colors.accent,
-                                    self.colors.bg_active,
+                                    bar_rect,
+                                    group,
+                                    &zoomed_tab_labels,
+                                    &self.colors,
+                                    self.config.pane_title_font_size.unwrap_or(11.0),
                                 );
                             }
-                            if let Some(ref name) = zoomed_pane_name {
-                                ui.painter().text(
-                                    bar_rect.center(),
-                                    egui::Align2::CENTER_CENTER,
-                                    name,
-                                    egui::FontId::proportional(11.0),
-                                    self.colors.text_dim,
-                                );
+                            if zoomed_tab_info.is_none() {
+                                if let Some(ref name) = zoomed_pane_name {
+                                    ui.painter().text(
+                                        bar_rect.center(),
+                                        egui::Align2::CENTER_CENTER,
+                                        name,
+                                        egui::FontId::proportional(11.0),
+                                        self.colors.text_dim,
+                                    );
+                                }
                             }
                         }
                         // Frame rect starts exactly where the name bar ends (or at the
@@ -717,19 +736,19 @@ impl PlexiApp {
                                     !modal_open,
                                 );
                             }
-                            // Tab indicator dots for unnamed panes in a tab group —
-                            // painter-only, painted after the app render so they
-                            // sit on top of the app content.
                             if !has_name {
-                                if let Some((active_idx, count)) = zoomed_tab_info {
-                                    crate::spatial::tiling::paint_tab_dots(
+                                if let Some(ref group) = zoomed_tab_info {
+                                    let tab_bar_rect = egui::Rect::from_min_size(
+                                        frame_rect.min,
+                                        egui::vec2(frame_rect.width(), crate::spatial::tiling::TAB_BAR_HEIGHT),
+                                    );
+                                    crate::spatial::tiling::paint_tab_bar(
                                         app_ui.painter(),
-                                        frame_rect.left(),
-                                        frame_rect.top() + 2.0 + 4.0, // 4.0 = dot radius
-                                        active_idx,
-                                        count,
-                                        self.colors.accent,
-                                        self.colors.bg_active,
+                                        tab_bar_rect,
+                                        group,
+                                        &zoomed_tab_labels,
+                                        &self.colors,
+                                        self.config.pane_title_font_size.unwrap_or(11.0),
                                     );
                                 }
                             }
@@ -786,10 +805,9 @@ impl PlexiApp {
                                                     },
                                                 );
                                             } else {
-                                                // Reserve space for tab dots when no name bar
                                                 if !has_name && zoomed_tab_info.is_some() {
                                                     ui.add_space(
-                                                        crate::spatial::tiling::TAB_DOT_RESERVED_HEIGHT,
+                                                        crate::spatial::tiling::TAB_BAR_HEIGHT,
                                                     );
                                                 }
                                                 let font_size = t.font_size;
@@ -810,18 +828,20 @@ impl PlexiApp {
                                         }
                                     }
 
-                                    // Draw tab indicator dots for unnamed panes in a tab group
                                     if !has_name {
-                                        if let Some((active_idx, count)) = zoomed_tab_info {
+                                        if let Some(ref group) = zoomed_tab_info {
                                             let rect = ui.max_rect();
-                                            crate::spatial::tiling::paint_tab_dots(
+                                            let tab_bar_rect = egui::Rect::from_min_size(
+                                                rect.min,
+                                                egui::vec2(rect.width(), crate::spatial::tiling::TAB_BAR_HEIGHT),
+                                            );
+                                            crate::spatial::tiling::paint_tab_bar(
                                                 ui.painter(),
-                                                rect.left(),
-                                                rect.top() + 2.0 + 4.0, // 4.0 = dot radius
-                                                active_idx,
-                                                count,
-                                                self.colors.accent,
-                                                self.colors.bg_active,
+                                                tab_bar_rect,
+                                                group,
+                                                &zoomed_tab_labels,
+                                                &self.colors,
+                                                self.config.pane_title_font_size.unwrap_or(11.0),
                                             );
                                         }
                                     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -669,6 +669,11 @@ impl PlexiApp {
                         // is no cursor/spacing gap between them.
                         let has_name = zoomed_pane_name.is_some();
                         let has_tabs = zoomed_tab_info.is_some();
+                        let is_overtaken_app = ctx
+                            .panes
+                            .get(&pane_id)
+                            .and_then(|p| p.as_app())
+                            .is_some_and(|a| a.overlay_replaced.is_some());
                         let has_top_bar = has_name || has_tabs;
                         const NAME_BAR_HEIGHT: f32 = 20.0;
                         if has_top_bar {
@@ -690,6 +695,7 @@ impl PlexiApp {
                                     &zoomed_tab_labels,
                                     &self.colors,
                                     self.config.pane_title_font_size.unwrap_or(11.0),
+                                    is_overtaken_app,
                                 ) {
                                     zoomed_tab_click = Some((group.container_tile, idx));
                                 }
@@ -733,6 +739,7 @@ impl PlexiApp {
                                     app_pane,
                                     &self.colors,
                                     !modal_open,
+                                    has_tabs,
                                 );
                             }
                         } else {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -149,8 +149,10 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "new_tab",
     "next_tab",
     "prev_tab",
-    "first_tab",
-    "last_tab",
+    "next_context",
+    "prev_context",
+    "move_context_up",
+    "move_context_down",
     "nav_back",
     "focus_history_forward",
     "toggle_sidebar",
@@ -333,8 +335,10 @@ pub struct KeybindingsConfig {
     pub new_tab: Option<String>,
     pub next_tab: Option<String>,
     pub prev_tab: Option<String>,
-    pub first_tab: Option<String>,
-    pub last_tab: Option<String>,
+    pub next_context: Option<String>,
+    pub prev_context: Option<String>,
+    pub move_context_up: Option<String>,
+    pub move_context_down: Option<String>,
     pub nav_back: Option<String>,
     pub focus_history_forward: Option<String>,
     pub toggle_sidebar: Option<String>,
@@ -397,8 +401,10 @@ impl KeybindingsConfig {
         overlay_field!(new_tab);
         overlay_field!(next_tab);
         overlay_field!(prev_tab);
-        overlay_field!(first_tab);
-        overlay_field!(last_tab);
+        overlay_field!(next_context);
+        overlay_field!(prev_context);
+        overlay_field!(move_context_up);
+        overlay_field!(move_context_down);
         overlay_field!(nav_back);
         overlay_field!(focus_history_forward);
         overlay_field!(toggle_sidebar);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -70,6 +70,7 @@ const KNOWN_TOP_LEVEL: &[&str] = &[
     "ai",
     "confirm_quit",
     "confirm_close",
+    "confirm_context_close",
     "keybindings",
     "focus_history_depth",
     "agents",
@@ -182,6 +183,7 @@ const KNOWN_KEYBINDINGS: &[&str] = &[
     "hide_pane",
     "park_context",
     "open_notes_picker",
+    "close_context",
 ];
 
 pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
@@ -368,6 +370,7 @@ pub struct KeybindingsConfig {
     pub hide_pane: Option<String>,
     pub park_context: Option<String>,
     pub open_notes_picker: Option<String>,
+    pub close_context: Option<String>,
 }
 
 impl KeybindingsConfig {
@@ -434,6 +437,7 @@ impl KeybindingsConfig {
         overlay_field!(hide_pane);
         overlay_field!(park_context);
         overlay_field!(open_notes_picker);
+        overlay_field!(close_context);
     }
 }
 
@@ -458,6 +462,8 @@ pub struct PlexiConfig {
     pub confirm_quit: Option<bool>,
     /// Set to false to close panes immediately on Cmd+W without a confirmation dialog (default: true).
     pub confirm_close: Option<bool>,
+    /// Set to false to close contexts immediately on Cmd+Shift+W without a confirmation dialog (default: true).
+    pub confirm_context_close: Option<bool>,
     pub keybindings: Option<KeybindingsConfig>,
     pub focus_history_depth: Option<usize>,
     pub agents: Option<AgentsConfig>,
@@ -1230,6 +1236,9 @@ impl PlexiConfig {
         }
         if other.confirm_close.is_some() {
             self.confirm_close = other.confirm_close;
+        }
+        if other.confirm_context_close.is_some() {
+            self.confirm_context_close = other.confirm_context_close;
         }
         if other.pane_gap.is_some() {
             self.pane_gap = other.pane_gap;

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -220,7 +220,7 @@ impl Window {
 
     pub(crate) fn compute_tab_info(&self) -> HashMap<TileId, TabGroupInfo> {
         let mut info = HashMap::new();
-        for (_tile_id, tile) in self.tree.tiles.iter() {
+        for (container_id, tile) in self.tree.tiles.iter() {
             if let Tile::Container(Container::Tabs(tabs)) = tile {
                 let children = &tabs.children;
                 if children.len() < 2 {
@@ -237,6 +237,7 @@ impl Window {
                 let group = TabGroupInfo {
                     active_idx,
                     members,
+                    container_tile: *container_id,
                 };
                 for child in children {
                     self.collect_panes(*child, &mut |pane_tile| {

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -1,7 +1,7 @@
 use crate::host::keys::Direction;
 use crate::host::pane::Pane;
 use crate::host::shell;
-use crate::spatial::tiling::PaneId;
+use crate::spatial::tiling::{PaneId, TabGroupInfo};
 use egui_tiles::{Container, Tile, TileId, Tree};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -218,7 +218,7 @@ impl Window {
         find_in_direction_geometric(from_rect, candidates, dir)
     }
 
-    pub(crate) fn compute_tab_info(&self) -> HashMap<TileId, (usize, usize)> {
+    pub(crate) fn compute_tab_info(&self) -> HashMap<TileId, TabGroupInfo> {
         let mut info = HashMap::new();
         for (_tile_id, tile) in self.tree.tiles.iter() {
             if let Tile::Container(Container::Tabs(tabs)) = tile {
@@ -226,19 +226,41 @@ impl Window {
                 if children.len() < 2 {
                     continue;
                 }
-                let count = children.len();
                 let active_idx = tabs
                     .active
                     .and_then(|a| children.iter().position(|&c| c == a))
                     .unwrap_or(0);
+                let members: Vec<PaneId> = children
+                    .iter()
+                    .filter_map(|&child| self.find_first_pane_id(child))
+                    .collect();
+                let group = TabGroupInfo {
+                    active_idx,
+                    members,
+                };
                 for child in children {
                     self.collect_panes(*child, &mut |pane_tile| {
-                        info.insert(pane_tile, (active_idx, count));
+                        info.insert(pane_tile, group.clone());
                     });
                 }
             }
         }
         info
+    }
+
+    fn find_first_pane_id(&self, tile_id: TileId) -> Option<PaneId> {
+        match self.tree.tiles.get(tile_id) {
+            Some(Tile::Pane(id)) => Some(*id),
+            Some(Tile::Container(container)) => {
+                for &child in container.children() {
+                    if let Some(id) = self.find_first_pane_id(child) {
+                        return Some(id);
+                    }
+                }
+                None
+            }
+            None => None,
+        }
     }
 
     fn collect_panes(&self, tile_id: TileId, f: &mut dyn FnMut(TileId)) {

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -31,6 +31,7 @@ use crate::config::KeybindingsConfig;
 // Cmd+F                       — terminal search (handled inside egui_term, not host)
 // Cmd+U                       — toggle pane hidden state
 // Cmd+E                       — file browser
+// Cmd+Shift+W                 — close context (with confirm dialog)
 // Cmd+Shift+I                 — set context root from focused pane CWD
 // Cmd+Shift+U                 — park/unpark context
 // Cmd+Option+N                — extract focused pane into a new sub-context (portal)
@@ -148,6 +149,8 @@ pub enum Action {
     ParkContext,
     /// Open the notes picker overlay from any pane type. Bound to Cmd+O.
     OpenNotesPicker,
+    /// Close the active context with a confirm dialog. Bound to Cmd+Shift+W.
+    CloseContext,
 }
 
 /// Resolved keybindings — one `(Modifiers, Key)` pair per named action.
@@ -210,6 +213,7 @@ pub struct KeyBindings {
     pub hide_pane: (egui::Modifiers, egui::Key),
     pub park_context: (egui::Modifiers, egui::Key),
     pub open_notes_picker: (egui::Modifiers, egui::Key),
+    pub close_context: (egui::Modifiers, egui::Key),
 }
 
 fn cmd() -> egui::Modifiers {
@@ -313,6 +317,7 @@ impl Default for KeyBindings {
             hide_pane: (cmd(), egui::Key::U),
             park_context: (cmd_shift(), egui::Key::U),
             open_notes_picker: (cmd(), egui::Key::O),
+            close_context: (cmd_shift(), egui::Key::W),
         }
     }
 }
@@ -495,6 +500,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(hide_pane, "hide_pane");
     apply_override!(park_context, "park_context");
     apply_override!(open_notes_picker, "open_notes_picker");
+    apply_override!(close_context, "close_context");
 
     // Conflict detection
     let named: &[(&str, (egui::Modifiers, egui::Key))] = &[
@@ -559,6 +565,7 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("hide_pane", bindings.hide_pane),
         ("park_context", bindings.park_context),
         ("open_notes_picker", bindings.open_notes_picker),
+        ("close_context", bindings.close_context),
     ];
 
     let mut seen: std::collections::HashMap<u64, &str> = std::collections::HashMap::new();
@@ -663,6 +670,13 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
             exact: true,
             context: BindingContext::Global,
             action: Action::ToggleNotificationModal,
+        },
+        BindingEntry {
+            modifiers: b.close_context.0,
+            key: b.close_context.1,
+            exact: true,
+            context: BindingContext::Global,
+            action: Action::CloseContext,
         },
         // ── Normal bindings (suppressed when overlay/capture active) ─────────
         BindingEntry {

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -14,7 +14,8 @@ use crate::config::KeybindingsConfig;
 // Cmd+Shift+M                 — toggle minimap overlay
 // Cmd+T                       — new tab
 // Cmd+Shift+L/H               — next/prev tab
-// Cmd+Shift+K/J               — first/last tab
+// Cmd+Shift+J/K               — next/prev context
+// Cmd+Shift+Ctrl+J/K           — move context down/up
 // Cmd+Q                       — quit
 // Cmd+B                       — toggle sidebar
 // Cmd+Enter                   — zoom into sub-context (Portal focus) or toggle pane zoom
@@ -68,8 +69,10 @@ pub enum Action {
     SwitchContext(usize),
     NextTab,
     PrevTab,
-    FirstTab,
-    LastTab,
+    NextContext,
+    PrevContext,
+    MoveContextUp,
+    MoveContextDown,
     Quit,
     ToggleSidebar,
     ToggleShortcuts,
@@ -173,8 +176,10 @@ pub struct KeyBindings {
     pub new_tab: (egui::Modifiers, egui::Key),
     pub next_tab: (egui::Modifiers, egui::Key),
     pub prev_tab: (egui::Modifiers, egui::Key),
-    pub first_tab: (egui::Modifiers, egui::Key),
-    pub last_tab: (egui::Modifiers, egui::Key),
+    pub next_context: (egui::Modifiers, egui::Key),
+    pub prev_context: (egui::Modifiers, egui::Key),
+    pub move_context_up: (egui::Modifiers, egui::Key),
+    pub move_context_down: (egui::Modifiers, egui::Key),
     pub nav_back: (egui::Modifiers, egui::Key),
     pub focus_history_forward: (egui::Modifiers, egui::Key),
     pub toggle_sidebar: (egui::Modifiers, egui::Key),
@@ -242,6 +247,13 @@ fn cmd_ctrl_alt() -> egui::Modifiers {
         ..egui::Modifiers::COMMAND
     }
 }
+fn cmd_shift_ctrl() -> egui::Modifiers {
+    egui::Modifiers {
+        shift: true,
+        ctrl: true,
+        ..egui::Modifiers::COMMAND
+    }
+}
 impl Default for KeyBindings {
     fn default() -> Self {
         Self {
@@ -267,8 +279,10 @@ impl Default for KeyBindings {
             new_tab: (cmd(), egui::Key::T),
             next_tab: (cmd_shift(), egui::Key::L),
             prev_tab: (cmd_shift(), egui::Key::H),
-            first_tab: (cmd_shift(), egui::Key::K),
-            last_tab: (cmd_shift(), egui::Key::J),
+            next_context: (cmd_shift(), egui::Key::J),
+            prev_context: (cmd_shift(), egui::Key::K),
+            move_context_up: (cmd_shift_ctrl(), egui::Key::K),
+            move_context_down: (cmd_shift_ctrl(), egui::Key::J),
             nav_back: (cmd(), egui::Key::OpenBracket),
             focus_history_forward: (cmd(), egui::Key::CloseBracket),
             toggle_sidebar: (cmd(), egui::Key::B),
@@ -448,8 +462,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
     apply_override!(new_tab, "new_tab");
     apply_override!(next_tab, "next_tab");
     apply_override!(prev_tab, "prev_tab");
-    apply_override!(first_tab, "first_tab");
-    apply_override!(last_tab, "last_tab");
+    apply_override!(next_context, "next_context");
+    apply_override!(prev_context, "prev_context");
+    apply_override!(move_context_up, "move_context_up");
+    apply_override!(move_context_down, "move_context_down");
     apply_override!(nav_back, "nav_back");
     apply_override!(focus_history_forward, "focus_history_forward");
     apply_override!(toggle_sidebar, "toggle_sidebar");
@@ -504,8 +520,10 @@ pub fn build_key_bindings(overrides: Option<&KeybindingsConfig>) -> KeyBindings 
         ("new_tab", bindings.new_tab),
         ("next_tab", bindings.next_tab),
         ("prev_tab", bindings.prev_tab),
-        ("first_tab", bindings.first_tab),
-        ("last_tab", bindings.last_tab),
+        ("next_context", bindings.next_context),
+        ("prev_context", bindings.prev_context),
+        ("move_context_up", bindings.move_context_up),
+        ("move_context_down", bindings.move_context_down),
         ("nav_back", bindings.nav_back),
         ("focus_history_forward", bindings.focus_history_forward),
         ("toggle_sidebar", bindings.toggle_sidebar),
@@ -739,18 +757,32 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
             action: Action::PrevTab,
         },
         BindingEntry {
-            modifiers: b.first_tab.0,
-            key: b.first_tab.1,
+            modifiers: b.next_context.0,
+            key: b.next_context.1,
             exact: false,
             context: BindingContext::Normal,
-            action: Action::FirstTab,
+            action: Action::NextContext,
         },
         BindingEntry {
-            modifiers: b.last_tab.0,
-            key: b.last_tab.1,
+            modifiers: b.prev_context.0,
+            key: b.prev_context.1,
             exact: false,
             context: BindingContext::Normal,
-            action: Action::LastTab,
+            action: Action::PrevContext,
+        },
+        BindingEntry {
+            modifiers: b.move_context_up.0,
+            key: b.move_context_up.1,
+            exact: false,
+            context: BindingContext::Normal,
+            action: Action::MoveContextUp,
+        },
+        BindingEntry {
+            modifiers: b.move_context_down.0,
+            key: b.move_context_down.1,
+            exact: false,
+            context: BindingContext::Normal,
+            action: Action::MoveContextDown,
         },
         BindingEntry {
             modifiers: b.navigate_left.0,

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -58,6 +58,7 @@ impl PlexiApp {
                                         (&["\u{2318}", "\\"], "Split right (mirror)"),
                                         (&["\u{2318}", "\u{21E7}", "\\"], "Split below (mirror)"),
                                         (&["\u{2318}", "W"], "Close pane"),
+                                        (&["\u{2318}", "\u{21E7}", "W"], "Close context"),
                                         (&["\u{2318}", "T"], "New tab"),
                                     ];
                                     for (keys, desc) in rows {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -580,41 +580,6 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn jump_to_tab(&mut self, index: usize) {
-        let ctx = &self.windows[self.active_window];
-        let Some(focused) = ctx.focused_pane else {
-            return;
-        };
-
-        let Some((tabs_id, _)) = ctx.find_ancestor_tabs(focused) else {
-            return;
-        };
-
-        let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get(tabs_id) else {
-            return;
-        };
-
-        let children = &tabs.children;
-        if children.is_empty() {
-            return;
-        }
-
-        let clamped = index.min(children.len() - 1);
-        let target = children[clamped];
-
-        let ctx = &mut self.windows[self.active_window];
-        if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(tabs_id) {
-            tabs.set_active(target);
-        }
-
-        if let Some(pane_tile) = ctx.find_first_pane_in(target) {
-            if ctx.zoomed_pane.is_some() {
-                ctx.zoom_to(pane_tile);
-            } else {
-                ctx.navigate_to(pane_tile);
-            }
-        }
-    }
 
     pub(crate) fn close_focused(&mut self) {
         let focused = match self.windows[self.active_window].focused_pane {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -581,6 +581,32 @@ impl PlexiApp {
     }
 
 
+    pub(crate) fn switch_to_tab(&mut self, container_tile: TileId, idx: usize) {
+        let ctx = &self.windows[self.active_window];
+        let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get(container_tile) else {
+            return;
+        };
+        let children = &tabs.children;
+        if idx >= children.len() {
+            return;
+        }
+        let target = children[idx];
+
+        let ctx = &mut self.windows[self.active_window];
+        if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(container_tile) {
+            tabs.set_active(target);
+        }
+
+        if let Some(pane_tile) = ctx.find_first_pane_in(target) {
+            if ctx.zoomed_pane.is_some() {
+                ctx.zoom_to(pane_tile);
+            } else {
+                ctx.navigate_to(pane_tile);
+            }
+        }
+        log::info!("tab_click: switched to tab index={idx} in container={container_tile:?}");
+    }
+
     pub(crate) fn close_focused(&mut self) {
         let focused = match self.windows[self.active_window].focused_pane {
             Some(f) => f,

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -19,9 +19,8 @@ const NAV_BAR_PAD: f32 = style::SPACE_SM;
 /// Height of the overtake indicator bar shown when this app replaced another pane.
 const OVERTAKE_BAR_HEIGHT: f32 = 24.0;
 
-pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_focused: bool) {
-    // Viewport overtake indicator — shows when this app has replaced another pane's content.
-    if app_pane.overlay_replaced.is_some() {
+pub fn render(ui: &mut egui::Ui, app_pane: &mut AppPane, colors: &Colors, is_focused: bool, suppress_overtake: bool) {
+    if app_pane.overlay_replaced.is_some() && !suppress_overtake {
         let (bar_rect, _) = ui.allocate_exact_size(
             egui::vec2(ui.available_width(), OVERTAKE_BAR_HEIGHT),
             egui::Sense::hover(),

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -11,7 +11,7 @@
 
 use crate::app_protocol::AgentState;
 use crate::host::pane::TerminalPane;
-use crate::spatial::tiling::{paint_tab_dots, PaneId, DOT_RADIUS, TAB_DOT_RESERVED_HEIGHT};
+use crate::spatial::tiling::{paint_tab_bar, PaneId, TabGroupInfo, TAB_BAR_HEIGHT};
 use crate::ui::theme::{self, Colors};
 use egui::Vec2;
 use egui_term::{TerminalTheme, TerminalView};
@@ -37,7 +37,8 @@ pub fn render(
     theme: &TerminalTheme,
     colors: &Colors,
     pane_names: &HashMap<PaneId, String>,
-    tab_info: &HashMap<TileId, (usize, usize)>,
+    tab_info: &HashMap<TileId, TabGroupInfo>,
+    tab_labels: &HashMap<PaneId, String>,
     workspace_root: Option<&Path>,
     pane_title_font_size: f32,
 ) -> bool {
@@ -58,11 +59,12 @@ pub fn render(
     }
 
     let outside_workspace = is_terminal_outside_workspace(terminal, workspace_root);
-    render_name_bar_and_dots(
+    render_name_bar_and_tabs(
         ui,
         tile_id,
         pane_id,
         tab_info,
+        tab_labels,
         pane_names,
         colors,
         outside_workspace,
@@ -89,68 +91,50 @@ pub fn render(
         .set_size(Vec2::new(ui.available_width(), ui.available_height()));
     ui.add(view);
 
-    // Draw tab indicator dots (top-left) when 2+ tabs and NO name bar.
-    if !pane_names.contains_key(pane_id) {
-        if let Some(&(active_idx, count)) = tab_info.get(&tile_id) {
-            let rect = ui.max_rect();
-            paint_tab_dots(
-                ui.painter(),
-                rect.left(),
-                rect.top() + 2.0 + DOT_RADIUS,
-                active_idx,
-                count,
-                colors.accent,
-                colors.bg_active,
-            );
-        }
-    }
+    // The tab bar for unnamed panes is rendered by render_name_bar_and_tabs
+    // above (it now always shows the full bar when tabs exist), so no
+    // additional dot overlay is needed here.
 
     false
 }
 
-/// Render the pane name bar (if named) and reserve tab-dot space for a
-/// terminal in full-pane mode. When `outside_workspace` is true, paint a
-/// small right-aligned "↗ outside workspace" badge so the user can see the
-/// scope drift without it being intrusive.
-fn render_name_bar_and_dots(
+fn render_name_bar_and_tabs(
     ui: &mut egui::Ui,
     tile_id: TileId,
     pane_id: &PaneId,
-    tab_info: &HashMap<TileId, (usize, usize)>,
+    tab_info: &HashMap<TileId, TabGroupInfo>,
+    tab_labels: &HashMap<PaneId, String>,
     pane_names: &HashMap<PaneId, String>,
     colors: &Colors,
     outside_workspace: bool,
     name_font_size: f32,
     agent_state: Option<&AgentState>,
 ) {
-    let name_bar_height = 20.0;
     let has_name = pane_names.contains_key(pane_id);
-    let has_tabs = tab_info.contains_key(&tile_id);
+    let tab_group = tab_info.get(&tile_id);
 
-    // The full name-bar strip is allocated when there's a name to print or
-    // an outside-workspace badge to draw. Without one, the slim tab-dot
-    // reservation (or no reservation at all) is enough.
-    let needs_full_bar = has_name || outside_workspace;
-
-    if needs_full_bar {
+    if let Some(group) = tab_group {
         let bar_rect = egui::Rect::from_min_size(
             ui.cursor().min,
-            egui::vec2(ui.available_width(), name_bar_height),
+            egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
+        );
+        ui.advance_cursor_after_rect(bar_rect);
+        paint_tab_bar(ui.painter(), bar_rect, group, tab_labels, colors, name_font_size);
+
+        if outside_workspace {
+            paint_outside_workspace_badge(ui.painter(), bar_rect);
+        }
+
+        if let Some(state) = agent_state {
+            paint_activity_dot(ui, bar_rect, state, colors);
+        }
+    } else if has_name || outside_workspace {
+        let bar_rect = egui::Rect::from_min_size(
+            ui.cursor().min,
+            egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
         ui.painter().rect_filled(bar_rect, 0.0, colors.pane_header_bg());
-
-        if let Some(&(active_idx, count)) = tab_info.get(&tile_id) {
-            paint_tab_dots(
-                ui.painter(),
-                bar_rect.left(),
-                bar_rect.center().y,
-                active_idx,
-                count,
-                colors.accent,
-                colors.bg_active,
-            );
-        }
 
         if has_name {
             let name = &pane_names[pane_id];
@@ -163,61 +147,65 @@ fn render_name_bar_and_dots(
             );
         }
 
-        // Activity dot — rendered left of center when there's a named bar.
         if let Some(state) = agent_state {
-            const ACTIVITY_DOT_RADIUS: f32 = 3.0;
-            const ACTIVITY_DOT_MARGIN: f32 = 6.0;
-            let t = ui.input(|i| i.time);
-            let color = crate::ui::activity::dot_color_from_time(state, colors, t, 0);
-            let cx = bar_rect.left() + ACTIVITY_DOT_MARGIN + ACTIVITY_DOT_RADIUS;
-            ui.painter().circle_filled(
-                egui::pos2(cx, bar_rect.center().y),
-                ACTIVITY_DOT_RADIUS,
-                color,
-            );
-            if matches!(state, AgentState::Working) {
-                // Pulse only needs ~10fps; an unconditional request_repaint
-                // pins the window at display refresh while agents work.
-                ui.ctx()
-                    .request_repaint_after(std::time::Duration::from_millis(100));
-            }
+            paint_activity_dot(ui, bar_rect, state, colors);
         }
 
         if outside_workspace {
-            // Right-aligned amber badge. Mirrors the lifecycle-pill pattern
-            // — minimal, glanceable, never intrusive.
-            let label = "↗ outside workspace";
-            let amber = egui::Color32::from_rgb(0xff, 0xb8, 0x6b);
-            let font = egui::FontId::proportional(10.0);
-            let galley = ui
-                .painter()
-                .layout_no_wrap(label.to_string(), font.clone(), amber);
-            let pad_x = 6.0;
-            let badge_w = galley.size().x + pad_x * 2.0;
-            let badge_h = 14.0;
-            let badge_rect = egui::Rect::from_min_size(
-                egui::pos2(
-                    bar_rect.right() - badge_w - 4.0,
-                    bar_rect.center().y - badge_h / 2.0,
-                ),
-                egui::vec2(badge_w, badge_h),
-            );
-            ui.painter().rect_filled(
-                badge_rect,
-                egui::CornerRadius::same(3),
-                egui::Color32::from_rgba_unmultiplied(0xff, 0xb8, 0x6b, 28),
-            );
-            ui.painter().text(
-                badge_rect.center(),
-                egui::Align2::CENTER_CENTER,
-                label,
-                font,
-                amber,
-            );
+            paint_outside_workspace_badge(ui.painter(), bar_rect);
         }
-    } else if has_tabs {
-        ui.add_space(TAB_DOT_RESERVED_HEIGHT);
     }
+}
+
+fn paint_activity_dot(
+    ui: &mut egui::Ui,
+    bar_rect: egui::Rect,
+    state: &AgentState,
+    colors: &Colors,
+) {
+    const ACTIVITY_DOT_RADIUS: f32 = 3.0;
+    const ACTIVITY_DOT_MARGIN: f32 = 6.0;
+    let t = ui.input(|i| i.time);
+    let color = crate::ui::activity::dot_color_from_time(state, colors, t, 0);
+    let cx = bar_rect.left() + ACTIVITY_DOT_MARGIN + ACTIVITY_DOT_RADIUS;
+    ui.painter().circle_filled(
+        egui::pos2(cx, bar_rect.center().y),
+        ACTIVITY_DOT_RADIUS,
+        color,
+    );
+    if matches!(state, AgentState::Working) {
+        ui.ctx()
+            .request_repaint_after(std::time::Duration::from_millis(100));
+    }
+}
+
+fn paint_outside_workspace_badge(painter: &egui::Painter, bar_rect: egui::Rect) {
+    let label = "↗ outside workspace";
+    let amber = egui::Color32::from_rgb(0xff, 0xb8, 0x6b);
+    let font = egui::FontId::proportional(10.0);
+    let galley = painter.layout_no_wrap(label.to_string(), font.clone(), amber);
+    let pad_x = 6.0;
+    let badge_w = galley.size().x + pad_x * 2.0;
+    let badge_h = 14.0;
+    let badge_rect = egui::Rect::from_min_size(
+        egui::pos2(
+            bar_rect.right() - badge_w - 4.0,
+            bar_rect.center().y - badge_h / 2.0,
+        ),
+        egui::vec2(badge_w, badge_h),
+    );
+    painter.rect_filled(
+        badge_rect,
+        egui::CornerRadius::same(3),
+        egui::Color32::from_rgba_unmultiplied(0xff, 0xb8, 0x6b, 28),
+    );
+    painter.text(
+        badge_rect.center(),
+        egui::Align2::CENTER_CENTER,
+        label,
+        font,
+        amber,
+    );
 }
 
 /// True when the terminal's child PID has a CWD that is not an ancestor of

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -27,6 +27,7 @@ static LOG_TERMINAL_GLYPH_PADDING: Once = Once::new();
 
 /// Render one frame of a terminal pane. Returns `true` if the process has
 /// exited and the user pressed a key (the caller should close the tile).
+/// Returns (close_exited, tab_click).
 #[allow(clippy::too_many_arguments)]
 pub fn render(
     ui: &mut egui::Ui,
@@ -41,7 +42,7 @@ pub fn render(
     tab_labels: &HashMap<PaneId, String>,
     workspace_root: Option<&Path>,
     pane_title_font_size: f32,
-) -> bool {
+) -> (bool, Option<(TileId, usize)>) {
     if terminal.exited {
         let rect = ui.max_rect();
         ui.painter().rect_filled(rect, 0.0, colors.terminal_bg);
@@ -50,16 +51,17 @@ pub fn render(
                 ui.colored_label(colors.text_dim, "[process exited]");
             });
         });
-        return is_focused
+        let close = is_focused
             && ui.input(|i| {
                 i.events
                     .iter()
                     .any(|e| matches!(e, egui::Event::Key { pressed: true, .. }))
             });
+        return (close, None);
     }
 
     let outside_workspace = is_terminal_outside_workspace(terminal, workspace_root);
-    render_name_bar_and_tabs(
+    let tab_click = render_name_bar_and_tabs(
         ui,
         tile_id,
         pane_id,
@@ -91,11 +93,7 @@ pub fn render(
         .set_size(Vec2::new(ui.available_width(), ui.available_height()));
     ui.add(view);
 
-    // The tab bar for unnamed panes is rendered by render_name_bar_and_tabs
-    // above (it now always shows the full bar when tabs exist), so no
-    // additional dot overlay is needed here.
-
-    false
+    (false, tab_click)
 }
 
 fn render_name_bar_and_tabs(
@@ -109,9 +107,10 @@ fn render_name_bar_and_tabs(
     outside_workspace: bool,
     name_font_size: f32,
     agent_state: Option<&AgentState>,
-) {
+) -> Option<(TileId, usize)> {
     let has_name = pane_names.contains_key(pane_id);
     let tab_group = tab_info.get(&tile_id);
+    let mut tab_click = None;
 
     if let Some(group) = tab_group {
         let bar_rect = egui::Rect::from_min_size(
@@ -119,7 +118,9 @@ fn render_name_bar_and_tabs(
             egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
-        paint_tab_bar(ui.painter(), bar_rect, group, tab_labels, colors, name_font_size);
+        if let Some(idx) = paint_tab_bar(ui.ctx(), ui.painter(), bar_rect, group, tab_labels, colors, name_font_size) {
+            tab_click = Some((group.container_tile, idx));
+        }
 
         if outside_workspace {
             paint_outside_workspace_badge(ui.painter(), bar_rect);
@@ -155,6 +156,8 @@ fn render_name_bar_and_tabs(
             paint_outside_workspace_badge(ui.painter(), bar_rect);
         }
     }
+
+    tab_click
 }
 
 fn paint_activity_dot(

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -118,7 +118,7 @@ fn render_name_bar_and_tabs(
             egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
-        if let Some(idx) = paint_tab_bar(ui.ctx(), ui.painter(), bar_rect, group, tab_labels, colors, name_font_size) {
+        if let Some(idx) = paint_tab_bar(ui.ctx(), ui.painter(), bar_rect, group, tab_labels, colors, name_font_size, false) {
             tab_click = Some((group.container_tile, idx));
         }
 

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -18,30 +18,41 @@ pub struct TabGroupInfo {
     pub active_idx: usize,
     /// Primary pane ID for each tab, in display order.
     pub members: Vec<PaneId>,
+    /// The TileId of the `Container::Tabs` that owns this group.
+    pub container_tile: TileId,
 }
 
-/// Render a full-width tab bar using the painter API (no Ui allocation).
+/// Render a full-width tab bar and return the index of a clicked tab (if any).
 /// The caller must pre-allocate `bar_rect` (typically `TAB_BAR_HEIGHT` px tall)
-/// and advance the cursor past it. `tab_labels` maps each PaneId to its display
-/// label (pre-computed from name or pane type).
+/// and advance the cursor past it.
 pub(crate) fn paint_tab_bar(
+    ctx: &egui::Context,
     painter: &egui::Painter,
     bar_rect: egui::Rect,
     group: &TabGroupInfo,
     tab_labels: &HashMap<PaneId, String>,
     colors: &Colors,
     font_size: f32,
-) {
+) -> Option<usize> {
     painter.rect_filled(bar_rect, 0.0, colors.pane_header_bg());
 
     let tab_count = group.members.len();
     if tab_count == 0 {
-        return;
+        return None;
     }
 
     let tab_width = bar_rect.width() / tab_count as f32;
     let accent_bar_height = 2.0;
     let font = egui::FontId::proportional(font_size);
+
+    let clicked = ctx.input(|i| {
+        if i.pointer.any_pressed() {
+            i.pointer.interact_pos()
+        } else {
+            None
+        }
+    });
+    let mut clicked_idx = None;
 
     for (i, &pane_id) in group.members.iter().enumerate() {
         let is_active = i == group.active_idx;
@@ -52,6 +63,25 @@ pub(crate) fn paint_tab_bar(
 
         if is_active {
             painter.rect_filled(tab_rect, 0.0, colors.bg_active);
+        }
+
+        if let Some(pos) = clicked {
+            if tab_rect.contains(pos) && !is_active {
+                clicked_idx = Some(i);
+            }
+        }
+
+        // Vertical divider between tabs (skip before first)
+        if i > 0 {
+            let divider_x = tab_rect.left();
+            let inset = 4.0;
+            painter.line_segment(
+                [
+                    egui::pos2(divider_x, bar_rect.top() + inset),
+                    egui::pos2(divider_x, bar_rect.bottom() - inset),
+                ],
+                egui::Stroke::new(1.0, colors.border),
+            );
         }
 
         let label = tab_labels
@@ -83,6 +113,8 @@ pub(crate) fn paint_tab_bar(
             painter.rect_filled(accent_rect, 0.0, colors.accent);
         }
     }
+
+    clicked_idx
 }
 
 /// What kind of pane occupies a minimap slot.
@@ -148,6 +180,8 @@ pub struct PlexiBehavior<'a> {
     pub theme: TerminalTheme,
     pub new_focused: Option<TileId>,
     pub close_exited: Option<TileId>,
+    /// Set when a tab bar click selects a different tab: (container_tile, child_index).
+    pub tab_click: Option<(TileId, usize)>,
     pub tab_info: HashMap<TileId, TabGroupInfo>,
     /// Pre-computed display label for each pane: user-set name, then app name, then type string.
     pub tab_labels: HashMap<PaneId, String>,
@@ -241,7 +275,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
-            let close_exited = render::terminal_pane::render(
+            let (close_exited, tab_click) = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,
                 tile_id,
@@ -257,6 +291,9 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             );
             if close_exited {
                 self.close_exited = Some(tile_id);
+            }
+            if tab_click.is_some() {
+                self.tab_click = tab_click;
             }
         } else if pane.as_portal().is_some() {
             // Portal tile — direct egui rendering.

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -2,7 +2,6 @@ use crate::host::pane::{Pane, TerminalPane};
 use crate::render;
 use crate::ui::style;
 use crate::ui::theme::Colors;
-use egui::Color32;
 use egui_term::{BackendCommand, TerminalTheme};
 use egui_tiles::{
     Behavior, ResizeState, SimplificationOptions, TabState, TileId, Tiles, UiResponse,
@@ -12,29 +11,77 @@ use std::path::PathBuf;
 
 pub type PaneId = u64;
 
-pub(crate) const DOT_RADIUS: f32 = 4.0;
-const DOT_SPACING: f32 = 12.0;
-const DOT_LEFT_MARGIN: f32 = 6.0;
-pub(crate) const TAB_DOT_RESERVED_HEIGHT: f32 = 14.0;
+pub(crate) const TAB_BAR_HEIGHT: f32 = 20.0;
 
-pub(crate) fn paint_tab_dots(
+#[derive(Clone)]
+pub struct TabGroupInfo {
+    pub active_idx: usize,
+    /// Primary pane ID for each tab, in display order.
+    pub members: Vec<PaneId>,
+}
+
+/// Render a full-width tab bar using the painter API (no Ui allocation).
+/// The caller must pre-allocate `bar_rect` (typically `TAB_BAR_HEIGHT` px tall)
+/// and advance the cursor past it. `tab_labels` maps each PaneId to its display
+/// label (pre-computed from name or pane type).
+pub(crate) fn paint_tab_bar(
     painter: &egui::Painter,
-    left_x: f32,
-    center_y: f32,
-    active_idx: usize,
-    count: usize,
-    active_color: Color32,
-    inactive_color: Color32,
+    bar_rect: egui::Rect,
+    group: &TabGroupInfo,
+    tab_labels: &HashMap<PaneId, String>,
+    colors: &Colors,
+    font_size: f32,
 ) {
-    let start_x = left_x + DOT_LEFT_MARGIN;
-    for i in 0..count {
-        let cx = start_x + (i as f32) * DOT_SPACING + DOT_RADIUS;
-        let color = if i == active_idx {
-            active_color
+    painter.rect_filled(bar_rect, 0.0, colors.pane_header_bg());
+
+    let tab_count = group.members.len();
+    if tab_count == 0 {
+        return;
+    }
+
+    let tab_width = bar_rect.width() / tab_count as f32;
+    let accent_bar_height = 2.0;
+    let font = egui::FontId::proportional(font_size);
+
+    for (i, &pane_id) in group.members.iter().enumerate() {
+        let is_active = i == group.active_idx;
+        let tab_rect = egui::Rect::from_min_size(
+            egui::pos2(bar_rect.left() + i as f32 * tab_width, bar_rect.top()),
+            egui::vec2(tab_width, TAB_BAR_HEIGHT),
+        );
+
+        if is_active {
+            painter.rect_filled(tab_rect, 0.0, colors.bg_active);
+        }
+
+        let label = tab_labels
+            .get(&pane_id)
+            .cloned()
+            .unwrap_or_else(|| "Tab".to_string());
+
+        let text_color = if is_active {
+            colors.text_primary
         } else {
-            inactive_color
+            colors.text_dim
         };
-        painter.circle_filled(egui::pos2(cx, center_y), DOT_RADIUS, color);
+        let text_pad = 8.0;
+        let max_text_width = (tab_width - text_pad * 2.0).max(0.0);
+
+        let galley = painter.layout(label, font.clone(), text_color, max_text_width);
+
+        let text_pos = egui::pos2(
+            tab_rect.center().x - galley.size().x / 2.0,
+            tab_rect.center().y - galley.size().y / 2.0,
+        );
+        painter.galley(text_pos, galley, text_color);
+
+        if is_active {
+            let accent_rect = egui::Rect::from_min_size(
+                egui::pos2(tab_rect.left(), tab_rect.bottom() - accent_bar_height),
+                egui::vec2(tab_width, accent_bar_height),
+            );
+            painter.rect_filled(accent_rect, 0.0, colors.accent);
+        }
     }
 }
 
@@ -101,7 +148,9 @@ pub struct PlexiBehavior<'a> {
     pub theme: TerminalTheme,
     pub new_focused: Option<TileId>,
     pub close_exited: Option<TileId>,
-    pub tab_info: HashMap<TileId, (usize, usize)>, // tile_id -> (index, count)
+    pub tab_info: HashMap<TileId, TabGroupInfo>,
+    /// Pre-computed display label for each pane: user-set name, then app name, then type string.
+    pub tab_labels: HashMap<PaneId, String>,
     pub zoomed_pane: Option<TileId>,
     pub colors: Colors,
     pub pane_names: HashMap<PaneId, String>,
@@ -202,6 +251,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 &self.colors,
                 &self.pane_names,
                 &self.tab_info,
+                &self.tab_labels,
                 self.workspace_root.as_deref(),
                 self.pane_title_font_size,
             );

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -296,8 +296,25 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
             let mut app_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
-            let suppress_overtake = self.tab_info.contains_key(&tile_id);
-            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused, suppress_overtake);
+
+            let tab_group = self.tab_info.get(&tile_id);
+            let has_tabs = tab_group.is_some();
+            if let Some(group) = tab_group {
+                let bar_rect = egui::Rect::from_min_size(
+                    app_ui.cursor().min,
+                    egui::vec2(app_ui.available_width(), TAB_BAR_HEIGHT),
+                );
+                app_ui.advance_cursor_after_rect(bar_rect);
+                let is_overtaken = app_pane.overlay_replaced.is_some();
+                if let Some(idx) = paint_tab_bar(
+                    app_ui.ctx(), app_ui.painter(), bar_rect, group,
+                    &self.tab_labels, &self.colors, self.pane_title_font_size, is_overtaken,
+                ) {
+                    self.tab_click = Some((group.container_tile, idx));
+                }
+            }
+
+            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused, has_tabs);
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -33,6 +33,7 @@ pub(crate) fn paint_tab_bar(
     tab_labels: &HashMap<PaneId, String>,
     colors: &Colors,
     font_size: f32,
+    overtake_hint: bool,
 ) -> Option<usize> {
     painter.rect_filled(bar_rect, 0.0, colors.pane_header_bg());
 
@@ -80,7 +81,7 @@ pub(crate) fn paint_tab_bar(
                     egui::pos2(divider_x, bar_rect.top() + inset),
                     egui::pos2(divider_x, bar_rect.bottom() - inset),
                 ],
-                egui::Stroke::new(1.0, colors.border),
+                egui::Stroke::new(1.5, colors.border),
             );
         }
 
@@ -112,6 +113,31 @@ pub(crate) fn paint_tab_bar(
             );
             painter.rect_filled(accent_rect, 0.0, colors.accent);
         }
+    }
+
+    if overtake_hint {
+        let hint_font = egui::FontId::monospace(font_size - 1.0);
+        let hint_text = "Esc";
+        let hint_galley = painter.layout_no_wrap(hint_text.to_string(), hint_font, colors.text_dim);
+        let chip_pad = 4.0;
+        let chip_w = hint_galley.size().x + chip_pad * 2.0;
+        let chip_h = (TAB_BAR_HEIGHT - 6.0).max(10.0);
+        let chip_rect = egui::Rect::from_min_size(
+            egui::pos2(
+                bar_rect.right() - chip_w - 4.0,
+                bar_rect.center().y - chip_h / 2.0,
+            ),
+            egui::vec2(chip_w, chip_h),
+        );
+        painter.rect_filled(chip_rect, egui::CornerRadius::same(3), colors.bg_active);
+        painter.rect_stroke(chip_rect, egui::CornerRadius::same(3), egui::Stroke::new(1.0, colors.border), egui::StrokeKind::Inside);
+        painter.text(
+            chip_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            hint_text,
+            egui::FontId::monospace(font_size - 1.0),
+            colors.text_dim,
+        );
     }
 
     clicked_idx
@@ -270,7 +296,8 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.bg_darkest);
             let mut app_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
-            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused);
+            let suppress_overtake = self.tab_info.contains_key(&tile_id);
+            render::app_pane::render(&mut app_ui, app_pane, &self.colors, is_focused, suppress_overtake);
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);


### PR DESCRIPTION
## Summary

- **Tab bar redesign**: Replace dot-based tab indicators with full-width segmented tab bar. Each tab gets a labeled segment showing pane name (if set) or type ("Terminal"/"App name"/"Portal"). Active tab has `bg_active` background fill with accent-colored bottom border (2px). Single-tab panes show no tab bar.

- **Context navigation shortcuts**: Remap Cmd+Shift+J/K from first/last tab to next/prev context. Add Cmd+Shift+Ctrl+J/K for moving contexts up/down in sidebar order. Context cycling skips parked contexts.

- **Removed**: `FirstTab`/`LastTab` actions and `jump_to_tab()` (replaced by context navigation). Removed `paint_tab_dots()` and associated dot constants.

## Shortcut changes

| Shortcut | Before | After |
|---|---|---|
| Cmd+Shift+H/L | prev/next tab | prev/next tab (unchanged) |
| Cmd+Shift+J/K | first/last tab | next/prev context |
| Cmd+Shift+Ctrl+J/K | (none) | move context down/up |

## Test plan

- [ ] Create 2+ tabs (Cmd+T), verify segmented tab bar appears with labeled segments
- [ ] Active tab shows accent bottom border and brighter background
- [ ] Tab labels show pane name when named, "Terminal" when unnamed
- [ ] Cmd+Shift+H/L cycles between tabs as before
- [ ] With 2+ contexts: Cmd+Shift+J cycles to next context, Cmd+Shift+K to previous
- [ ] Cmd+Shift+Ctrl+J/K moves the active context down/up in sidebar order
- [ ] Zoomed pane (Cmd+Enter) shows tab bar correctly
- [ ] Panes without tabs show name bar only when named (no visual change)